### PR TITLE
Add `quote-props` rule

### DIFF
--- a/config/eslint.json
+++ b/config/eslint.json
@@ -13,7 +13,8 @@
         "camelcase": 1,
         "curly": 1,
         "eqeqeq": 1,
-        "new-cap": 1
+        "new-cap": 1,
+        "quote-props": 0
 
     }
 }

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Rule to flag non-quoted property names in object literals.
+ * @author Mathias Bynens <http://mathiasbynens.be/>
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "Property": function(node) {
+            var key = node.key;
+
+            // Check if the property name is quoted
+            if (key.type != "Literal") {
+                context.report(node, "Non-quoted property `" + key.name + "` found.");
+            }
+
+        }
+    };
+
+};

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Tests for quote-props rule.
+ * @author Mathias Bynens <http://mathiasbynens.be/>
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    sinon = require("sinon"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "quote-props";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating `var x = { foo: 42 }`": {
+
+        topic: "var x = { foo: 42 }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Non-quoted property `foo` found.");
+            assert.include(messages[0].node.type, "Property");
+            assert.include(messages[0].node.key.name, "foo");
+        }
+    },
+
+    "when evaluating `var x = { 'foo': 42 }`": {
+
+        topic: "var x = { 'foo': 42 }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating `var x = { \"foo\": 42 }`": {
+
+        topic: "var x = { \"foo\": 42 }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
I like to ensure property names in object literals are always wrapped in quotes, since [depending on the property name sometimes you need to quote them anyway](http://mathiasbynens.be/notes/javascript-properties).

I’ve always wanted this in JS{L,H}int. It was surprisingly easy to add this rule to ESLint :)
