### PR TITLE
Rule: no undefined when initializing variables

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -10,6 +10,7 @@
         "no-eval": 1,
         "no-with": 1,
         "no-unreachable": 1,
+        "no-undef-init": 1,
 
         "camelcase": 1,
         "curly": 1,

--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Rule to flag when initializing to undefined
+ * @author Ilya Volodin
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "VariableDeclarator": function(node) {
+            var name = node.id.name;
+            var init = node.init.name;
+
+            if (init === "undefined") {
+                context.report(node, "Variable '" + name + "' initialized to undefined.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Tests for undefined rule.
+ * @author Ilya Volodin
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    sinon = require("sinon"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-undef-init";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var a = undefined'": {
+
+        topic: "var a = undefined;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Variable 'a' initialized to undefined.");
+            assert.include(messages[0].node.type, "VariableDeclarator");
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Closes #31. Simple rule to check for undefined when initializing variables.
