### PR TITLE
Rule: Warn on comparison with NaN

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -18,7 +18,8 @@
         "guard-for-in": 0,
         "new-cap": 1,
         "quote-props": 0,
-        "semi": 1
+        "semi": 1,
+        "use-isnan": 1
 
     }
 }

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Rule to flag comparisons to the value NaN
+ * @author James Allardice
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "BinaryExpression": function(node) {
+
+            if (!/^[|&^]$/.test(node.operator) && node.left.name === "NaN" || node.right.name === "NaN") {
+                context.report(node, "Use the isNaN function to compare with NaN.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Tests for use-isnan rule.
+ * @author James Allardice
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    sinon = require("sinon"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "use-isnan";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating '123 === NaN;'": {
+
+        topic: "123 === NaN;",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Use the isNaN function to compare with NaN.");
+            assert.include(messages[0].node.type, "BinaryExpression");
+        }
+    },
+
+    "when evaluating 'NaN == \"abc\";'": {
+
+        topic: "NaN == \"abc\";",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Use the isNaN function to compare with NaN.");
+            assert.include(messages[0].node.type, "BinaryExpression");
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
We should warn when a comparison with the value `NaN` is encountered. For example:

``` javascript
if ("123" == NaN) // ...
```

The warning should indicate that `isNaN` should be used instead.

See http://jslinterrors.com/use-the-isnan-function-to-compare-with-nan
