### PR TITLE
Rule: Warn on leading/trailing decimal points

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -8,6 +8,7 @@
         "no-debugger": 1,
         "no-empty": 1,
         "no-eval": 1,
+        "no-floating-decimal": 0,
         "no-with": 1,
         "no-unreachable": 1,
         "no-undef-init": 1,

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -79,7 +79,7 @@ module.exports = (function() {
          * that this type of node has been found and react accordingly.
          */
         try {
-            var ast = esprima.parse(text, { loc: true, range: true });
+            var ast = esprima.parse(text, { loc: true, range: true, raw: true });
             estraverse.traverse(ast, {
                 enter: function(node) {
                     api.emit(node.type, node);

--- a/lib/rules/no-floating-decimal.js
+++ b/lib/rules/no-floating-decimal.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Rule to flag use of a leading/trailing decimal point in a numeric literal
+ * @author James Allardice
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "Literal": function(node) {
+
+            if (typeof node.value === "number") {
+                if (node.raw.indexOf(".") === 0) {
+                    context.report(node, "A leading decimal point can be confused with a dot.");
+                }
+                if (node.raw.indexOf(".") === node.raw.length - 1) {
+                    context.report(node, "A trailing decimal point can be confused with a dot.");
+                }
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-floating-decimal.js
+++ b/tests/lib/rules/no-floating-decimal.js
@@ -1,0 +1,94 @@
+/**
+ * @fileoverview Tests for no-floating-decimal rule.
+ * @author James Allardice
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    sinon = require("sinon"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-floating-decimal";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = .5;'": {
+
+        topic: "var x = .5;",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "A leading decimal point can be confused with a dot.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var x = -.5;'": {
+
+        topic: "var x = -.5;",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "A leading decimal point can be confused with a dot.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var x = 2.;'": {
+
+        topic: "var x = 2.;",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "A trailing decimal point can be confused with a dot.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var x = 2.5;'": {
+
+        topic: "var x = 2.5;",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
We should warn when a numeric literal with a leading or trailing decimal point is encountered. For example:

``` javascript
var x = .5,
    y = 2.;
```

See http://jslinterrors.com/a-leading-decimal-point-can-be-confused-with-a-dot-a/

This pull request also adds the `raw` option to the Esprima invocation, as it's necessary to inspect the actual string as it appears in the source, rather than the numeric representation of it available in the `value` property of the node.
