### PR TITLE
Rule: Warn on duplicate property identifiers

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -6,6 +6,7 @@
         "no-bitwise": 0,
         "no-console": 1,
         "no-debugger": 1,
+        "no-duplicate-keys": 0,
         "no-empty": 1,
         "no-eval": 1,
         "no-with": 1,

--- a/lib/rules/no-duplicate-keys.js
+++ b/lib/rules/no-duplicate-keys.js
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Rule to flag use of duplicate property identifers in object literals
+ * @author James Allardice
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "ObjectExpression": function(node) {
+
+            var keys = {};
+
+            node.properties.forEach(function (property) {
+                var identifier = property.key.name;
+                keys[identifier] = ++keys[identifier] || 1;
+            });
+
+            Object.keys(keys).forEach(function (key) {
+                if (keys[key] > 1) {
+                    context.report(node, "Duplicate key '" + key + "'.");
+                }
+            });
+        }
+    };
+
+};

--- a/tests/lib/rules/no-duplicate-keys.js
+++ b/tests/lib/rules/no-duplicate-keys.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Tests for no-duplicate-keys rule.
+ * @author James Allardice
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    sinon = require("sinon"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-duplicate-keys";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = { a: 1, a: 2, b: 3 };'": {
+
+        topic: "var x = { a: 1, a: 2, b: 3 };",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Duplicate key 'a'.");
+            assert.include(messages[0].node.type, "ObjectExpression");
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
We should warn when an object literal contains more than one property with the same identifier:

``` javascript
var x = {
    a: 1,
    a: 2
};
```

See http://jslinterrors.com/duplicate-key-a/
