### PR TITLE
Rule: Constructor should use prentices

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -16,6 +16,7 @@
 
         "camelcase": 1,
         "curly": 1,
+        "ctor-prentices": 1,
         "eqeqeq": 1,
         "guard-for-in": 0,
         "new-cap": 1,

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -79,13 +79,13 @@ module.exports = (function() {
          * that this type of node has been found and react accordingly.
          */
         try {
-            var ast = esprima.parse(text, { loc: true, range: true, raw: true });
+            var ast = esprima.parse(text, { loc: true, range: true, raw: true, tokens: true });
             estraverse.traverse(ast, {
                 enter: function(node) {
-                    api.emit(node.type, node);
+                    api.emit(node.type, node, api.getMatchingTokens(node, ast.tokens));
                 },
                 leave: function(node) {
-                    api.emit(node.type + ":after", node);
+                    api.emit(node.type + ":after", node, api.getMatchingTokens(node, ast.tokens));
                 }
             });
 
@@ -147,6 +147,24 @@ module.exports = (function() {
             return currentText || null;
         }
 
+    };
+
+    /**
+     * Gets all tokens that are related to the given node.
+     * @param (ASTNode) [node] The AST node to get the tokens for.
+     * @param (Object[]) [tokens] All tokens for the AST.
+     */
+    api.getMatchingTokens = function(node, tokens) {
+        var startLocation = node.loc.start;
+        var endLocation = node.loc.end;
+        return tokens.filter(function(token) {
+            return (token.loc.start.line === startLocation.line &&
+                    token.loc.end.line === endLocation.line &&
+                    token.loc.start.column >= startLocation.column &&
+                    token.loc.start.column <= endLocation.column &&
+                    token.loc.end.column >= startLocation.column &&
+                    token.loc.end.column <= endLocation.column);
+        });
     };
 
     return api;

--- a/lib/rules/ctor-prentices.js
+++ b/lib/rules/ctor-prentices.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Rule to flag when using constructor without prentices
+ * @author Ilya Volodin
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "NewExpression": function(node, tokens) {
+            var prenticesTokens = tokens.filter(function(token) {
+                return token.value === "(" || token.value === ")";
+            });
+            if (prenticesTokens.length !== 2) {
+                context.report(node, "Missing '()' invoking a constructor");
+            }
+        }
+    };
+
+};

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -123,6 +123,8 @@ vows.describe("eslint").addBatch({
                 spyVariableDeclaration = sinon.spy(),
                 spyIdentifier = sinon.spy(),
                 spyBinaryExpression = sinon.spy();
+            // spy for getMatchingTokens function
+            sinon.spy(eslint, "getMatchingTokens");
 
             eslint.reset();
             eslint.on("Literal", spyLiteral);
@@ -139,6 +141,8 @@ vows.describe("eslint").addBatch({
             sinon.assert.calledOnce(spyIdentifier);
             sinon.assert.calledTwice(spyLiteral);
             sinon.assert.calledOnce(spyBinaryExpression);
+            assert(eslint.getMatchingTokens.called);
+            eslint.getMatchingTokens.restore();
         }
     },
 

--- a/tests/lib/rules/ctor-prentices.js
+++ b/tests/lib/rules/ctor-prentices.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Tests for ctor-prentices rule.
+ * @author Ilya Volodin
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    sinon = require("sinon"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "ctor-prentices";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var a = new Date'": {
+
+        topic: "var a = new Date;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Missing '()' invoking a constructor");
+            assert.include(messages[0].node.type, "NewExpression");
+        }
+    },
+
+    "when evaluating 'var a = new Date()'": {
+
+        topic: "var a = new Date();",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
I've added an ability to pull tokens from the esprima and link them to the nodes. I know the same can be done with the getSource function, but it feels a bit nicer working with the organized data instead of strings. If you do not like this approach, I can switch to getSource but I think it will be beneficial in the long run.
