### PR TITLE
Add git attributes file for converting line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Convert text file line endings to lf
+* text=auto
+
+*.js    text


### PR DESCRIPTION
See issue #43.

This pull request only includes the git attributes file because apparently the files already use unix line endings.
