### PR TITLE
Fix reference to CSS Lint

### DIFF
--- a/docs/Contributing.md
+++ b/docs/Contributing.md
@@ -25,7 +25,7 @@ We want to accept your contribution. Following these guidelines helps to create 
 
 ## New Rules 
 
-Once you've written a rule, you can decide whether the rule is generic enough to be included in CSS Lint or if it's specific to your own use case. If you decide to submit your rule via a pull request, there are some things to keep in mind:
+Once you've written a rule, you can decide whether the rule is generic enough to be included in ESLint or if it's specific to your own use case. If you decide to submit your rule via a pull request, there are some things to keep in mind:
 
 1. Rules must be accompanied by unit tests.
 1. In your pull request include:


### PR DESCRIPTION
Not sure how the docs/ directory is going to work but noticed a typo.
