### PR TITLE
Remove unused sinon requires

### DIFF
--- a/.jshintignore
+++ b/.jshintignore
@@ -1,0 +1,2 @@
+node_modules/**
+coverage/**

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -33,7 +33,7 @@ vows.describe("eslint").addBatch({
             var config = { rules: {} };
 
             eslint.reset();
-            eslint.on("Program", function(node) {
+            eslint.on("Program", function() {
                 var source = eslint.getSource();
                 assert.equal(source, TEST_CODE);
             });

--- a/tests/lib/formatters/compact.js
+++ b/tests/lib/formatters/compact.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     formatter = require("../../../lib/formatters/compact");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     options = require("../../lib/options");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/guard-for-in.js
+++ b/tests/lib/rules/guard-for-in.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-alert.js
+++ b/tests/lib/rules/no-alert.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-bitwise.js
+++ b/tests/lib/rules/no-bitwise.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-console.js
+++ b/tests/lib/rules/no-console.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-debugger.js
+++ b/tests/lib/rules/no-debugger.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-empty.js
+++ b/tests/lib/rules/no-empty.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-floating-decimal.js
+++ b/tests/lib/rules/no-floating-decimal.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-octal.js
+++ b/tests/lib/rules/no-octal.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-with.js
+++ b/tests/lib/rules/no-with.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/use-isnan.js
+++ b/tests/lib/rules/use-isnan.js
@@ -9,7 +9,6 @@
 
 var vows = require("vows"),
     assert = require("assert"),
-    sinon = require("sinon"),
     eslint = require("../../../lib/eslint");
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Also add .jshintignore to exclude coverage and installed modules. 
A single unused `node` parameter was removed.
