### PR TITLE
Adds a breaking test for no-unreachable rule

### DIFF
--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -22,6 +22,18 @@ var RULE_ID = "no-unreachable";
 //------------------------------------------------------------------------------
 
 vows.describe(RULE_ID).addBatch({
+    "when evaluating a function which contains a function": {
+        topic: "function foo() { function bar() { return 1; } return bar(); }",
+
+        "should not return a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
 
     "when evaluation 'function foo() { return; x = 1; }'": {
         topic: "function foo() { return; x = 1; }",


### PR DESCRIPTION
#26 adds a rule for unreachable statements but fails to check functions that are defined inside functions. This commit adds a failing test.

cc @jrfeenst
