### PR TITLE
Fixes no-octal check to only check for numbers

### DIFF
--- a/lib/rules/no-octal.js
+++ b/lib/rules/no-octal.js
@@ -12,7 +12,7 @@ module.exports = function(context) {
     return {
 
         "Literal": function(node) {
-            if (node.raw !== node.value.toString() && node.raw.indexOf("x") < 0) {
+            if (typeof node.value === "number" && node.raw[0] === "0" && node.raw.indexOf("x") < 0) {
                 context.report(node, "Octal literals should not be used.");
             }
         }

--- a/tests/lib/rules/no-octal.js
+++ b/tests/lib/rules/no-octal.js
@@ -22,6 +22,16 @@ var RULE_ID = "no-octal";
 //------------------------------------------------------------------------------
 
 vows.describe(RULE_ID).addBatch({
+    "when evaluating a string": {
+        topic: "var a = 'hello world';",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
 
     "when evaluating 'var a = 01234'": {
 


### PR DESCRIPTION
Fix for #35

This diff checks if the node we're comparing is a number first of all then performs the octal checks.
