### PR TITLE
Fixes exception when init is null

### DIFF
--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -13,7 +13,7 @@ module.exports = function(context) {
 
         "VariableDeclarator": function(node) {
             var name = node.id.name;
-            var init = node.init.name;
+            var init = node.init && node.init.name;
 
             if (init === "undefined") {
                 context.report(node, "Variable '" + name + "' initialized to undefined.");

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -23,6 +23,18 @@ var RULE_ID = "no-undef-init";
 
 vows.describe(RULE_ID).addBatch({
 
+    "when evaluating an empty var": {
+        topic: "var a;",
+
+        "should not die": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
     "when evaluating 'var a = undefined'": {
 
         topic: "var a = undefined;",


### PR DESCRIPTION
#34

When not initializing a var it's `init` property is set to null. Perform the check here so this doesn't throw
