### PR TITLE
Fixes no-alert lint rule for non identifier calls

### DIFF
--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -33,7 +33,7 @@ module.exports = function(context) {
                     context.report(node, "Unexpected " + result[1] + ".");
                 }
 
-            } else if (node.callee.type === "MemberExpression") {
+            } else if (node.callee.type === "MemberExpression" && node.callee.property.type === "Identifier") {
 
                 result = matchProhibited(node.callee.property.name);
 

--- a/tests/lib/rules/no-alert.js
+++ b/tests/lib/rules/no-alert.js
@@ -23,6 +23,18 @@ var RULE_ID = "no-alert";
 
 vows.describe(RULE_ID).addBatch({
 
+    "when attempting to lint a bracket notation MemberExpression": {
+        topic: "a[o.k](1)",
+
+        "should not report violation or crash": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
     "when evaluating 'alert(foo)'": {
 
         topic: "alert(foo)",


### PR DESCRIPTION
no-alert was throwing exceptions because node.callee.property.name was `undefined` when the property was a Literal instead of an Identifier.
