### PR TITLE
Changes eqeqeq to be smarter about warnings

### DIFF
--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -7,11 +7,24 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+function isTypeOf(node) {
+    if (node.left.type === "UnaryExpression" && node.left.operator === "typeof") {
+        return true;
+    } else if (node.right.type === "UnaryExpression" && node.right.operator === "typeof") {
+        return true;
+    }
+    return false;
+}
+
 module.exports = function(context) {
 
     return {
         "BinaryExpression": function(node) {
             var operator = node.operator;
+
+            if (isTypeOf(node)) {
+                return;
+            }
 
             if (operator === "==") {
                 context.report(node, "Unexpected use of ==, use === instead.");

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -22,6 +22,29 @@ var RULE_ID = "eqeqeq";
 //------------------------------------------------------------------------------
 
 vows.describe(RULE_ID).addBatch({
+    "when evaluating typeof": {
+        topic: "typeof a == 'number'",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating yoda comparison typeof": {
+        topic: "'string' != typeof a",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
 
     "when evaluating 'a == b'": {
 


### PR DESCRIPTION
When comparing against a `typeof` check there's no sense in using strict equality since typeof always returns a string and there's no type coercion monkey business going on there. So this lets the cool kids feel smart and use `==` for typeof checks without having lint complain.
