### PR TITLE
Adds test and fix for no-octal on 0 literal

### DIFF
--- a/lib/rules/no-octal.js
+++ b/lib/rules/no-octal.js
@@ -12,7 +12,7 @@ module.exports = function(context) {
     return {
 
         "Literal": function(node) {
-            if (typeof node.value === "number" && node.raw[0] === "0" && node.raw.indexOf("x") < 0) {
+            if (typeof node.value === "number" && node.raw[0] === "0" && node.raw.length > 1 && node.raw.indexOf("x") < 0) {
                 context.report(node, "Octal literals should not be used.");
             }
         }

--- a/tests/lib/rules/no-octal.js
+++ b/tests/lib/rules/no-octal.js
@@ -83,4 +83,19 @@ vows.describe(RULE_ID).addBatch({
             assert.include(messages[0].node.type, "Literal");
         }
     },
+
+    "when evaluating the literal 0": {
+
+        topic: "a = 0;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
 }).export(module);


### PR DESCRIPTION
Running ESLint on this code:

```
var a = 0;
```

produces a warning "Warning - Octal literals should not be used". I expected it to pass with no warnings, since zero is just… zero :)

This pull request fixes the issue, and adds a test.
