### PR TITLE
Rule: One True Brace Style

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -17,6 +17,7 @@
         "no-new": 1,
 
         "smarter-eqeqeq": 0,
+        "brace-style": 0,
         "camelcase": 1,
         "curly": 1,
         "eqeqeq": 1,

--- a/docs/brace-style.md
+++ b/docs/brace-style.md
@@ -1,0 +1,63 @@
+# brace style
+
+One true brace style is a common coding style in JavaScript, in which the opening curly brace of a block is placed on the same line as its corresponding statement or declaration.
+
+```js
+function foo()
+{
+  return true;
+}
+
+if (foo)
+{
+  bar();
+}
+```
+
+## Rule Details
+
+This rule is aimed at enforcing one true brace style across your JavaScript. As such, it warns whenever it sees a statement or declaration that does not adhere to the one true brace style.
+
+The following patterns are considered warnings:
+
+```js
+function foo()
+{
+  return true;
+}
+
+if (foo)
+{
+  bar();
+}
+
+try
+{
+  somethingRisky();
+} catch(e)
+{
+  handleError();
+}
+```
+
+The following patterns adhere to one true brace style and do not cause warnings:
+
+```js
+function foo() {
+  return true;
+}
+
+if (foo) {
+  bar();
+}
+
+try {
+  somethingRisky();
+} catch(e) {
+  handleError();
+}
+```
+
+## When Not To Use It
+
+If your project will not be using the one true brace style, turn this rule off.

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Rule to flag block statements that do not use the one true brace style
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    function checkBlockStartsAtIdentifier(node) {
+        var startLine = node.loc.start.line;
+
+        // Checks for opening curly brace on FunctionDeclarations.
+        if (node.body && startLine !== node.body.loc.start.line) {
+            context.report(node, "Opening curly brace does not appear on the same line as the block identifier.");
+        }
+
+        // Checks for opening curly brace on IfStatement, DoWhileStatement,
+        // WhileStatement, WithStatement, ForStatement, and ForInStatement.
+        if (node.consequent && startLine !== node.consequent.loc.start.line) {
+            context.report(node, "Opening curly brace does not appear on the same line as the block identifier.");
+        }
+
+        // Checks for opening curly brace on TryStatement.
+        if (node.block && startLine !== node.block.loc.start.line) {
+            context.report(node, "Opening curly brace does not appear on the same line as the block identifier.");
+        }
+
+        // Checks for opening curly on SwitchStatement.
+        if (node.discriminant && startLine !== node.cases[0].loc.start.line - 1) {
+            context.report(node, "Opening curly brace does not appear on the same line as the block identifier.");
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+        "FunctionDeclaration": checkBlockStartsAtIdentifier,
+        "IfStatement": checkBlockStartsAtIdentifier,
+        "SwitchStatement": checkBlockStartsAtIdentifier,
+        "TryStatement": checkBlockStartsAtIdentifier,
+        "DoWhileStatement": checkBlockStartsAtIdentifier,
+        "WhileStatement": checkBlockStartsAtIdentifier,
+        "WithStatement": checkBlockStartsAtIdentifier,
+        "ForStatement": checkBlockStartsAtIdentifier,
+        "ForInStatement": checkBlockStartsAtIdentifier
+    };
+
+};

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -1,0 +1,305 @@
+/**
+ * @fileoverview Tests for one-true-brace rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "brace-style";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating function declaration without one true brace style": {
+
+        topic: "function foo() \n { \n return; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "FunctionDeclaration");
+        }
+    },
+
+    "when evaluating function declaration with one true brace style": {
+
+        topic: "function foo () { return; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating if statement without one true brace style": {
+
+        topic: "if (foo) \n { \n bar(); }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "IfStatement");
+        }
+    },
+
+    "when evaluating if statement with one true brace style": {
+
+        topic: "if (foo) { \n bar(); }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating while statement without one true brace style": {
+
+        topic: "while (foo) \n { \n bar(); }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "WhileStatement");
+        }
+    },
+
+    "when evaluating while statement with one true brace style": {
+
+        topic: "while (foo) { \n bar(); }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating for statement without one true brace style": {
+
+        topic: "for (;;) \n { \n bar(); }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "ForStatement");
+        }
+    },
+
+    "when evaluating for statement with one true brace style": {
+
+        topic: "for (;;) { \n bar(); }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating with statement without one true brace style": {
+
+        topic: "with (foo) \n { \n bar(); }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "WithStatement");
+        }
+    },
+
+    "when evaluating with statement with one true brace style": {
+
+        topic: "with (foo) { \n bar(); }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating switch statement without one true brace style": {
+
+        topic: "switch (foo) \n { \n case \"bar\": break; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "SwitchStatement");
+        }
+    },
+
+    "when evaluating switch statement with one true brace style": {
+
+        topic: "switch (foo) { \n case \"bar\": break; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating try statement without one true brace style": {
+
+        topic: "try \n { \n bar(); \n } catch (e) {}",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "TryStatement");
+        }
+    },
+
+    "when evaluating try/catch statement with one true brace style": {
+
+        topic: "try { \n bar();\n } catch (e) {\n baz(); \n }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating do/while statement without one true brace style": {
+
+        topic: "do \n { \n bar(); \n} while (true)",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "DoWhileStatement");
+        }
+    },
+
+    "when evaluating do/while statement with one true brace style": {
+
+        topic: "do { \n bar();\n } while (true)",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating for/in statement without one true brace style": {
+
+        topic: "for (foo in bar) \n { \n baz(); \n }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Opening curly brace does not appear on the same line as the block identifier.");
+            assert.include(messages[0].node.type, "ForInStatement");
+        }
+    },
+
+    "when evaluating for/in statement with one true brace style": {
+
+        topic: "for (foo in bar) { \n baz(); \n }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+}).export(module);


### PR DESCRIPTION
One true brace style is a common coding style in JavaScript, in which the opening curly brace of a block is placed on the same line as its corresponding statement or declaration. Because it's a very common coding convention in JavaScript I think it makes sense to be part of the main distribution, though I think it should be defaulted to off. 

This rule is aimed at enforcing one true brace style across your JavaScript. As such, it warns whenever it sees a statement or declaration that does not adhere to the one true brace style.

The following patterns are considered warnings:

``` js
function foo() 
{
  return true;
}

if (foo) 
{
  bar();
}

try 
{
  somethingRisky();
}
catch(e) 
{
  handleError();
}
```

The following patterns adhere to one true brace style and do not cause warnings:

``` js
function foo() {
  return true;
}

if (foo) {
  bar();
}

try {
  somethingRisky();
} catch(e) {
  handleError();
}
```
