### PR TITLE
Fix the positive case for no-unreachable

### DIFF
--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -36,7 +36,9 @@ module.exports = function(context) {
             var i, unreachableType = false;
             for (i = 1; i < node.body.length; i++) {
                 unreachableType = unreachableType || checkForUnreachable(node.body[i - 1]);
-                context.report(node.body[i], "Found unexpected statement after a " + unreachableType + ".");
+                if (unreachableType) {
+                    context.report(node.body[i], "Found unexpected statement after a " + unreachableType + ".");
+                }
             }
         },
 
@@ -44,7 +46,9 @@ module.exports = function(context) {
             var i, unreachableType = false;
             for (i = 1; i < node.consequent.length; i++) {
                 unreachableType = unreachableType || checkForUnreachable(node.consequent[i - 1]);
-                context.report(node.consequent[i], "Found unexpected statement after a " + unreachableType + ".");
+                if (unreachableType) {
+                    context.report(node.consequent[i], "Found unexpected statement after a " + unreachableType + ".");
+                }
             }
         }
     };

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -26,6 +26,45 @@ var RULE_ID = "no-unreachable";
 
 vows.describe(RULE_ID).addBatch({
 
+    "when evaluating a function which contains a function": {
+        topic: "function foo() { function bar() { return 1; } return bar(); }",
+
+        "should not return a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a function with no return": {
+        topic: "function foo() { var x = 1; var y = 2; }",
+
+        "should not return a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a function with return at end": {
+        topic: "function foo() { var x = 1; var y = 2; return; }",
+
+        "should not return a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
     "when evaluation 'function foo() { return; x = 1; }'": {
         topic: "function foo() { return; x = 1; }",
 


### PR DESCRIPTION
Fix the positive case for no-unreachable where there is no return statement at all, or if the return is at the end. Those cases should not return any errors. The error condition was not be checked before throwing the rule error.

This addresses the issue found in https://github.com/nzakas/eslint/pull/59
