### PR TITLE
Enabled require("eslint") and exposed out CLI.

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -1,0 +1,9 @@
+/**
+ * @fileoverview Expose out ESLint and CLI to require.
+ * @author Ian Christian Myers
+ */
+
+module.exports = {
+    linter: require("./eslint"),
+    cli: require("./cli")
+};

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "bin": {
         "eslint": "./bin/eslint.js"
     },
+    "main": "./lib/api.js",
     "scripts": {
         "changelog": "bash ./scripts/changelog-update.sh",
         "test": "npm run-script lint && node ./node_modules/istanbul/lib/cli.js cover --print both ./node_modules/vows/bin/vows -- --spec ./tests/*/*.js ./tests/*/*/*.js",


### PR DESCRIPTION
I've added the "main" key to the package.json, pointing it to lib/eslint.js. This enables those who have run `npm install eslint` to then require eslint in their project like so:

``` js
var eslint = require("eslint");
```

Prior to this change calling `require("eslint")` would throw an error.

I've also added the CLI to the exported modules from eslint. This means that developers can now use the CLI from their projects, without having to `require` it from the `node_modules` directory (which is generally not good). Developers can now use the CLI programatically, like so:

``` js
var eslint = require("eslint");
eslint.cli.execute(["-h"]);
```
