### PR TITLE
Rule: The Function constructor is eval

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -15,6 +15,7 @@
         "no-octal": 1,
         "no-new-wrappers": 1,
         "no-new": 1,
+        "no-new-func": 1,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -25,6 +25,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-floating-decimal] - disallow the use of leading or trailing decimal points in numeric literals
 * [no-octal] - disallow use of octal literals
 * [no-new] - disallow use of new operator when not part of the assignment or comparison
+* [no-new-func] - disallow use of new operator for `Function` object
 
 ## Stylistic Issues
 

--- a/docs/no-new-func.md
+++ b/docs/no-new-func.md
@@ -1,0 +1,25 @@
+# no function constructor
+
+## Rule Details
+
+This error is raised to highlight the use of a bad practice. By passing a string to the Function constructor, you are requiring the engine to parse that string much in the way it has to when you call the eval function.
+
+```js
+var x = new Function("a", "b", "return a + b");
+```
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+var x = function (a, b) {
+    return a + b;
+};
+```
+
+## When Not To Use It
+
+In more advanced cases where you really need to use the Function constructor
+
+## Further Reading
+
+* [The Function constructor is eval](http://jslinterrors.com/the-function-constructor-is-eval/)

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Rule to flag when using new Function
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "NewExpression": function(node) {
+            if (node.callee.name === "Function") {
+                context.report(node, "The Function constructor is eval");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Tests for no-new-func rule.
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-new-func";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+    "when evaluating a string": {
+        topic: "var a = new Function(\"b\", \"c\", \"return b+c\");",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "The Function constructor is eval");
+            assert.include(messages[0].node.type, "NewExpression");
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Closes #76 No Function constructor allowed. Renamed the rule and rebased against new changes.
