### PR TITLE
Create way to pass configuration info to rules

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -53,14 +53,16 @@ module.exports = (function() {
 
         // enable appropriate rules
         Object.keys(config.rules).filter(function(key) {
-            return config.rules[key] > 0;   // ignore rules that are turned off
+            return (!config.rules[key].length && config.rules[key] > 0) ||
+            (!isNaN(parseFloat(config.rules[key][0])) && isFinite(config.rules[key][0])) && config.rules[key][0] > 0;   // ignore rules that are turned off or where first param is not a number
         }).forEach(function(key) {
 
             var ruleCreator = rules.get(key),
                 rule;
 
             if (ruleCreator) {
-                rule = ruleCreator(new RuleContext(key, api));
+                var ruleConfiguration = config.rules[key].length ? config.rules[key].slice(1) : null;
+                rule = ruleCreator(new RuleContext(key, api, ruleConfiguration));
 
                 // add all the node types as listeners
                 Object.keys(rule).forEach(function(nodeType) {

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -24,7 +24,7 @@ var PASSTHROUGHS = [
  * @param {string} ruleId The ID of the rule using this object.
  * @param {eslint} eslint The eslint object.
  */
-function RuleContext(ruleId, eslint) {
+function RuleContext(ruleId, eslint, configuration) {
 
     /**
      * The read-only ID of the rule.
@@ -32,6 +32,13 @@ function RuleContext(ruleId, eslint) {
     Object.defineProperty(this, "id", {
         value: ruleId
     });
+    /**
+     * Rule configurations
+     */
+    Object.defineProperty(this, "configuration", {
+        value: configuration
+    });
+
 
     // copy over passthrough methods
     PASSTHROUGHS.forEach(function(name) {


### PR DESCRIPTION
Let me know if this looks right to you and I can add some unit tests and finish this up. I think, however, I would prefer to use object instead of an array. Something like "camelcase": { enabled: 1, configuration: {}}. I think that will make it easier to read configuration file.
