### PR TITLE
Fixed CLI output on serial programatic executions

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -179,6 +179,9 @@ var cli = {
             config,
             result;
 
+        // Ensure results from previous execution are not printed.
+        results = [];
+
         if (currentOptions.v) { // version from package.json
 
             console.log("v" + require("../package.json").version);

--- a/tests/fixtures/missing-semicolon.js
+++ b/tests/fixtures/missing-semicolon.js
@@ -1,0 +1,1 @@
+var foo = "bar"

--- a/tests/fixtures/passing.js
+++ b/tests/fixtures/passing.js
@@ -1,0 +1,1 @@
+var foo = "bar";

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -34,6 +34,33 @@ vows.describe("cli").addBatch({
             console.log = _log;
         }
 
+    },
+
+    "when calling execute more than once": {
+
+        topic: ["tests/fixtures/missing-semicolon.js", "tests/fixtures/passing.js"],
+
+        "should not print the results from previous execution": function(topic) {
+            var results = '',
+                _log = console.log;
+
+            // Collect the CLI output.
+            console.log = function(msg) {
+                results += msg;
+            };
+
+            cli.execute([topic[0]]);
+            assert.notEqual(results, "\n0 problems");
+
+            // Reset results collected between executions.
+            results = '';
+
+            cli.execute([topic[1]]);
+            assert.equal(results, "\n0 problems");
+
+            console.log = _log;
+        }
+
     }
 
 }).export(module);


### PR DESCRIPTION
This commit fixes an issue where calling the `execute` function on the CLI multiple times would produce the incorrect output because the results array was not being cleared out between executions.

Example of the issue:

``` js
var cli = require("eslint").cli;

// This execution will display errors.
cli.execute(["file-with-errors.js"]);

// This should pass, but will display the errors from the previous execution.
cli.execute(["passing-file.js"]);
```
