### PR TITLE
Rule: Warn on use of Math and JSON as functions

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -16,6 +16,7 @@
         "no-unreachable": 1,
         "no-undef-init": 1,
         "no-octal": 1,
+        "no-obj-calls": 1,
         "no-new-wrappers": 1,
         "no-new": 1,
         "no-new-func": 1,

--- a/docs/Rules.md
+++ b/docs/Rules.md
@@ -10,6 +10,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-dangle](no-dangle.md) - disallow trailing commas in object literals
 * [no-debugger](No-debugger.md) - disallow use of `debugger`
 * [no-empty](No-empty.md) - disallow empty statements
+* [no-obj-calls](no-obj-calls.md) - disallow the use of object properties of the global object (`Math` and `JSON`) as functions
 * [no-unreachable](No-unreachable.md) - disallow unreachable statements after a return, throw, continue, or break statement
 * [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
 

--- a/docs/no-obj-calls.md
+++ b/docs/no-obj-calls.md
@@ -1,0 +1,16 @@
+# No global object function calls
+
+This rule prevents the use of object properties of the global object (`Math` and `JSON`) as functions:
+
+```javascript
+var x = Math(); // Both of these will cause a warning
+var y = JSON();
+```
+
+The [ES5 spec](http://es5.github.io/#x15.8) makes it clear that both `Math` and `JSON` cannot be invoked:
+
+> The Math object does not have a [[Call]] internal property; it is not possible to invoke the Math object as a function.
+
+## Further Reading
+
+* ['{a}' is not a function](http://jslinterrors.com/a-is-not-a-function/)

--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Rule to flag use of an object property of the global object (Math and JSON) as a function
+ * @author James Allardice
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "CallExpression": function(node) {
+
+            if (node.callee.type === "Identifier") {
+                var name = node.callee.name;
+                if (name === "Math" || name === "JSON") {
+                    context.report(node, "'{{name}}' is not a function.", { name: name });
+                }
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-obj-calls.js
+++ b/tests/lib/rules/no-obj-calls.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Tests for no-obj-calls rule.
+ * @author James Allardice
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-obj-calls";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = Math();'": {
+
+        topic: "var x = Math();",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "'Math' is not a function.");
+            assert.include(messages[0].node.type, "CallExpression");
+        }
+    },
+
+    "when evaluating 'var x = JSON();'": {
+
+        topic: "var x = JSON();",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "'JSON' is not a function.");
+            assert.include(messages[0].node.type, "CallExpression");
+        }
+    },
+
+    "when evaluating 'var x = Math.random();'": {
+
+        topic: "var x = Math.random();",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
This rule should warn when it encounters the use of object properties of the global object (`Math` and `JSON`) as functions:

```
var x = Math();
var y = JSON();
```

See http://jslinterrors.com/a-is-not-a-function/

---

I'm unsure of the rule name... I've called it "no-obj-calls" for now but I'm open to suggestions.
