### PR TITLE
Fixes incorrect reporting of missing semicolon

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
     function checkForSemicolon(node) {
 
         // get tokens for the node plus one more token at the end
-        var tokens = context.getTokens(node, 0, 1),
+        var tokens = context.getTokens(node),
             nextToken = tokens.pop();
 
         if (nextToken.type !== "Punctuator" || nextToken.value !== ";") {

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -153,7 +153,36 @@ vows.describe(RULE_ID).addBatch({
 
             assert.equal(messages.length, 0);
         }
-    }
+    },
 
+    "when evaluation 'setTimeout(function() {foo = \"bar\"; });'": {
+
+        topic: "setTimeout(function() {foo = \"bar\"; });",
+
+        "should not report and violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+
+    },
+
+    "when evaluation 'setTimeout(function() {foo = \"bar\";});'": {
+
+        topic: "setTimeout(function() {foo = \"bar\";});",
+
+        "should not report and violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+
+    }
 
 }).export(module);


### PR DESCRIPTION
This fixes the incorrect reporting of missing semicolons when there is no whitespace between the end of a statement and the next token. The semicolon is already included in the tokens returned by `getTokens`, so grabbing one more character after would just grab a whitespace character. In this case because whitespace was not present it grabbed the closing curly, saw that it wasn't a semicolon and reported it as an error.

`setTimeout(function() {foo = "bar";});`

Fixes #121
