### PR TITLE
Rule: maxstatements

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -39,7 +39,8 @@
         "semi": 1,
         "use-isnan": 1,
         "quotes": [1, "double"],
-        "max-params": [0, 3]
+        "max-params": [0, 3],
+        "max-statements": [0, 10]
 
     }
 }

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -54,3 +54,4 @@ The following rules are included for compatibility with [JSHint](http://jshint.c
 * [no-plusplus] - disallow use of unary operators, `++` and `--` (off by default)
 * [no-bitwise] - disallow use of bitwise operators (off by default)
 * [guard-for-in] - make sure `for-in` loops have an `if` statement (off by default)
+* [max-statements](max-statements.md) - specify the maximum number of statement allowed in a function (off by default)

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -1,0 +1,47 @@
+# max statements
+
+The `max-statements` rule allows you to specify the maximum number statements allow in a function.
+
+```js
+// max-statements: [1, 2]  // Maximum of 2 statements. 
+function foo() {
+  var bar = 1;
+  var baz = 2;
+
+  var qux = 3; // Too many.
+}
+```
+
+## Rule Details
+
+This rule allows you to configure the maximum number of statements allowed in a function.
+
+The following patterns are considered warnings:
+
+```js
+// max-statements: [1, 2]  // Maximum of 2 statements. 
+function foo() {
+  var bar = 1;
+  var baz = 2;
+
+  var qux = 3; // Too many.
+}
+```
+
+The following patterns are not warnings:
+
+```js
+// max-statements: [1, 2]  // Maximum of 2 statements. 
+function foo() {
+  var bar = 1;
+  return function () {
+
+    // The number of statements in the inner function does not count toward the
+    // statement maximum.
+
+    return 42;
+  };
+}
+
+}
+```

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview A rule to set the maximum number of statements in a function.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    //--------------------------------------------------------------------------
+    // Constants
+    //--------------------------------------------------------------------------
+
+
+    var STATEMENT_TYPES = ["IfStatement", "WhileStatement", "SwitchStatement",
+            "TryStatement", "DoWhileStatement", "ForStatement", "WithStatement",
+            "ForInStatement"];
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    function getStatementCount(node) {
+        var count = 0;
+
+        function countStatements(statement) {
+            if (STATEMENT_TYPES.indexOf(statement.type) !== -1) {
+                count += getStatementCount(statement);
+            }
+        }
+
+        if (node.body && node.body.body) {
+            count += node.body.body.length;
+            node.body.body.forEach(countStatements);
+        }
+
+        if (node.consequent && node.consequent.body) {
+            count += node.consequent.body.length;
+            node.consequent.body.forEach(countStatements);
+        }
+
+        if (node.alternate && node.alternate.body) {
+            count += node.alternate.body.length;
+            node.alternate.body.forEach(countStatements);
+        }
+
+        return count;
+    }
+
+    function checkForMaxStatements(node) {
+        var max = context.options[0],
+            count = getStatementCount(node);
+        
+        if (count > max) {
+            context.report(node, "Function contains " + count + " statements, maximum allowed is " + max + ".");
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+        "FunctionDeclaration": checkForMaxStatements,
+        "FunctionExpression": checkForMaxStatements
+    };
+
+};

--- a/tests/lib/rules/max-statements.js
+++ b/tests/lib/rules/max-statements.js
@@ -1,0 +1,206 @@
+/**
+ * @fileoverview Tests for max-statements rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "max-statements";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating FunctionDeclaration with 3 statements and max-statements set to 2": {
+
+        topic: "function foo() { var bar = 1; var baz = 2; var qux = 3; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Function contains 3 statements, maximum allowed is 2.");
+        }
+    },
+
+    "when evaluating FunctionExpression with 3 statements and max-statements set to 2": {
+
+        topic: "var foo = function() { var bar = 1; var baz = 2; var qux = 3; };",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Function contains 3 statements, maximum allowed is 2.");
+        }
+    },
+
+    "when evaluating FunctionDeclaration 2 statements and max-statements set to 2": {
+
+        topic: "var foo = { thing: function() { var bar = 1; var baz = 2; } }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating with an inner function and max-statements set to 3": {
+
+        topic: "function foo() { var bar = 1; function qux () { var noCount = 2; } return 3; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 3];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating with nested if/while and max-statements set to 4": {
+
+        topic: "function foo() { var bar = 1; if (true) { while (false) { var qux = null; } } return 3; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 4];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Function contains 5 statements, maximum allowed is 4.");
+        }
+    },
+
+    "when evaluating with nested if/for and max-statements set to 4": {
+
+        topic: "function foo() { var bar = 1; if (true) { for (;;) { var qux = null; } } return 3; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 4];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Function contains 5 statements, maximum allowed is 4.");
+        }
+    },
+
+    "when evaluating with nested if/else and max-statements set to 6": {
+
+        topic: "function foo() { var bar = 1; if (true) { for (;;) { var qux = null; } } else { quxx(); } return 3; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 6];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating with nested if/else and max-statements set to 5": {
+
+        topic: "function foo() { var bar = 1; if (true) { for (;;) { var qux = null; } } else { quxx(); } return 3; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 5];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Function contains 6 statements, maximum allowed is 5.");
+        }
+    },
+
+    "when evaluating with function calls and nested function and max-statements set to 3": {
+        
+        topic: "function foo() { var x = 5; function bar() { var y = 6; } bar(); z = 10; baz(); }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 3];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Function contains 5 statements, maximum allowed is 3.");
+        }
+    },
+
+    "when evaluating with function calls and nested function and max-statements set to 4": {
+        
+        topic: "function foo() { var x = 5; function bar() { var y = 6; } bar(); z = 10; baz(); }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 4];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Function contains 5 statements, maximum allowed is 4.");
+        }
+    },
+
+    "when evaluating with function calls and nested function and max-statements set to 5": {
+        
+        topic: "function foo() { var x = 5; function bar() { var y = 6; } bar(); z = 10; baz(); }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 5];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+
+}).export(module);
+
+
+


### PR DESCRIPTION
Created maxstatements rule, which allows you to specify the maximum number of statement in a function. Statements in inner functions do not count toward the statement count of the outer function.

``` js
// maxstatements: [1, 2]  // Maximum of 2 statements.
function foo() {
  var bar = 1;
  var baz = 2;

  var qux = 3; // Too many.
}
```

This rule matches JSHint's **maxstatements** rule.
