### PR TITLE
Rule: No multiline strings. Closes #132

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -49,6 +49,7 @@
         "max-statements": [0, 10],
         "regex-spaces": 1,
         "complexity": [0, 11],
-        "wrap-iife": 0
+        "wrap-iife": 0,
+        "no-multi-str": 1
     }
 }

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -35,6 +35,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-label-var](no-label-var.md) - disallow labels that share a name with a variable
 * [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses
 * [no-self-compare] - disallow comparisons where both sides are exactly the same
+* [no-multi-str](no-multi-str.md) - disallow use of multiline strings
 
 ## Stylistic Issues
 

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -1,0 +1,14 @@
+# No multiline strings
+
+This rule prevents the use of ES5 only feature that allows usage of multiline strings:
+
+```javascript
+var x = "Line 1 \
+         Line 2";
+```
+
+This feature is only supported in the browsers that can parse and process ES5. Older browsers will likely throw an exception when they try to parse this code.
+
+## Further Reading
+
+* [Bad escapement of EOL](http://jslinterrors.com/bad-escapement-of-eol-use-option-multistr-if-needed/)

--- a/lib/rules/no-multi-str.js
+++ b/lib/rules/no-multi-str.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Rule to flag when using multiline strings
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    "use strict";
+
+    return {
+
+        "Literal": function(node) {
+            var lineBreak = /\n/;
+            if (lineBreak.test(node.raw)) {
+                context.report(node, "Multiline support is limitted to browsers supporting ES5 only.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-multi-str.js
+++ b/tests/lib/rules/no-multi-str.js
@@ -1,0 +1,73 @@
+/**
+ * @fileoverview Tests for no-multi-str rule.
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-multi-str";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = \"Line 1 \\\n Line 2\"'": {
+
+        topic: "var x = 'Line 1 \\\n Line 2'",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Multiline support is limitted to browsers supporting ES5 only.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'test(\"Line 1 \\\n Line 2\")'": {
+
+        topic: "test('Line 1 \\\n Line 2');",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Multiline support is limitted to browsers supporting ES5 only.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var a = \"Line 1 Line 2\"'": {
+
+        topic: "var a = 'Line 1 Line 2';",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
ES5 feature that will most likely break older browsers, because of that it's on by default.
