### PR TITLE
Initial checkin for context identifiers

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -39,7 +39,14 @@
         "semi": 1,
         "use-isnan": 1,
         "quotes": [1, "double"],
-        "max-params": [0, 3]
+        "max-params": [0, 3],
 
+        //jQuery rules
+        "jQuery-find": 1
+    },
+    "identifiers": {
+        "Backbone": 0,
+        "jQuery": 0,
+        "underscore": 0
     }
 }

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -10,6 +10,7 @@
 var esprima = require("esprima"),
     estraverse = require("estraverse"),
     rules = require("./rules"),
+    identifiers = require("./identifiers"),
     RuleContext = require("./rule-context"),
     EventEmitter = require("events").EventEmitter;
 
@@ -32,6 +33,7 @@ module.exports = (function() {
         currentText = null,
         currentConfig = null,
         currentTokens = null,
+        nodeContext = null,
         controller = null;
 
     /**
@@ -44,6 +46,7 @@ module.exports = (function() {
         currentConfig = null;
         currentText = null;
         currentTokens = null;
+        nodeContext = null;
         controller = null;
     };
 
@@ -57,6 +60,28 @@ module.exports = (function() {
 
         if (!saveState) {
             this.reset();
+        }
+
+        // first process rule identifiers
+        if (config.identifiers)
+        {
+            Object.keys(config.identifiers).filter(function(key) {
+                return config.identifiers[key] > 0;
+            }).forEach(function(key) {
+                var identifierCreator = identifiers.get(key),
+                identifier;
+
+                if (identifierCreator) {
+                    identifier = identifierCreator(new RuleContext(key, api, []));
+
+                    // add all the node types as listeners
+                    Object.keys(identifier).forEach(function(nodeType) {
+                        api.on(nodeType, identifier[nodeType]);
+                    });
+                } else {
+                    throw new Error("Definition for rule identifier '" + key + "' was not found.");
+                }
+            });
         }
 
         // enable appropriate rules
@@ -199,6 +224,69 @@ module.exports = (function() {
             return currentTokens || null;
         }
     };
+
+    /**
+     * Sets the context of the current node.
+     * @param {ASTNode} [node] The AST node to set the context for.
+     * @param {string} [context] Name of the context to add.
+     */
+    api.addContext = function(node, context) {
+        if (!nodeContext) {
+            nodeContext = [];
+        }
+
+        var match = nodeContext.filter(function(item) {
+            return item.node === node;
+        });
+
+        if (match.length > 0) {
+            if (match[0].context.indexOf(context) < 0)
+            {
+                match[0].context.push(context);
+            }
+        } else {
+            nodeContext.push({"node": node, "context": [context]});
+        }
+    },
+
+    /**
+     * Checks if current node is in the context.
+     * @param (string) [context] Name of the context to check.
+     */
+    api.isInContext = function(context) {
+        if (!nodeContext) {
+            return false;
+        }
+
+        return nodeContext.some(function(item) {
+            return item.context.indexOf(context) >=0;
+        });
+    },
+
+    /**
+     * Removes the context of the current node.
+     * @param {ASTNode} [node] The AST node to remove the context for.
+     * @param {string} [context] Name of the context to remove.
+     */
+    api.removeContext = function(node, context) {
+        if (!nodeContext){
+            return;
+        }
+
+        var match = nodeContext.filter(function(item) {
+            return item.node === node;
+        });
+
+        if (match.length > 0) {
+            if (match[0].context.indexOf(context) >= 0) {
+                match[0].context.splice(match[0].context.indexOf(context), 1);
+                //if no more contexts left for this node, remove the whole thing
+                if (match[0].context.length === 0) {
+                    nodeContext.splice(nodeContext.indexOf(match[0]));
+                }
+            }
+        }
+    },
 
     /**
      * Gets nodes that are ancestors of current node.

--- a/lib/identifiers.js
+++ b/lib/identifiers.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Main CLI object.
+ * @author Nicholas C. Zakas
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+
+var fs = require("fs"),
+    path = require("path");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var JS_EXT = ".js";
+
+//------------------------------------------------------------------------------
+// Privates
+//------------------------------------------------------------------------------
+
+var identifiers = {};
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+exports.load = function(directory) {
+
+    try {
+        var fullPath = path.resolve(process.cwd(), directory),
+            files = fs.readdirSync(fullPath);
+
+        files.forEach(function(file) {
+            if (path.extname(file) === JS_EXT) {
+                var identifierId = file.replace(JS_EXT, "");
+                identifiers[identifierId] = require(path.join(fullPath, identifierId));
+            }
+        });
+    } catch (ex) {
+        console.error("Couldn't load identifiers from " + directory + ": " + ex.message);
+        process.exit(1);
+    }
+
+};
+
+exports.get = function(identifierId) {
+    return identifiers[identifierId];
+};
+
+//------------------------------------------------------------------------------
+// Initialization
+//------------------------------------------------------------------------------
+
+// loads built-in identifiers
+exports.load(path.join(__dirname, "./identifiers"));

--- a/lib/identifiers/jQuery.js
+++ b/lib/identifiers/jQuery.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Identifier for jQuery framework
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Identifier Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "CallExpression": function(node) {
+            if (node.callee && (node.callee.name === "$" || node.callee.name === "jQuery")) {
+                //Set jQuery as a framework used
+                context.addContext(node, "jQuery");
+                context.isInContext("jQuery");
+            }
+        },
+
+        "MemberExpression": function(node) {
+
+            if (node.object && (node.object.name === "$" || node.object.name === "jQuery")) {
+                //Set jQuery as a framework used
+                context.addContext(node, "jQuery");
+            }
+        },
+
+        "CallExpression:after": function(node) {
+            context.removeContext(node, "jQuery");
+        },
+
+        "MemberExpression:after": function(node) {
+            context.removeContext(node, "jQuery");
+        }
+    };
+
+};

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -11,7 +11,10 @@ var PASSTHROUGHS = [
         "getSource",
         "getTokens",
         "isNodeJS",
-        "getAncestors"
+        "getAncestors",
+        "addContext",
+        "removeContext",
+        "isInContext"
     ];
 
 //------------------------------------------------------------------------------

--- a/lib/rules/jQuery-find.js
+++ b/lib/rules/jQuery-find.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Rule to suggest using find() instead of context
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "CallExpression": function(node) {
+            if (context.isInContext("jQuery")) {
+                if (node.arguments.length > 1) {
+                    context.report(node, "Use .find() instead of context.");
+                }
+            }
+        }
+    };
+
+};

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -256,6 +256,18 @@ vows.describe("eslint").addBatch({
         }
     },
 
+    "when passing identifier": {
+        
+        topic: "$('div').parent();",
+
+        "should detect jQuery": function(topic) {
+            var config = { rules: {}, identifiers: {"jQuery" : 1}};
+
+            var messages = eslint.verify(topic, config, true);
+            assert.equal(true, true);
+        }
+    },
+
     "when passing in configuration values for rules": {
 
         topic: "var answer = 6 * 7",

--- a/tests/lib/rules/jQuery-find.js
+++ b/tests/lib/rules/jQuery-find.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Tests for jQuery-find rule.
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "jQuery-find";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating '$(\"div\", \"li\")'": {
+
+        topic: "$('div', 'li')",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {}, identifiers: {} };
+            config.rules[RULE_ID] = 1;
+            config.identifiers["jQuery"] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Use .find() instead of context.");
+            assert.include(messages[0].node.type, "CallExpression");
+        }
+    },
+
+    "when evaluating '$(\"div\"); test(\"div\", \"li\");'": {
+
+        topic: "$('div'); test('div', 'li');",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {}, identifiers: {} };
+            config.rules[RULE_ID] = 1;
+            config.identifiers["jQuery"] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
This checkin is just to test waters for the issue #36 . I know the name is terrible, but I couldn't come up with anything other then identifiers. This should be able to stack as many context identifiers as needed on the single node, and all children of that node will be in the same context as well. Let me know what do you think.
