### PR TITLE
Rule: no-ternary

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -25,6 +25,7 @@
         "no-delete-var": 1,
         "no-return-assign": 1,
         "no-label-var": 1,
+        "no-ternary": 0,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -43,6 +43,7 @@ These rules are purely matters of style and are quite subjective.
 * [quote-props](quote-props.md) - require quotes around object literal property names
 * [semi] - require use of semicolons instead of relying on ASI
 * [max-params] - limits the number of parameters that can be used in the function declaration. Configurable. Default is 3.
+* [no-ternary](no-ternary.md) - disallow the use of ternary operators
 
 ## Alternate Rules
 

--- a/docs/rules/no-ternary.md
+++ b/docs/rules/no-ternary.md
@@ -1,0 +1,49 @@
+# no ternary
+
+Some people believe that the use of ternary operators leads to unclear code. The `no-ternary` rule disallows the use of ternary operators.
+
+```js
+var foo = isBar ? baz : qux;
+```
+
+## Rule Details
+
+The `no-ternary` rule aims to increase the clarity and readability of code by disallowing the use of ternary operators.
+
+The following patterns are considered warnings:
+
+```js
+var foo = isBar ? baz : qux;
+
+foo ? bar() : baz();
+
+function quux() {
+  return foo ? bar : baz;
+}
+```
+
+The following patterns are considered okay and could be used alternatively:
+
+```js
+var foo;
+
+if (isBar) {
+  foo = baz;
+} else {
+  foo = qux;
+}
+
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+
+function quux() {
+  if (foo) {
+    return bar;
+  } else {
+    return baz;
+  }
+}
+```

--- a/lib/rules/no-ternary.js
+++ b/lib/rules/no-ternary.js
@@ -1,0 +1,20 @@
+/**
+ * @fileoverview Rule to flag use of ternary operators.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "ConditionalExpression": function(node) {
+            context.report(node, "Ternary operator used.");
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-ternary.js
+++ b/tests/lib/rules/no-ternary.js
@@ -1,0 +1,77 @@
+/**
+ * @fileoverview Tests for no-ternary.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-ternary";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating ternary assignment": {
+
+        topic: "var foo = true ? thing : stuff;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Ternary operator used.");
+            assert.include(messages[0].node.type, "ConditionalExpression");
+        }
+    },
+
+    "when evaluating ternary function call": {
+
+        topic: "true ? thing() : stuff();",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Ternary operator used.");
+            assert.include(messages[0].node.type, "ConditionalExpression");
+        }
+    },
+
+    "when evaluating ternary return statement": {
+
+        topic: "function foo(bar) { return bar ? baz : qux; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Ternary operator used.");
+            assert.include(messages[0].node.type, "ConditionalExpression");
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
The `no-ternary` rule disallows the use of ternary operators, as some people believe they reduce code clarity. When the `no-ternary` rule is enabled the following patterns are considered warnings:

``` js
var foo = isBar ? baz : qux;

foo ? bar() : baz();

function quux() {
  return foo ? bar : baz;
}
```
