### PR TITLE
Rule: no-todo - disallow TODOs in source code

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -24,6 +24,7 @@
         "no-plusplus": 0,
         "no-delete-var": 1,
         "no-return-assign": 1,
+        "no-todo": 0,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -100,7 +100,8 @@ module.exports = (function() {
          * that this type of node has been found and react accordingly.
          */
         try {
-            var ast = esprima.parse(text, { loc: true, range: true, raw: true, tokens: true });
+            var ast = esprima.parse(text, { loc: true, range: true, raw: true, tokens: true, comment: true });
+
             currentTokens = ast.tokens;
             controller.traverse(ast, {
                 enter: function(node) {
@@ -109,6 +110,10 @@ module.exports = (function() {
                 leave: function(node) {
                     api.emit(node.type + ":after", node);
                 }
+            });
+
+            ast.comments.forEach(function(comment) {
+                api.emit(comment.type, comment);
             });
 
         } catch (ex) {

--- a/lib/rules/no-todo.js
+++ b/lib/rules/no-todo.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview A rule to disallow TODOs in code
+ * @author Matt DuVall <http://www.mattduvall.com/>
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    function checkForTodoComment(node) {
+        if (/TODO\:/.exec(node.value) !== null) {
+            context.report(node, "Unexpected TODO comment");
+        }
+    }
+
+    return {
+
+        "Block": checkForTodoComment,
+        "Line": checkForTodoComment
+    };
+
+};

--- a/tests/lib/rules/no-todo.js
+++ b/tests/lib/rules/no-todo.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Tests for the no-todo rule
+ * @author Matt DuVall <http://www.mattduvall.com/>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-todo";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating a comment that has a TODO block comment": {
+
+        topic: "var foo = function() { bar(); /* TODO: fix this security hole before release */ }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected TODO comment");
+            assert.include(messages[0].node.type, "Block");
+        }
+    },
+
+    "when evaluating a comment that has a TODO line comment": {
+
+        topic: "// TODO: fix this security hole before release",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected TODO comment");
+            assert.include(messages[0].node.type, "Line");
+        }
+    }
+
+
+}).export(module);


### PR DESCRIPTION
This fixes issue https://github.com/nzakas/eslint/issues/138. While the rule may not be particularly useful it would be interesting to allow the comments to be emitted through the API which is in this commit. This would allow for custom rules (ie not allowing code to leak the name of employees in comments or other sensitive information) to filter comments on `Block` and `Line` node types from esprima without having to search the raw source of the other nodes.
