### PR TITLE
Bug fix: no-return-assign rule

### DIFF
--- a/lib/rules/no-return-assign.js
+++ b/lib/rules/no-return-assign.js
@@ -12,7 +12,7 @@ module.exports = function(context) {
     return {
 
         "ReturnStatement": function(node) {
-            if (node.argument.type === "AssignmentExpression") {
+            if (node.argument && node.argument.type === "AssignmentExpression") {
                 context.report(node, "Return statement should not contain assigment");
             }
         }


### PR DESCRIPTION
The `return` statement does not require an argument:

``` javascript
function example() {
    return; // This currently causes ESLint to throw an error
}
```

This fixes the above issue by checking that the `argument` property of the `ReturnStatement` node is truthy (in the above case it will be `null`) before testing its `type` property.
