### PR TITLE
Rule: wrap-iife closes #156

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -46,7 +46,7 @@
         "max-params": [0, 3],
         "max-statements": [0, 10],
         "count-spaces": 1,
-        "complexity": [0, 11]
-
+        "complexity": [0, 11],
+        "wrap-iife": 0
     }
 }

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -33,6 +33,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-delete-var](no-delete-var.md) - disallow deletion of variables
 * [no-return-assign] - disallow use of assignment in return statement
 * [no-label-var](no-label-var.md) - disallow labels that share a name with a variable
+* [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses
 
 ## Stylistic Issues
 

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -1,0 +1,23 @@
+# wrap iife
+
+Require immediate function invocation to be wrapped in parentheses
+
+```js
+var x = function () { return { y: 1 };}();
+```
+
+## Rule Details
+
+Since function statements cannot be immediately invoked, and function expressions can be, a common technique to create an immediately-invoked function expression is to simply wrap a function statement in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.
+
+The following patterns are considered warnings:
+
+```js
+var x = function () { return { y: 1 };}();
+```
+
+The following patterns adhere to this rule:
+
+```js
+var x = (function () { return { y: 1 };})();
+```

--- a/lib/rules/wrap-iife.js
+++ b/lib/rules/wrap-iife.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Rule to flag when IIFE is not wrapped in parens
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "CallExpression": function(node) {
+            if (node.callee.type === "FunctionExpression") {
+                var tokens = context.getTokens(node.callee, 1, 1);
+                if (tokens[0].value !== "(" && tokens[tokens.length - 1].value !== ")") {
+                    context.report(node, "Wrap an immediate function invocation in parentheses");
+                }
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/wrap-iife.js
+++ b/tests/lib/rules/wrap-iife.js
@@ -1,0 +1,87 @@
+/**
+ * @fileoverview Tests for wrap-iife rule.
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "wrap-iife";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = function () { return { y: 1 };}();'": {
+
+        topic: "var x = function () { return { y: 1 };}();",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Wrap an immediate function invocation in parentheses");
+            assert.include(messages[0].node.type, "CallExpression");
+        }
+    },
+
+    "when evaluating 'var x = [function () { return { y: 1 };}()]'": {
+
+        topic: "var x = [function () { return { y: 1 };}()];",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Wrap an immediate function invocation in parentheses");
+            assert.include(messages[0].node.type, "CallExpression");
+        }
+    },
+
+    "when evaluating 'var x = (function () { return { y: 1 };})();'": {
+
+        topic: "var x = (function () { return { y: 1 };})();",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var x = test(function () { return { y: 1 };})();'": {
+
+        topic: "var x = test(function () { return { y: 1 };})();",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Closes #156 

Unfortunately, esprima can't parse iife without parens when it's not part of the assignment. So I can't add that check.
