### PR TITLE
Fixing no-self-compare. Fixes #161

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -29,7 +29,7 @@
         "no-new-object": 1,
         "no-label-var": 1,
         "no-ternary": 0,
-        "no-self-compare": 1,
+        "no-self-compare": 0,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/lib/rules/no-self-compare.js
+++ b/lib/rules/no-self-compare.js
@@ -14,8 +14,8 @@ module.exports = function(context) {
     return {
 
         "BinaryExpression": function(node) {
-
-            if (node.left.name === node.right.name) {
+            if (node.left.type === "Identifier" && node.right.type === "Identifier" && node.left.name === node.right.name ||
+                node.left.type === "Literal" && node.right.type === "Literal" && node.left.value === node.right.value) {
                 context.report(node, "Comparing to itself is potentially pointless");
             }
         }

--- a/tests/lib/rules/no-self-compare.js
+++ b/tests/lib/rules/no-self-compare.js
@@ -120,6 +120,48 @@ vows.describe(RULE_ID).addBatch({
 
             assert.equal(messages.length, 0);
         }
+    },
+
+    "when evaluating 'if (f() === f()) { }": {
+
+        topic: "if (f() === f()) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'if (a[1] === a[1]) { }": {
+
+        topic: "if (a[1] === a[1]) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'if (1 === 2) { }": {
+
+        topic: "if (1 === 2) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
     }
 
 


### PR DESCRIPTION
This fixes #161 Should now check for only Identifiers and Literals. It will not check for arrays and functions
