### PR TITLE
Rule: no-sync to encourage async usage

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -30,6 +30,7 @@
         "no-label-var": 1,
         "no-ternary": 0,
         "no-self-compare": 0,
+        "no-sync": 0,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Rule to check for properties whose identifier ends with the string Sync
+ * @author Matt DuVall<http://mattduvall.com/>
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "MemberExpression": function(node) {
+            var propertyName = node.property.name,
+                syncRegex = /.*Sync$/;
+
+            if (syncRegex.exec(propertyName) !== null) {
+                context.report(node, "Unexpected sync method: '" + propertyName + "'.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-sync.js
+++ b/tests/lib/rules/no-sync.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview Tests for no-sync.
+ * @author Matt DuVall <http://www.mattduvall.com>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-sync";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating code that uses a *Sync method": {
+
+        topic: "var foo = fs.fooSync();",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected sync method: 'fooSync'.");
+            assert.include(messages[0].node.type, "MemberExpression");
+        }
+    },
+
+    "when evaluating code that uses a *Sync property": {
+
+        topic: "var foo = fs.fooSync;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected sync method: 'fooSync'.");
+            assert.include(messages[0].node.type, "MemberExpression");
+        }
+    },
+
+    "when evaluating code that uses a non *Sync method": {
+
+        topic: "var foo = fs.foo.foo();",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
Fixes https://github.com/nzakas/eslint/issues/177. I chose to call this one `no-sync` instead of `stupid` as Crockford put it in JSLint.
