### PR TITLE
Rule: no-eq-null

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -8,6 +8,7 @@
         "no-dangle": 1,
         "no-debugger": 1,
         "no-empty": 1,
+        "no-eq-null": 0,
         "no-eval": 1,
         "no-ex-assign": 1,
         "no-floating-decimal": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -35,6 +35,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-label-var](no-label-var.md) - disallow labels that share a name with a variable
 * [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses
 * [no-self-compare] - disallow comparisons where both sides are exactly the same
+* [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator
 * [no-multi-str](no-multi-str.md) - disallow use of multiline strings
 
 ## Stylistic Issues

--- a/docs/rules/no-eq-null.md
+++ b/docs/rules/no-eq-null.md
@@ -1,0 +1,37 @@
+# no eq null
+
+Comparing to `null` without a type-checking operator (`==` or `!=`), can have unintended results as the comparison will evaluate to true when comparing to not just a `null`, but also an `undefined` value.
+
+```js
+if (foo == null) {
+  bar();
+}
+```
+
+## Rule Details
+
+The `no-eq-null` rule aims reduce potential bug and unwanted behavior by ensuring that comparisons to `null` only match `null`, and not also `undefined`. As such it will flag comparisons to null when using `==` and `!=`.
+
+The following patterns are considered warnings:
+
+```js
+if (foo == null) {
+  bar();
+}
+
+while (qux != null) {
+  baz();
+}
+```
+
+The following patterns are considered okay:
+
+```js
+if (foo === null) {
+  bar();
+}
+
+while (qux !== null) {
+  baz();
+}
+```

--- a/lib/rules/no-eq-null.js
+++ b/lib/rules/no-eq-null.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Rule to flag comparisons to null without a type-checking
+ * operator.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    "use strict";
+
+    return {
+
+        "BinaryExpression": function(node) {
+            var badOperator = node.operator === "==" || node.operator === "!=";
+
+            if (node.right.type === "Literal" && node.right.raw === "null" && badOperator ||
+                    node.left.type === "Literal" && node.left.raw === "null" && badOperator) {
+                context.report(node, "Use ‘===’ to compare with ‘null’.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-eq-null.js
+++ b/tests/lib/rules/no-eq-null.js
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview Tests for no-eq-null rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-eq-null";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'if (x==null) { }": {
+
+        topic: "if (x == null) { }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Use ‘===’ to compare with ‘null’.");
+            assert.include(messages[0].node.type, "BinaryExpression");
+        }
+    },
+
+    "when evaluating 'if (x!=null) { }": {
+
+        topic: "if (x != null) { }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Use ‘===’ to compare with ‘null’.");
+            assert.include(messages[0].node.type, "BinaryExpression");
+        }
+    },
+
+    "when evaluating 'do {} while (null == x)": {
+
+        topic: "do {} while (null == x)",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Use ‘===’ to compare with ‘null’.");
+            assert.include(messages[0].node.type, "BinaryExpression");
+        }
+    },
+
+    "when evaluating 'if (x === null) { }": {
+
+        topic: "if (x === null) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'if (null === f()) { }": {
+
+        topic: "if (null === f()) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+
+}).export(module);


### PR DESCRIPTION
The `no-eq-null` rule flags comparisons to null that do not use a type-checking operator.

Comparing to `null` without a type-checking operator (`==` or `!=`), can have unintended results as the comparison will evaluate to true when comparing to not just a `null`, but also an `undefined` value.

``` js
if (foo == null) {
  bar();
}
```

This rule provides the functionality of JSHint's **eqnull** rule.
