### PR TITLE
Add builtin globals to the global scope (fixes #185)

### DIFF
--- a/conf/environments.json
+++ b/conf/environments.json
@@ -1,4 +1,40 @@
 {
+    "builtin": {
+        "NaN"                : false,
+        "Infinity"           : false,
+        "undefined"          : false,
+        "eval"               : false,
+
+        "parseFloat"         : false,
+        "parseInt"           : false,
+        "isNaN"              : false,
+        "isFinite"           : false,
+
+        "decodeURI"          : false,
+        "decodeURIComponent" : false,
+        "encodeURI"          : false,
+        "encodeURIComponent" : false,
+
+        "Object"             : false,
+        "Function"           : false,
+        "Array"              : false,
+        "String"             : false,
+        "Boolean"            : false,
+        "Number"             : false,
+        "Date"               : false,
+        "RegExp"             : false,
+        "Error"              : false,
+        "EvalError"          : false,
+        "RangeError"         : false,
+        "ReferenceError"     : false,
+        "SyntaxError"        : false,
+        "TypeError"          : false,
+        "URIError"           : false,
+
+        "Math"               : false,
+        "JSON"               : false
+    },
+
     "browser": {
         "addEventListener"     : false,
         "applicationCache"     : false,

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -96,14 +96,21 @@ function getVariable(scope, name) {
 }
 
 /**
- * Parses options from certain special block comments that declare globals, and
- * ensures the corresponding variables are present in the global scope.
+ * Ensures that variables representing built-in properties of the Global Object,
+ * and any globals declared by special block comments, are present in the global
+ * scope.
  * @param {ASTNode} program The top node of the AST.
  * @param {Scope} globalScope The global scope.
  * @returns {void}
  */
 function addDeclaredGlobals(program, globalScope) {
-    var declaredGlobals = {};
+    var declaredGlobals = {},
+        builtin = environments.builtin;
+
+    Object.keys(builtin).forEach(function(name) {
+        declaredGlobals[name] = builtin[name];
+    });
+
     program.comments.forEach(function(comment) {
         parseComment(comment, declaredGlobals);
     });

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -538,7 +538,6 @@ vows.describe("eslint").addBatch({
             eslint.on("Program", function(node) {
                 var scope = eslint.getScope();
 
-                assert.equal(scope.variables.length, 1);
                 assert.equal(getVariable(scope, "a"), null);
             });
             eslint.verify(topic, config, true);
@@ -557,7 +556,30 @@ vows.describe("eslint").addBatch({
             eslint.on("Program", function(node) {
                 var scope = eslint.getScope();
 
-                assert.equal(scope.variables.length, 0);
+                assert.equal(getVariable(scope, "a"), null);
+                assert.equal(getVariable(scope, "b"), null);
+                assert.equal(getVariable(scope, "foo"), null);
+                assert.equal(getVariable(scope, "c"), null);
+            });
+            eslint.verify(topic, config, true);
+        }
+    },
+
+    "when evaluating any code": {
+
+        topic: "",
+
+        "builtin global variables should be available in the global scope": function(topic) {
+
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function(node) {
+                var scope = eslint.getScope();
+
+                assert.notEqual(getVariable(scope, "Object"), null);
+                assert.notEqual(getVariable(scope, "Array"), null);
+                assert.notEqual(getVariable(scope, "undefined"), null);
             });
             eslint.verify(topic, config, true);
         }

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -344,6 +344,38 @@ vows.describe(RULE_ID).addBatch({
             assert.equal(messages[0].message, "'require' is not defined.");
             assert.include(messages[0].node.type, "Identifier");
         }
+    },
+
+    //------------------------------------------------------------------------------
+    // Test references to builtins
+    //------------------------------------------------------------------------------
+    "when evaluating reference to a builtin": {
+        topic: "Object; isNaN();",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating write to a builtin": {
+        topic: "Array = 1;",
+
+        "should report a violation (readonly)": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "'Array' is read only.");
+            assert.include(messages[0].node.type, "Identifier");
+        }
     }
 
 }).export(module);


### PR DESCRIPTION
- Adds a "builtin" environment, which is used to augment the global scope object with properties that are expected to be available in every ES5 environment.
- Fixed a few tests that relied on zero variables being defined in the global scope.
