### PR TITLE
Fixing no-caller bug (Fixes  #190)

### DIFF
--- a/lib/rules/no-caller.js
+++ b/lib/rules/no-caller.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
             var objectName = node.object.name,
                 propertyName = node.property.name;
 
-            if (objectName === "arguments" && propertyName.match(/^calle[er]$/)) {
+            if (objectName === "arguments" && !node.computed && propertyName && propertyName.match(/^calle[er]$/)) {
                 context.report(node, "Avoid arguments.{{property}}.", { property: propertyName });
             }
 

--- a/tests/lib/rules/no-caller.js
+++ b/tests/lib/rules/no-caller.js
@@ -87,6 +87,36 @@ vows.describe(RULE_ID).addBatch({
 
             assert.equal(messages.length, 0);
         }
+    },
+
+    "when evaluating 'var x = arguments[0]'": {
+
+        topic: "var x = arguments[0]",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var x = arguments[caller]'": {
+
+        topic: "var x = arguments[caller]",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
     }
 
 }).export(module);


### PR DESCRIPTION
A fix for #190. Just added a check for the existence of the propertyName before running match on it
