### PR TITLE
Rule: no-dupe-keys

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -7,6 +7,7 @@
         "no-console": 1,
         "no-comma-dangle": 1,
         "no-debugger": 1,
+        "no-dupe-keys": 1,
         "no-empty": 1,
         "no-eq-null": 0,
         "no-eval": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -13,6 +13,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-obj-calls](no-obj-calls.md) - disallow the use of object properties of the global object (`Math` and `JSON`) as functions
 * [no-unreachable](no-unreachable.md) - disallow unreachable statements after a return, throw, continue, or break statement
 * [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
+* [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals
 
 ## Best Practices
 

--- a/docs/rules/no-dupe-keys.md
+++ b/docs/rules/no-dupe-keys.md
@@ -1,0 +1,42 @@
+# no dupe keys
+
+Creating objects with duplicate keys in objects can cause unexpected behavior in your application. The `no-dupe-keys` rule flags the use of duplicate keys in object literals.
+
+```js
+var foo = {
+    bar: "baz",
+    bar: "qux"
+};
+```
+
+## Rule Details
+
+This rule is aimed at preventing possible errors and unexpected behavior that might arise from using duplicate keys in object literals. As such, it warns whenever it finds a duplicate key.
+
+The following patterns are considered warnings:
+
+```js
+var foo = {
+    bar: "baz",
+    bar: "qux"
+};
+
+var foo = {
+    "bar": "baz",
+    bar: "qux"
+};
+
+var foo = {
+    0x1: "baz",
+    1: "qux"
+};
+```
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+var foo = {
+    bar: "baz",
+    quxx: "qux"
+};
+```

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Rule to flag use of duplicate keys in an object.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "ObjectExpression": function(node) {
+
+            // Object that will be a map of properties--safe because we will
+            // prefix all of the keys.
+            var nodeProps = {};
+
+            node.properties.forEach(function(property) {
+
+                // Create a safe key by prefixing with "$-".
+                var safeKey = "$-" + (property.key.name || property.key.value);
+
+                if (nodeProps[safeKey]) {
+                    context.report(node, "Duplicate key '{{key}}'.", { key: safeKey.split("-")[1] });
+                } else {
+                    nodeProps[safeKey] = true;
+                }
+            });
+
+        }
+    };
+
+};

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -1,0 +1,107 @@
+/**
+ * @fileoverview Tests for no-dupe-keys rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-dupe-keys";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = { y: 1, y: 2 };'": {
+
+        topic: "var x = { y: 1, y: 2 };",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Duplicate key 'y'.");
+            assert.include(messages[0].node.type, "ObjectExpression");
+        }
+    },
+
+    "when evaluating 'var foo = { 0x1: 1, 1: 2};'": {
+
+        topic: "var foo = { 0x1: 1, 1: 2};",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Duplicate key '1'.");
+            assert.include(messages[0].node.type, "ObjectExpression");
+        }
+    },
+
+    "when evaluating 'var foo = { __proto__: 1, two: 2};'": {
+
+        topic: "var foo = { __proto__: 1, two: 2};",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var x = { \"z\": 1, z: 2 };'": {
+
+        topic: "var x = { \"z\": 1, z: 2 };",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Duplicate key 'z'.");
+            assert.include(messages[0].node.type, "ObjectExpression");
+        }
+    },
+
+    "when evaluating 'var x = { foo: 1, bar: 2 };'": {
+
+        topic: "var x = { foo: 1, bar: 2 };",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+
+
+}).export(module);


### PR DESCRIPTION
The `no-dupe-keys` warns on the use of duplicate keys when declaring object literals:

``` js
var foo = {
    bar: "baz",
    bar: "qux"
};
```

Fixes #40 Fixes #44 Fixes #154 Fixes #155
