### PR TITLE
Improve performance of getTokens (Closes #189)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -235,7 +235,14 @@ module.exports = (function() {
 
             // gather data that may be needed by the rules
             currentScopes = escope.analyze(ast).scopes;
-            currentTokens = ast.tokens;
+            /* get all tokens from the ast and store them as a hashtable to
+             * improve traversal speed when wanting to find tokens for a given
+             * node
+             */
+            currentTokens = {};
+            ast.tokens.forEach(function(token) {
+                currentTokens[token.range[0]] = token;
+            });
 
             // augment global scope with declared global variables
             addDeclaredGlobals(ast, currentScopes[0]);
@@ -322,14 +329,20 @@ module.exports = (function() {
         if (node) {
             var startLocation = node.range[0] - (beforeCount || 0);
             var endLocation = node.range[1] + (afterCount || 0) ;
-            return currentTokens.filter(function(token) {
-                return (token.range[0] >= startLocation &&
-                        token.range[0] <= endLocation &&
-                        token.range[1] >= startLocation &&
-                        token.range[1] <= endLocation);
-            });
+            var tokens = [];
+            while (startLocation < endLocation) {
+                if (currentTokens[startLocation]) {
+                    tokens.push(currentTokens[startLocation]);
+                    startLocation = currentTokens[startLocation].range[1];
+                } else {
+                    startLocation += 1;
+                }
+            }
+            return tokens;
         } else {
-            return currentTokens || null;
+            return Object.keys(currentTokens).map(function(item) {
+                return item;
+            }) || null;
         }
     };
 


### PR DESCRIPTION
Closes #189 (putting this into a title of the pull request doesn't work for me half the time, don't know why)

I re-wrote getTokens to improve performance. I decided not to add tokens directly to ast, and instead I just populate them into hashtable with startLocation as a key.

Performance increase is pretty good. Running eslint with default rules on jshint file before the changes:
Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 41
Milliseconds      : 917
Ticks             : 419175419
TotalDays         : 0.000485156734953704
TotalHours        : 0.0116437616388889
TotalMinutes      : 0.698625698333333
TotalSeconds      : 41.9175419
TotalMilliseconds : 41917.5419

after the changes:

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 1
Milliseconds      : 968
Ticks             : 19688548
TotalDays         : 2.27876712962963E-05
TotalHours        : 0.000546904111111111
TotalMinutes      : 0.0328142466666667
TotalSeconds      : 1.9688548
TotalMilliseconds : 1968.8548
