### PR TITLE
Rule: unnecessary-strict

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -58,6 +58,7 @@
         "complexity": [0, 11],
         "wrap-iife": 0,
         "no-multi-str": 1,
-        "consistent-this": [0, "that"]
+        "consistent-this": [0, "that"],
+        "unnecessary-strict": 1
     }
 }

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -40,7 +40,8 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator
 * [no-multi-str](no-multi-str.md) - disallow use of multiline strings
 * [no-loop-func](no-loop-func.md) - disallow creation of functions within loops
-* [no-empty-label](no-empty-label) - disallow use of labels for anything other then loops and switches
+* [no-empty-label](no-empty-label.md) - disallow use of labels for anything other then loops and switches
+* [unnecessary-strict](unnecessary-strict.md) - disallow unnecessary use of `"use strict";` when already in strict mode
 
 ## Stylistic Issues
 

--- a/docs/rules/unnecessary-strict.md
+++ b/docs/rules/unnecessary-strict.md
@@ -1,0 +1,50 @@
+# unnecessary strict
+
+The `"use strict";` directive applies to the scope in which it appears and all inner scopes contained within that scope. Therefore, using the `"use strict";` directive in one of these inner scopes is unnecessary.
+
+```js
+"use strict";
+
+(function () {
+    "use strict";
+    var foo = true;
+}());
+```
+
+## Rule Details
+
+This rule is aimed at preventing unnecessary `"use strict";` directives. As such, it will warn when it encounters a `"use strict";` directive when already in strict mode.
+
+The following patterns are considered warnings:
+
+```js
+"use strict";
+
+(function () {
+    "use strict";
+    var foo = true;
+}());
+```
+
+The following patterns are not considered warnings:
+
+```js
+"use strict";
+
+(function () {
+    var foo = true;
+}());
+```
+
+
+
+```js
+(function () {
+    "use strict";
+    var foo = true;
+}());
+```
+
+## Further Reading
+
+* [The ECMAScript 5 Annotated Specification - Strict Mode](http://es5.github.io/#C)

--- a/lib/rules/unnecessary-strict.js
+++ b/lib/rules/unnecessary-strict.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Rule to flag unnecessary strict directives.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "Literal": function(node) {
+            if (node.value === "use strict") {
+                var scope = context.getScope();
+
+                if (scope.upper && scope.upper.isStrict) {
+                    context.report(node, "Unnecessary 'use strict'.");
+                }
+            }
+        }
+
+    };
+
+};

--- a/tests/lib/rules/unnecessary-strict.js
+++ b/tests/lib/rules/unnecessary-strict.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Tests for unnecessary-strict.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "unnecessary-strict";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating strict in global and function scope": {
+
+        topic: "\"use strict\"; function foo() { \"use strict\"; var bar = true; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unnecessary 'use strict'.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating strict in global scope": {
+
+        topic: "\"use strict\"; function foo() { var bar = true; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating strict in function scope": {
+
+        topic: "function foo() { \"use strict\"; var bar = true; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating strict in global and nested function scope": {
+
+        topic: "\"use strict\"; (function foo() { function bar () { \"use strict\"; } }());",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unnecessary 'use strict'.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    }
+
+
+}).export(module);


### PR DESCRIPTION
The `unnecessary-strict` rule flags the use of the `"use strict";` directive when already in strict mode.

``` js
"use strict";

(function () {
    "use strict";
    var foo = true;
}());
```

See http://jslinterrors.com/unnecessary-use-strict/
