### PR TITLE
Refactored `max-statements` rule.

### DIFF
--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -12,52 +12,27 @@ module.exports = function(context) {
     "use strict";
 
     //--------------------------------------------------------------------------
-    // Constants
-    //--------------------------------------------------------------------------
-
-
-    var STATEMENT_TYPES = ["IfStatement", "WhileStatement", "SwitchStatement",
-            "TryStatement", "DoWhileStatement", "ForStatement", "WithStatement",
-            "ForInStatement"];
-
-    //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
-    function getStatementCount(node) {
-        var count = 0;
+    var functionStack = [],
+        maxStatements = context.options[0] || 10;
 
-        function countStatements(statement) {
-            if (STATEMENT_TYPES.indexOf(statement.type) !== -1) {
-                count += getStatementCount(statement);
-            }
-        }
-
-        if (node.body && node.body.body) {
-            count += node.body.body.length;
-            node.body.body.forEach(countStatements);
-        }
-
-        if (node.consequent && node.consequent.body) {
-            count += node.consequent.body.length;
-            node.consequent.body.forEach(countStatements);
-        }
-
-        if (node.alternate && node.alternate.body) {
-            count += node.alternate.body.length;
-            node.alternate.body.forEach(countStatements);
-        }
-
-        return count;
+    function startFunction() {
+        functionStack.push(0);
     }
 
-    function checkForMaxStatements(node) {
-        var max = context.options[0],
-            count = getStatementCount(node);
+    function endFunction(node) {
+        var count = functionStack.pop();
 
-        if (count > max) {
-            context.report(node, "This function has too many statements ({{count}}). Maximum allowed is {{max}}.", { count: count, max: max });
+        if (count > maxStatements) {
+            context.report(node, "This function has too many statements ({{count}}). Maximum allowed is {{max}}.",
+                    { count: count, max: maxStatements });
         }
+    }
+
+    function countStatements(node) {
+        functionStack[functionStack.length - 1] += node.body.length;
     }
 
     //--------------------------------------------------------------------------
@@ -65,8 +40,13 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
 
     return {
-        "FunctionDeclaration": checkForMaxStatements,
-        "FunctionExpression": checkForMaxStatements
+        "FunctionDeclaration": startFunction,
+        "FunctionExpression": startFunction,
+
+        "BlockStatement": countStatements,
+
+        "FunctionDeclaration:after": endFunction,
+        "FunctionExpression:after": endFunction
     };
 
 };

--- a/tests/lib/rules/max-statements.js
+++ b/tests/lib/rules/max-statements.js
@@ -125,7 +125,7 @@ vows.describe(RULE_ID).addBatch({
 
         topic: "function foo() { var bar = 1; if (true) { for (;;) { var qux = null; } } else { quxx(); } return 3; }",
 
-        "should report a violation": function(topic) {
+        "should not report a violation": function(topic) {
 
             var config = { rules: {} };
             config.rules[RULE_ID] = [1, 6];
@@ -154,7 +154,7 @@ vows.describe(RULE_ID).addBatch({
     },
 
     "when evaluating with function calls and nested function and max-statements set to 3": {
-        
+
         topic: "function foo() { var x = 5; function bar() { var y = 6; } bar(); z = 10; baz(); }",
 
         "should report a violation": function(topic) {
@@ -170,7 +170,7 @@ vows.describe(RULE_ID).addBatch({
     },
 
     "when evaluating with function calls and nested function and max-statements set to 4": {
-        
+
         topic: "function foo() { var x = 5; function bar() { var y = 6; } bar(); z = 10; baz(); }",
 
         "should report a violation": function(topic) {
@@ -186,10 +186,10 @@ vows.describe(RULE_ID).addBatch({
     },
 
     "when evaluating with function calls and nested function and max-statements set to 5": {
-        
+
         topic: "function foo() { var x = 5; function bar() { var y = 6; } bar(); z = 10; baz(); }",
 
-        "should report a violation": function(topic) {
+        "should not report a violation": function(topic) {
             var config = { rules: {} };
             config.rules[RULE_ID] = [1, 5];
 
@@ -197,8 +197,21 @@ vows.describe(RULE_ID).addBatch({
 
             assert.equal(messages.length, 0);
         }
-    }
+    },
 
+    "when evaluating a function with max-statements on, but no max option passed": {
+
+        topic: "function foo() { var a; var b; var c; var x; var y; var z; bar(); baz(); qux(); quxx(); }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
 
 }).export(module);
 


### PR DESCRIPTION
Refactored the max-statements rule to push/pop from a function stack to evaluate the number of statements in a function. Previously the number of statements were being calculated by recursive traversal. Additionally, I've cleaned up a few of the tests.
