### PR TITLE
rule: maxlen to lint maximum length of a line

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -47,6 +47,8 @@
         "no-unused-vars": 1,
         "no-script-url": 1,
         "no-proto": 1,
+        "no-mixed-requires": [0, false],
+        "no-wrap-func": 1,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,
@@ -72,7 +74,6 @@
         "no-multi-str": 1,
         "consistent-this": [0, "that"],
         "unnecessary-strict": 1,
-        "no-mixed-requires": [0, false],
-        "no-wrap-func": 1
+        "max-len": [0, 80, 4]
     }
 }

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Rule to check for max length on a line.
+ * @author Matt DuVall <http://www.mattduvall.com>
+ */
+
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    var maxLength = context.options[0],
+        tabWidth = context.options[1],
+        tabString = stringRepeat(" ", tabWidth);
+
+    function stringRepeat(num) {
+        num = parseInt(num, 10);
+        var tabString = "",
+            i;
+
+        for (i = 0; i < tabWidth; i += 1) {
+            tabString += " ";
+        }
+
+        return tabString;
+    }
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+    function checkProgramForMaxLength(node) {
+        // Esprima does not include leading whitespace on the first line, this
+        // sets the initial range to 80 for getSource
+        node.range[0] = 0;
+        var lines = context.getSource(node).split("\n"),
+            i,
+            line;
+
+        for (i = 0; i < lines.length; i++) {
+            line = lines[i];
+
+            // Replace the tabs with the tab width
+            line = line.replace(/\t/g, tabString);
+
+            if (line.length > maxLength) {
+                context.report(node, "Line " + i + " exceeds the maximum line length of " + maxLength + ".");
+            }
+        }
+    }
+
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+        "Program": checkProgramForMaxLength
+    };
+
+};

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -1,0 +1,110 @@
+/**
+ * @fileoverview Tests for max-len rule.
+ * @author Matt DuVall <http://www.mattduvall.com>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "max-len";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = 5\nvar x = 2;'": {
+
+        topic: 'var x = 5;\nvar x = 2;',
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 80, 4];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var x = 5, y = 2, z = 5;'": {
+
+        topic: 'var x = 5, y = 2, z = 5;',
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 10, 4];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Line 0 exceeds the maximum line length of 10.");
+            assert.include(messages[0].node.type, "Program");
+        }
+    },
+
+    "when evaluating '\t\t\tvar i = 1;'": {
+
+        topic: '\t\t\tvar i = 1;',
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 15, 4];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Line 0 exceeds the maximum line length of 15.");
+            assert.include(messages[0].node.type, "Program");
+        }
+    },
+
+    "when evaluating '\t\t\tvar i = 1;\n\t\t\tvar j = 1;'": {
+
+        topic: '\t\t\tvar i = 1;\n\t\t\tvar j = 1;',
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 15, 4];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 2);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Line 0 exceeds the maximum line length of 15.");
+            assert.include(messages[0].node.type, "Program");
+        }
+    },
+
+    "when evaluating '\t\t\tvar i = 1;\n\t\t\tvar j = 1;'": {
+
+        topic: '\t\t\tvar i = 1;\n\t\t\tvar j = 1;',
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 15, 1];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
Fixes issue https://github.com/nzakas/eslint/issues/219.

I'm looking for feedback on this one, it's incomplete since it doesn't take into account tabs and spaces - how should we detect this? Should the `eslint.json` file contain a `tabs` key that represents how many spaces there are per tab?
