### PR TITLE
Fix loading rules from a rules directory

### DIFF
--- a/lib/load-rules.js
+++ b/lib/load-rules.js
@@ -2,7 +2,12 @@ var fs = require("fs"),
     path = require("path");
 
 module.exports = function(rulesDir) {
-    if (!rulesDir) { rulesDir = path.join(__dirname, "rules"); }
+    if (!rulesDir) {
+        rulesDir = path.join(__dirname, "rules");
+    } else {
+        rulesDir = path.resolve(process.cwd(), rulesDir);
+    }
+
     var rules = Object.create(null);
     fs.readdirSync(rulesDir).forEach(function(file) {
         if (path.extname(file) !== ".js") { return; }

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -30,7 +30,7 @@ vows.describe("rules").addBatch({
 
     "when given a valid rules directory": {
 
-        topic: path.join(process.cwd(), "tests/fixtures/rules"),
+        topic: "tests/fixtures/rules",
 
         "should load rules and not log an error or exit": function(topic) {
             assert.equal(typeof rules.get("fixture-rule"), "undefined");


### PR DESCRIPTION
This fixes an issue where trying to load rules from the command line would fail because the load path was relative to `/lib` rather than the directory of the ESLint process.
