### PR TITLE
Rule: max-depth

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -54,6 +54,7 @@
         "semi": 1,
         "use-isnan": 1,
         "quotes": [1, "double"],
+        "max-depth": [0, 4],
         "max-params": [0, 3],
         "max-statements": [0, 10],
         "regex-spaces": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -71,3 +71,4 @@ The following rules are included for compatibility with [JSHint](http://jshint.c
 * [no-bitwise] - disallow use of bitwise operators (off by default)
 * [guard-for-in] - make sure `for-in` loops have an `if` statement (off by default)
 * [max-statements](max-statements.md) - specify the maximum number of statement allowed in a function (off by default)
+* [max-depth](max-depth.md) - specify the maximum depth that blocks can be nested (off by default)

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -1,0 +1,48 @@
+# max depth
+
+The `max-depth` rule allows you to specify the maximum depth blocks can be nested.
+
+```js
+// max-depth: [1, 2]  // Maximum of 2 deep.
+function foo() {
+  for (;;) {
+    if (true) {
+      if (true) { // Nested 3 deep.
+
+      }
+    }
+  }
+}
+```
+
+## Rule Details
+
+This rule aims to reduce the complexity of your code by allowing you to configure the maximum depth blocks can be nested in a function. As such, it will warn when blocks are nested too deeply.
+
+The following patterns are considered warnings:
+
+```js
+// max-depth: [1, 2]  // Maximum of 2 deep.
+function foo() {
+  for (;;) {
+    if (true) {
+      if (true) { // Nested 3 deep.
+
+      }
+    }
+  }
+}
+```
+
+The following patterns are not warnings:
+
+```js
+// max-depth: [1, 2]  // Maximum of 2 deep.
+function foo() {
+  for (;;) {
+    if (true) {
+
+    }
+  }
+}
+```

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -1,0 +1,74 @@
+/**
+ * @fileoverview A rule to set the maximum depth block can be nested in a function.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    var functionStack = [],
+        maxDepth = context.options[0] || 4;
+
+    function startFunction() {
+        functionStack.push(0);
+    }
+
+    function endFunction() {
+        functionStack.pop();
+    }
+
+    function pushBlock(node) {
+        var len = ++functionStack[functionStack.length - 1];
+
+        if (len > maxDepth) {
+            context.report(node, "Blocks are nested too deeply ({{depth}}).",
+                    { depth: len });
+        }
+    }
+
+    function popBlock() {
+        functionStack[functionStack.length - 1]--;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+        "Program": startFunction,
+        "FunctionDeclaration": startFunction,
+        "FunctionExpression": startFunction,
+
+        "IfStatement": pushBlock,
+        "SwitchStatement": pushBlock,
+        "TryStatement": pushBlock,
+        "DoWhileStatement": pushBlock,
+        "WhileStatement": pushBlock,
+        "WithStatement": pushBlock,
+        "ForStatement": pushBlock,
+        "ForInStatement": pushBlock,
+
+        "IfStatement:after": popBlock,
+        "SwitchStatement:after": popBlock,
+        "TryStatement:after": popBlock,
+        "DoWhileStatement:after": popBlock,
+        "WhileStatement:after": popBlock,
+        "WithStatement:after": popBlock,
+        "ForStatement:after": popBlock,
+        "ForInStatement:after": popBlock,
+
+        "FunctionDeclaration:after": endFunction,
+        "FunctionExpression:after": endFunction,
+        "Program:after": endFunction
+    };
+
+};

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview Tests for max-depth.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "max-depth";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating a function with blocks 3 deep and a threshold of 2": {
+
+        topic: "function foo() { if (true) { if (false) { if (true) { } } } }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Blocks are nested too deeply (3).");
+            assert.include(messages[0].node.type, "IfStatement");
+        }
+    },
+
+    "when evaluating a function with blocks 3 deep and a threshold of 3": {
+
+        topic: "function foo() { if (true) { if (false) { if (true) { } } } }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 3];
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a function with blocks 2 deep and a threshold of 1": {
+
+        topic: "function foo() { if (true) {} else { for(;;) {} } }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 1];
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Blocks are nested too deeply (2).");
+            assert.include(messages[0].node.type, "ForStatement");
+        }
+    },
+
+    "when evaluating a function with blocks 2 deep and a threshold of 1": {
+
+        topic: "function foo() { while (true) { if (true) {} } }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 1];
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Blocks are nested too deeply (2).");
+            assert.include(messages[0].node.type, "IfStatement");
+        }
+    },
+
+    "when evaluating a function with blocks 3 deep and a threshold of 1": {
+
+        topic: "function foo() { while (true) { if (true) { if (false) { } } } }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 1];
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 2);
+
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Blocks are nested too deeply (2).");
+            assert.include(messages[0].node.type, "IfStatement");
+
+            assert.equal(messages[1].ruleId, RULE_ID);
+            assert.equal(messages[1].message, "Blocks are nested too deeply (3).");
+            assert.include(messages[1].node.type, "IfStatement");
+        }
+    }
+
+
+}).export(module);


### PR DESCRIPTION
Created the `max-depth` rule, which allows the user to specify the maximum depth that blocks can be nested:

``` js
// max-depth: [1, 2]  // Maximum of 2 deep.
function foo() {
  for (;;) {
    if (true) {
      if (true) { // Nested 3 deep.

      }
    }
  }
}
```

This rule matches the _maxdepth_ rule for JSHint.
