### PR TITLE
Fix: Error severity for rules with options.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -137,11 +137,20 @@ function processFile(filename, config) {
 
     // count all errors and return the total
     return messages.reduce(function(previous, message) {
-        if (message.fatal || config.rules[message.ruleId] === 2) {
+        var severity = null;
+
+        if (message.fatal) {
             return previous + 1;
-        } else {
-            return previous;
         }
+
+        severity = config.rules[message.ruleId][0] ||
+                config.rules[message.ruleId];
+
+        if (severity === 2) {
+            return previous + 1;
+        }
+
+        return previous;
     }, 0);
 }
 

--- a/lib/formatters/checkstyle.js
+++ b/lib/formatters/checkstyle.js
@@ -9,12 +9,20 @@
 
 function getMessageType(message, rules) {
 
-    if (message.fatal || rules[message.ruleId] === 2) {
+    // TODO: Get rule severity in a better way
+    var severity = null;
+
+    if (message.fatal) {
         return "error";
-    } else {
-        return "warning";
     }
 
+    severity = rules[message.ruleId][0] || rules[message.ruleId];
+
+    if (severity === 2) {
+        return "error";
+    }
+
+    return "warning";
 }
 
 //------------------------------------------------------------------------------
@@ -31,13 +39,13 @@ module.exports = function(results, config) {
 
     results.forEach(function(result) {
         var messages = result.messages;
-        
+
         output += "<file name=\"" + result.filePath + "\">";
 
         messages.forEach(function(message) {
-            output += "<error line=\"" + message.line + "\" " + 
-                "column=\"" + message.column + "\" " + 
-                "severity=\"" + getMessageType(message, rules) + "\" " + 
+            output += "<error line=\"" + message.line + "\" " +
+                "column=\"" + message.column + "\" " +
+                "severity=\"" + getMessageType(message, rules) + "\" " +
                 "message=\"" + message.message + "\" />";
         });
 

--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -10,12 +10,19 @@
 function getMessageType(message, rules) {
 
     // TODO: Get rule severity in a better way
-    if (message.fatal || rules[message.ruleId] === 2) {
+    var severity = null;
+
+    if (message.fatal) {
         return "Error";
-    } else {
-        return "Warning";
     }
 
+    severity = rules[message.ruleId][0] || rules[message.ruleId];
+
+    if (severity === 2) {
+        return "Error";
+    }
+
+    return "Warning";
 }
 
 

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -11,12 +11,20 @@
 
 function getMessageType(message, rules) {
 
-    if (message.fatal || rules[message.ruleId] === 2) {
+    // TODO: Get rule severity in a better way
+    var severity = null;
+
+    if (message.fatal) {
         return "Error";
-    } else {
-        return "Warning";
     }
 
+    severity = rules[message.ruleId][0] || rules[message.ruleId];
+
+    if (severity === 2) {
+        return "Error";
+    }
+
+    return "Warning";
 }
 
 /**

--- a/tests/fixtures/configurations/quotes-error.json
+++ b/tests/fixtures/configurations/quotes-error.json
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "quotes": [2, "double"]
+    }
+}

--- a/tests/fixtures/single-quoted.js
+++ b/tests/fixtures/single-quoted.js
@@ -1,0 +1,1 @@
+var foo = 'bar';

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -36,6 +36,24 @@ vows.describe("cli").addBatch({
 
     },
 
+    "when given a config with rules with options and severity level set to error": {
+        topic: ["--config", "tests/fixtures/configurations/quotes-error.json", "single-quoted.js"],
+
+        "should exit with an error status (1)": function(topic) {
+            var log = console.log,
+                exitStatus;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            assert.doesNotThrow(function () {
+                exitStatus = cli.execute(topic);
+            });
+            console.log = log;
+
+            assert.equal(exitStatus, 1);
+        },
+    },
 
     "when given a config file and a directory of files": {
 

--- a/tests/lib/formatters/checkstyle.js
+++ b/tests/lib/formatters/checkstyle.js
@@ -45,8 +45,16 @@ vows.describe("formatter:checkstyle").addBatch({
 
             var result = formatter(topic, config);
             assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"warning\" message=\"Unexpected foo.\" /></file></checkstyle>", result);
-        }
+        },
 
+        "should return a string in the format filename: line x, col y, Error - z for errors with options config": function(topic) {
+            var config = {
+                rules: { foo: [2, "option"] }
+            };
+
+            var result = formatter(topic, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" /></file></checkstyle>", result);
+        }
     },
 
     "when passed a fatal error message": {

--- a/tests/lib/formatters/compact.js
+++ b/tests/lib/formatters/compact.js
@@ -45,7 +45,16 @@ vows.describe("formatter:compact").addBatch({
 
             var result = formatter(topic, config);
             assert.equal("foo.js: line 5, col 10, Warning - Unexpected foo.\n\n1 problem", result);
-        }
+        },
+
+        "should return a string in the format filename: line x, col y, Error - z for errors with options config": function(topic) {
+            var config = {
+                rules: { foo: [2, "option"] }
+            };
+
+            var result = formatter(topic, config);
+            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo.\n\n1 problem", result);
+        },
 
     },
 

--- a/tests/lib/formatters/junit.js
+++ b/tests/lib/formatters/junit.js
@@ -59,7 +59,16 @@ vows.describe("formatter:junit").addBatch({
 
             var result = formatter(topic, config);
             assert.equal('<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="foo.js"><testcase time="0" name="org.eslint.foo"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Warning - Unexpected foo.]]></failure></testcase></testsuite></testsuites>', result.replace(/\n/g, ""));
-        }
+        },
+
+        "should return a single <testcase> with a message and the line and col number in the body (error) with options config": function(topic) {
+            var config = {
+                rules: { foo: [2, "option"] }
+            };
+
+            var result = formatter(topic, config);
+            assert.equal('<?xml version="1.0" encoding="utf-8"?><testsuites><testsuite package="org.eslint" time="0" tests="1" errors="1" name="foo.js"><testcase time="0" name="org.eslint.foo"><failure message="Unexpected foo."><![CDATA[line 5, col 10, Error - Unexpected foo.]]></failure></testcase></testsuite></testsuites>', result.replace(/\n/g, ""));
+        },
 
     },
 


### PR DESCRIPTION
This fixes an issue where rules that accept options would be unable to report an error severity.

As the TODO has and continues to say, we should refactor how we get error severity in the formatters.

Fixes #229
