### PR TITLE
Rule: No shadow (Closes #237)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -49,6 +49,7 @@
         "no-proto": 1,
         "no-mixed-requires": [0, false],
         "no-wrap-func": 1,
+        "no-shadow": 1,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -46,6 +46,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
 * [no-proto](no-proto.md) - disallow usage of `__proto__` property
 * [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if`.
+* [no-shadow](no-shadow.md) - disallow declaration of variables already declared in the outer scope
 
 ## Stylistic Issues
 

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -1,0 +1,29 @@
+# no shadow
+
+## Rule Details
+
+This error is raised to highlight a declaration of variable when the variable with the same name is already declared in the upper scope. Reusing variable names in the inner scope can lead to confusion and decrease readability of the code. When the inner scope variable is declared with the same name as the variable in the outer scope, it's also impossible to access outer variable.
+
+The following patterns are considered warnings:
+
+```js
+
+var a = 3;
+function b() {
+    var a = 10;
+}
+```
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+var a = 3;
+function b(a) {
+    a = 10;
+}
+b(a);
+```
+
+## Further Reading
+
+* [Don't make functions within a loop](http://jslinterrors.com/dont-make-functions-within-a-loop/)

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -408,6 +408,12 @@ module.exports = (function() {
         // Don't do this for Program nodes - they have no parents
         if (parents.length) {
 
+            // if current node is function declaration, add it to the list
+            var current = controller.current();
+            if (current.type === "FunctionDeclaration" || current.type === "FunctionExpression") {
+                parents.splice(0, 0, current);
+            }
+
             // Ascend the current node's parents
             for (var i = 0; i < parents.length; i++) {
 

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Rule to flag on declaring variables already declared in the outer scope
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    var checkForShadows = function(node) {
+        var scope = context.getScope();
+        if (!scope.upper) {
+            return;
+        }
+
+        //remove variabes that were passed as arguments
+        var args = node.params;
+        //push 'arguments' into the array
+        //args.push({name: "arguments" });
+        var variables = scope.variables.filter(function(item) {
+            return !args.some(function(variable) {
+                return variable.name === item.name;
+            });
+        });
+        //iterate through the array of variables and find duplicates with the upper scope
+        var upper = scope.upper;
+
+        var findDups = function(variables) {
+            variables.forEach(function(variable) {
+                if (upper.variables.some(function(scopeVar) {
+                    //filter out global variables that we add as part of ESLint
+                    if (scopeVar.identifiers.length > 0) {
+                        return scopeVar.name === variable.name;
+                    }
+                    return false;
+                })) {
+                    context.report(variable.identifiers[0], "{{a}} is already declared in the upper scope.", {a: variable.name});
+                }
+            });
+        };
+
+        while(upper) {
+            findDups(variables);
+            upper = upper.upper;
+        }
+    };
+
+    return {
+
+        "FunctionDeclaration": checkForShadows,
+        "FunctionExpression": checkForShadows
+    };
+
+};

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -334,13 +334,13 @@ vows.describe("eslint").addBatch({
             eslint.verify(topic, config, true);
         },
 
-        "should retrieve the global scope correctly from a FunctionDeclaration": function(topic) {
+        "should retrieve the function scope correctly from a FunctionDeclaration": function(topic) {
             var config = { rules: {} };
 
             eslint.reset();
             eslint.on("FunctionDeclaration", function(node) {
                 var scope = eslint.getScope();
-                assert.equal(scope.type, "global");
+                assert.equal(scope.type, "function");
             });
 
             eslint.verify(topic, config, true);

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Tests for no-shadow rule.
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-shadow";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+    "when evaluating 'var a=3; function b() { var a=10; }": {
+        topic: "var a=3; function b() { var a=10; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "a is already declared in the upper scope.");
+            assert.include(messages[0].node.type, "Identifier");
+        }
+    },
+
+    "when evaluating 'var a=3; function b() { var a=10; }; setTimeout(function() { b(); }, 0);": {
+        topic: "var a=3; function b() { var a=10; }; setTimeout(function() { b(); }, 0);",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "a is already declared in the upper scope.");
+            assert.include(messages[0].node.type, "Identifier");
+        }
+    },
+
+    "when evaluating 'var a=3; function b() { var a=10; var b=0; }; setTimeout(function() { b(); }, 0);": {
+        topic: "var a=3; function b() { var a=10; var b=0; }; setTimeout(function() { b(); }, 0);",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 2);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "a is already declared in the upper scope.");
+            assert.include(messages[0].node.type, "Identifier");
+        }
+    },
+
+    "when evaluating 'var a=3; function b(a) { a++; return a; }; setTimeout(function() { b(a); }, 0);": {
+        topic: "var a=3; function b(a) { a++; return a; }; setTimeout(function() { b(a); }, 0);",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Closes #237 I had a few issues with this rule. First of all, I had to change getScope slightly. Now if you try to get the scope while current node is function declaration it will get the scope of the function, and not the global scope. I can see how both ways are valid, but we have no use case for the old behavior and I couldn't find a way to get function scope with the current code.
Second issue was that I could not get JSHint or JavaScriptLint (I know it also has the same rule) to fail with shadow error. So I couldn't copy jshint error message, and I couldn't verify if naming attributes in a way that would cause shadowing is considered a problem. Let me know if you think that I shouldn't exclude attributes from this rule. I don't feel strongly either way.
