### PR TITLE
Rule: no-else-return

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -8,6 +8,7 @@
         "no-comma-dangle": 1,
         "no-debugger": 1,
         "no-dupe-keys": 1,
+        "no-else-return": 0,
         "no-empty": 1,
         "no-eq-null": 0,
         "no-eval": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -45,6 +45,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-unused-vars](no-unused-vars.md) - disallow declaration of variables that are not used in the code
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
 * [no-proto](no-proto.md) - disallow usage of `__proto__` property
+* [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if`.
 
 ## Stylistic Issues
 

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -1,0 +1,60 @@
+# no else return
+
+If a an `if` block contains a return statement, the `else` block becomes unnecessary. Its contents can be placed outside of the block.
+
+```js
+function foo() {
+    if (x) {
+        return y;
+    } else {
+        return z;
+    }
+}
+```
+## Rule Details
+
+This rule is aimed at highlighting an unnecessary block of code following an `if` containing a return statement. As such, it will warn when it encounters an `else` following an `if` containing a `return`.
+
+The following patterns are considered warnings:
+
+```js
+function foo() {
+    if (x) {
+        return y;
+    } else {
+        return z;
+    }
+}
+
+function foo() {
+    if (x) {
+        return y;
+    } else {
+        var t = "foo";
+    }
+
+    return t;
+}
+```
+
+The follow patterns are not considered warnings:
+
+```js
+function foo() {
+    if (x) {
+        return y;
+    }
+
+    return z;
+}
+
+function foo() {
+    if (x) {
+        if (z) {
+            return y;
+        }
+    } else {
+        return z;
+    }
+}
+```

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Rule to flag `else` after a `return` in `if`
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    function checkForReturnStatement(node, alternate) {
+        if (node.type === "ReturnStatement") {
+            context.report(alternate, "Unexpected 'else' after 'return'​.");
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "IfStatement": function(node) {
+
+            // Don't bother finding a ReturnStatement, if there's no `else`.
+            if (node.alternate && node.consequent) {
+
+                // If we have a BlockStatement, check each consequent body node.
+                if (node.consequent.type === "BlockStatement") {
+                    node.consequent.body.forEach(function (bodyNode) {
+                        checkForReturnStatement(bodyNode, node.alternate);
+                    });
+
+                // If not a block statement, make sure the consequent isn't a
+                // ReturnStatement
+                } else {
+                    checkForReturnStatement(node.consequent, node.alternate);
+                }
+            }
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -1,0 +1,127 @@
+/**
+ * @fileoverview Tests for no-else-return rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-else-return";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'function foo() { if (true) { return x; } else { return y; } }": {
+
+        topic: "function foo() { if (true) { return x; } else { return y; } }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected 'else' after 'return'​.");
+            assert.include(messages[0].node.type, "BlockStatement");
+        }
+    },
+
+    "when evaluating 'function foo() { if (true) { if (false) { return x; } } else { return y; } }": {
+
+        topic: "function foo() { if (true) { if (false) { return x; } } else { return y; } }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'function foo() { if (true) { return x; } return y; }": {
+
+        topic: "function foo() { if (true) { return x; } return y; }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'function foo() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }": {
+
+        topic: "function foo() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected 'else' after 'return'​.");
+            assert.include(messages[0].node.type, "BlockStatement");
+        }
+    },
+
+    "when evaluating 'function foo() { if (true) return x; else return y; }": {
+
+        topic: "function foo() { if (true) return x; else return y; }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected 'else' after 'return'​.");
+            assert.include(messages[0].node.type, "ReturnStatement");
+        }
+    },
+
+    "when evaluating 'function foo() { if (true) { for (;;) { return x; } } else { return y; } }": {
+
+        topic: "function foo() { if (true) { for (;;) { return x; } } else { return y; } }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'function foo() { if (true) notAReturn(); else return y; }": {
+
+        topic: "function foo() { if (true) notAReturn(); else return y; }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    }
+
+
+}).export(module);


### PR DESCRIPTION
The `no-else-return` rule (I am open to suggestions on a better name) will warn when it encouters an `else` block following an `if` block which contains a return statement, as that `else` block is unnecessary and its contents could be placed outside of the `else` block.

``` js
function foo() {
    if (x) {
        return y;
    } else {
        return z;
    }
}
```

This rule matches the same rule from JSLint: http://jslinterrors.com/unexpected-else-after-return/
