### PR TITLE
Fix issues with function in no-unused-vars (Fixes #256)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -55,10 +55,15 @@ module.exports = function(context) {
         "Identifier": function(node) {
             var ancestors = context.getAncestors(node);
             var parent = ancestors.pop();
+            var grandparent = ancestors.pop();
             /*if it's not an assignment expression find corresponding
               *variable in the array and mark it as used
               */
-            if ((parent.type !== "AssignmentExpression" || node !== parent.left) && parent.type !== "VariableDeclarator") {
+            if ((parent.type !== "AssignmentExpression" || node !== parent.left) &&
+                parent.type !== "VariableDeclarator" &&
+                parent.type !== "FunctionDeclaration" &&
+                (parent.type !== "FunctionExpression" ||
+                (grandparent!==null && grandparent.type === "CallExpression"))) {
                 var variable = findVariable(node.name);
                 if (variable) {
                     variable.used = true;


### PR DESCRIPTION
Fixes #256 This fix should get no-unused-vars to treat functions correctly. The only problem that I have is unittest with the following topic:

``` js
function f() {
var a=[];
return a.map(function g(){});
}
```

Theoretically, it should return two errors since both f and g are never called directly. However, g is called by map function, so it's not being caught by the rule. I don't feel strongly about this issue, since in reality, g will be called. I feel like if we want to catch g, it should be some other rule's job to do so, since g should be anonymous function to begin with.
