### PR TITLE
Rule: Expected break inside case (Closes #258)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -51,6 +51,7 @@
         "no-wrap-func": 1,
         "no-shadow": 1,
 
+        "break-case": 1,
         "smarter-eqeqeq": 0,
         "brace-style": 0,
         "camelcase": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -14,6 +14,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-unreachable](no-unreachable.md) - disallow unreachable statements after a return, throw, continue, or break statement
 * [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
 * [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals
+* [break-case](break-case) - require use of `break` keyword inside case statements
 
 ## Best Practices
 

--- a/docs/rules/break-case.md
+++ b/docs/rules/break-case.md
@@ -1,0 +1,64 @@
+# break case
+
+`Break` is used to prevent the code from running into the next case automatically. If it's not use, it might lead to unexpected behavior and errors.
+
+```js
+switch (a) {
+    case 0:
+        b = "zero";
+    case 1:
+        b = "one";
+        break;
+}
+```
+
+## Rule Details
+
+This rule is aimed at preventing possible errors and unexpected behavior that might arise from not using `break` keyword inside case statements.
+
+The following patterns are considered warnings:
+
+```js
+switch (a) {
+    case 0:
+        b = "zero";
+    case 1:
+        b = "one";
+        break;
+}
+
+switch (a) {
+    case 0:
+        b = "zero";
+        break;
+    case 1:
+        b = "one";
+        break;
+    default:
+        b = "none";
+}
+```
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+switch (a) {
+    case 0:
+        b = "zero";
+        break;
+    case 1:
+        b = "one";
+        break;
+}
+
+switch (a) {
+    case 0:
+        return "zero";
+    case 1:
+        return "one";
+}
+```
+
+## When Not To Use It
+
+If you want to fall back to the next case statement.

--- a/lib/rules/break-case.js
+++ b/lib/rules/break-case.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Rule to case statements without break
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "SwitchCase": function(node) {
+            if (!node.consequent.some(function(item) {
+                return item.type === "BreakStatement" || item.type === "ReturnStatement" ;
+            })) {
+                context.report(node, "Expected a 'break' statement in case statement.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/break-case.js
+++ b/tests/lib/rules/break-case.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview Tests for break-case rule.
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "break-case";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+    "when evaluating 'switch (foo) { case 2: break; default: }'": {
+
+        topic: "switch (foo) { case 2: break; default: }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Expected a 'break' statement in case statement.");
+            assert.include(messages[0].node.type, "SwitchCase");
+        }
+    },
+
+    "when evaluating 'switch (foo) { case 2: default: break; }'": {
+
+        topic: "switch (foo) { case 2: default: break; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Expected a 'break' statement in case statement.");
+            assert.include(messages[0].node.type, "SwitchCase");
+        }
+    },
+
+    "when evaluating 'switch (foo) { case 2: break; default: break; }'": {
+
+        topic: "switch (foo) { case 2: break; default: break; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'function a() { switch (foo) { case 2: return foo; default: break; }}'": {
+
+        topic: "function a() { switch (foo) { case 2: return foo; default: break; }}",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Closes #258 It will handle both `break` as well as `return` statements. However, it's not as smart as I would like it to be. It only checks top level nodes of `case` statement and doesn't try to verify that each code path uses return or break (I checked, JSHint does the same thing, but they don't check for returns). Also, I can't get error message to match JSHint, since they check the next node, and we can't do that. Ideally it should check if this is the last case/default statement inside switch and not warn about lack of break there.
