### PR TITLE
Rule: no-empty-class

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -16,6 +16,7 @@
         "no-dupe-keys": 1,
         "no-else-return": 0,
         "no-empty": 1,
+        "no-empty-class": 1,
         "no-eq-null": 0,
         "no-eval": 1,
         "no-ex-assign": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -14,6 +14,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-unreachable](no-unreachable.md) - disallow unreachable statements after a return, throw, continue, or break statement
 * [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
 * [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals
+* [no-empty-class](no-empty-class.md) - disallow the use of empty character classes in regular expressions
 
 ## Best Practices
 

--- a/docs/rules/no-empty-class.md
+++ b/docs/rules/no-empty-class.md
@@ -1,0 +1,31 @@
+# no empty class
+
+Empty character classes in regular expressions do not match anything and can result in code that may not work as intended.
+
+```js
+var foo = /^abc[]/;
+```
+
+## Rule Details
+
+This rule is aimed at highlighting possible typos and unexpected behavior in regular expressions which may arise from the use of empty character classes.
+
+The following patterns are considered warnings:
+
+```js
+var foo = /^abc[]/;
+
+/^abc[]/.test(foo);
+
+bar.match(/^abc[]/);
+```
+
+The following patterns are not considered warnings:
+
+```js
+var foo = /^abc/;
+
+var foo = /^abc[a-z]/;
+
+var bar = new RegExp("^abc[]");
+```

--- a/lib/rules/no-empty-class.js
+++ b/lib/rules/no-empty-class.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Rule to flag the use of empty character classes in regular expressions
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "Literal": function(node) {
+            var tokens = context.getTokens(node);
+            tokens.forEach(function (token) {
+                if (token.type === "RegularExpression" && /\[\]/.test(token.value) &&
+                        !/\[(.*)?\[\]/.test(token.value)) {
+                    context.report(node, "Empty class.");
+                }
+            });
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-empty-class.js
+++ b/tests/lib/rules/no-empty-class.js
@@ -1,0 +1,221 @@
+/**
+ * @fileoverview Tests for no-empty-class rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-empty-class";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+    "when evaluating 'var foo = /^abc[]/;'": {
+
+        topic: "var foo = /^abc[]/;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Empty class.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var foo = /foo[]bar/;'": {
+
+        topic: "var foo = /foo[]bar/;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Empty class.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'if (foo.match(/^abc[]/)) {}'": {
+
+        topic: "if (foo.match(/^abc[]/)) {}",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Empty class.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'if (/^abc[]/.test(foo)) {}'": {
+
+        topic: "if (/^abc[]/.test(foo)) {}",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Empty class.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var foo = /^abc[a-zA-Z]/;'": {
+
+        topic: "var foo = /^abc[a-zA-Z]/;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var regExp = new RegExp(\"^abc[]\");'": {
+
+        topic: "var regExp = new RegExp(\"^abc[]\");",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /^abc/;'": {
+
+        topic: "var foo = /^abc/;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /[\\[]/;'": {
+
+        topic: "var foo = /[\\[]/;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /[\\]]/;'": {
+
+        topic: "var foo = /[\\]]/;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /[a-zA-Z\\[]/;'": {
+
+        topic: "var foo = /[a-zA-Z\\[]/;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /[[]/;'": {
+
+        topic: "var foo = /[[]/;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /[]]/;'": {
+
+        topic: "var foo = /[]]/;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Empty class.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    }
+
+
+}).export(module);


### PR DESCRIPTION
The `no-empty-class` rule disallows the use of empty character classes in regular expression literals:

``` js
var foo = /^abc[]/;
```

It does not disallow empty character classes in the `RegExp` constructor:

``` js
var foo = new RegExp("^abc[]");
```

This rule matches the JSLint rule: http://jslinterrors.com/empty-class/
