### PR TITLE
Fix `no-empty-class` false negatives

### DIFF
--- a/lib/rules/no-empty-class.js
+++ b/lib/rules/no-empty-class.js
@@ -16,9 +16,39 @@ module.exports = function(context) {
         "Literal": function(node) {
             var tokens = context.getTokens(node);
             tokens.forEach(function (token) {
-                if (token.type === "RegularExpression" && /\[\]/.test(token.value) &&
-                        !/\[(.*)?\[\]/.test(token.value)) {
-                    context.report(node, "Empty class.");
+                if (token.type === "RegularExpression") {
+                    var open = false,
+                        tokenValue = token.value,
+                        at,
+                        character;
+
+                    for (at = 0; at < tokenValue.length; at++) {
+                        character = tokenValue.charAt(at);
+                        switch (character) {
+
+                        // Character is escaped, skip it.
+                        case "\\":
+                            at += 1;
+                            break;
+                        case "[":
+
+                            // Check for a matching closing bracket indicating
+                            // an empty class.
+                            if (tokenValue.charAt(at + 1) === "]" && !open) {
+                                context.report(node, "Empty class.");
+                            }
+
+                            // We are now inside a character class.
+                            open = true;
+                            break;
+
+                        // We are no longer in a character class, continue
+                        // checking for empty class.
+                        case "]":
+                            open = false;
+                            break;
+                        }
+                    }
                 }
             });
         }

--- a/tests/lib/rules/no-empty-class.js
+++ b/tests/lib/rules/no-empty-class.js
@@ -215,6 +215,57 @@ vows.describe(RULE_ID).addBatch({
             assert.equal(messages[0].message, "Empty class.");
             assert.include(messages[0].node.type, "Literal");
         }
+    },
+
+    "when evaluating 'var foo = /\\[[]/;'": {
+
+        topic: "var foo = /\\[[]/;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Empty class.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var foo = /[\\[a-z[]]/;'": {
+
+        topic: "var foo = /[\\[a-z[]]/;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /\\[\\[\\]a-z[]/;'": {
+
+        topic: "var foo = /\\[\\[\\]a-z[]/;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Empty class.");
+            assert.include(messages[0].node.type, "Literal");
+        }
     }
 
 


### PR DESCRIPTION
This fixes several false negatives when attempting to catch empty character classes in regular expressions, like so:

``` js
var foo = /\[[]/;
```

A more robust approach was taken in parsing the regular expression, which loosely follows the algorithm that JSLint uses for a similar purpose.

Fixes #267
