### PR TITLE
Fixing typo in guard-for-in documentation

### DIFF
--- a/docs/rules/guard-for-in.md
+++ b/docs/rules/guard-for-in.md
@@ -1,6 +1,6 @@
 # guard for in
 
-Looping over objects with a `for in` loop will include properties that are inherited through the prototype chain. This behavior can lean to unexpected items in your for loop.
+Looping over objects with a `for in` loop will include properties that are inherited through the prototype chain. This behavior can lead to unexpected items in your for loop.
 
 ```js
 for (key in foo) {


### PR DESCRIPTION
Just a small typo fix. No ticket created for it.
