### PR TITLE
Rule: no-iterator

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -48,6 +48,7 @@
         "no-unused-vars": 1,
         "no-script-url": 1,
         "no-proto": 1,
+        "no-iterator": 1,
         "no-mixed-requires": [0, false],
         "no-wrap-func": 1,
         "no-shadow": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -46,6 +46,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-unused-vars](no-unused-vars.md) - disallow declaration of variables that are not used in the code
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
 * [no-proto](no-proto.md) - disallow usage of `__proto__` property
+* [no-iterator](no-iterator.md) - disallow usage of `__iterator__` property
 * [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if`.
 * [no-shadow](no-shadow.md) - disallow declaration of variables already declared in the outer scope
 * [no-alert](no-alert.md) - disallow the use of `alert`, `confirm`, and `prompt`

--- a/docs/rules/no-iterator.md
+++ b/docs/rules/no-iterator.md
@@ -1,0 +1,37 @@
+# no iterator
+
+The `__iterator__` property can used to create custom iterators that are compatible with JavaScript's `for in` and `for each` constructs. However, this property is not supported in many browsers, so it should be used with caution.
+
+```js
+Foo.prototype.__iterator__ = function() {
+    return new FooIterator(this);
+}
+```
+
+## Rule Details
+
+This rule is aimed at preventing errors that may arise from using the `__iterator__` property, which is not implemented in several browsers. As such, it will warn whenever it encounters the `__iterator__` property.
+
+The following patterns are considered warnings:
+
+```js
+Foo.prototype.__iterator__ = function() {
+    return new FooIterator(this);
+};
+
+foo.__iterator__ = function () {};
+
+foo["__iterator__"] = function () {};
+
+```
+
+The following patterns are not considered warnings:
+
+```js
+var __iterator__ = foo; // Not using the `__iterator__` property.
+```
+
+## Further Reading
+
+* [MDN - Iterators and Generators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Iterators_and_Generators)
+* [ECMAScript 6 compatibility table - Iterators](http://kangax.github.io/es5-compat-table/es6/#Iterators)

--- a/lib/rules/no-iterator.js
+++ b/lib/rules/no-iterator.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Rule to flag usage of __iterator__ property
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "MemberExpression": function(node) {
+
+            if (node.property && (node.property.type === "Identifier" && node.property.name === "__iterator__") ||
+               (node.property.type === "Literal" && node.property.value === "__iterator__")) {
+                context.report(node, "Reserved name '__iterator__'.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-iterator.js
+++ b/tests/lib/rules/no-iterator.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Tests for no-iterator rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-iterator";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+    "when evaluating 'var a = test.__iterator__;": {
+
+        topic: "var a = test.__iterator__;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Reserved name '__iterator__'.");
+            assert.include(messages[0].node.type, "MemberExpression");
+        }
+    },
+
+    "when evaluating 'Foo.prototype.__iterator__ = function () {};": {
+
+        topic: "Foo.prototype.__iterator__ = function () {};",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Reserved name '__iterator__'.");
+            assert.include(messages[0].node.type, "MemberExpression");
+        }
+    },
+
+    "when evaluating 'var a = test[\"__iterator__\"];": {
+
+        topic: "var a = test['__iterator__'];",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Reserved name '__iterator__'.");
+            assert.include(messages[0].node.type, "MemberExpression");
+        }
+    },
+
+    "when evaluating a string 'var __iterator__ = null;": {
+
+        topic: "var __iterator__ = null;",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
The `no-iterator` rule disallows the use of the `__iterator__` property. The `__iterator__` property is not supported in many browsers and should be used with caution.

``` js
Foo.prototype.__iterator__ = function() {
    return new FooIterator(this);
}
```

This rule matches the _iterator_ rule in JS(H|L)int.
