### PR TITLE
Fix for `no-proto` and `no-iterator` false positive

### DIFF
--- a/lib/rules/no-iterator.js
+++ b/lib/rules/no-iterator.js
@@ -15,8 +15,9 @@ module.exports = function(context) {
 
         "MemberExpression": function(node) {
 
-            if (node.property && (node.property.type === "Identifier" && node.property.name === "__iterator__") ||
-               (node.property.type === "Literal" && node.property.value === "__iterator__")) {
+            if (node.property &&
+                    (node.property.type === "Identifier" && node.property.name === "__iterator__" && !node.computed) ||
+                    (node.property.type === "Literal" && node.property.value === "__iterator__")) {
                 context.report(node, "Reserved name '__iterator__'.");
             }
         }

--- a/lib/rules/no-proto.js
+++ b/lib/rules/no-proto.js
@@ -15,8 +15,9 @@ module.exports = function(context) {
 
         "MemberExpression": function(node) {
 
-            if (node.property && (node.property.type === "Identifier" && node.property.name === "__proto__") ||
-               (node.property.type === "Literal" && node.property.value === "__proto__")) {
+            if (node.property &&
+                    (node.property.type === "Identifier" && node.property.name === "__proto__" && !node.computed) ||
+                    (node.property.type === "Literal" && node.property.value === "__proto__")) {
                 context.report(node, "The '__proto__' property is deprecated.");
             }
         }

--- a/tests/lib/rules/no-iterator.js
+++ b/tests/lib/rules/no-iterator.js
@@ -40,6 +40,21 @@ vows.describe(RULE_ID).addBatch({
         }
     },
 
+    "when evaluating 'var a = test[__iterator__];": {
+
+        topic: "var a = test[__iterator__];",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
     "when evaluating 'Foo.prototype.__iterator__ = function () {};": {
 
         topic: "Foo.prototype.__iterator__ = function () {};",

--- a/tests/lib/rules/no-proto.js
+++ b/tests/lib/rules/no-proto.js
@@ -58,6 +58,22 @@ vows.describe(RULE_ID).addBatch({
         }
     },
 
+    "when evaluating 'var a = test[__proto__];": {
+
+        topic: "var a = test[__proto__];",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+
     "when evaluating a string 'var __proto__ = null;": {
 
         topic: "var __proto__ = null;",


### PR DESCRIPTION
This fixes an issue where both `no-proto` and `no-iterator` would incorrectly warn on the following code:

``` js
var foo = bar[__iterator__];
```

Because `__iterator__` is a variable and not a property on `bar`, there should be no warning.

This issue was raised with this comment: https://github.com/nzakas/eslint/pull/275#issuecomment-23296294
