### PR TITLE
Rule: no-octal-escape

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -28,6 +28,7 @@
         "no-undef": 1,
         "no-undef-init": 1,
         "no-octal": 1,
+        "no-octal-escape": 1,
         "no-obj-calls": 1,
         "no-new-wrappers": 1,
         "no-new": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -30,6 +30,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-undef-init] - disallow use of undefined when initializing variables
 * [no-floating-decimal] - disallow the use of leading or trailing decimal points in numeric literals
 * [no-octal] - disallow use of octal literals
+* [no-octal-escape] - disallow use of octal escape sequences in string literals, such as `var foo = "Copyright \251";`
 * [no-new](no-new.md) - disallow use of new operator when not part of the assignment or comparison
 * [no-new-func] - disallow use of new operator for `Function` object
 * [no-native-reassign] - disallow reassignments of native objects

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -1,0 +1,25 @@
+# no octal escape
+
+As of version 5 of the ECMAScript specification, octal escape sequences are a deprecated feature and should not be used. It is recommended that unicode escapes be used instead.
+
+```js
+var foo = "Copyright \251";
+```
+
+## Rule Details
+
+The rule is aimed at preventing the use of a deprecated JavaScript feature, the use of octal escape sequences. As such it will warn whenever an octal escape sequence is found in a string literal.
+
+The following patterns are considered warnings:
+
+```js
+var foo = "Copyright \251";
+```
+
+The following patterns are not considered warnings:
+
+```js
+var foo = "Copyright \u00A9";   // unicode
+
+var foo = "Copyright \xA9";     // hexadecimal
+```

--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Rule to flag octal escape sequences in string literals.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "Literal": function(node) {
+            var match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-7])/),
+                octalDigit;
+
+            if (match) {
+                octalDigit = match[2];
+                context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
+                        { octalDigit: octalDigit });
+            }
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-octal-escape.js
+++ b/tests/lib/rules/no-octal-escape.js
@@ -1,0 +1,129 @@
+/**
+ * @fileoverview Tests for no-octal-escape rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-octal-escape";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+    "when evaluating 'var foo = \"foo \\251 bar\";'": {
+
+        topic: "var foo = \"foo \\251 bar\";",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Don't use octal: '\\2'. Use '\\u....' instead.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+    "when evaluating 'var foo = \"\\751\";'": {
+
+        topic: "var foo = \"\\751\";",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Don't use octal: '\\7'. Use '\\u....' instead.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+
+    "when evaluating 'var foo = \"\\3s51\";'": {
+
+        topic: "var foo = \"\\3s51\";",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Don't use octal: '\\3'. Use '\\u....' instead.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+
+    "when evaluating 'var foo = \"\\851\";'": {
+
+        topic: "var foo = \"\\851\";",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = \"foo \\\\251 bar\";'": {
+
+        topic: "var foo = \"foo \\\\251 bar\";",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = \"\\\\\\751\";'": {
+
+        topic: "var foo = \"\\\\\\751\";",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Don't use octal: '\\7'. Use '\\u....' instead.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
+}).export(module);


### PR DESCRIPTION
The `no-octal-escape` rule disallows the use of octal escape sequences in string literals:

``` js
var foo = "Copyright \251";
```

This rule matches one with the same behavior in JSLint.

Fixes #246 Fixes #247
