### PR TITLE
Rule: no-func-assign

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -20,6 +20,7 @@
         "no-eq-null": 0,
         "no-eval": 1,
         "no-ex-assign": 1,
+        "no-func-assign": 1,
         "no-floating-decimal": 0,
         "no-implied-eval": 1,
         "no-with": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -15,6 +15,7 @@ The following rules point out areas where you might have made mistakes.
 * [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
 * [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals
 * [no-empty-class](no-empty-class.md) - disallow the use of empty character classes in regular expressions
+* [no-func-assign](no-func-assign.md) - disallow overwriting functions written as FunctionDeclarations
 
 ## Best Practices
 

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -1,0 +1,38 @@
+# no func assign
+
+JavaScript functions can be written as a FunctionDeclaration `function foo() { ... }` or as a FunctionExpression `var foo = function() { ... };`. While a JavaScript interpreter might tolerate it, overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
+
+```js
+function foo() {}
+foo = bar;
+```
+
+## Rule Details
+
+This rule is aimed at flagging probable mistakes and issues in the form of overwriting a function that was written as a FunctionDeclaration. As such it will warn when this issue is encountered.
+
+The following patterns are considered warnings:
+
+```js
+function foo() {}
+foo = bar;
+
+function foo {
+    foo = bar;
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+var foo = function () {}
+foo = bar;
+
+function foo(foo) { // `foo` is shadowed.
+    foo = bar;
+}
+
+function foo() {
+    var foo = bar;  // `foo` is shadowed.
+}
+```

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -1,0 +1,80 @@
+/**
+ * @fileoverview Rule to flag use of function declaration identifiers as variables.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /*
+     * Walk the scope chain looking for either a FunctionDeclaration or a
+     * VariableDeclaration with the same name as left-hand side of the
+     * AssignmentExpression. If we find the FunctionDeclaration first, then we
+     * warn, because a FunctionDeclaration is trying to become a Variable or a
+     * FunctionExpression. If we find a VariableDeclaration first, then we have
+     * a legitimate shadow variable.
+     */
+    function checkIfIdentifierIsFunction(scope, name) {
+        var variable,
+            def,
+            i,
+            j;
+
+        // Loop over all of the identifiers available in scope.
+        for (i = 0; i < scope.variables.length; i++) {
+            variable = scope.variables[i];
+
+            // For each identifier, see if it was defined in _this_ scope.
+            for (j = 0; j < variable.defs.length; j++) {
+                def = variable.defs[j];
+
+                // Identifier is a function and was declared in this scope
+                if (def.name.name === name && def.type === "FunctionName") {
+                    return true;
+                }
+
+                // Identifier is a variable and was declared in this scope. This
+                // is a legitimate shadow variable.
+                if (def.name.name === name) {
+                    return false;
+                }
+            }
+        }
+
+        // Check the upper scope.
+        if (scope.upper) {
+            return checkIfIdentifierIsFunction(scope.upper, name);
+        }
+
+        // We've reached the global scope and haven't found anything.
+        return false;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "AssignmentExpression": function(node) {
+            var scope = context.getScope(),
+                name = node.left.name;
+
+            if (checkIfIdentifierIsFunction(scope, name)) {
+                context.report(node, "'{{name}}' is a function.", { name: name });
+            }
+
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-func-assign.js
+++ b/tests/lib/rules/no-func-assign.js
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Tests for no-func-assign.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-func-assign";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'function foo() {} foo = bar;'": {
+
+        topic: "function foo() {} foo = bar;",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "'foo' is a function.");
+            assert.include(messages[0].node.type, "AssignmentExpression");
+        }
+    },
+
+    "when evaluating 'function foo() { foo = bar; }'": {
+
+        topic: "function foo() { foo = bar; }",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "'foo' is a function.");
+            assert.include(messages[0].node.type, "AssignmentExpression");
+        }
+    },
+
+    "when evaluating 'function foo() { var foo = bar; }'": {
+
+        topic: "function foo() { var foo = bar; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'function foo(foo) { foo = bar; }'": {
+
+        topic: "function foo(foo) { foo = bar; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'function foo() { var foo; foo = bar; }'": {
+
+        topic: "function foo() { var foo; foo = bar; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = function() {}; foo = bar;'": {
+
+        topic: "var foo = function() {}; foo = bar;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = function() { foo = bar; };'": {
+
+        topic: "var foo = function() { foo = bar; };",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'foo = bar; function foo() { };'": {
+
+        topic: "foo = bar; function foo() { };",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+}).export(module);


### PR DESCRIPTION
I'm not sure this is the best name for this rule is and I'm also having a difficult time articulating in the documentation what this rule does and why. I would love feedback on that if anyone has suggestions.

---

The `no-func-assign` rule disallows overwriting functions that were written as a FunctionDeclaration.

``` js
function foo() {}
foo = bar;
```

This rule matches JSHint rule W021.
