### PR TITLE
Fix false warning from no-undef rule (fixes #283)

### DIFF
--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 function isImplicitGlobal(variable) {
-    return variable.defs.some(function(def) {
+    return variable.defs.every(function(def) {
         return def.type === "ImplicitGlobalVariable";
     });
 }

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -159,6 +159,19 @@ vows.describe(RULE_ID).addBatch({
         }
     },
 
+    "when evaluating write to to an explicitly declared variable in global scope from function scope": {
+        topic: "var a; function f() { a = 1; }",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
     "when evaluating write to a declared writeable global": {
         topic: "/*global b:true*/ b++;",
 


### PR DESCRIPTION
This fixes the helper function used to determine whether a given variable represents an implicit global. Previously, it would flag variable `a` (in the test code) as an implicit global, when it is not.
