### PR TITLE
Rule: ie-catch-leak

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -10,6 +10,7 @@
         "no-alert": 1,
         "no-caller": 1,
         "no-bitwise": 0,
+        "no-catch-shadow": 1,
         "no-console": 1,
         "no-comma-dangle": 1,
         "no-debugger": 1,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -25,6 +25,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [curly](curly.md) - require curly brace for all control statements
 * [eqeqeq](eqeqeq.md) - require the use of `===` and `!==`
 * [dot-notation](dot-notation.md) - encourages use of dot notation whenever possible
+* [no-catch-shadow](no-catch-shadow.md) - disallow the catch clause parameter name being the same as a variable in the outer scope
 * [no-eval](no-eval.md) - disallow use of `eval()`
 * [no-with](no-with.md) - disallow use of the `with` statement
 * [no-undef](no-undef.md) - disallow use of undeclared variables unless mentioned in a `/*global */` block

--- a/docs/rules/no-catch-shadow.md
+++ b/docs/rules/no-catch-shadow.md
@@ -1,0 +1,67 @@
+# no catch shadow
+
+In IE 8 and earlier, the catch clause parameter can overwrite the value of a variable in the outer scope, if that variable has the same name as the catch clause parameter.
+
+```js
+var err = "x";
+
+try {
+    throw "problem";
+} catch (err) {
+
+}
+
+console.log(err)    // err is 'problem', not 'x'
+```
+
+## Rule Details
+
+This rule is aimed at preventing unexpected behavior in your program that may arise from a bug in IE 8 and earlier, in which the catch clause parameter can leak into outer scopes. This rule will warn whenever it encounters a catch clause parameter that has the same name as a variable in an outer scope.
+
+The following patterns are considered warnings:
+
+```js
+var err = "x";
+
+try {
+    throw "problem";
+} catch (err) {
+
+}
+
+function err() {
+    ...
+};
+
+try {
+    throw "problem";
+} catch (err) {
+
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+var err = "x";
+
+try {
+    throw "problem";
+} catch (e) {
+
+}
+
+function err() {
+    ...
+};
+
+try {
+    throw "problem";
+} catch (e) {
+
+}
+```
+
+## When Not To Use It
+
+If you do not need to support IE 8 and earlier, you should turn this rule off.

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -1,0 +1,50 @@
+/**
+ * @fileoverview Rule to flag variable leak in CatchClauses in IE 8 and earlier
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    function paramIsShadowing(scope, name) {
+        var found = scope.variables.some(function(variable) {
+            return variable.name === name;
+        });
+
+        if (found) {
+            return true;
+        }
+
+        if (scope.upper) {
+            return paramIsShadowing(scope.upper, name);
+        }
+
+        return false;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "CatchClause": function(node) {
+            var scope = context.getScope();
+
+            if (paramIsShadowing(scope, node.param.name)) {
+                context.report(node, "Value of '{{name}}' may be overwritten in IE 8 and earlier.",
+                        { name: node.param.name });
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-catch-shadow.js
+++ b/tests/lib/rules/no-catch-shadow.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Tests for no-catch-shadow rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-catch-shadow";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var foo = 1; try { bar(); } catch(foo) { }'": {
+
+        topic: "var foo = 1; try { bar(); } catch(foo) { }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Value of 'foo' may be overwritten in IE 8 and earlier.");
+            assert.include(messages[0].node.type, "CatchClause");
+        }
+    },
+
+    "when evaluating 'function foo(){} try { bar(); } catch(foo) { }'": {
+
+        topic: "function foo(){} try { bar(); } catch(foo) { }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Value of 'foo' may be overwritten in IE 8 and earlier.");
+            assert.include(messages[0].node.type, "CatchClause");
+        }
+    },
+
+    "when evaluating 'function foo(){ try { bar(); } catch(foo) { } }'": {
+
+        topic: "function foo(){ try { bar(); } catch(foo) { } }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Value of 'foo' may be overwritten in IE 8 and earlier.");
+            assert.include(messages[0].node.type, "CatchClause");
+        }
+    },
+
+    "when evaluating 'var foo = function(){ try { bar(); } catch(foo) { } };'": {
+
+        topic: "var foo = function(){ try { bar(); } catch(foo) { } };",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Value of 'foo' may be overwritten in IE 8 and earlier.");
+            assert.include(messages[0].node.type, "CatchClause");
+        }
+    },
+
+    "when evaluating 'var foo = 1; try { bar(); } catch(baz) { }'": {
+
+        topic: "var foo = 1; try { bar(); } catch(baz) { }",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = [1, 2];
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
The `ie-catch-leak` rule disallows a catch clause parameter with the same name as a variable in the outer scope. IE 8 and earlier will leak the catch clause parameter into the outer scope and overwrite the outer scope variable value.

``` js
var err = "x";

try {
    throw "problem";
} catch (err) {

}

console.log(err)    // err is 'problem', not 'x'
```

This rule matches JSHint rule W002.
