### PR TITLE
Update no-empty for compatibility with esprima@1.0.4 (fixes #290)

### DIFF
--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -27,7 +27,7 @@ module.exports = function(context) {
 
         "SwitchStatement": function(node) {
 
-            if (typeof node.cases === "undefined") {
+            if (typeof node.cases === "undefined" || node.cases.length === 0) {
                 context.report(node, "Empty switch statement.");
             }
         }


### PR DESCRIPTION
As of esprima 1.0.4, an empty switch statement will have a `cases` property set to a 0-length array. Prior to that, no `cases` property would be defined. This change should make `no-empty` work correctly under both versions of esprima.
