### PR TITLE
bug: no-empty-class does not respect escape

### DIFF
--- a/lib/rules/no-empty-class.js
+++ b/lib/rules/no-empty-class.js
@@ -15,9 +15,38 @@ module.exports = function(context) {
 
         "Literal": function(node) {
             var tokens = context.getTokens(node);
+
             tokens.forEach(function (token) {
-                if (token.type === "RegularExpression" && !/^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/$/.test(token.value)) {
-                    context.report(node, "Empty class.");
+                if (token.type === "RegularExpression") {
+                    var open = false,
+                        tokenValue = token.value,
+                        at,
+                        character;
+
+                    for (at = 0; at < tokenValue.length; at++) {
+                        character = tokenValue.charAt(at);
+                        switch (character) {
+                        // Character is escaped, skip it.
+                        case "\\":
+                            at += 1;
+                            break;
+                        case "[":
+                            // Check for a matching closing bracket indicating
+                            // an empty class.
+                            if (tokenValue.charAt(at + 1) === "]" && !open) {
+                                context.report(node, "Empty class.");
+                            }
+
+                            // We are now inside a character class.
+                            open = true;
+                            break;
+                        // We are no longer in a character class, continue
+                        // checking for empty class.
+                        case "]":
+                            open = false;
+                            break;
+                        }
+                    }
                 }
             });
         }

--- a/tests/lib/rules/no-empty-class.js
+++ b/tests/lib/rules/no-empty-class.js
@@ -266,6 +266,36 @@ vows.describe(RULE_ID).addBatch({
             assert.equal(messages[0].message, "Empty class.");
             assert.include(messages[0].node.type, "Literal");
         }
+    },
+
+    "when evaluating 'var foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;'": {
+
+        topic: "var foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var foo = /\\s*:\\s*/g;'": {
+
+        topic: "var foo = /\\s*:\\s*/g;",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 0);
+        }
     }
 
 


### PR DESCRIPTION
This addresses and fixes issue https://github.com/nzakas/eslint/issues/289. It seems like the regression was originally introduced in 66d211ce3807890d9531dc4754961870349ac6db, this commit mostly just reverts the change and adds the test cases for these specific escapings.
