### PR TITLE
Rule: no-var-leak

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -57,6 +57,7 @@
         "no-shadow": 1,
         "no-use-before-define": 1,
         "no-redeclare": 1,
+        "no-var-leak": 1,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -16,6 +16,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals
 * [no-empty-class](no-empty-class.md) - disallow the use of empty character classes in regular expressions
 * [no-func-assign](no-func-assign.md) - disallow overwriting functions written as FunctionDeclarations
+* [no-var-leak](no-var-leak.md) - disallow leaking variables into outer scopes with improper variable declarations.
 
 ## Best Practices
 

--- a/docs/rules/no-var-leak.md
+++ b/docs/rules/no-var-leak.md
@@ -1,0 +1,31 @@
+# no var leak
+
+Variables declared without the `var` keyword are implicity given global scope. A common mistake is to accidentally declare an implicit global variable or to override a variable in an outer scope by improperly declaring variables in multiple inline assignments.
+
+```js
+var x = y = "example";
+```
+
+## Rule Details
+
+This rule is aimed at preventing unexpected behavior that could arise from leaking variables into outer scopes by improperly declaring variables in multiple inline assignments. As such, it will warn when it encounters an assignment expression as the initial value of a variable declaration.
+
+The following patterns are considered warnings:
+
+```js
+var x = y = "example";
+
+var x = y = z;
+```
+
+The following patterns are not considered warnings:
+
+```js
+x = y = z;
+
+x = y = {
+    key: "example"
+};
+
+var w = x >= y;
+```

--- a/lib/rules/no-var-leak.js
+++ b/lib/rules/no-var-leak.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Rule to flag possible variable leaks in variable declarations
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "VariableDeclarator": function(node) {
+            if (node.init && node.init.type === "AssignmentExpression" && node.init.left.type === "Identifier") {
+                context.report(node.init,
+                        "You might be leaking a variable ({{name}}) here.", { name: node.init.left.name });
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-var-leak.js
+++ b/tests/lib/rules/no-var-leak.js
@@ -1,0 +1,134 @@
+/**
+ * @fileoverview Tests for no-var-leak rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-var-leak";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating 'var x = y = \"example\";'": {
+
+        topic: "var x = y = \"example\";",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "You might be leaking a variable (y) here.");
+            assert.include(messages[0].node.type, "AssignmentExpression");
+        }
+    },
+
+    "when evaluating 'var x = y = z = \"example\";'": {
+
+        topic: "var x = y = z = \"example\";",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "You might be leaking a variable (y) here.");
+            assert.include(messages[0].node.type, "AssignmentExpression");
+        }
+    },
+
+    "when evaluating 'var w = x = y = z = \"example\";'": {
+
+        topic: "var w = x = y = z = \"example\";",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "You might be leaking a variable (x) here.");
+            assert.include(messages[0].node.type, "AssignmentExpression");
+        }
+    },
+
+    "when evaluating 'var w = x = y, q = z = \"example\";'": {
+
+        topic: "var w = x = y, q = z = \"example\";",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 2);
+
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "You might be leaking a variable (x) here.");
+            assert.include(messages[0].node.type, "AssignmentExpression");
+
+            assert.equal(messages[1].ruleId, RULE_ID);
+            assert.equal(messages[1].message, "You might be leaking a variable (z) here.");
+            assert.include(messages[1].node.type, "AssignmentExpression");
+        }
+    },
+
+    "when evaluating 'var x = y.z = \"example\";'": {
+
+        topic: "var x = y.z = \"example\";",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'x = y = \"example\";'": {
+
+        topic: "x = y = \"example\";",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating 'var w = x >= y;'": {
+
+        topic: "var w = x >= y;",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+}).export(module);


### PR DESCRIPTION
The `no-var-leak` rule disallows multiple inline assignments in variable declarations, as this can lead to implicit global variables and accidental variable leaks into the outer scope.

``` js
var x = y = "example";
```

This rule matches JSHint warning W120.
