### PR TITLE
Upgrading escope version and fixing related bugs (Closes #296)

### DIFF
--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -22,6 +22,13 @@ function foo {
 }
 ```
 
+Unlike the same rule in JSHint, the following pattern is also considered a warning:
+```js
+foo = bar;
+function foo() {}
+```
+
+
 The following patterns are not considered warnings:
 
 ```js

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "estraverse": "~1.3.0",
         "esprima": "*",
         "jshint": "*",
-        "escope": "0.0.14"
+        "escope": "1.0.0"
     },
     "devDependencies": {
         "vows": "~0.7.0",

--- a/tests/lib/rules/no-func-assign.js
+++ b/tests/lib/rules/no-func-assign.js
@@ -23,9 +23,9 @@ var RULE_ID = "no-func-assign";
 
 vows.describe(RULE_ID).addBatch({
 
-    "when evaluating 'function foo() {} foo = bar;'": {
+    "when evaluating 'function foo() {}; foo = bar;'": {
 
-        topic: "function foo() {} foo = bar;",
+        topic: "function foo() {}; foo = bar;",
 
         "should report a violation": function(topic) {
 
@@ -131,13 +131,16 @@ vows.describe(RULE_ID).addBatch({
 
         topic: "foo = bar; function foo() { };",
 
-        "should not report a violation": function(topic) {
+        "should report a violation": function(topic) {
 
             var config = { rules: {} };
             config.rules[RULE_ID] = 1;
 
             var messages = eslint.verify(topic, config);
-            assert.equal(messages.length, 0);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "'foo' is a function.");
+            assert.include(messages[0].node.type, "AssignmentExpression");
         }
     },
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -245,7 +245,7 @@ vows.describe(RULE_ID).addBatch({
             config.rules[RULE_ID] = 1;
             var messages = eslint.verify(topic, config);
 
-            assert.equal(messages.length, 4);
+            assert.equal(messages.length, 3); //f, a, b are unused
             assert.equal(messages[0].ruleId, RULE_ID);
             assert.equal(messages[0].message, "f is defined but never used");
             assert.include(messages[0].node.type, "Identifier");


### PR DESCRIPTION
Closes #296 Escope 1.0.0 fixed the issue described in the ticket. Fixing some broken unittests that were passing because they were expecting incorrect results.
