### PR TITLE
Rule: No conditional expression (Closes #307)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -57,6 +57,7 @@
         "no-shadow": 1,
         "no-use-before-define": 1,
         "no-redeclare": 1,
+        "no-logic-outside-tests": 1,
 
         "smarter-eqeqeq": 0,
         "brace-style": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -55,6 +55,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-alert](no-alert.md) - disallow the use of `alert`, `confirm`, and `prompt`
 * [no-use-before-define](no-use-before-define.md) - disallow use of variables before they are defined
 * [no-redeclare](no-redeclare.md) - disallow declaring the same variable more then once
+* [no-logic-outside-tests](no-logic-outside-tests.md) - disallow use of conditional expressions outside of `if`, `for`, `while` and `do`
 
 ## Stylistic Issues
 

--- a/docs/rules/no-logic-outside-tests.md
+++ b/docs/rules/no-logic-outside-tests.md
@@ -1,0 +1,23 @@
+# no logical expressions outside tests
+
+## Rule Details
+
+This error is raised to highlight the use of a bad practice. Logical expressions outside if, for, while and do decrease readability of the code and can lead to confusion.
+
+The following patterns are considered warnings:
+
+```js
+v && arr.push(v)
+```
+
+The following patterns are not considered warnings:
+
+```js
+if (v) {
+    arr.push(v);
+}
+
+if (v && arr.push(v)) {
+    ...
+}
+```

--- a/lib/rules/no-logic-outside-tests.js
+++ b/lib/rules/no-logic-outside-tests.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Rule to flag when using logical expressions outside of if, for, while, do statements
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "LogicalExpression": function(node) {
+            var ancestors = context.getAncestors(node);
+            var parent = ancestors.pop();
+            if(!(parent && (node === parent.test || parent.type === "LogicalExpression"))) {
+                context.report(node, "Expected an assignment or function call and instead saw an expression");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-logic-outside-tests.js
+++ b/tests/lib/rules/no-logic-outside-tests.js
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview Tests for no-logic-outside-tests rule.
+ * @author Ilya Volodin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-logic-outside-tests";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+    "when evaluating 'v && arr.push(v);'": {
+
+        topic: "v && arr.push(v);",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Expected an assignment or function call and instead saw an expression");
+            assert.include(messages[0].node.type, "LogicalExpression");
+        }
+    },
+
+    "when evaluating a string 'if (v && arr.push(v)) { }": {
+
+        topic: "if (v && arr.push(v)) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a string 'while (v && arr.push(v)) { }": {
+
+        topic: "while (v && arr.push(v)) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a string 'for (var v=0; v && arr.push(v); v++) { }": {
+
+        topic: "for (var v=0; v && arr.push(v); v++) { }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a string 'do {} while (v && arr.push(v))": {
+
+        topic: "do {} while (v && arr.push(v))",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a string 'var test = v && arr.push(v) ? v : arr[0];": {
+
+        topic: "var test = v && arr.push(v) ? v : arr[0];",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a string 'if (a && b && c) { alert(a); }": {
+
+        topic: "if (a && b && c) { alert(a); }",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    }
+}).export(module);


### PR DESCRIPTION
Closes #307 I'm not 100% I caught all use cases that matter and that JSHint W030 rule is supposed to catch. W030 rules is also supposed to catch the following case:

```
var a = 0;
a;
```

But I have no idea how to catch something like that. Let me know if you don't want to merge it as it is now.
