### PR TITLE
no-use-before-define.js respects function declarations

### DIFF
--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -8,7 +8,7 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    
+
     "use strict";
 
     var findDeclaration = function(name, scope) {
@@ -27,9 +27,15 @@ module.exports = function(context) {
     var findVariables = function() {
         var scope = context.getScope();
 
+        var isFunctionDeclaration = function(declaration) {
+            return declaration.defs[0].node.type === "FunctionDeclaration";
+        };
+
         var checkLocationAndReport = function(reference, declaration) {
             if (declaration.identifiers[0].range[1] > reference.identifier.range[1]) {
-                context.report(reference.identifier, "{{a}} was used before it was defined", {a: reference.identifier.name});
+                if (!isFunctionDeclaration(declaration)) {
+                    context.report(reference.identifier, "{{a}} was used before it was defined", {a: reference.identifier.name});
+                }
             }
         };
 

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -72,7 +72,7 @@ vows.describe(RULE_ID).addBatch({
             assert.equal(messages[0].message, "a was used before it was defined");
             assert.include(messages[0].node.type, "Identifier");
         }
-    },    
+    },
 
     "when evaluating 'a(); function a() { alert(b); var b=10; a(); }'": {
 
@@ -84,9 +84,9 @@ vows.describe(RULE_ID).addBatch({
 
             var messages = eslint.verify(topic, config);
 
-            assert.equal(messages.length, 2);
+            assert.equal(messages.length, 1);
             assert.equal(messages[0].ruleId, RULE_ID);
-            assert.equal(messages[0].message, "a was used before it was defined");
+            assert.equal(messages[0].message, "b was used before it was defined");
             assert.include(messages[0].node.type, "Identifier");
         }
     },
@@ -141,5 +141,19 @@ vows.describe(RULE_ID).addBatch({
             var messages = eslint.verify(topic, config);
             assert.equal(messages.length, 0);
         }
+    },
+
+    "when evaluating 'namedFunctionDeclaration(); function namedFunctionDeclaration() {};'": {
+
+        topic: "myFunctionDeclaration(); function myFunctionDeclaration() {};",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
     }
+
 }).export(module);


### PR DESCRIPTION
Previously the no-use-before-define.js rule would throw a warning when you reference a named function declaration (i.e. named function defined in Program scope or Function scope, but not in a block or other expression). With this you can now declare your functions at the end of your files or the end of your functions if you prefer. It also allows you to have recursive functions (Yay!!).

This pull request fixes #306 . I didn't check if it fixes issue #302, but it may.

More info on the difference between named Function Declarations and named Function Expressions:

http://kangax.github.io/nfe/
