### PR TITLE
Added further instructions for multiline test cases.

### DIFF
--- a/docs/developer-guide/unit-tests.md
+++ b/docs/developer-guide/unit-tests.md
@@ -7,3 +7,15 @@ When you first get the source code, you need to run `npm link` once initially to
     npm test
 
 This automatically starts Vows and runs all tests in the `tests` directory. You need only add yours and it will automatically be picked up when running tests.
+
+## Multiline Tests
+
+Tests should be discrete and test one thing and one thing only whenever possible. Most tests should be kept short enough that they fit on one line. However, if your test case is long, you can use the following format for the `topic`:
+
+    topic: [
+        "// my line comment",
+        "var a = 42;",
+        "/* my block comment */"
+    ].join("\n"),
+    
+This example can be found in `tests/lib/rules/no-unused-vars.js`


### PR DESCRIPTION
Added some details to the unit test docs, explaining how people should write multiline tests so they don't have to go looking for the one or two examples currently in the code base. Fixes #312 
