### PR TITLE
recognise CallExpression variant of RegExp constructor in no-control-regex rule

### DIFF
--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -19,7 +19,8 @@ module.exports = function(context) {
         } else if (typeof node.value === "string") {
 
             var parent = context.getAncestors().pop();
-            if (parent.type === "NewExpression" && parent.callee.name === "RegExp") {
+            if ((parent.type === "NewExpression" || parent.type === "CallExpression") &&
+            parent.callee.type === "Identifier" && parent.callee.name === "RegExp") {
 
                 // there could be an invalid regular expression string
                 try {

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -57,6 +57,23 @@ vows.describe(RULE_ID).addBatch({
         }
     },
 
+    "when evaluating a regular expression object with a control character (without new)": {
+
+        topic: "var regex = RegExp('\\x1f')",
+
+        "should report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "Unexpected control character in regular expression.");
+            assert.include(messages[0].node.type, "Literal");
+        }
+    },
+
     "when evaluating a regular expression literal without a control character": {
 
         topic: "var regex = /x1f/",
@@ -85,9 +102,37 @@ vows.describe(RULE_ID).addBatch({
         }
     },
 
+    "when evaluating a regular expression object without a control character (without new)": {
+
+        topic: "var regex = RegExp('x1f')",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
     "when evaluating a regular expression object with invalid pattern": {
 
         topic: "new RegExp('[')",
+
+        "should not report a violation": function(topic) {
+
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a regular expression object with invalid pattern (without new)": {
+
+        topic: "RegExp('[')",
 
         "should not report a violation": function(topic) {
 


### PR DESCRIPTION
This corrects the inconsistency I mentioned in https://github.com/nzakas/eslint/commit/ec6a485a2e0ade0701f5908e4264c97eb01c9c5f#commitcomment-4499816.
