### PR TITLE
added files array in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,13 @@
     "lint": "node node_modules/jshint/bin/jshint ./conf/eslint.json ./lib",
     "bundle": "bash scripts/bundle.sh"
   },
+  "files": [
+    "LICENSE",
+    "README.md",
+    "bin",
+    "conf",
+    "lib"
+  ],
   "repository": {
     "type": "git",
     "url": "https://github.com/nzakas/eslint"


### PR DESCRIPTION
I added the files array to the `package.json` file. The [files property](https://npmjs.org/doc/json.html#files) allows to define what files are included in a package. 

This way you can define what files and folders are included if someone uses eslint as a dependency. The pull request has the `LICENSE`, `README.md` files and `bin`, `conf`, `lib` directories added in the `files` array.

This results in the following structure when installed with npm:
![eslint-node_modules](https://f.cloud.github.com/assets/1205444/1485592/554ffa2c-4717-11e3-98c6-efce80ef47c7.png)

The reason I added this is that I want to use eslint as jslint/jshint replacement. Both of them have an additional phrase in their [MIT license](https://github.com/jshint/jshint/issues/1234) which makes jshint/jslint [nonfree software](https://www.gnu.org/licenses/license-list.html#JSON). Right now the `jshint.js` is included in the `tests/performance`. 
This is a problem for some users.

If there's something wrong with this patch, I would appreciate feedback.

Cheers
