### PR TITLE
fixes #372: disallow negated left operand in `in` operator

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -62,6 +62,7 @@
         "no-shadow": 2,
         "no-use-before-define": 2,
         "no-redeclare": 2,
+        "no-negated-in-lhs": 2,
 
         "brace-style": 0,
         "block-scoped-var": 0,

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -1,0 +1,29 @@
+# no negated left operand of `in` operator
+
+## Rule Details
+
+This error is raised to highlight a potential error. Commonly, when a developer intends to write
+
+```js
+if(!(a in b)) // do something
+```
+
+they will instead write
+
+```js
+if(!a in b) // do something
+```
+
+If one intended the original behaviour, the left operand should be explicitly coerced to a string like below.
+
+```js
+if(('' + !a) in b) // do something
+```
+
+## When Not To Use It
+
+Never.
+
+## Further Reading
+
+None.

--- a/lib/rules/no-negated-in-lhs.js
+++ b/lib/rules/no-negated-in-lhs.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview A rule to disallow negated left operands of the `in` operator
+ * @author Michael Ficarra
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "BinaryExpression": function(node) {
+            if (node.operator === "in" && node.left.type === "UnaryExpression" && node.left.operator === "!") {
+                context.report(node, "The `in` expression's left operand is negated");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-negated-in-lhs.js
+++ b/tests/lib/rules/no-negated-in-lhs.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview Tests for the no-negated-in-lhs rule
+ * @author Michael Ficarra
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var vows = require("vows"),
+    assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var RULE_ID = "no-negated-in-lhs";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+vows.describe(RULE_ID).addBatch({
+
+    "when evaluating an 'in' expression": {
+
+        topic: "a in b",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating a negated 'in' expression": {
+
+        topic: "!(a in b)",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
+    },
+
+    "when evaluating an 'in' expression with a negated LHS": {
+
+        topic: "!a in b",
+
+        "should report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, RULE_ID);
+            assert.equal(messages[0].message, "The `in` expression's left operand is negated");
+            assert.include(messages[0].node.type, "BinaryExpression");
+        }
+    }
+
+}).export(module);


### PR DESCRIPTION
Fixes #372.
