### PR TITLE
Fix browser build

### DIFF
--- a/scripts/bundle.sh
+++ b/scripts/bundle.sh
@@ -1,3 +1,5 @@
+#!/bin/sh
+
 outputDir=build
 bundleFile=$outputDir/eslint-min.js
 excludes=(


### PR DESCRIPTION
This fixes #384 by manually excluding rules that cannot run in the browser (currently just `no-mixed-requires`).
