### PR TITLE
Fix error about IIFE if the function is in a new

### DIFF
--- a/lib/rules/no-wrap-func.js
+++ b/lib/rules/no-wrap-func.js
@@ -14,10 +14,10 @@ module.exports = function(context) {
     return {
 
         "FunctionExpression": function(node) {
-            
+
             var ancestors = context.getAncestors();
-            
-            if (ancestors.pop().type !== "CallExpression") {
+
+            if (!/CallExpression|NewExpression/.test(ancestors.pop().type)) {
                 var tokens = context.getTokens(node, 1, 1);
                 if (tokens[0].value === "(" && tokens[tokens.length - 1].value === ")") {
                     context.report(node, "Wrapping non-IIFE function literals in parens is unnecessary.");

--- a/tests/lib/rules/no-wrap-func.js
+++ b/tests/lib/rules/no-wrap-func.js
@@ -81,6 +81,18 @@ vows.describe(RULE_ID).addBatch({
             var messages = eslint.verify(topic, config);
             assert.equal(messages.length, 0);
         }
+    },
+
+    "when evaluating a string 'new Object(function() {})": {
+
+        topic: "new Object(function() {})",
+
+        "should not report a violation": function(topic) {
+            var config = { rules: {} };
+            config.rules[RULE_ID] = 1;
+            var messages = eslint.verify(topic, config);
+            assert.equal(messages.length, 0);
+        }
     }
 
 }).export(module);


### PR DESCRIPTION
If a function is inside a `new` construct, it warns about IIFE while it shouldn't.
