### PR TITLE
added mocha conversion tests for quote-props and one-var

### DIFF
--- a/tests/mocha/lib/rules/one-var.js
+++ b/tests/mocha/lib/rules/one-var.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Tests for one-var.
+ * @author Ian Christian Myers and Michael Paulukonis
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("../../../../lib/tests/eslintTester");
+
+eslintTester.add("one-var", {
+    valid: [
+        "function foo() { var bar = true; }",
+        "function foo() { var bar = true, baz = 1; if (qux) { bar = false; } }",
+        "var foo = function () { var bar = true; baz(); }"
+    ],
+    invalid: [
+        { code: "function foo() { var bar = true; var baz = false; }",
+          errors: [{ message: "Combine this with the previous 'var' statement.", type: "VariableDeclaration"}] },
+        { code: "function foo() { var bar = true; if (qux) { var baz = false; } else { var quxx = 42; } }",
+          errors: [
+              { message: "Combine this with the previous 'var' statement.", type: "VariableDeclaration"},
+              { message: "Combine this with the previous 'var' statement.", type: "VariableDeclaration"}
+          ] },
+        { code: "var foo = function () { var bar = true; var baz = false; }",
+          errors: [{ message: "Combine this with the previous 'var' statement.", type: "VariableDeclaration"}] },
+        { code: "var foo = function () { var bar = true; if (qux) { var baz = false; } }",
+          errors: [{ message: "Combine this with the previous 'var' statement.", type: "VariableDeclaration"}] },
+        { code: "var foo; var bar;",
+          errors: [{ message: "Combine this with the previous 'var' statement.", type: "VariableDeclaration"}] }
+    ]
+});

--- a/tests/mocha/lib/rules/quote-props.js
+++ b/tests/mocha/lib/rules/quote-props.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Tests for quote-props rule.
+ * @author Mathias Bynens <http://mathiasbynens.be/>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("../../../../lib/tests/eslintTester");
+
+eslintTester.add("quote-props", {
+    valid: [
+        "var x = { 'foo': 42 }",
+        "var x = { \"foo\": 42 }"
+           ],
+    invalid: [
+        { code: "var x = { foo: 42 }",
+          errors: [{ message: "Non-quoted property `foo` found.", type: "Property"}] }
+    ]
+});


### PR DESCRIPTION
Continuing the lists at issue #397 - enhanced one of the invalid one-var tests that was expecting two messages to actually check the content of both messages
