### PR TITLE
Converting formatter tests and core to mocha

### DIFF
--- a/tests/mocha/lib/cli.js
+++ b/tests/mocha/lib/cli.js
@@ -1,0 +1,231 @@
+/**
+ * @fileoverview Tests for cli.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    cli = require("../../../lib/cli"),
+    path = require("path");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("cli", function() {
+    describe("when given a config file", function() {
+        var code = "conf/eslint.json";
+
+        it("should load the specified config file", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            assert.doesNotThrow(function () {
+                cli.execute(["-c", code, "lib/cli.js"]);
+            });
+
+            console.log = log;
+        });
+    });
+
+    describe("when there is a local config file", function() {
+        var code = ["lib/cli.js"];
+
+        it("should load the local config file", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            // Mock CWD
+            process.eslintCwd = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes");
+
+            assert.doesNotThrow(function () {
+                exitStatus = cli.execute(code);
+            });
+
+            cli.execute(code);
+
+            process.eslintCwd = null;
+            console.log = log;
+        });
+    });
+
+    describe("when given a config with rules with options and severity level set to error", function() {
+        var code = ["--config", "tests/fixtures/configurations/quotes-error.json", "single-quoted.js"];
+
+        it("should exit with an error status (1)", function() {
+            var log = console.log,
+                exitStatus;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            assert.doesNotThrow(function () {
+                exitStatus = cli.execute(code);
+            });
+            console.log = log;
+
+            assert.equal(exitStatus, 1);
+        });
+    });
+
+    describe("when given a config file and a directory of files", function() {
+        var code = ["--config","tests/fixtures/configurations/semi-error.json", "tests/fixtures/formatters"];
+
+        it("should load and execute without error", function() {
+            var log = console.log,
+                exitStatus;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            assert.doesNotThrow(function () {
+                exitStatus = cli.execute(code);
+            });
+            console.log = log;
+
+            assert.equal(exitStatus, 0);
+        });
+    });
+
+    describe("when given a config with environment set to browser", function() {
+        var code = ["--config", "tests/fixtures/configurations/env-browser.json", "tests/fixtures/globals-browser.js"];
+
+        it("should execute without any errors", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+            var exit = cli.execute(code);
+            assert.equal(exit, 0);
+
+            console.log = log;
+        });
+    });
+
+    describe("when given a config with environment set to Node.js", function() {
+        var code = ["--config", "tests/fixtures/configurations/env-node.json", "tests/fixtures/globals-node.js"];
+
+        it("should execute without any errors", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+            var exit = cli.execute(code);
+            assert.equal(exit, 0);
+
+            console.log = log;
+        });
+    });
+
+    describe("when given a valid built-in formatter name", function() {
+        var code = "checkstyle";
+
+        it("should execute without any errors", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            assert.equal(exit, 0);
+
+            console.log = log;
+        });
+    });
+
+    describe("when given an invalid built-in formatter name", function() {
+        var code = "fakeformatter";
+
+        it("should execute with error", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            assert.equal(exit, 1);
+
+            console.log = log;
+        });
+    });
+
+    describe("when given a valid formatter path", function() {
+        var code = "tests/fixtures/formatters/simple.js";
+
+        it("should execute without any errors", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            assert.equal(exit, 0);
+
+            console.log = log;
+        });
+    });
+
+    describe("when given an invalid formatter path", function() {
+        var code = "tests/fixtures/formatters/file-does-not-exist.js";
+
+        it("should execute with error", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            assert.equal(exit, 1);
+
+            console.log = log;
+        });
+    });
+
+    describe("when executing a file with an error", function() {
+        var code = "tests/fixtures/configurations/semi-error.js";
+
+        it("should execute with error", function() {
+            var log = console.log;
+
+            // Assign console.log to noop to skip CLI output
+            console.log = function() {};
+
+            var exit = cli.execute([code]);
+            assert.equal(exit, 1);
+
+            console.log = log;
+        });
+    });
+
+    describe("when calling execute more than once", function() {
+        var code = ["tests/fixtures/missing-semicolon.js", "tests/fixtures/passing.js"];
+
+        it("should not print the results from previous execution", function() {
+            var results = "",
+                log = console.log;
+
+            // Collect the CLI output.
+            console.log = function(msg) {
+                results += msg;
+            };
+
+            cli.execute([code[0]]);
+            assert.notEqual(results, "");
+
+            // Reset results collected between executions.
+            results = "";
+
+            cli.execute([code[1]]);
+            assert.equal(results, "");
+
+            console.log = log;
+        });
+    });
+});

--- a/tests/mocha/lib/config.js
+++ b/tests/mocha/lib/config.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Tests for config object.
+ * @author Seth McLaughlin
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    path = require("path"),
+    Config = require("../../../lib/config");
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("config", function() {
+    describe("findLocalConfigFile", function() {
+        var code = path.resolve(__dirname, "../..", "fixtures", "configurations", "single-quotes");
+
+        it("should find local config file", function() {
+            var configHelper = new Config(),
+                expected = path.resolve(code, ".eslintrc"),
+                actual = configHelper.findLocalConfigFile(code);
+
+            assert.equal(expected, actual);
+        });
+    });
+
+    describe("mergeConfigs", function() {
+        var code = { person: { name: "Seth", car: "prius" }, town: "MV" };
+
+        it("should merge configs", function() {
+            var configHelper = new Config(),
+                expected = { person: { name: "Bob", car: "prius" }, town: "PA" },
+                actual = configHelper.mergeConfigs(code, { person: { name: "Bob" }, town: "PA" });
+
+            assert.deepEqual(expected, actual);
+        });
+    });
+
+    describe("getConfig with env rules", function() {
+        var code = path.resolve(__dirname, "../..", "fixtures", "configurations",
+                "env-node.json");
+
+        it("should be no-global-strict off for node env", function() {
+
+            var configHelper = new Config({config: code}),
+                config = configHelper.getConfig(),
+                expected = 0,
+                actual = config.rules["no-global-strict"];
+
+            assert.equal(expected, actual);
+        });
+    });
+
+    describe("getConfig with env and user rules", function() {
+        var code = path.resolve(__dirname, "../..", "fixtures", "configurations",
+                "env-node-override.json");
+
+        it("should be no-global-strict a warning", function() {
+            var configHelper = new Config({config: code}),
+                config = configHelper.getConfig(),
+                expected = 1,
+                actual = config.rules["no-global-strict"];
+
+            assert.equal(expected, actual);
+        });
+    });
+});

--- a/tests/mocha/lib/eslint.js
+++ b/tests/mocha/lib/eslint.js
@@ -1,0 +1,730 @@
+/**
+ * @fileoverview Tests for eslint object.
+ * @author Nicholas C. Zakas
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    sinon = require("sinon"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var TEST_CODE = "var answer = 6 * 7;",
+    BROKEN_TEST_CODE = "var;";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+function getVariable(scope, name) {
+    var variable = null;
+    scope.variables.some(function(v) {
+        if (v.name === name) {
+            variable = v;
+            return true;
+        }
+        return false;
+    });
+    return variable;
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("eslint", function() {
+    describe("when using events", function() {
+        var code = TEST_CODE;
+
+        it("an error should be thrown when an error occurs inside of an event handler", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                throw new Error("Intentional error.");
+            });
+
+            assert.throws(function() {
+                eslint.verify(code, config, true);
+            }, Error);
+        });
+    });
+
+    describe("when calling toSource()", function() {
+        var code = TEST_CODE;
+
+        it("should retrieve all text when used without parameters", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var source = eslint.getSource();
+                assert.equal(source, TEST_CODE);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all text for root node", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function(node) {
+                var source = eslint.getSource(node);
+                assert.equal(source, TEST_CODE);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all text for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var source = eslint.getSource(node);
+                assert.equal(source, "6 * 7");
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all text plus two characters before for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var source = eslint.getSource(node, 2);
+                assert.equal(source, "= 6 * 7");
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all text plus one character after for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var source = eslint.getSource(node, 0, 1);
+                assert.equal(source, "6 * 7;");
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all text plus two characters before and one character after for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var source = eslint.getSource(node, 2, 1);
+                assert.equal(source, "= 6 * 7;");
+            });
+
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when calling getTokens", function() {
+        var code = TEST_CODE;
+
+        it("should retrieve all tokens when used without parameters", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var tokens = eslint.getTokens();
+                assert.equal(tokens.length, 7);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all tokens for root node", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function(node) {
+                var tokens = eslint.getTokens(node);
+                assert.equal(tokens.length, 7);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all tokens for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var tokens = eslint.getTokens(node);
+                assert.equal(tokens.length, 3);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all tokens plus equals sign for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var tokens = eslint.getTokens(node, 2);
+                assert.equal(tokens.length, 4);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all tokens plus one character after for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var tokens = eslint.getTokens(node, 0, 1);
+                assert.equal(tokens.length, 4);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve all tokens plus two characters before and one character after for binary expression", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var tokens = eslint.getTokens(node, 2, 1);
+                assert.equal(tokens.length, 5);
+            });
+
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when retrieving comments", function() {
+        var code = [
+            "// my line comment",
+            "var a = 42;",
+            "/* my block comment */"
+        ].join("\n");
+
+        it("should retrieve all comments", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function(/*node*/) {
+                var comments = eslint.getAllComments();
+                assert.equal(comments.length, 2);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should attach them to all nodes", function() {
+            function assertCommentCount(leading, trailing) {
+                return function (node) {
+                    var comments = eslint.getComments(node);
+                    assert.equal(comments.leading.length, leading);
+                    assert.equal(comments.trailing.length, trailing);
+                };
+            }
+
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", assertCommentCount(1, 0));
+            eslint.on("VariableDeclaration", assertCommentCount(0, 1));
+            eslint.on("VariableDeclarator", assertCommentCount(0, 0));
+            eslint.on("Identifier", assertCommentCount(0, 0));
+            eslint.on("Literal", assertCommentCount(0, 0));
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should attach them lazily", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("VariableDeclaration", function (node) {
+                assert.equal(node.hasOwnProperty("leadingComments"), false);
+                assert.equal(node.hasOwnProperty("trailingComments"), false);
+                eslint.getComments(node);
+                assert.equal(node.hasOwnProperty("leadingComments"), false);
+                assert.equal(node.hasOwnProperty("trailingComments"), true);
+            });
+
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when calling getAncestors", function() {
+        var code = TEST_CODE;
+
+        it("should retrieve all ancestors when used", function() {
+
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function() {
+                var ancestors = eslint.getAncestors();
+                assert.equal(ancestors.length, 3);
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve empty ancestors for root node", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var ancestors = eslint.getAncestors();
+                assert.equal(ancestors.length, 0);
+            });
+
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when calling getScope", function() {
+        var code = "function foo() { q: for(;;) { break q; } } function bar () { var q = t; }";
+
+        it("should retrieve the global scope correctly from a Program", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "global");
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve the function scope correctly from a FunctionDeclaration", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("FunctionDeclaration", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "function");
+            });
+
+            eslint.verify(code, config, true);
+        });
+
+        it("should retrieve the function scope correctly from a LabeledStatement", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("LabeledStatement", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "function");
+                assert.equal(scope.block.id.name, "foo");
+            });
+
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when evaluating code", function() {
+        var code = TEST_CODE;
+
+        it("events for each node type should fire", function() {
+            var config = { rules: {} };
+
+            // spies for various AST node types
+            var spyLiteral = sinon.spy(),
+                spyVariableDeclarator = sinon.spy(),
+                spyVariableDeclaration = sinon.spy(),
+                spyIdentifier = sinon.spy(),
+                spyBinaryExpression = sinon.spy();
+
+            eslint.reset();
+            eslint.on("Literal", spyLiteral);
+            eslint.on("VariableDeclarator", spyVariableDeclarator);
+            eslint.on("VariableDeclaration", spyVariableDeclaration);
+            eslint.on("Identifier", spyIdentifier);
+            eslint.on("BinaryExpression", spyBinaryExpression);
+
+            var messages = eslint.verify(code, config, true);
+
+            assert.equal(messages.length, 0);
+            sinon.assert.calledOnce(spyVariableDeclaration);
+            sinon.assert.calledOnce(spyVariableDeclarator);
+            sinon.assert.calledOnce(spyIdentifier);
+            sinon.assert.calledTwice(spyLiteral);
+            sinon.assert.calledOnce(spyBinaryExpression);
+        });
+    });
+
+    describe("when passing in configuration values for rules", function() {
+        var code = "var answer = 6 * 7";
+
+        it("should be configurable by only setting the boolean value", function() {
+            var rule = "semi",
+                config = { rules: {} };
+
+            config.rules[rule] = 1;
+            eslint.reset();
+
+            var messages = eslint.verify(code, config, true);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, rule);
+        });
+
+        it("should be configurable by passing in values as an array", function() {
+            var rule = "semi",
+                config = { rules: {} };
+
+            config.rules[rule] = [1];
+            eslint.reset();
+
+            var messages = eslint.verify(code, config, true);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, rule);
+        });
+    });
+
+    describe("after calling reset()", function() {
+        var code = TEST_CODE;
+
+        it("previously registered event handlers should not be called", function() {
+
+            var config = { rules: {} };
+
+            // spies for various AST node types
+            var spyLiteral = sinon.spy(),
+                spyVariableDeclarator = sinon.spy(),
+                spyVariableDeclaration = sinon.spy(),
+                spyIdentifier = sinon.spy(),
+                spyBinaryExpression = sinon.spy();
+
+            eslint.reset();
+            eslint.on("Literal", spyLiteral);
+            eslint.on("VariableDeclarator", spyVariableDeclarator);
+            eslint.on("VariableDeclaration", spyVariableDeclaration);
+            eslint.on("Identifier", spyIdentifier);
+            eslint.on("BinaryExpression", spyBinaryExpression);
+            eslint.reset();
+
+            var messages = eslint.verify(code, config, true);
+
+            assert.equal(messages.length, 0);
+            sinon.assert.notCalled(spyVariableDeclaration);
+            sinon.assert.notCalled(spyVariableDeclarator);
+            sinon.assert.notCalled(spyIdentifier);
+            sinon.assert.notCalled(spyLiteral);
+            sinon.assert.notCalled(spyBinaryExpression);
+        });
+
+        it("text should not be available", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            var messages = eslint.verify(code, config, true);
+            eslint.reset();
+
+            assert.equal(messages.length, 0);
+            assert.isNull(eslint.getSource());
+        });
+
+        it("source for nodes should not be available", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            var messages = eslint.verify(code, config, true);
+            eslint.reset();
+
+            assert.equal(messages.length, 0);
+            assert.isNull(eslint.getSource({}));
+        });
+    });
+
+    describe("when evaluating code containing /*global */ and /*globals */ blocks", function() {
+        var code = "/*global a b:true c:false*/ function foo() {} /*globals d:true*/";
+
+        it("variables should be available in global scope", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope();
+                var a = getVariable(scope, "a"),
+                    b = getVariable(scope, "b"),
+                    c = getVariable(scope, "c"),
+                    d = getVariable(scope, "d");
+
+                assert.equal(a.name, "a");
+                assert.equal(a.writeable, false);
+                assert.equal(b.name, "b");
+                assert.equal(b.writeable, true);
+                assert.equal(c.name, "c");
+                assert.equal(c.writeable, false);
+                assert.equal(d.name, "d");
+                assert.equal(d.writeable, true);
+            });
+
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when evaluating code containing a /*global */ block with sloppy whitespace", function() {
+        var code = "/* global  a b  : true   c:  false*/";
+
+        it("variables should be available in global scope", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope(),
+                    a = getVariable(scope, "a"),
+                    b = getVariable(scope, "b"),
+                    c = getVariable(scope, "c");
+
+                assert.equal(a.name, "a");
+                assert.equal(a.writeable, false);
+                assert.equal(b.name, "b");
+                assert.equal(b.writeable, true);
+                assert.equal(c.name, "c");
+                assert.equal(c.writeable, false);
+            });
+
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when evaluating code containing /*jshint */ block", function() {
+        var code = "/*jslint node:true*/ function f() {} /*jshint browser:true foo:bar*/";
+
+        it("variables should be available in global scope", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope(),
+                    exports = getVariable(scope, "exports"),
+                    window = getVariable(scope, "window");
+
+                assert.equal(exports.writeable, true);
+                assert.equal(window.writeable, false);
+            });
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when evaluating code containing a /*jshint */ block with sloppy whitespace", function() {
+        var code = "/* jshint node  : true browser     : false*/";
+
+        it("variables should be available in global scope", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope(),
+                    exports = getVariable(scope, "exports"),
+                    window = getVariable(scope, "window");
+
+                assert.equal(exports.writeable, true);
+                assert.equal(window, null);
+            });
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when evaluating code containing a line comment", function() {
+        var code = "//global a \n function f() {}";
+
+        it("should not introduce a global variable", function() {
+
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope();
+
+                assert.equal(getVariable(scope, "a"), null);
+            });
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when evaluating code containing normal block comments", function() {
+        var code = "/**/  /*a*/  /*b:true*/  /*foo c:false*/";
+
+        it("should not introduce a global variable", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope();
+
+                assert.equal(getVariable(scope, "a"), null);
+                assert.equal(getVariable(scope, "b"), null);
+                assert.equal(getVariable(scope, "foo"), null);
+                assert.equal(getVariable(scope, "c"), null);
+            });
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("when evaluating any code", function() {
+        var code = "";
+
+        it("builtin global variables should be available in the global scope", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope();
+
+                assert.notEqual(getVariable(scope, "Object"), null);
+                assert.notEqual(getVariable(scope, "Array"), null);
+                assert.notEqual(getVariable(scope, "undefined"), null);
+            });
+            eslint.verify(code, config, true);
+        });
+    });
+
+    describe("at any time", function() {
+        var code = "new-rule";
+
+        it("can add a rule dynamically", function() {
+            eslint.reset();
+            eslint.defineRule(code, function(context) {
+                return {"Literal": function(node) { context.report(node, "message"); }};
+            });
+
+            var config = { rules: {} };
+            config.rules[code] = 1;
+
+            var messages = eslint.verify("0", config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, code);
+            assert.equal(messages[0].node.type, "Literal");
+        });
+    });
+
+    describe("at any time", function() {
+        var code = ["new-rule-0", "new-rule-1"];
+
+        it("can add multiple rules dynamically", function() {
+            eslint.reset();
+            var config = { rules: {} };
+            var newRules = {};
+            code.forEach(function(item){
+                config.rules[item] = 1;
+                newRules[item] = function(context) {
+                    return {"Literal": function(node) { context.report(node, "message"); }};
+                };
+            });
+            eslint.defineRules(newRules);
+
+            var messages = eslint.verify("0", config);
+
+            assert.equal(messages.length, code.length);
+            code.forEach(function(item){
+                assert.ok(messages.some(function(message){ return message.ruleId === item; }));
+            });
+            messages.forEach(function(message){ assert.equal(message.node.type, "Literal"); });
+        });
+    });
+
+    describe("when evaluating code with comments to enable rules", function() {
+        var code = "/*eslint no-alert:1*/ alert('test');";
+
+        it("should report a violation", function() {
+            var config = { rules: {} };
+
+            var messages = eslint.verify(code, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, "no-alert");
+            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].node.type, "CallExpression");
+        });
+    });
+
+    describe("when evaluating code with comments to disable rules", function() {
+        var code = "/*eslint no-alert:0*/ alert('test');";
+
+        it("should not report a violation", function() {
+            var config = { rules: { "no-alert" : 1 } };
+
+            var messages = eslint.verify(code, config);
+            assert.equal(messages.length, 0);
+        });
+    });
+
+    describe("when evaluating code with comments to enable multiple rules", function() {
+        var code = "/*eslint no-alert:1 no-console:1*/ alert('test'); console.log('test');";
+
+        it("should report a violation", function() {
+            var config = { rules: {} };
+
+            var messages = eslint.verify(code, config);
+            assert.equal(messages.length, 2);
+            assert.equal(messages[0].ruleId, "no-alert");
+            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].node.type, "CallExpression");
+            assert.equal(messages[1].ruleId, "no-console");
+        });
+    });
+
+    describe("when evaluating code with comments to enable and disable multiple rules", function() {
+        var code = "/*eslint no-alert:1 no-console:0*/ alert('test'); console.log('test');";
+        it("should report a violation", function() {
+            var config = { rules: { "no-console" : 1, "no-alert" : 0 } };
+
+            var messages = eslint.verify(code, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, "no-alert");
+            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].node.type, "CallExpression");
+        });
+    });
+
+    describe("when evaluating code with comments to enable and disable multiple comma separated rules", function() {
+        var code = "/*eslint no-alert:1, no-console:0*/ alert('test'); console.log('test');";
+
+        it("should report a violation", function() {
+            var config = { rules: { "no-console" : 1, "no-alert" : 0 } };
+
+            var messages = eslint.verify(code, config);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, "no-alert");
+            assert.equal(messages[0].message, "Unexpected alert.");
+            assert.include(messages[0].node.type, "CallExpression");
+        });
+    });
+
+    describe("when evaluating broken code", function() {
+        var code = BROKEN_TEST_CODE;
+
+        it("should report a violation", function() {
+            var messages = eslint.verify(code);
+            assert.equal(messages.length, 1);
+            assert.isTrue(messages[0].fatal);
+        });
+    });
+
+    describe("when using an invalid rule", function() {
+        var code = TEST_CODE;
+
+        it("should throw an error", function() {
+            assert.throws(function() {
+                eslint.verify(code, { foobar: 2 });
+            }, "Object.keys called on non-object",
+            "Definition for rule 'foobar' was not found.");
+        });
+    });
+});

--- a/tests/mocha/lib/formatters/checkstyle.js
+++ b/tests/mocha/lib/formatters/checkstyle.js
@@ -1,0 +1,126 @@
+/**
+ * @fileoverview Tests for checkstyle reporter.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    formatter = require("../../../../lib/formatters/checkstyle");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("formatter:checkstyle", function() {
+    describe("when passed a single message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+        it("should return a string in the format filename: line x, col y, Error - z for errors", function() {
+            var config = { rules: { foo: 2 } };
+            var result = formatter(code, config);
+
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" /></file></checkstyle>", result);
+        });
+        it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
+            var config = {
+                rules: { foo: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"warning\" message=\"Unexpected foo.\" /></file></checkstyle>", result);
+        });
+        it("should return a string in the format filename: line x, col y, Error - z for errors with options config", function() {
+            var config = {
+                rules: { foo: [2, "option"] }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" /></file></checkstyle>", result);
+        });
+    });
+
+    describe("when passed a fatal error message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a string in the format filename: line x, col y, Error - z", function() {
+            var config = {};    // doesn't matter what's in the config for this test
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" /></file></checkstyle>", result);
+        });
+    });
+
+    describe("when passed multiple messages", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }, {
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return a string with multiple entries", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" /><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar.\" /></file></checkstyle>", result);
+        });
+    });
+
+    describe("when passed multiple files with 1 message each", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }, {
+            filePath: "bar.js",
+            messages: [{
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return a string with multiple entries", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo.\" /></file><file name=\"bar.js\"><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar.\" /></file></checkstyle>", result);
+        });
+    });
+});

--- a/tests/mocha/lib/formatters/compact.js
+++ b/tests/mocha/lib/formatters/compact.js
@@ -1,0 +1,166 @@
+/**
+ * @fileoverview Tests for options.
+ * @author Nicholas C. Zakas
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    formatter = require("../../../../lib/formatters/compact");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("formatter:compact", function() {
+    describe("when passed no messages", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: []
+        }];
+
+        it("should return nothing", function() {
+            var config = {
+                rules: { foo: 2 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("", result);
+        });
+    });
+
+    describe("when passed a single message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a string in the format filename: line x, col y, Error - z for errors", function() {
+            var config = {
+                rules: { foo: 2 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo.\n\n1 problem", result);
+        });
+
+        it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
+            var config = {
+                rules: { foo: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("foo.js: line 5, col 10, Warning - Unexpected foo.\n\n1 problem", result);
+        });
+
+        it("should return a string in the format filename: line x, col y, Error - z for errors with options config", function() {
+            var config = {
+                rules: { foo: [2, "option"] }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo.\n\n1 problem", result);
+        });
+    });
+
+    describe("when passed a fatal error message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a string in the format filename: line x, col y, Error - z", function() {
+            var config = {};    // doesn't matter what's in the config for this test
+
+            var result = formatter(code, config);
+            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo.\n\n1 problem", result);
+        });
+    });
+
+    describe("when passed multiple messages", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }, {
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return a string with multiple entries", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo.\nfoo.js: line 6, col 11, Warning - Unexpected bar.\n\n2 problems", result);
+        });
+    });
+
+    describe("when passed multiple files with 1 message each", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }, {
+            filePath: "bar.js",
+            messages: [{
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return a string with multiple entries", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo.\nbar.js: line 6, col 11, Warning - Unexpected bar.\n\n2 problems", result);
+        });
+    });
+
+    describe("when passed one file not found message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Couldn't find foo.js."
+            }]
+        }];
+
+        it("should return a string without line and column", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem", result);
+        });
+    });
+});

--- a/tests/mocha/lib/formatters/jslint-xml.js
+++ b/tests/mocha/lib/formatters/jslint-xml.js
@@ -1,0 +1,121 @@
+/**
+ * @fileoverview Tests for JSLint XML reporter.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    formatter = require("../../../../lib/formatters/jslint-xml");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("formatter:jslint-xml", function() {
+    describe("when passed a single message", function() {
+
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo",
+                source: "foo"
+            }]
+        }];
+
+        it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
+            var config = {
+                rules: { foo: 2 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo.\" /></file></jslint>", result);
+        });
+    });
+
+    describe("when passed a fatal error message", function() {
+
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo",
+                source: "foo"
+            }]
+        }];
+
+        it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
+            var config = {};    // doesn't matter what's in the config for this test
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo.\" /></file></jslint>", result);
+        });
+    });
+
+    describe("when passed multiple messages", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo",
+                source: "foo"
+            }, {
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar",
+                source: "bar"
+            }]
+        }];
+
+        it("should return a string in JSLint XML format with 2 issues in 1 file", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo.\" /><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar.\" /></file></jslint>", result);
+        });
+    });
+
+    describe("when passed multiple files with 1 message each", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo",
+                source: "foo"
+            }]
+        }, {
+            filePath: "bar.js",
+            messages: [{
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar",
+                source: "bar"
+            }]
+        }];
+
+        it("should return a string in JSLint XML format with 2 issues in 2 files", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo.\" /></file><file name=\"bar.js\"><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar.\" /></file></jslint>", result);
+        });
+    });
+});

--- a/tests/mocha/lib/formatters/junit.js
+++ b/tests/mocha/lib/formatters/junit.js
@@ -1,0 +1,218 @@
+/**
+ * @fileoverview Tests for jUnit Formatter.
+ * @author Jamund Ferguson
+ */
+
+/*jshint node:true*/
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    formatter = require("../../../../lib/formatters/junit");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("formatter:junit", function() {
+    describe("when there are no problems", function() {
+        var code = [];
+
+        it("should not complain about anything", function() {
+            var config = {}; // not needed for this test
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed a single message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a single <testcase> with a message and the line and col number in the body (error)", function() {
+            var config = {
+                rules: { foo: 2 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo.]]></failure></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+
+        it("should return a single <testcase> with a message and the line and col number in the body (warning)", function() {
+            var config = {
+                rules: { foo: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo.]]></failure></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+
+        it("should return a single <testcase> with a message and the line and col number in the body (error) with options config", function() {
+            var config = {
+                rules: { foo: [2, "option"] }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo.]]></failure></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed a fatal error message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a single <testcase> and an <error>", function() {
+            var config = {};
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed a fatal error message with no line or column", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Unexpected foo."
+            }]
+        }];
+
+        it("should return a single <testcase> and an <error>", function() {
+            var config = {};
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed a fatal error message with no line, column, or message text", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true
+            }]
+        }];
+
+        it("should return a single <testcase> and an <error>", function() {
+            var config = {};
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed multiple messages", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }, {
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return a multiple <testcase>'s", function() {
+            var config = {
+                rules: { foo: 2, bar: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo.]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar.]]></failure></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed special characters", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected <foo></foo>.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should make them go away", function() {
+            var config = {
+                rules: { foo: 1 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;.]]></failure></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed multiple files with 1 message each", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }, {
+            filePath: "bar.js",
+            messages: [{
+                message: "Unexpected bar.",
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return 2 <testsuite>'s", function() {
+            var config = {
+                rules: { foo: 1, bar: 2 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo.]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar.]]></failure></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+
+    describe("when passed multiple files with total 1 failure", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }, {
+            filePath: "bar.js",
+            messages: []
+        }];
+
+        it("should return 1 <testsuite>", function() {
+            var config = {
+                rules: { foo: 1, bar: 2 }
+            };
+
+            var result = formatter(code, config);
+            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo.]]></failure></testcase></testsuite></testsuites>", result.replace(/\n/g, ""));
+        });
+    });
+});

--- a/tests/mocha/lib/options.js
+++ b/tests/mocha/lib/options.js
@@ -1,0 +1,122 @@
+/**
+ * @fileoverview Tests for options.
+ * @author Nicholas C. Zakas
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    options = require("../../../lib/options");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+/*
+ * This may look like it's simply testing optimist under the covers, but really
+ * it's testing the interface of the options object. I want to make sure the
+ * interface is solid and tested because I'm not sure I want to use optimist
+ * long-term.
+ */
+
+describe("options", function() {
+    describe("when passed --help", function() {
+        var code = [ "--help" ];
+
+        it("should return true for .h", function() {
+            var currentOptions = options.parse(code);
+            assert.isTrue(currentOptions.h);
+        });
+    });
+
+    describe("when passed -h", function() {
+        var code = [ "-h" ];
+
+        it("should return true for .h", function() {
+            var currentOptions = options.parse(code);
+            assert.isTrue(currentOptions.h);
+        });
+    });
+
+    describe("when passed --config", function() {
+        var code = [ "--config" ];
+
+        it("should return true for .c", function() {
+            var currentOptions = options.parse(code);
+            assert.isTrue(currentOptions.c);
+        });
+    });
+
+    describe("when passed -c", function() {
+        var code = [ "-c" ];
+
+        it("should return true for .c", function() {
+            var currentOptions = options.parse(code);
+            assert.isTrue(currentOptions.c);
+        });
+    });
+
+    describe("when passed --rulesdir", function() {
+        var code = [ "--rulesdir", "/morerules" ];
+
+        it("should return a string for .rulesdir", function() {
+            var currentOptions = options.parse(code);
+            assert.isString(currentOptions.rulesdir);
+            assert.equal(currentOptions.rulesdir, "/morerules");
+        });
+    });
+
+    describe("when passed --format", function() {
+        var code = [ "--format", "compact" ];
+
+        it("should return a string for .f", function() {
+            var currentOptions = options.parse(code);
+            assert.equal(currentOptions.f, "compact");
+        });
+    });
+
+    describe("when passed -f", function() {
+        var code = [ "-f", "compact" ];
+
+        it("should return a string for .f", function() {
+            var currentOptions = options.parse(code);
+            assert.equal(currentOptions.f, "compact");
+        });
+    });
+
+    describe("when passed -v", function() {
+        var code = [ "-v" ];
+
+        it("should return true for .v", function() {
+            var currentOptions = options.parse(code);
+            assert.isTrue(currentOptions.v);
+        });
+    });
+
+    describe("when passed --version", function() {
+        var code = [ "--version" ];
+
+        it("should return true for .v", function() {
+            var currentOptions = options.parse(code);
+            assert.isTrue(currentOptions.v);
+        });
+    });
+
+    describe("when asking for help", function() {
+        it("should log the help content to the console", function() {
+            var log = console.log;
+
+            var loggedMessages = [];
+            console.log = function(message) {
+                loggedMessages.push(message);
+            };
+
+            options.help();
+            assert.equal(loggedMessages.length, 1);
+
+            console.log = log;
+        });
+    });
+});

--- a/tests/mocha/lib/rules.js
+++ b/tests/mocha/lib/rules.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Tests for rules.
+ * @author Patrick Brosset
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    rules = require("../../../lib/rules");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("rules", function() {
+    describe("when given an invalid rules directory", function() {
+        var code = "invaliddir";
+
+        it("should log an error and exit", function() {
+            assert.throws(function() { rules.load(code); });
+        });
+    });
+
+    describe("when given a valid rules directory", function() {
+        var code = "tests/fixtures/rules";
+
+        it("should load rules and not log an error or exit", function() {
+            assert.equal(typeof rules.get("fixture-rule"), "undefined");
+            rules.load(code);
+            assert.equal(typeof rules.get("fixture-rule"), "object");
+        });
+    });
+
+    describe("when a rule has been defined", function() {
+        it("should be able to retrieve the rule", function() {
+            var ruleId = "michaelficarra";
+            rules.define(ruleId, {});
+            assert.ok(rules.get(ruleId));
+        });
+    });
+});

--- a/tests/mocha/lib/util.js
+++ b/tests/mocha/lib/util.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Tests for util.
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    util = require("../../../lib/util");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("util", function() {
+    describe("when calling mixin()", function() {
+        var code = function() {
+            var a = {}, b = { foo: "f", bar: 1 };
+            util.mixin(a, b);
+            return [a, b];
+        };
+
+        it("should add properties to target object", function() {
+            var a = code()[0];
+            assert.equal(Object.keys(a).length, 2);
+            assert.equal(a.foo, "f");
+            assert.equal(a.bar, 1);
+        });
+
+        it("should not change the source object", function() {
+            var b = code()[1];
+            assert.equal(Object.keys(b).length, 2);
+            assert.equal(b.foo, "f");
+            assert.equal(b.bar, 1);
+        });
+    });
+
+    describe("when calling mergeConfigs()", function() {
+        var code = [
+            { env: { browser: true } },
+            { globals: { foo: "bar"} }
+        ];
+
+        it("should combine the two objects", function() {
+            var result = util.mergeConfigs(code[0], code[1]);
+
+            assert.equal(result.globals.foo, "bar");
+            assert.isTrue(result.env.browser);
+        });
+    });
+});


### PR DESCRIPTION
And this concludes mindless copy-paste exercise... Here are the stats:

Vows coverage:

=============================== Coverage summary ===============================
Statements   : 98.05% ( 1260/1285 )
Branches      : 95.54% ( 750/785 )
Functions      : 98.64% ( 362/367 )
Lines              : 98.05% ( 1258/1283 )

Mocha coverage:
=============================== Coverage summary ===============================
Statements   : 98.12% ( 1302/1327 )
Branches      : 95.75% ( 788/823 )
Functions      : 98.68% ( 373/378 )
Lines             : 98.26% ( 1298/1321 )

Once this is merged in, I will create another pull request to remove all vows tests and replace them with mocha
