### PR TITLE
fixes #415: fix unnecessary-strict rule false positives

### DIFF
--- a/lib/rules/unnecessary-strict.js
+++ b/lib/rules/unnecessary-strict.js
@@ -10,18 +10,46 @@
 
 module.exports = function(context) {
 
-    return {
-
-        "Literal": function(node) {
-            if (node.value === "use strict") {
-                var scope = context.getScope();
-
-                if (scope.upper && scope.upper.isStrict) {
-                    context.report(node, "Unnecessary 'use strict'.");
-                }
+    function directives(block) {
+        var ds = [], body = block.body, e, i, l;
+        for(i = 0, l = body.length; i < l; ++i) {
+            e = body[i];
+            if(
+                e.type === "ExpressionStatement" &&
+                e.expression.type === "Literal" &&
+                typeof e.expression.value === "string"
+            ) {
+                ds.push(e.expression);
+            } else {
+                break;
             }
         }
+        return ds;
+    }
 
+    function isStrict(directive) { return directive.value === "use strict"; }
+
+    function checkForUnnecessaryUseStrict(node) {
+        var useStrictDirectives, scope;
+        useStrictDirectives = directives(node).filter(isStrict);
+        switch(useStrictDirectives.length) {
+            case 0:
+                break;
+            case 1:
+                scope = context.getScope();
+                if (scope.upper && scope.upper.isStrict) {
+                    context.report(useStrictDirectives[0], "Unnecessary 'use strict'.");
+                }
+                break;
+            default:
+                context.report(useStrictDirectives[1], "Multiple 'use strict' directives.");
+        }
+    }
+
+    return {
+        "Program": checkForUnnecessaryUseStrict,
+        "FunctionExpression": function(node) { checkForUnnecessaryUseStrict(node.body); },
+        "FunctionDeclaration": function(node) { checkForUnnecessaryUseStrict(node.body); }
     };
 
 };

--- a/tests/lib/rules/unnecessary-strict.js
+++ b/tests/lib/rules/unnecessary-strict.js
@@ -14,8 +14,10 @@ eslintTester.addRuleTest("unnecessary-strict", {
         "\"use strict\"; function foo() { var bar = true; }",
         "'use strict'; function foo() { var bar = true; }",
         "function foo() { \"use strict\"; var bar = true; }",
-        "function foo() { 'use strict'; var bar = true; }"
-           ],
+        "function foo() { 'use strict'; var bar = true; }",
+        "function foo() { 'use strict'; f('use strict'); }",
+        "function foo() { 'use strict'; { 'use strict'; } }"
+    ],
     invalid: [
         { code: "\"use strict\"; function foo() { \"use strict\"; var bar = true; }",
           errors: [{ message: "Unnecessary 'use strict'.", type: "Literal"}] },
@@ -24,6 +26,8 @@ eslintTester.addRuleTest("unnecessary-strict", {
         { code: "\"use strict\"; (function foo() { function bar () { \"use strict\"; } }());",
           errors: [{ message: "Unnecessary 'use strict'.", type: "Literal"}] },
         { code: "'use strict'; (function foo() { function bar () { 'use strict'; } }());",
-          errors: [{ message: "Unnecessary 'use strict'.", type: "Literal"}] }
+          errors: [{ message: "Unnecessary 'use strict'.", type: "Literal"}] },
+        { code: "(function foo() { 'use strict'; 'use strict'; }());",
+          errors: [{ message: "Multiple 'use strict' directives.", type: "Literal"}] }
     ]
 });


### PR DESCRIPTION
The rule now also detects directives that are unnecessary because there exists another "use strict" directive in the same scope. Should also be more efficient since it now only looks where necessary for directives.

Fixes #415.
