### PR TITLE
fixes #346: validate strings passed to the RegExp constructor

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -27,6 +27,7 @@
         "no-func-assign": 2,
         "no-floating-decimal": 0,
         "no-implied-eval": 2,
+        "no-invalid-regexp": 2,
         "no-with": 2,
         "no-fallthrough": 2,
         "no-global-strict": 2,

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -1,0 +1,37 @@
+# no invalid regexp
+
+This rule validates string arguments passed to the `RegExp` constructor.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+RegExp('['])
+```
+
+```js
+RegExp('.', 'z') // invalid flags
+```
+
+```js
+new RegExp('\\')
+```
+
+The following patterns are not considered warnings:
+
+```js
+RegExp('.')
+```
+
+```js
+new RegExp
+```
+
+```js
+this.RegExp('[')
+```
+
+## Further Reading
+
+* [Annotated ES5 §7.8.5 - Regular Expression Literals](http://es5.github.io/#x7.8.5)

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Validate strings passed to the RegExp constructor
+ * @author Michael Ficarra
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    function isString(node) {
+        return node && node.type === "Literal" && typeof node.value === "string";
+    }
+
+    function check(node) {
+        if(node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(node.arguments[0])) {
+            try {
+                if(isString(node.arguments[1])) {
+                    void new RegExp(node.arguments[0].value, node.arguments[1].value);
+                } else {
+                    void new RegExp(node.arguments[0].value);
+                }
+            } catch(e) {
+                context.report(node, e.message);
+            }
+        }
+    }
+
+    return {
+        "CallExpression": check,
+        "NewExpression": check
+    };
+
+};

--- a/tests/lib/rules/no-invalid-regexp.js
+++ b/tests/lib/rules/no-invalid-regexp.js
@@ -1,0 +1,27 @@
+/**
+ * @fileoverview Validate strings passed to the RegExp constructor
+ * @author Michael Ficarra
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("../../../lib/tests/eslintTester");
+
+eslintTester.addRuleTest("no-invalid-regexp", {
+    valid: [
+        "RegExp('')",
+        "RegExp()",
+        "RegExp('.', 'g')",
+        "new RegExp('.')",
+        "new RegExp",
+        "new RegExp('.', 'im')",
+        "global.RegExp('\\\\')"
+    ],
+    invalid: [
+        { code: "RegExp('[');", errors: [{ message: "Invalid regular expression: /[/: Unterminated character class", type: "CallExpression" }] },
+        { code: "RegExp('.', 'z');", errors: [{ message: "Invalid flags supplied to RegExp constructor 'z'", type: "CallExpression" }] },
+        { code: "new RegExp(')');", errors: [{ message: "Invalid regular expression: /)/: Unmatched ')'", type: "NewExpression" }] }
+    ]
+});


### PR DESCRIPTION
Fixes #346.
