### PR TITLE
fixes #437: fragile no-extend-native rule

### DIFF
--- a/docs/rules/no-extend-native.md
+++ b/docs/rules/no-extend-native.md
@@ -27,13 +27,13 @@ A common suggestion to avoid this problem would be to wrap the inside of the `fo
 Disallows directly modifying the prototype of builtin objects by looking for the following styles:
 
 - `Object.prototype.a = "a";`
-- `Object.defineProperty(Math.prototype, "times", {value: 999});`
+- `Object.defineProperty(Array.prototype, "times", {value: 999});`
 
 It *does not* check for any of the following less obvious approaches:
 
 - `var x = Object; x.prototype.thing = a;`
 - `eval("Array.prototype.forEach = 'muhahaha'");`
-- `with(Math) { prototype.thing = 'thing'; };`
+- `with(Array) { prototype.thing = 'thing'; };`
 - `window.Function.prototype.bind = 'tight';`
 
 ## When Not To Use It

--- a/lib/rules/no-extend-native.js
+++ b/lib/rules/no-extend-native.js
@@ -7,8 +7,11 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var environments = require("../../conf/environments.json"),
-    builtins = Object.keys(environments.builtin);
+var BUILTINS = [
+    "Object", "Function", "Array", "String", "Boolean", "Number", "Date",
+    "RegExp", "Error", "EvalError", "RangeError", "ReferenceError",
+    "SyntaxError", "TypeError", "URIError"
+];
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -22,16 +25,18 @@ module.exports = function(context) {
 
         // handle the Array.prototype.extra style case
         "AssignmentExpression": function(node) {
+            var lhs = node.left, affectsProto;
 
-            if (typeof node.left.object === "undefined" ||
-                typeof node.left.object.object === "undefined") {
-                return;
-            }
+            if (lhs.type !== "MemberExpression" || lhs.object.type !== "MemberExpression") { return; }
 
-            builtins.forEach(function(builtin) {
-                var sameName = node.left.object.object.name === builtin;
-                var hasLength = node.left.property.name.length > 0;
-                if (sameName && hasLength) {
+            affectsProto = lhs.object.computed ?
+                lhs.object.property.type === "Literal" && lhs.object.property.value === "prototype" :
+                lhs.object.property.name === "prototype";
+
+            if (!affectsProto) { return; }
+
+            BUILTINS.forEach(function(builtin) {
+                if (lhs.object.object.name === builtin) {
                     context.report(node, builtin + " prototype is read only, properties should not be added.");
                 }
             });
@@ -55,7 +60,7 @@ module.exports = function(context) {
 
                 if (object &&
                     object.type === "Identifier" &&
-                    (builtins.indexOf(object.name) > -1) &&
+                    (BUILTINS.indexOf(object.name) > -1) &&
                     subject.property.name === "prototype") {
 
                     context.report(node, object.name + " prototype is read only, properties should not be added.");

--- a/tests/lib/rules/no-extend-native.js
+++ b/tests/lib/rules/no-extend-native.js
@@ -7,51 +7,56 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var eslintTester = require("../../../lib/tests/eslintTester"),
-    environment = require("../../../conf/environments.json"),
-    builtins = Object.keys(environment.builtin);
+var eslintTester = require("../../../lib/tests/eslintTester");
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-eslintTester.addRuleTest( "no-extend-native", {
+eslintTester.addRuleTest("no-extend-native", {
     valid: [
-        "x.prototype.newthing = 'good'",
-        "Object.defineProperty(x, 'newthing', {value: 'good'})",
-        "m = Math; m.prototype.times = 3",
-        "with(Object) { prototype.blast = 'off'; }",
-        "eval('Object.prototype.seven = 7')"
+        "x.prototype.p = 0",
+        "x.prototype['p'] = 0",
+        "Math.prototype.p = 0",
+        "Object.p = 0",
+        "Object.toString.bind = 0",
+        "Object['toString'].bind = 0",
+        "Object.defineProperty(x, 'p', {value: 0})",
+        "global.Object.prototype.toString = 0",
+        "this.Object.prototype.toString = 0",
+        "with(Object) { prototype.p = 0; }",
+        "o = Object; o.prototype.toString = 0",
+        "eval('Object.prototype.toString = 0')"
     ],
     invalid: [{
-        code: "Math.prototype.gonzo = 333",
+        code: "Object.prototype.p = 0",
         errors: [{
-            message: "Math prototype is read only, properties should not be added.",
+            message: "Object prototype is read only, properties should not be added.",
             type: "AssignmentExpression"
         }]
     }, {
-        code: "Object.defineProperty(Array.prototype, 'toast', {value:666})",
+        code: "Function.prototype['p'] = 0",
+        errors: [{
+            message: "Function prototype is read only, properties should not be added.",
+            type: "AssignmentExpression"
+        }]
+    }, {
+        code: "String['prototype'].p = 0",
+        errors: [{
+            message: "String prototype is read only, properties should not be added.",
+            type: "AssignmentExpression"
+        }]
+    }, {
+        code: "Number['prototype']['p'] = 0",
+        errors: [{
+            message: "Number prototype is read only, properties should not be added.",
+            type: "AssignmentExpression"
+        }]
+    }, {
+        code: "Object.defineProperty(Array.prototype, 'p', {value: 0})",
         errors: [{
             message: "Array prototype is read only, properties should not be added.",
             type: "CallExpression"
         }]
-    // loop through all of the builtins and test for adding to the prototype
-    }].concat(builtins.map(function(builtin) {
-        return {
-            code: builtin + ".prototype.fake = 'fake'",
-            errors: [{
-                message: builtin + " prototype is read only, properties should not be added.",
-                type: "AssignmentExpression"
-            }]
-        };
-    // loop through all of the builtins and test for using Object.defineProperty
-    })).concat(builtins.map(function(builtin) {
-        return {
-            code: "Object.defineProperty(" + builtin + ".prototype, 'fake', {value: 'fake'})",
-            errors: [{
-                message: builtin + " prototype is read only, properties should not be added.",
-                type: "CallExpression"
-            }]
-        };
-    }))
+    }]
 });


### PR DESCRIPTION
I've also changed it to only affect the native constructors (not all properties of the global object) and support `ctor['prototype']` access.
