### PR TITLE
Fixed reported line number for trailing comma error

### DIFF
--- a/lib/rules/no-comma-dangle.js
+++ b/lib/rules/no-comma-dangle.js
@@ -22,7 +22,8 @@ module.exports = function(context) {
         // The last token in an object/array literal will always be a closing
         // curly, so we check the second to last token for a comma.
         if (secondToLastToken.value === ",") {
-            context.report(node, "Trailing comma.");
+            var items = node.properties || node.elements;
+            context.report(items[items.length - 1], "Trailing comma.");
         }
     }
 

--- a/tests/lib/rules/no-comma-dangle.js
+++ b/tests/lib/rules/no-comma-dangle.js
@@ -19,8 +19,8 @@ eslintTester.addRuleTest("no-comma-dangle", {
         "var foo = [ \"baz\" ]"
     ],
     invalid: [
-        { code: "var foo = { bar: \"baz\", }", errors: [{ message: "Trailing comma.", type: "ObjectExpression"}] },
-        { code: "foo({ bar: \"baz\", qux: \"quux\", });", errors: [{ message: "Trailing comma.", type: "ObjectExpression"}] },
-        { code: "var foo = [ \"baz\", ]", errors: [{ message: "Trailing comma.", type: "ArrayExpression"}] }
+        { code: "var foo = { bar: \"baz\", }", errors: [{ message: "Trailing comma.", type: "Property"}] },
+        { code: "foo({ bar: \"baz\", qux: \"quux\", });", errors: [{ message: "Trailing comma.", type: "Property"}] },
+        { code: "var foo = [ \"baz\", ]", errors: [{ message: "Trailing comma.", type: "Literal"}] }
     ]
 });


### PR DESCRIPTION
The `no-comma-dangle` rule previously reported the ArrayExpression or ObjectExpression node when finding a tailing comma. As a result the rule would report the incorrect line for the error.

For example, in the code below, line 1 would be reported as having a trailing comma when line 3 is the true culprit!

``` js
var obj = {
    prop: "val",
    anotherProp: "val",
};
```

This fix reports the Punctuator node instead, thus fixing the reported line number.
