### PR TITLE
fixes #449: no-mixed-requires throws TypeError when grouping is enabled

### DIFF
--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -111,8 +111,10 @@ module.exports = function(context) {
             contains[type] = true;
         });
 
-        return contains[DECL_REQUIRE] &&
-            (contains[DECL_UNINITIALIZED] || contains[DECL_OTHER]);
+        return !!(
+            contains[DECL_REQUIRE] &&
+            (contains[DECL_UNINITIALIZED] || contains[DECL_OTHER])
+        );
     }
 
     /**
@@ -125,7 +127,9 @@ module.exports = function(context) {
         var found = {};
 
         declarations.forEach(function (declaration) {
-            found[inferModuleType(declaration.init)] = true;
+            if(getDeclarationType(declaration.init) === DECL_REQUIRE) {
+                found[inferModuleType(declaration.init)] = true;
+            }
         });
 
         return Object.keys(found).length <= 1;

--- a/tests/lib/rules/no-mixed-requires.js
+++ b/tests/lib/rules/no-mixed-requires.js
@@ -24,8 +24,8 @@ eslintTester.addRuleTest("no-mixed-requires", {
         { code: "var emitter = require('events').EventEmitter, fs = require('fs')", args: [1, false] },
         { code: "var foo = require(42), bar = require(getName())", args: [1, false] },
         { code: "var foo = require(42), bar = require(getName())", args: [1, true] },
-        { code: "var foo = require('foo'), bar = require(getName())", args: [1, false] }
-
+        { code: "var foo = require('foo'), bar = require(getName())", args: [1, false] },
+        { code: "var a;", args: [1, true] }
     ],
     invalid: [
         { code: "var fs = require('fs'), foo = 42", args: [1, false], errors: [{ message: "Do not mix 'require' and other declarations.", type: "VariableDeclaration"}] },


### PR DESCRIPTION
Fixes #449. On a related note, I don't like how this rule uses objects with non-null prototypes as maps. Either they should be created with `Object.create(null)` or we should be using `hasOwnProperty`.
