### PR TITLE
Add allow-avoiding-escaped-quotes option to quotes rule (fixes #199)

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -9,7 +9,10 @@ var double = "double";
 var single = 'single';
 ```
 
-The third parameter enables an exception to the rule to avoid escaping quotes. For example, when `"single"` is the standard, this option allows the use of double quotes to avoid escaping single quotes. This option can have the value `"allow-avoiding-escaped-quotes"` and is off by default.
+The third parameter enables an exception to the rule to avoid escaping quotes. For example, when `"single"` is the standard, this option allows the use of double quotes to avoid escaping single quotes. This option can have the value `"avoid-escape"` and is off by default.
+```js
+[2, "single", "avoid-escape"]
+```
 
 ## Rule Details
 
@@ -24,10 +27,10 @@ var single = 'single';
 // When [1, "single"]
 var double = "double";
 
-// When [1, "double", "allow-avoiding-escaped-quotes"]
+// When [1, "double", "avoid-escape"]
 var single = 'single';
 
-// When [1, "single", "allow-avoiding-escaped-quotes"]
+// When [1, "single", "avoid-escape"]
 var double = "double";
 ```
 
@@ -40,10 +43,10 @@ var double = "double";
 // When [1, "single"]
 var single = 'single';
 
-// When [1, "double", "allow-avoiding-escaped-quotes"]
+// When [1, "double", "avoid-escape"]
 var single = 'a string containing "double" quotes';
 
-// When [1, "single", "allow-avoiding-escaped-quotes"]
+// When [1, "single", "avoid-escape"]
 var double = "a string containing 'single' quotes";
 ```
 

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -20,7 +20,7 @@ var QUOTE_SETTINGS = {
     }
 };
 
-var ALLOW_AVOIDING_ESCAPED_QUOTES = "allow-avoiding-escaped-quotes";
+var AVOID_ESCAPE = "avoid-escape";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -47,13 +47,13 @@ module.exports = function(context) {
                 rawVal = node.raw,
                 quoteOption = context.options[0],
                 settings = QUOTE_SETTINGS[quoteOption],
-                allowAvoidingEscapedQuotes = context.options[1] === ALLOW_AVOIDING_ESCAPED_QUOTES,
+                avoidEscape = context.options[1] === AVOID_ESCAPE,
                 isValid;
 
             if (settings && typeof val === "string") {
                 isValid = surroundedBy(rawVal, settings.quote);
 
-                if (!isValid && allowAvoidingEscapedQuotes) {
+                if (!isValid && avoidEscape) {
                     isValid = surroundedBy(rawVal, settings.alternateQuote) && rawVal.indexOf(settings.quote) >= 0;
                 }
 

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -15,8 +15,8 @@ eslintTester.addRuleTest("quotes", {
         {code: "var foo = \"bar\";", args: [1, "double"] },
         { code: "var foo = 1;", args: [1, "single"] },
         { code: "var foo = 1;", args: [1, "double"] },
-        { code: "var foo = \"'\";", args: [1, "single", "allow-avoiding-escaped-quotes"] },
-        { code: "var foo = '\"';", args: [1, "double", "allow-avoiding-escaped-quotes"] }
+        { code: "var foo = \"'\";", args: [1, "single", "avoid-escape"] },
+        { code: "var foo = '\"';", args: [1, "double", "avoid-escape"] }
     ],
     invalid: [
         { code: "var foo = \"bar\";",
@@ -26,10 +26,10 @@ eslintTester.addRuleTest("quotes", {
           args: [1, "double"],
           errors: [{ message: "Strings must use doublequote.", type: "Literal"}] },
         { code: "var foo = \"bar\";",
-          args: [1, "single", "allow-avoiding-escaped-quotes"],
+          args: [1, "single", "avoid-escape"],
           errors: [{ message: "Strings must use singlequote.", type: "Literal" }]},
         { code: "var foo = 'bar';",
-          args: [1, "double", "allow-avoiding-escaped-quotes"],
+          args: [1, "double", "avoid-escape"],
           errors: [{ message: "Strings must use doublequote.", type: "Literal" }]}
     ]
 });


### PR DESCRIPTION
This addresses #199 by adding an `"allow-avoiding-escaped-quotes"` option to the quotes rule.
