### PR TITLE
add ruleId to formatter output

### DIFF
--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -47,7 +47,8 @@ module.exports = function(results, config) {
             output += result.filePath + ": ";
             output += "line " + (message.line || 0) +  ", col " +
                 (message.column || 0) + ", " + getMessageType(message, rules);
-            output += " - " + message.message + "\n";
+            output += " - " + message.message;
+            output += " (" + message.ruleId + ")\n";
         });
 
     });


### PR DESCRIPTION
Making it write output like this:

```
timers.js: line 483, col 2, Warning - Expected a conditional expression and instead saw an assignment. (no-cond-assign) 
tls.js: line 82, col 9, Warning - Wrap the /regexp/ literal in parens to disambiguate the slash operator. (wrap-regex) 
```

Note ruleId in parens at the end of the strings. Yes, it makes strings even longer, I know that.

Rationale:
It's needed to find an offending rule quickly. Without this I would've grepped the ruleset trying to find out which rule is writing a certain message, and it ain't very nice.
