### PR TITLE
Rule: max-nested-callbacks

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -82,6 +82,7 @@
         "guard-for-in": 0,
         "max-depth": [0, 4],
         "max-len": [0, 80, 4],
+        "max-nested-callbacks": [0, 2],
         "max-params": [0, 3],
         "max-statements": [0, 10],
         "new-cap": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -80,6 +80,7 @@ These rules are purely matters of style and are quite subjective.
 * [quote-props](quote-props.md) - require quotes around object literal property names
 * [semi](semi.md) - require use of semicolons instead of relying on ASI
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block
+* [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested
 * [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses
 
 ## Legacy

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -1,0 +1,68 @@
+# Set Maximum Depth of Nested Callbacks
+
+Many JavaScript libraries use the callback pattern to manage asynchronous operations. A program of any complexity will most likely need to manage several asynchronous operations at various levels of concurrency. A common pitfall that is easy to fall into is nesting callbacks, which makes code more difficult to read the deeper the callbacks are nested.
+
+```js
+foo(function () {
+    bar(function () {
+        baz(function() {
+            qux(function () {
+
+            });
+        });
+    });
+});
+```
+
+## Rule Details
+
+This rule is aimed at increasing code clarity by discouraging deeply nesting callbacks. As such, it will warn when callbacks are nested deeper than the specified limit.
+
+The following patterns are considered warnings:
+
+```js
+foo(function () {
+    bar(function () {
+        baz(function() {
+            qux(function () {
+
+            });
+        });
+    });
+});
+```
+
+The following patterns are not considered warnings:
+
+```js
+foo(handleFoo);
+
+function handleFoo (){
+    bar(handleBar);
+}
+
+function handleBar() {
+    baz(handleBaz);
+}
+
+function handleBaz() {
+    qux(handleQux);
+}
+
+function handleQux() {
+
+}
+```
+
+### Options
+
+You can configure the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error (code is 2) with a maximum depth of 3:
+
+```json
+"max-nested-callbacks": [2, 3]
+```
+
+## Further Reading
+* [Control flow in Node.js](http://book.mixu.net/node/ch7.html)
+* [Control Flow in Node](http://howtonode.org/control-flow)
+* [Control Flow in Node Part II](http://howtonode.org/control-flow-part-ii)

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Rule to enforce a maximum number of nested callbacks.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    //--------------------------------------------------------------------------
+    // Constants
+    //--------------------------------------------------------------------------
+
+    var THRESHOLD = context.options[0];
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    var callbackStack = [];
+
+    return {
+
+        "FunctionExpression": function (node) {
+            var parent = context.getAncestors().pop();
+
+            if (parent.type === "CallExpression") {
+                callbackStack.push(node);
+            }
+
+            if (callbackStack.length > THRESHOLD) {
+                var opts = {num: callbackStack.length, max: THRESHOLD};
+                context.report(node, "Too many nested callbacks ({{num}}). Maximum allowed is {{max}}.", opts);
+            }
+        },
+
+
+        "FunctionExpression:after": function() {
+            callbackStack.pop();
+        }
+
+    };
+
+};

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Tests for max-nested-callbacks rule.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("../../../lib/tests/eslintTester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("max-nested-callbacks", {
+    valid: [
+        { code: "foo(function () { bar(thing, function (data) {}); });", args: [1, 3] },
+        { code: "var foo = function () {}; bar(function(){ baz(function() { qux(foo); }) });", args: [1, 2] },
+        { code: "fn(function(){}, function(){}, function(){});", args: [1,2] }
+    ],
+    invalid: [
+        { code: "foo(function () { bar(thing, function (data) { baz(function () {}); }); });", args: [1, 2], errors: [{ message: "Too many nested callbacks (3). Maximum allowed is 2.", type: "FunctionExpression"}] },
+        { code: "foo(function () { if (isTrue) { bar(function (data) { baz(function () {}); }); } });", args: [1, 2], errors: [{ message: "Too many nested callbacks (3). Maximum allowed is 2.", type: "FunctionExpression"}] }
+    ]
+});


### PR DESCRIPTION
Created the `max-nested-callbacks` rule. This rule allows you to configure the maximum depth that callbacks may be nested inside of each other. This rule is aimed at discouraging the so-called "callback hell" that is a common pitfall of asynchronous programming with callbacks.

The `max-nested-callbacks` rule differs from `max-depth` in that it only takes callbacks into consideration when determining depth, as opposed to all block statements. This level of granularity is useful because the theshold beyond which code becomes less clear is much lower for nested callbacks than for block statements in general.

``` js
foo(function () {
    bar(function () {
        baz(function() {
            qux(function () {

            });
        });
    });
});
```
