### PR TITLE
fixes #494 and #496: allow shebangs and allow explicit CLI args to override .eslintignore

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -125,7 +125,7 @@ function processFile(filename, configHelper) {
 
     if (existsSync(filePath)) {
         config = configHelper.getConfig(filePath);
-        text = fs.readFileSync(path.resolve(filename), "utf8");
+        text = fs.readFileSync(path.resolve(filename), "utf8").replace(/^#![^\r\n]+[\r\n]/, "");
         messages = eslint.verify(text, config);
     } else {
         messages = [{

--- a/tests/fixtures/shebang.js
+++ b/tests/fixtures/shebang.js
@@ -1,0 +1,5 @@
+#!/usr/bin/env node
+
+var cli = require("../lib/cli");
+var exitCode = cli.execute(Array.prototype.slice.call(process.argv, 2));
+process.exit(exitCode);

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -228,6 +228,15 @@ describe("cli", function() {
 
             assert.isTrue(console.log.called);
             assert.isFalse(console.log.alwaysCalledWith(""));
+            assert.equal(exit, 0);
+        });
+    });
+
+    describe("when executing a file with a shebang", function() {
+        var code = "tests/fixtures/shebang.js";
+
+        it("should execute without error", function() {
+            var exit = cli.execute([code]);
 
             assert.equal(exit, 0);
         });


### PR DESCRIPTION
Fixes #494 and #496.
