### PR TITLE
fixes #495: holey arrays cause no-comma-dangle rule to throw

### DIFF
--- a/lib/rules/no-comma-dangle.js
+++ b/lib/rules/no-comma-dangle.js
@@ -19,11 +19,12 @@ module.exports = function(context) {
         var tokens = context.getTokens(node),
             secondToLastToken = tokens[tokens.length - 2];
 
+        var items = node.properties || node.elements,
+            lastItem = items[items.length - 1];
         // The last token in an object/array literal will always be a closing
         // curly, so we check the second to last token for a comma.
-        if (secondToLastToken.value === ",") {
-            var items = node.properties || node.elements;
-            context.report(items[items.length - 1], "Trailing comma.");
+        if(secondToLastToken.value === "," && items.length && lastItem) {
+            context.report(lastItem, "Trailing comma.");
         }
     }
 

--- a/tests/lib/rules/no-comma-dangle.js
+++ b/tests/lib/rules/no-comma-dangle.js
@@ -16,7 +16,10 @@ var eslintTester = require("../../../lib/tests/eslintTester");
 eslintTester.addRuleTest("no-comma-dangle", {
     valid: [
         "var foo = { bar: \"baz\" }",
-        "var foo = [ \"baz\" ]"
+        "var foo = [ \"baz\" ]",
+        "[,,]",
+        "[,]",
+        "[]"
     ],
     invalid: [
         { code: "var foo = { bar: \"baz\", }", errors: [{ message: "Trailing comma.", type: "Property"}] },


### PR DESCRIPTION
Fixes #495.
