### PR TITLE
fixes #505: no-cond-assign should ignore doubly parenthesised tests

### DIFF
--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -11,13 +11,26 @@ module.exports = function(context) {
 
     "use strict";
 
-    var message     = "Expected a conditional expression and instead saw an assignment.",
-        targetExpr  = "AssignmentExpression";
+    function isParenthesised(node) {
+        var tokens = context.getTokens(node, 1, 1),
+            firstToken = tokens[0],
+            lastToken = tokens[tokens.length - 1];
+        return firstToken.value === "(" && firstToken.range[1] <= node.range[0] &&
+            lastToken.value === ")" && lastToken.range[0] >= node.range[1];
+    }
+
+    function isParenthesisedTwice(node) {
+        var tokens = context.getTokens(node, 2, 2),
+            firstToken = tokens[0],
+            lastToken = tokens[tokens.length - 1];
+        return isParenthesised(node) &&
+            firstToken.value === "(" && firstToken.range[1] <= node.range[0] &&
+            lastToken.value === ")" && lastToken.range[0] >= node.range[1];
+    }
 
     function testForAssign(node) {
-        var type = node.test.type;
-        if (type === targetExpr) {
-            context.report(node, message);
+        if ("AssignmentExpression" === node.test.type && !isParenthesisedTwice(node.test)) {
+            context.report(node, "Expected a conditional expression and instead saw an assignment.");
         }
     }
 

--- a/tests/lib/rules/no-cond-assign.js
+++ b/tests/lib/rules/no-cond-assign.js
@@ -18,12 +18,14 @@ eslintTester.addRuleTest("no-cond-assign", {
         "var x = 0; if (x == 0) { var b = 1; }",
         "var x = 5; while (x < 5) { x = x + 1; }",
         "var x = 0; if (x == 0) { var b = 1; }",
-        "if ((someNode = someNode.parentNode) !== null) { }"
+        "if ((someNode = someNode.parentNode) !== null) { }",
+        "if ((a = b));"
     ],
     invalid: [
         { code: "var x; if (x = 0) { var b = 1; }", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "IfStatement"}] },
         { code: "var x; while (x = 0) { var b = 1; }", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "WhileStatement"}] },
         { code: "var x = 0, y; do { y = x; } while (x = x + 1);", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "DoWhileStatement"}] },
-        { code: "var x; for(; x+=1 ;){};", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "ForStatement"}] }
+        { code: "var x; for(; x+=1 ;){};", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "ForStatement"}] },
+        { code: "var x; if ((x) = (0));", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "IfStatement"}] },
     ]
 });


### PR DESCRIPTION
Fixes #505. On a related note, we really need to consolidate all these helpers and then DRY up the tests.
