### PR TITLE
Allow config files to have any name (fixes #486).

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -50,6 +50,26 @@ function loadIgnoreFile(directory) {
 }
 
 /**
+ * Load and parse a JSON config object from a file.
+ * @param {string} filePath the path to the JSON config file
+ * @return {object} the parsed config object (empty object if there was a parse error)
+ */
+function loadConfig(filePath) {
+    var config = {};
+
+    if (filePath) {
+        try {
+            config = JSON.parse(fs.readFileSync(filePath));
+        } catch (e) {
+            console.error("Cannot read config file:", filePath);
+            console.error("Error: ", e.message);
+        }
+    }
+
+    return config;
+}
+
+/**
  * Get a local config object.
  * @param {string} directory the directory to start looking for a local config
  * @return {object} the local config object (empty object if there is no local config)
@@ -60,12 +80,7 @@ function getLocalConfig(helper, directory) {
 
     /* istanbul ignore else Too complicated to create unittest*/
     if (localConfigFile) {
-        try {
-            config = JSON.parse(fs.readFileSync(localConfigFile));
-        } catch (e) {
-            console.error("Cannot read config file:", localConfigFile);
-            console.error("Error: ", e.message);
-        }
+        config = loadConfig(localConfigFile);
     }
 
     return config;
@@ -93,7 +108,7 @@ function Config(options) {
     useConfig = options.c || options.config;
 
     if (useConfig) {
-        this.useSpecificConfig = require(path.resolve(process.cwd(), useConfig));
+        this.useSpecificConfig = loadConfig(path.resolve(process.cwd(), useConfig));
     }
 }
 

--- a/tests/fixtures/configurations/my-awesome-config
+++ b/tests/fixtures/configurations/my-awesome-config
@@ -1,0 +1,9 @@
+{
+    "env": {
+        "browser": true
+    },
+
+    "rules": {
+        "quotes": [3, "triple"]
+    }
+}

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -27,7 +27,7 @@ describe("cli", function() {
     });
 
     describe("when given a config file", function() {
-        var code = "conf/eslint.json";
+        var code = path.join(__dirname, "..", ".eslintrc");
 
         it("should load the specified config file", function() {
             assert.doesNotThrow(function () {

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -176,4 +176,14 @@ describe("config", function() {
             }
         });
     });
+
+    describe("Config with abitrarily named config file", function() {
+        it ("should load the config file", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "my-awesome-config"),
+                configHelper = new Config({config: configPath}),
+                quotes = configHelper.useSpecificConfig.rules.quotes[0];
+
+            assert.equal(quotes, 3);
+        });
+    });
 });


### PR DESCRIPTION
Currently require is used to load and parse the config file. Unfortunately this forces the filename extension to be .json.

As discussed in https://github.com/eslint/eslint/issues/486, the consensus was that since config files should be JSON and not executable code, the .json restriction is unnecessary and it is preferable to parse the file ourselves instead of using require (which ultimately does exactly what this commit does).
