### PR TITLE
Preliminary disable per line with comments

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -283,22 +283,19 @@ module.exports = (function() {
                 /* istanbul ignore else Too complicate to fake invalid rule*/
                 if (ruleCreator) {
                     rule = ruleCreator(new RuleContext(key, api, options));
-                    rule.name = key;
 
                     // add all the node types as listeners
                     Object.keys(rule).forEach(function(nodeType) {
-                        if (nodeType !== "name") {
-                            api.on(nodeType, function(node) {
-                                if (node.leadingComments && node.leadingComments.value && node.leadingComments.value.length > 0) {
-                                    //verify that comment doesn't turn off the rule
-                                    if (node.leadingComments.value.indexOf("eslint: " + rule.name) < 0) {
-                                        rule[nodeType].apply(this, arguments);
-                                    }
-                                } else {
+                        api.on(nodeType, function(node) {
+                            if (node.leadingComments && node.leadingComments.value && node.leadingComments.value.length > 0) {
+                                //verify that comment doesn't turn off the rule
+                                if (node.leadingComments.value.indexOf("eslint: " + key) < 0) {
                                     rule[nodeType].apply(this, arguments);
                                 }
-                            });
-                        }
+                            } else {
+                                rule[nodeType].apply(this, arguments);
+                            }
+                        });
                     });
                 } else {
                     throw new Error("Definition for rule '" + key + "' was not found.");


### PR DESCRIPTION
This is very preliminary checkin to add an ability to disable rules per line. I mostly just want to verify the direction. I also have a request, could somebody educate me as to what is going on with scope in this example? I'm confused why is `rule` accessible from inside `forEach` loop, but things like `key` and `ruleCreator` are not (that's why I had to assign `key` to be a property of the `rule`, which is not something I want to do).
