### PR TITLE
Build: Use browserify to create browser-ready ESLint (fixes #119)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@ node_modules/
 test.js
 coverage/
 build/
-lib/rules/index.js
-build/
 npm-debug.log
 .DS_Store
+tmp/

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -282,12 +282,17 @@ module.exports = (function() {
 
                 /* istanbul ignore else Too complicate to fake invalid rule*/
                 if (ruleCreator) {
-                    rule = ruleCreator(new RuleContext(key, api, options));
+                    try {
+                        rule = ruleCreator(new RuleContext(key, api, options));
 
-                    // add all the node types as listeners
-                    Object.keys(rule).forEach(function(nodeType) {
-                        api.on(nodeType, rule[nodeType]);
-                    });
+                        // add all the node types as listeners
+                        Object.keys(rule).forEach(function(nodeType) {
+                            api.on(nodeType, rule[nodeType]);
+                        });
+                    } catch(ex) {
+                        throw new Error("Error while loading rule '" + key + "'.");
+                    }
+
                 } else {
                     throw new Error("Definition for rule '" + key + "' was not found.");
                 }

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "minor": "node Makefile.js minor",
     "major": "node Makefile.js major",
     "gensite": "node Makefile.js gensite",
-    "bundle": "bash scripts/bundle.sh"
+    "browserify": "node Makefile.js browserify"
   },
   "files": [
     "LICENSE",
@@ -38,14 +38,16 @@
     "doctrine": "~0.2.0"
   },
   "devDependencies": {
-    "sinon": "*",
-    "commonjs-everywhere": "~0.9.0",
+    "sinon": "1.7.3",
     "mocha": "~1.13.0",
     "chai": "~1.8.1",
     "shelljs": "~0.2",
     "jsonlint": "~1.6.0",
     "istanbul": "~0.2.3",
-    "dateformat": "~1.0.7-1.2.3"
+    "dateformat": "~1.0.7-1.2.3",
+    "browserify": "~3.20.0",
+    "mocha-phantomjs": "~3.3.1",
+    "phantomjs": "~1.9.2-6"
   },
   "keywords": [
     "ast",

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -4,12 +4,27 @@
  */
 
 //------------------------------------------------------------------------------
+// Helper
+//------------------------------------------------------------------------------
+
+/**
+ * To make sure this works in both browsers and Node.js
+ */
+function compatRequire(name, windowName) {
+    if (typeof require === "function") {
+        return require(name);
+    } else {
+        return window[windowName || name];
+    }
+}
+
+//------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
 
-var assert = require("chai").assert,
-    sinon = require("sinon"),
-    eslint = require("../../lib/eslint");
+var assert = compatRequire("chai").assert,
+    sinon = compatRequire("sinon"),
+    eslint = compatRequire("../../lib/eslint", "eslint");
 
 //------------------------------------------------------------------------------
 // Constants
@@ -862,9 +877,8 @@ describe("eslint", function() {
 
         it("should throw an error", function() {
             assert.throws(function() {
-                eslint.verify(code, { foobar: 2 });
-            }, "Object.keys called on non-object",
-            "Definition for rule 'foobar' was not found.");
+                eslint.verify(code, { rules: {foobar: 2 } });
+            }, /Definition for rule 'foobar' was not found\./);
         });
     });
 

--- a/tests/tests.htm
+++ b/tests/tests.htm
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Browser smoke test</title>
+    <meta charset="utf-8">
+    <link rel="stylesheet" href="../node_modules/mocha/mocha.css" />
+  </head>
+  <body>
+    <div id="mocha"></div>
+    <!-- test framework -->
+    <script src="../node_modules/mocha/mocha.js"></script>
+    <script src="../node_modules/chai/chai.js"></script>
+    <script src="../node_modules/sinon/pkg/sinon-1.7.3.js"></script>
+
+    <!-- source -->
+    <script src="../build/eslint.js"></script>
+
+    <!-- mocha setup -->
+    <script>
+        mocha.ui('bdd');
+        mocha.reporter('html');
+    </script>
+
+    <!-- test suite -->
+    <script src="lib/eslint.js"></script>
+
+    <!-- runner -->
+    <script>
+        window.mochaPhantomJS
+          ? mochaPhantomJS.run()
+          : mocha.run();
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
This issue has been open for a while and is holding up the release, so I decided to switch to browserify and make something that works. 

I also added a build step to test ESLint using PhantomJS for a quick sanity test of browser compatibility.
