### PR TITLE
Allow YAML configuration files (fixes #491)

### DIFF
--- a/docs/command-line-interface/config-files.md
+++ b/docs/command-line-interface/config-files.md
@@ -4,12 +4,12 @@ ESLint is fully configurable using configuration files. The configuration files 
 
 ## Format
 
-ESLint configuration files are simply JSON files that follow a particular format. These are the top-level properties of a configuration file:
+ESLint configuration files are simply JSON or YAML files that follow a particular format. These are the top-level properties of a configuration file:
 
 * `env` - specifies environment information
 * `rules` - specifies which rules are enabled
 
-Here's a simple example:
+Here's a simple JSON example:
 
 ```json
 {
@@ -21,6 +21,18 @@ Here's a simple example:
         "strict": 0
     }
 }
+```
+
+Here's a simple YAML example:
+
+```yaml
+---
+  env:
+    browser: true
+
+  rules:
+    eqeqeq: 1
+    strict: 0
 ```
 
 ### Environment
@@ -68,6 +80,23 @@ Passing in the configuration file in this manner will override any default setti
 The second way to use configuration files is via `.eslintrc` files. These files you place directly into your project directory and ESLint will automatically find them and read configuration information from them. This option is useful when you want different configurations for different parts of a project or when you want others to be able to use ESLint directly without needing to remember to pass in the configuration file.
 
 In either case, the settings in the configuration file override default settings.
+
+## Comments in Configuration Files
+
+Both the JSON and YAML configuration file formats support comments. You can use JavaScript-style comments or YAML-style comments in either type of file and ESLint will safely ignore them. This allows your configuration files to be more human-friendly. For example:
+
+```json
+    "env": {
+        "browser": true
+    },
+    "rules": {
+
+        // Override our default settings just for this directory
+        "eqeqeq": 1,
+        "strict": 0
+    }
+}
+```
 
 ## Using Comments To Configure Rules
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -13,7 +13,8 @@ var fs = require("fs"),
     environments = require("../conf/environments.json"),
     util = require("./util"),
     glob = require("glob"),
-    stripComments = require("strip-json-comments");
+    stripComments = require("strip-json-comments"),
+    yaml = require("js-yaml");
 
 var existsSync = fs.existsSync || path.existsSync;
 
@@ -60,7 +61,7 @@ function loadConfig(filePath) {
 
     if (filePath) {
         try {
-            config = JSON.parse(stripComments(fs.readFileSync(filePath, "utf8")));
+            config = yaml.safeLoad(stripComments(fs.readFileSync(filePath, "utf8")));
         } catch (e) {
             console.error("Cannot read config file:", filePath);
             console.error("Error: ", e.message);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "glob": "~3.2.7",
     "text-table": "~0.2.0",
     "chalk": "~0.4.0",
-    "strip-json-comments": "~0.1.1"
+    "strip-json-comments": "~0.1.1",
+    "js-yaml": "~3.0.1"
   },
   "devDependencies": {
     "sinon": "1.7.3",

--- a/tests/fixtures/configurations/env-browser.yaml
+++ b/tests/fixtures/configurations/env-browser.yaml
@@ -1,0 +1,7 @@
+---
+  env:
+    browser: true
+
+  rules:
+    no-alert: 0
+    no-undef: 2

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -199,4 +199,16 @@ describe("config", function() {
         });
     });
 
+    describe("YAML config", function() {
+        it ("should load the config file", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "env-browser.yaml"),
+                configHelper = new Config({config: configPath}),
+                noAlert = configHelper.useSpecificConfig.rules["no-alert"],
+                noUndef = configHelper.useSpecificConfig.rules["no-undef"];
+
+            assert.equal(noAlert, 0);
+            assert.equal(noUndef, 2);
+        });
+    });
+
 });


### PR DESCRIPTION
This switches to using `js-yaml` for parsing configuration files. Since YAML is a superset of JSON, JSON files and YAML files can be parsed using the same command, eliminating the need to look for configuration file signals (such as extension).
