### PR TITLE
New Rule: consistent-return (fixes #481)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -77,6 +77,7 @@
         "camelcase": 2,
         "complexity": [0, 11],
         "consistent-this": [0, "that"],
+        "consistent-return": 2,
         "curly": 2,
         "dot-notation": 2,
         "eqeqeq": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -30,6 +30,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 
 * [block-scoped-var](block-scoped-var.md) - treat `var` statements as if they were block scoped
 * [complexity](complexity.md) - specify the maximum cyclomatic complexity allowed in a program
+* [consistent-return](consistent-return.md) - require `return` statements to either always or never specify values
 * [curly](curly.md) - require curly brace for all control statements
 * [dot-notation](dot-notation.md) - encourages use of dot notation whenever possible
 * [eqeqeq](eqeqeq.md) - require the use of `===` and `!==`

--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -1,0 +1,61 @@
+# Require Consistent Returns
+
+One of the confusing aspects of JavaScript is that any function may or may not return a value at any point in time. When a function exits without any `return` statement executing, the function returns `undefined`. Similarly, calling `return` without specifying any value will cause the function to return `undefined`. Only when `return` is called with a value is there a change in the function's return value.
+
+Unlike statically-typed languages that tend will catch when a function doesn't return the type of data expected, JavaScript has no such checks, meaning that it's easy to make mistakes such as this:
+
+```js
+function doSomething(condition) {
+
+    if (condition) {
+        return true;
+    } else {
+        return;
+    }
+}
+```
+
+Here, one branch of the function returns `true`, a Boolean value, while the other exits without specifying any value (and so returns `undefined`). This may be an indicator of a coding error, especially if this pattern is found in larger functions.
+
+## Rule Details
+
+This rule is aimed at ensuring all `return` statements either specify a value or don't specify a value.
+
+The following patterns are considered warnings:
+
+```js
+function doSomething(condition) {
+
+    if (condition) {
+        return true;
+    } else {
+        return;
+    }
+}
+
+function doSomething(condition) {
+
+    if (condition) {
+        return;
+    } else {
+        return true;
+    }
+}
+```
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+function doSomething(condition) {
+
+    if (condition) {
+        return true;
+    } else {
+        return false;
+    }
+}
+```
+
+## When Not To Use It
+
+If you want to allow functions to have different `return` behavior depending on code branching, then it is safe to disable this rule.

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -59,11 +59,11 @@ function parseBoolean(str) {
  * Parses info about globals from a special block comment and adds them to the `declaredGlobals` map.
  * @param {ASTNode} comment
  * @param {object} declaredGlobals
- * @returns {void}
+ * @returns {boolean} True if globals were added, false if not.
  */
 function parseComment(comment, declaredGlobals) {
     if (comment.type !== "Block") {
-        return;
+        return false;
     }
     var text = comment.value;
     var match;

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -1,0 +1,57 @@
+/**
+ * @fileoverview Rule to flag consistent return values
+ * @author Nicholas C. Zakas
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var functions = [];
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    function enterFunction() {
+        functions.push({});
+    }
+
+    function exitFunction() {
+        functions.pop();
+    }
+
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "FunctionDeclaration": enterFunction,
+        "FunctionExpression": enterFunction,
+        "FunctionDeclaration:after": exitFunction,
+        "FunctionExpression:after": exitFunction,
+
+        "ReturnStatement": function(node) {
+
+            var returnInfo = functions[functions.length - 1],
+                returnTypeDefined = "type" in returnInfo;
+
+            if (returnTypeDefined) {
+
+                if (returnInfo.type !== !!node.argument) {
+                    context.report(node, "Expected " + (returnInfo.type ? "a" : "no") + " return value.");
+                }
+
+            } else {
+                returnInfo.type = !!node.argument;
+            }
+
+        }
+    };
+
+};

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Tests for consistent-return rule.
+ * @author Raphael Pigulla
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+var eslintTester = require("../../../lib/tests/eslintTester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("consistent-return", {
+
+    valid: [
+        "function foo() { return; }",
+        "function foo() { if (true) return; else return; }",
+        "function foo() { if (true) return true; else return false; }",
+        "f(function() { return; })",
+        "f(function() { if (true) return; else return; })",
+        "f(function() { if (true) return true; else return false; })",
+        "function foo() { function bar() { return true; } return; }",
+        "function foo() { function bar() { return; } return false; }"
+    ],
+
+    invalid: [
+        {
+            code: "function foo() { if (true) return true; else return; }",
+            errors: [
+                {
+                    message: "Expected a return value.",
+                    type: "ReturnStatement"
+                }
+            ]
+        },
+        {
+            code: "function foo() { if (true) return; else return false; }",
+            errors: [
+                {
+                    message: "Expected no return value.",
+                    type: "ReturnStatement"
+                }
+            ]
+        },
+        {
+            code: "f(function () { if (true) return true; else return; })",
+            errors: [
+                {
+                    message: "Expected a return value.",
+                    type: "ReturnStatement"
+                }
+            ]
+        },
+        {
+            code: "f(function () { if (true) return; else return false; })",
+            errors: [
+                {
+                    message: "Expected no return value.",
+                    type: "ReturnStatement"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
For this version, I just check to see that `return` either has a value or not. I think this is still quite useful even though not as useful as testing all code branches for returns (which is quite a bit more complicated).
