### PR TITLE
Fix #570

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -415,10 +415,10 @@ module.exports = (function() {
      */
     api.getSource = function(node, beforeCount, afterCount) {
         if (node) {
-            return currentText ? currentText.slice(node.range[0] - (beforeCount || 0),
+            return (currentText !== null) ? currentText.slice(node.range[0] - (beforeCount || 0),
                 node.range[1] + (afterCount || 0)) : null;
         } else {
-            return currentText || null;
+            return currentText;
         }
 
     };

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -44,10 +44,6 @@ module.exports = function(context) {
         // sets the initial range to 80 for getSource
         node.range[0] = 0;
         var lines = context.getSource(node);
-        // getSource might return null if fed an empty string
-        if(!lines) {
-            return;
-        }
 
         // Replace the tabs
         // Split (honors line-ending)

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -687,6 +687,16 @@ describe("eslint", function() {
         });
     });
 
+    describe("when evaluating empty code", function() {
+        var code = "", config = { rules: {} };
+
+        it("getSource() should return an empty string", function() {
+            eslint.reset();
+            eslint.verify(code, config, true);
+            assert.equal(eslint.getSource(), "");
+        });
+    });
+
     describe("at any time", function() {
         var code = "new-rule";
 


### PR DESCRIPTION
The main fix changes the behavior of getSource, and should return null only if currentText is null itself.

The fix in the max-len rule removes the now unnecessary special-case handling of null  as returned by getSource that I had to introduce earlier.

The last fix adds a test for "" being fed to verify (is this the proper place/test to do that?).

Thanks a lot!
