### PR TITLE
New Rule: no-lone-blocks (fixes #512)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -74,6 +74,7 @@
         "no-extend-native": 2,
         "no-yoda": 2,
         "no-path-concat": 0,
+        "no-lone-blocks": 2,
 
         "brace-style": 0,
         "block-scoped-var": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -48,6 +48,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-floating-decimal](no-floating-decimal.md) - disallow the use of leading or trailing decimal points in numeric literals
 * [no-implied-eval](no-implied-eval.md) - disallow use of `eval()`-like methods
 * [no-iterator](no-iterator.md) - disallow usage of `__iterator__` property
+* [no-lone-blocks](no-lone-blocks.md) - disallow unnecessary nested blocks
 * [no-loop-func](no-loop-func.md) - disallow creation of functions within loops
 * [no-multi-str](no-multi-str.md) - disallow use of multiline strings
 * [no-native-reassign](no-native-reassign.md) - disallow reassignments of native objects

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -1,0 +1,50 @@
+# Disallow Unnecessary Nested Blocks
+
+In JavaScript, standalone code blocks delimited by curly braces do not create a new scope and have have no use. For example, these curly braces do nothing to `foo`:
+
+```js
+{
+    var foo = bar();
+}
+```
+
+## Rule details
+
+This rule aims to eliminate unnecessary and potentially confusing blocks at the top level of a script or within other blocks.
+
+The following patterns are considered warnings:
+
+```js
+{}
+
+if (foo) {
+    bar();
+    {
+        baz();
+    }
+}
+
+function bar() {
+    {
+        baz();
+    }
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+while (foo) {
+    bar();
+}
+
+if (foo) {
+    if (bar) {
+        baz();
+    }
+}
+
+functin bar() {
+    baz();
+}
+```

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Rule to flag blocks with no reason to exist
+ * @author Brandon Mills
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+        "BlockStatement": function (node) {
+            // Check for any occurrence of BlockStatement > BlockStatement or
+            // Program > BlockStatement
+            var parent = context.getAncestors().pop();
+            if (parent.type === "BlockStatement" || parent.type === "Program") {
+                context.report(node, "Block is nested inside another block.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-lone-blocks.js
+++ b/tests/lib/rules/no-lone-blocks.js
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Tests for no-lone-blocks rule.
+ * @author Brandon Mills
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/no-lone-blocks", {
+    valid: [
+        "if (foo) { if (bar) { baz(); } }",
+        "do { bar(); } while (foo)",
+        "function foo() { while (bar) { baz() } }"
+    ],
+    invalid: [
+        { code: "{}", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
+        { code: "foo(); {} bar();", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
+        { code: "if (foo) { bar(); {} baz(); }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
+        { code: "{ { } }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}, { message: "Block is nested inside another block.", type: "BlockStatement"}] },
+        { code: "function foo() { bar(); {} baz(); }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
+        { code: "while (foo) { {} }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] }
+    ]
+});


### PR DESCRIPTION
Implements @michaelficarra's proposal to disallow `BlockStatement > BlockStatement` or `Program > BlockStatement` forms as described in #512.
