### PR TITLE
New Rule: no-extra-boolean-cast (fixes #557)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -27,6 +27,7 @@
         "no-eval": 2,
         "no-ex-assign": 2,
         "no-extend-native": 2,
+        "no-extra-boolean-cast": 2,
         "no-extra-parens": 0,
         "no-extra-semi": 2,
         "no-extra-strict": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -15,6 +15,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-empty](no-empty.md) - disallow empty statements
 * [no-empty-class](no-empty-class.md) - disallow the use of empty character classes in regular expressions
 * [no-ex-assign](no-ex-assign.md) - disallow assigning to the exception in a `catch` block
+* [no-extra-boolean-cast](no-extra-boolean-cast.md) - disallow double-negation boolean casts in a boolean context
 * [no-extra-parens](no-extra-parens.md) - disallow unnecessary parentheses
 * [no-extra-semi](no-extra-semi.md) - disallow unnecessary semicolons
 * [no-func-assign](no-func-assign.md) - disallow overwriting functions written as function declarations

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -1,0 +1,57 @@
+# Disallow Extra Boolean Casts
+
+In contexts such as an `if` statement's test where the result of the expression will already be coerced to a Boolean, casting to a Boolean via double negation (`!!`) is unnecessary. For example, these `if` statements are equivalent:
+
+```js
+if (!!foo) {
+    // ...
+}
+
+if (foo) {
+    // ...
+}
+```
+
+## Rule Details
+
+This rule aims to eliminate the use of double-negation Boolean casts in an already Boolean context.
+
+The following patterns are considered warnings:
+
+```js
+var foo = !!!bar;
+
+var foo = !!bar ? baz : bat;
+
+var foo = Boolean(!!bar);
+
+var foo = new Boolean(!!bar);
+
+if (!!foo) {
+    // ...
+}
+
+while (!!foo) {
+    // ...
+}
+
+do {
+    // ...
+} while (!!foo);
+
+for (; !!foo; ) {
+    // ...
+}
+```
+
+The following patterns are not warnings:
+
+```js
+var foo = !!bar;
+
+function foo() {
+    return !!bar;
+}
+
+var foo = bar ? !!baz : !!bat;
+```

--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Rule to flag unnecessary double negation in Boolean contexts
+ * @author Brandon Mills
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+        "UnaryExpression": function (node) {
+            var ancestors   = context.getAncestors(),
+                parent      = ancestors.pop(),
+                grandparent = ancestors.pop(),
+                operator;
+
+            // Exit early if it's guaranteed not to match
+            if (node.operator !== "!" ||
+                    parent.type !== "UnaryExpression" ||
+                    parent.operator !== "!") {
+                return;
+            }
+
+            // if (<bool>) ...
+            if (grandparent.type === "IfStatement") {
+                context.report(node, "Redundant double negation in an if statement condition.");
+
+            // do ... while (<bool>)
+            } else if (grandparent.type === "DoWhileStatement") {
+                context.report(node, "Redundant double negation in a do while loop condition.");
+
+            // while (<bool>) ...
+            } else if (grandparent.type === "WhileStatement") {
+                context.report(node, "Redundant double negation in a while loop condition.");
+
+            // <bool> ? ... : ...
+            } else if ((grandparent.type === "ConditionalExpression" &&
+                    parent === grandparent.test)) {
+                context.report(node, "Redundant double negation in a ternary condition.");
+
+            // for (...; <bool>; ...) ...
+            } else if ((grandparent.type === "ForStatement" &&
+                    parent === grandparent.test)) {
+                context.report(node, "Redundant double negation in a for loop condition.");
+
+            // !<bool>
+            } else if ((grandparent.type === "UnaryExpression" &&
+                    grandparent.operator === "!")) {
+                context.report(node, "Redundant multiple negation.");
+
+            // Boolean(<bool>)
+            } else if ((grandparent.type === "CallExpression" &&
+                    grandparent.callee.type === "Identifier" &&
+                    grandparent.callee.name === "Boolean")) {
+                context.report(node, "Redundant double negation in call to Boolean().");
+
+            // new Boolean(<bool>)
+            } else if ((grandparent.type === "NewExpression" &&
+                    grandparent.callee.type === "Identifier" &&
+                    grandparent.callee.name === "Boolean")) {
+                context.report(node, "Redundant double negation in Boolean constructor call.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-extra-boolean-cast.js
+++ b/tests/lib/rules/no-extra-boolean-cast.js
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Tests for no-extra-boolean-cast rule.
+ * @author Brandon Mills
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/no-extra-boolean-cast", {
+
+    valid: [
+        "var foo = !!bar;",
+        "function foo() { return !!bar; }",
+        "var foo = bar() ? !!baz : !!bat",
+        "for(!!foo;;) {}",
+        "for(;; !!foo) {}"
+    ],
+
+    invalid: [
+        {
+            code: "if (!!foo) {}",
+            errors: [{
+                message: "Redundant double negation in an if statement condition.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "do {} while (!!foo)",
+            errors: [{
+                message: "Redundant double negation in a do while loop condition.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "while (!!foo) {}",
+            errors: [{
+                message: "Redundant double negation in a while loop condition.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "!!foo ? bar : baz",
+            errors: [{
+                message: "Redundant double negation in a ternary condition.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "for (; !!foo;) {}",
+            errors: [{
+                message: "Redundant double negation in a for loop condition.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "!!!foo",
+            errors: [{
+                message: "Redundant multiple negation.",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "Boolean(!!foo)",
+            errors: [{
+                message: "Redundant double negation in call to Boolean().",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "Boolean(!!foo)",
+            errors: [{
+                message: "Redundant double negation in call to Boolean().",
+                type: "UnaryExpression"
+            }]
+        },
+        {
+            code: "new Boolean(!!foo)",
+            errors: [{
+                message: "Redundant double negation in Boolean constructor call.",
+                type: "UnaryExpression"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
Disallows double-negation Boolean casts in contexts where the result is already coerced to a Boolean. Proposed in #557 by @michaelficarra.
