### PR TITLE
readme: Remove stray asterisk

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -6,7 +6,7 @@
 * **Vim**: https://github.com/scrooloose/syntastic/tree/master/syntax_checkers/javascript
 * **Emacs**: [Flycheck](http://flycheck.readthedocs.org/en/latest/) supports ESLint in recent versions.
 * **Eclipse Orion**: ESLint is the default linter (http://dev.eclipse.org/mhonarc/lists/orion-dev/msg02718.html)
-*
+
 
 ## Build Systems
 


### PR DESCRIPTION
It got rendered as literal inline text at the end of the preceding item.

> ![screen shot 2014-02-04 at 17 20 35](https://f.cloud.github.com/assets/156867/2083493/bfa6c940-8e03-11e3-8e8c-1fe7f79d773a.png)
