### PR TITLE
WIP: Optimize findVariable() in no-unused-vars

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -13,20 +13,27 @@ module.exports = function(context) {
 
     var allowUnusedGlobals = context.options[0] === "all" ? false : true;
 
-    var variables     = [],
-        variableNames = {};
+    var variables = {};
 
-    function lookupVariable(variable) {
-        if (!Object.prototype.hasOwnProperty.call(variableNames, variable.name)) {
+    function lookupVariableName(name) {
+
+        // Convoluted check in case name is "hasOwnProperty"
+        if (!Object.prototype.hasOwnProperty.call(variables, name)) {
             return null;
         }
-        return variableNames[variable.name].map(function (index) {
-            return variables[index];
-        }).filter(function (candidate) {
-            return candidate.name === variable.name && variable.identifiers.some(function (identifier) {
-                return candidate.node === identifier;
-            });
-        })[0];
+        return variables[name];
+    }
+
+    function lookupVariable(variable) {
+        var candidates = lookupVariableName(variable.name);
+        if (candidates) {
+            return candidates.filter(function (candidate) {
+                return variable.identifiers.some(function (identifier) {
+                    return candidate.node === identifier;
+                });
+            })[0];
+        }
+        return candidates;
     }
 
     function populateVariables(node) {
@@ -38,23 +45,21 @@ module.exports = function(context) {
             functionNameUsed = parent && parent.type === "MemberExpression";
 
         scope.variables.forEach(function(variable) {
-            var index;
 
             //filter out global variables that we add as part of eslint or arguments variable
             if (variable.identifiers.length > 0) {
 
                 //make sure that this variable is not already in the array
                 if (!lookupVariable(variable)) {
-                    index = variables.push({
+
+                    if (!lookupVariableName(variable.name)) {
+                        variables[variable.name] = [];
+                    }
+                    variables[variable.name].push({
                         name: variable.name,
                         node: variable.identifiers[0],
                         used: (variable.name === functionName) && functionNameUsed
                     });
-                    if (!Object.prototype.hasOwnProperty.call(variableNames, variable.name)) {
-                        variableNames[variable.name] = [index - 1];
-                    } else {
-                        variableNames[variable.name].push(index - 1);
-                    }
                 }
             }
         });
@@ -122,10 +127,9 @@ module.exports = function(context) {
                 var ignorableVariables = fnParamNames.slice(0, variableIndex);
                 // Mark them as ignorable.
                 ignorableVariables.forEach(function(ignorableVariable){
-                    variables.forEach(function(variable){
-                        if (variable.name === ignorableVariable) {
-                            variable.ignorable = true;
-                        }
+
+                    (lookupVariableName(ignorableVariable) || []).forEach(function(variable){
+                        variable.ignorable = true;
                     });
                 });
             }
@@ -159,12 +163,15 @@ module.exports = function(context) {
         },
 
         "Program:after": function() {
-            var unused = variables.filter(function(variable) {
-                return !variable.used && !variable.ignorable;
-            });
-            unused.forEach(function(variable) {
-                context.report(variable.node, "{{var}} is defined but never used", {"var": variable.name});
-            });
+            Object.keys(variables)
+                .forEach(function (name) {
+                    variables[name].forEach(function (variable) {
+                        if (variable.used || variable.ignorable) {
+                            return;
+                        }
+                        context.report(variable.node, "{{var}} is defined but never used", {"var": variable.name});
+                    });
+                });
         }
     };
 


### PR DESCRIPTION
This is the lowest-hanging fruit - `findVariable()` was taking a significant portion of the overall time due to a linear search of the `variables` array. The first step, with the smallest change to the code, was to add a map of variable names to indices. Look up the variable by name, then get it by its index in the existing list.

This is definitely a work in progress, but I wanted to get feedback before I pursue this further. From this change, I'm seeing a speedup in the profiler from ~20s to <10s.
