### PR TITLE
Use optionator for option parsing, not optimist - for #596

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
 var cli = require("../lib/cli");
-var exitCode = cli.execute(Array.prototype.slice.call(process.argv, 2));
+var exitCode = cli.execute(process.argv);
 process.exit(exitCode);

--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -22,11 +22,11 @@ The command line utility has several options. You can view the options by runnin
 eslint [options] file.js [file.js] [dir]
 
 Options:
-  -h, --help    Show help.
-  -c, --config  Load configuration data from this file.
-  --rulesdir    Load additional rules from this directory.
-  -f, --format  Use a specific output format.               [default: "stylish"]
-  -v, --version  Outputs the version number.
+  -h, --help                 show help
+  -c, --config path::String  load configuration data from this file
+  --rulesdir path::String    load additional rules from this directory
+  -f, --format String        use a specific output format - default: stylish
+  -v, --version              outputs the version number
 ```
 
 ### `-h`, `--help`

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -208,26 +208,35 @@ var cli = {
 
     /**
      * Executes the CLI based on an array of arguments that is passed in.
-     * @param {String[]} argv The array of arguments to process.
+     * @param {string|Array|Object} args The arguments to process.
      * @returns {int} The exit code for the operation.
      */
-    execute: function(argv) {
+    execute: function(args) {
 
-        var currentOptions = options.parse(argv),
-            files = currentOptions._,
+        var currentOptions,
+            files,
             configHelper,
             result;
+
+        try {
+          currentOptions = options.parse(args);
+        } catch (error) {
+          console.error(error.message);
+          return 1;
+        }
+
+        files = currentOptions._;
 
         // Ensure results from previous execution are not printed.
         results = [];
 
-        if (currentOptions.v) { // version from package.json
+        if (currentOptions.version) { // version from package.json
 
             console.log("v" + require("../package.json").version);
 
-        } else if (currentOptions.h || !files.length) {
+        } else if (currentOptions.help || !files.length) {
 
-            options.help();
+            console.log(options.generateHelp());
 
         } else {
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -106,22 +106,8 @@ function Config(options) {
     this.cache = {};
     this.exclusionsCache = {};
     this.baseConfig = require(path.resolve(__dirname, "..", "conf", "eslint.json"));
-
-    /*
-     * TODO: When running "npm test", options.format somehow ends up as an array
-     * with two items rather than a single string value. This doesn't happen if
-     * you run the CLI test on its own with Mocha, only when run in conjunction
-     * with rule tests.
-     *
-     * In the meantime, options.f always returns a single string value in all
-     * circumstances and everything continues to work. Switching to options.f
-     * for now, but when this file is cleaned up, we really need to figure out
-     * why this weird behavior happens. It began when we integrated ESLintTester
-     * into the rules tests as a standalone component. See:
-     * https://github.com/eslint/eslint/issues/480
-     */
-    this.baseConfig.format = options.f;
-    useConfig = options.c || options.config;
+    this.baseConfig.format = options.format;
+    useConfig = options.config;
 
     if (useConfig) {
         this.useSpecificConfig = loadConfig(path.resolve(process.cwd(), useConfig));

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,6 +1,6 @@
 /**
- * @fileoverview Wrapper around Optimist to preconfigure CLI options output.
- * @author Nicholas C. Zakas
+ * @fileoverview Options configuration for optionator.
+ * @author George Zahariev
  */
 "use strict";
 
@@ -8,43 +8,41 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var optimist = require("optimist");
+var optionator = require("optionator");
 
 //------------------------------------------------------------------------------
-// Initialization
+// Initialization and Public Interface
 //------------------------------------------------------------------------------
 
-optimist.usage("eslint [options] file.js [file.js] [dir]");
-
-// Help
-optimist.boolean("h");
-optimist.alias("h", "help");
-optimist.describe("h", "Show help.");
-
-// Config
-optimist.alias("c", "config");
-optimist.describe("c", "Load configuration data from this file.");
-
-// RulesDir
-optimist.describe("rulesdir", "Load additional rules from this directory.");
-
-// Format
-optimist.alias("f", "format");
-optimist.default("f", "stylish");
-optimist.describe("f", "Use a specific output format.");
-
-// Version
-optimist.alias("v", "version");
-optimist.describe("v", "Outputs the version number.");
-
-//------------------------------------------------------------------------------
-// Public Interface
-//------------------------------------------------------------------------------
-
-exports.help = function() {
-    console.log(optimist.help());
-};
-
-exports.parse = function(argv) {
-    return optimist.parse(argv);
-};
+// exports "parse(args)", "generateHelp()", and "generateHelpForOption(optionName)"
+module.exports = optionator({
+  prepend: "eslint [options] file.js [file.js] [dir]",
+  options: [{
+    heading: "Options"
+  }, {
+    option: "help",
+    alias: "h",
+    type: "Boolean",
+    description: "Show help."
+  }, {
+    option: "config",
+    alias: "c",
+    type: "path::String",
+    description: "Load configuration data from this file."
+  }, {
+    option: "rulesdir",
+    type: "path::String",
+    description: "Load additional rules from this directory."
+  }, {
+    option: "format",
+    alias: "f",
+    type: "String",
+    default: "stylish",
+    description: "Use a specific output format."
+  }, {
+    option: "version",
+    alias: "v",
+    type: "Boolean",
+    description: "Outputs the version number."
+  }]
+});

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "url": "https://github.com/eslint/eslint"
   },
   "dependencies": {
-    "optimist": "~0.6.0",
+    "optionator": "~0.1.1",
     "estraverse": "~1.3.0",
     "esprima": "*",
     "escope": "1.0.0",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -29,17 +29,15 @@ describe("cli", function() {
     });
 
     describe("when given a config file", function() {
-        var code = path.join(__dirname, "..", ".eslintrc");
-
         it("should load the specified config file", function() {
             assert.doesNotThrow(function () {
-                cli.execute(["-c", code, "lib/cli.js"]);
+                cli.execute("-c " + path.join(__dirname, "..", ".eslintrc") + " lib/cli.js");
             });
         });
     });
 
     describe("when there is a local config file", function() {
-        var code = ["lib/cli.js"];
+        var code = "lib/cli.js";
 
         it("should load the local config file", function() {
             // Mock CWD
@@ -56,7 +54,7 @@ describe("cli", function() {
     });
 
     describe("when given a config with rules with options and severity level set to error", function() {
-        var code = ["--config", "tests/fixtures/configurations/quotes-error.json", "single-quoted.js"];
+        var code = "--config tests/fixtures/configurations/quotes-error.json single-quoted.js";
 
         it("should exit with an error status (1)", function() {
             var exitStatus;
@@ -70,7 +68,7 @@ describe("cli", function() {
     });
 
     describe("when given a config file and a directory of files", function() {
-        var code = ["--config","tests/fixtures/configurations/semi-error.json", "tests/fixtures/formatters"];
+        var code = "--config tests/fixtures/configurations/semi-error.json tests/fixtures/formatters";
 
         it("should load and execute without error", function() {
             var exitStatus;
@@ -84,7 +82,7 @@ describe("cli", function() {
     });
 
     describe("when given a config with environment set to browser", function() {
-        var code = ["--config", "tests/fixtures/configurations/env-browser.json", "tests/fixtures/globals-browser.js"];
+        var code = "--config tests/fixtures/configurations/env-browser.json tests/fixtures/globals-browser.js";
 
         it("should execute without any errors", function() {
             var exit = cli.execute(code);
@@ -94,7 +92,7 @@ describe("cli", function() {
     });
 
     describe("when given a config with environment set to Node.js", function() {
-        var code = ["--config", "tests/fixtures/configurations/env-node.json", "tests/fixtures/globals-node.js"];
+        var code = "--config tests/fixtures/configurations/env-node.json tests/fixtures/globals-node.js";
 
         it("should execute without any errors", function() {
             var exit = cli.execute(code);
@@ -104,115 +102,93 @@ describe("cli", function() {
     });
 
     describe("when given a valid built-in formatter name", function() {
-        var code = "checkstyle";
-
         it("should execute without any errors", function() {
-            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            var exit = cli.execute("-f checkstyle tests/fixtures/passing.js");
 
             assert.equal(exit, 0);
         });
     });
 
     describe("when given an invalid built-in formatter name", function() {
-        var code = "fakeformatter";
-
         it("should execute with error", function() {
-            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            var exit = cli.execute("-f fakeformatter tests/fixtures/passing.js");
 
             assert.equal(exit, 1);
         });
     });
 
     describe("when given a valid formatter path", function() {
-        var code = "tests/fixtures/formatters/simple.js";
-
         it("should execute without any errors", function() {
-            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            var exit = cli.execute("-f tests/fixtures/formatters/simple.js tests/fixtures/passing.js");
 
             assert.equal(exit, 0);
         });
     });
 
     describe("when given an invalid formatter path", function() {
-        var code = "tests/fixtures/formatters/file-does-not-exist.js";
-
         it("should execute with error", function() {
-            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
+            var exit = cli.execute("-f tests/fixtures/formatters/file-does-not-exist.js tests/fixtures/passing.js");
 
             assert.equal(exit, 1);
         });
     });
 
     describe("when executing a file with an error", function() {
-        var code = "tests/fixtures/configurations/semi-error.js";
-
         it("should execute with error", function() {
-            var exit = cli.execute([code]);
+            var exit = cli.execute("tests/fixtures/configurations/semi-error.js");
 
             assert.equal(exit, 1);
         });
     });
 
     describe("when calling execute more than once", function() {
-        var code = ["tests/fixtures/missing-semicolon.js", "tests/fixtures/passing.js"];
-
         it("should not print the results from previous execution", function() {
-            cli.execute([code[0]]);
+            cli.execute("tests/fixtures/missing-semicolon.js");
             assert.isTrue(console.log.called);
 
             console.log.reset();
 
-            cli.execute([code[1]]);
+            cli.execute("tests/fixtures/passing.js");
             assert.isTrue(console.log.notCalled);
 
         });
     });
 
     describe("when executing with version flag", function() {
-        var code = "-v";
-
         it ("should print out current version", function() {
-            cli.execute([code]);
+            cli.execute("-v");
 
             assert.equal(console.log.callCount, 1);
         });
     });
 
     describe("when executing with help flag", function() {
-        var code = "-h";
-
         it("should print out help", function() {
-            cli.execute([code]);
+            cli.execute("-h");
 
             assert.equal(console.log.callCount, 1);
         });
     });
 
     describe("when given a directory with eslint excluded files", function() {
-        var code = "tests/fixtures";
-
         it("should not process any files", function() {
-            cli.execute([code]);
+            cli.execute("tests/fixtures");
 
             assert.isTrue(console.log.notCalled);
         });
     });
 
     describe("when given a directory with jshint excluded files", function() {
-        var code = "tests/fixtures";
-
         it("should not process any files", function() {
-            cli.execute([code]);
+            cli.execute("tests/fixtures");
 
             assert.isTrue(console.log.notCalled);
         });
     });
 
     describe("when given a directory with eslint excluded files in the directory", function() {
-        var code = "tests/fixtures";
-
         it("should not process any files", function() {
-            var exit = cli.execute([code]);
+            var exit = cli.execute("tests/fixtures");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -220,10 +196,9 @@ describe("cli", function() {
     });
 
     describe("when given a file in excluded files list", function() {
-        var code = "tests/fixtures/missing-semicolon.js";
 
         it("should process the file anyway", function() {
-            var exit = cli.execute([code]);
+            var exit = cli.execute("tests/fixtures/missing-semicolon.js");
 
             assert.isTrue(console.log.called);
             assert.isFalse(console.log.alwaysCalledWith(""));
@@ -232,17 +207,16 @@ describe("cli", function() {
     });
 
     describe("when executing a file with a shebang", function() {
-        var code = "tests/fixtures/shebang.js";
 
         it("should execute without error", function() {
-            var exit = cli.execute([code]);
+            var exit = cli.execute("tests/fixtures/shebang.js");
 
             assert.equal(exit, 0);
         });
     });
 
     describe("when given a custom rule, verify that it's loaded", function() {
-        var code = ["--rulesdir", "./tests/fixtures/rules", "--config", "./tests/fixtures/rules/eslint.json", "tests/fixtures/rules/test/test-custom-rule.js"];
+        var code = "--rulesdir ./tests/fixtures/rules --config ./tests/fixtures/rules/eslint.json tests/fixtures/rules/test/test-custom-rule.js";
 
         it("should return a warning", function() {
             var exit = cli.execute(code);

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Tests for options.
- * @author Nicholas C. Zakas
+ * @author George Zahariev
  */
 
 //------------------------------------------------------------------------------
@@ -15,108 +15,82 @@ var assert = require("chai").assert,
 //------------------------------------------------------------------------------
 
 /*
- * This may look like it's simply testing optimist under the covers, but really
- * it's testing the interface of the options object. I want to make sure the
- * interface is solid and tested because I'm not sure I want to use optimist
- * long-term.
+ * This is testing the interface of the options object.
  */
 
 describe("options", function() {
     describe("when passed --help", function() {
-        var code = [ "--help" ];
-
-        it("should return true for .h", function() {
-            var currentOptions = options.parse(code);
-            assert.isTrue(currentOptions.h);
+        it("should return true for .help", function() {
+            var currentOptions = options.parse("--help");
+            assert.isTrue(currentOptions.help);
         });
     });
 
     describe("when passed -h", function() {
-        var code = [ "-h" ];
-
-        it("should return true for .h", function() {
-            var currentOptions = options.parse(code);
-            assert.isTrue(currentOptions.h);
+        it("should return true for .help", function() {
+            var currentOptions = options.parse("-h");
+            assert.isTrue(currentOptions.help);
         });
     });
 
     describe("when passed --config", function() {
-        var code = [ "--config" ];
-
-        it("should return true for .c", function() {
-            var currentOptions = options.parse(code);
-            assert.isTrue(currentOptions.c);
+        it("should return a string for .config", function() {
+            var currentOptions = options.parse("--config file");
+            assert.isString(currentOptions.config);
+            assert.equal(currentOptions.config, "file");
         });
     });
 
     describe("when passed -c", function() {
-        var code = [ "-c" ];
-
-        it("should return true for .c", function() {
-            var currentOptions = options.parse(code);
-            assert.isTrue(currentOptions.c);
+        it("should return a string for .config", function() {
+            var currentOptions = options.parse("-c file");
+            assert.isString(currentOptions.config);
+            assert.equal(currentOptions.config, "file");
         });
     });
 
     describe("when passed --rulesdir", function() {
-        var code = [ "--rulesdir", "/morerules" ];
-
         it("should return a string for .rulesdir", function() {
-            var currentOptions = options.parse(code);
+            var currentOptions = options.parse("--rulesdir /morerules");
             assert.isString(currentOptions.rulesdir);
             assert.equal(currentOptions.rulesdir, "/morerules");
         });
     });
 
     describe("when passed --format", function() {
-        var code = [ "--format", "compact" ];
-
-        it("should return a string for .f", function() {
-            var currentOptions = options.parse(code);
-            assert.equal(currentOptions.f, "compact");
+        it("should return a string for .format", function() {
+            var currentOptions = options.parse("--format compact");
+            assert.isString(currentOptions.format);
+            assert.equal(currentOptions.format, "compact");
         });
     });
 
     describe("when passed -f", function() {
-        var code = [ "-f", "compact" ];
-
-        it("should return a string for .f", function() {
-            var currentOptions = options.parse(code);
-            assert.equal(currentOptions.f, "compact");
-        });
-    });
-
-    describe("when passed -v", function() {
-        var code = [ "-v" ];
-
-        it("should return true for .v", function() {
-            var currentOptions = options.parse(code);
-            assert.isTrue(currentOptions.v);
+        it("should return a string for .format", function() {
+            var currentOptions = options.parse("-f compact");
+            assert.isString(currentOptions.format);
+            assert.equal(currentOptions.format, "compact");
         });
     });
 
     describe("when passed --version", function() {
-        var code = [ "--version" ];
+        it("should return true for .version", function() {
+            var currentOptions = options.parse("--version");
+            assert.isTrue(currentOptions.version);
+        });
+    });
 
-        it("should return true for .v", function() {
-            var currentOptions = options.parse(code);
-            assert.isTrue(currentOptions.v);
+    describe("when passed -v", function() {
+        it("should return true for .version", function() {
+            var currentOptions = options.parse("-v");
+            assert.isTrue(currentOptions.version);
         });
     });
 
     describe("when asking for help", function() {
-        it("should log the help content to the console", function() {
-            var log = console.log;
-
-            var loggedMessages = [];
-            console.log = function(message) {
-                loggedMessages.push(message);
-            };
-
-            options.help();
-            assert.equal(loggedMessages.length, 1);
-
-            console.log = log;
+        it("should return string of help text", function() {
+            var helpText = options.generateHelp();
+            assert.isString(helpText);
         });
     });
 });


### PR DESCRIPTION
For #596.

Optimist is now deprecated, this commit changes option parsing
and help generation to be done with [optionator](https://github.com/gkz/optionator).

Tests are simplified in that they now can pass in a string of arguments,
just like on the command line, instead of an array of strings.

Options are now accessible through the option's full name.
Eg. `currentOptions.help` instead of `currentOptions.h`

A lengthy comment labeled TODO is gone since it is no longer an issue
when using optionator.

The responsibility of printing the help text to the console is given to
`cli.js` instead of `options.js`, which I feel is more appropriate.

In the future, you could add `longDescription` and `example` fields to all the options, and use `generateHelpForOption` from optionator to display more detailed help for an option when you do `--help option-name`, and even generate your options documentation automatically from the options specification object - [Grasp](http://graspjs.com) does these things.
