### PR TITLE
Fix: Make sure no-unused-vars doesn't get confused by nested functions

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -11,9 +11,8 @@
 
 module.exports = function(context) {
 
-    var allowUnusedGlobals = context.options[0] === "all" ? false : true;
-
-    var variables = {};
+    var allowUnusedGlobals = (context.options[0] !== "all"),
+        variables = {};
 
     function lookupVariableName(name) {
 
@@ -96,15 +95,8 @@ module.exports = function(context) {
         return node && node.type && (node.type === "FunctionDeclaration" || node.type === "FunctionExpression");
     }
 
-    function findFirstAncestorThatIsFunctionExpressionOrDeclaration(ancestors) {
-        var currentAncestor;
-        while (ancestors.length !== 0 && !isFunction(currentAncestor)) {
-            currentAncestor = ancestors.pop();
-        }
-        return isFunction(currentAncestor) ? currentAncestor : undefined;
-    }
+    function markIgnorableUnusedVariables(usedVariable) {
 
-    function markIgnorableUnusedVariables(usedVariable, ancestors) {
         /* When variables are declared as parameters in a FunctionExpression or
          * FunctionDeclaration, they can go unused so long as at least one
          * to the right of them is used.
@@ -112,10 +104,10 @@ module.exports = function(context) {
 
         // Find the FunctionExpressions and FunctionDeclarations in which this used variable
         // may be a parameter
-        var ancestorFunctionNode = findFirstAncestorThatIsFunctionExpressionOrDeclaration(ancestors);
-        if (ancestorFunctionNode) {
+        var parent = usedVariable.node.parent;
+        if (isFunction(parent)) {
             // Get a list of the param names used in the ancestor Function
-            var fnParamNames = ancestorFunctionNode.params.map(function(param){
+            var fnParamNames = parent.params.map(function(param){
                 return param.name;
             });
             // Check if the used variable exists among those params
@@ -154,6 +146,7 @@ module.exports = function(context) {
                 (grandparent !== null && (grandparent.type === "CallExpression" || grandparent.type === "AssignmentExpression")))) {
 
                 var variable = findVariable(node.name);
+
                 if (variable) {
                     variable.used = true;
                     markIgnorableUnusedVariables(variable, ancestors);

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -28,7 +28,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "var a=10;", args: [1, "local"] },
         "var a=10",
         "myFunc(function foo() {}.bind(this))",
-        "myFunc(function foo(){}.toString())"
+        "myFunc(function foo(){}.toString())",
+        "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});};"
     ],
     invalid: [
         { code: "var a=10;", args: [1, "all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },


### PR DESCRIPTION
Tried implementing the fix that @ilyavolodin suggested on #584.
