### PR TITLE
Fix: radix rule should warn (not throw error) when parseInt() is called ...

### DIFF
--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -18,7 +18,7 @@ module.exports = function(context) {
 
             if (node.callee.name === "parseInt") {
 
-                if (node.arguments.length === 1) {
+                if (node.arguments.length < 2) {
                     context.report(node, "Missing radix parameter.");
                 } else {
 

--- a/tests/lib/rules/radix.js
+++ b/tests/lib/rules/radix.js
@@ -18,6 +18,13 @@ eslintTester.addRuleTest("lib/rules/radix", {
 
     invalid: [
         {
+            code: "parseInt();",
+            errors: [{
+                message: "Missing radix parameter.",
+                type: "CallExpression"
+            }]
+        },
+        {
             code: "parseInt(\"10\");",
             errors: [{
                 message: "Missing radix parameter.",


### PR DESCRIPTION
...without arguments (fixes #611)
