### PR TITLE
New: Added ability to get indent information for a node (fixes #625)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -200,6 +200,7 @@ module.exports = (function() {
         currentConfig = null,
         currentTokens = null,
         currentScopes = null,
+        currentLines = null,
         controller = null;
 
 
@@ -249,6 +250,7 @@ module.exports = (function() {
         commentsAttached = false;
         currentConfig = null;
         currentText = null;
+        currentLines = null;
         currentTokens = null;
         currentScopes = null;
         controller = null;
@@ -317,6 +319,7 @@ module.exports = (function() {
             // save config so rules can access as necessary
             currentConfig = config;
             currentText = text;
+            currentLines = text.split(/\r?\n/g);
             controller = new estraverse.Controller();
 
             // gather data that may be needed by the rules
@@ -439,6 +442,36 @@ module.exports = (function() {
             return currentText;
         }
 
+    };
+
+    /**
+     * Returns the text for the given line number.
+     * @param {int} lineNumber The 1-based line number to retrieve.
+     * @returns {?string} The line of text or null if the line doesn't exist.
+     */
+    api.getLine = function(lineNumber) {
+        return currentLines[lineNumber - 1] || null;
+    };
+
+    /**
+     * Returns the indentation text for the given node.
+     * @param {ASTNode} node The node to retrieve indentation information for.
+     * @returns {?string} The string of indentation for that node or null.
+     */
+    api.getIndent = function(node) {
+        var line = this.getLine(node.loc.start.line),
+            indentMatch = line.match(/^\s+/),
+            indent = null;
+
+        if (indentMatch) {
+
+            // it's only an indent for that node if the statement starts right after the indent
+            if (node.loc.start.column === indentMatch[0].length) {
+                indent = indentMatch[0];
+            }
+        }
+
+        return indent;
     };
 
     /**

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -14,7 +14,8 @@ var PASSTHROUGHS = [
         "getComments",
         "getAncestors",
         "getScope",
-        "getJSDocComment"
+        "getJSDocComment",
+        "getIndent"
     ];
 
 //------------------------------------------------------------------------------

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -474,6 +474,136 @@ describe("eslint", function() {
 
     });
 
+    describe("getLine()", function() {
+
+        beforeEach(function() {
+            eslint.reset();
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(function() {
+            sandbox.verifyAndRestore();
+        });
+
+        it("should get a line of text when called on \\n separated lines", function() {
+
+            var lines = [
+                    "/** Desc*/",
+                    "function Foo(){}"
+                ],
+                code = lines.join("\n");
+
+            eslint.verify(code, { rules: {}}, true);
+
+            var line1 = eslint.getLine(1),
+                line2 = eslint.getLine(2),
+                line3 = eslint.getLine(3);
+
+            assert.equal(line1, lines[0]);
+            assert.equal(line2, lines[1]);
+            assert.isNull(line3);
+        });
+
+        it("should get a line of text when called on \\r\\n separated lines", function() {
+
+            var lines = [
+                    "/** Desc*/",
+                    "function Foo(){}"
+                ],
+                code = lines.join("\r\n");
+
+            eslint.verify(code, { rules: {}}, true);
+
+            var line1 = eslint.getLine(1),
+                line2 = eslint.getLine(2),
+                line3 = eslint.getLine(3);
+
+            assert.equal(line1, lines[0]);
+            assert.equal(line2, lines[1]);
+            assert.isNull(line3);
+        });
+
+    });
+
+    describe("getIndent()", function() {
+
+        beforeEach(function() {
+            eslint.reset();
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(function() {
+            sandbox.verifyAndRestore();
+        });
+
+        it("should retrieve the indent when called on a node with an indent", function() {
+
+            var lines = [
+                    "if (foo) {",
+                    "    doSomething()",
+                    "}"
+                ],
+                code = lines.join("\n");
+
+            function assertIndent(node) {
+                var indent = eslint.getIndent(node);
+                assert.equal(indent, "    ");
+            }
+
+            var spy = sandbox.spy(assertIndent);
+
+            eslint.on("CallExpression", spy);
+            eslint.verify(code, { rules: {}}, true);
+
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+        it("should return null when called on a node without an indent", function() {
+
+            var lines = [
+                    "if (foo) {",
+                    "doSomething()",
+                    "}"
+                ],
+                code = lines.join("\n");
+
+            function assertIndent(node) {
+                var indent = eslint.getIndent(node);
+                assert.isNull(indent);
+            }
+
+            var spy = sandbox.spy(assertIndent);
+
+            eslint.on("CallExpression", spy);
+            eslint.verify(code, { rules: {}}, true);
+
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+        it("should return null when called on a node that isn't the outermost on an indented line", function() {
+
+            var lines = [
+                    "if (foo) {",
+                    "   doSomething(5)",
+                    "}"
+                ],
+                code = lines.join("\n");
+
+            function assertIndent(node) {
+                var indent = eslint.getIndent(node);
+                assert.isNull(indent);
+            }
+
+            var spy = sandbox.spy(assertIndent);
+
+            eslint.on("Literal", spy);
+            eslint.verify(code, { rules: {}}, true);
+
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+    });
+
     describe("when retrieving comments", function() {
         var sandbox,
             code = [

--- a/tests/lib/rule-context.js
+++ b/tests/lib/rule-context.js
@@ -1,0 +1,172 @@
+/**
+ * @fileoverview Tests for RuleContext object.
+ * @author Nicholas C. Zakas
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    sinon = require("sinon"),
+    RuleContext = require("../../lib/rule-context");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var TEST_CODE = "var answer = 6 * 7;",
+    BROKEN_TEST_CODE = "var;";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+function getVariable(scope, name) {
+    var variable = null;
+    scope.variables.some(function(v) {
+        if (v.name === name) {
+            variable = v;
+            return true;
+        }
+        return false;
+    });
+    return variable;
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("RuleContext", function() {
+
+    var context,
+        sandbox,
+        eslint;
+
+    beforeEach(function() {
+        eslint = {};
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.verifyAndRestore();
+        eslint = null;
+        context = null;
+    });
+
+    describe("options", function() {
+
+        it("should contain options when passed in from the constructor", function() {
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            assert.equal(context.options[0], "foo");
+        });
+    });
+
+    describe("id", function() {
+
+        it("should contain the rule ID when passed in from the constructor", function() {
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            assert.equal(context.id, "id");
+        });
+    });
+
+    describe("report()", function() {
+
+        it("should call eslint.report() with appropriate arguments when called", function() {
+            var node = {},
+                opts = {};
+
+            eslint.report = sandbox.mock().withArgs("id", node, "Foo", opts);
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            context.report(node, "Foo", opts);
+        });
+    });
+
+    describe("getSource", function() {
+
+        it("should call eslint.getSource() with appropriate arguments when called", function() {
+            var node = {};
+
+            eslint.getSource = sandbox.mock().withArgs(node).returns("foo");
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            var result = context.getSource(node);
+            assert.equal(result, "foo");
+        });
+    });
+
+    describe("getTokens", function() {
+
+        it("should call eslint.getTokens() with appropriate arguments when called", function() {
+            var node = {};
+
+            eslint.getTokens = sandbox.mock().withArgs(node).returns("foo");
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            var result = context.getTokens(node);
+            assert.equal(result, "foo");
+        });
+    });
+
+    describe("getComments", function() {
+
+        it("should call eslint.getComments() with appropriate arguments when called", function() {
+            var node = {};
+
+            eslint.getComments = sandbox.mock().withArgs(node).returns("foo");
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            var result = context.getComments(node);
+            assert.equal(result, "foo");
+        });
+    });
+
+    describe("getAncestors", function() {
+
+        it("should call eslint.getAncestors() with appropriate arguments when called", function() {
+            var node = {};
+
+            eslint.getAncestors = sandbox.mock().withArgs(node).returns("foo");
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            var result = context.getAncestors(node);
+            assert.equal(result, "foo");
+        });
+    });
+
+    describe("getJSDocComment", function() {
+
+        it("should call eslint.getJSDocComment() with appropriate arguments when called", function() {
+            var node = {};
+
+            eslint.getJSDocComment = sandbox.mock().withArgs(node).returns("foo");
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            var result = context.getJSDocComment(node);
+            assert.equal(result, "foo");
+        });
+    });
+
+    describe("getScope", function() {
+
+        it("should call eslint.getScope() with appropriate arguments when called", function() {
+            var node = {};
+
+            eslint.getScope = sandbox.mock().withArgs(node).returns("foo");
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            var result = context.getScope(node);
+            assert.equal(result, "foo");
+        });
+    });
+
+    describe("getIndent", function() {
+
+        it("should call eslint.getIndent() with appropriate arguments when called", function() {
+            var node = {};
+
+            eslint.getIndent = sandbox.mock().withArgs(node).returns("foo");
+            context = new RuleContext("id", eslint, [ "foo" ]);
+            var result = context.getIndent(node);
+            assert.equal(result, "foo");
+        });
+    });
+
+
+
+});


### PR DESCRIPTION
Give rules the ability to retrieve the indentation text for a given node. I'm not sure if this is the right way to do it, but seems plausible. This assumes we want to use nodes as the basis for retrieving indentation rather than lines. I'm debating whether overloading this method to also accept line numbers would be useful.
