### PR TITLE
New Rule: missing-err (fixes #567)

### DIFF
--- a/conf/environments.json
+++ b/conf/environments.json
@@ -362,6 +362,7 @@
             "no-global-strict": 0,
             "no-mixed-requires": 2,
             "no-path-concat": 2,
+            "handle-callback-err": [2, "err"],
             "no-process-exit": 2
         }
     },

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -99,6 +99,7 @@
         "max-nested-callbacks": [0, 2],
         "max-params": [0, 3],
         "max-statements": [0, 10],
+        "handle-callback-err": 0,
         "new-cap": 2,
         "new-parens": 2,
         "one-var": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -99,6 +99,7 @@ These rules have to do with variable declarations.
 
 These rules are specific to JavaScript running on Node.js.
 
+* [handle-callback-err](handle-callback-err.md) - enforces error handling in callbacks
 * [no-mixed-requires](no-mixed-requires.md) - disallow mixing regular variable and require declarations
 * [no-path-concat](no-path-concat.md) - disallow string concatenation with `__dirname` and `__filename`
 * [no-process-exit](no-process-exit.md) - disallow `process.exit()`

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -1,0 +1,62 @@
+# Ensures Callback Error Handling
+
+In node, a common pattern for dealing with asynchronous behavior is called the callback pattern.
+This pattern expects as the first argument of the callback an `Error` object, which may be `null`.
+Forgetting to handle these errors can lead to some really strange behavior in your application.
+
+```js
+function loadData (err, data) {
+    doSomething(); // forgot to handle error
+}
+```
+
+## Rule Details
+
+This rule expects that when you're using the callback pattern in node you'll handle the error and
+requires that you specify the name of your error object. The name of the argument will default to `err`.
+
+**The following are considered warnings:**
+
+```js
+function loadData (err, data) {
+    doSomething(); // forgot to handle error
+}
+
+```
+
+**The following are not considered warnings:**
+
+```js
+function loadData (err, data) {
+    if (err) {
+    	console.log(err.stack);
+    }
+    doSomething();
+}
+
+function generateError (err) {
+    if (err) {} 
+}
+```
+
+**You can also customize the name of the error object:**
+
+```js
+// missing-err: [2, "error"]
+function loadData (error, data) {
+    if (error) {
+       console.log(error.stack);
+    }
+}
+```
+
+## When Not To Use This Rule
+
+There are cases where it may be safe for your application to ignore errors, however only ignore errors if you are
+confident that some other form of monitoring will help you catch the problem.
+
+## Further Reading
+
+- [The Art Of Node: Callbacks](https://github.com/maxogden/art-of-node#callbacks)
+- [Nodejitsu: What are the error conventions?](http://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions)
+- [Node Tuts: The Callback Pattern](http://nodetuts.com/02-callback-pattern.html)

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Ensure handling of errors when we know they exist.
+ * @author Jamund Ferguson
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+	"use strict";
+
+	var errorArgument = context.options[0] || "err";
+	var callbacks = [];
+	var scopes = 0;
+
+	/**
+	 * Check the arguments to see if we need to start tracking the error object.
+	 * @param {ASTNode} node The AST node to check.
+	 * @returns {void}
+	 */
+	function startFunction(node) {
+
+		// keep track of nested scopes
+		scopes++;
+
+		// check if the first argument matches our argument name
+		var firstArg = node.params && node.params[0];
+		if (firstArg && firstArg.name === errorArgument) {
+			callbacks.push({handled: false, depth: scopes});
+		}
+	}
+
+	/**
+	 * At the end of a function check to see if the error was handled.
+	 * @param {ASTNode} node The AST node to check.
+	 * @returns {void}
+	 */
+	function endFunction(node) {
+
+		var callback = callbacks[callbacks.length - 1] || {};
+
+		// check if a callback is ending, if so pop it off the stack
+		if (callback.depth === scopes) {
+			callbacks.pop();
+
+			// check if there were no handled errors since the last callback
+			if (!callback.handled) {
+				context.report(node, "Expected error to be handled.");
+			}
+		}
+
+		// less nested functions
+		scopes--;
+
+	}
+
+	/**
+	 * Check to see if we're handling the error object properly.
+	 * @param {ASTNode} node The AST node to check.
+	 * @returns {void}
+	 */
+	function checkForError(node) {
+
+		// make sure the node's name matches our error argument name
+		var isAboutError = node.name === errorArgument;
+
+		// we don't consider these use cases as "handling" the error
+		var doNotCount = ["FunctionDeclaration", "FunctionExpression", "CatchClause"];
+
+		// make sure this identifier isn't used as part of one of them
+		var isHandled = doNotCount.indexOf(node.parent.type) === -1;
+
+		// record that this callback handled its error
+		if (isAboutError && isHandled) {
+			callbacks[callbacks.length - 1].handled = true;
+		}
+	}
+
+	return {
+		"FunctionDeclaration": startFunction,
+		"FunctionExpression": startFunction,
+		"Identifier": checkForError,
+		"FunctionDeclaration:exit": endFunction,
+		"FunctionExpression:exit": endFunction
+	};
+
+};

--- a/tests/lib/rules/handle-callback-err.js
+++ b/tests/lib/rules/handle-callback-err.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Tests for missing-err rule.
+ * @author Jamund Ferguson
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/handle-callback-err", {
+	valid: [
+		"function test(error) {}",
+		"function test(err) {console.log(err);}",
+		"function test(err, data) {if(err){ data = 'ERROR';}}",
+		"var test = function(err) {console.log(err);};",
+		"var test = function(err) {if(err){/* do nothing */}};",
+		"var test = function(err) {if(!err){doSomethingHere();}else{};}",
+		"var test = function(err, data) {if(!err) { good(); } else { bad(); }}",
+		"try { } catch(err) {}",
+		"getData(function(err, data) {if (err) {}getMoreDataWith(data, function(err, moreData) {if (err) {}getEvenMoreDataWith(moreData, function(err, allOfTheThings) {if (err) {}});});});",
+		"var test = function(err) {if(! err){doSomethingHere();}};",
+		"function test(err, data) {if (data) {doSomething(function(err) {console.error(err);});} else if (err) {console.log(err);}}",
+		"function handler(err, data) {if (data) {doSomethingWith(data);} else if (err) {console.log(err);}}",
+		"function handler(err) {logThisAction(function(err) {if (err) {}}); console.log(err);}",
+		"function userHandler(err) {process.nextTick(function() {if (err) {}})}",
+		"function help() { function userHandler(err) {function tester() { err; process.nextTick(function() { err; }); } } }",
+		{ code: "var test = function(error) {if(error){/* do nothing */}};", args: [2, "error"] },
+		{ code: "var test = function(error) {if(! error){doSomethingHere();}};", args: [2, "error"] }
+	],
+	invalid: [
+		{ code: "function test(err) {}", errors: [{ message: "Expected error to be handled.", type: "FunctionDeclaration"}] },
+		{ code: "function test(err, data) {}", errors: [{ message: "Expected error to be handled.", type: "FunctionDeclaration"}] },
+		{ code: "function test(err) {errorLookingWord();}", errors: [{ message: "Expected error to be handled.", type: "FunctionDeclaration"}] },
+		{ code: "function test(err) {try{} catch(err) {}}", errors: [{ message: "Expected error to be handled.", type: "FunctionDeclaration"}] },
+		{ code: "function test(err, callback) { foo(function(err, callback) {}); }", errors: [{ message: "Expected error to be handled.", type: "FunctionExpression"}, { message: "Expected error to be handled.", type: "FunctionDeclaration"}]},
+		{ code: "var test = function(err) {};", errors: [{ message: "Expected error to be handled.", type: "FunctionExpression"}] },
+		{ code: "var test = function test(err, data) {};", errors: [{ message: "Expected error to be handled.", type: "FunctionExpression"}] },
+		{ code: "var test = function test(err) {/* if(err){} */};", errors: [{ message: "Expected error to be handled.", type: "FunctionExpression"}] },
+		{ code: "function test(err) {doSomethingHere(function(err){console.log(err);})}", errors: [{ message: "Expected error to be handled.", type: "FunctionDeclaration"}] },
+		{ code: "function test(error) {}", args: [2, "error"], errors: [{ message: "Expected error to be handled.", type: "FunctionDeclaration"}] },
+		{ code: "getData(function(err, data) {getMoreDataWith(data, function(err, moreData) {if (err) {}getEvenMoreDataWith(moreData, function(err, allOfTheThings) {if (err) {}});}); });", errors: [{ message: "Expected error to be handled.", type: "FunctionExpression"}]},
+		{ code: "getData(function(err, data) {getMoreDataWith(data, function(err, moreData) {getEvenMoreDataWith(moreData, function(err, allOfTheThings) {if (err) {}});}); });", errors: [{ message: "Expected error to be handled.", type: "FunctionExpression"}, { message: "Expected error to be handled.", type: "FunctionExpression"}]},
+		{ code: "function userHandler(err) {logThisAction(function(err) {if (err) { console.log(err); } })}", errors: [{ message: "Expected error to be handled."}]},
+		{ code: "function help() { function userHandler(err) {function tester(err) { err; process.nextTick(function() { err; }); } } }",  errors: [{ message: "Expected error to be handled."}]}
+	]
+});


### PR DESCRIPTION
Adds a check for missing error handling in node.js mode. Defaults to off. Lets you specify the name of the error argument. Assumes the callback pattern, which puts the error as the first argument. #567
