### PR TITLE
Created space-in-brackets rule

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -106,6 +106,7 @@
         "radix": 0,
         "semi": 2,
         "sort-vars": 0,
+        "space-in-brackets": [0, "never"],
         "space-infix-ops": 2,
         "space-return-throw-case": 2,
         "space-unary-word-ops": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -126,6 +126,7 @@ These rules are purely matters of style and are quite subjective.
 * [quote-props](quote-props.md) - require quotes around object literal property names
 * [semi](semi.md)- require or disallow use of semicolons instead of ASI
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block
+* [space-in-brackets](space-in-brackets.md) - require or disallow spaces between brackets
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators
 * [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`
 * [space-unary-word-ops](space-unary-word-ops.md) - require a space around word operators such as `typeof`

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -1,0 +1,166 @@
+# Disallow or enforce spaces inside of brackets. (space-in-brackets)
+
+While formatting preferences are very personal, a number of style guides require or disallow spaces between brackets:
+
+```js
+var obj = { foo: 'bar' };
+var arr = [ 'foo', 'bar' ];
+foo[ 'bar' ];
+
+var obj = {foo: 'bar'};
+var arr = ['foo', 'bar'];
+foo['bar'];
+```
+
+## Rule Details
+
+This rule aims to maintain consistency around the spacing inside of square brackets, either by disallowing spaces inside of brackets between the brackets and other tokens or enforcing spaces. Multi-line Array and Object literals with no values on the same line as the brackets are excepted from this rule as this is a common pattern.
+
+The following patterns are considered warnings:
+
+```js
+// When options are [2, "never"]
+
+foo[ 'bar' ];
+
+foo['bar' ];
+
+foo[
+    'bar'
+];
+
+var arr = [ 'foo', 'bar' ];
+
+var arr = ['foo', 'bar' ];
+
+var arr = [ ['foo'], 'bar'];
+
+var arr = [[ 'foo' ], 'bar'];
+
+var arr = ['foo', 
+  'bar' 
+];
+
+var arr = [
+  'foo', 
+  'bar'];
+
+var obj = { 'foo': 'bar' };
+
+var obj = {'foo': 'bar' };
+
+var obj = { baz: {'foo': 'qux'}, 'bar'};
+
+var obj = {baz: { 'foo': 'qux' }, 'bar'};
+
+var obj = {'foo': 'bar' 
+};
+
+var obj = {
+  'foo':bar'};
+
+// When options are [2, "always"]
+
+foo['bar'];
+
+foo['bar' ];
+
+foo[ 'bar'];
+
+var arr = ['foo', 'bar'];
+
+var arr = ['foo', 'bar' ];
+
+var arr = [ ['foo'], 'bar' ];
+
+var arr = ['foo', 
+  'bar' 
+];
+
+var arr = [
+  'foo', 
+  'bar'];
+
+var obj = {'foo': 'bar'};
+
+var obj = {'foo': 'bar' };
+
+var obj = { baz: {'foo': 'qux'}, 'bar'};
+
+var obj = {baz: { 'foo': 'qux' }, 'bar'};
+
+var obj = {'foo': 'bar' 
+};
+
+var obj = {
+  'foo':bar'};
+
+```
+
+The following patterns are not warnings:
+
+```js
+// When options are [2, "never"]
+
+foo['bar'];
+
+var arr = ['foo', 'bar', 'baz'];
+
+var arr = [['foo'], 'bar', 'baz'];
+
+var arr = [
+  'foo', 
+  'bar', 
+  'baz'
+];
+
+var obj = {'foo': 'bar'};
+
+var obj = {'foo': {'bar': 'baz'}, 'qux': 'quxx'};
+
+var obj = {
+  'foo': 'bar'
+};
+
+// When options are [2, "always"]
+
+foo[ 'bar' ];
+
+foo[
+  'bar' 
+];
+
+var arr = [ 'foo', 'bar', 'baz' ];
+
+var arr = [ [ 'foo' ], 'bar', 'baz' ];
+
+var arr = [
+  'foo', 
+  'bar', 
+  'baz'
+];
+
+var obj = { 'foo': 'bar' };
+
+var obj = { 'foo': { 'bar': 'baz' }, 'qux': 'quxx' };
+
+var obj = {
+  'foo': 'bar'
+};
+```
+
+### Options
+
+The rule takes one option, a string which must be either "always" or "never". The default is "never".
+
+```js
+"space-in-brackets": [2, "never"]
+```
+
+Setting the option to "always" means that there must always be a space between brackets and tokens inside of brackets.
+
+Setting the option to "never" means that there must never be a space between brackets at the tokens inside of brackets. An exception is made for multi-line Array and Object literals where no values appear on the same line as brackets.
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the consistency of spacing between brackets.

--- a/lib/rules/space-in-brackets.js
+++ b/lib/rules/space-in-brackets.js
@@ -1,0 +1,119 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside of brackets.
+ * @author Ian Christian Myers
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var shouldSpace = context.options[0] || "never";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Determines whether two adjacent tokens are have whitespace between them.
+     * @param {Object} left The left token object.
+     * @param {Object} right The right token object.
+     * @returns {Boolean} Whether or not there is space between the tokens.
+     */
+    function isSpaced(left, right) {
+        return left.range[1] < right.range[0];
+    }
+
+    /**
+     * Determines whether two adjacent tokens are on the same line.
+     * @param {Object} left The left token object.
+     * @param {Object} right The right token object.
+     * @returns {Boolean} Whether or not the tokens are on the same line.
+     */
+    function isSameLine(left, right) {
+        return left.loc.start.line === right.loc.start.line;
+    }
+
+    /**
+     * Checks whether the given set of tokens are spaced according to the user
+     * given preferences. Reports the node, if the tokens are improperly spaced.
+     * @param {ASTNode} node The node to report in the event of an error.
+     * @param {Object[]} tokens The tokens to be checked for spacing.
+     * @returns {void}
+     */
+    function verifySpacing(node, tokens) {
+        if (shouldSpace === "always") {
+            if (!isSpaced(tokens[0], tokens[1])) {
+                context.report(node, tokens[0].loc.end, 
+                        "A space is required after '" + tokens[0].value + "'");
+            }
+
+            if (!isSpaced(tokens[tokens.length - 2], tokens[tokens.length - 1])) {
+                context.report(node, tokens[tokens.length - 1].loc.start, 
+                        "A space is required before '" + tokens[tokens.length - 1].value + "'");
+            }
+        } else if (shouldSpace === "never") {
+
+            // This is an exception for Array and Object literals that do not 
+            // have any values on the same lines as brackets.
+            if ((node.type === "ArrayExpression" || node.type === "ObjectExpression") &&
+                    !isSameLine(tokens[0], tokens[1]) &&
+                    !isSameLine(tokens[tokens.length - 2], tokens[tokens.length - 1])) {
+                return; 
+            }
+
+            if (isSpaced(tokens[0], tokens[1])) {
+                context.report(node, tokens[0].loc.end, 
+                        "There should be no space after '" + tokens[0].value + "'");
+            }
+            
+            if (isSpaced(tokens[tokens.length - 2], tokens[tokens.length - 1])) {
+                context.report(node, tokens[tokens.length - 1].loc.start, 
+                        "There should be no space before '" + tokens[tokens.length - 1].value + "'");
+            }
+        }
+    }
+
+    /**
+     * Checks whether the brackets of an Object or Array literal are spaced  
+     * according to the given preferences.
+     * @param {ASTNode} node The ArrayExpression or ObjectExpression node.
+     * @returns {void}
+     */
+    function checkLiteral(node) {
+        var tokens = context.getTokens(node);
+        verifySpacing(node, tokens);
+    }
+
+    /**
+     * Checks whether the brackets of an Object's member are spaced according to 
+     * the given preferences, if the member is being accessed with bracket
+     * notation
+     * @param {ASTNode} node The MemberExpression node.
+     * @returns {void}
+     */
+    function checkMember(node) {
+
+        // Ensure the property is not enclosed in brackets.
+        if (node.computed) {
+            var tokens = context.getTokens(node.property, 1, 1);
+            verifySpacing(node, tokens);
+        }        
+    }
+
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "MemberExpression": checkMember,
+        "ArrayExpression": checkLiteral,
+        "ObjectExpression": checkLiteral
+
+    };
+
+};

--- a/tests/lib/rules/space-in-brackets.js
+++ b/tests/lib/rules/space-in-brackets.js
@@ -1,0 +1,338 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside of brackets.
+ * @author Ian Christian Myers
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/space-in-brackets", {
+
+    valid: [
+        { code: "obj[ foo ]", args: ["2", "always"] },
+        { code: "obj[\nfoo\n]", args: ["2", "always"] },
+        { code: "obj[ 'foo' ]", args: ["2", "always"] },
+        { code: "obj[ 'foo' + 'bar' ]", args: ["2", "always"] },
+        { code: "obj[ obj2[ foo ] ]", args: ["2", "always"] },
+        { code: "obj.map(function (item) { return [\n1,\n2,\n3,\n4\n]; })", args: ["2", "always"] },
+        { code: "obj[ 'map' ](function (item) { return [\n1,\n2,\n3,\n4\n]; })", args: ["2", "always"] },
+        { code: "obj[ 'for' + 'Each' ](function (item) { return [\n1,\n2,\n3,\n4\n]; })", args: ["2", "always"] },
+
+        { code: "var arr = [ 1, 2, 3, 4 ];", args: ["2", "always"] },
+        { code: "var arr = [ [ 1, 2 ], 2, 3, 4 ];", args: ["2", "always"] },
+        { code: "var arr = [\n1, 2, 3, 4\n];", args: ["2", "always"] },
+
+        { code: "var obj = { foo: bar, baz: qux };", args: ["2", "always"] },
+        { code: "var obj = { foo: { bar: quxx }, baz: qux };", args: ["2", "always"] },
+        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", args: ["2", "always"] },
+
+
+        { code: "obj[foo]", args: ["2", "never"] },
+        { code: "obj['foo']", args: ["2", "never"] },
+        { code: "obj['foo' + 'bar']", args: ["2", "never"] },
+        { code: "obj['foo'+'bar']", args: ["2", "never"] },
+        { code: "obj[obj2[foo]]", args: ["2", "never"] },
+        { code: "obj.map(function (item) { return [\n1,\n2,\n3,\n4\n]; })", args: ["2", "never"] },
+        { code: "obj['map'](function (item) { return [\n1,\n2,\n3,\n4\n]; })", args: ["2", "never"] },
+        { code: "obj['for' + 'Each'](function (item) { return [\n1,\n2,\n3,\n4\n]; })", args: ["2", "never"] },
+
+        { code: "var arr = [1, 2, 3, 4];", args: ["2", "never"] },
+        { code: "var arr = [[1, 2], 2, 3, 4];", args: ["2", "never"] },
+        { code: "var arr = [\n1, 2, 3, 4\n];", args: ["2", "never"] },
+
+        { code: "var obj = {foo: bar, baz: qux};", args: ["2", "never"] },
+        { code: "var obj = {foo: {bar: quxx}, baz: qux};", args: ["2", "never"] },
+        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", args: ["2", "never"] }
+    ],
+
+    invalid: [
+        {
+            code: "var obj = {foo: bar, baz: qux};",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectExpression"
+                },
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: bar, baz: qux };",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: bar, baz: qux};",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: bar, baz: qux };",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression"
+                },
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: bar, baz: qux };",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: bar, baz: qux};",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: { bar: quxx}, baz: qux};",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression"
+                },
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: {bar: quxx }, baz: qux };",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                },
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: bar,\nbaz: qux\n};",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = {\nfoo: bar,\nbaz: qux};",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [1, 2, 3, 4];",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "ArrayExpression"
+                },
+                {
+                    message: "A space is required before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [1, 2, 3, 4 ];",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [ 1, 2, 3, 4];",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "A space is required before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [ 1, 2, 3, 4 ];",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "ArrayExpression"
+                },
+                {
+                    message: "There should be no space before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [1, 2, 3, 4 ];",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [ 1, 2, 3, 4];",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [ [ 1], 2, 3, 4];",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "ArrayExpression"
+                },
+                {
+                    message: "There should be no space after '['",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [[1 ], 2, 3, 4 ];",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space before ']'",
+                    type: "ArrayExpression"
+                },
+                {
+                    message: "There should be no space before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [1,\n2,\n3,\n4\n];",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "var arr = [\n1,\n2,\n3,\n4];",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+        {
+            code: "obj[ foo ]",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "MemberExpression"
+                },
+                {
+                    message: "There should be no space before ']'",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "obj[foo ]",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space before ']'",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "obj[ foo]",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "obj[\nfoo\n]",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "MemberExpression"
+                },
+                {
+                    message: "There should be no space before ']'",
+                    type: "MemberExpression"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Created the `space-in-brackets` rule, which enforces spacing
preferences within brackets:

```
var arr = [ 'foo', 'bar' ];
foo[ 'bar' ];

var arr = ['foo', 'bar'];
foo['bar'];
```

The rule takes one option, a string, which may be either "always"
or "never".

Fixes #631
