### PR TITLE
Update: Allow valid-jsdoc to specify replacement tags (fixes #637)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,7 +10,11 @@
         "no-floating-decimal": 2,
         "no-nested-ternary": 2,
         "radix": 2,
-        "valid-jsdoc": 2,
+        "valid-jsdoc": [2, {
+            "prefer": {
+                "return": "returns"
+             }
+        }],
         "wrap-iife": 2
     }
 }

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -23,7 +23,6 @@ This rule aims to prevent invalid and incomplete JSDoc comments. In doing so, it
 1. There is a JSDoc syntax error
 1. A `@param` or `@returns` is used without a type specified
 1. A `@param` or `@returns` is used without a description
-1. `@return` is used instead of `@returns`
 1. A comment for a function is missing `@returns`
 1. A parameter has no associated `@param` in the JSDoc comment
 1. `@param`s are out of order with named arguments
@@ -41,12 +40,6 @@ The following patterns are considered warnings:
 /**
  * A description
  * @param {int} num1
- */
-
-// using @return instead of @returns
-/**
- * A description
- * @return {void}
  */
 
 // no description for @returns
@@ -98,6 +91,20 @@ The following patterns are not warnings:
  * @constructor
  */
 ```
+
+### Options
+
+JSDoc offers a lot of tags with overlapping meaning. For example, both `@return` and `@returns` are acceptable for specifying the return value of a function. However, you may want to enforce a certain tag be used instead of others. You can specify your preferences regarding tag substitution by providing a mapping called `prefer` in the rule configuration. For example, to specify that `@returns` should be used instead of `@return`, you can use the following configuration:
+
+```
+"valid-jsdoc": [2, {
+    "prefer": {
+        "return": "returns"
+    }
+}]
+```
+
+With this configuration, ESLint will warn when it finds `@return` and recommend to replace it with `@returns`.
 
 ## When Not To Use It
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -309,7 +309,8 @@ module.exports = (function() {
                             api.on(nodeType, rule[nodeType]);
                         });
                     } catch(ex) {
-                        throw new Error("Error while loading rule '" + key + "'.");
+                        ex.message = "Error while loading rule '" + key + "': " + ex.message;
+                        throw ex;
                     }
 
                 } else {

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -16,10 +16,18 @@ var doctrine = require("doctrine");
 
 module.exports = function(context) {
 
+    var options = context.options[0] || {},
+        prefer = options.prefer || {};
+
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
+    /**
+     * Validate the JSDoc node and output warnings if anything is wrong.
+     * @param {ASTNode} node The AST node to check.
+     * @returns {void}
+     */
     function checkJSDoc(node) {
         var jsdocNode = context.getJSDocComment(node),
             hasReturns = false,
@@ -68,10 +76,6 @@ module.exports = function(context) {
                         break;
 
                     case "return":
-                        hasReturns = true;
-                        context.report(jsdocNode, "Use @returns instead.");
-                        break;
-
                     case "returns":
                         hasReturns = true;
                         if (!tag.type) {
@@ -87,6 +91,11 @@ module.exports = function(context) {
                         hasConstructor = true;
                         break;
 
+                }
+
+                // check tag preferences
+                if (prefer.hasOwnProperty(tag.title)) {
+                    context.report(jsdocNode, "Use @{{name}} instead.", { name: prefer[tag.title] });
                 }
 
             });

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -25,7 +25,11 @@ eslintTester.addRuleTest("lib/rules/valid-jsdoc", {
         "/**\n* Description\n* @param {string} [p] bar\n* @returns {string} desc */\nfunction foo(p){}",
         "/**\n* Description\n* @param {string} p bar\n* @returns {string} desc */\nFoo.bar = function(p){};",
         "(function(){\n/**\n* Description\n* @param {string} p bar\n* @returns {string} desc */\nfunction foo(p){}\n}())",
-        "var o = {\n/**\n* Description\n* @param {string} p bar\n* @returns {string} desc */\nfoo: function(p){}\n};"
+        "var o = {\n/**\n* Description\n* @param {string} p bar\n* @returns {string} desc */\nfoo: function(p){}\n};",
+        {
+            code: "/**\n* Description\n* @return {void} */\nfunction foo(){}",
+            args: [1, {}]
+        }
     ],
 
     invalid: [
@@ -52,6 +56,7 @@ eslintTester.addRuleTest("lib/rules/valid-jsdoc", {
         },
         {
             code: "/** Foo \n@return {void} Foo\n */\nfunction foo(){}",
+            args: [1, { prefer: { "return": "returns" }}],
             errors: [{
                 message: "Use @returns instead.",
                 type: "Block"


### PR DESCRIPTION
Looking for feedback on the name of "prefer" in configuration. I'm not in love with it, but naming is hard.
