### PR TITLE
Added "stroustrup" option for brace-style

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,7 +4,7 @@
     },
 
     "rules": {
-        "brace-style": 2,
+        "brace-style": [2, "1tbs"],
         "func-style": [2, "declaration"],
         "guard-for-in": 2,
         "no-floating-decimal": 2,

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -82,7 +82,7 @@
         "no-yoda": 2,
 
         "block-scoped-var": 0,
-        "brace-style": 0,
+        "brace-style": [0, "1tbs"],
         "camelcase": 2,
         "complexity": [0, 11],
         "consistent-return": 2,

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -3,8 +3,17 @@
 One true brace style is a common coding style in JavaScript, in which the opening curly brace of a block is placed on the same line as its corresponding statement or declaration.
 
 ```js
-function foo() {
-  return true;
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+
+if (foo) {
+  bar();
+} 
+else {
+  baz();
 }
 ```
 
@@ -32,6 +41,23 @@ try
 {
   handleError();
 }
+
+// When "brace-style": ["2", "1tbs"]
+
+if (foo) {
+  bar();
+} 
+else {
+  baz();
+}
+
+// When "brace-style": ["2", "stroustrup"]
+
+if (foo) {
+  bar();
+} else {
+  baz();
+}
 ```
 
 The following patterns adhere to one true brace style and do not cause warnings:
@@ -45,9 +71,71 @@ if (foo) {
   bar();
 }
 
+// When "brace-style": ["2", "1tbs"]
+
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+
 try {
   somethingRisky();
 } catch(e) {
+  handleError();
+}
+
+// When "brace-style": ["2", "stroustrup"]
+
+if (foo) {
+  bar();
+} 
+else {
+  baz();
+}
+
+try {
+  somethingRisky();
+} 
+catch(e) {
+  handleError();
+}
+```
+
+### Options
+
+The rule takes one option, a string which must be either "1tbs" or "stroustrup". The default is "1tbs". 
+
+The "1tbs" option requires that the `else`, `catch`, and `finally` statements appear on the same line as the closing curly brace from the previous statement.
+
+```js
+if (foo) {
+  bar();
+} else {
+  baz();
+}
+
+try {
+  somethingRisky();
+} catch(e) {
+  handleError();
+}
+```
+
+The "stroustrup" option requires that the `else`, `catch`, and `finally` statements appear on a new line after the closing curly brace from the previous statement.
+
+```js
+if (foo) {
+  bar();
+} 
+else {
+  baz();
+}
+
+try {
+  somethingRisky();
+} 
+catch(e) {
   handleError();
 }
 ```

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -10,13 +10,22 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var style = context.options[0] || "1tbs";
 
-    var MESSAGE = "Opening curly brace does not appear on the same line as controlling statement.";
+    var OPEN_MESSAGE = "Opening curly brace does not appear on the same line as controlling statement.",
+        CLOSE_MESSAGE = "Closing curly brace does not appear on the same line as the subsequent block.";
 
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
+    /**
+     * Binds a list of properties to a function that verifies that the opening
+     * curly brace is on the same line as its controlling statement of a given
+     * node.
+     * @param {...string} The properties to check on the node.
+     * @returns {Function} A function that will perform the check on a node 
+     */
     function checkBlock() {
         var blockProperties = arguments;
         return function(node) {
@@ -26,25 +35,102 @@ module.exports = function(context) {
                 if(block && block.type === "BlockStatement") {
                     tokens = context.getTokens(block, 1);
                     if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {
-                        context.report(node, MESSAGE);
+                        context.report(node, OPEN_MESSAGE);
                     }
                 }
             });
         };
     }
 
+    /**
+     * Enforces the configured brace style on IfStatements
+     * @param {ASTNode} node An IfStatement node.
+     * @returns {void}
+     */
+    function checkIfStatement(node) {
+        var tokens;
+
+        checkBlock("consequent", "alternate")(node);
+
+        if (node.alternate && node.alternate.type === "BlockStatement") {
+            tokens = context.getTokens(node.alternate, 2);
+            if (style === "1tbs") {
+                if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {
+                    context.report(node.alternate, CLOSE_MESSAGE);
+                }
+            } else if (style === "stroustrup") {
+                if (tokens[0].loc.start.line === tokens[1].loc.start.line) {
+                    context.report(node.alternate, CLOSE_MESSAGE);
+                }
+            }
+        }
+    }
+
+    /**
+     * Enforces the configured brace style on TryStatements
+     * @param {ASTNode} node A TryStatement node.
+     * @returns {void}
+     */
+    function checkTryStatement(node) {
+        var tokens;
+
+        checkBlock("block", "finalizer")(node);
+
+        if (node.finalizer && node.finalizer.type === "BlockStatement") {
+            tokens = context.getTokens(node.finalizer, 2);
+            if (style === "1tbs") {
+                if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {
+                    context.report(node.finalizer, CLOSE_MESSAGE);
+                }
+            } else if (style === "stroustrup") {
+                if (tokens[0].loc.start.line === tokens[1].loc.start.line) {
+                    context.report(node.finalizer, CLOSE_MESSAGE);
+                }
+            }
+        }
+    }
+
+    /**
+     * Enforces the configured brace style on CatchClauses
+     * @param {ASTNode} node A CatchClause node.
+     * @returns {void}
+     */
+    function checkCatchClause(node) {
+        var tokens;
+
+        checkBlock("body")(node);
+
+        if (node.body && node.body.type === "BlockStatement") {
+            tokens = context.getTokens(node, 1);
+            if (style === "1tbs") {
+                if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {
+                    context.report(node, CLOSE_MESSAGE);
+                }
+            } else if (style === "stroustrup") {
+                if (tokens[0].loc.start.line === tokens[1].loc.start.line) {
+                    context.report(node, CLOSE_MESSAGE);
+                }
+            }
+        }
+    }
+
+    /**
+     * Enforces the configured brace style on SwitchStatements
+     * @param {ASTNode} node A SwitchStatement node.
+     * @returns {void}
+     */
     function checkSwitchStatement(node) {
         var tokens;
         if(node.cases && node.cases.length) {
             tokens = context.getTokens(node.cases[0], 2);
             if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {
-                context.report(node, MESSAGE);
+                context.report(node, OPEN_MESSAGE);
             }
         } else {
             tokens = context.getTokens(node);
             tokens.pop();
             if (tokens.pop().loc.start.line !== tokens.pop().loc.start.line) {
-                context.report(node, MESSAGE);
+                context.report(node, OPEN_MESSAGE);
             }
         }
     }
@@ -55,9 +141,9 @@ module.exports = function(context) {
 
     return {
         "FunctionDeclaration": checkBlock("body"),
-        "IfStatement": checkBlock("consequent", "alternate"),
-        "TryStatement": checkBlock("block", "finalizer"),
-        "CatchClause": checkBlock("body"),
+        "IfStatement": checkIfStatement,
+        "TryStatement": checkTryStatement,
+        "CatchClause": checkCatchClause,
         "DoWhileStatement": checkBlock("body"),
         "WhileStatement": checkBlock("body"),
         "WithStatement": checkBlock("body"),

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -8,7 +8,8 @@
 //------------------------------------------------------------------------------
 
 var eslintTester = require("eslint-tester"),
-    MESSAGE = "Opening curly brace does not appear on the same line as controlling statement.";
+    OPEN_MESSAGE = "Opening curly brace does not appear on the same line as controlling statement.",
+    CLOSE_MESSAGE = "Closing curly brace does not appear on the same line as the subsequent block.";
 
 //------------------------------------------------------------------------------
 // Tests
@@ -20,7 +21,6 @@ eslintTester.addRuleTest("lib/rules/brace-style", {
         "function a(b,\nc,\nd) { }",
         "if (foo) { \n bar(); }",
         "if (a) { b(); } else { c(); }",
-        "if (a) { b(); } \n else { c(); }",
         "while (foo) { \n bar(); }",
         "for (;;) { \n bar(); }",
         "with (foo) { \n bar(); }",
@@ -29,20 +29,28 @@ eslintTester.addRuleTest("lib/rules/brace-style", {
         "do { \n bar();\n } while (true)",
         "for (foo in bar) { \n baz(); \n }",
         "if (a &&\n b &&\n c) { \n }",
-        "switch(0) {}"
+        "switch(0) {}",
+        { code: "if (foo) {\n}\nelse {\n}", args: ["2", "stroustrup"] },
+        { code: "try { \n bar();\n }\ncatch (e) {\n baz(); \n }", args: ["2", "stroustrup"] }
     ],
     invalid: [
-        { code: "function foo() \n { \n return; }", errors: [{ message: MESSAGE, type: "FunctionDeclaration"}] },
-        { code: "if (foo) \n { \n bar(); }", errors: [{ message: MESSAGE, type: "IfStatement"}] },
-        { code: "if (a) { b(); } else \n { c(); }", errors: [{ message: MESSAGE, type: "IfStatement"}] },
-        { code: "while (foo) \n { \n bar(); }", errors: [{ message: MESSAGE, type: "WhileStatement"}] },
-        { code: "for (;;) \n { \n bar(); }", errors: [{ message: MESSAGE, type: "ForStatement"}] },
-        { code: "with (foo) \n { \n bar(); }", errors: [{ message: MESSAGE, type: "WithStatement"}] },
-        { code: "switch (foo) \n { \n case \"bar\": break; }", errors: [{ message: MESSAGE, type: "SwitchStatement"}] },
-        { code: "switch (foo) \n { }", errors: [{ message: MESSAGE, type: "SwitchStatement"}] },
-        { code: "try \n { \n bar(); \n } catch (e) {}", errors: [{ message: MESSAGE, type: "TryStatement"}] },
-        { code: "try { \n bar(); \n } catch (e) \n {}", errors: [{ message: MESSAGE, type: "CatchClause"}] },
-        { code: "do \n { \n bar(); \n} while (true)", errors: [{ message: MESSAGE, type: "DoWhileStatement"}] },
-        { code: "for (foo in bar) \n { \n baz(); \n }", errors: [{ message: MESSAGE, type: "ForInStatement"}] }
+        { code: "function foo() \n { \n return; }", errors: [{ message: OPEN_MESSAGE, type: "FunctionDeclaration"}] },
+        { code: "if (foo) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "IfStatement"}] },
+        { code: "if (a) { b(); } else \n { c(); }", errors: [{ message: OPEN_MESSAGE, type: "IfStatement"}] },
+        { code: "while (foo) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "WhileStatement"}] },
+        { code: "for (;;) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "ForStatement"}] },
+        { code: "with (foo) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "WithStatement"}] },
+        { code: "switch (foo) \n { \n case \"bar\": break; }", errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement"}] },
+        { code: "switch (foo) \n { }", errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement"}] },
+        { code: "try \n { \n bar(); \n } catch (e) {}", errors: [{ message: OPEN_MESSAGE, type: "TryStatement"}] },
+        { code: "try { \n bar(); \n } catch (e) \n {}", errors: [{ message: OPEN_MESSAGE, type: "CatchClause"}] },
+        { code: "do \n { \n bar(); \n} while (true)", errors: [{ message: OPEN_MESSAGE, type: "DoWhileStatement"}] },
+        { code: "for (foo in bar) \n { \n baz(); \n }", errors: [{ message: OPEN_MESSAGE, type: "ForInStatement"}] },
+        { code: "try { \n bar(); \n }\ncatch (e) {\n}", errors: [{ message: CLOSE_MESSAGE, type: "CatchClause"}] },
+        { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement"}] },
+        { code: "if (a) { b(); } \n else { c(); }", errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]},
+        { code: "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement"}] },
+        { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE, type: "CatchClause"}] },
+        { code: "if (a) { b(); } else { c(); }", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]}
     ]
 });


### PR DESCRIPTION
The `brace-style` rule now takes one option, which can be either "1tbs" or "stroustrup". The only difference between the two is that "stroustrup" requires `else`, `catch`, and `finally` to be on a new line after the closing curly brace:

``` js
// 1tbs
if (foo) {
    doSomething();
} else {
    somethingElse()
}

// stroustrup
if (foo) {
    doSomething();
} 
else {
    somethingElse()
}
```

In addition, I've set the `.eslintrc` for ESLint to explicitly use the "1tbs" option.

Fixes #645
Fixes #644
