### PR TITLE
Fixed context.report message parsing

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -410,7 +410,7 @@ module.exports = (function() {
         if (typeof location === "string") {
             opts = message;
             message = location;
-            location = {};
+            location = node.loc.start;
         }
 
         Object.keys(opts || {}).forEach(function (key) {
@@ -422,8 +422,8 @@ module.exports = (function() {
             ruleId: ruleId,
             node: node,
             message: message,
-            line: location.line || node.loc.start.line,
-            column: location.column || node.loc.start.column,
+            line: location.line,
+            column: location.column,
             source: api.getSource(node)
         });
     };

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -54,13 +54,14 @@ function RuleContext(ruleId, eslint, options) {
     /**
      * Passthrough to eslint.report() that automatically assigns the rule ID.
      * @param {ASTNode} node The AST node related to the message.
+     * @param {Object=} location The location of the error.
      * @param {string} message The message to display to the user.
      * @param {Object} opts Optional template data which produces a formatted message
      *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    this.report = function(node, message, opts) {
-        eslint.report(ruleId, node, message, opts);
+    this.report = function(node, location, message, opts) {
+        eslint.report(ruleId, node, location, message, opts);
     };
 
 }

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -681,6 +681,44 @@ describe("eslint", function() {
         });
     });
 
+    describe("when calling report", function() {
+        it("should correctly parse a message when being passed all options", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) { 
+                        context.report(node, node.loc.end, "hello {{dynamic}}", {dynamic: node.type}); 
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "hello Literal");
+        });
+
+        it("should use the report the provided location when given", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) { 
+                        context.report(node, {line: 42, column: 13}, "hello world"); 
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "hello world");
+            assert.equal(messages[0].line, 42);
+            assert.equal(messages[0].column, 13);
+        });
+    });
+
     describe("when evaluating code", function() {
         var code = TEST_CODE;
 


### PR DESCRIPTION
Fixed an issue where, if passed all available options, `context.report` would fail to properly parse the violation message and would instead display the raw message.

Fixes #642
