### PR TITLE
Update: camelcase rule now doesn't flag function calls (fixes #656)

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -4,12 +4,20 @@ When it comes to naming variables, styleguides generally fall into one of two ca
 
 ## Rule Details
 
-This rule looks for any underscores (_) located within the source code. It ignores leading and trailing underscores and only checks those in the middle of a variable name. If ESLint decides that the variable is a constant (all uppercase), then no warning will be thrown. Otherwise, a warning will be thrown.
+This rule looks for any underscores (`_`) located within the source code. It ignores leading and trailing underscores and only checks those in the middle of a variable name. If ESLint decides that the variable is a constant (all uppercase), then no warning will be thrown. Otherwise, a warning will be thrown. This rule only flags definitions and assignments but not function calls.
 
 The following patterns are considered warnings:
 
 ```js
 var my_favorite_color = "#112C85";
+
+function do_something() {
+    // ...
+}
+
+obj.do_something = function() {
+    // ...
+};
 ```
 
 The following patterns are considered okay and do not cause warnings:
@@ -19,6 +27,8 @@ var myFavoriteColor   = "#112C85";
 var _myFavoriteColor  = "#112C85";
 var myFavoriteColor_  = "#112C85";
 var MY_FAVORITE_COLOR = "#112C85";
+
+obj.do_something();
 ```
 
 ## When Not To Use It

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -15,10 +15,11 @@ module.exports = function(context) {
 
         "Identifier": function(node) {
             // Leading and trailing underscores are commonly used to flag private/protected identifiers, strip them
-            var name = node.name.replace(/^_+|_+$/g, "");
+            var name = node.name.replace(/^_+|_+$/g, ""),
+                effectiveParent = (node.parent.type === "MemberExpression") ? node.parent.parent : node.parent;
 
             // if there's an underscore, it might be A_CONSTANT, which is okay
-            if (name.indexOf("_") > -1 && name !== name.toUpperCase()) {
+            if (name.indexOf("_") > -1 && name !== name.toUpperCase() && effectiveParent.type !== "CallExpression") {
                 context.report(node, "Identifier '{{name}}' is not in camel case.", { name: node.name });
             }
         }

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -18,10 +18,48 @@ eslintTester.addRuleTest("lib/rules/camelcase", {
         "firstName = \"Nicholas\"",
         "FIRST_NAME = \"Nicholas\"",
         "__myPrivateVariable = \"Patrick\"",
-        "myPrivateVariable_ = \"Patrick\""
+        "myPrivateVariable_ = \"Patrick\"",
+        "function doSomething(){}",
+        "do_something()",
+        "foo.do_something()"
     ],
     invalid: [
-        { code: "first_name = \"Nicholas\"", errors: [{ message: "Identifier 'first_name' is not in camel case.", type: "Identifier"}] },
-        { code: "__private_first_name = \"Patrick\"", errors: [{ message: "Identifier '__private_first_name' is not in camel case.", type: "Identifier"}] }
+        {
+            code: "first_name = \"Nicholas\"",
+            errors: [
+                {
+                    message: "Identifier 'first_name' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "__private_first_name = \"Patrick\"",
+            errors: [
+                {
+                    message: "Identifier '__private_first_name' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "function foo_bar(){}",
+            errors: [
+                {
+                    message: "Identifier 'foo_bar' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "obj.foo_bar = function(){};",
+            errors: [
+                {
+                    message: "Identifier 'foo_bar' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        }
+
     ]
 });


### PR DESCRIPTION
Previously, the rule would flag this:

``` js
foo.do_something();
```

As pointed out in #656, you're at the mercy of external libraries on function and method calls, and where we really should flag is on declaration of these identifiers. So this changes the rule such that it does not flag `CallExpression` identifiers.
