### PR TITLE
Fix: Issues with named function expressions in no-unused-vars and no-shadow

### DIFF
--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -12,26 +12,26 @@ module.exports = function(context) {
     "use strict";
 
     function checkForShadows(node) {
-        var scope = context.getScope();
-
-        //remove variabes that were passed as arguments
-        var args = node.params;
-        //push 'arguments' into the array
-        //args.push({name: "arguments" });
-        var variables = scope.variables.filter(function(item) {
-            return !args.some(function(variable) {
-                return variable.name === item.name;
+        var scope = context.getScope(),
+            isFunctionExpression = (node.type === "FunctionExpression"),
+            funcName = node.id && node.id.name,
+            args = node.params,
+            variables = scope.variables.filter(function(item) {
+                return !args.some(function(variable) {
+                    return variable.name === item.name;
+                });
             });
-        });
+
         //iterate through the array of variables and find duplicates with the upper scope
         var upper = scope.upper;
 
         function findDups(variables) {
             variables.forEach(function(variable) {
+
                 if (upper.variables.some(function(scopeVar) {
                     //filter out global variables that we add as part of ESLint
                     if (scopeVar.identifiers.length > 0) {
-                        return scopeVar.name === variable.name;
+                        return scopeVar.name === variable.name && (!isFunctionExpression || variable.name !== funcName);
                     }
                     return false;
                 })) {

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -41,12 +41,13 @@ module.exports = function(context) {
             parent = context.getAncestors().pop(),
 
             // check for function foo(){}.bind(this)
-            functionNameUsed = parent && parent.type === "MemberExpression";
+            functionNameUsed = (node && node.type === "FunctionExpression") || (parent && parent.type === "MemberExpression");
 
         scope.variables.forEach(function(variable) {
 
             //filter out global variables that we add as part of eslint or arguments variable
             if (variable.identifiers.length > 0) {
+
 
                 //make sure that this variable is not already in the array
                 if (!lookupVariable(variable)) {
@@ -106,12 +107,15 @@ module.exports = function(context) {
         // may be a parameter
         var parent = usedVariable.node.parent;
         if (isFunction(parent)) {
+
             // Get a list of the param names used in the ancestor Function
             var fnParamNames = parent.params.map(function(param){
                 return param.name;
             });
+
             // Check if the used variable exists among those params
             var variableIndex = fnParamNames.indexOf(usedVariable.name);
+
             // This will be true if this variable appears in the param list of an ancestor Function Expression
             // or FunctionDeclaration.
             if (variableIndex !== -1) {
@@ -136,9 +140,11 @@ module.exports = function(context) {
             var ancestors = context.getAncestors(node);
             var parent = ancestors.pop();
             var grandparent = ancestors.pop();
-            /*if it's not an assignment expression find corresponding
-              *variable in the array and mark it as used
-              */
+
+            /*
+             * if it's not an assignment expression find corresponding
+             * variable in the array and mark it as used
+             */
             if ((parent.type !== "AssignmentExpression" || node !== parent.left) &&
                 (parent.type !== "VariableDeclarator" || (parent.init && parent.init === node)) &&
                 parent.type !== "FunctionDeclaration" &&

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -15,7 +15,8 @@ var eslintTester = require("eslint-tester");
 
 eslintTester.addRuleTest("lib/rules/no-shadow", {
     valid: [
-        "var a=3; function b(a) { a++; return a; }; setTimeout(function() { b(a); }, 0);"
+        "var a=3; function b(a) { a++; return a; }; setTimeout(function() { b(a); }, 0);",
+        "(function() { var doSomething = function doSomething() {}; doSomething() }())"
     ],
     invalid: [
         { code: "var a=3; function b() { var a=10; }", errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}] },

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -29,7 +29,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "var a=10",
         "myFunc(function foo() {}.bind(this))",
         "myFunc(function foo(){}.toString())",
-        "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});};"
+        "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});};",
+        "(function() { var doSomething = function doSomething() {}; doSomething() }())"
     ],
     invalid: [
         { code: "var a=10;", args: [1, "all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },


### PR DESCRIPTION
This takes care of the same issue in two rules, where named function expressions were incorrectly being reported for various reasons. This special cases function expression names in both rules.
