### PR TITLE
Added no-warning-comments rule (fixes #660)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -78,6 +78,7 @@
         "no-unused-expressions": 2,
         "no-unused-vars": [2, "local"],
         "no-use-before-define": 2,
+        "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 2,
         "no-wrap-func": 2,
         "no-yoda": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,6 +68,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
 * [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same
 * [no-unused-expressions](no-unused-expressions.md) - disallow usage of expressions in statement position
+* [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME`
 * [no-with](no-with.md) - disallow use of the `with` statement
 * [no-yoda](no-yoda.md) - disallow Yoda conditions
 * [radix](radix.md) - require use of the second argument for `parseInt()`

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -1,0 +1,108 @@
+# Disallow Warning Comments
+
+Often code is marked during development process for later work on it or with additional thoughts. Examples are typically `// TODO: do something` or `// FIXME: this is not a good idea`. These comments are a warning signal, that there is something not production ready in your code. Most likely you want to fix it or remove the comments before you roll out your code with a good feeling.
+
+## Rule Details
+
+This rule can be used to help finding these `warning-comments`. It can be configured with an array of terms you don't want to exist in your code. It will raise a warning when one or more of the configured `warning-comments` are present in the checked files.
+
+The default configuration has this rule disabled and looks like this:
+```js
+...
+"no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }]
+...
+```
+
+This preconfigures
+* the rule is disabled because it is set to `0`. Changing this to `1` for warn or `2` for error mode activates it (this works exactly the same as everywhere else in `ESLint`).
+* the `terms` array is set to `todo`, `fixme` and `xxx` as `warning-comments`. `terms` has to be an array. It can hold any terms you might want to warn about in your comments - they do not have to be single words. E.g. `really bad idea` is as valid as `attention`.
+* the `location`-option set to `start` configures the rule to check only the start of comments. E.g. `// TODO` would be matched, `// This is a TODO` not. You can change this to `anywhere` to check your complete comments.
+
+As already seen above, the configuration in the `eslint.json` file is quite simple. Example that enables the rule and
+configures it to check the complete comment, not only the start:
+
+```js
+...
+"no-warning-comments": [2, { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]
+...
+```
+
+The following patterns are considered warnings with the example configuration from above:
+```js
+// TODO: this
+// todo: this too
+// Even this: TODO
+/*
+ * The same goes for this TODO comment
+ * Or a fixme
+ * as well as any other term
+ */
+...
+```
+
+These patterns would not be considered warnings with the same example configuration:
+```js
+// This is to do
+// even not any other    term
+/*
+ * The same goes for block comments
+ * with any other interesting term
+ * or fix me this
+ */
+...
+```
+
+As mentationed above, patterns are matched when they match exactly to one of the terms specified (ignoring the case).
+
+## Rule Options
+```js
+...
+"no-warning-comments": [<enabled>, { "terms": <terms>, "location": <location> }]
+...
+```
+* `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to `0`.
+* `terms`: optional array of terms to match. Terms are matched ignoring the case. Defaults to `["todo", "fixme", "xxx"]`.
+* `location`: optional string that configures where in your comments to check for matches. Defaults to `"start"`.
+
+## When not to use it
+
+* If you have a large code base that was not developed with a policy to not use such warning terms, you might get hundreds of warnings / errors which might be contra-productive if you can't fix all of them (e.g. if you don't get the time to do it) as you might overlook other warnings / errors or get used to many of them and don't pay attention on it anymore.
+* Same reason as the point above: You shouldn't configure terms that are used very often (e.g. central parts of the native language used in your comments).
+
+## Further reading
+
+### More examples of valid configurations
+1. Rule configured to warn on matches and search the complete comment, not only the start of it. Note that the `term` configuration is omitted to use the defaults terms.
+   ```js
+   ...
+   "no-warning-comments": [1, { "location": "anywhere" }]
+   ...
+   ```
+
+2. Rule configured to warn on matches of the term `bad string` at the start of comments. Note that the `location` configuration is omitted to use the default location.
+   ```js
+   ...
+   "no-warning-comments": [1, { "terms": ["bad string"] }]
+   ...
+   ```
+
+3. Rule configured to warn with error on matches of the default terms at the start of comments. Note that the complete configuration object (that normally holds `terms` and/or `location`) can be omitted for simplicity.
+   ```js
+   ...
+   "no-warning-comments": [2]
+   ...
+   ```
+
+4. Rule configured to warn on matches of the default terms at the start of comments. Note that the complete configuration object (as already seen in the example above) and even the square brackets can be omitted for simplicity.
+   ```js
+   ...
+   "no-warning-comments": 1
+   ...
+   ```
+
+5. Rule configured to warn on matches of the specified terms at the start of comments. Note that you can use as many terms as you want.
+   ```js
+   ...
+   "no-warning-comments": [1, { "terms": ["any really", "interesting", "or even not", "term", "can be matched"] }]
+   ...
+   ```

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Rule that warns about used warning comments
+ * @author Alexander Schmidt <https://github.com/lxanders>
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function (context) {
+    "use strict";
+
+    var configuration = context.options[0] || {},
+        warningTerms = configuration.terms || ["todo", "fixme", "xxx"],
+        location = configuration.location || "start";
+
+    /**
+     * Prepares a specified comment for being checked.
+     * @param {String} comment The comment to prepare.
+     * @returns {String} The specified comment prepared for being checked.
+     */
+    function prepareCommentForChecking(comment) {
+        var commentToCheck;
+
+        commentToCheck = comment.toLowerCase();
+        commentToCheck = commentToCheck.trim();
+
+        return commentToCheck;
+    }
+
+    /**
+     * Checks if the specified comment starts with a specified term.
+     * @param {String} commentToCheck The comment to check.
+     * @param {String} lowerCaseTerm The term to search for.
+     * @returns {Boolean} True if the comment started with the specified term, else false.
+     */
+    function commentStartsWithTerm(commentToCheck, lowerCaseTerm) {
+        return commentToCheck.indexOf(lowerCaseTerm) === 0;
+    }
+
+    /**
+     * Checks if the specified comment contains a specified term at any location.
+     * @param {String} commentToCheck The comment to check.
+     * @param {String} lowerCaseTerm The term to search for.
+     * @returns {Boolean} True if the term was contained in the comment, else false.
+     */
+    function commentContainsTerm(commentToCheck, lowerCaseTerm) {
+        return commentToCheck.indexOf(lowerCaseTerm) !== -1;
+    }
+
+
+    /**
+     * Checks the specified comment for matches of the configured warning terms and returns the matches.
+     * @param {String} comment The comment which is checked.
+     * @returns {Array} All matched warning terms for this comment.
+     */
+    function commentContainsWarningTerm(comment) {
+        var matches = [];
+
+        warningTerms.forEach(function (term) {
+            var lowerCaseTerm = term.toLowerCase(),
+                commentToCheck = prepareCommentForChecking(comment);
+
+            if (location === "start") {
+                if (commentStartsWithTerm(commentToCheck, lowerCaseTerm)) {
+                    matches.push(term);
+                }
+            } else if (location === "anywhere") {
+                if (commentContainsTerm(commentToCheck, lowerCaseTerm)) {
+                    matches.push(term);
+                }
+            }
+        });
+
+        return matches;
+    }
+
+    /**
+     * Checks the specified node for matching warning comments and reports them.
+     * @param {ASTNode} node The AST node being checked.
+     * @returns {void} undefined.
+     */
+    function checkComment(node) {
+        var matches = commentContainsWarningTerm(node.value);
+
+        matches.forEach(function (matchedTerm) {
+            context.report(node, "Unexpected " + matchedTerm + " comment.");
+        });
+    }
+
+    return {
+        "BlockComment": checkComment,
+        "LineComment": checkComment
+    };
+};

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Tests for no-warning-comments rule.
+ * @author Alexander Schmidt <https://github.com/lxanders>
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/no-warning-comments", {
+    valid: [
+        { code: "// any comment", args: [1, { "terms": ["fixme"] } ] },
+        { code: "// any comment", args: [1, { "terms": ["fixme", "todo"] } ] },
+        { code: "// any comment", args: [1] },
+        { code: "// any comment", args: [1, { "location": "anywhere" } ] },
+        { code: "// any comment with TODO, FIXME or XXX", args: [1, { "location": "start" } ] },
+        { code: "// any comment with TODO, FIXME or XXX", args: [1] },
+        { code: "// any comment with TODO, FIXME or XXX", args: 1 },
+        { code: "/* any block comment */", args: [1, { "terms": ["fixme"] } ] },
+        { code: "/* any block comment */", args: [1, { "terms": ["fixme", "todo"] } ] },
+        { code: "/* any block comment */", args: [1] },
+        { code: "/* any block comment */", args: [1, { "location": "anywhere" } ] },
+        { code: "/* any block comment with TODO, FIXME or XXX */", args: [1, { "location": "start" } ] },
+        { code: "/* any block comment with TODO, FIXME or XXX */", args: [1] },
+        { code: "/* any block comment with TODO, FIXME or XXX */", args: 1 }
+    ],
+    invalid: [
+        { code: "// fixme", args: [1], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "// any fixme", args: [1, { "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "// any fixme", args: [1, { "terms": ["fixme"], "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "// any FIXME", args: [1, { "terms": ["fixme"], "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "// any fIxMe", args: [1, { "terms": ["fixme"], "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "/* any fixme */", args: [1, { "terms": ["FIXME"], "location": "anywhere" } ], errors: [ { message: "Unexpected FIXME comment." } ] },
+        { code: "/* any FIXME */", args: [1, { "terms": ["FIXME"], "location": "anywhere" } ], errors: [ { message: "Unexpected FIXME comment." } ] },
+        { code: "/* any fIxMe */", args: [1, { "terms": ["FIXME"], "location": "anywhere" } ], errors: [ { message: "Unexpected FIXME comment." } ] },
+        { code: "// any fixme or todo", args: [1, { "terms": ["fixme", "todo"], "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." }, { message: "Unexpected todo comment." } ] },
+        { code: "/* any fixme or todo */", args: [1, { "terms": ["fixme", "todo"], "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." }, { message: "Unexpected todo comment." } ] },
+        { code: "/* any fixme or todo */", args: [1, { "location": "anywhere" } ], errors: [ { message: "Unexpected todo comment." }, { message: "Unexpected fixme comment." } ] },
+        { code: "/* fixme and todo */", args: [1], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "/* any fixme */", args: [1, { "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." } ] }
+    ]
+});


### PR DESCRIPTION
As mentioned this fixes #660.
- As #580 removed the `getAllComments` function I used the `LineComment` and `BlockComment` AST nodes. The use of them is discouraged in the [documentation](https://github.com/eslint/eslint/blob/master/docs/developer-guide/working-with-rules.md#accessing-comments) but using `getComments` didn't work for this case. Do you know a better way to access all comments?
- My first version had a default warning term `todo` set, to match the [JSLint todo rule](http://jslinterrors.com/unexpected-todo-comment/). I had to remove this because the eslint project itself threw some errors as it has TODO comments on some places. I still think it would be a good idea to enable `TODO` (and maybe even `FIXME`) out of the box. What do you think about it?
