### PR TITLE
Relaxed enforcement of camelcase rule

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -27,6 +27,8 @@ var myFavoriteColor   = "#112C85";
 var _myFavoriteColor  = "#112C85";
 var myFavoriteColor_  = "#112C85";
 var MY_FAVORITE_COLOR = "#112C85";
+var foo = bar.baz_boom;
+var foo = { qux: bar.baz_boom };
 
 obj.do_something();
 ```

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -11,16 +11,61 @@ module.exports = function(context) {
 
     "use strict";
 
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Checks if a string contains an underscore and isn't all upper-case
+     * @param {String} name The string to check.
+     * @returns {boolean} if the string is underscored
+     * @private
+     */
+    function isUnderscored(name) {
+        
+        // if there's an underscore, it might be A_CONSTANT, which is okay
+        return name.indexOf("_") > -1 && name !== name.toUpperCase();
+    }
+
+    /**
+     * Reports an AST node as a rule violation.
+     * @param {ASTNode} node The node to report.
+     * @returns {void}
+     * @private
+     */
+    function report(node) {
+        context.report(node, "Identifier '{{name}}' is not in camel case.", { name: node.name });
+    }
+
     return {
 
         "Identifier": function(node) {
+
             // Leading and trailing underscores are commonly used to flag private/protected identifiers, strip them
             var name = node.name.replace(/^_+|_+$/g, ""),
                 effectiveParent = (node.parent.type === "MemberExpression") ? node.parent.parent : node.parent;
 
-            // if there's an underscore, it might be A_CONSTANT, which is okay
-            if (name.indexOf("_") > -1 && name !== name.toUpperCase() && effectiveParent.type !== "CallExpression") {
-                context.report(node, "Identifier '{{name}}' is not in camel case.", { name: node.name });
+            // MemberExpressions get special rules
+            if (node.parent.type === "MemberExpression") {
+
+                // Always report underscored object names
+                if (node.parent.object.type === "Identifier" &&
+                        node.parent.object.name === node.name &&
+                        isUnderscored(name)) {
+                    report(node);
+
+                // Report AssignmentExpressions only if they are the left side of the assignment
+                } else if (effectiveParent.type === "AssignmentExpression" &&
+                        isUnderscored(name) &&
+                        (effectiveParent.right.type !== "MemberExpression" ||
+                        effectiveParent.left.type === "MemberExpression" &&
+                        effectiveParent.left.property.name === node.name)) {
+                    report(node);
+                }
+
+            // Report anything that is underscored that isn't a CallExpression
+            } else if (isUnderscored(name) && effectiveParent.type !== "CallExpression") {
+                report(node);
             }
         }
     };

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -21,7 +21,17 @@ eslintTester.addRuleTest("lib/rules/camelcase", {
         "myPrivateVariable_ = \"Patrick\"",
         "function doSomething(){}",
         "do_something()",
-        "foo.do_something()"
+        "foo.do_something()",
+        "var foo = bar.baz_boom;",
+        "var foo = bar.baz_boom.something;",
+        "foo.boom_pow.qux = bar.baz_boom.something;",
+        "if (bar.baz_boom) {}",
+        "var obj = { key: foo.bar_baz };",
+        "var arr = [foo.bar_baz];",
+        "[foo.bar_baz]",
+        "var arr = [foo.bar_baz.qux];",
+        "[foo.bar_baz.nesting]",
+        "if (foo.bar_baz === boom.bam_pow) { [foo.baz_boom] }"
     ],
     invalid: [
         {
@@ -56,6 +66,60 @@ eslintTester.addRuleTest("lib/rules/camelcase", {
             errors: [
                 {
                     message: "Identifier 'foo_bar' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "bar_baz.foo = function(){};",
+            errors: [
+                {
+                    message: "Identifier 'bar_baz' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "[foo_bar.baz]",
+            errors: [
+                {
+                    message: "Identifier 'foo_bar' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "if (foo.bar_baz === boom.bam_pow) { [foo_bar.baz] }",
+            errors: [
+                {
+                    message: "Identifier 'foo_bar' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "foo.bar_baz = boom.bam_pow",
+            errors: [
+                {
+                    message: "Identifier 'bar_baz' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "var foo = { bar_baz: boom.bam_pow }",
+            errors: [
+                {
+                    message: "Identifier 'bar_baz' is not in camel case.",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "foo.qux.boom_pow = { bar: boom.bam_pow }",
+            errors: [
+                {
+                    message: "Identifier 'boom_pow' is not in camel case.",
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
The `camelcase` rule now allows reading underscored properties:

```
var foo = bar.baz_boom;
```

Fixes #672
