### PR TITLE
Fixes #677 getJSDocComment() should not search beyond FunctionExpression...

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -510,7 +510,7 @@ module.exports = (function() {
             case "FunctionExpression":
 
                 if (parent.type !== "CallExpression" || parent.callee !== node) {
-                    while (parent && !parent.leadingComments) {
+                    while (parent && !parent.leadingComments && parent.type !== "FunctionExpression" && parent.type !== "FunctionDeclaration") {
                         parent = parent.parent;
                     }
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -239,6 +239,48 @@ describe("eslint", function() {
             sandbox.verifyAndRestore();
         });
 
+        it("should not take a JSDoc comment from a FunctionDeclaration parent node when the node is a FunctionExpression", function() {
+
+            var code = [
+                "/** Desc*/",
+                "function Foo(){var t = function(){}}"
+            ].join("\n");
+
+            function assertJSDoc(node) {
+                var jsdoc = eslint.getJSDocComment(node);
+                assert.equal(null, jsdoc);
+            }
+
+            var spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("FunctionExpression", spy);
+            eslint.verify(code, { rules: {}}, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+
+        });
+
+        it("should not take a JSDoc comment from a FunctionExpression parent node when the node is a FunctionExpression", function() {
+
+            var code = [
+                "/** Desc*/",
+                "var f = function(){var t = function(arg){}}"
+            ].join("\n");
+
+            function assertJSDoc(node) {
+                if(node.params.length === 1) {
+                    var jsdoc = eslint.getJSDocComment(node);
+                    assert.equal(null, jsdoc);
+                }
+            }
+
+            var spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("FunctionExpression", spy);
+            eslint.verify(code, { rules: {}}, true);
+            assert.isTrue(spy.calledTwice, "Event handler should be called twice.");
+
+        });
+
         it("should get JSDoc comment for node when the node is a FunctionDeclaration", function() {
 
             var code = [


### PR DESCRIPTION
... or FunctionDeclaration parent nodes.

Fixes #677
