### PR TITLE
rewrite block-scoped-var

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -10,86 +10,101 @@
 
 module.exports = function(context) {
 
-    var stack = [{}]; // Start with the global block
+    var scopeStack = [];
 
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
-    function pushBlock() {
-        stack.push({});
-    }
 
-    function popBlock() {
-        stack.pop();
-    }
-
-    function hasAllowedAncestorsForCheck(ancestors) {
-        var grandparent = ancestors[ancestors.length - 1],
-            belongsToFunction = grandparent.type === "FunctionDeclaration";
-
-        return belongsToFunction;
-    }
-
-    function addCommonDeclaration(node) {
-        var type = node.type,
-            topObject = stack.pop(),
-            i,
-            len,
-            declarations;
-
-        switch (type) {
-        case "VariableDeclaration":
-            declarations = node.declarations;
-            for (i = 0, len = declarations.length; i < len; i++) {
-                topObject[declarations[i].id.name] = 1;
-            }
-            break;
-
-        case "FunctionDeclaration":
-            declarations = node.params;
-            topObject[node.id.name] = 1;
-            for (i = 0, len = declarations.length; i < len; i++) {
-                topObject[declarations[i].name] = 1;
-            }
-            break;
-
-        case "CatchClause":
-            declarations = [];
-            topObject[node.param.name] = 1;
-
-        // no default
+    /**
+     * Determines whether an identifier is in declaration position or is a non-declaration reference.
+     * @param {ASTNode} id The identifier.
+     * @param {ASTNode} parent The identifier's parent AST node.
+     * @returns {Boolean} true when the identifier is in declaration position.
+     */
+    function isDeclaration(id, parent) {
+        switch(parent.type) {
+            case "FunctionDeclaration":
+            case "FunctionExpression":
+                return parent.params.indexOf(id) > -1 || id === parent.id;
+            case "VariableDeclarator":
+                return id === parent.id;
+            case "CatchClause":
+                return id === parent.param;
         }
-
-        stack.push(topObject);
+        return false;
     }
 
-    function checkStackForIdentifier(node) {
-        var i,
-            len,
-            ancestors = context.getAncestors();
+    /**
+     * Pushes a new scope object on the scope stack.
+     * @returns {void}
+     */
+    function pushScope() {
+        scopeStack.push([]);
+    }
 
-        if (!hasAllowedAncestorsForCheck(ancestors)) {
-            for (i = 0, len = stack.length; i < len; i++) {
-                if (stack[i][node.name]) {
-                    return;
-                }
-            }
+    /**
+     * Removes the topmost scope object from the scope stack.
+     * @returns {void}
+     */
+    function popScope() {
+        scopeStack.pop();
+    }
 
-            context.report(node, node.name + " used outside of binding context.");
-        }
+    /**
+     * Declares the given names in the topmost scope object.
+     * @param {[String]} names A list of names to declare.
+     * @returns {void}
+     */
+    function declare(names) {
+        [].push.apply(scopeStack[scopeStack.length - 1], names);
     }
 
     //--------------------------------------------------------------------------
     // Public API
     //--------------------------------------------------------------------------
 
+    function functionHandler(node) {
+        pushScope();
+        declare(node.params.concat(node.id).map(function(id) { return id.name; }));
+    }
+
     return {
-        "BlockStatement": pushBlock,
-        "BlockStatement:exit": popBlock,
-        "CatchClause": addCommonDeclaration,
-        "VariableDeclaration": addCommonDeclaration,
-        "FunctionDeclaration": addCommonDeclaration,
-        "Identifier": checkStackForIdentifier
+        "Program": function() {
+            scopeStack = [context.getScope().variables.map(function(v) { return v.name; })];
+        },
+
+        "BlockStatement": function(node) {
+            var statements = node.body;
+            pushScope();
+            statements.forEach(function(stmt) {
+                if (stmt.type === "VariableDeclaration") {
+                    declare(stmt.declarations.map(function(decl) { return decl.id.name; }));
+                } else if (stmt.type === "FunctionDeclaration") {
+                    declare([stmt.id.name]);
+                }
+            });
+        },
+        "BlockStatement:exit": popScope,
+
+        "CatchClause": function(node) {
+            pushScope();
+            declare([node.param.name]);
+        },
+
+        "FunctionDeclaration": functionHandler,
+        "FunctionExpression": functionHandler,
+
+        "Identifier": function(node) {
+            if (isDeclaration(node, context.getAncestors().pop())) { return; }
+            for (var i = 0, l = scopeStack.length; i < l; i++) {
+                if (scopeStack[i].indexOf(node.name) > -1) {
+                    return;
+                }
+            }
+
+            context.report(node, "\"" + node.name + "\" used outside of binding context.");
+        }
     };
 
 };

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -15,15 +15,27 @@ var eslintTester = require("eslint-tester");
 
 eslintTester.addRuleTest("lib/rules/block-scoped-var", {
     valid: [
-        "function doSomething() { var build, f; if (true) { build = true; } f = build; }",
-        "var build; function doSomething() { var f = build; }",
-        "function doSomething(e) { }",
-        "function doSomething(e) { var f = e; }",
-        "function doSomething() { var f = doSomething; }",
-        "function foo() { } function doSomething() { var f = foo; }"
+        "function f() { var a, b; { a = true; } b = a; }",
+        "var a; function f() { var b = a; }",
+        "function f(a) { }",
+        "!function f(a) { };",
+        "function f(a) { var b = a; }",
+        "!function f(a) { var b = a; };",
+        "function f() { var g = f; }",
+        "function f() { } function g() { var f = g; }",
+        "function f() { var hasOwnProperty; { hasOwnProperty; } }",
+        "function f(){ a; b; var a, b; }",
+        "function f(){ g(); function g(){} }",
+        { code: "new Date", globals: {Date: false} },
+        { code: "new Date", globals: {} },
+        { code: "var eslint = require('eslint');", globals: {require: false} }
     ],
     invalid: [
-        { code: "function doSomething() { var f; if (true) { var build = true; } f = build; }", errors: [{ message: "build used outside of binding context.", type: "Identifier" }] },
-        { code: "function doSomething() { try { var build = 1; } catch (e) { var f = build; } }", errors: [{ message: "build used outside of binding context.", type: "Identifier" }] }
+        { code: "function f(){ x; }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function f(){ x; { var x; } }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function f(){ { var x; } x; }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function f() { var a; { var b = 0; } a = b; }", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function f() { try { var a = 0; } catch (e) { var b = a; } }", errors: [{ message: "\"a\" used outside of binding context.", type: "Identifier" }] },
+        { code: "var eslint = require('eslint');", globals: {}, errors: [{ message: "\"require\" used outside of binding context.", type: "Identifier" }] }
     ]
 });


### PR DESCRIPTION
- fixes #693: block-scoped-var does not respect globals
- fixes #701: block-scoped-var additionally enforcing that declarations come before use
- fixes #702: block-scoped-var considers function expression names as usage, not declaration
- fixes #703: block-scoped-var considers function expression parameters as usage, not declaration
