### PR TITLE
fixes #711: preserve line numbers when shebang is stripped

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -135,7 +135,7 @@ function processFile(filename, configHelper) {
 
     if (existsSync(filePath)) {
         config = configHelper.getConfig(filePath);
-        text = fs.readFileSync(path.resolve(filename), "utf8").replace(/^#![^\r\n]+[\r\n]/, "");
+        text = fs.readFileSync(path.resolve(filename), "utf8");
         messages = eslint.verify(text, config, filename);
     } else {
         messages = [{

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -279,7 +279,7 @@ module.exports = (function() {
             this.reset();
         }
 
-        ast = parse(text);
+        ast = parse(text.replace(/^(#![^\r\n]+[\r\n]+)/, "//$1"));
 
         //if Esprima failed to parse the file, there's no sense in setting up rules
         if (ast) {

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -730,8 +730,8 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    "Literal": function(node) { 
-                        context.report(node, node.loc.end, "hello {{dynamic}}", {dynamic: node.type}); 
+                    "Literal": function(node) {
+                        context.report(node, node.loc.end, "hello {{dynamic}}", {dynamic: node.type});
                     }
                 };
             });
@@ -747,8 +747,8 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    "Literal": function(node) { 
-                        context.report(node, {line: 42, column: 13}, "hello world"); 
+                    "Literal": function(node) {
+                        context.report(node, {line: 42, column: 13}, "hello world");
                     }
                 };
             });
@@ -1238,6 +1238,21 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, "no-alert");
             assert.equal(messages[0].message, "Unexpected alert.");
             assert.include(messages[0].node.type, "CallExpression");
+        });
+    });
+
+    describe("when evaluating a file with a shebang", function() {
+        var code = "#!bin/program\n\n;";
+
+        it("should preserve line numbers", function() {
+            var config = { rules: { "no-extra-semi": 1 } };
+            var messages = eslint.verify(code, config);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, "no-extra-semi");
+            assert.equal(messages[0].node.type, "EmptyStatement");
+            assert.equal(messages[0].line, 3);
+            assert.equal(messages[0].line, messages[0].node.loc.start.line);
         });
     });
 


### PR DESCRIPTION
**update:**

Fixes #711. I also took the liberty of moving the shebang stripping to `lib/eslint.js` so it is supported through the API, not just the CLI. Same test should cover both.
