### PR TITLE
Add reset cli flag

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -26,6 +26,7 @@ Options:
   -c, --config path::String  load configuration data from this file
   --rulesdir path::String    load additional rules from this directory
   -f, --format String        use a specific output format - default: stylish
+  --reset                    set all default rules to off
   -v, --version              outputs the version number
 ```
 
@@ -65,7 +66,15 @@ Example:
 
     eslint --rulesdir my-rules/ file.js
 
-The rules in your custom rules directory must following the same format as bundled rules to work properly.
+The rules in your custom rules directory must follow the same format as bundled rules to work properly.
+
+### `--reset`
+
+This option turns off all rules enabled in ESLint's default configuration file located at `conf/eslint.json`. ESLint will still report syntax errors.
+
+Example:
+
+    eslint --reset file.js
 
 ### `-v`, `--version`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -125,7 +125,8 @@ function Config(options) {
 
     this.cache = {};
     this.exclusionsCache = {};
-    this.baseConfig = require(path.resolve(__dirname, "..", "conf", "eslint.json"));
+    this.baseConfig = options.reset ? {} :
+            require(path.resolve(__dirname, "..", "conf", "eslint.json"));
     this.baseConfig.format = options.format;
     useConfig = options.config;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -44,5 +44,9 @@ module.exports = optionator({
     alias: "v",
     type: "Boolean",
     description: "Outputs the version number."
+  }, {
+    option: "reset",
+    type: "Boolean",
+    description: "Set all default rules to off."
   }]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -226,4 +226,13 @@ describe("cli", function() {
             assert.equal(exit, 1);
         });
     });
+
+    describe("when executing with reset flag", function() {
+        it("should execute without any errors", function () {
+            var exit = cli.execute("--reset tests/fixtures/missing-semicolon.js");
+
+            assert.isTrue(console.log.notCalled);
+            assert.equal(exit, 0);
+        });
+    });
 });


### PR DESCRIPTION
This is an initial stab at the first of [four changes](https://github.com/eslint/eslint/issues/692#issuecomment-38209348) discussed in #692. It adds a `--reset` (`-r`) flag to the cli options that resets all default rules to be off. As @nzakas suggested, it simply doesn't load `conf/eslint.json`.

@visionmedia [proposed](https://github.com/eslint/eslint/issues/692#issuecomment-38236247) only turning off the stylistic rules and leaving syntax errors and the "Possible Errors" rules enabled. This change does not do that but instead turns everything off. If there is consensus that the proposed behavior is desirable, I can go ahead and implement that.
