### PR TITLE
Fix #716 crash with reset flag

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -27,6 +27,7 @@ Options:
   --rulesdir path::String    load additional rules from this directory
   -f, --format String        use a specific output format - default: stylish
   --reset                    set all default rules to off
+  --eslintrc                 enable loading .eslintrc configuration. - default: true
   -v, --version              outputs the version number
 ```
 
@@ -75,6 +76,14 @@ This option turns off all rules enabled in ESLint's default configuration file l
 Example:
 
     eslint --reset file.js
+
+### `--eslintrc`
+
+This option, on by default, enables automatically loading `.eslintrc` configuration files. Use as `--no-eslintrc` to disable.
+
+Example
+
+    eslint --no-eslintrc file.js
 
 ### `-v`, `--version`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -128,6 +128,7 @@ function Config(options) {
     this.baseConfig = options.reset ? { rules: {} } :
             require(path.resolve(__dirname, "..", "conf", "eslint.json"));
     this.baseConfig.format = options.format;
+    this.useEslintrc = (options.eslintrc !== false);
     useConfig = options.config;
 
     if (useConfig) {
@@ -155,8 +156,10 @@ Config.prototype.getConfig = function (filePath) {
 
     if (this.useSpecificConfig) {
         userConfig = this.useSpecificConfig;
-    } else {
+    } else if (this.useEslintrc) {
         userConfig = getLocalConfig(this, directory);
+    } else {
+        userConfig = {};
     }
 
     if (userConfig.env) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -48,5 +48,10 @@ module.exports = optionator({
     option: "reset",
     type: "Boolean",
     description: "Set all default rules to off."
+  }, {
+    option: "eslintrc",
+    type: "Boolean",
+    default: "true", // Optionator only accepts string defaults
+    description: "Enable loading .eslintrc configuration."
   }]
 });

--- a/tests/fixtures/eslintrc/.eslintrc
+++ b/tests/fixtures/eslintrc/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "quotes": [2, "single"]
+    }
+}

--- a/tests/fixtures/eslintrc/quotes.js
+++ b/tests/fixtures/eslintrc/quotes.js
@@ -1,0 +1,1 @@
+var str = "quotes!";

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -229,10 +229,28 @@ describe("cli", function() {
 
     describe("when executing with reset flag", function() {
         it("should execute without any errors", function () {
-            var exit = cli.execute("--reset tests/fixtures/missing-semicolon.js");
+            var exit = cli.execute("--reset --no-eslintrc ./tests/fixtures/missing-semicolon.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
+        });
+    });
+
+    describe("when executing with no-eslintrc flag", function () {
+        it("should ignore a local config file", function () {
+            var exit = cli.execute("--no-eslintrc ./tests/fixtures/eslintrc/quotes.js");
+
+            assert.isTrue(console.log.notCalled);
+            assert.equal(exit, 0);
+        });
+    });
+
+    describe("when executing without no-eslintrc flag", function () {
+        it("should load a local config file", function () {
+            var exit = cli.execute("./tests/fixtures/eslintrc/quotes.js");
+
+            assert.isTrue(console.log.calledOnce);
+            assert.equal(exit, 1);
         });
     });
 });


### PR DESCRIPTION
Adds a `rules` key when the `--reset` flag is used so that `Object.keys(config.rules)` doesn't fail. There were multiple similar issues where the presence of `rules` was assumed, so changing it once was the most straightforward solution.

This issue wasn't picked up by the tests because the tests saw the .eslintrc in the project root, which gave the config a `rules` key and masked the error.
