### PR TITLE
fixes #723: block-scoped-var throws on unnamed function expression

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -66,7 +66,8 @@ module.exports = function(context) {
 
     function functionHandler(node) {
         pushScope();
-        declare(node.params.concat(node.id).map(function(id) { return id.name; }));
+        declare(node.params.map(function(id) { return id.name; }));
+        declare(node.id ? [node.id.name] : []);
     }
 
     return {

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -18,6 +18,7 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         "function f() { var a, b; { a = true; } b = a; }",
         "var a; function f() { var b = a; }",
         "function f(a) { }",
+        "!function(a) { };",
         "!function f(a) { };",
         "function f(a) { var b = a; }",
         "!function f(a) { var b = a; };",


### PR DESCRIPTION
Fixes #723.
