### PR TITLE
Fixed JSON formatting and highlighting

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -149,12 +149,12 @@ In either case, the settings in the configuration file override default settings
 
 Both the JSON and YAML configuration file formats support comments. You can use JavaScript-style comments or YAML-style comments in either type of file and ESLint will safely ignore them. This allows your configuration files to be more human-friendly. For example:
 
-```json
+```js
+{
     "env": {
         "browser": true
     },
     "rules": {
-
         // Override our default settings just for this directory
         "eqeqeq": 1,
         "strict": 0


### PR DESCRIPTION
It really looks broken otherwise.

Before:
![2014-03-28_2211](https://cloud.githubusercontent.com/assets/1444210/2553375/901c0da6-b6a4-11e3-9077-600a47e3e3d1.png)

After:
![2014-03-28_2210](https://cloud.githubusercontent.com/assets/1444210/2553372/874384b6-b6a4-11e3-8c2d-0816b054d484.png)
