### PR TITLE
Fix: Make sure semi reports correct location of missing semicolon

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -2,14 +2,12 @@
  * @fileoverview Rule to flag missing semicolons.
  * @author Nicholas C. Zakas
  */
-
+"use strict";
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 module.exports = function(context) {
-
-    "use strict";
 
     var always = context.options[0] !== "never";
 
@@ -29,7 +27,7 @@ module.exports = function(context) {
 
         if (always) {
             if (token.type !== "Punctuator" || token.value !== ";") {
-                context.report(node, node.loc.end, "Missing semicolon.");
+                context.report(node, token.loc.end, "Missing semicolon.");
             }
         } else {
             if (token.type === "Punctuator" && token.value === ";") {

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -48,6 +48,7 @@ eslintTester.addRuleTest("lib/rules/semi", {
         { code: "for (;;) var i ", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration"}] },
         { code: "for (var j;;) {var i}", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration"}] },
         { code: "var foo = {\n bar: baz\n}", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration", line: 3}] },
+        { code: "var foo\nvar bar;", errors: [{ message: "Missing semicolon.", type: "VariableDeclaration", line: 1}] },
 
         { code: "function foo() { return []; }", args: [1, "never"], errors: [{ message: "Extra semicolon.", type: "ReturnStatement"}] },
         { code: "while(true) { break; }", args: [1, "never"], errors: [{ message: "Extra semicolon.", type: "BreakStatement"}] },


### PR DESCRIPTION
Simple change, just switch to using the last token's position in the statement.
