### PR TITLE
Build: Add perf check into Travis build to better monitor performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,14 @@ language: node_js
 node_js:
     - "0.8"
     - "0.10"
+    - "0.11"
+
+matrix:
+    allowed_failures:
+        node: "0.8"
+        node: "0.11"
+
+script: "npm test && npm run perf"
 
 before_install:
     - npm link

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "major": "node Makefile.js major",
     "gensite": "node Makefile.js gensite",
     "browserify": "node Makefile.js browserify",
+    "perf": "node Makefile.js perf",
     "profile": "beefy tests/bench/bench.js --open -- -t brfs -t ./tests/bench/xform-rules.js"
   },
   "files": [


### PR DESCRIPTION
This adds performance testing to the Travis build (but not `npm test`).
