### PR TITLE
Adding homepage and bugs links to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,8 @@
     "type": "git",
     "url": "https://github.com/eslint/eslint"
   },
+  "homepage": "http://eslint.org",
+  "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
     "optionator": "~0.1.1",
     "estraverse": "~1.3.0",
@@ -65,8 +67,8 @@
     "ecmascript"
   ],
   "preferGlobal": true,
-  "license": {
+  "licenses": [{
     "type": "MIT",
     "url": "https://github.com/eslint/eslint/blob/master/LICENSE"
-  }
+  }]
 }


### PR DESCRIPTION
Note, this still throws warnings on http://package-json-validator.com/ saying that "latest" isnt semver-ey:

``` json
{
  "valid": false,
  "errors": [
    "Invalid version range for dependency eslint-tester: latest"
  ],
  "warnings": [
    "Missing recommended field: contributors"
  ],
  "recommendations": [
    "Missing optional field: engines"
  ]
}
```
