### PR TITLE
fixes #743: wrap-regex rule warns on regex used in dynamic member access

### DIFF
--- a/lib/rules/wrap-regex.js
+++ b/lib/rules/wrap-regex.js
@@ -25,9 +25,9 @@ module.exports = function(context) {
                 ancestors = context.getAncestors();
                 grandparent = ancestors[ancestors.length - 1];
 
-                if (grandparent.type === "MemberExpression" &&
+                if (grandparent.type === "MemberExpression" && grandparent.object === node &&
                         source[0] !== "(" && source[source.len - 1] !== ")") {
-                    context.report(node, "Wrap the /regexp/ literal in parens to disambiguate the slash operator.");
+                    context.report(node, "Wrap the regexp literal in parens to disambiguate the slash.");
                 }
             }
         }

--- a/tests/lib/rules/wrap-regex.js
+++ b/tests/lib/rules/wrap-regex.js
@@ -16,16 +16,17 @@ var eslintTester = require("eslint-tester");
 
 eslintTester.addRuleTest("lib/rules/wrap-regex", {
     valid: [
-        "var f = function() { return (/foo/).test(bar); };",
-        "var f = function() { return (/foo/ig).test(bar); };",
-        "var f = function() { return /foo/; };",
-        "var f = 0;"
+        "(/foo/).test(bar);",
+        "(/foo/ig).test(bar);",
+        "/foo/;",
+        "var f = 0;",
+        "a[/b/];"
     ],
     invalid: [
-        { code: "var f = function() { return /foo/.test(bar); };",
-          errors: [{ message: "Wrap the /regexp/ literal in parens to disambiguate the slash operator.", type: "Literal"}] },
-        { code: "var f = function() { return /foo/ig.test(bar); };",
-          errors: [{ message: "Wrap the /regexp/ literal in parens to disambiguate the slash operator.", type: "Literal"}] }
+        { code: "/foo/.test(bar);",
+          errors: [{ message: "Wrap the regexp literal in parens to disambiguate the slash.", type: "Literal"}] },
+        { code: "/foo/ig.test(bar);",
+          errors: [{ message: "Wrap the regexp literal in parens to disambiguate the slash.", type: "Literal"}] }
 
     ]
 });


### PR DESCRIPTION
Fixes #743. I also took the liberty of cleaning up the test cases and the reported message a bit.
