### PR TITLE
Add --env cli flag (ref #692)

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -47,7 +47,7 @@ This example uses the configuration file at `~/my-eslint.json` instead of the de
 
 ### `-f`, `--format`
 
-This options specifies the output format for the console. Possible formats are "stylish" (the default), "compact", "checkstyle", "jslint-xml", "junit" and "tap".
+This option specifies the output format for the console. Possible formats are "stylish" (the default), "compact", "checkstyle", "jslint-xml", "junit" and "tap".
 
 Example:
 
@@ -84,6 +84,14 @@ This option, on by default, enables automatically loading `.eslintrc` configurat
 Example
 
     eslint --no-eslintrc file.js
+
+### `--env`
+
+This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](../configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas.
+
+Example
+
+    eslint --env browser,node file.js
 
 ### `-v`, `--version`
 

--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -24,7 +24,7 @@ An environment defines both global variables that are predefined as well as whic
 
 These environments are not mutually exclusive, so you can define more than one at a time.
 
-Environments can only be specified in configuration files. To do so, use the `env` key and specify which environments you want to enable by setting each to `true`. For example, the following JSON enables the browser and Node.js environments:
+Environments can be specified in configuration files or using the `--env` [command line](../command-line-interface) flag. To specify environments in a configuration file, use the `env` key and specify which environments you want to enable by setting each to `true`. For example, the following JSON enables the browser and Node.js environments:
 
 ```json
 {

--- a/lib/config.js
+++ b/lib/config.js
@@ -129,6 +129,9 @@ function Config(options) {
             require(path.resolve(__dirname, "..", "conf", "eslint.json"));
     this.baseConfig.format = options.format;
     this.useEslintrc = (options.eslintrc !== false);
+    this.env = options.env ? options.env.split(",").filter(function (s) {
+        return s.length > 0;
+    }) : null;
     useConfig = options.config;
 
     if (useConfig) {
@@ -160,6 +163,16 @@ Config.prototype.getConfig = function (filePath) {
         userConfig = getLocalConfig(this, directory);
     } else {
         userConfig = {};
+    }
+
+    // Add cli-supplied environments
+    if (this.env) {
+        if (!userConfig.env) {
+            userConfig.env = {};
+        }
+        this.env.forEach(function (env) {
+            userConfig.env[env] = true;
+        });
     }
 
     if (userConfig.env) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -53,5 +53,9 @@ module.exports = optionator({
     type: "Boolean",
     default: "true", // Optionator only accepts string defaults
     description: "Enable loading .eslintrc configuration."
+  }, {
+    option: "env",
+    type: "String",
+    description: "Specify one or more comma-separated environments."
   }]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -253,4 +253,28 @@ describe("cli", function() {
             assert.equal(exit, 1);
         });
     });
+
+    describe("when executing with env flag", function () {
+        var files = [
+            "./tests/fixtures/globals-browser.js",
+            "./tests/fixtures/globals-node.js"
+        ];
+
+        it("should allow environment-specific globals", function () {
+            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser,node " + files.join(" "));
+            assert.equal(console.log.args[0][0].split("\n").length, 11);
+        });
+    });
+
+    describe("when executing without env flag", function () {
+        var files = [
+            "./tests/fixtures/globals-browser.js",
+            "./tests/fixtures/globals-node.js"
+        ];
+
+        it("should not define environment-specific globals", function () {
+            cli.execute("--no-eslintrc --config ./conf/eslint.json " + files.join(" "));
+            assert.equal(console.log.args[0][0].split("\n").length, 14);
+        });
+    });
 });


### PR DESCRIPTION
This PR enables adding environments using a new `--env` CLI flag. It will not disable environments specified elsewhere; it only enables additional environments. To guarantee the set of enabled environments matches exactly what is specified via this flag, combine with the `--reset` and `--no-eslintrc` flags. The list of environments following this flag must be comma-separated, as the flag cannot be used more than once.

Example:

```
eslint --env browser,node file.js
```
