### PR TITLE
Add global cli flag (ref #692)

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -30,6 +30,7 @@ Options:
   --reset                    Set all default rules to off.
   --eslintrc                 Enable loading .eslintrc configuration. - default: true
   --env [String]             Specify environments.
+  --global [String]          Define global variables.
 ```
 
 ### `-h`, `--help`
@@ -94,6 +95,15 @@ Example
 
     eslint --env browser,node file.js
     eslint --env browser --env node file.js
+
+### `--global`
+
+This option defines global variables so that they will not be flagged as undefined by the `no-undef` rule. Global variables are read-only by default, but appending `:true` to a variable's name makes it writable. To define multiple variables, separate them using commas, or use the flag multiple times.
+
+Example:
+
+    eslint --global require,exports:true file.js
+    eslint --global require --global exports:true
 
 ### `-v`, `--version`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -130,6 +130,13 @@ function Config(options) {
     this.baseConfig.format = options.format;
     this.useEslintrc = (options.eslintrc !== false);
     this.env = options.env;
+    this.globals = (options.global || []).reduce(function (globals, def) {
+
+        // Default "foo" to false and handle "foo:false" and "foo:true"
+        var parts = def.split(":");
+        globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
+        return globals;
+    }, {});
     useConfig = options.config;
 
     if (useConfig) {
@@ -188,6 +195,7 @@ Config.prototype.getConfig = function (filePath) {
 
     config = this.mergeConfigs(Object.create(this.baseConfig), envConfig);
     config = this.mergeConfigs(config, userConfig);
+    config = this.mergeConfigs(config, { globals: this.globals });
 
     this.cache[directory] = config;
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -58,5 +58,9 @@ module.exports = optionator({
     option: "env",
     type: "[String]",
     description: "Specify environments."
+  }, {
+    option: "global",
+    type: "[String]",
+    description: "Define global variables."
   }]
 });

--- a/tests/fixtures/undef.js
+++ b/tests/fixtures/undef.js
@@ -1,0 +1,2 @@
+var bar = baz;
+bat = 42;

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -282,4 +282,27 @@ describe("cli", function() {
             assert.equal(console.log.args[0][0].split("\n").length, 14);
         });
     });
+
+    describe("when executing with global flag", function () {
+        it("should default defined variables to read-only", function () {
+            var exit = cli.execute("--global baz,bat ./tests/fixtures/undef.js");
+
+            assert.isTrue(console.log.calledOnce);
+            assert.equal(exit, 1);
+        });
+
+        it("should allow defining writable global variables", function () {
+            var exit = cli.execute("--global baz:false,bat:true ./tests/fixtures/undef.js");
+
+            assert.isTrue(console.log.notCalled);
+            assert.equal(exit, 0);
+        });
+
+        it("should allow defining variables with multiple flags", function () {
+            var exit = cli.execute("--global baz --global bat:true ./tests/fixtures/undef.js");
+
+            assert.isTrue(console.log.notCalled);
+            assert.equal(exit, 0);
+        });
+    });
 });

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -93,4 +93,37 @@ describe("options", function() {
             assert.isString(helpText);
         });
     });
+
+    describe("when passed --global", function() {
+        it("should return an array for a single occurrence", function () {
+            var currentOptions = options.parse("--global foo");
+            assert.isArray(currentOptions.global);
+            assert.equal(currentOptions.global.length, 1);
+            assert.equal(currentOptions.global[0], "foo");
+        });
+
+        it("should split variable names using commas", function() {
+            var currentOptions = options.parse("--global foo,bar");
+            assert.isArray(currentOptions.global);
+            assert.equal(currentOptions.global.length, 2);
+            assert.equal(currentOptions.global[0], "foo");
+            assert.equal(currentOptions.global[1], "bar");
+        });
+
+        it("should not split on colons", function() {
+            var currentOptions = options.parse("--global foo:false,bar:true");
+            assert.isArray(currentOptions.global);
+            assert.equal(currentOptions.global.length, 2);
+            assert.equal(currentOptions.global[0], "foo:false");
+            assert.equal(currentOptions.global[1], "bar:true");
+        });
+
+        it("should concatenate successive occurrences", function() {
+            var currentOptions = options.parse("--global foo:true --global bar:false");
+            assert.isArray(currentOptions.global);
+            assert.equal(currentOptions.global.length, 2);
+            assert.equal(currentOptions.global[0], "foo:true");
+            assert.equal(currentOptions.global[1], "bar:false");
+        });
+    });
 });


### PR DESCRIPTION
Adds a --global cli flag to define global variables. To define multiple variables, either separate them using commas, or use the flag multiple times. By default, all variables are read-only, but appending `:true` to the name will mark it as writable.

Example:

```
eslint --global require,exports:true file.js
eslint --global require --global exports:true file.js
```
