### PR TITLE
readme: npm i -> npm install

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ When ESLint v0.5.0 is released, it will be in beta and will have more stability 
 
 You can install ESLint using npm:
 
-    npm i -g eslint
+    npm install -g eslint
 
 ## Usage
 


### PR DESCRIPTION
Although `npm i` is shorter to type, having it in the readme adds some unnecessary complexity. I had to stop and think to figure out what the command actually did. As all other projects I've come across uses `npm install`, I think it's better to follow an accepted convention and show the longer command.

For people that copy and pastes it won't make a difference, and people that type it out can still use the sort version.
