### PR TITLE
New: Experimental support for CSS Auron (fixes #765)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -15,7 +15,8 @@ var esprima = require("esprima"),
     rules = require("./rules"),
     util = require("./util"),
     RuleContext = require("./rule-context"),
-    EventEmitter = require("events").EventEmitter;
+    EventEmitter = require("events").EventEmitter,
+    cssauron = require("cssauron-esprima");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -785,6 +786,16 @@ module.exports = (function() {
         } else {
             return currentScopes[0];    // global scope
         }
+    };
+
+    /**
+     * Determines if a given node matches a given selector.
+     * @param {ASTNode} node An AST node.
+     * @param {string} selector The CSS Auron query selector to match.
+     * @returns {boolean} True if the node matches, false if not.
+     */
+    api.matches = function(node, selector) {
+        return !!cssauron(selector)(node);
     };
 
     /**

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -23,7 +23,8 @@ var PASSTHROUGHS = [
         "getAncestors",
         "getScope",
         "getJSDocComment",
-        "getFilename"
+        "getFilename",
+        "matches"
     ];
 
 //------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "chalk": "~0.4.0",
     "strip-json-comments": "~0.1.1",
     "js-yaml": "~3.0.1",
-    "doctrine": "~0.5.0"
+    "doctrine": "~0.5.0",
+    "cssauron-esprima": "0.0.1"
   },
   "devDependencies": {
     "sinon": "1.7.3",

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -592,6 +592,61 @@ describe("eslint", function() {
         });
     });
 
+    describe("matches()", function() {
+
+        var sandbox;
+
+        beforeEach(function() {
+            eslint.reset();
+            sandbox = sinon.sandbox.create();
+        });
+
+        afterEach(function() {
+            sandbox.verifyAndRestore();
+        });
+
+        it("should return true when a node matches a selector", function() {
+
+            var code = [
+                "/** Desc*/",
+                "function Foo(){var t = function(){}}"
+            ].join("\n");
+
+            function assertJSDoc(node) {
+                var result = eslint.matches(node, "VariableDeclarator > FunctionExpression");
+                assert.equal(result, true);
+            }
+
+            var spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("FunctionExpression", spy);
+            eslint.verify(code, { rules: {}}, filename, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+
+        it("should return false when a node doesn't match a selector", function() {
+
+            var code = [
+                "/** Desc*/",
+                "function Foo(){var t = function(){}}"
+            ].join("\n");
+
+            function assertJSDoc(node) {
+                var result = eslint.matches(node, "FunctionDeclaration > FunctionExpression");
+                assert.equal(result, false);
+            }
+
+            var spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("FunctionExpression", spy);
+            eslint.verify(code, { rules: {}}, filename, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
+
+    });
+
     describe("getJSDocComment()", function() {
 
         var sandbox;


### PR DESCRIPTION
Experimental support for CSS Auron. I'm leaving out documentation for now, just in case we decide this isn't working out. Waiting on some additional documentation for CSS Auron, but the basic idea is that inside of a rule you can do:

``` js
if (context.matches(node, "FunctionExpression Identifier")) {
    // ...
}
```

So it doesn't replace the current way of traversing the tree, but augments what we already have to hopefully help make the code inside of rules a bit easier to deal with.

The big thing holding back further testing is the lack of documentation related to patterns. I've filed https://github.com/chrisdickinson/cssauron-esprima/issues/1 requesting that.
