### PR TITLE
Rule: valid-typeof

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -116,6 +116,7 @@
         "strict": 2,
         "use-isnan": 2,
         "valid-jsdoc": 0,
+        "valid-typeof": 2,
         "wrap-iife": 0,
         "wrap-regex": 0
     }

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -28,6 +28,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-unreachable](no-unreachable.md) - disallow unreachable statements after a return, throw, continue, or break statement
 * [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
 * [valid-jsdoc](valid-jsdoc.md) - Ensure JSDoc comments are valid (off by default)
+* [valid-typeof](valid-typeof.md) - Ensure that the results of typeof are compared against a valid string
 
 ## Best Practices
 

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -1,0 +1,31 @@
+# Ensures that the results of typeof are compared against a valid string  (valid-typeof)
+
+For a vast majority of use-cases, the only valid results of the `typeof` operator will be one of the following: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, and `"function"`. When the result of a `typeof` operation is compared against a string that is not one of these strings, it is usually a typo. This rule ensures that when the result of a `typeof` operation is compared against a string, that string is in the aforementioned set.
+
+## Rule Details
+
+This rule aims to prevent errors from likely typos by ensuring that when the result of a `typeof` operation is compared against a string, that the string is a valid value.
+
+The following patterns are considered warnings:
+
+```js
+typeof foo === "strnig"
+typeof foo == "undefimed"
+typeof bar != "nunber"
+typeof bar !== "fucntion"
+```
+
+The following patterns are not warnings:
+
+```js
+typeof foo === "string"
+typeof bar == "undefined"
+
+typeof foo === baz
+
+typeof bar === typeof qux
+```
+
+## When Not To Use It
+
+You may want to turn this rule off if you will be using the `typeof` operator on host objects.

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Ensures that the results of typeof are compared against a valid string 
+ * @author Ian Christian Myers
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var VALID_TYPES = ["symbol", "undefined", "object", "boolean", "number", "string", "function"],
+        OPERATORS = ["==", "===", "!=", "!=="];
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "UnaryExpression": function (node) {
+            var parent, sibling;
+
+            if (node.operator === "typeof") {
+                parent = context.getAncestors().pop();
+
+                if (parent.type === "BinaryExpression" && OPERATORS.indexOf(parent.operator) !== -1) {
+                    sibling = parent.left === node ? parent.right : parent.left;
+
+                    if (sibling.type === "Literal" && VALID_TYPES.indexOf(sibling.value) === -1) {
+                        context.report(sibling, "Invalid typeof comparison value");
+                    }
+                }
+            }
+        }
+
+    };
+
+};

--- a/tests/lib/rules/valid-typeof.js
+++ b/tests/lib/rules/valid-typeof.js
@@ -1,0 +1,96 @@
+/**
+ * @fileoverview Ensures that the results of typeof are compared against a valid string 
+ * @author Ian Christian Myers
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/valid-typeof", {
+
+    valid: [
+        "typeof foo === 'string'",
+        "typeof foo === 'object'",
+        "typeof foo === 'function'",
+        "typeof foo === 'undefined'",
+        "typeof foo === 'boolean'",
+        "typeof foo === 'number'",
+        "'string' === typeof foo",
+        "'object' === typeof foo",
+        "'function' === typeof foo",
+        "'undefined' === typeof foo",
+        "'boolean' === typeof foo",
+        "'number' === typeof foo",
+        "typeof foo === typeof bar",
+        "typeof foo === baz",
+        "typeof foo !== someType",
+        "typeof bar != someType",
+        "someType === typeof bar",
+        "someType == typeof bar",
+        "typeof foo == 'string'",
+        "typeof(foo) === 'string'",
+        "typeof(foo) !== 'string'",
+        "typeof(foo) == 'string'",
+        "typeof(foo) != 'string'",
+        "var oddUse = typeof foo + 'thing'"
+    ],
+
+    invalid: [
+        {
+            code: "typeof foo === 'strnig'",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "'strnig' === typeof foo",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "if (typeof bar === 'umdefined') {}",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "typeof foo !== 'strnig'",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "'strnig' !== typeof foo",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "if (typeof bar !== 'umdefined') {}",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "typeof foo != 'strnig'",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "'strnig' != typeof foo",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "if (typeof bar != 'umdefined') {}",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "typeof foo == 'strnig'",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "'strnig' == typeof foo",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        },
+        {
+            code: "if (typeof bar == 'umdefined') {}",
+            errors: [{ message: "Invalid typeof comparison value", type: "Literal" }]
+        }
+    ]
+});


### PR DESCRIPTION
For a vast majority of use-cases, the only valid results of the `typeof` operator will be one of the following: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, and `"function"`. When a user compares the result of a `typeof` operation against a string that is not one of these strings, it is usually a typo. This rule ensures that when the result of a `typeof` operation is compared against a string, that string is in the aforementioned set.

```
typeof foo === "strnig"
```

Fixes #715
