### PR TITLE
Replace optionator with nopt (fixes #769)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
 var cli = require("../lib/cli");
-var exitCode = cli.execute(process.argv);
+var exitCode = cli.execute(Array.prototype.slice.call(process.argv, 2));
 process.exit(exitCode);

--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -22,14 +22,14 @@ The command line utility has several options. You can view the options by runnin
 eslint [options] file.js [file.js] [dir]
 
 Options:
-  -h, --help                 show help
-  -c, --config path::String  load configuration data from this file
-  --rulesdir path::String    load additional rules from this directory
-  -f, --format String        use a specific output format - default: stylish
-  --reset                    set all default rules to off
-  --eslintrc                 enable loading .eslintrc configuration - default: true
-  --env                      specify one or more comma-separated environments
-  -v, --version              outputs the version number
+  --help, -h    Show help.
+  --config, -c  Load configuration data from this file.
+  --rulesdir    Load additional rules from this directory.
+  --format, -f  Use a specific output format. - default: stylish
+  --reset       Set all default rules to off.
+  --eslintrc    Enable loading .eslintrc configuration. - default: true
+  --env         Specify environments.
+  --version, -v Outputs the version number.
 ```
 
 ### `-h`, `--help`
@@ -88,11 +88,11 @@ Example
 
 ### `--env`
 
-This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](../configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas.
+This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](../configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files.
 
 Example
 
-    eslint --env browser,node file.js
+    eslint --env browser --env node file.js
 
 ### `-v`, `--version`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -208,24 +208,15 @@ var cli = {
 
     /**
      * Executes the CLI based on an array of arguments that is passed in.
-     * @param {string|Array|Object} args The arguments to process.
+     * @param {String[]} argv The array of arguments to process.
      * @returns {int} The exit code for the operation.
      */
-    execute: function(args) {
+    execute: function(argv) {
 
-        var currentOptions,
-            files,
+        var currentOptions = options.parse(argv),
+            files = currentOptions.argv.remain,
             configHelper,
             result;
-
-        try {
-          currentOptions = options.parse(args);
-        } catch (error) {
-          console.error(error.message);
-          return 1;
-        }
-
-        files = currentOptions._;
 
         // Ensure results from previous execution are not printed.
         results = [];
@@ -236,7 +227,7 @@ var cli = {
 
         } else if (currentOptions.help || !files.length) {
 
-            console.log(options.generateHelp());
+            options.help();
 
         } else {
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,6 +1,6 @@
 /**
- * @fileoverview Options configuration for optionator.
- * @author George Zahariev
+ * @fileoverview Options configuration for nopt.
+ * @author Brandon Mills
  */
 "use strict";
 
@@ -8,54 +8,60 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var optionator = require("optionator");
+var path = require("path");
+var nopt = require("nopt");
+var noptDefaults = require("nopt-defaults");
+var noptUsage = require("nopt-usage");
+var extend = require("extend");
 
 //------------------------------------------------------------------------------
-// Initialization and Public Interface
+// Initialization
 //------------------------------------------------------------------------------
 
-// exports "parse(args)", "generateHelp()", and "generateHelpForOption(optionName)"
-module.exports = optionator({
-  prepend: "eslint [options] file.js [file.js] [dir]",
-  options: [{
-    heading: "Options"
-  }, {
-    option: "help",
-    alias: "h",
-    type: "Boolean",
-    description: "Show help."
-  }, {
-    option: "config",
-    alias: "c",
-    type: "path::String",
-    description: "Load configuration data from this file."
-  }, {
-    option: "rulesdir",
-    type: "path::String",
-    description: "Load additional rules from this directory."
-  }, {
-    option: "format",
-    alias: "f",
-    type: "String",
-    default: "stylish",
-    description: "Use a specific output format."
-  }, {
-    option: "version",
-    alias: "v",
-    type: "Boolean",
-    description: "Outputs the version number."
-  }, {
-    option: "reset",
-    type: "Boolean",
-    description: "Set all default rules to off."
-  }, {
-    option: "eslintrc",
-    type: "Boolean",
-    default: "true", // Optionator only accepts string defaults
-    description: "Enable loading .eslintrc configuration."
-  }, {
-    option: "env",
-    type: "[String]",
-    description: "Specify one or more comma-separated environments."
-  }]
-});
+var knownOpts = {
+  "help": Boolean,
+  "config": String,
+  "rulesdir": path,
+  "format": String,
+  "version": Boolean,
+  "reset": Boolean,
+  "eslintrc": Boolean,
+  "env": [Array, "node", "browser", "amd", "mocha"]
+};
+
+var shortHands = {
+  "h": "--help",
+  "c": "--config",
+  "f": "--format",
+  "v": "--version"
+};
+
+var descriptions = {
+  "help": "Show help.",
+  "config": "Load configuration data from this file.",
+  "rulesdir": "Load additional rules from this directory.",
+  "format": "Use a specific output format.",
+  "version": "Outputs the version number.",
+  "reset": "Set all default rules to off.",
+  "eslintrc": "Enable loading .eslintrc configuration.",
+  "env": "Specify environments."
+};
+
+var defaults = {
+  "format": "stylish",
+  "eslintrc": true
+};
+
+exports.parse = function(args) {
+  return noptDefaults(nopt(knownOpts, extend({}, shortHands), args, 0), defaults);
+};
+
+exports.help = function() {
+  var output = [
+    "eslint [options] file.js [file.js] [dir]",
+    "",
+    "Options:",
+    noptUsage(knownOpts, shortHands, descriptions, defaults)
+  ].join("\n");
+  console.log(output);
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "homepage": "http://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "optionator": "~0.1.1",
     "estraverse": "~1.3.0",
     "esprima": "~1.1.1",
     "escope": "~1.0.0",
@@ -41,7 +40,11 @@
     "chalk": "~0.4.0",
     "strip-json-comments": "~0.1.1",
     "js-yaml": "~3.0.1",
-    "doctrine": "~0.5.0"
+    "doctrine": "~0.5.0",
+    "nopt-usage": "~0.1.0",
+    "nopt": "~2.2.0",
+    "nopt-defaults": "0.0.1",
+    "extend": "~1.2.1"
   },
   "devDependencies": {
     "sinon": "1.7.3",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -29,15 +29,17 @@ describe("cli", function() {
     });
 
     describe("when given a config file", function() {
+        var code = path.join(__dirname, "..", ".eslintrc");
+
         it("should load the specified config file", function() {
             assert.doesNotThrow(function () {
-                cli.execute("-c " + path.join(__dirname, "..", ".eslintrc") + " lib/cli.js");
+                cli.execute(["-c", code, "lib/cli.js"]);
             });
         });
     });
 
     describe("when there is a local config file", function() {
-        var code = "lib/cli.js";
+        var code = ["lib/cli.js"];
 
         it("should load the local config file", function() {
             // Mock CWD
@@ -54,7 +56,7 @@ describe("cli", function() {
     });
 
     describe("when given a config with rules with options and severity level set to error", function() {
-        var code = "--config tests/fixtures/configurations/quotes-error.json single-quoted.js";
+        var code = ["--config", "tests/fixtures/configurations/quotes-error.json", "single-quoted.js"];
 
         it("should exit with an error status (1)", function() {
             var exitStatus;
@@ -68,7 +70,7 @@ describe("cli", function() {
     });
 
     describe("when given a config file and a directory of files", function() {
-        var code = "--config tests/fixtures/configurations/semi-error.json tests/fixtures/formatters";
+        var code = ["--config", "tests/fixtures/configurations/semi-error.json", "tests/fixtures/formatters"];
 
         it("should load and execute without error", function() {
             var exitStatus;
@@ -82,7 +84,10 @@ describe("cli", function() {
     });
 
     describe("when given a config with environment set to browser", function() {
-        var code = "--config tests/fixtures/configurations/env-browser.json tests/fixtures/globals-browser.js";
+        var code = [
+            "--config", "tests/fixtures/configurations/env-browser.json",
+            "tests/fixtures/globals-browser.js"
+        ];
 
         it("should execute without any errors", function() {
             var exit = cli.execute(code);
@@ -92,7 +97,7 @@ describe("cli", function() {
     });
 
     describe("when given a config with environment set to Node.js", function() {
-        var code = "--config tests/fixtures/configurations/env-node.json tests/fixtures/globals-node.js";
+        var code = ["--config", "tests/fixtures/configurations/env-node.json", "tests/fixtures/globals-node.js"];
 
         it("should execute without any errors", function() {
             var exit = cli.execute(code);
@@ -102,93 +107,115 @@ describe("cli", function() {
     });
 
     describe("when given a valid built-in formatter name", function() {
+        var code = "checkstyle";
+
         it("should execute without any errors", function() {
-            var exit = cli.execute("-f checkstyle tests/fixtures/passing.js");
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
 
             assert.equal(exit, 0);
         });
     });
 
     describe("when given an invalid built-in formatter name", function() {
+        var code = "fakeformatter";
+
         it("should execute with error", function() {
-            var exit = cli.execute("-f fakeformatter tests/fixtures/passing.js");
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
 
             assert.equal(exit, 1);
         });
     });
 
     describe("when given a valid formatter path", function() {
+        var code = "tests/fixtures/formatters/simple.js";
+
         it("should execute without any errors", function() {
-            var exit = cli.execute("-f tests/fixtures/formatters/simple.js tests/fixtures/passing.js");
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
 
             assert.equal(exit, 0);
         });
     });
 
     describe("when given an invalid formatter path", function() {
+        var code = "tests/fixtures/formatters/file-does-not-exist.js";
+
         it("should execute with error", function() {
-            var exit = cli.execute("-f tests/fixtures/formatters/file-does-not-exist.js tests/fixtures/passing.js");
+            var exit = cli.execute(["-f", code, "tests/fixtures/passing.js"]);
 
             assert.equal(exit, 1);
         });
     });
 
     describe("when executing a file with an error", function() {
+        var code = "tests/fixtures/configurations/semi-error.js";
+
         it("should execute with error", function() {
-            var exit = cli.execute("tests/fixtures/configurations/semi-error.js");
+            var exit = cli.execute([code]);
 
             assert.equal(exit, 1);
         });
     });
 
     describe("when calling execute more than once", function() {
+        var code = ["tests/fixtures/missing-semicolon.js", "tests/fixtures/passing.js"];
+
         it("should not print the results from previous execution", function() {
-            cli.execute("tests/fixtures/missing-semicolon.js");
+            cli.execute([code[0]]);
             assert.isTrue(console.log.called);
 
             console.log.reset();
 
-            cli.execute("tests/fixtures/passing.js");
+            cli.execute([code[1]]);
             assert.isTrue(console.log.notCalled);
 
         });
     });
 
     describe("when executing with version flag", function() {
+        var code = "-v";
+
         it("should print out current version", function() {
-            cli.execute("-v");
+            cli.execute([code]);
 
             assert.equal(console.log.callCount, 1);
         });
     });
 
     describe("when executing with help flag", function() {
+        var code = "-h";
+
         it("should print out help", function() {
-            cli.execute("-h");
+            cli.execute([code]);
 
             assert.equal(console.log.callCount, 1);
         });
     });
 
     describe("when given a directory with eslint excluded files", function() {
+        var code = "tests/fixtures";
+
         it("should not process any files", function() {
-            cli.execute("tests/fixtures");
+            cli.execute([code]);
 
             assert.isTrue(console.log.notCalled);
         });
     });
 
     describe("when given a directory with jshint excluded files", function() {
+        var code = "tests/fixtures";
+
         it("should not process any files", function() {
-            cli.execute("tests/fixtures");
+            cli.execute([code]);
 
             assert.isTrue(console.log.notCalled);
         });
     });
 
     describe("when given a directory with eslint excluded files in the directory", function() {
+        var code = "tests/fixtures";
+
         it("should not process any files", function() {
-            var exit = cli.execute("tests/fixtures");
+            var exit = cli.execute([code]);
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -196,9 +223,10 @@ describe("cli", function() {
     });
 
     describe("when given a file in excluded files list", function() {
+        var code = "tests/fixtures/missing-semicolon.js";
 
         it("should process the file anyway", function() {
-            var exit = cli.execute("tests/fixtures/missing-semicolon.js");
+            var exit = cli.execute([code]);
 
             assert.isTrue(console.log.called);
             assert.isFalse(console.log.alwaysCalledWith(""));
@@ -207,16 +235,17 @@ describe("cli", function() {
     });
 
     describe("when executing a file with a shebang", function() {
+        var code = "tests/fixtures/shebang.js";
 
         it("should execute without error", function() {
-            var exit = cli.execute("tests/fixtures/shebang.js");
+            var exit = cli.execute([code]);
 
             assert.equal(exit, 0);
         });
     });
 
     describe("when given a custom rule, verify that it's loaded", function() {
-        var code = "--rulesdir ./tests/fixtures/rules --config ./tests/fixtures/rules/eslint.json tests/fixtures/rules/test/test-custom-rule.js";
+        var code = ["--rulesdir", "./tests/fixtures/rules", "--config", "./tests/fixtures/rules/eslint.json", "tests/fixtures/rules/test/test-custom-rule.js"];
 
         it("should return a warning", function() {
             var exit = cli.execute(code);
@@ -229,7 +258,7 @@ describe("cli", function() {
 
     describe("when executing with reset flag", function() {
         it("should execute without any errors", function () {
-            var exit = cli.execute("--reset --no-eslintrc ./tests/fixtures/missing-semicolon.js");
+            var exit = cli.execute(["--reset", "--no-eslintrc", "./tests/fixtures/missing-semicolon.js"]);
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -238,7 +267,7 @@ describe("cli", function() {
 
     describe("when executing with no-eslintrc flag", function () {
         it("should ignore a local config file", function () {
-            var exit = cli.execute("--no-eslintrc ./tests/fixtures/eslintrc/quotes.js");
+            var exit = cli.execute(["--no-eslintrc", "./tests/fixtures/eslintrc/quotes.js"]);
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -247,7 +276,7 @@ describe("cli", function() {
 
     describe("when executing without no-eslintrc flag", function () {
         it("should load a local config file", function () {
-            var exit = cli.execute("./tests/fixtures/eslintrc/quotes.js");
+            var exit = cli.execute(["./tests/fixtures/eslintrc/quotes.js"]);
 
             assert.isTrue(console.log.calledOnce);
             assert.equal(exit, 1);
@@ -255,25 +284,31 @@ describe("cli", function() {
     });
 
     describe("when executing with env flag", function () {
-        var files = [
+        var code = [
+            "--no-eslintrc",
+            "--config", "./conf/eslint.json",
+            "--env", "browser",
+            "--env", "node",
             "./tests/fixtures/globals-browser.js",
             "./tests/fixtures/globals-node.js"
         ];
 
         it("should allow environment-specific globals", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser,node " + files.join(" "));
+            cli.execute(code);
             assert.equal(console.log.args[0][0].split("\n").length, 11);
         });
     });
 
     describe("when executing without env flag", function () {
-        var files = [
+        var code = [
+            "--no-eslintrc",
+            "--config", "./conf/eslint.json",
             "./tests/fixtures/globals-browser.js",
             "./tests/fixtures/globals-node.js"
         ];
 
         it("should not define environment-specific globals", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json " + files.join(" "));
+            cli.execute(code);
             assert.equal(console.log.args[0][0].split("\n").length, 14);
         });
     });

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -1,6 +1,6 @@
 /**
  * @fileoverview Tests for options.
- * @author George Zahariev
+ * @author Nicholas C. Zakas
  */
 
 //------------------------------------------------------------------------------
@@ -20,77 +20,137 @@ var assert = require("chai").assert,
 
 describe("options", function() {
     describe("when passed --help", function() {
+        var code = ["--help"];
+
         it("should return true for .help", function() {
-            var currentOptions = options.parse("--help");
+            var currentOptions = options.parse(code);
             assert.isTrue(currentOptions.help);
         });
     });
 
     describe("when passed -h", function() {
+        var code = ["-h"];
+
         it("should return true for .help", function() {
-            var currentOptions = options.parse("-h");
+            var currentOptions = options.parse(code);
             assert.isTrue(currentOptions.help);
         });
     });
 
     describe("when passed --config", function() {
+        var code = ["--config", "file"];
+
         it("should return a string for .config", function() {
-            var currentOptions = options.parse("--config file");
+            var currentOptions = options.parse(code);
             assert.isString(currentOptions.config);
             assert.equal(currentOptions.config, "file");
         });
     });
 
     describe("when passed -c", function() {
+        var code = ["-c", "file"];
+
         it("should return a string for .config", function() {
-            var currentOptions = options.parse("-c file");
+            var currentOptions = options.parse(code);
             assert.isString(currentOptions.config);
             assert.equal(currentOptions.config, "file");
         });
     });
 
     describe("when passed --rulesdir", function() {
+        var code = ["--rulesdir", "/morerules"];
+
         it("should return a string for .rulesdir", function() {
-            var currentOptions = options.parse("--rulesdir /morerules");
+            var currentOptions = options.parse(code);
             assert.isString(currentOptions.rulesdir);
             assert.equal(currentOptions.rulesdir, "/morerules");
         });
     });
 
     describe("when passed --format", function() {
+        var code = ["--format", "compact"];
+
         it("should return a string for .format", function() {
-            var currentOptions = options.parse("--format compact");
+            var currentOptions = options.parse(code);
             assert.isString(currentOptions.format);
             assert.equal(currentOptions.format, "compact");
         });
     });
 
     describe("when passed -f", function() {
+        var code = ["-f", "compact"];
+
         it("should return a string for .format", function() {
-            var currentOptions = options.parse("-f compact");
+            var currentOptions = options.parse(code);
             assert.isString(currentOptions.format);
             assert.equal(currentOptions.format, "compact");
         });
     });
 
     describe("when passed --version", function() {
+        var code = ["--version"];
+
         it("should return true for .version", function() {
-            var currentOptions = options.parse("--version");
+            var currentOptions = options.parse(code);
             assert.isTrue(currentOptions.version);
         });
     });
 
     describe("when passed -v", function() {
+        var code = ["-v"];
+
         it("should return true for .version", function() {
-            var currentOptions = options.parse("-v");
+            var currentOptions = options.parse(code);
             assert.isTrue(currentOptions.version);
         });
     });
 
     describe("when asking for help", function() {
-        it("should return string of help text", function() {
-            var helpText = options.generateHelp();
-            assert.isString(helpText);
+        it("should log the help content to the console", function() {
+            var log = console.log;
+
+            var loggedMessages = [];
+            console.log = function(message) {
+                loggedMessages.push(message);
+            };
+
+            options.help();
+            assert.equal(loggedMessages.length, 1);
+
+            console.log = log;
+        });
+    });
+
+    describe("when not passed --no-eslintrc", function() {
+        it("should default .eslintrc to true", function() {
+            var currentOptions = options.parse([]);
+            assert.isTrue(currentOptions.eslintrc);
+        });
+    });
+
+    describe("when passed --no-eslintrc", function() {
+        var code = ["--no-eslintrc"];
+
+        it("should return false for .eslintrc", function() {
+            var currentOptions = options.parse(code);
+            assert.isFalse(currentOptions.eslintrc);
+        });
+    });
+
+    describe("when passed --env", function() {
+        var envs = ["--env", "browser", "--env", "node"];
+
+        it("should return an array for a single env", function() {
+            var currentOptions = options.parse(envs.slice(0, 2));
+            assert.equal(currentOptions.env.length, 1);
+            assert.equal(currentOptions.env[0], "browser");
+        });
+
+        it("should concat consecutive occurrences", function() {
+            var currentOptions = options.parse(envs);
+            assert.equal(currentOptions.env.length, 2);
+            assert.equal(currentOptions.env[0], "browser");
+            assert.equal(currentOptions.env[1], "node");
         });
     });
 });


### PR DESCRIPTION
I'd like to submit [nopt](https://https://github.com/npm/nopt) as my preferred option for CLI parsing, based on some of the issues with [Optionator](https://github.com/gkz/optionator) outlined in #769. I believe this implementation meets the current requirements:
- **Explicit type checks**
  
  `lib/options.js` includes type information, verified by nopt.
- **Automatic help text generation**
  
  While this is not included in core nopt, [nopt-usage](https://github.com/zaach/nopt-usage) adds it.
- **Suggestions for misspelled options**
  
  Rather than suggesting a correct spelling, nopt matches a partially-spelled flag. For example, just by defining a single `--globals` flag, `--globals window`, `--global window`, and `-g window` all work. There are still explicitly-defined short flags for help, config, format, and version, maintaining parity with the current version. Personally I like the flexibility this gives, but I see how it could be a potential hangup.
- _Parses objects and strings, not just `process.argv`_
  
  This is not supported in nopt; it only accepts an array, defaulted to `process.argv`. The only change required is to the tests, passing in arrays instead of strings, which is how the tests worked before the switch to Optionator. Though this is missing, I don't see it as terribly important. It might in fact be an advantage because it doesn't get tripped up by `exports:true`.
- **Repeated flags**
  
  From my perspective, this is the single biggest issue solved by using nopt. It came up when adding `--env` and `--globals`, and it will be a problem again when adding a flag to configure rules. See L29 in `lib/options.js` below - `options.env` will now be an array containing an element for each occurrence of `--env`, so the [originally-preferred](https://github.com/eslint/eslint/issues/692#issuecomment-38208490) syntax of `--env browser --env node` now works. I should note, however, that the comma syntax introduced in #745 is removed. Since that hasn't been shipped in a new version yet, it's not a breaking change, but I could add it back easily if desired.

If there's consensus on this and it gets merged, the `--globals` flag (#751) will only require a slight change, and I anticipate adding rules configuration via the CLI to finish #692 will be much simpler. Thoughts?
