### PR TITLE
Add options for 'no-unused-vars' to check all arguments in functions (fixes #728)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -76,7 +76,7 @@
         "no-underscore-dangle": 2,
         "no-unreachable": 2,
         "no-unused-expressions": 2,
-        "no-unused-vars": [2, "local"],
+        "no-unused-vars": [2, {"vars": "local", "args": "after-used"}],
         "no-use-before-define": 2,
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 2,

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -4,7 +4,7 @@ Variables that are declared and not used anywhere in the code are most likely an
 
 ## Rule Details
 
-This rule is aimed at eliminating unused variables and functions, as such, warns when one is found.
+This rule is aimed at eliminating unused variables, functions and variables in parameters of functions, as such, warns when one is found.
 
 The following patterns are considered warnings:
 
@@ -13,6 +13,14 @@ var x = 10;
 ```
 ```js
 var x = 10; x = 5;
+```
+
+By default, unused arguments cause warnings:
+
+```js
+(function(foo) {
+    return 5;
+})();
 ```
 
 The following patterns are not considered warnings:
@@ -25,48 +33,48 @@ alert(x);
 myFunc(function foo() {
     // ...
 }.bind(this));
-```
 
-No warning will be thrown for unused variables in the parameters of function declarations or function expressions if any of the variables following the unused variable are used in that function's scope. This allows you to have unused variables in a function.
-
-```js
-"use strict";
-
-function A(x, y) {
-    this.x = y;
-    this.x = y;
-}
-
-A.prototype.getY = function () {
-    return this.y;
-};
-
-function B(x, y) {
-    A.apply(this, arguments);
-    this.y = 2 * y;
-}
-
-var b = new B(1, 2);
-
-b.getY();
+(function(foo) {
+    return foo;
+})();
 ```
 
 ### Options
 
-By default this rule is enabled with "local" option.
-```
+By default this rule is enabled with `local` option for variables and `after-used` for arguments.
+
+```json
 {
     "rules": {
-        "no-unused-vars": [2, "local"]
+        "no-unused-vars": [2, {"vars": "local", "args": "after-used"}]
     }
 }
 ```
- This will check that all local variables are used, but it will allow global variables to be unused.
-"All" option will disable this behavior and will not allow any variables to be unused.
+
+
+#### vars
+
+When sets to `local` will check that all local variables are used, but it will allow global variables to be unused.
+
+`all` option will disable this behavior and will not allow any variables to be unused.
+
+#### args
+
+Sets to `after-used` will skip some unused arguments. No warning will be thrown for unused variables in the parameters of function declarations or function expressions if any of the variables following the unused variable are used in that function's scope. This allows you to have unused variables in a function.
+
+`all` checks that all arguments to be used.
+
+`none` skips all arguments to check.
+
+The following code:
+
+- will throw `baz is defined but never used` when `args`: `after-used`
+- will throw `foo is defined but never used` and `baz is defined but never used` when `args`: `all`
+- will throw nothing when `args`: `none`
+
+```js
+(function(foo, bar, baz) {
+    return bar;
+})();
 ```
-{
-    "rules": {
-        "no-unused-vars": [2, "all"],
-    }
-}
-```
+

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -11,7 +11,20 @@
 
 module.exports = function(context) {
 
-    var allowUnusedGlobals = (context.options[0] !== "all"),
+    var config = {
+        vars: "local",
+        args: "after-used"
+    };
+    if (context.options[0]) {
+        if (typeof(context.options[0]) === "string") {
+            config.vars = context.options[0];
+        } else {
+            config.vars = context.options[0].vars || config.vars;
+            config.args = context.options[0].args || config.args;
+        }
+    }
+
+    var allowUnusedGlobals = (config.vars !== "all"),
         variables = {};
 
     function lookupVariableName(name) {
@@ -126,19 +139,41 @@ module.exports = function(context) {
         var parent = usedVariable.node.parent;
         if (isFunction(parent)) {
 
-            // Get a list of the param names used in the ancestor Function
-            var fnParamNames = parent.params.map(function(param){
-                return param.name;
-            });
+            var ignorableVariables;
+            var fnParamNames;
 
-            // Check if the used variable exists among those params
-            var variableIndex = fnParamNames.indexOf(usedVariable.name);
+            if (config.args !== "all") {
+                // Get a list of the param names used in the ancestor Function
+                fnParamNames = parent.params.map(function(param){
+                    return param.name;
+                });
+            }
 
-            // This will be true if this variable appears in the param list of an ancestor Function Expression
-            // or FunctionDeclaration.
-            if (variableIndex !== -1) {
-                // All params left of the used variables are ignorable.
-                var ignorableVariables = fnParamNames.slice(0, variableIndex);
+            switch (config.args) {
+
+                case "all":
+                    break;
+
+                case "none":
+                    ignorableVariables = fnParamNames;
+                    break;
+
+                case "after-used":
+                default:
+
+                    // Check if the used variable exists among those params
+                    var variableIndex = fnParamNames.indexOf(usedVariable.name);
+
+                    // This will be true if this variable appears in the param list of an ancestor Function Expression
+                    // or FunctionDeclaration.
+                    if (variableIndex !== -1) {
+                        // All params left of the used variables are ignorable.
+                        ignorableVariables = fnParamNames.slice(0, variableIndex);
+                    }
+                    break;
+            }
+
+            if (ignorableVariables) {
                 // Mark them as ignorable.
                 ignorableVariables.forEach(function(ignorableVariable){
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -32,7 +32,13 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "myFunc(function foo() {}.bind(this))",
         "myFunc(function foo(){}.toString())",
         "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});};",
-        "(function() { var doSomething = function doSomething() {}; doSomething() }())"
+        "(function() { var doSomething = function doSomething() {}; doSomething() }())",
+        { code: "var a=10; (function() { alert(a); })();", args: [1, {vars: "all"}] },
+        { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all"}] },
+        { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all", "args": "after-used"}] },
+        { code: "function g(bar, baz) { return bar; }; g();", args: [1, {"vars": "all", "args": "none"}] },
+        { code: "function g(bar, baz) { return 2; }; g();", args: [1, {"vars": "all", "args": "none"}] },
+        { code: "function g(bar, baz) { return bar + baz; }; g();", args: [1, {"vars": "locals", "args": "all"}] }
     ],
     invalid: [
         { code: "var a=10;", args: [1, "all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },
@@ -48,6 +54,10 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "function a(x, y, z){ return y; }; a();", args: [1, "all"], errors: [{ message: "z is defined but never used", type: "Identifier"}] },
         { code: "var min = Math.min", args: [1, "all"], errors: [{ message: "min is defined but never used" }] },
         { code: "var min = {min: 1}", args: [1, "all"], errors: [{ message: "min is defined but never used" }] },
-        { code: "Foo.bar = function(baz) { return 1; };", args: [1, "all"], errors: [{ message: "baz is defined but never used" }] }
+        { code: "Foo.bar = function(baz) { return 1; };", args: [1, "all"], errors: [{ message: "baz is defined but never used" }] },
+        { code: "var min = {min: 1}", args: [1, {"vars": "all"}], errors: [{ message: "min is defined but never used" }] },
+        { code: "function gg(baz, bar) { return baz; }; gg();", args: [1, {"vars": "all"}], errors: [{ message: "bar is defined but never used" }] },
+        { code: "(function(foo, baz, bar) { return baz; })();", args: [1, {"vars": "all", "args": "after-used"}], errors: [{ message: "bar is defined but never used" }]},
+        { code: "(function(foo, baz, bar) { return baz; })();", args: [1, {"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]}
     ]
 });


### PR DESCRIPTION
Now it can be set 

``` js
"no-unused-vars": [2, {"vars": "local", "args": "used-first"}]
```

Left `"no-unused-vars": [2, "local"]` for compatibility
