### PR TITLE
'no-unused-var' in functional expression with identifier (fixed #775)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -750,7 +750,7 @@ module.exports = (function() {
      */
     api.getScope = function() {
         var parents = controller.parents().reverse(),
-            innerScope = null;
+            innerBlock = null;
 
         // Don't do this for Program nodes - they have no parents
         if (parents.length) {
@@ -767,7 +767,7 @@ module.exports = (function() {
                 // The first node that requires a scope is the node that will be
                 // our current node's innermost scope.
                 if (escope.Scope.isScopeRequired(parents[i])) {
-                    innerScope = parents[i];
+                    innerBlock = parents[i];
                     break;
                 }
             }
@@ -775,9 +775,17 @@ module.exports = (function() {
             // Loop through the scopes returned by escope to find the innermost
             // scope and return that scope.
             for (var j = 0; j < currentScopes.length; j++) {
-                if (innerScope.type === currentScopes[j].block.type &&
-                    innerScope.range[0] === currentScopes[j].block.range[0] &&
-                    innerScope.range[1] === currentScopes[j].block.range[1]) {
+                if (innerBlock.type === currentScopes[j].block.type &&
+                    innerBlock.range[0] === currentScopes[j].block.range[0] &&
+                    innerBlock.range[1] === currentScopes[j].block.range[1]) {
+
+                    // Escope returns two similar scopes for named functional
+                    // expression, we should take the last
+                    if ((innerBlock.type === "FunctionExpression" && innerBlock.id && innerBlock.id.name)) {
+
+                        var nextScope = currentScopes[j + 1];
+                        return nextScope;
+                    }
 
                     return currentScopes[j];
                 }

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -14,7 +14,6 @@ module.exports = function(context) {
     function checkForShadows(node) {
         var scope = context.getScope(),
             isFunctionExpression = (node.type === "FunctionExpression"),
-            funcName = node.id && node.id.name,
             args = node.params,
             variables = scope.variables.filter(function(item) {
                 return !args.some(function(variable) {
@@ -31,7 +30,7 @@ module.exports = function(context) {
                 if (upper.variables.some(function(scopeVar) {
                     //filter out global variables that we add as part of ESLint
                     if (scopeVar.identifiers.length > 0) {
-                        return scopeVar.name === variable.name && (!isFunctionExpression || variable.name !== funcName);
+                        return scopeVar.name === variable.name && !isFunctionExpression;
                     }
                     return false;
                 })) {

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -50,11 +50,7 @@ module.exports = function(context) {
 
     function populateVariables(node) {
         var scope = context.getScope(),
-            functionName = node && node.id && node.id.name,
-            parent = context.getAncestors().pop(),
-
-            // check for function foo(){}.bind(this)
-            functionNameUsed = (node && node.type === "FunctionExpression") || (parent && parent.type === "MemberExpression");
+            functionName = node && node.id && node.id.name;
 
         scope.variables.forEach(function(variable) {
 
@@ -71,7 +67,7 @@ module.exports = function(context) {
                     variables[variable.name].push({
                         name: variable.name,
                         node: variable.identifiers[0],
-                        used: (variable.name === functionName) && functionNameUsed
+                        used: (variable.name === functionName)
                     });
                 }
             }
@@ -177,7 +173,7 @@ module.exports = function(context) {
                 // Mark them as ignorable.
                 ignorableVariables.forEach(function(ignorableVariable){
 
-                    (lookupVariableName(ignorableVariable) || []).forEach(function(variable){
+                    lookupVariableName(ignorableVariable).forEach(function(variable){
                         variable.ignorable = true;
                     });
                 });

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -38,7 +38,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all", "args": "after-used"}] },
         { code: "function g(bar, baz) { return bar; }; g();", args: [1, {"vars": "all", "args": "none"}] },
         { code: "function g(bar, baz) { return 2; }; g();", args: [1, {"vars": "all", "args": "none"}] },
-        { code: "function g(bar, baz) { return bar + baz; }; g();", args: [1, {"vars": "locals", "args": "all"}] }
+        { code: "function g(bar, baz) { return bar + baz; }; g();", args: [1, {"vars": "locals", "args": "all"}] },
+        "(function z() { z(); })();"
     ],
     invalid: [
         { code: "var a=10;", args: [1, "all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },
@@ -58,6 +59,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "var min = {min: 1}", args: [1, {"vars": "all"}], errors: [{ message: "min is defined but never used" }] },
         { code: "function gg(baz, bar) { return baz; }; gg();", args: [1, {"vars": "all"}], errors: [{ message: "bar is defined but never used" }] },
         { code: "(function(foo, baz, bar) { return baz; })();", args: [1, {"vars": "all", "args": "after-used"}], errors: [{ message: "bar is defined but never used" }]},
-        { code: "(function(foo, baz, bar) { return baz; })();", args: [1, {"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]}
+        { code: "(function(foo, baz, bar) { return baz; })();", args: [1, {"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]},
+        { code: "(function z(foo) { var bar = 33; })();", args: [1, {"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]},
+        { code: "(function z(foo) { z(); })();", args: [1, {}], errors: [{ message: "foo is defined but never used" }]}
     ]
 });


### PR DESCRIPTION
It seems escope returns two almost similar scopes when parsing functional expression with identifier.

Also, I am confused that coverage is below limit after my changes. My code didn't aim to bring any significant lack of coverage. Can you give an advice how can I return it back to normal?
