### PR TITLE
Rule: no-sequences (fixes #561)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -64,6 +64,7 @@
         "no-return-assign": 2,
         "no-script-url": 2,
         "no-self-compare": 0,
+        "no-sequences": 2,
         "no-shadow": 2,
         "no-shadow-restricted-names": 2,
         "no-spaced-func": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -68,6 +68,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-return-assign](no-return-assign.md) - disallow use of assignment in `return` statement
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
 * [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same
+* [no-sequences](no-sequences.md) - disallow use of comma operator
 * [no-unused-expressions](no-unused-expressions.md) - disallow usage of expressions in statement position
 * [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME`
 * [no-with](no-with.md) - disallow use of the `with` statement

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -1,0 +1,62 @@
+# Disallow Use of Comma Operator (no-sequences)
+
+The comma operator includes multiple expressions where only one is expected. It evaluates each operand from left to right and returns the value of the last operand. However, this frequently obscures side effects, and its use is often an accident. Here are some examples of its use:
+
+```js
+var a = (3, 5); // a = 5
+
+a = b += 5, a + b;
+
+while (a = next(), a && a.length);
+
+(0,eval)("doSomething();");
+```
+
+## Rule Details
+
+This rule forbids the use of the comma operator, with the following exceptions:
+
+- In the initialization or update portions of a `for` statement.
+- If the expression sequence is explicitly wrapped in parentheses.
+
+The following patterns are considered warnings:
+
+```js
+foo = doSomething, val;
+
+do {} while (doSomething(), !!test);
+
+for (; doSomething(), !!test; );
+
+if (doSomething(), !!test);
+
+switch (val = foo(), val) {}
+
+while (val = foo(), val < 42);
+
+with (doSomething(), val) {}
+```
+
+The following patterns are not considered warnings:
+
+```js
+foo = (doSomething(), val);
+
+(0,eval)("doSomething();");
+
+do {} while ((doSomething(), !!test));
+
+for (i = 0, j = 10; i < j; i++, j--);
+
+if ((doSomething(), !!test));
+
+switch ((val = foo(), val)) {}
+
+while ((val = foo(), val < 42));
+
+with ((doSomething(), val)) {}
+```
+
+## When Not To Use It
+
+Disable this rule if sequence expressions with the comma operator are acceptable.

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview Rule to flag use of comma operator
+ * @author Brandon Mills
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    /**
+     * Parts of the grammar that are required to have parens.
+     */
+    var parenthesized = {
+        "DoWhileStatement": "test",
+        "IfStatement": "test",
+        "SwitchStatement": "discriminant",
+        "WhileStatement": "test",
+        "WithStatement": "object"
+
+        // Omitting CallExpression - commas are parsed as argument separators
+        // Omitting NewExpression - commas are parsed as argument separators
+        // Omitting ForInStatement - parts aren't individually parenthesised
+        // Omitting ForStatement - parts aren't individually parenthesised
+    };
+
+    /**
+     * Determines whether a node is required by the grammar to be wrapped in
+     * parens, e.g. the test of an if statement.
+     * @param {ASTNode} node - The AST node
+     * @returns {boolean} True if parens around node belong to parent node.
+     */
+    function requiresExtraParens(node) {
+        return node.parent && parenthesized[node.parent.type] !== undefined &&
+                node === node.parent[parenthesized[node.parent.type]];
+    }
+
+    /**
+     * Check if a node is wrapped in parens.
+     * @param {ASTNode} node - The AST node
+     * @returns {boolean} True if the node has a paren on each side.
+     */
+    function isParenthesised(node) {
+        var previousToken = context.getTokenBefore(node),
+            nextToken = context.getTokenAfter(node);
+
+        return previousToken && nextToken &&
+            previousToken.value === "(" && previousToken.range[1] <= node.range[0] &&
+            nextToken.value === ")" && nextToken.range[0] >= node.range[1];
+    }
+
+    /**
+     * Check if a node is wrapped in two levels of parens.
+     * @param {ASTNode} node - The AST node
+     * @returns {boolean} True if two parens surround the node on each side.
+     */
+    function isParenthesisedTwice(node) {
+        var previousToken = context.getTokenBefore(node, 1),
+            nextToken = context.getTokenAfter(node, 1);
+
+        return isParenthesised(node) && previousToken && nextToken &&
+            previousToken.value === "(" && previousToken.range[1] <= node.range[0] &&
+            nextToken.value === ")" && nextToken.range[0] >= node.range[1];
+    }
+
+    return {
+        "SequenceExpression": function(node) {
+            // Always allow sequences in for statement update
+            if (node.parent.type === "ForStatement" &&
+                    (node === node.parent.init || node === node.parent.update)) {
+                return;
+            }
+
+            // Wrapping a sequence in extra parens indicates intent
+            if (requiresExtraParens(node)) {
+                if (isParenthesisedTwice(node)) {
+                    return;
+                }
+            } else {
+                if (isParenthesised(node)) {
+                    return;
+                }
+            }
+
+            context.report(node, "Unexpected use of comma operator.");
+        }
+    };
+
+};

--- a/tests/lib/rules/no-sequences.js
+++ b/tests/lib/rules/no-sequences.js
@@ -1,0 +1,51 @@
+/**
+ * @fileoverview Tests for no-sequences rule.
+ * @author Brandon Mills
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var errors = [{
+    message: "Unexpected use of comma operator.",
+    type: "SequenceExpression"
+}];
+
+eslintTester.addRuleTest("lib/rules/no-sequences", {
+
+    // Examples of code that should not trigger the rule
+    valid: [
+        "var arr = [1, 2];",
+        "var obj = {a: 1, b: 2};",
+        "var a = 1, b = 2;",
+        "var foo = (1, 2);",
+        "(0,eval)(\"foo()\");",
+        "for (i = 1, j = 2;; i++, j++);",
+        "foo(a, (b, c), d);",
+        "do {} while ((doSomething(), !!test));",
+        "for ((doSomething(), somethingElse()); (doSomething(), !!test); );",
+        "if ((doSomething(), !!test));",
+        "switch ((doSomething(), !!test)) {}",
+        "while ((doSomething(), !!test));",
+        "with ((doSomething(), val)) {}"
+    ],
+
+    // Examples of code that should trigger the rule
+    invalid: [
+        { code: "a = 1, 2", errors: errors },
+        { code: "do {} while (doSomething(), !!test);", errors: errors },
+        { code: "for (; doSomething(), !!test; );", errors: errors },
+        { code: "if (doSomething(), !!test);", errors: errors },
+        { code: "switch (doSomething(), val) {}", errors: errors },
+        { code: "while (doSomething(), !!test);", errors: errors },
+        { code: "with (doSomething(), val) {}", errors: errors }
+    ]
+});


### PR DESCRIPTION
Adds a new rule, `no-sequences`, that disallows use of the comma operator, except in the initialization or update portions of for loops or when wrapped in parens.
