### PR TITLE
Added Mocha global variables for TDD style.

### DIFF
--- a/conf/environments.json
+++ b/conf/environments.json
@@ -381,7 +381,14 @@
             "before": false,
             "after": false,
             "beforeEach": false,
-            "afterEach": false
+            "afterEach": false,
+
+            "suite": false,
+            "test": false,
+            "setup": false,
+            "teardown": false,
+            "suiteSetup": false,
+            "suiteTeardown": false
         }
     }
 }


### PR DESCRIPTION
When using the `mocha` environment, ESLint currently assumes the `bdd` style, i.e., tests must be written using `describe` and `it`.

I wanted to be able to use the `tdd` style as well, as my tests use `suite` and `test`.

This pull requests adds the required global variables to the `mocha` environment.
