### PR TITLE
Add ignore comments in file (fixes #305)

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -143,6 +143,26 @@ There's no need to specify every single rule - you will automatically get the de
 
 **Note:** All rules that are enabled by default are set to 2, so they will cause a non-zero exit code when encountered. You can lower these rule to a warning by setting them to 1, which has the effect of outputting the message onto the console but doesn't affect the exit code.
 
+To temporary disable warnings in your file use the following format
+```js
+/*eslint-disable */
+
+//supress all warnings between comments
+alert('foo');
+
+/*eslint-enable */
+```
+
+You can also disable and enable back warnings of specific rules
+```js
+/*eslint-disable no-alert, no-console */
+
+alert('foo');
+console.log('bar');
+
+/*eslint-enable no-alert */
+```
+
 ## Using Configuration Files
 
 There are two ways to use configuration files. The first is to save the file wherever you would like an pass its location to the CLI using the `-c` option, such as:

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -151,13 +151,77 @@ function addDeclaredGlobals(program, globalScope, config) {
 }
 
 /**
+ * Add data to reporting configuration to disable reporting for list of rules
+ * starting from start location
+ * @param  {Object[]} reportingConfig Current reporting configuration
+ * @param  {Object} start Position to start
+ * @param  {string[]} rules List of rules
+ * @returns {void}
+ */
+function disableReporting(reportingConfig, start, rules) {
+
+    if (rules.length) {
+        rules.forEach(function(rule){
+            reportingConfig.push({
+                start: start,
+                end: null,
+                rule: rule
+            });
+        });
+    } else {
+        reportingConfig.push({
+            start: start,
+            end: null,
+            rule: null
+        });
+    }
+}
+
+/**
+ * Add data to reporting configuration to enable reporting for list of rules
+ * starting from start location
+ * @param  {Object[]} reportingConfig Current reporting configuration
+ * @param  {Object} start Position to start
+ * @param  {string[]} rules List of rules
+ * @returns {void}
+ */
+function enableReporting(reportingConfig, start, rules) {
+    if (rules.length) {
+        rules.forEach(function(rule){
+            for (var i = reportingConfig.length - 1; i >= 0; i--) {
+                if (!reportingConfig[i].end && reportingConfig[i].rule === rule ) {
+                    reportingConfig[i].end = start;
+                    break;
+                }
+            }
+        });
+    } else {
+        // find all previous disabled locations if they was started as list of rules
+        var prevStart;
+        for (var i = reportingConfig.length - 1; i >= 0; i--) {
+            if (prevStart && prevStart !== reportingConfig[i].start) {
+                break;
+            }
+
+            if (!reportingConfig[i].end) {
+                reportingConfig[i].end = start;
+                prevStart = reportingConfig[i].start;
+            }
+        }
+    }
+}
+
+
+/**
  * Parses comments in file to extract file-specific config of rules, globals
- * and environments and merges them with global config.
+ * and environments and merges them with global config; also code blocks
+ * where reporting is disabled or enabled and merges them with reporting config.
  * @param {ASTNode} ast The top node of the AST.
  * @param {Object} config The existing configuration data.
- * @returns {Object} Merged config
+ * @param {Object[]} reportingConfig The existing reporting configuration data.
+ * @returns {void}
  */
-function modifyConfigFromComments(ast, config) {
+function modifyConfigsFromComments(ast, config, reportingConfig) {
 
     var commentConfig = {
         globals: {},
@@ -170,7 +234,7 @@ function modifyConfigFromComments(ast, config) {
         if (comment.type === "Block") {
 
             var value = comment.value.trim();
-            var match = /^(eslint-env|eslint|globals?)\s/.exec(value);
+            var match = /^(eslint-\w+|eslint|globals?)(\s|$)/.exec(value);
 
             if (match) {
                 value = value.substring(match.index + match[1].length);
@@ -183,6 +247,14 @@ function modifyConfigFromComments(ast, config) {
 
                     case "eslint-env":
                         util.mixin(commentConfig.env, parseListConfig(value));
+                        break;
+
+                    case "eslint-disable":
+                        disableReporting(reportingConfig, comment.loc.start, Object.keys(parseListConfig(value)));
+                        break;
+
+                    case "eslint-enable":
+                        enableReporting(reportingConfig, comment.loc.start, Object.keys(parseListConfig(value)));
                         break;
 
                     case "eslint":
@@ -210,7 +282,29 @@ function modifyConfigFromComments(ast, config) {
     });
     util.mixin(commentConfig.rules, commentRules);
 
-    return util.mergeConfigs(config, commentConfig);
+    util.mergeConfigs(config, commentConfig);
+}
+
+/**
+ * Check if message of rule with ruleId should be ignored in location
+ * @param  {Object[]} reportingConfig  Collection of ignore records
+ * @param  {string} ruleId   Id of rule
+ * @param  {Object} location Location of message
+ * @returns {boolean}          True if message should be ignored, false otherwise
+ */
+function isDisabledByReportingConfig(reportingConfig, ruleId, location) {
+
+    for (var i = 0, c = reportingConfig.length; i < c; i++) {
+
+        var ignore = reportingConfig[i];
+        if ((!ignore.rule || ignore.rule === ruleId) &&
+            (location.line > ignore.start.line || (location.line === ignore.start.line && location.column >= ignore.start.column)) &&
+            (!ignore.end || (location.line < ignore.end.line || (location.line === ignore.end.line && location.column <= ignore.end.column)))) {
+                return true;
+        }
+    }
+
+    return false;
 }
 
 //------------------------------------------------------------------------------
@@ -231,8 +325,8 @@ module.exports = (function() {
         currentTokens = null,
         currentScopes = null,
         currentFilename = null,
-        controller = null;
-
+        controller = null,
+        reportingConfig = [];
 
     /**
      * Parses text into an AST. Moved out here because the try-catch prevents
@@ -283,6 +377,7 @@ module.exports = (function() {
         currentTokens = null;
         currentScopes = null;
         controller = null;
+        reportingConfig = [];
     };
 
     /**
@@ -315,7 +410,7 @@ module.exports = (function() {
             delete config.global;
 
             // parse global comments and modify config
-            config = modifyConfigFromComments(ast, config);
+            modifyConfigsFromComments(ast, config, reportingConfig);
 
             // enable appropriate rules
             Object.keys(config.rules).filter(function(key) {
@@ -455,6 +550,10 @@ module.exports = (function() {
             var rx = new RegExp("{{" + escapeRegExp(key) + "}}", "g");
             message = message.replace(rx, opts[key]);
         });
+
+        if (isDisabledByReportingConfig(reportingConfig, ruleId, location)) {
+            return;
+        }
 
         messages.push({
             ruleId: ruleId,


### PR DESCRIPTION
I guess it would be useful to have possibility to suppress error messages for specific lines in file. Not it can be made as 

``` js
alert('test'); // message here
/*eslint-ignore*/
alert('test'); // nothing here
/*eslint-end-ignore */
```

or for specific rules

``` js
alert('test'); // message here
/*eslint-ignore no-alert, strict */
alert('test'); // nothing here
console.log('test') //message here
/*eslint-end-ignore */
```

I don't want to make special `/*eslint-end-ignore rule*/`, I guess it would be too complicated for user to track ignore then.

I'll be glad to have feedback, maybe comments should have better names or something. 
