### PR TITLE
Adds `space-after-keywords` rule, along with associated tests and docs

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -110,6 +110,7 @@
         "radix": 0,
         "semi": 2,
         "sort-vars": 0,
+        "space-after-keywords": [0, "always"],
         "space-in-brackets": [0, "never"],
         "space-infix-ops": 2,
         "space-return-throw-case": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -131,6 +131,7 @@ These rules are purely matters of style and are quite subjective.
 * [quote-props](quote-props.md) - require quotes around object literal property names
 * [semi](semi.md)- require or disallow use of semicolons instead of ASI
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block
+* [space-after-keywords](space-after-keywords.md) - require a space after certain keywords
 * [space-in-brackets](space-in-brackets.md) - require or disallow spaces between brackets
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators
 * [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -1,0 +1,58 @@
+# Require or disallow spaces following keywords (space-after-keyword)
+
+Some style guides will require or disallow spaces following the certain keywords.
+
+```js
+if (condition) {
+    doSomething();
+} else {
+    doSomethingElse();
+}
+
+if(condition) {
+    doSomething();
+}else{
+    doSomethingElse();
+}
+```
+
+## Rule Details
+
+This rule will enforce consistency of spacing after the keywords `if`, `else`, `for`, `while`, `do`, `switch`, `try`, `catch`, and `with`.
+
+This rule takes one argument. If it is `"always"` then the keywords must be followed by at least one space. If `"never"`
+then there should be no spaces following. The default is `"always"`.
+
+The following patterns are considered warnings:
+
+```js
+if(a) {}
+```
+
+```js
+if (a) {} else{}
+```
+
+```js
+do{} while (a);
+```
+
+```js
+// When ["never"]
+if (a) {}
+```
+
+The following patterns are not considered warnings:
+
+```js
+if (a) {}
+```
+
+```js
+if (a) {} else {}
+```
+
+```js
+// When ["never"]
+if(a) {}
+```

--- a/lib/rules/space-after-keywords.js
+++ b/lib/rules/space-after-keywords.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Rule to enforce the number of spaces after certain keywords
+ * @author Nick Fisher
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    // unless the first option is `"never"`, then a space is required
+    var requiresSpace = context.options[0] !== "never";
+
+    /**
+     * Check if the separation of two adjacent tokens meets the spacing rules, and report a problem if not.
+     *
+     * @param {ASTNode} node  The node to which the potential problem belongs.
+     * @param {Token} left    The first token.
+     * @param {Token} right   The second token
+     * @returns {void}
+     */
+    function checkTokens(node, left, right) {
+        var hasSpace = left.range[1] < right.range[0],
+            value = left.value;
+
+        if (hasSpace !== requiresSpace) {
+            context.report(node, "Keyword \"{{value}}\" must {{not}}be followed by whitespace.", {
+                value: value,
+                not: requiresSpace ? "" : "not "
+            });
+        }
+    }
+
+    /**
+     * Check if the given node (`if`, `for`, `while`, etc), has the correct spacing after it.
+     * @param {ASTNode} node The node to check.
+     * @returns {void}
+     */
+    function check(node) {
+        var tokens = context.getFirstTokens(node, 2);
+        checkTokens(node, tokens[0], tokens[1]);
+
+        // check the `else` of an `if`.
+        if (tokens[0].value === "if" && node.alternate) {
+            checkTokens(node.alternate, context.getTokenBefore(node.alternate), context.getFirstToken(node.alternate));
+        }
+    }
+
+    return {
+        "IfStatement": check,
+        "ForStatement": check,
+        "ForOfStatement": check,
+        "ForInStatement": check,
+        "WhileStatement": check,
+        "DoWhileStatement": check,
+        "SwitchStatement": check,
+        "TryStatement": check,
+        "CatchStatement": check,
+        "WithStatement": check
+    };
+};
+

--- a/tests/lib/rules/space-after-keywords.js
+++ b/tests/lib/rules/space-after-keywords.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Rule to enforce the number of spaces after certain keywords
+ * @author Nick Fisher
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+eslintTester.addRuleTest("lib/rules/space-after-keywords", {
+    valid: [
+        { code: "switch (a){ default: break; }", args: [1] },
+        { code: "if (a) {}", args: [1] },
+        { code: "if (a) {} else {}", args: [1] },
+        { code: "for (;;){}", args: [1] },
+        { code: "while (true) {}", args: [1]},
+        { code: "do {} while (true);", args: [1]},
+        { code: "try {} catch (e) {}", args: [1]},
+        { code: "with (a) {}", args: [1]},
+        { code: "if(a) {}", args: [1, "never"]},
+        { code: "if(a){}else{}", args: [1, "never"]}
+    ],
+    invalid: [
+        { code: "if (a) {} else if(b){}", args: [1], errors: [{ message: "Keyword \"if\" must be followed by whitespace.", type: "IfStatement" }] },
+        { code: "if (a) {} else{}", args: [1], errors: [{ message: "Keyword \"else\" must be followed by whitespace." }] },
+        { code: "switch(a){ default: break; }", errors: [{ message: "Keyword \"switch\" must be followed by whitespace.", type: "SwitchStatement" }] },
+        { code: "if(a){}", errors: [{ message: "Keyword \"if\" must be followed by whitespace.", type: "IfStatement" }] },
+        { code: "do{} while (true);", args: [1], errors: [{ message: "Keyword \"do\" must be followed by whitespace.", type: "DoWhileStatement" }]},
+        { code: "if (a) {}", args: [1, "never"], errors: [{ message: "Keyword \"if\" must not be followed by whitespace.", type: "IfStatement" }]},
+        { code: "if(a){}else {}", args: [1, "never"], errors: [{ message: "Keyword \"else\" must not be followed by whitespace." }]}
+    ]
+});


### PR DESCRIPTION
Creates a new rule which is essentially an extension of space-case-return-throw but with more configuration.

Discussion issue: #807
