### PR TITLE
Fixes general config not to be modified by comment config (fixes #806)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -213,6 +213,23 @@ function modifyConfigFromComments(ast, config) {
     return util.mergeConfigs(config, commentConfig);
 }
 
+/**
+ * Process initial config to make it safe to extend by file comment config
+ * @param  {Object} config Initial config
+ * @returns {Object}        Processed config
+ */
+function prepareConfig(config) {
+
+    config.globals = config.globals || config.global || {};
+    delete config.global;
+
+    return {
+        rules: util.mergeConfigs({}, config.rules || {}),
+        globals: util.mergeConfigs({}, config.globals),
+        env: util.mergeConfigs({}, config.env || {})
+    };
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -310,9 +327,8 @@ module.exports = (function() {
 
         //if Esprima failed to parse the file, there's no sense in setting up rules
         if (ast) {
-
-            config.globals = config.globals || config.global || {};
-            delete config.global;
+            // process initial config to make it safe to extend
+            config = prepareConfig(config);
 
             // parse global comments and modify config
             config = modifyConfigFromComments(ast, config);

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1253,6 +1253,14 @@ describe("eslint", function() {
 
             assert.equal(messages.length, 0);
         });
+
+        it("should process empty config", function() {
+            var config = {};
+
+            eslint.reset();
+            var messages = eslint.verify(code, config, filename, true);
+            assert.equal(messages.length, 0);
+        });
     });
 
     describe("after calling reset()", function() {
@@ -1543,9 +1551,9 @@ describe("eslint", function() {
     });
 
     describe("when evaluating code with comments to enable rules", function() {
-        var code = "/*eslint no-alert:1*/ alert('test');";
 
         it("should report a violation", function() {
+            var code = "/*eslint no-alert:1*/ alert('test');";
             var config = { rules: {} };
 
             var messages = eslint.verify(code, config, filename);
@@ -1553,6 +1561,19 @@ describe("eslint", function() {
             assert.equal(messages[0].ruleId, "no-alert");
             assert.equal(messages[0].message, "Unexpected alert.");
             assert.include(messages[0].node.type, "CallExpression");
+        });
+
+        it("rules should not change inital config", function() {
+            var config = { rules: {"strict": 2} };
+            var codeA = "/*eslint strict: 0*/ function bar() { return 2; }";
+            var codeB = "function foo() { return 1; }";
+
+            eslint.reset();
+            var messages = eslint.verify(codeA, config, filename, false);
+            assert.equal(messages.length, 0);
+
+            messages = eslint.verify(codeB, config, filename, false);
+            assert.equal(messages.length, 1);
         });
     });
 


### PR DESCRIPTION
Prevent issues when comment config from one file affects general config.
