### PR TITLE
Rule: no-lonely-if (fixes #790)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -42,6 +42,7 @@
         "no-label-var": 2,
         "no-labels": 2,
         "no-lone-blocks": 2,
+        "no-lonely-if": 0,
         "no-loop-func": 2,
         "no-mixed-requires": [0, false],
         "no-multi-str": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -121,6 +121,7 @@ These rules are purely matters of style and are quite subjective.
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a contructor with no arguments
 * [no-nested-ternary](no-nested-ternary.md) - disallow nested ternary expressions
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
+* [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block
 * [no-new-object](no-new-object.md) - disallow use of the `Object` constructor
 * [no-spaced-func](no-spaced-func.md) - disallow space between function identifier and application
 * [no-space-before-semi](no-space-before-semi.md) - disallow space before semicolon

--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -1,0 +1,62 @@
+# Disallow if as the Only Statmenent in an else Block (no-lonely-if)
+
+If an `if` statement is the only statement in the `else` block of a parent `if` statement, it is often clearer to combine the two to using `else if` form.
+
+```js
+if (...) {
+    ...
+} else {
+    if (...) {
+        ...
+    }
+}
+```
+
+should be rewritten as
+
+```js
+if (...) {
+    ...
+} else if (...) {
+    ...
+}
+```
+
+## Rule Details
+
+This rule warns when an `if` statement's `else` block contains only another `if` statement.
+
+The following patterns are considered warnings:
+
+```js
+if (condition) {
+    // ...
+} else {
+    if (anotherCondition) {
+        // ...
+    }
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+if (condition) {
+    // ...
+} else if (anotherCondition) {
+    // ...
+}
+
+if (condition) {
+    // ...
+} else {
+    if (anotherCondition) {
+        // ...
+    }
+    doSomething();
+}
+```
+
+## When Not To Use It
+
+Disable this rule if the code is clearer without requiring the `else if` form.

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -1,0 +1,28 @@
+/**
+ * @fileoverview Rule to disallow if as the only statmenet in an else block
+ * @author Brandon Mills
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "IfStatement": function(node) {
+            var ancestors = context.getAncestors(),
+                parent = ancestors.pop(),
+                grandparent = ancestors.pop();
+
+            if (parent && parent.type === "BlockStatement" &&
+                    parent.body.length === 1 && grandparent &&
+                    grandparent.type === "IfStatement" &&
+                    parent === grandparent.alternate) {
+                context.report(node, "Unexpected if as the only statement in an else block.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-lonely-if.js
+++ b/tests/lib/rules/no-lonely-if.js
@@ -1,0 +1,33 @@
+/**
+ * @fileoverview Tests for no-lonely-if rule.
+ * @author Brandon Mills
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/no-lonely-if", {
+
+    // Examples of code that should not trigger the rule
+    valid: [
+        "if (a) {;} else if (b) {;}",
+        "if (a) {;} else { if (b) {;} ; }"
+    ],
+
+    // Examples of code that should trigger the rule
+    invalid: [{
+        code: "if (a) {;} else { if (b) {;} }",
+        errors: [{
+            message: "Unexpected if as the only statement in an else block.",
+            type: "IfStatement"
+        }]
+    }]
+});


### PR DESCRIPTION
Adds a new rule, `no-lonely-if`, which warns whenever an `if` statement is the only statement inside the `else` block of another `if` statement. The rule is off by default.
