### PR TITLE
Remove warning about ESLint being in Alpha

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,6 @@ ESLint is a tool for identifying and reporting on patterns found in ECMAScript/J
 * ESLint uses an AST to evaluate patterns in code.
 * ESLint is completely pluggable, every single rule is a plugin and you can add more at runtime.
 
-## Alpha Version
-
-ESLint, as of v0.1.0, is in alpha, meaning that there is some stability but you shouldn't be depending on it as your only means of code verification at this time. The alpha version is intended to gather feedback from the community, catch bugs, and determine general direction for the project.
-
-When ESLint v0.5.0 is released, it will be in beta and will have more stability in terms of interface and API.
-
 ## Installation
 
 You can install ESLint using npm:


### PR DESCRIPTION
Currently, the README warns users that ESLint is alpha and shouldn't be relied upon until 0.5.0 is released. Now that 0.5.1 is out, there's no need for the big 'keep out' sign, so this PR removes that section from the README.
