### PR TITLE
Ignored files are excluded unless --force is passed on the CLI (fixes #813)

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -30,6 +30,7 @@ Options:
   --reset                    Set all default rules to off.
   --eslintrc                 Enable loading .eslintrc configuration. - default: true
   --env [String]             Specify environments.
+  --force                    Allow linting of otherwise ignored files.
   --global [String]          Define global variables.
 ```
 
@@ -95,6 +96,14 @@ Example
 
     eslint --env browser,node file.js
     eslint --env browser --env node file.js
+
+### `--force`
+
+This option allows you to override the ignore rules defined in `.eslintignore` files and always lint each file passed to eslint. Without this option enabled, ignored files will not be linted even if specifically listed in the list of files.
+
+Example
+
+    eslint --force an-ignored-file.js
 
 ### `--global`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -96,24 +96,22 @@ function printResults(config) {
     var formatter,
         formatterPath,
         output;
-
     if (existsSync(path.resolve(process.cwd(), config.format))) {
         formatterPath = path.resolve(process.cwd(), config.format);
     } else {
         formatterPath = "./formatters/" + config.format;
     }
-
     try {
         formatter = require(formatterPath);
-        output = formatter(results, config);
-        if (output) {
-            console.log(output);
-        }
-        return true;
     } catch (ex) {
         console.error("Could not find formatter '%s'.", config.format);
         return false;
     }
+    output = formatter(results, config);
+    if (output) {
+        console.log(output);
+    }
+    return true;
 
 }
 
@@ -178,10 +176,19 @@ function processFiles(files, configHelper) {
         errors = 0;
 
     files.forEach(function(file) {
-
         if (isDirectory(file)) {
             fullFileList = fullFileList.concat(getFiles(file, configHelper));
         } else {
+            if (!configHelper.options.force) {
+                configHelper.cacheExclusions(path.dirname(file));
+                if (configHelper.checkForExclusion(path.resolve(file))) {
+                    storeResults(file, [{
+                        fatal: false,
+                        message: "File ignored because of your .eslintignore file. Use --force to override."
+                    }]);
+                    return;
+                }
+            }
             fullFileList.push(file);
         }
     });
@@ -219,10 +226,10 @@ var cli = {
             result;
 
         try {
-          currentOptions = options.parse(args);
+            currentOptions = options.parse(args);
         } catch (error) {
-          console.error(error.message);
-          return 1;
+            console.error(error.message);
+            return 1;
         }
 
         files = currentOptions._;

--- a/lib/formatters/checkstyle.js
+++ b/lib/formatters/checkstyle.js
@@ -9,15 +9,12 @@
 //------------------------------------------------------------------------------
 
 function getMessageType(message, rules) {
-
-    // TODO: Get rule severity in a better way
-    var severity = null;
-
     if (message.fatal) {
         return "error";
     }
 
-    severity = rules[message.ruleId][0] || rules[message.ruleId];
+    var rule = rules[message.ruleId],
+        severity = rule && (rule[0] || rule);
 
     if (severity === 2) {
         return "error";

--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -9,15 +9,12 @@
 //------------------------------------------------------------------------------
 
 function getMessageType(message, rules) {
-
-    // TODO: Get rule severity in a better way
-    var severity = null;
-
     if (message.fatal) {
         return "Error";
     }
 
-    severity = rules[message.ruleId][0] || rules[message.ruleId];
+    var rule = rules[message.ruleId],
+        severity = rule && (rule[0] || rule);
 
     if (severity === 2) {
         return "Error";

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -11,15 +11,12 @@
 //------------------------------------------------------------------------------
 
 function getMessageType(message, rules) {
-
-    // TODO: Get rule severity in a better way
-    var severity = null;
-
     if (message.fatal) {
         return "Error";
     }
 
-    severity = rules[message.ruleId][0] || rules[message.ruleId];
+    var rule = rules[message.ruleId],
+        severity = rule && (rule[0] || rule);
 
     if (severity === 2) {
         return "Error";

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -16,7 +16,8 @@ function getMessageType(message, rules) {
         return chalk.red("error");
     }
 
-    var severity = rules[message.ruleId][0] || rules[message.ruleId];
+    var rule = rules[message.ruleId],
+        severity = rule && (rule[0] || rule);
 
     if (severity === 2) {
         return chalk.red("error");

--- a/lib/formatters/tap.js
+++ b/lib/formatters/tap.js
@@ -20,15 +20,12 @@ var yaml = require("js-yaml");
  * @returns {String} Error level string
  */
 function getMessageType(message, rules) {
-
-    // TODO: Get rule severity in a better way
-    var severity = null;
-
     if (message.fatal) {
         return "error";
     }
 
-    severity = rules[message.ruleId][0] || rules[message.ruleId];
+    var rule = rules[message.ruleId],
+        severity = rule && (rule[0] || rule);
 
     if (severity === 2) {
         return "error";
@@ -94,7 +91,7 @@ module.exports = function(results, config) {
 
         output += testResult + " " + (id + 1) + " - " + result.filePath + "\n";
 
-        // If we have an error include diagnostics 
+        // If we have an error include diagnostics
         if (messages.length > 0) {
             output += outputDiagnostics(diagnostics);
         }

--- a/lib/options.js
+++ b/lib/options.js
@@ -59,6 +59,10 @@ module.exports = optionator({
     type: "[String]",
     description: "Specify environments."
   }, {
+    option: "force",
+    type: "Boolean",
+    description: "Allow linting of otherwise ignored files."
+  }, {
     option: "global",
     type: "[String]",
     description: "Define global variables."

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -134,8 +134,8 @@ describe("cli", function() {
     });
 
     describe("when executing a file with an error", function() {
-        it("should execute with error", function() {
-            var exit = cli.execute("tests/fixtures/configurations/semi-error.js");
+        it("should exit with error", function() {
+            var exit = cli.execute("--force tests/fixtures/undef.js");
 
             assert.equal(exit, 1);
         });
@@ -143,12 +143,12 @@ describe("cli", function() {
 
     describe("when calling execute more than once", function() {
         it("should not print the results from previous execution", function() {
-            cli.execute("tests/fixtures/missing-semicolon.js");
+            cli.execute("--force tests/fixtures/missing-semicolon.js");
             assert.isTrue(console.log.called);
 
             console.log.reset();
 
-            cli.execute("tests/fixtures/passing.js");
+            cli.execute("--force tests/fixtures/passing.js");
             assert.isTrue(console.log.notCalled);
 
         });
@@ -197,11 +197,19 @@ describe("cli", function() {
 
     describe("when given a file in excluded files list", function() {
 
-        it("should process the file anyway", function() {
-            var exit = cli.execute("tests/fixtures/missing-semicolon.js");
+        it("should not process the file", function () {
+            var exit = cli.execute("tests/fixtures/passing.js");
 
+            // a warning about the ignored file
             assert.isTrue(console.log.called);
-            assert.isFalse(console.log.alwaysCalledWith(""));
+            assert.equal(exit, 0);
+        });
+
+        it("should process the file when forced", function() {
+            var exit = cli.execute("--force tests/fixtures/passing.js");
+
+            // no warnings
+            assert.isFalse(console.log.called);
             assert.equal(exit, 0);
         });
     });
@@ -209,7 +217,7 @@ describe("cli", function() {
     describe("when executing a file with a shebang", function() {
 
         it("should execute without error", function() {
-            var exit = cli.execute("tests/fixtures/shebang.js");
+            var exit = cli.execute("--force tests/fixtures/shebang.js");
 
             assert.equal(exit, 0);
         });
@@ -218,7 +226,7 @@ describe("cli", function() {
     describe("when given a custom rule, verify that it's loaded", function() {
 
         it("should return a warning", function() {
-            var code = "--rulesdir ./tests/fixtures/rules/wrong --config ./tests/fixtures/rules/eslint.json tests/fixtures/rules/test/test-custom-rule.js";
+            var code = "--rulesdir ./tests/fixtures/rules/wrong --config ./tests/fixtures/rules/eslint.json --force tests/fixtures/rules/test/test-custom-rule.js";
 
             assert.throws(function() {
                 var exit = cli.execute(code);
@@ -227,7 +235,7 @@ describe("cli", function() {
         });
 
         it("should return a warning", function() {
-            var code = "--rulesdir ./tests/fixtures/rules --config ./tests/fixtures/rules/eslint.json tests/fixtures/rules/test/test-custom-rule.js";
+            var code = "--rulesdir ./tests/fixtures/rules --config ./tests/fixtures/rules/eslint.json --force tests/fixtures/rules/test/test-custom-rule.js";
             var exit = cli.execute(code);
 
             assert.isTrue(console.log.calledOnce);
@@ -238,14 +246,14 @@ describe("cli", function() {
 
     describe("when executing with reset flag", function() {
         it("should execute without any errors", function () {
-            var exit = cli.execute("--reset --no-eslintrc ./tests/fixtures/missing-semicolon.js");
+            var exit = cli.execute("--reset --no-eslintrc --force ./tests/fixtures/missing-semicolon.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
         });
 
         it("should execute without any errors in Node.js environment", function () {
-            var exit = cli.execute("--reset --no-eslintrc --env node ./tests/fixtures/process-exit.js");
+            var exit = cli.execute("--reset --no-eslintrc --env node --force ./tests/fixtures/process-exit.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -255,7 +263,7 @@ describe("cli", function() {
 
     describe("when executing with no-eslintrc flag", function () {
         it("should ignore a local config file", function () {
-            var exit = cli.execute("--no-eslintrc ./tests/fixtures/eslintrc/quotes.js");
+            var exit = cli.execute("--no-eslintrc --force ./tests/fixtures/eslintrc/quotes.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -264,7 +272,7 @@ describe("cli", function() {
 
     describe("when executing without no-eslintrc flag", function () {
         it("should load a local config file", function () {
-            var exit = cli.execute("./tests/fixtures/eslintrc/quotes.js");
+            var exit = cli.execute("--force ./tests/fixtures/eslintrc/quotes.js");
 
             assert.isTrue(console.log.calledOnce);
             assert.equal(exit, 1);
@@ -278,12 +286,12 @@ describe("cli", function() {
         ];
 
         it("should allow environment-specific globals", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser,node " + files.join(" "));
+            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser,node --force " + files.join(" "));
             assert.equal(console.log.args[0][0].split("\n").length, 11);
         });
 
         it("should allow environment-specific globals, with multiple flags", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser --env node " + files.join(" "));
+            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser --env node --force " + files.join(" "));
             assert.equal(console.log.args[0][0].split("\n").length, 11);
         });
     });
@@ -295,28 +303,28 @@ describe("cli", function() {
         ];
 
         it("should not define environment-specific globals", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json " + files.join(" "));
+            cli.execute("--no-eslintrc --config ./conf/eslint.json --force " + files.join(" "));
             assert.equal(console.log.args[0][0].split("\n").length, 14);
         });
     });
 
     describe("when executing with global flag", function () {
         it("should default defined variables to read-only", function () {
-            var exit = cli.execute("--global baz,bat ./tests/fixtures/undef.js");
+            var exit = cli.execute("--global baz,bat --force ./tests/fixtures/undef.js");
 
             assert.isTrue(console.log.calledOnce);
             assert.equal(exit, 1);
         });
 
         it("should allow defining writable global variables", function () {
-            var exit = cli.execute("--global baz:false,bat:true ./tests/fixtures/undef.js");
+            var exit = cli.execute("--global baz:false,bat:true --force ./tests/fixtures/undef.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
         });
 
         it("should allow defining variables with multiple flags", function () {
-            var exit = cli.execute("--global baz --global bat:true ./tests/fixtures/undef.js");
+            var exit = cli.execute("--global baz --global bat:true --force ./tests/fixtures/undef.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -94,6 +94,13 @@ describe("options", function() {
         });
     });
 
+    describe("when passed --force", function() {
+        it("should return true for .force", function() {
+            var currentOptions = options.parse("--force");
+            assert.isTrue(currentOptions.force);
+        });
+    });
+
     describe("when passed --global", function() {
         it("should return an array for a single occurrence", function () {
             var currentOptions = options.parse("--global foo");


### PR DESCRIPTION
This PR implements the suggestion in #813 -- to exclude ignored files passed on the CLI.

To override this behaviour and lint all files passed in regardless of their ignore-state, I've added a flag `--force`.

This is still WIP, since there's no documentation of the feature yet, but I didn't want to spend time on that when the interface was not yet agreed upon.

One other thing which I think is missing is some form of alert to users when one or more ignored files were passed in. Without that, it would be quite possible that someone would run `eslint my-ignored-file.js` expecting it to be linted, and receive no errors.

As a point of reference, when ignored files are passed to `git add`, it will always exit immediately. I don't think this is useful for eslint though, since the purpose of this feature is to allow a list of files to be passed in and a subset to be linted.
