### PR TITLE
Rule: default-case (fixes #787)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -92,6 +92,7 @@
         "consistent-return": 2,
         "consistent-this": [0, "that"],
         "curly": [2, "all"],
+        "default-case": 0,
         "dot-notation": 2,
         "eqeqeq": 2,
         "func-names": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -38,6 +38,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [complexity](complexity.md) - specify the maximum cyclomatic complexity allowed in a program
 * [consistent-return](consistent-return.md) - require `return` statements to either always or never specify values
 * [curly](curly.md) - specify curly brace conventions for all control statements
+* [default-case](default-case.md) - require `default` case in `switch` statements
 * [dot-notation](dot-notation.md) - encourages use of dot notation whenever possible
 * [eqeqeq](eqeqeq.md) - require the use of `===` and `!==`
 * [guard-for-in](guard-for-in.md) - make sure `for-in` loops have an `if` statement (off by default)

--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -1,0 +1,53 @@
+# Require Default Case in Switch Statements (default-case)
+
+In order to be sure that the `switch` statement treats all conditions,  `default` case should be included. Still, sometimes `default` case has no special treatment and can be skipped. It is preferable to mark this specially in purpose to show intention of statement more clear. This rule obligates user to follow such policy.
+
+## Rule Details
+
+This rule aims to require `defaut` case in `switch` statements. User must add comment `//no default` after the last `case` if there is no `default` case.
+
+The following pattern is considered warnings:
+
+```js
+
+switch (a) {
+    case 1:
+        /* code */
+        break;
+}
+
+```
+
+The following patterns are not warnings:
+
+```js
+
+switch (a) {
+    case 1:
+        /* code */
+        break;
+
+    default:
+        /* code */
+        break;
+}
+
+```
+
+```js
+
+switch (a) {
+    case 1:
+        /* code */
+        break;
+
+    // no default
+}
+
+```
+
+
+## When Not To Use It
+
+If you don't make difference between `switch` statements with or without `default` case.
+

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -1,0 +1,69 @@
+/**
+ * @fileoverview require default case in switch statements
+ * @author Aliaksei Shytkin
+ */
+"use strict";
+
+var COMMENT_VALUE = "no default";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Shortcut to get last element of array
+     * @param  {*[]} collection Array
+     * @returns {*} Last element
+     */
+    function last(collection) {
+        return collection[collection.length - 1];
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "SwitchStatement": function(node) {
+
+            if (!node.cases.length) {
+                // skip check of empty switch because there is no easy way
+                // to extract comments inside it now
+                return;
+            }
+
+            var hasDefault = node.cases.some(function(v) {
+                return v.test === null;
+            });
+
+            if (!hasDefault) {
+
+                var comment;
+                var comments;
+
+                var lastCase = last(node.cases);
+                if (lastCase.consequent.length) {
+                    var lastBreak = last(lastCase.consequent);
+                    comments = context.getComments(lastBreak).trailing;
+                } else {
+                    comments = context.getComments(lastCase).trailing;
+                }
+
+                if (comments.length) {
+                    comment = last(comments);
+                }
+
+                if (!comment || comment.value.trim() !== COMMENT_VALUE) {
+                    context.report(node, "No default case.");
+                }
+            }
+        }
+    };
+};

--- a/tests/lib/rules/default-case.js
+++ b/tests/lib/rules/default-case.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview require default case in switch statements
+ * @author Aliaksei Shytkin
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/default-case", {
+
+    valid: [
+        "switch (a) { case 1: break; default: break; }",
+        "switch (a) { case 1: break; case 2: default: break; }",
+        "switch (a) { case 1: break; default: break; \n //no default \n }",
+        "switch (a) { \n    case 1: break; \n\n//oh-oh \n // no default\n }",
+        "switch (a) { \n    case 1: \n\n// no default\n }",
+        "switch (a) { \n    case 1: a = 4; \n\n// no default\n }",
+        "switch (a) { \n    case 1: a = 4; \n\n/* no default */\n }",
+        "switch (a) { \n    case 1: a = 4; break; break; \n\n// no default\n }",
+        "switch (a) { // no default\n }",
+        "switch (a) { }"
+    ],
+
+    invalid: [
+        {
+            code: "switch (a) { case 1: break; }",
+            errors: [{
+                message: "No default case.",
+                type: "SwitchStatement"
+            }]
+        },
+        {
+            code: "switch (a) { \n // no default \n case 1: break;  }",
+            errors: [{
+                message: "No default case.",
+                type: "SwitchStatement"
+            }]
+        },
+        {
+            code: "switch (a) { case 1: break; \n // no default \n // nope \n  }",
+            errors: [{
+                message: "No default case.",
+                type: "SwitchStatement"
+            }]
+        }
+
+    ]
+});


### PR DESCRIPTION
As I marked in code, rule skips when there is an empty `switch`. I found it impossible to get comments inside it with current tools and I don't think it is a clever way to try extract them by hands, so I guess this case can be skipped.
