### PR TITLE
Replaces .some() with .indexOf() where appropriate (fixed #825)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -260,9 +260,7 @@ Config.prototype.cacheExclusions = function(directory) {
  */
 Config.prototype.checkForExclusion = function(filePath) {
     return Object.keys(this.exclusionsCache).some(function(directory) {
-        return this.exclusionsCache[directory].some(function(file) {
-            return file === filePath;
-        });
+        return this.exclusionsCache[directory].indexOf(filePath) > -1;
     }, this);
 };
 

--- a/lib/rules/no-sparse-arrays.js
+++ b/lib/rules/no-sparse-arrays.js
@@ -19,9 +19,7 @@ module.exports = function(context) {
 
         "ArrayExpression": function(node) {
 
-            var emptySpot = node.elements.some(function(value) {
-                return value === null;
-            });
+            var emptySpot = node.elements.indexOf(null) > -1;
 
             if (emptySpot) {
                 context.report(node, "Unexpected comma in middle of array.");

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -42,9 +42,7 @@ module.exports = function(context) {
         var candidates = lookupVariableName(variable.name);
         if (candidates) {
             return candidates.filter(function (candidate) {
-                return variable.identifiers.some(function (identifier) {
-                    return candidate.node === identifier;
-                });
+                return variable.identifiers.indexOf(candidate.node) > -1;
             })[0];
         }
         return candidates;


### PR DESCRIPTION
A couple of places there were some loops inside of loops when a simple `.indexOf` would suffice. Saves a couple hundred milliseconds on a big project.
