### PR TITLE
Optionally allow function statements to be used before they are defined (fixes #829)

### DIFF
--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -2,8 +2,10 @@
 
 Since variable and function declarations are hoisted to the top of a scope, it's possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
 
+It takes an optional option as the second parameter which can be `"nofunc"` to allow named function definitions to be used before the location where they are defined.
+
 ```js
-alert(a); 
+alert(a);
 
 var a = 10;
 ```
@@ -15,10 +17,17 @@ This rule will warn when it encounters a reference to an identifier that has not
 The following patterns are considered warnings:
 
 ```js
-alert(a); 
+alert(a);
 var a = 10;
 
-f(); 
+f();
+function f() {}
+```
+
+The following patterns are not considered warnings when `"nofunc"` is specified:
+
+```js
+f();
 function f() {}
 ```
 

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -49,4 +49,3 @@ var single = 'a string containing "double" quotes';
 // When [1, "single", "avoid-escape"]
 var double = "a string containing 'single' quotes";
 ```
-

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -4,6 +4,12 @@
  */
 
 //------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var NO_FUNC = "nofunc";
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -26,10 +32,13 @@ module.exports = function(context) {
 
     function findVariables() {
         var scope = context.getScope();
+        var typeOption = context.options[0];
 
         function checkLocationAndReport(reference, declaration) {
-            if (declaration.identifiers[0].range[1] > reference.identifier.range[1]) {
-                context.report(reference.identifier, "{{a}} was used before it was defined", {a: reference.identifier.name});
+            if (typeOption !== NO_FUNC || declaration.defs[0].type !== "FunctionName") {
+                if (declaration.identifiers[0].range[1] > reference.identifier.range[1]) {
+                    context.report(reference.identifier, "{{a}} was used before it was defined", {a: reference.identifier.name});
+                }
             }
         }
 

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -18,12 +18,14 @@ eslintTester.addRuleTest("lib/rules/no-use-before-define", {
         "var a=10; alert(a);",
         "function b(a) { alert(a); }",
         "Object.hasOwnProperty.call(a);",
-        "function a() { alert(arguments);}"
+        "function a() { alert(arguments);}",
+        { code: "a(); function a() { alert(arguments); }", args: [1, "nofunc"] }
     ],
     invalid: [
         { code: "a++; var a=19;", errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
         { code: "a(); var a=function() {};", errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
         { code: "alert(a[1]); var a=[1,3];", errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
-        { code: "a(); function a() { alert(b); var b=10; a(); }", errors: [{ message: "a was used before it was defined", type: "Identifier"}, { message: "b was used before it was defined", type: "Identifier"}] }
+        { code: "a(); function a() { alert(b); var b=10; a(); }", errors: [{ message: "a was used before it was defined", type: "Identifier"}, { message: "b was used before it was defined", type: "Identifier"}] },
+        { code: "a(); var a=function() {};", args: [1, "nofunc"], errors: [{ message: "a was used before it was defined", type: "Identifier"}] }
     ]
 });


### PR DESCRIPTION
This adds an `"nofunc"` option to the `no-use-before-define` rule that allows a named function definition to be used before the location that it is defined. This is the same as setting the [latedef](http://jshint.com/docs/options/#latedef) option in JSHint to `"nofunc"`.

This pattern is commonly used in asynchronous code, see [Callback Hell](http://callbackhell.com/).

This is my first time contributing to `eslint`, not sure that I got all the correct code style.
