### PR TITLE
Rule 'block-scoped-var': fixes function scope and arguments (fixes #832)

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -93,6 +93,7 @@ module.exports = function(context) {
             return id.name;
         }));
         declare(node.id ? [node.id.name] : []);
+        declare(["arguments"]);
     }
 
     return {
@@ -125,6 +126,9 @@ module.exports = function(context) {
 
         "FunctionDeclaration": functionHandler,
         "FunctionExpression": functionHandler,
+
+        "FunctionDeclaration:exit": popScope,
+        "FunctionExpression:exit": popScope,
 
         "Identifier": function(node) {
             var ancestor = context.getAncestors().pop();

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -34,7 +34,10 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         "var a = { \"foo\": 3 };",
         "var a = { foo: 3 };",
         "var a = { foo: 3, bar: 5 };",
-        "var a = { set foo(a){}, get bar(){} };"
+        "var a = { set foo(a){}, get bar(){} };",
+        "function f(a) { return arguments[0]; }",
+        "function f() { }; var a = f;",
+        "var a = f; function f() { };"
     ],
     invalid: [
         { code: "function f(){ x; }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
@@ -47,6 +50,10 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         { code: "function f() { return b.a; }", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
         { code: "var a = { foo: bar };", errors: [{ message: "\"bar\" used outside of binding context.", type: "Identifier" }] },
         { code: "var a = { foo: foo };", errors: [{ message: "\"foo\" used outside of binding context.", type: "Identifier" }] },
-        { code: "var a = { bar: 7, foo: bar };", errors: [{ message: "\"bar\" used outside of binding context.", type: "Identifier" }] }
+        { code: "var a = { bar: 7, foo: bar };", errors: [{ message: "\"bar\" used outside of binding context.", type: "Identifier" }] },
+        { code: "var a = arguments;", errors: [{ message: "\"arguments\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function x(){}; var a = arguments;", errors: [{ message: "\"arguments\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function z(b){}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function z(){var b;}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] }
     ]
 });


### PR DESCRIPTION
Just an observation, it's interesting that `block-scoped-var` looks like some "superset" for `no-undef` rule (except check global var is writable now), means valid and invalid cases for `no-undef` will be the same for `block-scoped-var`. 
