### PR TITLE
Rule: no-inner-declarations (fixes #587)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -37,6 +37,7 @@
         "no-func-assign": 2,
         "no-global-strict": 2,
         "no-implied-eval": 2,
+        "no-inner-declarations": [2, "functions"],
         "no-invalid-regexp": 2,
         "no-iterator": 2,
         "no-label-var": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -20,6 +20,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-extra-parens](no-extra-parens.md) - disallow unnecessary parentheses
 * [no-extra-semi](no-extra-semi.md) - disallow unnecessary semicolons
 * [no-func-assign](no-func-assign.md) - disallow overwriting functions written as function declarations
+* [no-inner-declarations](no-inner-declarations.md) - disallow function or variable declarations in nested blocks
 * [no-invalid-regexp](no-invalid-regexp.md) - disallow invalid regular expression strings in the `RegExp` constructor
 * [no-negated-in-lhs](no-negated-in-lhs.md) - disallow negation of the left operand of an `in` expression
 * [no-obj-calls](no-obj-calls.md) - disallow the use of object properties of the global object (`Math` and `JSON`) as functions

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -1,0 +1,111 @@
+# Declarations in Program or Function Body (no-inner-declarations)
+
+In JavaScript, a function declaration is only allowed in the first level of a program or the body of another function, though parsers sometimes [erroneously accept them elsewhere](https://code.google.com/p/esprima/issues/detail?id=422). This only applies to function declarations; named or anonymous function expressions can occur anywhere an expression is permitted.
+
+```js
+// Good
+function doSomething() { }
+
+// Bad
+if (test) {
+    function doSomethingElse () { }
+}
+
+function anotherThing() {
+    var fn;
+
+    if (test) {
+
+        // Good
+        fn = function expression() { };
+
+        // Bad
+        function declaration() { }
+    }
+}
+```
+
+A variable declaration is permitted anwhere a statement can go, even nested deeply inside other blocks. This is often undesirable due to variable hoisting, and moving declarations to the root of the program or function body can increase clarity.
+
+```js
+// Good
+var foo = 42;
+
+// Bad
+while (test) {
+    var bar;
+}
+
+function doSomething() {
+    // Good
+    var baz = true;
+
+    // Bad
+    if (baz) {
+        var quux;
+    }
+}
+```
+
+## Rule Details
+
+This rule requires that function declarations and, optionally, variable declarations be in the root of a program or the body of a function.
+
+The following patterns are considered warnings:
+
+```js
+if (test) {
+    function doSomething() { }
+}
+
+function doSomethingElse() {
+    if (test) {
+        function doAnotherThing() { }
+    }
+}
+
+// With "both" option to check variable declarations
+if (test) {
+    var foo = 42;
+}
+
+// With "both" option to check variable declarations
+function doAnotherThing() {
+    if (test) {
+        var bar = 81;
+    }
+}
+```
+
+The following patterns are considered valid:
+
+```js
+function doSomething() { }
+
+function doSomethingElse() {
+    function doAnotherThing() { }
+}
+
+if (test) {
+    asyncCall(id, function (err, data) { });
+}
+
+var fn;
+if (test) {
+    fn = function fnExpression() { };
+}
+
+var foo = 42;
+
+function doAnotherThing() {
+    var bar = 81;
+}
+```
+
+## Options
+
+This rule takes a single option to specify whether it should check just function declarations or both function and variable declarations. The default is `"functions"`. Setting it to `"both"` will apply the same rules to both types of declarations.
+
+## When Not To Use It
+
+The function declaration portion rule will be rendered obsolete when [block-scoped functions](https://bugzilla.mozilla.org/show_bug.cgi?id=585536) land in ES6, but until then, it should be left on to enforce valid constructions. Disable checking variable declarations when using [block-scoped-var](block-scoped-var.md) or if declaring variables in nested blocks is acceptable despite hoisting.

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -1,0 +1,70 @@
+/**
+ * @fileoverview Rule to enforce declarations in program or function body root.
+ * @author Brandon Mills
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    /**
+     * Find the nearest Program or Function ancestor node.
+     * @returns {Object} Ancestor's type and distance from node.
+     */
+    function nearestBody() {
+        var ancestors = context.getAncestors(),
+            ancestor = ancestors.pop(),
+            generation = 1;
+
+        while (ancestor && ["Program", "FunctionDeclaration",
+                "FunctionExpression"].indexOf(ancestor.type) < 0) {
+            generation += 1;
+            ancestor = ancestors.pop();
+        }
+
+        return {
+            // Type of containing ancestor
+            type: ancestor.type,
+            // Separation between ancestor and node
+            distance: generation
+        };
+    }
+
+    /**
+     * Ensure that a given node is at a program or function body's root.
+     * @param {ASTNode} node Declaration node to check.
+     * @returns {void}
+     */
+    function check(node) {
+        var body = nearestBody(node),
+            valid = ((body.type === "Program" && body.distance === 1) ||
+                body.distance === 2);
+
+        if (!valid) {
+            context.report(node, "Move {{type}} declaration to {{body}} root.",
+                {
+                    type: (node.type === "FunctionDeclaration" ?
+                        "function" : "variable"),
+                    body: (body.type === "Program" ?
+                        "program" : "function body")
+                }
+            );
+        }
+    }
+
+    return {
+
+        "FunctionDeclaration": check,
+        "VariableDeclaration": function(node) {
+            if (context.options[0] === "both") {
+                check(node);
+            }
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-inner-declarations.js
+++ b/tests/lib/rules/no-inner-declarations.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Tests for declaration-position rule.
+ * @author Brandon Mills
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/no-inner-declarations", {
+
+    // Examples of code that should not trigger the rule
+    valid: [
+        "function doSomething() { }",
+        "function doSomething() { function somethingElse() { } }",
+        "(function() { function doSomething() { } }());",
+        "if (test) { var fn = function() { }; }",
+        "if (test) { var fn = function expr() { }; }",
+        "function decl() { var fn = function expr() { }; }",
+        "function decl(arg) { var fn; if (arg) { fn = function() { }; } }",
+        "function decl(arg) { var fn; if (arg) { fn = function expr() { }; } }",
+        "if (test) { var foo; }",
+        "function doSomething() { while (test) { var foo; } }",
+        { code: "var foo;", args: [2, "both"] },
+        { code: "var foo = 42;", args: [2, "both"] },
+        { code: "function doSomething() { var foo; }", args: [2, "both"] },
+        { code: "(function() { var foo; }());", args: [2, "both"] }
+    ],
+
+    // Examples of code that should trigger the rule
+    invalid: [{
+        code: "if (test) { function doSomething() { } }",
+        args: [2, "both"],
+        errors: [{
+            message: "Move function declaration to program root.",
+            type: "FunctionDeclaration"
+        }]
+    }, {
+        code: "function doSomething() { do { function somethingElse() { } } while (test); }",
+        errors: [{
+            message: "Move function declaration to function body root.",
+            type: "FunctionDeclaration"
+        }]
+    }, {
+        code: "(function() { if (test) { function doSomething() { } } }());",
+        errors: [{
+            message: "Move function declaration to function body root.",
+            type: "FunctionDeclaration"
+        }]
+    }, {
+        code: "while (test) { var foo; }",
+        args: [2, "both"],
+        errors: [{
+            message: "Move variable declaration to program root.",
+            type: "VariableDeclaration"
+        }]
+    }, {
+        code: "function doSomething() { if (test) { var foo = 42; } }",
+        args: [2, "both"],
+        errors: [{
+            message: "Move variable declaration to function body root.",
+            type: "VariableDeclaration"
+        }]
+    }, {
+        code: "(function() { if (test) { var foo; } }());",
+        args: [2, "both"],
+        errors: [{
+            message: "Move variable declaration to function body root.",
+            type: "VariableDeclaration"
+        }]
+    }]
+});


### PR DESCRIPTION
Adds a new rule, `no-inner-declarations`, that enforces placing function declarations and, optionally, variable declarations at the root level of the program body or a function body. By default, misplaced function declarations result in an error, and variable declarations are not checked.
