### PR TITLE
(Fixes #837) Better checking for excluded files when individually specified

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -62,7 +62,7 @@ function getFiles(dir, configHelper){
                 stat = fs.statSync(filePath);
 
             //if this file or directory is excluded from linting, skip over it.
-            if (configHelper.checkForExclusion(path.resolve(filePath))) {
+            if (!configHelper.options.force && configHelper.checkForExclusion(path.resolve(filePath))) {
                 return;
             }
 
@@ -84,6 +84,24 @@ function getFiles(dir, configHelper){
 
 function storeResults(filename, messages) {
     results.push({filePath: filename, messages: messages});
+}
+
+/**
+ * Check if an individual file should be excluded.
+ * @param {string} file Path to the file, relative to the cwd
+ * @param {Config} configHelper The configuration options
+ * @returns {boolean} True if the file should be excluded
+ */
+function fileIsExcluded(file, configHelper) {
+    var stack = [],
+        dirParts = ["."].concat(path.dirname(file).split(path.sep)),
+        ancestorDirExcluded = dirParts.some(function (pathPart) {
+            stack.push(pathPart);
+            var directory = path.resolve(path.join.apply(path, stack));
+            configHelper.cacheExclusions(directory);
+            return configHelper.checkForExclusion(directory);
+        });
+    return ancestorDirExcluded || configHelper.checkForExclusion(path.resolve(file));
 }
 
 /**
@@ -177,18 +195,15 @@ function processFiles(files, configHelper) {
 
     files.forEach(function(file) {
         if (isDirectory(file)) {
-            fullFileList = fullFileList.concat(getFiles(file, configHelper));
-        } else {
-            if (!configHelper.options.force) {
-                configHelper.cacheExclusions(path.dirname(file));
-                if (configHelper.checkForExclusion(path.resolve(file))) {
-                    storeResults(file, [{
-                        fatal: false,
-                        message: "File ignored because of your .eslintignore file. Use --force to override."
-                    }]);
-                    return;
-                }
+            if (configHelper.options.force || !fileIsExcluded(file, configHelper)) {
+                fullFileList = fullFileList.concat(getFiles(file, configHelper));
             }
+        } else if (!configHelper.options.force && fileIsExcluded(file, configHelper)) {
+            storeResults(file, [{
+                fatal: false,
+                message: "File ignored because of your .eslintignore file. Use --force to override."
+            }]);
+        } else {
             fullFileList.push(file);
         }
     });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -214,6 +214,25 @@ describe("cli", function() {
         });
     });
 
+    describe("when given a directory in excluded files list", function() {
+
+        it("should not process the directory", function () {
+            var exit = cli.execute("tests/fixtures");
+
+            // no warnings
+            assert.isFalse(console.log.called);
+            assert.equal(exit, 0);
+        });
+
+        it("should process the directory when forced", function() {
+            var exit = cli.execute("--force tests/fixtures");
+
+            // some of the files have errors which should be picked up
+            assert.isTrue(console.log.called);
+            assert.equal(exit, 1);
+        });
+    });
+
     describe("when executing a file with a shebang", function() {
 
         it("should execute without error", function() {


### PR DESCRIPTION
Description of problem is in #837.

I believe the tests are failing in this branch because of #838 -- config from previous tests are leaking over and affecting others. I am quite confused how this code change effected these errors, but I'm not sure whether they should be fixed here or in a separate branch.
