### PR TITLE
Rule: no-new-require (fixes #847)

### DIFF
--- a/conf/environments.json
+++ b/conf/environments.json
@@ -370,6 +370,7 @@
             "no-console": 0,
             "no-global-strict": 0,
             "no-mixed-requires": 2,
+            "no-new-require": 2,
             "no-path-concat": 2,
             "handle-callback-err": [2, "err"],
             "no-process-exit": 2

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -53,6 +53,7 @@
         "no-new": 2,
         "no-new-func": 2,
         "no-new-object": 2,
+        "no-new-require": 0,
         "no-new-wrappers": 2,
         "no-obj-calls": 2,
         "no-octal": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -106,6 +106,7 @@ These rules are specific to JavaScript running on Node.js.
 
 * [handle-callback-err](handle-callback-err.md) - enforces error handling in callbacks
 * [no-mixed-requires](no-mixed-requires.md) - disallow mixing regular variable and require declarations
+* [no-new-require](no-new-require.md) - disallow use of new operator with the `require` function
 * [no-path-concat](no-path-concat.md) - disallow string concatenation with `__dirname` and `__filename`
 * [no-process-exit](no-process-exit.md) - disallow `process.exit()`
 * [no-restricted-modules](no-restricted-modules.md) - restrict usage of specified node modules
@@ -154,3 +155,4 @@ The following rules are included for compatibility with [JSHint](http://jshint.c
 * [max-statements](max-statements.md) - specify the maximum number of statement allowed in a function (off by default)
 * [no-bitwise](no-bitwise.md) - disallow use of bitwise operators (off by default)
 * [no-plusplus](no-plusplus.md) - disallow use of unary operators, `++` and `--` (off by default)
+

--- a/docs/rules/no-new-require.md
+++ b/docs/rules/no-new-require.md
@@ -1,0 +1,42 @@
+# Disallow new require (no-new-require)
+
+The `require` function is used to include modules that exist in separate files, such as:
+
+```js
+var appHeader = require('app-header');
+```
+
+Some modules return a constructor which can potentially lead to code such as:
+
+```js
+var appHeader = new require('app-header');
+```
+
+Unfortunately, this introduces a high potential for confusion since the code author likely meant to write:
+
+```js
+var appHeader = new (require('app-header'));
+```
+
+For this reason, it is usually best to disallow this particular expression.
+
+## Rule Details
+
+This rule aims to eliminate use of the `new require` expression. As such, it warns whenever `new require` is found in code.
+
+The following pattern is considered a warning:
+
+```js
+var appHeader = new require('app-header');
+```
+
+The following pattern is not a warning:
+
+```js
+var AppHeader = require('app-header');
+```
+
+## When Not To Use It
+
+If you are using a custom implementation of `require` and your code will never be used in projects where a standard `require` (CommonJS, Node.js, AMD) is expected, you can safely turn this rule off.
+

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -1,0 +1,23 @@
+/**
+ * @fileoverview Rule to disallow use of new operator with the `require` function
+ * @author Wil Moore III
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    return {
+
+        "NewExpression": function(node) {
+            if (node.callee.type === "Identifier" && node.callee.name === "require") {
+                context.report(node, "Unexpected use of new with require.");
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-new-require.js
+++ b/tests/lib/rules/no-new-require.js
@@ -1,0 +1,26 @@
+/**
+ * @fileoverview Tests for no-new-require rule.
+ * @author Wil Moore III
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+eslintTester.addRuleTest("lib/rules/no-new-require", {
+    valid: [
+        "var appHeader = require('app-header')",
+        "var AppHeader = new (require('app-header'))",
+        "var AppHeader = new (require('headers').appHeader)"
+    ],
+    invalid: [
+        { code: "var appHeader = new require('app-header')", errors: [{ message: "Unexpected use of new with require.", type: "NewExpression"}] },
+        { code: "var appHeader = new require('headers').appHeader", errors: [{ message: "Unexpected use of new with require.", type: "NewExpression"}] }
+    ]
+});


### PR DESCRIPTION
This adds the no-new-require rule and fixes #847.

> The use case for the rule - what is it trying to prevent or flag?

This rule would disallow the use of the `new require(...)` expression.

> Why you believe this rule is generic enough to be included in the main distribution

While I've only seen this manifest with r.js; it is such a subtle expression and is easily missed. Lots of people use RequireJS and could be in for a surprise when they finally decide to optimize their code (lots of people don't try it until they are about to deploy for the first time).

> Whether the rule should be on or off by default.

Since I've only seen this manifest with `r.js` and not everyone will be using `r.js`, I believe this rule should be off by default.
