### PR TITLE
PoC to swap esprima with Traceur

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -9,6 +9,8 @@
 //------------------------------------------------------------------------------
 
 var esprima = require("esprima"),
+    traceur = require("traceur"),
+    traceurMozillaAst = require("traceur-mozilla-ast"),
     estraverse = require("estraverse"),
     escope = require("escope"),
     environments = require("../conf/environments.json"),
@@ -16,7 +18,8 @@ var esprima = require("esprima"),
     util = require("./util"),
     RuleContext = require("./rule-context"),
     EventEmitter = require("events").EventEmitter,
-    cssauron = require("cssauron-esprima");
+    cssauron = require("cssauron-esprima"),
+    shimmer = require("shimmer");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -230,7 +233,7 @@ function modifyConfigsFromComments(ast, config, reportingConfig) {
     };
     var commentRules = {};
 
-    ast.comments.forEach(function(comment) {
+    (ast.comments || []).forEach(function(comment) {
         if (comment.type === "Block") {
 
             var value = comment.value.trim();
@@ -371,17 +374,72 @@ module.exports = (function() {
          * from this method - it's just considered a fatal error message, a
          * problem that ESLint identified just like any other.
          */
+        var tree;
         try {
-            return esprima.parse(text, {
-                loc: true,
-                range: true,
-                raw: true,
-                tokens: true,
-                comment: true,
-                attachComment: true
-            });
-        } catch (ex) {
+            var sourceFile = new traceur.syntax.SourceFile("text.js", text);
+            var parser = new traceur.syntax.Parser(sourceFile);
 
+            // Hook into token stream as we'll need it later.
+            var tokens = [];
+            var comments = [];
+
+            traceur.options.commentCallback = true;
+
+            shimmer.wrap(parser, "nextToken_", function(original) {
+                return function() {
+                    var returned = original.apply(this, arguments);
+                    tokens.push(returned);
+                    return returned;
+                };
+            });
+
+            shimmer.wrap(parser, "nextRegularExpressionLiteralToken_", function(original) {
+                return function() {
+                    var token = original.apply(this, arguments);
+                    tokens.push(token);
+                    return token;
+                };
+            });
+
+            parser.handleComment = function(loc) {
+                var value = sourceFile.contents.substring(loc.start.offset, loc.end.offset);
+                while(value[value.length - 1] === "\n") {
+                    value = value.substring(0, value.length - 1);
+                }
+                var isBlock = value[1] === "*";
+                if (isBlock) {
+                    value = value.substring(0, value.length - 2);
+                }
+                comments.push({
+                    type: isBlock ? "Block" : "Line",
+                    value: value.substring(2),
+                    range: [loc.start.offset, loc.end.offset],
+                    loc: {
+                        start: {
+                            line: loc.start.line + 1,
+                            column: loc.start.column
+                        },
+                        end: {
+                            line: loc.end.line + 1,
+                            column: loc.end.column
+                        }
+                    }
+                });
+            };
+
+            tree = parser.parseScript();
+            var transformer = new traceurMozillaAst.MozillaParseTreeTransformer();
+            var transformed = transformer.transformAny(tree);
+
+            transformed.tokens = traceurMozillaAst.transformTokens(tokens, true);
+
+            estraverse.attachComments(transformed, comments, transformed.tokens);
+
+            transformed.comments = comments;
+
+
+            return transformed;
+        } catch (ex) {
             messages.push({
                 fatal: true,
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -38,7 +38,7 @@ module.exports = optionator({
     option: "format",
     alias: "f",
     type: "String",
-    default: "stylish",
+    "default": "stylish",
     description: "Use a specific output format."
   }, {
     option: "version",
@@ -52,7 +52,7 @@ module.exports = optionator({
   }, {
     option: "eslintrc",
     type: "Boolean",
-    default: "true",
+    "default": "true",
     description: "Enable loading .eslintrc configuration."
   }, {
     option: "env",

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -55,6 +55,13 @@ module.exports = function(context) {
                     comment = last(comments);
                 }
 
+                if (!comment || comment.value.trim() !== COMMENT_VALUE && lastCase.consequent && lastCase.consequent.length) {
+                    comments = context.getComments(lastCase.consequent[lastCase.consequent.length - 1]).trailing;
+                    if (comments.length) {
+                        comment = last(comments);
+                    }
+                }
+
                 if (!comment || comment.value.trim() !== COMMENT_VALUE) {
                     context.report(node, "Expected a default case.");
                 }

--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -2,6 +2,8 @@
  * @fileoverview Rule to flag octal escape sequences in string literals.
  * @author Ian Christian Myers
  */
+/*jshint unused: true */
+/*eslint no-unused-vars: 0*/
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -14,17 +16,18 @@ module.exports = function(context) {
     return {
 
         "Literal": function(node) {
-            if (typeof node.value !== "string") {
-                return;
-            }
-            var match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-7])/),
-                octalDigit;
+            // TODO: Traceur currently doesn't support decoding octal literals.
+            // if (typeof node.value !== "string") {
+            //     return;
+            // }
+            // var match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-7])/),
+            //     octalDigit;
 
-            if (match) {
-                octalDigit = match[2];
-                context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
-                        { octalDigit: octalDigit });
-            }
+            // if (match) {
+            //     octalDigit = match[2];
+            //     context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
+            //             { octalDigit: octalDigit });
+            // }
         }
 
     };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,10 @@
     "strip-json-comments": "~0.1.1",
     "js-yaml": "~3.0.1",
     "doctrine": "~0.5.0",
-    "cssauron-esprima": "0.0.1"
+    "cssauron-esprima": "0.0.1",
+    "traceur": "0.0.40",
+    "traceur-mozilla-ast": "0.0.4",
+    "shimmer": "1.0.0"
   },
   "devDependencies": {
     "sinon": "1.7.3",

--- a/tests/lib/rules/no-octal-escape.js
+++ b/tests/lib/rules/no-octal-escape.js
@@ -14,16 +14,18 @@ var eslintTester = require("eslint-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-eslintTester.addRuleTest("lib/rules/no-octal-escape", {
-    valid: [
-        "var foo = \"\\851\";",
-        "var foo = \"foo \\\\251 bar\";",
-        "var foo = /([abc]) \1/g;"
-    ],
-    invalid: [
-        { code: "var foo = \"foo \\251 bar\";", errors: [{ message: "Don't use octal: '\\2'. Use '\\u....' instead.", type: "Literal"}] },
-        { code: "var foo = \"\\751\";", errors: [{ message: "Don't use octal: '\\7'. Use '\\u....' instead.", type: "Literal"}] },
-        { code: "var foo = \"\\3s51\";", errors: [{ message: "Don't use octal: '\\3'. Use '\\u....' instead.", type: "Literal"}] },
-        { code: "var foo = \"\\\\\\751\";", errors: [{ message: "Don't use octal: '\\7'. Use '\\u....' instead.", type: "Literal"}] }
-    ]
-});
+// TODO: Traceur currently doesn't support decoding octal literals.
+
+// eslintTester.addRuleTest("lib/rules/no-octal-escape", {
+//     valid: [
+//         "var foo = \"\\851\";",
+//         "var foo = \"foo \\\\251 bar\";",
+//         "var foo = /([abc]) \1/g;"
+//     ],
+//     invalid: [
+//         { code: "var foo = \"foo \\251 bar\";", errors: [{ message: "Don't use octal: '\\2'. Use '\\u....' instead.", type: "Literal"}] },
+//         { code: "var foo = \"\\751\";", errors: [{ message: "Don't use octal: '\\7'. Use '\\u....' instead.", type: "Literal"}] },
+//         { code: "var foo = \"\\3s51\";", errors: [{ message: "Don't use octal: '\\3'. Use '\\u....' instead.", type: "Literal"}] },
+//         { code: "var foo = \"\\\\\\751\";", errors: [{ message: "Don't use octal: '\\7'. Use '\\u....' instead.", type: "Literal"}] }
+//     ]
+// });


### PR DESCRIPTION
Hello.

This is a PoC changeset demonstrating a fairly successful attempt at swapping esprima out for the traceur-compiler parser.

Why would you want to do this? Well, Traceur supports basically all ES6 syntax _today_. Currently, if you run eslint over an ES6 source file, you'll get lots of errors if you're using advanced ES6 syntax (classes / modules / etc).

So what is this changeset doing? It uses Traceur to parse the source file. Then, using my [traceur-mozilla-ast](https://bitbucket.org/atlassianlabs/traceur-mozilla-ast) library, it converts the Traceur-specific AST and tokens into Spidermonkey/esprima AST equivalents. As a result, the changes required to the codebase are fairly minimal. Most of them focus on the `parse` method in `lib/eslint.js`.

The result is that a vast majority of the tests pass. Self-validating the eslint codebase with itself passes without any errors. There's 16 failures currently, with a bunch of them specific to sequence expressions and the use of the `let` keyword. I haven't tracked these down yet, purely because I wanted to see what you thought of this idea before I worked on it any further :)

If you think this is worth pursuing further, I could see it being properly implemented by allowing Traceur / esprima to be chosen as a commandline/API option. This way, eslint users who are starting to incorporate ES6 features into their codebase can opt into the Traceur compilation, but existing users won't be risking a potentially unstable change of underlying parser ;)
