### PR TITLE
fixes #655: add IIFE exception to no-extra-parens

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -87,6 +87,10 @@ module.exports = function(context) {
             case "UpdateExpression":
                 return 15;
             case "CallExpression":
+                // IIFE is allowed to have parens in any position (#655)
+                if (node.callee.type === "FunctionExpression") {
+                    return -1;
+                }
                 return 16;
             case "NewExpression":
                 return 17;
@@ -211,7 +215,7 @@ module.exports = function(context) {
         },
         "SequenceExpression": function(node) {
             [].forEach.call(node.expressions, function(e) {
-                if(isParenthesised(e)) { report(e); }
+                if(isParenthesised(e) && precedence(e) >= precedence(node)) { report(e); }
             });
         },
         "SwitchCase": function(node) {

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -99,7 +99,13 @@ eslintTester.addRuleTest("lib/rules/no-extra-parens", {
         "(0).a",
         "(function(){ }())",
         "({a: function(){}}.a());",
-        "({a:0}.a ? b : c)"
+        "({a:0}.a ? b : c)",
+
+        // IIFE is allowed to have parens in any position (#655)
+        "var foo = (function() { return bar(); }())",
+        "var o = { foo: (function() { return bar(); }()) };",
+        "o.foo = (function(){ return bar(); }());",
+        "(function(){ return bar(); }()), (function(){ return bar(); }())"
     ],
     invalid: [
         invalid("(0)", "Literal"),


### PR DESCRIPTION
Fixes #655 by [changing the perceived precedence of `CallExpression` nodes when the `callee` is a `FunctionExpression`](https://github.com/eslint/eslint/pull/852#issuecomment-42780096). Usurps #852.
