### PR TITLE
(fixes #622) Add rule ID on documentation pages

### DIFF
--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -1,4 +1,4 @@
-# Treat var as Block Scoped
+# Treat var as Block Scoped (block-scoped-var)
 
 The `block-scoped-var` rule generates warnings when variables are used outside of the block in which they were defined. This emulates C-style block scope.
 

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -1,4 +1,4 @@
-# Require One True Brace Style
+# Require One True Brace Style (brace-style)
 
 One true brace style is a common coding style in JavaScript, in which the opening curly brace of a block is placed on the same line as its corresponding statement or declaration.
 

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -1,4 +1,4 @@
-# Require Camelcase
+# Require Camelcase (camelcase)
 
 When it comes to naming variables, styleguides generally fall into one of two camps: camelcased (`variableName`) and underscores(`variable_name`). This rule focuses on using the camelcase approach. If your styleguide calls for camelcasing your variable names, then this rule is for you!
 

--- a/docs/rules/complexity.md
+++ b/docs/rules/complexity.md
@@ -1,4 +1,4 @@
-# Limit Cyclomatic Complexity
+# Limit Cyclomatic Complexity (complexity)
 
 Cyclomatic complexity measures the number of linearly independent paths through a program's source code. This rule allows setting a cyclomatic complexity threshold.
 

--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -1,4 +1,4 @@
-# Require Consistent Returns
+# Require Consistent Returns (consistent-return)
 
 One of the confusing aspects of JavaScript is that any function may or may not return a value at any point in time. When a function exits without any `return` statement executing, the function returns `undefined`. Similarly, calling `return` without specifying any value will cause the function to return `undefined`. Only when `return` is called with a value is there a change in the function's return value.
 

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -1,4 +1,4 @@
-# Require Consistent This
+# Require Consistent This (consistent-this)
 
 It is often necessary to capture the current execution context in order to make it available subsequently. A prominent example of this are jQuery callbacks:
 

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -1,4 +1,4 @@
-# Require Following Curly Brace Conventions
+# Require Following Curly Brace Conventions (curly)
 
 JavaScript allows the omition of curly braces when a block contains only one statement. However, it is considered by many to be best practice to _never_ omit curly braces around blocks, even when they optional, because it can lead to bugs and reduces code clarity. So the following:
 

--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -1,4 +1,4 @@
-# Require Dot Notation
+# Require Dot Notation (dot-notation)
 
 In JavaScript, one can access properties using the dot notation (`foo.bar`) or square-bracket notation (`foo["bar"]`). However, the dot notation is often preferred because it is easier to read, less verbose, and works better with aggressive JavaScript minimizers.
 

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -1,4 +1,4 @@
-# Require === and !==
+# Require === and !== (eqeqeq)
 
 It is considered good practice to use the type-safe equality operators `===` and `!==` instead of their regular counterparts `==` and `!=`.
 

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -1,4 +1,4 @@
-# Require Function Expressions to have a Name
+# Require Function Expressions to have a Name (func-names)
 
 A pattern that's becoming more common is to give function expressions names to aid in debugging, such as:
 

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -1,4 +1,4 @@
-# Enforce Function Style
+# Enforce Function Style (func-style)
 
 There are two ways of defining functions in JavaScript: function declarations and function expressions. Declarations have the `function` keyword first, followed by a name, followed by its arguments and the function body, such as:
 

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -1,4 +1,4 @@
-# Ensures Callback Error Handling
+# Ensures Callback Error Handling (handle-callback-err)
 
 In node, a common pattern for dealing with asynchronous behavior is called the callback pattern.
 This pattern expects as the first argument of the callback an `Error` object, which may be `null`.

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -1,4 +1,4 @@
-# Limit Maximum Depth
+# Limit Maximum Depth (max-depth)
 
 The `max-depth` rule allows you to specify the maximum depth blocks can be nested.
 

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -1,4 +1,4 @@
-# Limit Maximum Length of Line
+# Limit Maximum Length of Line (max-len)
 
 Very long lines of code in any language can be difficult to read. In order to aid in readability and maintainability many coders have developed a convention to limit lines of code to X number of characters (traditionally 80 characters).
 

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -1,4 +1,4 @@
-# Set Maximum Depth of Nested Callbacks
+# Set Maximum Depth of Nested Callbacks (max-nested-callbacks)
 
 Many JavaScript libraries use the callback pattern to manage asynchronous operations. A program of any complexity will most likely need to manage several asynchronous operations at various levels of concurrency. A common pitfall that is easy to fall into is nesting callbacks, which makes code more difficult to read the deeper the callbacks are nested.
 

--- a/docs/rules/max-params.md
+++ b/docs/rules/max-params.md
@@ -1,4 +1,4 @@
-# Limit Maximum Number of Parameters
+# Limit Maximum Number of Parameters (max-params)
 
 Functions that take numerous parameters can be difficult to read and write because it requires the memorization of what each parameter is, its type, and the order they should appear in. As a result, many coders adhere to a convention that caps the number of parameters a function can take.
 

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -1,9 +1,9 @@
-# Limit Maximum Number of Statements
+# Limit Maximum Number of Statements (max-statements)
 
 The `max-statements` rule allows you to specify the maximum number statements allow in a function.
 
 ```js
-// max-statements: [1, 2]  // Maximum of 2 statements. 
+// max-statements: [1, 2]  // Maximum of 2 statements.
 function foo() {
   var bar = 1;
   var baz = 2;
@@ -19,7 +19,7 @@ This rule allows you to configure the maximum number of statements allowed in a 
 The following patterns are considered warnings:
 
 ```js
-// max-statements: [1, 2]  // Maximum of 2 statements. 
+// max-statements: [1, 2]  // Maximum of 2 statements.
 function foo() {
   var bar = 1;
   var baz = 2;
@@ -31,7 +31,7 @@ function foo() {
 The following patterns are not warnings:
 
 ```js
-// max-statements: [1, 2]  // Maximum of 2 statements. 
+// max-statements: [1, 2]  // Maximum of 2 statements.
 function foo() {
   var bar = 1;
   return function () {

--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -1,4 +1,4 @@
-# Require Constructors to Use Initial Caps
+# Require Constructors to Use Initial Caps (new-cap)
 
 The `new` operator in JavaScript creates a new instance of a particular type of object. That type of object is represented by a constructor function. Since constructor functions are just regular functions, the only defining characteristic is that `new` is being used as part of the call. Native JavaScript functions begin with an uppercase letter to distinguish those functions that are to be used as constructors from functions that are not. Many style guides recommend following this pattern to more easily determine which functions are to e used as constructors.
 

--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -1,4 +1,4 @@
-# Require Parens for Constructors
+# Require Parens for Constructors (new-parens)
 
 JavaScript allows the omission of parentheses when invoking a function via the `new` keyword and the constructor has no arguments. However, some coders believe that omitting the parentheses is inconsistent with the rest of the language and thus makes code less clear.
 

--- a/docs/rules/no-alert.md
+++ b/docs/rules/no-alert.md
@@ -1,4 +1,4 @@
-# Disallow Use of Alert
+# Disallow Use of Alert (no-alert)
 
 JavaScripts' alert, confirm, and prompt functions are widely considered to be obtrusive as UI elements and should be replaced by a more appropriate custom UI implementation. Furthermore, alert is often used while debugging code, which should be removed before deployment to production.
 

--- a/docs/rules/no-array-constructor.md
+++ b/docs/rules/no-array-constructor.md
@@ -1,4 +1,4 @@
-# Disallow creation of dense arrays using the `Array` constructor
+# Disallow creation of dense arrays using the `Array` constructor (no-array-constructor)
 
 Use of the `Array` constructor to construct a new array is generally
 discouraged in favour of array literal notation because of the single-argument

--- a/docs/rules/no-bitwise.md
+++ b/docs/rules/no-bitwise.md
@@ -1,4 +1,4 @@
-# Disallow Bitwise Operators
+# Disallow Bitwise Operators (no-bitwise)
 
 The use of bitwise operators in JavaScript is very rare and often `&` or `|` is simply a mistyped `&&` or `||`, which will lead to unexpected behavior.
 

--- a/docs/rules/no-caller.md
+++ b/docs/rules/no-caller.md
@@ -1,4 +1,4 @@
-# Disallow Use of caller/callee
+# Disallow Use of caller/callee (no-caller)
 
 The use of `arguments.caller` and `arguments.callee` make several code optimizations impossible. They have been deprecated in future versions of JavaScript and their use is forbidden in ECMAScript 5 while in strict mode.
 

--- a/docs/rules/no-catch-shadow.md
+++ b/docs/rules/no-catch-shadow.md
@@ -1,4 +1,4 @@
-# Disallow Shadowing of Variables Inside of catch
+# Disallow Shadowing of Variables Inside of catch (no-catch-shadow)
 
 In IE 8 and earlier, the catch clause parameter can overwrite the value of a variable in the outer scope, if that variable has the same name as the catch clause parameter.
 

--- a/docs/rules/no-comma-dangle.md
+++ b/docs/rules/no-comma-dangle.md
@@ -1,4 +1,4 @@
-# Disallow Dangling Commas
+# Disallow Dangling Commas (no-comma-dangle)
 
 Trailing commas in object literals are valid according to the ECMAScript 5 (and ECMAScript 3!) spec, however IE8 (when not in IE8 document mode) and below will throw an error when it encounters trailing commas in JavaScript.
 

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -1,4 +1,4 @@
-# Disallow Assignment in Conditional Expressions
+# Disallow Assignment in Conditional Expressions (no-cond-assign)
 
 It is uncommon to use an assignment operator inside of a conditional statement, such as:
 

--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -1,4 +1,4 @@
-# Disallow Use of console
+# Disallow Use of console (no-console)
 
 In JavaScript that is designed to be executed in the browser, it's considered a best practice to avoid using methods on `console`. Such messages are considered to be for debugging purposes and therefore not suitable to ship to the client. In general, calls using `console` should be stripped before being pushed to production.
 

--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -1,4 +1,4 @@
-# Disallow use of constant expressions in conditions
+# Disallow use of constant expressions in conditions (no-constant-condition)
 
 Comparing a literal expression in a condition is usually a typo or development trigger for a specific behavior.
 

--- a/docs/rules/no-control-regex.md
+++ b/docs/rules/no-control-regex.md
@@ -1,4 +1,4 @@
-# Disallow Controls Characters in Regular Expressions
+# Disallow Controls Characters in Regular Expressions (no-control-regex)
 
 Control characters are special, invisible characters in the ASCII range 0-31. These characters are rarely used in JavaScript strings so a regular expression containing these characters is most likely a mistake.
 

--- a/docs/rules/no-debugger.md
+++ b/docs/rules/no-debugger.md
@@ -1,4 +1,4 @@
-# Disallow debugger
+# Disallow debugger (no-debugger)
 
 The `debugger` statement is used to tell the executing JavaScript environment to stop execution and start up a debugger at the current point in the code. This has fallen out of favor as a good practice with the advent of modern debugging and development tools. Production code should definitely not contain `debugger`, as it will cause the browser to stop executing code and open an appropriate debugger.
 

--- a/docs/rules/no-delete-var.md
+++ b/docs/rules/no-delete-var.md
@@ -1,4 +1,4 @@
-# Disallow Variables Deletion
+# Disallow Variables Deletion (no-delete-var)
 
 This rule prevents the use of `delete` operator on variables:
 

--- a/docs/rules/no-div-regex.md
+++ b/docs/rules/no-div-regex.md
@@ -1,4 +1,4 @@
-# Disallow Regexs That Look Like Division
+# Disallow Regexs That Look Like Division (no-div-regex)
 
 Require regex literals to escape division operators.
 

--- a/docs/rules/no-dupe-keys.md
+++ b/docs/rules/no-dupe-keys.md
@@ -1,4 +1,4 @@
-# Disallow Duplicate Keys
+# Disallow Duplicate Keys (no-dupe-keys)
 
 Creating objects with duplicate keys in objects can cause unexpected behavior in your application. The `no-dupe-keys` rule flags the use of duplicate keys in object literals.
 

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -1,4 +1,4 @@
-# Disallow return in else
+# Disallow return in else (no-else-return)
 
 If a an `if` block contains a `return` statement, the `else` block becomes unnecessary. Its contents can be placed outside of the block.
 

--- a/docs/rules/no-empty-class.md
+++ b/docs/rules/no-empty-class.md
@@ -1,4 +1,4 @@
-# Disallow Empty Character Classes
+# Disallow Empty Character Classes (no-empty-class)
 
 Empty character classes in regular expressions do not match anything and can result in code that may not work as intended.
 

--- a/docs/rules/no-empty-label.md
+++ b/docs/rules/no-empty-label.md
@@ -1,4 +1,4 @@
-# No empty labels
+# No empty labels (no-empty-label)
 
 Labeled statements are only used in conjunction with labeled break and continue statements. ECMAScript has no goto statement.
 

--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -1,4 +1,4 @@
-# Disallow Empty Block Statements
+# Disallow Empty Block Statements (no-empty)
 
 Empty statements usually occur due to refactoring that wasn't completed, such as:
 

--- a/docs/rules/no-eq-null.md
+++ b/docs/rules/no-eq-null.md
@@ -1,4 +1,4 @@
-# Disallow Null Comparisons
+# Disallow Null Comparisons (no-eq-null)
 
 Comparing to `null` without a type-checking operator (`==` or `!=`), can have unintended results as the comparison will evaluate to true when comparing to not just a `null`, but also an `undefined` value.
 

--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -1,4 +1,4 @@
-# Disallow eval()
+# Disallow eval() (no-eval)
 
 JavaScript's `eval` function is potentially dangerous and is often misused. Using `eval` on untrusted code can open a program up to several different injection attacks. The of `eval` in most contexts can be substituted for a better, alternative approach to a problem.
 

--- a/docs/rules/no-ex-assign.md
+++ b/docs/rules/no-ex-assign.md
@@ -1,11 +1,11 @@
-# Disallow Assignment of the Exception Parameter
+# Disallow Assignment of the Exception Parameter (no-ex-assign)
 
 When an error is thrown an caught using a `catch` block, it's possible to accidentally (or purposely) overwrite the reference to the error. Such as:
 
 ```js
 try {
     // code
-} catch (e) { 
+} catch (e) {
     e = 10;
 }
 ```
@@ -22,7 +22,7 @@ The following patterns are considered warnings:
 ```js
 try {
     // code
-} catch (e) { 
+} catch (e) {
     e = 10;
 }
 ```
@@ -32,7 +32,7 @@ The following patterns are considered okay and do not cause warnings:
 ```js
 try {
     // code
-} catch (e) { 
+} catch (e) {
     var foo = 'bar';
 }
 ```

--- a/docs/rules/no-extend-native.md
+++ b/docs/rules/no-extend-native.md
@@ -1,4 +1,4 @@
-# Disallow Extending of Native Objects
+# Disallow Extending of Native Objects (no-extend-native)
 
 In JavaScript, you can extend any object, including builtin or "native" objects. Sometimes people change the behavior of these native objects in ways that break the assumptions made about them in other parts of the code.
 

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -1,4 +1,4 @@
-# Disallow Extra Boolean Casts
+# Disallow Extra Boolean Casts (no-extra-boolean-cast)
 
 In contexts such as an `if` statement's test where the result of the expression will already be coerced to a Boolean, casting to a Boolean via double negation (`!!`) is unnecessary. For example, these `if` statements are equivalent:
 

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -1,4 +1,4 @@
-# Disallow Extra Parens
+# Disallow Extra Parens (no-extra-parens)
 
 This rule restricts the use of parentheses to only where they are necessary.
 

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -1,4 +1,4 @@
-# Disallow Extra Semicolons
+# Disallow Extra Semicolons (no-extra-semi)
 
 JavaScript will more or less let you put semicolons after any statement without complaining. Typos and misunderstandings about where semicolons are required can lead to extra semicolons that are unnecessary.
 

--- a/docs/rules/no-extra-strict.md
+++ b/docs/rules/no-extra-strict.md
@@ -1,4 +1,4 @@
-# Disallow Unnecessary Strict Pragma
+# Disallow Unnecessary Strict Pragma (no-extra-strict)
 
 The `"use strict";` directive applies to the scope in which it appears and all inner scopes contained within that scope. Therefore, using the `"use strict";` directive in one of these inner scopes is unnecessary.
 

--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -1,4 +1,4 @@
-# Disallow Case Statement Fallthrough
+# Disallow Case Statement Fallthrough (no-fallthrough)
 
 The `switch` statement in JavaScript is one of the more error-prone constructs of the language thanks in part to the ability to "fall through" from one `case` to the next. For example:
 

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -1,4 +1,4 @@
-# Disallow Floating Decimals
+# Disallow Floating Decimals (no-floating-decimal)
 
 Float values in JavaScript contain a decimal point, and there is no requirement that the decimal point be preceded or followed by a number. For example, the following are all valid JavaScript numbers:
 

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -1,4 +1,4 @@
-# Disallow Function Assigment
+# Disallow Function Assigment (no-func-assign)
 
 JavaScript functions can be written as a FunctionDeclaration `function foo() { ... }` or as a FunctionExpression `var foo = function() { ... };`. While a JavaScript interpreter might tolerate it, overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
 

--- a/docs/rules/no-global-strict.md
+++ b/docs/rules/no-global-strict.md
@@ -1,4 +1,4 @@
-# Disallow Global Strict Mode
+# Disallow Global Strict Mode (no-global-strict)
 
 Strict mode is enabled by using the following pragma in your code:
 

--- a/docs/rules/no-implied-eval.md
+++ b/docs/rules/no-implied-eval.md
@@ -1,4 +1,4 @@
-# Disallow Implied eval()
+# Disallow Implied eval() (no-implied-eval)
 
 It's considered a good practice to avoid using `eval()` in JavaScript. There are security and performance implications involved with doing so, which is why many linters (including ESLint) disallow `eval()` by default. However, there are some other ways to pass a string and have it interpreted as JavaScript code that have similar concerns.
 

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -1,4 +1,4 @@
-# Disallow Invalid Regular Expressions
+# Disallow Invalid Regular Expressions (no-invalid-regexp)
 
 This rule validates string arguments passed to the `RegExp` constructor.
 

--- a/docs/rules/no-iterator.md
+++ b/docs/rules/no-iterator.md
@@ -1,4 +1,4 @@
-# Disallow Iterator
+# Disallow Iterator (no-iterator)
 
 The `__iterator__` property can used to create custom iterators that are compatible with JavaScript's `for in` and `for each` constructs. However, this property is not supported in many browsers, so it should be used with caution.
 

--- a/docs/rules/no-label-var.md
+++ b/docs/rules/no-label-var.md
@@ -1,4 +1,4 @@
-# Disallow Labels That Are Variables Names
+# Disallow Labels That Are Variables Names (no-label-var)
 
 ## Rule Details
 

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -1,4 +1,4 @@
-# Disallow Labeled Statements
+# Disallow Labeled Statements (no-labels)
 
 Labeled statements in JavaScript are used in conjunction with `break` and `continue` to control flow around multiple loops. For example:
 

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -1,4 +1,4 @@
-# Disallow Unnecessary Nested Blocks
+# Disallow Unnecessary Nested Blocks (no-lone-blocks)
 
 In JavaScript, standalone code blocks delimited by curly braces do not create a new scope and have have no use. For example, these curly braces do nothing to `foo`:
 

--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -1,4 +1,4 @@
-# Disallow Functions in Loops
+# Disallow Functions in Loops (no-loop-func)
 
 Writing functions within loops tends to result in errors due to the way the function creates a closure around the loop. For example:
 

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -1,4 +1,4 @@
-# Disallow Mixed Requires
+# Disallow Mixed Requires (no-mixed-requires)
 
 In the Node.JS community it is often customary to separate the `require`d modules from other variable declarations, sometimes also grouping them by their type. This rule helps you enforce this convention.
 

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -1,4 +1,4 @@
-# Disallow Multiline Strings
+# Disallow Multiline Strings (no-multi-str)
 
 It's possible to create multiline strings in JavaScript by using a slash before a newline, such as:
 

--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -1,4 +1,4 @@
-# Disallow Reassignment of Native Objects
+# Disallow Reassignment of Native Objects (no-native-reassign)
 
 Reports an error when they encounter an attempt to assign a value to built-in native object.
 

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -1,4 +1,4 @@
-# no negated left operand of `in` operator
+# Disallow negated left operand of `in` operator (no-negated-in-lhs)
 
 ## Rule Details
 

--- a/docs/rules/no-nested-ternary.md
+++ b/docs/rules/no-nested-ternary.md
@@ -1,4 +1,4 @@
-# Disallow Nested Ternaries
+# Disallow Nested Ternaries (no-nested-ternary)
 
 Nesting ternary expressions makes code unclear. The `no-nested-ternary` rule disallows the use of nested ternary expressions.
 

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -1,4 +1,4 @@
-# Disallow Function Constructor
+# Disallow Function Constructor (no-new-func)
 
 It's possible to create functions in JavaScript using the `Function` constructor, such as:
 

--- a/docs/rules/no-new-object.md
+++ b/docs/rules/no-new-object.md
@@ -1,4 +1,4 @@
-# Disallow new Object
+# Disallow new Object (no-new-object)
 
 The `Object` constructor is used to create new generic objects in JavaScript, such as:
 

--- a/docs/rules/no-new-wrappers.md
+++ b/docs/rules/no-new-wrappers.md
@@ -1,4 +1,4 @@
-# Disallow Primitive Wrapper Instances
+# Disallow Primitive Wrapper Instances (no-new-wrappers)
 
 There are three primitive types in JavaScript that have wrapper objects: string, number, and boolean. These are represented by the constructors `String`, `Number`, and `Boolean`, respectively. The primitive wrapper types are used whenever one of these primitive values is read, providing them with object-like capabilities such as methods. Behind the scenes, an object of the associated wrapper type is created and then destroyed, which is why you can call methods on primitive values, such as:
 

--- a/docs/rules/no-new.md
+++ b/docs/rules/no-new.md
@@ -1,4 +1,4 @@
-# Disallow new For Side Effects
+# Disallow new For Side Effects (no-new)
 
 Calling contructors with the `new` keyword, without assigning the resulting object to a variable does is equivalent to simply calling the constructor without the `new` keyword. Thus, the constructor can be avoided and the function can be called directly.
 

--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -1,4 +1,4 @@
-# Disallow Global Object Function Calls
+# Disallow Global Object Function Calls (no-obj-calls)
 
 This rule prevents the use of object properties of the global object (`Math` and `JSON`) as functions:
 

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -1,4 +1,4 @@
-# Disallow Octal Escapes
+# Disallow Octal Escapes (no-octal-escape)
 
 As of version 5 of the ECMAScript specification, octal escape sequences are a deprecated feature and should not be used. It is recommended that Unicode escapes be used instead.
 

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -1,4 +1,4 @@
-# Disallow Octal Literals
+# Disallow Octal Literals (no-octal)
 
 Octal literals are numerals that begin with a leading zero, such as:
 

--- a/docs/rules/no-path-concat.md
+++ b/docs/rules/no-path-concat.md
@@ -1,4 +1,4 @@
-# Disallow string concatenation when using __dirname and __filename
+# Disallow string concatenation when using __dirname and __filename (no-path-concat)
 
 In Node.js, the `__dirname` and `__filename` global variables contain the directory path and the file path of the currently executing script file, respectively. Sometimes, developers try to use these variables to create paths to other files, such as:
 

--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -1,4 +1,4 @@
-# Disallow ++ and --
+# Disallow ++ and -- (no-plusplus)
 
 The `no-plusplus` rule flags the use of unary operators, `++` and `--`.
 

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -1,4 +1,4 @@
-# Disallow process.exit()
+# Disallow process.exit() (no-process-exit)
 
 The `process.exit()` method in Node.js is used to immediately stop the Node.js process and exit. This is a dangerous operation because it can occur in any method at any point in time, potentially stopping a Node.js application completely when an error occurs. For example:
 

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -1,4 +1,4 @@
-# Disallow Use of __proto__
+# Disallow Use of __proto__ (no-proto)
 
 `__proto__` property has been deprecated as of ECMAScript 3.1 and shouldn't be used in the code. Use `getPrototypeOf` method instead.
 

--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -1,4 +1,4 @@
-# Disallow Redeclaring Variables
+# Disallow Redeclaring Variables (no-redeclare)
 
 In JavaScript, it's possible to redeclare the same variable name using `var`. This can lead to confusion as to where the variable is actually declared and initialized.
 

--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -1,4 +1,4 @@
-# Disallow Spaces in Regular Expressions
+# Disallow Spaces in Regular Expressions (no-regex-spaces)
 
 Regular expressions can be very complex and difficult to understand, which is why it's important to keep them as simple as possible in order to avoid mistakes. One of the more error-prone things you can do with a regular expression is to use more than one space, such as:
 

--- a/docs/rules/no-return-assign.md
+++ b/docs/rules/no-return-assign.md
@@ -1,4 +1,4 @@
-# Disallow Assignment in return Statement
+# Disallow Assignment in return Statement (no-return-assign)
 
 One of the interesting, and sometimes confusing, aspects of JavaScript is that assignment can happen at almost any point. Because of this, an errant equals sign can end up causing assignment when the true intent was to do a comparison. This is especially true when using a `return` statement. For example:
 

--- a/docs/rules/no-script-url.md
+++ b/docs/rules/no-script-url.md
@@ -1,6 +1,6 @@
-# Disallow Script URLs
+# Disallow Script URLs (no-script-url)
 
-Using `javascript:` urls is considered by some as a form of eval. Script passed after javascript: has to be parsed and evaluated by the browser the same way that it does eval. 
+Using `javascript:` urls is considered by some as a form of eval. Script passed after javascript: has to be parsed and evaluated by the browser the same way that it does eval.
 
 ## Rule Details
 

--- a/docs/rules/no-self-compare.md
+++ b/docs/rules/no-self-compare.md
@@ -1,4 +1,4 @@
-# Disallow Self Compare
+# Disallow Self Compare (no-self-compare)
 
 Comparing a variable against itself is usually an error, either an typo or refactoring error. It is confusing to the reader and may potentially introduce a runtime error.
 

--- a/docs/rules/no-shadow-restricted-names.md
+++ b/docs/rules/no-shadow-restricted-names.md
@@ -1,4 +1,4 @@
-# Disallow Shadowing of Restricted Names
+# Disallow Shadowing of Restricted Names (no-shadow-restricted-names)
 
 ES5 §15.1.1 Value Properties of the Global Object (`NaN`, `Infinity`, `undefined`) as well as strict mode restricted identifiers `eval` and `arguments` are considered to be restricted names in JavaScript. Defining them to mean something else can have unintended consequences and confuse others reading the code. For example, there's nothing prevent you from writing:
 

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -1,4 +1,4 @@
-# Disallow Shadowing
+# Disallow Shadowing (no-shadow)
 
 Shadowing is the process by which a local variable shares the same name as a variable in its containing scope. For example:
 

--- a/docs/rules/no-space-before-semi.md
+++ b/docs/rules/no-space-before-semi.md
@@ -1,4 +1,4 @@
-# Disallow Spaces Before Semicolon
+# Disallow Spaces Before Semicolon (no-space-before-semi)
 
 JavaScript allows for placing unnecessary spaces between an expression and the closing semicolon.
 

--- a/docs/rules/no-spaced-func.md
+++ b/docs/rules/no-spaced-func.md
@@ -1,4 +1,4 @@
-# Disallow Spaces in Function Calls
+# Disallow Spaces in Function Calls (no-spaced-func)
 
 While it's possible to have whitespace between the name of a function and the parentheses that execute it, such patterns tend to look more like errors.
 

--- a/docs/rules/no-sparse-arrays.md
+++ b/docs/rules/no-sparse-arrays.md
@@ -1,4 +1,4 @@
-# Disallow Sparse Arrays
+# Disallow Sparse Arrays (no-sparse-arrays)
 
 Sparse arrays contain empty slots, most frequently due to multiple commas being used in an array literal, such as:
 

--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -1,4 +1,4 @@
-# Disallow Synchronous Methods
+# Disallow Synchronous Methods (no-sync)
 
 In Node.js, most I/O is done through asynchronous methods. However, there are often synchronous versions of the asynchronous methods. For example, `fs.exists()` and `fs.existsSync()`. In some contexts, using synchronous operations is okay (if, as with ESLint, you are writing a command line utility). However, in other contexts the use of synchronous operations is considered a bad practice that should be avoided. For example, if you are running a high-travel web server on Node.js, you should consider carefully if you want to allow any synchronous operations that could lock up the server.
 

--- a/docs/rules/no-ternary.md
+++ b/docs/rules/no-ternary.md
@@ -1,6 +1,6 @@
-# Disallow Ternary Operators
+# Disallow Ternary Operators (no-ternary)
 
-The ternary operator is used to conditionally assign a value to a variable. Some believe that the use of ternary operators leads to unclear code. 
+The ternary operator is used to conditionally assign a value to a variable. Some believe that the use of ternary operators leads to unclear code.
 
 ```js
 var foo = isBar ? baz : qux;

--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -1,4 +1,4 @@
-# Disallow Initializing to undefined
+# Disallow Initializing to undefined (no-undef-init)
 
 In JavaScript, a variable that is declared and not initialized to any value automatically gets the value of `undefined`. For example:
 

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -1,4 +1,4 @@
-# Disallow Undeclared Variables
+# Disallow Undeclared Variables (no-undef)
 
 Any reference to an undeclared variable causes a warning, unless the variable is explicitly mentioned in a `/*global ...*/` comment. This rule provides compatibility with [JSHint](http://www.jshint.com)'s and [JSLint](http://www.jslint.com)'s treatment of global variables.
 

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -1,4 +1,4 @@
-# Disallow Dangling Underscores in Identifiers
+# Disallow Dangling Underscores in Identifiers (no-underscore-dangle)
 
 As far as naming conventions for identifiers go, dangling underscores may be the most polarizing in JavaScript. Dangling underscores are underscores at either the beginning or end of an identifier, such as:
 

--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -1,4 +1,4 @@
-# Disallow Unreachable Code
+# Disallow Unreachable Code (no-unreachable)
 
 A number of statements unconditionally exit a block of code. Any statements after that will not be executed and may be an error. The presence of unreachable code is usually a sign of a coding error.
 

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -1,4 +1,4 @@
-# Disallow Unused Expressions
+# Disallow Unused Expressions (no-unused-expressions)
 
 Unused expressions are those expressions that evaluate to a value but are never used. For example:
 

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -1,4 +1,4 @@
-# Disallow Unused Variables
+# Disallow Unused Variables (no-unused-vars)
 
 Variables that are declared and not used anywhere in the code are most likely an error due to incomplete refactoring. Such variables take up space in the code and can lead to confusion by readers.
 

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -1,4 +1,4 @@
-# Disallow Early Use
+# Disallow Early Use (no-use-before-define)
 
 Since variable and function declarations are hoisted to the top of a scope, it's possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
 

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -1,4 +1,4 @@
-# Disallow Warning Comments
+# Disallow Warning Comments (no-warning-comments)
 
 Often code is marked during development process for later work on it or with additional thoughts. Examples are typically `// TODO: do something` or `// FIXME: this is not a good idea`. These comments are a warning signal, that there is something not production ready in your code. Most likely you want to fix it or remove the comments before you roll out your code with a good feeling.
 

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -1,4 +1,4 @@
-# No with Statements
+# No with Statements (no-with)
 
 The `with` statement is potentially problematic because it adds members of an object to the current scope, making it impossible to tell what a variable inside the block actually refers to. Additionally, the `with` statement cannot be used in strict mode.
 

--- a/docs/rules/no-wrap-func.md
+++ b/docs/rules/no-wrap-func.md
@@ -1,4 +1,4 @@
-# Disallow Parens Around Functions
+# Disallow Parens Around Functions (no-wrap-func)
 
 Although it's possible to wrap functions in parentheses, this can be confusing when the code also contains immediately-invoked function expressions (IIFEs) since parentheses are often used to make this distinction. For example:
 

--- a/docs/rules/no-yoda.md
+++ b/docs/rules/no-yoda.md
@@ -1,4 +1,4 @@
-# Disallow Yoda Conditions
+# Disallow Yoda Conditions (no-yoda)
 
 Yoda conditions are so named because the literal value of the condition comes first while the variable comes second. For example, the following is a Yoda condition:
 

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -1,4 +1,4 @@
-# Require Just One var Statement Per Scope
+# Require Just One var Statement Per Scope (one-var)
 
 JavaScript has function scope, not block scope and all variable declarations are hoisted to the top of the function. Therefore, some people believe that all variables in a function scope should be declared in a single variable declaration at the top of the function and not in multiple declarations throughout the function.
 

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -1,4 +1,4 @@
-# Require Quotes for Property Names
+# Require Quotes for Property Names (quote-props)
 
 Some believe that ensuring property names in object literals are always wrapped in quotes is generally a good idea, since [depending on the property name you may need to quote them anyway](http://mathiasbynens.be/notes/javascript-properties). Consider this example:
 

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -1,4 +1,4 @@
-# Enforce Quote Style
+# Enforce Quote Style (quotes)
 
 Enforces coding style that string literals are delimited with single or double quotes.
 

--- a/docs/rules/radix.md
+++ b/docs/rules/radix.md
@@ -1,4 +1,4 @@
-# Require Radix Parameter
+# Require Radix Parameter (radix)
 
 When using the `parseInt()` function it is common to omit the second argument, the radix, and let the function try to determine from the first argument what type of number it is. By default, `parseInt()` will autodetect decimal and hexadecimal (via `0x` prefix). Prior to ECMAScript 5, `parseInt()` also autodetected octal literals, which caused problems because many developers assumed a leading `0` would be ignored.
 

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -1,4 +1,4 @@
-﻿# Variable Sorting
+# Variable Sorting (sort-vars)
 
 When declaring multiple variables within the same block, some developers prefer to sort variable names alphabetically to be able to find necessary variable easier at the later time. Others feel that it adds complexity and becomes burden to maintain.
 

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -1,4 +1,4 @@
-# Require or disallow spaces following keywords (space-after-keyword)
+# Require or disallow spaces following keywords (space-after-keywords)
 
 Some style guides will require or disallow spaces following the certain keywords.
 

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -1,4 +1,4 @@
-# Require Spaces Around Infix Operators
+# Require Spaces Around Infix Operators (space-infix-ops)
 
 While formatting preferences are very personal, a number of style guides require spaces around operators, such as:
 

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -1,4 +1,4 @@
-# Require spaces following `return`, `throw`, and `case`
+# Require spaces following `return`, `throw`, and `case` (space-return-throw-case)
 
 Require spaces following `return`, `throw`, and `case`.
 

--- a/docs/rules/space-unary-word-ops.md
+++ b/docs/rules/space-unary-word-ops.md
@@ -1,4 +1,4 @@
-# Require spaces following unary word operators
+# Require spaces following unary word operators (space-unary-word-ops)
 
 Require spaces following unary word operators.
 

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -1,4 +1,4 @@
-# Require Function Strict Mode
+# Require Function Strict Mode (strict)
 
 Strict mode is enabled by using the following pragma in your code:
 

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -1,4 +1,4 @@
-# Require isNaN()
+# Require isNaN() (use-isnan)
 
 In JavaScript, `NaN` is a special value of the `Number` type. It's used to represent any of the "not-a-number" values represented by the double-precision 64-bit format as specified by the IEEE Standard for Binary Floating-Point Arithmetic. `NaN` has the unique property of not being equal to anything, including itself. That is to say, that the condition `NaN !== NaN` evaluates to true.
 

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -1,4 +1,4 @@
-# Validates JSDoc comments are syntactically correct
+# Validates JSDoc comments are syntactically correct (valid-jsdoc)
 
 [JSDoc](http://usejsdoc.org) is a JavaScript API documentation generator. It uses specially-formatted comments inside of code to generate API documentation automatically. For example, this is what a JSDoc comment looks like for a function:
 

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -1,4 +1,4 @@
-# Ensures that the results of typeof are compared against a valid string  (valid-typeof)
+# Ensures that the results of typeof are compared against a valid string (valid-typeof)
 
 For a vast majority of use-cases, the only valid results of the `typeof` operator will be one of the following: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, and `"function"`. When the result of a `typeof` operation is compared against a string that is not one of these strings, it is usually a typo. This rule ensures that when the result of a `typeof` operation is compared against a string, that string is in the aforementioned set.
 

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -1,4 +1,4 @@
-# Require IFFEs to be Wrapped
+# Require IFFEs to be Wrapped (wrap-iife)
 
 Require immediate function invocation to be wrapped in parentheses.
 

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -1,9 +1,9 @@
-# Require Regex Literals to be Wrapped
+# Require Regex Literals to be Wrapped (wrap-regex)
 
 When a regular expression is used in certain situation, it can end up looking like a divison operator. For example:
 
 ```js
-function a() { 
+function a() {
     return /foo/.test("bar");
 }
 ```
@@ -16,7 +16,7 @@ The following patterns are considered warnings:
 
 ```js
 function a() {
-    return /foo/.test("bar"); 
+    return /foo/.test("bar");
 }
 ```
 


### PR DESCRIPTION
Added the ruleId in page title (H1) following the convention enforced by the yeoman generator.
