### PR TITLE
Add Build Next mention in integrations README.

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -2,7 +2,9 @@
 
 ## Editors
 
-* [Sublime Text 3](https://github.com/roadhump/SublimeLinter-eslint)
+* Sublime Text 3:
+    * [SublimeLinter-eslint](https://github.com/roadhump/SublimeLinter-eslint)
+    * [Build Next](https://github.com/albertosantini/sublimetext-buildnext)
 * [Vim](https://github.com/scrooloose/syntastic/tree/master/syntax_checkers/javascript)
 * Emacs: [Flycheck](http://flycheck.readthedocs.org/en/latest/) supports ESLint in recent versions.
 * Eclipse Orion: ESLint is the [default linter](http://dev.eclipse.org/mhonarc/lists/orion-dev/msg02718.html)


### PR DESCRIPTION
I introduce yet another plugin for Sublime Text editor to integrate ESLint: Build Next.

https://sublime.wbond.net/packages/Build%20Next

Features
- Extend Default.exec plugin and no external dependencies.
- Zero user preferences and preferences per build system.
- Close build results view if there are not errors.
- Show a dot icon in the gutter area close to the error.
- Draw an horizontal region close to the column (tabs-aware) of the error.
- Open finally the output panel.
- Go to the results following a line number order.
- Wrap around the end of the document for the next (previous) result.
- The output panel content is refreshed on the next (previous) result command.

Installation
1. Add the build system file to your Sublime Text configuration.
2. Add Build Next plugin with Package Control.

ESLint.sublime-build

```
{
    "selector": "source.js",

    "cmd": ["eslint", "--format", "compact", "$file"],
    "shell": true,

    "file_regex": "^(.*): line (\\d+), col (\\d+), (.+)$",

    "windows":
    {
        "cmd": ["eslint.cmd", "--format", "compact", "$file"]
    },

    "env":
    {
        "ST_BUILD_ADJUST_COLUMNERROR": "1"
    }
}
```
