### PR TITLE
Add check if there is text 'off by default' in index.

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -17,7 +17,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-empty-class](no-empty-class.md) - disallow the use of empty character classes in regular expressions
 * [no-ex-assign](no-ex-assign.md) - disallow assigning to the exception in a `catch` block
 * [no-extra-boolean-cast](no-extra-boolean-cast.md) - disallow double-negation boolean casts in a boolean context
-* [no-extra-parens](no-extra-parens.md) - disallow unnecessary parentheses
+* [no-extra-parens](no-extra-parens.md) - disallow unnecessary parentheses (off by default)
 * [no-extra-semi](no-extra-semi.md) - disallow unnecessary semicolons
 * [no-func-assign](no-func-assign.md) - disallow overwriting functions written as function declarations
 * [no-inner-declarations](no-inner-declarations.md) - disallow function or variable declarations in nested blocks
@@ -35,24 +35,24 @@ The following rules point out areas where you might have made mistakes.
 
 These are rules designed to prevent you from making mistakes. They either prescribe a better way of doing something or help you avoid footguns.
 
-* [block-scoped-var](block-scoped-var.md) - treat `var` statements as if they were block scoped
-* [complexity](complexity.md) - specify the maximum cyclomatic complexity allowed in a program
+* [block-scoped-var](block-scoped-var.md) - treat `var` statements as if they were block scoped (off by default)
+* [complexity](complexity.md) - specify the maximum cyclomatic complexity allowed in a program (off by default)
 * [consistent-return](consistent-return.md) - require `return` statements to either always or never specify values
 * [curly](curly.md) - specify curly brace conventions for all control statements
-* [default-case](default-case.md) - require `default` case in `switch` statements
+* [default-case](default-case.md) - require `default` case in `switch` statements (off by default)
 * [dot-notation](dot-notation.md) - encourages use of dot notation whenever possible
 * [eqeqeq](eqeqeq.md) - require the use of `===` and `!==`
 * [guard-for-in](guard-for-in.md) - make sure `for-in` loops have an `if` statement (off by default)
 * [no-alert](no-alert.md) - disallow the use of `alert`, `confirm`, and `prompt`
 * [no-caller](no-caller.md) - disallow use of `arguments.caller` or `arguments.callee`
-* [no-div-regex](no-div-regex.md) - disallow division operators explicitly at beginning of regular expression
-* [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if`.
+* [no-div-regex](no-div-regex.md) - disallow division operators explicitly at beginning of regular expression (off by default)
+* [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if` (off by default)
 * [no-empty-label](no-empty-label.md) - disallow use of labels for anything other then loops and switches
-* [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator
+* [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator (off by default)
 * [no-eval](no-eval.md) - disallow use of `eval()`
 * [no-extend-native](no-extend-native.md) - disallow adding to native types
 * [no-fallthrough](no-fallthrough.md) - disallow fallthrough of `case` statements
-* [no-floating-decimal](no-floating-decimal.md) - disallow the use of leading or trailing decimal points in numeric literals
+* [no-floating-decimal](no-floating-decimal.md) - disallow the use of leading or trailing decimal points in numeric literals (off by default)
 * [no-implied-eval](no-implied-eval.md) - disallow use of `eval()`-like methods
 * [no-labels](no-labels.md) - disallow use of labeled statements
 * [no-iterator](no-iterator.md) - disallow usage of `__iterator__` property
@@ -69,14 +69,14 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-redeclare](no-redeclare.md) - disallow declaring the same variable more then once
 * [no-return-assign](no-return-assign.md) - disallow use of assignment in `return` statement
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
-* [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same
+* [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same (off by default)
 * [no-sequences](no-sequences.md) - disallow use of comma operator
 * [no-unused-expressions](no-unused-expressions.md) - disallow usage of expressions in statement position
-* [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME`
+* [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME` (off by default)
 * [no-with](no-with.md) - disallow use of the `with` statement
 * [no-yoda](no-yoda.md) - disallow Yoda conditions
-* [radix](radix.md) - require use of the second argument for `parseInt()`
-* [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses
+* [radix](radix.md) - require use of the second argument for `parseInt()` (off by default)
+* [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses (off by default)
 
 ## Strict Mode
 
@@ -104,46 +104,46 @@ These rules have to do with variable declarations.
 
 These rules are specific to JavaScript running on Node.js.
 
-* [handle-callback-err](handle-callback-err.md) - enforces error handling in callbacks
-* [no-mixed-requires](no-mixed-requires.md) - disallow mixing regular variable and require declarations
-* [no-new-require](no-new-require.md) - disallow use of new operator with the `require` function
-* [no-path-concat](no-path-concat.md) - disallow string concatenation with `__dirname` and `__filename`
+* [handle-callback-err](handle-callback-err.md) - enforces error handling in callbacks (off by default)
+* [no-mixed-requires](no-mixed-requires.md) - disallow mixing regular variable and require declarations (off by default)
+* [no-new-require](no-new-require.md) - disallow use of new operator with the `require` function (off by default)
+* [no-path-concat](no-path-concat.md) - disallow string concatenation with `__dirname` and `__filename` (off by default)
 * [no-process-exit](no-process-exit.md) - disallow `process.exit()`
-* [no-restricted-modules](no-restricted-modules.md) - restrict usage of specified node modules
+* [no-restricted-modules](no-restricted-modules.md) - restrict usage of specified node modules (off by default)
 * [no-sync](no-sync.md) - disallow use of synchronous methods (off by default)
 
 ## Stylistic Issues
 
 These rules are purely matters of style and are quite subjective.
 
-* [brace-style](brace-style.md) - enforce one true brace style
+* [brace-style](brace-style.md) - enforce one true brace style (off by default)
 * [camelcase](camelcase.md) - require camel case names
 * [consistent-this](consistent-this.md) - enforces consistent naming when capturing the current execution context (off by default)
-* [func-names](func-names.md) - require function expressions to have a name
-* [func-style](func-style.md) - enforces use of function declarations or expressions
+* [func-names](func-names.md) - require function expressions to have a name (off by default)
+* [func-style](func-style.md) - enforces use of function declarations or expressions (off by default)
 * [new-cap](new-cap.md) - require a capital letter for constructors
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a contructor with no arguments
-* [no-nested-ternary](no-nested-ternary.md) - disallow nested ternary expressions
+* [no-nested-ternary](no-nested-ternary.md) - disallow nested ternary expressions (off by default)
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
-* [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block
+* [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block (off by default)
 * [no-new-object](no-new-object.md) - disallow use of the `Object` constructor
 * [no-spaced-func](no-spaced-func.md) - disallow space between function identifier and application
 * [no-space-before-semi](no-space-before-semi.md) - disallow space before semicolon
-* [no-ternary](no-ternary.md) - disallow the use of ternary operators
+* [no-ternary](no-ternary.md) - disallow the use of ternary operators (off by default)
 * [no-underscore-dangle](no-underscore-dangle.md) - disallow dangling underscores in identifiers
 * [no-wrap-func](no-wrap-func.md) - disallow wrapping of none IIFE statements in parents
 * [quotes](quotes.md) - specify whether double or single quotes should be used
-* [quote-props](quote-props.md) - require quotes around object literal property names
+* [quote-props](quote-props.md) - require quotes around object literal property names (off by default)
 * [semi](semi.md)- require or disallow use of semicolons instead of ASI
-* [sort-vars](sort-vars.md) - sort variables within the same declaration block
-* [space-after-keywords](space-after-keywords.md) - require a space after certain keywords
-* [space-in-brackets](space-in-brackets.md) - require or disallow spaces between brackets
+* [sort-vars](sort-vars.md) - sort variables within the same declaration block (off by default)
+* [space-after-keywords](space-after-keywords.md) - require a space after certain keywords (off by default)
+* [space-in-brackets](space-in-brackets.md) - require or disallow spaces between brackets (off by default)
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators
 * [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`
-* [space-unary-word-ops](space-unary-word-ops.md) - require a space around word operators such as `typeof`
-* [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested
-* [one-var](one-var.md) - allow just one var statement per function
-* [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses
+* [space-unary-word-ops](space-unary-word-ops.md) - require a space around word operators such as `typeof` (off by default)
+* [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested (off by default)
+* [one-var](one-var.md) - allow just one var statement per function (off by default)
+* [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses (off by default)
 
 ## Legacy
 


### PR DESCRIPTION
See issue #865.

I ran `node Makefile.js checkRuleFiles` and checked manually the result.
It works fine.

If you agree, I would add in this PR the fixes for the index.

```
Validating rules                                                                                       
Missing '(off by default)' for rule block-scoped-var in index                                          
Missing '(off by default)' for rule brace-style in index                                               
Missing '(off by default)' for rule complexity in index                                                
Missing '(off by default)' for rule default-case in index                                              
Missing '(off by default)' for rule func-names in index                                                
Missing '(off by default)' for rule func-style in index                                                
Missing '(off by default)' for rule handle-callback-err in index                                       
Missing '(off by default)' for rule max-nested-callbacks in index                                      
Missing '(off by default)' for rule no-div-regex in index                                              
Missing '(off by default)' for rule no-else-return in index                                            
Missing '(off by default)' for rule no-eq-null in index                                                
Missing '(off by default)' for rule no-extra-parens in index                                           
Missing '(off by default)' for rule no-floating-decimal in index                                       
Missing '(off by default)' for rule no-lonely-if in index                                              
Missing '(off by default)' for rule no-mixed-requires in index                                         
Missing '(off by default)' for rule no-nested-ternary in index                                         
Missing '(off by default)' for rule no-new-require in index                                            
Missing '(off by default)' for rule no-path-concat in index                                            
Missing '(off by default)' for rule no-restricted-modules in index                                     
Missing '(off by default)' for rule no-self-compare in index                                           
Missing '(off by default)' for rule no-ternary in index                                                
Missing '(off by default)' for rule no-warning-comments in index                                       
Missing '(off by default)' for rule one-var in index                                                   
Missing '(off by default)' for rule quote-props in index                                               
Missing '(off by default)' for rule radix in index                                                     
Missing '(off by default)' for rule sort-vars in index                                                 
Missing '(off by default)' for rule space-after-keywords in index                                      
Missing '(off by default)' for rule space-in-brackets in index                                         
Missing '(off by default)' for rule space-unary-word-ops in index                                      
Missing '(off by default)' for rule wrap-iife in index                                                 
Missing '(off by default)' for rule wrap-regex in index                                                
```
