### PR TITLE
add rule flag, closes #692

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -24,7 +24,7 @@ eslint [options] file.js [file.js] [dir]
 Options:
   -h, --help                 Show help.
   -c, --config path::String  Load configuration data from this file.
-  --rulesdir path::String    Load additional rules from this directory.
+  --rulesdir [path::String]  Load additional rules from this directory.
   -f, --format String        Use a specific output format. - default: stylish
   -v, --version              Outputs the version number.
   --reset                    Set all default rules to off.
@@ -32,6 +32,7 @@ Options:
   --env [String]             Specify environments.
   --force                    Allow linting of otherwise ignored files.
   --global [String]          Define global variables.
+  -r, --rule Object          Specify rules.
 ```
 
 ### `-h`, `--help`
@@ -113,6 +114,15 @@ Example:
 
     eslint --global require,exports:true file.js
     eslint --global require --global exports:true
+
+### `-r, --rule`
+
+This option specifies rules to be used. They will be merged into any previously defined rules. To start fresh, simply combine with the `--reset` flag. To define multiple rules, separate them using commas, or use the flag multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
+
+Example:
+
+    eslint --rule 'quotes: [2, double]'
+    eslint --rule 'guard-for-in: 2' --rule 'brace-style: [2, 1tbs]'
 
 ### `-v`, `--version`
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -210,6 +210,10 @@ Config.prototype.getConfig = function (filePath) {
     config = this.mergeConfigs(config, userConfig);
     config = this.mergeConfigs(config, { globals: this.globals });
 
+    if (this.options.rule) {
+      config = this.mergeConfigs(config, { rules: this.options.rule });
+    }
+
     this.cache[directory] = config;
 
     return config;

--- a/lib/options.js
+++ b/lib/options.js
@@ -18,6 +18,7 @@ var optionator = require("optionator");
 module.exports = optionator({
     prepend: "eslint [options] file.js [file.js] [dir]",
     concatRepeatedArrays: true,
+    mergeRepeatedObjects: true,
     options: [{
         heading: "Options"
     }, {
@@ -66,5 +67,10 @@ module.exports = optionator({
         option: "global",
         type: "[String]",
         description: "Define global variables."
+    },{
+      option: "rule",
+      alias: "r",
+      type: "Object",
+      description: "Specify rules."
     }]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -345,4 +345,18 @@ describe("cli", function() {
             assert.equal(exit, 0);
         });
     });
+
+    describe("when supplied with rule flag and severity level set to error", function() {
+        var code = "--rule 'quotes: [2, double]' single-quoted.js";
+
+        it("should exit with an error status (1)", function() {
+            var exitStatus;
+
+            assert.doesNotThrow(function () {
+                exitStatus = cli.execute(code);
+            });
+
+            assert.equal(exitStatus, 1);
+        });
+    });
 });


### PR DESCRIPTION
This is an initial attempt at this - please let me know if this is what you want.

I think this style - `--rule` merging with previous rules - is more useful than starting fresh with it, as it allows you to easily test out one small change to an existing config. If you want to start fresh you can simply use in combination with the `--reset` flag.

Also, is this using the `-r` alias OK, or should that be reserved for another flag?
