### PR TITLE
Fix: no-fallthrough should respect block statements in case statements

### DIFF
--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -25,6 +25,14 @@ module.exports = function(context) {
                 comments,
                 comment;
 
+            /*
+             * Some developers wrap case bodies in blocks, so if there is just one
+             * node and it's a block statement, check inside.
+             */
+            if (consequent.length === 1 && consequent[0].type === "BlockStatement") {
+                consequent = consequent[0];
+            }
+
             // checking on previous case
             if (!switchData.lastCaseClosed) {
 

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -27,6 +27,9 @@ eslintTester.addRuleTest("lib/rules/no-fallthrough", {
         "switch(foo) { case 0: case 1: a(); }",
         "switch(foo) { case 0: case 1: a(); break; }",
         "switch(foo) { case 0: case 1: break; }",
+        "function foo() { switch(foo) { case 0: case 1: return; } }",
+        "function foo() { switch(foo) { case 0: {return;}\n case 1: {return;} } }",
+        "switch(foo) { case 0: case 1: {break;} }",
         "switch(foo) { }",
         "switch(foo) { case 0: switch(bar) { case 2: break; } /* falls through */ case 1: break; }",
         "function foo() { switch(foo) { case 1: return a; a++; }}"


### PR DESCRIPTION
This checks to see if a `case` statement has only one child, a block statement, and if so, only looks inside of the block statement.
