### PR TITLE
Fix: Merge configs with ancestors (Fixes #820)

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -173,7 +173,7 @@ There are two ways to use configuration files. The first is to save the file whe
 
 Passing in the configuration file in this manner will override any default settings.
 
-The second way to use configuration files is via `.eslintrc` files. These files you place directly into your project directory and ESLint will automatically find them and read configuration information from them. This option is useful when you want different configurations for different parts of a project or when you want others to be able to use ESLint directly without needing to remember to pass in the configuration file.
+The second way to use configuration files is via `.eslintrc` files. Place these files in any directory and ESLint will automatically find them when invoked there or in any subdirectories. This option is useful when you want different configurations for different parts of a project or when you want others to be able to use ESLint directly without needing to remember to pass in the configuration file.
 
 In either case, the settings in the configuration file override default settings.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -92,12 +92,18 @@ function loadConfig(filePath) {
  * @returns {Object} the local config object (empty object if there is no local config)
  */
 function getLocalConfig(helper, directory) {
-    var localConfigFile = helper.findLocalConfigFile(directory),
-        config = {};
+    var localConfigFile,
+        config = {},
+        parentDirectory;
 
-    /* istanbul ignore else Too complicated to create unittest*/
-    if (localConfigFile) {
-        config = loadConfig(localConfigFile);
+    while ((localConfigFile = helper.findLocalConfigFile(directory))) {
+        config = util.mergeConfigs(loadConfig(localConfigFile), config);
+
+        parentDirectory = path.dirname(directory);
+        if (directory === parentDirectory) {
+            break;
+        }
+        directory = parentDirectory;
     }
 
     return config;

--- a/tests/fixtures/configurations/single-quotes/.eslintrc
+++ b/tests/fixtures/configurations/single-quotes/.eslintrc
@@ -4,6 +4,7 @@
     },
 
     "rules": {
-        "quotes": [1, "single"]
+        "quotes": [1, "single"],
+        "no-new": 1
     }
 }

--- a/tests/fixtures/configurations/single-quotes/subdir/.eslintrc
+++ b/tests/fixtures/configurations/single-quotes/subdir/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "rules": {
+        "dot-notation": 0
+    }
+}

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -223,9 +223,9 @@ describe("cli", function() {
         });
     });
 
-    describe("when given a custom rule, verify that it's loaded", function() {
+    describe("when loading a custom rule", function() {
 
-        it("should return a warning", function() {
+        it("should return an error when rule isn't found", function() {
             var code = "--rulesdir ./tests/fixtures/rules/wrong --config ./tests/fixtures/rules/eslint.json --force tests/fixtures/rules/test/test-custom-rule.js";
 
             assert.throws(function() {
@@ -234,13 +234,13 @@ describe("cli", function() {
             }, /Error while loading rule 'custom-rule': Cannot read property/);
         });
 
-        it("should return a warning", function() {
+        it("should return a warning when rule is matched", function() {
             var code = "--rulesdir ./tests/fixtures/rules --config ./tests/fixtures/rules/eslint.json --force tests/fixtures/rules/test/test-custom-rule.js";
-            var exit = cli.execute(code);
+
+            cli.execute(code);
 
             assert.isTrue(console.log.calledOnce);
             assert.isTrue(console.log.neverCalledWith(""));
-            assert.equal(exit, 1);
         });
 
         it("should return warnings from multiple rules in different directories", function() {

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -84,6 +84,18 @@ describe("config", function() {
         });
     });
 
+    describe("getLocalConfig with nested directories", function() {
+        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", "subdir", ".eslintrc");
+
+        it("should be merged config", function() {
+            var configHelper = new Config(),
+                config = configHelper.getConfig(code);
+
+            assert.equal(config.rules["dot-notation"], 0);
+            assert.equal(config.rules["no-new"], 1);
+        });
+    });
+
     describe("getConfig with exclude", function() {
         var code = path.resolve(__dirname, "..", "fixtures", ".eslintrc");
 
@@ -102,12 +114,14 @@ describe("config", function() {
 
         it("should be default config", function() {
             var configHelper = new Config();
-            sinon.stub(configHelper, "findLocalConfigFile", function(directory) { return path.resolve(directory, ".eslintrc"); });
+            sinon.stub(configHelper, "findLocalConfigFile", function(directory) {
+                return path.resolve(directory, ".eslintrc");
+            });
             sinon.stub(console, "error").returns({});
 
             configHelper.getConfig(code);
 
-            assert.isTrue(console.error.calledTwice);
+            assert.isTrue(console.error.called);
             configHelper.findLocalConfigFile.restore();
             console.error.restore();
         });
@@ -120,10 +134,13 @@ describe("config", function() {
             var configHelper = new Config();
 
             sinon.spy(configHelper, "findLocalConfigFile");
+
             configHelper.getConfig(code);
+            var callcount = configHelper.findLocalConfigFile.callcount;
             configHelper.getConfig(code);
 
-            assert.isTrue(configHelper.findLocalConfigFile.calledOnce);
+            assert.equal(callcount, configHelper.findLocalConfigFile.callcount);
+
             configHelper.findLocalConfigFile.restore();
         });
     });
@@ -200,8 +217,7 @@ describe("config", function() {
                     actualQuotes = actual.rules.quotes[0];
 
                 assert.notEqual(expectedQuotes, actualQuotes);
-            }
-            finally {
+            } finally {
                 process.chdir(cwd);
             }
         });

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -8,9 +8,7 @@
 // Helper
 //------------------------------------------------------------------------------
 
-/**
- * To make sure this works in both browsers and Node.js
- */
+// To make sure this works in both browsers and Node.js
 function compatRequire(name, windowName) {
     if (typeof require === "function") {
         return require(name);
@@ -688,7 +686,7 @@ describe("eslint", function() {
             ].join("\n");
 
             function assertJSDoc(node) {
-                if(node.params.length === 1) {
+                if (node.params.length === 1) {
                     var jsdoc = eslint.getJSDocComment(node);
                     assert.equal(jsdoc, null);
                 }
@@ -1497,7 +1495,11 @@ describe("eslint", function() {
         it("can add a rule dynamically", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
-                return {"Literal": function(node) { context.report(node, "message"); }};
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message");
+                    }
+                };
             });
 
             var config = { rules: {} };
@@ -1518,10 +1520,14 @@ describe("eslint", function() {
             eslint.reset();
             var config = { rules: {} };
             var newRules = {};
-            code.forEach(function(item){
+            code.forEach(function(item) {
                 config.rules[item] = 1;
                 newRules[item] = function(context) {
-                    return {"Literal": function(node) { context.report(node, "message"); }};
+                    return {
+                        "Literal": function(node) {
+                            context.report(node, "message");
+                        }
+                    };
                 };
             });
             eslint.defineRules(newRules);
@@ -1529,10 +1535,14 @@ describe("eslint", function() {
             var messages = eslint.verify("0", config, filename);
 
             assert.equal(messages.length, code.length);
-            code.forEach(function(item){
-                assert.ok(messages.some(function(message){ return message.ruleId === item; }));
+            code.forEach(function(item) {
+                assert.ok(messages.some(function(message) {
+                    return message.ruleId === item;
+                }));
             });
-            messages.forEach(function(message){ assert.equal(message.node.type, "Literal"); });
+            messages.forEach(function(message) {
+                assert.equal(message.node.type, "Literal");
+            });
         });
     });
 
@@ -1542,7 +1552,11 @@ describe("eslint", function() {
         it("has access to the filename", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
-                return {"Literal": function(node) { context.report(node, context.getFilename()); }};
+                return {
+                    "Literal": function(node) {
+                        context.report(node, context.getFilename());
+                    }
+                };
             });
 
             var config = { rules: {} };
@@ -1556,7 +1570,11 @@ describe("eslint", function() {
         it("defaults filename to '<input>'", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
-                return {"Literal": function(node) { context.report(node, context.getFilename()); }};
+                return {
+                    "Literal": function(node) {
+                        context.report(node, context.getFilename());
+                    }
+                };
             });
 
             var config = { rules: {} };

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -28,7 +28,9 @@ describe("rules", function() {
         var code = "invaliddir";
 
         it("should log an error and exit", function() {
-            assert.throws(function() { rules.load(code); });
+            assert.throws(function() {
+                rules.load(code);
+            });
         });
     });
 

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -15,11 +15,11 @@ var assert = require("chai").assert,
 
 describe("util", function() {
     describe("when calling mixin()", function() {
-        var code = function() {
+        function code() {
             var a = {}, b = { foo: "f", bar: 1 };
             util.mixin(a, b);
             return [a, b];
-        };
+        }
 
         it("should add properties to target object", function() {
             var a = code()[0];


### PR DESCRIPTION
This change re-introduces the behavior of searching up through parent directories for .eslintrc config files, all the way up to root. Further notes on the commit.
