### PR TITLE
Fix: block-scoped-var respects decls in for and for-in (fixes #919)

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -96,6 +96,12 @@ module.exports = function(context) {
         declare(["arguments"]);
     }
 
+    function variableDeclarationHandler(node) {
+        declare(node.declarations.map(function(decl) {
+            return decl.id.name;
+        }));
+    }
+
     return {
         "Program": function() {
             scopeStack = [context.getScope().variables.map(function(v) {
@@ -108,9 +114,7 @@ module.exports = function(context) {
             pushScope();
             statements.forEach(function(stmt) {
                 if (stmt.type === "VariableDeclaration") {
-                    declare(stmt.declarations.map(function(decl) {
-                        return decl.id.name;
-                    }));
+                    variableDeclarationHandler(stmt);
                 } else if (stmt.type === "FunctionDeclaration") {
                     declare([stmt.id.name]);
                 }
@@ -125,10 +129,26 @@ module.exports = function(context) {
         },
 
         "FunctionDeclaration": functionHandler,
-        "FunctionExpression": functionHandler,
-
         "FunctionDeclaration:exit": popScope,
+
+        "FunctionExpression": functionHandler,
         "FunctionExpression:exit": popScope,
+
+        "ForStatement": function(node) {
+            pushScope();
+            if (node.init && node.init.type === "VariableDeclaration") {
+                variableDeclarationHandler(node.init);
+            }
+        },
+        "ForStatement:exit": popScope,
+
+        "ForInStatement": function(node) {
+            pushScope();
+            if (node.left.type === "VariableDeclaration") {
+                variableDeclarationHandler(node.left);
+            }
+        },
+        "ForInStatement:exit": popScope,
 
         "Identifier": function(node) {
             var ancestor = context.getAncestors().pop();

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -39,7 +39,10 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         "var a = { set foo(a){}, get bar(){} };",
         "function f(a) { return arguments[0]; }",
         "function f() { }; var a = f;",
-        "var a = f; function f() { };"
+        "var a = f; function f() { };",
+        "function f(){ for(var i; i; i) i; }",
+        "function f(){ for(var a=0, b=1; a; b) a, b; }",
+        "function f(){ for(var a in {}) a; }"
     ],
     invalid: [
         { code: "function f(){ x; }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },


### PR DESCRIPTION
Fixes #919.
