### PR TITLE
Docs: Add '/', forgotten in first commit (Fixes #931)

### DIFF
--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -94,7 +94,7 @@ object.method = function() {
 }
 ```
 
-Even in "never" mode, semicolons are still allowed to disambiguate statements beginning with `[`, `(`, `+`, or `-`:
+Even in "never" mode, semicolons are still allowed to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`:
 
 ```js
 var name = "ESLint"


### PR DESCRIPTION
I missed one of the characters in the opt-out-pattern in the first pull request (#932). Whoopsie.
