### PR TITLE
Fix: Adding check if char can be capitalized to new-cap (Fixes #940)

### DIFF
--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -53,12 +53,23 @@ module.exports = function(context) {
     }
 
     /**
-     * Check if string first letter is upper-case
+     * Check if first letter of string can be upper-case
+     * @param {String} str String
+     * @returns {Boolean} Can be upper-case
+     */
+    function canCap(str) {
+        var firstChar = str.charAt(0);
+        return firstChar.toLowerCase() !== firstChar.toUpperCase();
+    }
+
+    /**
+     * Check if first letter of string is upper-case
      * @param {String} str String
      * @returns {Boolean} Is upper-case
      */
     function isCap(str) {
-        return str.charAt(0) === str.charAt(0).toUpperCase();
+        var firstChar = str.charAt(0);
+        return firstChar === firstChar.toUpperCase();
     }
 
     //--------------------------------------------------------------------------
@@ -69,7 +80,7 @@ module.exports = function(context) {
         listeners.NewExpression = function(node) {
 
             var constructorName = extractNameFromExpression(node);
-            if (constructorName && !isCap(constructorName)) {
+            if (constructorName && canCap(constructorName) && !isCap(constructorName)) {
                 context.report(node, "A constructor name should start with an uppercase letter.");
             }
         };
@@ -79,7 +90,7 @@ module.exports = function(context) {
         listeners.CallExpression = function(node) {
 
             var calleeName = extractNameFromExpression(node);
-            if (calleeName && CAPS_ALLOWED.indexOf(calleeName) < 0 && isCap(calleeName)) {
+            if (calleeName && canCap(calleeName) && CAPS_ALLOWED.indexOf(calleeName) < 0 && isCap(calleeName)) {
                 context.report(node, "Function with uppercase-started name should be used as a constructor only.");
             }
         };

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -36,6 +36,8 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         "var x = Array(42)",
         "var x = String(42)",
         "var x = RegExp(42)",
+        "var x = $(42)",
+        "var x = Σ;",
         {code: "var x = Foo(42)", args: [1, {"capIsNew": false}]},
         {code: "var x = bar.Foo(42)", args: [1, {"capIsNew": false}]},
         "var x = bar[Foo](42)",


### PR DESCRIPTION
Fixes #940 

Adding a check to new new-cap options added in #904 to first see if the first character **can** be capitalized (in other words, if it's alphabetic). If it can't, then without this fix, one or the other of the rules' options must fail.

Note that the set of characters that can be capitalized is much larger than [A-Za-z].
