### PR TITLE
Fix: Adding check if char is non-alphabetic to new-cap (Fixes #940)

### DIFF
--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -53,12 +53,25 @@ module.exports = function(context) {
     }
 
     /**
-     * Check if string first letter is upper-case
+     * Returns the capitalization state of the string -
+     * Whether the first character is uppercase, lowercase, or non-alphabetic
      * @param {String} str String
-     * @returns {Boolean} Is upper-case
+     * @returns {String} capitalization state: "non-alpha", "lower", or "upper"
      */
-    function isCap(str) {
-        return str.charAt(0) === str.charAt(0).toUpperCase();
+    function getCap(str) {
+        var firstChar = str.charAt(0);
+
+        var firstCharLower = firstChar.toLowerCase();
+        var firstCharUpper = firstChar.toUpperCase();
+
+        if (firstCharLower === firstCharUpper) {
+            // char has no uppercase variant, so it's non-alphabetic
+            return "non-alpha";
+        } else if (firstChar === firstCharLower) {
+            return "lower";
+        } else {
+            return "upper";
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -69,8 +82,8 @@ module.exports = function(context) {
         listeners.NewExpression = function(node) {
 
             var constructorName = extractNameFromExpression(node);
-            if (constructorName && !isCap(constructorName)) {
-                context.report(node, "A constructor name should start with an uppercase letter.");
+            if (constructorName && getCap(constructorName) === "lower") {
+                context.report(node, "A constructor name should not start with a lowercase letter.");
             }
         };
     }
@@ -79,8 +92,8 @@ module.exports = function(context) {
         listeners.CallExpression = function(node) {
 
             var calleeName = extractNameFromExpression(node);
-            if (calleeName && CAPS_ALLOWED.indexOf(calleeName) < 0 && isCap(calleeName)) {
-                context.report(node, "Function with uppercase-started name should be used as a constructor only.");
+            if (calleeName && CAPS_ALLOWED.indexOf(calleeName) < 0 && getCap(calleeName) === "upper") {
+                context.report(node, "A function with a name starting with an uppercase letter should only be used as a constructor.");
             }
         };
     }

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -36,6 +36,8 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         "var x = Array(42)",
         "var x = String(42)",
         "var x = RegExp(42)",
+        "var x = _();",
+        "var x = $();",
         {code: "var x = Foo(42)", args: [1, {"capIsNew": false}]},
         {code: "var x = bar.Foo(42)", args: [1, {"capIsNew": false}]},
         "var x = bar[Foo](42)",
@@ -44,12 +46,12 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         {code: "var x = new foo(42)", args: [1, {"newIsCap": false}]}
     ],
     invalid: [
-        { code: "var x = new c();", errors: [{ message: "A constructor name should start with an uppercase letter.", type: "NewExpression"}] },
-        { code: "var x = new φ;", errors: [{ message: "A constructor name should start with an uppercase letter.", type: "NewExpression"}] },
-        { code: "var x = new a.b.c;", errors: [{ message: "A constructor name should start with an uppercase letter.", type: "NewExpression"}] },
-        { code: "var x = new a.b['c'];", errors: [{ message: "A constructor name should start with an uppercase letter.", type: "NewExpression"}] },
-        { code: "var b = Foo();", errors: [{ message: "Function with uppercase-started name should be used as a constructor only.", type: "CallExpression"}] },
-        { code: "var b = a.Foo();", errors: [{ message: "Function with uppercase-started name should be used as a constructor only.", type: "CallExpression"}] },
-        { code: "var b = a['Foo']();", errors: [{ message: "Function with uppercase-started name should be used as a constructor only.", type: "CallExpression"}] }
+        { code: "var x = new c();", errors: [{ message: "A constructor name should not start with a lowercase letter.", type: "NewExpression"}] },
+        { code: "var x = new φ;", errors: [{ message: "A constructor name should not start with a lowercase letter.", type: "NewExpression"}] },
+        { code: "var x = new a.b.c;", errors: [{ message: "A constructor name should not start with a lowercase letter.", type: "NewExpression"}] },
+        { code: "var x = new a.b['c'];", errors: [{ message: "A constructor name should not start with a lowercase letter.", type: "NewExpression"}] },
+        { code: "var b = Foo();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
+        { code: "var b = a.Foo();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
+        { code: "var b = a['Foo']();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] }
     ]
 });


### PR DESCRIPTION
Fixes #940

Prior discussion in #941

I also updated the error messages to be more consistent with the new logic of the rule.
