### PR TITLE
Fix: Corrects configs merging into base config (Fixes #838)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -187,7 +187,8 @@ Config.prototype.getConfig = function (filePath) {
         });
     }
 
-    config = this.mergeConfigs(Object.create(this.baseConfig), envConfig);
+    config = this.mergeConfigs({}, this.baseConfig);
+    config = this.mergeConfigs(config, envConfig);
     config = this.mergeConfigs(config, userConfig);
     config = this.mergeConfigs(config, { globals: this.globals });
 

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -285,13 +285,14 @@ describe("cli", function() {
         ];
 
         it("should allow environment-specific globals", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser,node --no-ignore " + files.join(" "));
-            assert.equal(console.log.args[0][0].split("\n").length, 11);
+            cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --env browser,node --no-ignore " + files.join(" "));
+
+            assert.equal(console.log.args[0][0].split("\n").length, 9);
         });
 
         it("should allow environment-specific globals, with multiple flags", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json --env browser --env node --no-ignore " + files.join(" "));
-            assert.equal(console.log.args[0][0].split("\n").length, 11);
+            cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --env browser --env node --no-ignore " + files.join(" "));
+            assert.equal(console.log.args[0][0].split("\n").length, 9);
         });
     });
 
@@ -302,8 +303,8 @@ describe("cli", function() {
         ];
 
         it("should not define environment-specific globals", function () {
-            cli.execute("--no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
-            assert.equal(console.log.args[0][0].split("\n").length, 14);
+            cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
+            assert.equal(console.log.args[0][0].split("\n").length, 12);
         });
     });
 

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -71,6 +71,22 @@ describe("config", function() {
         });
     });
 
+    describe("getConfig", function() {
+        var firstpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", "subdir", ".eslintrc");
+        var secondpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
+
+        it("should not retain configs from previous directories", function() {
+            var configHelper = new Config(),
+                config;
+
+            config = configHelper.getConfig(firstpath);
+            assert.equal(0, config.rules["dot-notation"]);
+
+            config = configHelper.getConfig(secondpath);
+            assert.equal(2, config.rules["dot-notation"]);
+        });
+    });
+
     describe("getLocalConfig with directory", function() {
         var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
 
@@ -114,14 +130,15 @@ describe("config", function() {
         });
     });
 
-    describe("should cache config", function() {
+    describe("getConfig", function() {
         var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
 
-        it("should resolve config only once", function() {
+        it("should cache config", function() {
             var configHelper = new Config();
 
             sinon.spy(configHelper, "findLocalConfigFile");
 
+            // If cached this should be called only once
             configHelper.getConfig(code);
             var callcount = configHelper.findLocalConfigFile.callcount;
             configHelper.getConfig(code);


### PR DESCRIPTION
Fixes #838

Took a while to track down but I found the problem causing #838. The baseConfig object was actually being used as the main config that new configs would write into, and retained over multiple runs of `getConfig()` - it seems that someone might have thought that `Object.create(this.baseConfig)` deep clones a new object based on the properties of `this.baseConfig`, when in fact it creates a new object with `this.baseConfig` as the prototype. Each subsequent `mergeConfig` was actually overwriting properties on `this.baseConfig`, which is why the .eslintrc from b/ was being used as the config for all subsequent lintings even when b/ was exited.

A better solution to this might be to just use underscore/lodash _.extend instead of `mergeConfigs()` in lib/util.js, but I didn't attempt that for this fix because I'm not sure of all the implications of `mergeConfigs()`'s logic.

Further comments inline with the commit.
