### PR TITLE
Fix: Correct order of arguments passed to assert.equal (fixes #945)

### DIFF
--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -26,7 +26,7 @@ describe("config", function() {
                 expected = path.resolve(code, ".eslintrc"),
                 actual = configHelper.findLocalConfigFile(code);
 
-            assert.equal(expected, actual);
+            assert.equal(actual, expected);
         });
     });
 
@@ -53,7 +53,7 @@ describe("config", function() {
                 expected = 0,
                 actual = config.rules["no-global-strict"];
 
-            assert.equal(expected, actual);
+            assert.equal(actual, expected);
         });
     });
 
@@ -67,7 +67,7 @@ describe("config", function() {
                 expected = 1,
                 actual = config.rules["no-global-strict"];
 
-            assert.equal(expected, actual);
+            assert.equal(actual, expected);
         });
     });
 
@@ -80,10 +80,10 @@ describe("config", function() {
                 config;
 
             config = configHelper.getConfig(firstpath);
-            assert.equal(0, config.rules["dot-notation"]);
+            assert.equal(config.rules["dot-notation"], 0);
 
             config = configHelper.getConfig(secondpath);
-            assert.equal(2, config.rules["dot-notation"]);
+            assert.equal(config.rules["dot-notation"], 2);
         });
     });
 
@@ -143,7 +143,7 @@ describe("config", function() {
             var callcount = configHelper.findLocalConfigFile.callcount;
             configHelper.getConfig(code);
 
-            assert.equal(callcount, configHelper.findLocalConfigFile.callcount);
+            assert.equal(configHelper.findLocalConfigFile.callcount, callcount);
 
             configHelper.findLocalConfigFile.restore();
         });

--- a/tests/lib/formatters/checkstyle.js
+++ b/tests/lib/formatters/checkstyle.js
@@ -29,7 +29,7 @@ describe("formatter:checkstyle", function() {
             var config = { rules: { foo: 2 } };
             var result = formatter(code, config);
 
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
         });
         it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
             var config = {
@@ -37,7 +37,7 @@ describe("formatter:checkstyle", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"warning\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"warning\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
         });
         it("should return a string in the format filename: line x, col y, Error - z for errors with options config", function() {
             var config = {
@@ -45,7 +45,7 @@ describe("formatter:checkstyle", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
         });
     });
 
@@ -65,7 +65,7 @@ describe("formatter:checkstyle", function() {
             var config = {};    // doesn't matter what's in the config for this test
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"&lt;&gt;&amp;&quot;&apos;.js\"><error line=\"&lt;\" column=\"&gt;\" severity=\"error\" message=\"Unexpected &lt;&gt;&amp;&quot;&apos;. (foo)\" /></file></checkstyle>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"&lt;&gt;&amp;&quot;&apos;.js\"><error line=\"&lt;\" column=\"&gt;\" severity=\"error\" message=\"Unexpected &lt;&gt;&amp;&quot;&apos;. (foo)\" /></file></checkstyle>");
         });
     });
 
@@ -85,7 +85,7 @@ describe("formatter:checkstyle", function() {
             var config = {};    // doesn't matter what's in the config for this test
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
         });
     });
 
@@ -111,7 +111,7 @@ describe("formatter:checkstyle", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" /></file></checkstyle>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" /></file></checkstyle>");
         });
     });
 
@@ -140,7 +140,7 @@ describe("formatter:checkstyle", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" /></file></checkstyle>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" /></file></checkstyle>");
         });
     });
 });

--- a/tests/lib/formatters/compact.js
+++ b/tests/lib/formatters/compact.js
@@ -27,7 +27,7 @@ describe("formatter:compact", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("", result);
+            assert.equal(result, "");
         });
     });
 
@@ -48,7 +48,7 @@ describe("formatter:compact", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem", result);
+            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
 
         it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
@@ -57,7 +57,7 @@ describe("formatter:compact", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("foo.js: line 5, col 10, Warning - Unexpected foo. (foo)\n\n1 problem", result);
+            assert.equal(result, "foo.js: line 5, col 10, Warning - Unexpected foo. (foo)\n\n1 problem");
         });
 
         it("should return a string in the format filename: line x, col y, Error - z for errors with options config", function() {
@@ -66,7 +66,7 @@ describe("formatter:compact", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem", result);
+            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
     });
 
@@ -86,7 +86,7 @@ describe("formatter:compact", function() {
             var config = {};    // doesn't matter what's in the config for this test
 
             var result = formatter(code, config);
-            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem", result);
+            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
     });
 
@@ -112,7 +112,7 @@ describe("formatter:compact", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems", result);
+            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
 
@@ -141,7 +141,7 @@ describe("formatter:compact", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems", result);
+            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
 
@@ -160,7 +160,7 @@ describe("formatter:compact", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem", result);
+            assert.equal(result, "foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem");
         });
     });
 });

--- a/tests/lib/formatters/jslint-xml.js
+++ b/tests/lib/formatters/jslint-xml.js
@@ -34,7 +34,7 @@ describe("formatter:jslint-xml", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
@@ -56,7 +56,7 @@ describe("formatter:jslint-xml", function() {
             var config = {};    // doesn't matter what's in the config for this test
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 
@@ -84,7 +84,7 @@ describe("formatter:jslint-xml", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
 
@@ -115,7 +115,7 @@ describe("formatter:jslint-xml", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
 
@@ -138,7 +138,7 @@ describe("formatter:jslint-xml", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected &gt; foo. (foo)\" /></file></jslint>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected &gt; foo. (foo)\" /></file></jslint>");
         });
     });
 
@@ -160,7 +160,7 @@ describe("formatter:jslint-xml", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"Unexpected foo. (foo)\" /></file></jslint>", result);
+            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
 });

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -62,7 +62,7 @@ describe("formatter:stylish", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("", result);
+            assert.equal(result, "");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 0);
         });
@@ -85,7 +85,7 @@ describe("formatter:stylish", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n", result);
+            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -96,7 +96,7 @@ describe("formatter:stylish", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem\n", result);
+            assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 1);
             assert.equal(chalkStub.red.bold.callCount, 0);
         });
@@ -107,7 +107,7 @@ describe("formatter:stylish", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n", result);
+            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -129,7 +129,7 @@ describe("formatter:stylish", function() {
             var config = {};    // doesn't matter what's in the config for this test
 
             var result = formatter(code, config);
-            assert.equal("\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n", result);
+            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -157,7 +157,7 @@ describe("formatter:stylish", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n", result);
+            assert.equal(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -188,7 +188,7 @@ describe("formatter:stylish", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n", result);
+            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -209,7 +209,7 @@ describe("formatter:stylish", function() {
             };
 
             var result = formatter(code, config);
-            assert.equal("\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem\n", result);
+            assert.equal(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });


### PR DESCRIPTION
Fixes #945
