### PR TITLE
Update: Search parent directories for .eslintignore (Fixes #933)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,16 +40,14 @@ function loadIgnoreFile(filePath) {
         text;
 
     if (filePath) {
-
-        // Read plain text .eslintignore file, one path per line, skipping empty lines
         try {
             text = fs.readFileSync(filePath, "utf8");
             exclusions = text.split("\n").filter(function (line) {
                 return line.trim() !== "";
             });
         } catch (e) {
-            /* istanbul ignore next Error handling doesn't need tests*/
-            throw new Error("Could not load local " + ESLINT_IGNORE_FILENAME + " file: " + filePath);
+            console.error("Cannot read ignore file: ", filePath);
+            console.error("Error: ", e.message);
         }
     }
 
@@ -68,7 +66,7 @@ function loadConfig(filePath) {
         try {
             config = yaml.safeLoad(stripComments(fs.readFileSync(filePath, "utf8")));
         } catch (e) {
-            console.error("Cannot read config file:", filePath);
+            console.error("Cannot read config file: ", filePath);
             console.error("Error: ", e.message);
         }
     }
@@ -115,7 +113,8 @@ function Config(options) {
     var useConfig;
     options = options || {};
 
-    this.ignorePath = options.ignore ? options.ignorePath || "./.eslintignore" : null;
+    this.ignore = options.ignore;
+    this.ignorePath = options.ignorePath;
 
     this.cache = {};
     this.baseConfig = options.reset ? { rules: {} } :
@@ -124,7 +123,6 @@ function Config(options) {
     this.useEslintrc = (options.eslintrc !== false);
     this.env = options.env;
     this.globals = (options.global || []).reduce(function (globals, def) {
-
         // Default "foo" to false and handle "foo:false" and "foo:true"
         var parts = def.split(":");
         globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
@@ -215,7 +213,7 @@ Config.prototype.mergeConfigs = function (base, custom) {
 /**
  * Find a local config file, relative to a specified directory.
  * @param {string} directory the directory to start searching from
- * @returns {string|boolean} returns path of config file if found, or false if no config is found
+ * @returns {string|boolean} path of config file if found, or false if no config is found
  */
 Config.prototype.findLocalConfigFile = function (directory) {
     if (!this.localConfigFinder) {
@@ -225,24 +223,29 @@ Config.prototype.findLocalConfigFile = function (directory) {
 };
 
 /**
- * Find a ignore file, relative to a specified directory.
- * @param {string} directory the directory to start searching from
- * @returns {string|boolean} returns path of ignore file if found, or false if no ignore is found
+ * Find an ignore file in the current directory.
+ * @returns {string|boolean} path of ignore file if found, or false if no ignore is found
  */
-Config.prototype.findIgnoreFile = function (directory) {
+Config.prototype.findIgnoreFile = function () {
     if (!this.ignoreFileFinder) {
         this.ignoreFileFinder = new FileFinder(ESLINT_IGNORE_FILENAME);
     }
-    return this.ignoreFileFinder.findInDirectory(directory);
+    return this.ignoreFileFinder.findInDirectory();
 };
 
-Config.prototype.getExclusions = function() {
-    if (this.ignorePath && fs.existsSync(this.ignorePath)) {
-        return loadIgnoreFile(this.ignorePath);
+/**
+ * Return the exclusions, the list of file patterns to ignore for linting
+ * @returns {Array} array of file patterns
+ */
+Config.prototype.getExclusions = function () {
+    var ignoreFile;
+
+    if (this.ignore) {
+        ignoreFile = this.ignorePath || this.findIgnoreFile();
+        return loadIgnoreFile(ignoreFile);
     } else {
         return [];
     }
-
 };
 
 module.exports = Config;

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -221,4 +221,21 @@ describe("config", function() {
         });
     });
 
+    describe("getExclusions", function() {
+        it("should travel to parent directories to find .eslintignore", function() {
+            var configHelper = new Config({ignore: true}),
+                cwd = process.cwd(),
+                exclusions;
+
+            process.chdir(path.resolve(__dirname, "..", "fixtures", "configurations"));
+
+            try {
+                exclusions = configHelper.getExclusions();
+                assert.notEqual(exclusions.length, 0);
+            } finally {
+                process.chdir(cwd);
+            }
+        });
+    });
+
 });


### PR DESCRIPTION
Fixes #933.

The refactor from #928 retained Config's `.findIgnoreFile()` method but didn't use it anywhere, thus skirting FileFinder's logic to search up through parent directories. This change merges that refactor and the logic from before which did use `.findIgnoreFile()`, restoring the behavior of searching parent directories if `.eslintignore` is not found in the current directory. Unlike for configs, multiple ignore files will not be merged, the first found will be the only one used. If an ignorePath is given as a command line option, that path will be the only location checked, parent directories will not be considered.

Test added to confirm the change, and other minor cleanup / consistency relevant to changes in config.js.
