### PR TITLE
Update: Search parent directories for .eslintignore (Fixes #933)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -40,16 +40,14 @@ function loadIgnoreFile(filePath) {
         text;
 
     if (filePath) {
-
-        // Read plain text .eslintignore file, one path per line, skipping empty lines
         try {
             text = fs.readFileSync(filePath, "utf8");
             exclusions = text.split("\n").filter(function (line) {
                 return line.trim() !== "";
             });
         } catch (e) {
-            /* istanbul ignore next Error handling doesn't need tests*/
-            throw new Error("Could not load local " + ESLINT_IGNORE_FILENAME + " file: " + filePath);
+            e.message = "Cannot read ignore file: " + filePath + "\nError: " + e.message;
+            throw e;
         }
     }
 
@@ -68,8 +66,8 @@ function loadConfig(filePath) {
         try {
             config = yaml.safeLoad(stripComments(fs.readFileSync(filePath, "utf8")));
         } catch (e) {
-            console.error("Cannot read config file:", filePath);
-            console.error("Error: ", e.message);
+            e.message = "Cannot read config file: " + filePath + "\nError: " + e.message;
+            throw e;
         }
     }
 
@@ -115,7 +113,8 @@ function Config(options) {
     var useConfig;
     options = options || {};
 
-    this.ignorePath = options.ignore ? options.ignorePath || "./.eslintignore" : null;
+    this.ignore = options.ignore;
+    this.ignorePath = options.ignorePath;
 
     this.cache = {};
     this.baseConfig = options.reset ? { rules: {} } :
@@ -124,7 +123,6 @@ function Config(options) {
     this.useEslintrc = (options.eslintrc !== false);
     this.env = options.env;
     this.globals = (options.global || []).reduce(function (globals, def) {
-
         // Default "foo" to false and handle "foo:false" and "foo:true"
         var parts = def.split(":");
         globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
@@ -215,7 +213,7 @@ Config.prototype.mergeConfigs = function (base, custom) {
 /**
  * Find a local config file, relative to a specified directory.
  * @param {string} directory the directory to start searching from
- * @returns {string|boolean} returns path of config file if found, or false if no config is found
+ * @returns {string|boolean} path of config file if found, or false if no config is found
  */
 Config.prototype.findLocalConfigFile = function (directory) {
     if (!this.localConfigFinder) {
@@ -225,24 +223,29 @@ Config.prototype.findLocalConfigFile = function (directory) {
 };
 
 /**
- * Find a ignore file, relative to a specified directory.
- * @param {string} directory the directory to start searching from
- * @returns {string|boolean} returns path of ignore file if found, or false if no ignore is found
+ * Find an ignore file in the current directory.
+ * @returns {string|boolean} path of ignore file if found, or false if no ignore is found
  */
-Config.prototype.findIgnoreFile = function (directory) {
+Config.prototype.findIgnoreFile = function () {
     if (!this.ignoreFileFinder) {
         this.ignoreFileFinder = new FileFinder(ESLINT_IGNORE_FILENAME);
     }
-    return this.ignoreFileFinder.findInDirectory(directory);
+    return this.ignoreFileFinder.findInDirectory();
 };
 
-Config.prototype.getExclusions = function() {
-    if (this.ignorePath && fs.existsSync(this.ignorePath)) {
-        return loadIgnoreFile(this.ignorePath);
+/**
+ * Return the exclusions, the list of file patterns to ignore for linting
+ * @returns {Array} array of file patterns
+ */
+Config.prototype.getExclusions = function () {
+    var ignoreFile;
+
+    if (this.ignore) {
+        ignoreFile = this.ignorePath || this.findIgnoreFile();
+        return loadIgnoreFile(ignoreFile);
     } else {
         return [];
     }
-
 };
 
 module.exports = Config;

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -9,6 +9,7 @@
 
 var assert = require("chai").assert,
     path = require("path"),
+    fs = require("fs"),
     Config = require("../../lib/config"),
     sinon = require("sinon");
 
@@ -113,20 +114,32 @@ describe("config", function() {
     });
 
     describe("getLocalConfig with invalid directory", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes");
+        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "foobaz", ".eslintrc");
 
-        it("should be default config", function() {
+        it("should throw error", function() {
             var configHelper = new Config();
-            sinon.stub(configHelper, "findLocalConfigFile", function(directory) {
-                return path.resolve(directory, ".eslintrc");
+
+            assert.throws(function () {
+                configHelper.getConfig(code);
             });
-            sinon.stub(console, "error").returns({});
+        });
+    });
 
-            configHelper.getConfig(code);
+    describe("getLocalConfig with invalid file", function() {
+        var code = path.resolve(__dirname, "..", "fixtures", "configurations", ".eslintrc");
 
-            assert.isTrue(console.error.called);
-            configHelper.findLocalConfigFile.restore();
-            console.error.restore();
+        it("should throw error", function() {
+            var configHelper = new Config();
+
+            sinon.stub(fs, "readFileSync", function() {
+                throw new Error();
+            });
+
+            assert.throws(function () {
+                configHelper.getConfig(code);
+            }, "Cannot read config file");
+
+            fs.readFileSync.restore();
         });
     });
 
@@ -218,6 +231,35 @@ describe("config", function() {
 
             assert.equal(noAlert, 0);
             assert.equal(noUndef, 2);
+        });
+    });
+
+    describe("getExclusions", function() {
+        it("should travel to parent directories to find .eslintignore", function() {
+            var configHelper = new Config({ignore: true}),
+                cwd = process.cwd(),
+                exclusions;
+
+            process.chdir(path.resolve(__dirname, "..", "fixtures", "configurations"));
+
+            try {
+                exclusions = configHelper.getExclusions();
+                assert.notEqual(exclusions.length, 0);
+            } finally {
+                process.chdir(cwd);
+            }
+        });
+    });
+
+    describe("getExclusions with invalid file", function() {
+        var code = path.resolve(__dirname, "..", "fixtures", "configurations", ".foobaz");
+
+        it("should throw error", function() {
+            var configHelper = new Config({ignore: true, ignorePath: code});
+
+            assert.throws(function () {
+                configHelper.getExclusions();
+            }, "Cannot read ignore file");
         });
     });
 


### PR DESCRIPTION
Fixes #933. Corrected to throw errors instead of just logging them based on discussion in #947. Changed tests to use `assert.throws` based on advice in #949.

The refactor from #928 retained Config's `.findIgnoreFile()` method but didn't use it anywhere, thus skirting FileFinder's logic to search up through parent directories. This change merges that refactor and the logic from before which did use `.findIgnoreFile()`, restoring the behavior of searching parent directories if `.eslintignore` is not found in the current directory. Unlike for configs, multiple ignore files will not be merged, the first found will be the only one used. If an ignorePath is given as a command line option, that path will be the only location checked, parent directories will not be considered.

Tests added to confirm the change and the error throwing, and other minor cleanup / consistency relevant to changes in config.js.
