### PR TITLE
Introduce '--silent' option, fixes #905

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -161,13 +161,12 @@ function processFiles(files, configHelper) {
 
             if (configHelper.options.force || !isExcluded(filename, exclusions)) {
                 errors += processFile(filename, configHelper);
-            } else if (files.indexOf(filename) > -1) {
-
+            } else if (files.indexOf(filename) > -1 && !configHelper.options.silent) {
                 debug("Ignoring " + filename);
                 // only warn for files explicitly passes on the command line
                 storeResults(filename, [{
                     fatal: false,
-                    message: "File ignored because of your .eslintignore file. Use --no-ignore to override."
+                    message: "File ignored because of your .eslintignore file. Use --no-ignore to override, or --silent to exclude warnings."
                 }]);
             }
         }

--- a/lib/options.js
+++ b/lib/options.js
@@ -78,5 +78,10 @@ module.exports = optionator({
         type: "Boolean",
         default: "true",
         description: "Enable loading of .eslintignore."
+    },
+    {
+        option: "silent",
+        type: "Boolean",
+        description: "Only output errors, and exclude warnings."
     }]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -189,6 +189,14 @@ describe("cli", function() {
             assert.equal(exit, 0);
         });
 
+        it("should not output a warning when silenced", function () {
+            var exit = cli.execute("--silent --ignore-path tests/fixtures/.eslintignore tests/fixtures/passing.js");
+
+            // no warnings
+            assert.isFalse(console.log.called);
+            assert.equal(exit, 0);
+        });
+
         it("should process the file when forced", function() {
             var exit = cli.execute("--ignore-path tests/fixtures/.eslintignore --no-ignore tests/fixtures/passing.js");
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -108,6 +108,13 @@ describe("options", function() {
         });
     });
 
+    describe("when passed --silent", function() {
+        it("should return true for .silent", function() {
+            var currentOptions = options.parse("--silent");
+            assert.isTrue(currentOptions.silent);
+        });
+    });
+
     describe("when passed --global", function() {
         it("should return an array for a single occurrence", function () {
             var currentOptions = options.parse("--global foo");


### PR DESCRIPTION
This fixes #905 **Implement --silent to only output errors and not warnings**

I initially envisioned this option as a more specific option like `--warn-ignored-files=false`, but finally decided to go with the result of the discussion that already took place in #905 and changed it to `--silent`

I'll be away until next week, so feel free to merge this change, perform additional changes, or just comment and wait for me to be back :)
