### PR TITLE
Allow the option "color".

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -78,5 +78,11 @@ module.exports = optionator({
         type: "Boolean",
         default: "true",
         description: "Enable loading of .eslintignore."
+    },
+    {
+        option: "color",
+        type: "Boolean",
+        default: "true",
+        description: "Enable color in piped output."
     }]
 });

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -108,6 +108,13 @@ describe("options", function() {
         });
     });
 
+    describe("when passed --color", function() {
+        it("should return true for .color", function() {
+            var currentOptions = options.parse("--color");
+            assert.isTrue(currentOptions.color);
+        });
+    });
+
     describe("when passed --global", function() {
         it("should return an array for a single occurrence", function () {
             var currentOptions = options.parse("--global foo");


### PR DESCRIPTION
This enables colourised output when piping eslint's output.

Useage: `eslint --color | head`
