### PR TITLE
Fix: valid-jsdoc no more warning for multi-level params (Fixes #925)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -102,7 +102,7 @@ module.exports = function(context) {
 
                         if (params[tag.name]) {
                             context.report(jsdocNode, "Duplicate JSDoc parameter '{{name}}'.", { name: tag.name });
-                        } else {
+                        } else if (tag.name.indexOf(".") === - 1){
                             params[tag.name] = 1;
                         }
                         break;

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -28,6 +28,7 @@ eslintTester.addRuleTest("lib/rules/valid-jsdoc", {
         "/**\n* Description\n* @param {Object} p bar\n* @param {string} p.name bar\n* @returns {string} desc */\nFoo.bar = function(p){};",
         "(function(){\n/**\n* Description\n* @param {string} p bar\n* @returns {string} desc */\nfunction foo(p){}\n}())",
         "var o = {\n/**\n* Description\n* @param {string} p bar\n* @returns {string} desc */\nfoo: function(p){}\n};",
+        "/**\n* Description\n* @param {Object} p bar\n* @param {string[]} p.files qux\n* @param {Function} cb baz\n* @returns {void} */\nfunction foo(p, cb){}",
         {
             code: "/**\n* Description\n* @return {void} */\nfunction foo(){}",
             args: [1, {}]


### PR DESCRIPTION
Multi-level params (containing a dot) format is checked but the final matching is skipped.
