### PR TITLE
Update: space-in-brackets now always allows empty object and array liter...

### DIFF
--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -14,82 +14,49 @@ foo['bar'];
 
 ## Rule Details
 
-This rule aims to maintain consistency around the spacing inside of square brackets, either by disallowing spaces inside of brackets between the brackets and other tokens or enforcing spaces. Multi-line Array and Object literals with no values on the same line as the brackets are excepted from this rule as this is a common pattern.
+This rule aims to maintain consistency around the spacing inside of square brackets, either by disallowing spaces inside of brackets between the brackets and other tokens or enforcing spaces. Multi-line array and object literals with no values on the same line as the brackets are excepted from this rule as this is a common pattern.
 
-The following patterns are considered warnings:
+### Options
+
+There are two options for this rule:
+
+* `"always"` enforces a space inside of object and array literals
+* `"never"` enforces zero spaces inside of object and array literals (default)
+
+Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+
+```json
+"space-in-brackets": [2, "always"]
+```
+
+#### never
+
+When `"never"` is set, the following patterns are considered warnings:
 
 ```js
-// When options are [2, "never"]
-
 foo[ 'bar' ];
-
 foo['bar' ];
-
 foo[
     'bar'
 ];
 
 var arr = [ 'foo', 'bar' ];
-
 var arr = ['foo', 'bar' ];
-
 var arr = [ ['foo'], 'bar'];
-
 var arr = [[ 'foo' ], 'bar'];
-
-var arr = ['foo', 
-  'bar' 
+var arr = ['foo',
+  'bar'
 ];
 
 var arr = [
-  'foo', 
+  'foo',
   'bar'];
 
 var obj = { 'foo': 'bar' };
-
 var obj = {'foo': 'bar' };
-
 var obj = { baz: {'foo': 'qux'}, 'bar'};
-
 var obj = {baz: { 'foo': 'qux' }, 'bar'};
-
-var obj = {'foo': 'bar' 
-};
-
-var obj = {
-  'foo':bar'};
-
-// When options are [2, "always"]
-
-foo['bar'];
-
-foo['bar' ];
-
-foo[ 'bar'];
-
-var arr = ['foo', 'bar'];
-
-var arr = ['foo', 'bar' ];
-
-var arr = [ ['foo'], 'bar' ];
-
-var arr = ['foo', 
-  'bar' 
-];
-
-var arr = [
-  'foo', 
-  'bar'];
-
-var obj = {'foo': 'bar'};
-
-var obj = {'foo': 'bar' };
-
-var obj = { baz: {'foo': 'qux'}, 'bar'};
-
-var obj = {baz: { 'foo': 'qux' }, 'bar'};
-
-var obj = {'foo': 'bar' 
+var obj = {'foo': 'bar'
 };
 
 var obj = {
@@ -104,13 +71,12 @@ The following patterns are not warnings:
 
 foo['bar'];
 
+var arr = [];
 var arr = ['foo', 'bar', 'baz'];
-
 var arr = [['foo'], 'bar', 'baz'];
-
 var arr = [
-  'foo', 
-  'bar', 
+  'foo',
+  'bar',
   'baz'
 ];
 
@@ -122,44 +88,68 @@ var obj = {
   'foo': 'bar'
 };
 
-// When options are [2, "always"]
+var obj = {};
+```
 
-foo[ 'bar' ];
+#### always
 
-foo[
-  'bar' 
+When `"always"` is used, the following patterns are considered warnings:
+
+```js
+foo['bar'];
+foo['bar' ];
+foo[ 'bar'];
+
+var arr = ['foo', 'bar'];
+var arr = ['foo', 'bar' ];
+var arr = [ ['foo'], 'bar' ];
+var arr = ['foo',
+  'bar'
 ];
 
-var arr = [ 'foo', 'bar', 'baz' ];
+var arr = [
+  'foo',
+  'bar'];
 
+var obj = {'foo': 'bar'};
+var obj = {'foo': 'bar' };
+var obj = { baz: {'foo': 'qux'}, 'bar'};
+var obj = {baz: { 'foo': 'qux' }, 'bar'};
+var obj = {'foo': 'bar'
+};
+
+var obj = {
+  'foo':bar'};
+
+```
+
+The following patterns are not warnings:
+
+```js
+foo[ 'bar' ];
+foo[
+  'bar'
+];
+
+var arr = [];
+var arr = [ 'foo', 'bar', 'baz' ];
 var arr = [ [ 'foo' ], 'bar', 'baz' ];
 
 var arr = [
-  'foo', 
-  'bar', 
+  'foo',
+  'bar',
   'baz'
 ];
 
+var obj = {};
 var obj = { 'foo': 'bar' };
-
 var obj = { 'foo': { 'bar': 'baz' }, 'qux': 'quxx' };
-
 var obj = {
   'foo': 'bar'
 };
 ```
 
-### Options
-
-The rule takes one option, a string which must be either "always" or "never". The default is "never".
-
-```js
-"space-in-brackets": [2, "never"]
-```
-
-Setting the option to "always" means that there must always be a space between brackets and tokens inside of brackets.
-
-Setting the option to "never" means that there must never be a space between brackets at the tokens inside of brackets. An exception is made for multi-line Array and Object literals where no values appear on the same line as brackets.
+Note that `"always"` has a special case where `{}` and `[]` are not considered warnings.
 
 ## When Not To Use It
 

--- a/lib/rules/space-in-brackets.js
+++ b/lib/rules/space-in-brackets.js
@@ -44,13 +44,17 @@ module.exports = function(context) {
      * @returns {void}
      */
     function verifySpacing(node, tokens) {
+
+        var hasElements = (node.type === "ObjectExpression" && node.properties.length > 0) ||
+                (node.type === "ArrayExpression" && node.elements.length > 0);
+
         if (shouldSpace === "always") {
-            if (!isSpaced(tokens[0], tokens[1])) {
+            if (hasElements && !isSpaced(tokens[0], tokens[1])) {
                 context.report(node, tokens[0].loc.end,
                         "A space is required after '" + tokens[0].value + "'");
             }
 
-            if (!isSpaced(tokens[tokens.length - 2], tokens[tokens.length - 1])) {
+            if (hasElements && !isSpaced(tokens[tokens.length - 2], tokens[tokens.length - 1])) {
                 context.report(node, tokens[tokens.length - 1].loc.start,
                         "A space is required before '" + tokens[tokens.length - 1].value + "'");
             }

--- a/tests/lib/rules/space-in-brackets.js
+++ b/tests/lib/rules/space-in-brackets.js
@@ -52,7 +52,11 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
 
         { code: "var obj = {foo: bar, baz: qux};", args: ["2", "never"] },
         { code: "var obj = {foo: {bar: quxx}, baz: qux};", args: ["2", "never"] },
-        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", args: ["2", "never"] }
+        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", args: ["2", "never"] },
+        { code: "var foo = {};", args: [2, "always"] },
+        { code: "var foo = {};", args: [2, "never"] },
+        { code: "var foo = [];", args: [2, "always"] },
+        { code: "var foo = [];", args: [2, "never"] }
     ],
 
     invalid: [


### PR DESCRIPTION
This change allows `{}` and `[]` for both options in `space-in-brackets`
