### PR TITLE
Fix: Fixes no-unused-vars to check /*globals*/ (Fixes #955)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -81,7 +81,7 @@
         "no-underscore-dangle": 2,
         "no-unreachable": 2,
         "no-unused-expressions": 2,
-        "no-unused-vars": [2, {"vars": "local", "args": "after-used"}],
+        "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
         "no-use-before-define": 2,
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 2,

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -119,6 +119,7 @@ function getVariable(scope, name) {
  */
 function addDeclaredGlobals(program, globalScope, config) {
     var declaredGlobals = {},
+        explicitGlobals = {},
         builtin = environments.builtin;
 
     Object.keys(builtin).forEach(function(name) {
@@ -137,16 +138,27 @@ function addDeclaredGlobals(program, globalScope, config) {
     });
 
     Object.keys(config.globals).forEach(function(name) {
-        declaredGlobals[name] = config.globals[name];
+        explicitGlobals[name] = config.globals[name];
     });
 
     Object.keys(declaredGlobals).forEach(function(name) {
         var variable = getVariable(globalScope, name);
         if (!variable) {
             variable = new escope.Variable(name, globalScope);
+            variable.explicitGlobal = false;
             globalScope.variables.push(variable);
         }
         variable.writeable = declaredGlobals[name];
+    });
+
+    Object.keys(explicitGlobals).forEach(function(name) {
+        var variable = getVariable(globalScope, name);
+        if (!variable) {
+            variable = new escope.Variable(name, globalScope);
+            variable.explicitGlobal = true;
+            globalScope.variables.push(variable);
+        }
+        variable.writeable = explicitGlobals[name];
     });
 }
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -42,7 +42,7 @@ module.exports = function(context) {
         var candidates = lookupVariableName(variable.name);
         if (candidates) {
             return candidates.filter(function (candidate) {
-                return variable.identifiers.indexOf(candidate.node) > -1;
+                return variable.identifiers.indexOf(candidate.node) > -1 || variable.explicitGlobal;
             })[0];
         }
         return candidates;
@@ -54,9 +54,8 @@ module.exports = function(context) {
 
         scope.variables.forEach(function(variable) {
 
-            //filter out global variables that we add as part of eslint or arguments variable
-            if (variable.identifiers.length > 0) {
-
+            //filter out global variables that are part of default environment globals
+            if (variable.explicitGlobal || variable.identifiers.length > 0) {
 
                 //make sure that this variable is not already in the array
                 if (!lookupVariable(variable)) {
@@ -66,7 +65,7 @@ module.exports = function(context) {
                     }
                     variables[variable.name].push({
                         name: variable.name,
-                        node: variable.identifiers[0],
+                        node: variable.identifiers[0] || node,
                         used: (variable.name === functionName)
                     });
                 }
@@ -74,9 +73,9 @@ module.exports = function(context) {
         });
     }
 
-    function populateGlobalVariables() {
+    function populateGlobalVariables(node) {
         if (!allowUnusedGlobals) {
-            populateVariables();
+            populateVariables(node);
         }
     }
 

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -262,7 +262,7 @@ describe("cli", function() {
 
     describe("when executing with no-eslintrc flag", function () {
         it("should ignore a local config file", function () {
-            var exit = cli.execute("--no-eslintrc --no-ignore ./tests/fixtures/eslintrc/quotes.js");
+            var exit = cli.execute("--reset --no-eslintrc --no-ignore ./tests/fixtures/eslintrc/quotes.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -317,14 +317,14 @@ describe("cli", function() {
         });
 
         it("should allow defining writable global variables", function () {
-            var exit = cli.execute("--global baz:false,bat:true --no-ignore ./tests/fixtures/undef.js");
+            var exit = cli.execute("--reset --global baz:false,bat:true --no-ignore ./tests/fixtures/undef.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
         });
 
         it("should allow defining variables with multiple flags", function () {
-            var exit = cli.execute("--global baz --global bat:true --no-ignore ./tests/fixtures/undef.js");
+            var exit = cli.execute("--reset --global baz --global bat:true --no-ignore ./tests/fixtures/undef.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -34,6 +34,7 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "myFunc(function foo(){}.toString())",
         "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});}; foo()",
         "(function() { var doSomething = function doSomething() {}; doSomething() }())",
+        "/*global a */ a;",
         { code: "var a=10; (function() { alert(a); })();", args: [1, {vars: "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all", "args": "after-used"}] },
@@ -44,6 +45,7 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
     ],
     invalid: [
         { code: "var a=10", errors: [{ message: "a is defined but never used", type: "Identifier"}] },
+        { code: "/*global a */", errors: [{ message: "a is defined but never used", type: "Program"}] },
         { code: "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});};", errors: [{ message: "foo is defined but never used", type: "Identifier"}] },
         { code: "var a=10;", args: [1, "all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },
         { code: "var a=10; a=20;", args: [1, "all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },


### PR DESCRIPTION
Fixes #955.

This changes the default back to the correct `"all"` for the **no-unused-vars** rule; it had been set to `"locals"` at some point.

It also augments the rule (which according to @nzakas should have been there all along, thus this is a Fix) to check for unused explicitly declared globals via `--global` or `/* global */`. This probably never worked before, since the plumbing wasn't really in place.
