### PR TITLE
Rule `no-unused-vars` checks only file globals (fixes #975)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -137,7 +137,11 @@ function addDeclaredGlobals(program, globalScope, config) {
     });
 
     Object.keys(config.globals).forEach(function(name) {
-        explicitGlobals[name] = config.globals[name];
+        declaredGlobals[name] = config.globals[name];
+    });
+
+    Object.keys(config.astGlobals).forEach(function(name) {
+        explicitGlobals[name] = config.astGlobals[name];
     });
 
     Object.keys(declaredGlobals).forEach(function(name) {
@@ -235,7 +239,7 @@ function enableReporting(reportingConfig, start, rules) {
 function modifyConfigsFromComments(ast, config, reportingConfig) {
 
     var commentConfig = {
-        globals: {},
+        astGlobals: {},
         rules: {},
         env: {}
     };
@@ -253,7 +257,7 @@ function modifyConfigsFromComments(ast, config, reportingConfig) {
                 switch (match[1]) {
                     case "globals":
                     case "global":
-                        util.mixin(commentConfig.globals, parseBooleanConfig(value));
+                        util.mixin(commentConfig.astGlobals, parseBooleanConfig(value));
                         break;
 
                     case "eslint-env":

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -41,7 +41,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "function g(bar, baz) { return bar; }; g();", args: [1, {"vars": "all", "args": "none"}] },
         { code: "function g(bar, baz) { return 2; }; g();", args: [1, {"vars": "all", "args": "none"}] },
         { code: "function g(bar, baz) { return bar + baz; }; g();", args: [1, {"vars": "locals", "args": "all"}] },
-        "(function z() { z(); })();"
+        "(function z() { z(); })();",
+        { code: " ", globals: {a: true} }
     ],
     invalid: [
         { code: "var a=10", errors: [{ message: "a is defined but never used", type: "Identifier"}] },


### PR DESCRIPTION
Rule `no-unused-vars` should not check other globals except of `/*globals */`section of file.
