### PR TITLE
Fix: Store rule severity in messages, rather than pulling from the config on-demand

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -123,20 +123,13 @@ function processFile(filename, configHelper) {
 
     // count all errors and return the total
     return messages.reduce(function(previous, message) {
-        var severity = null;
 
-        if (message.fatal) {
-            return previous + 1;
-        }
-
-        severity = config.rules[message.ruleId][0] ||
-                config.rules[message.ruleId];
-
-        if (severity === 2) {
+        if (message.fatal || message.severity === 2) {
             return previous + 1;
         }
 
         return previous;
+        
     }, 0);
 }
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -449,6 +449,35 @@ module.exports = (function() {
         emitComments(comments, commentLocsExit, "Comment:exit");
     }
 
+    /**
+     * Get the severity level of a rule (0 - none, 1 - warning, 2 - error)
+     * Returns 0 if the rule config is not valid (an Array or a number)
+     * @param {Array|number} ruleConfig rule configuration
+     * @returns {number} 0, 1, or 2, indicating rule severity
+     */
+    function getRuleSeverity(ruleConfig) {
+        if (typeof ruleConfig === "number") {
+            return ruleConfig;
+        } else if (Array.isArray(ruleConfig)) {
+            return ruleConfig[0];
+        } else {
+            return 0;
+        }
+    }
+
+    /**
+     * Get the options for a rule (not including severity), if any
+     * @param {Array|number} ruleConfig rule configuration
+     * @returns {Array} of rule options, empty Array if none
+     */
+    function getRuleOptions(ruleConfig) {
+        if (Array.isArray(ruleConfig)) {
+            return ruleConfig.slice(1);
+        } else {
+            return [];
+        }
+    }
+
     // set unlimited listeners (see https://github.com/eslint/eslint/issues/524)
     api.setMaxListeners(0);
 
@@ -502,28 +531,16 @@ module.exports = (function() {
 
             // enable appropriate rules
             Object.keys(config.rules).filter(function(key) {
-                if (typeof config.rules[key] === "number") {
-                    return config.rules[key] > 0;
-                } else if (Array.isArray(config.rules[key])) {
-                    // Here the rule looks like [1, ...] - the first value is the key we want
-                    return config.rules[key][0] > 0;
-                } else {
-                    return false;
-                }
+                return getRuleSeverity(config.rules[key]) > 0;
             }).forEach(function(key) {
                 var ruleCreator = rules.get(key),
-                    options = [],
+                    severity = getRuleSeverity(config.rules[key]),
+                    options = getRuleOptions(config.rules[key]),
                     rule;
-
-                if (Array.isArray(config.rules[key])) {
-
-                    // The additional config data is after the bool value
-                    options = config.rules[key].slice(1);
-                }
 
                 if (ruleCreator) {
                     try {
-                        rule = ruleCreator(new RuleContext(key, api, options));
+                        rule = ruleCreator(new RuleContext(key, api, severity, options));
 
                         // add all the node types as listeners
                         Object.keys(rule).forEach(function(nodeType) {
@@ -592,6 +609,7 @@ module.exports = (function() {
     /**
      * Reports a message from one of the rules.
      * @param {string} ruleId The ID of the rule causing the message.
+     * @param {number} severity The severity level of the rule as configured.
      * @param {ASTNode} node The AST node that the message relates to.
      * @param {Object=} location An object containing the error line and column
      *      numbers. If location is not provided the node's start location will
@@ -601,7 +619,7 @@ module.exports = (function() {
      *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    api.report = function(ruleId, node, location, message, opts) {
+    api.report = function(ruleId, severity, node, location, message, opts) {
 
         if (typeof location === "string") {
             opts = message;
@@ -620,6 +638,7 @@ module.exports = (function() {
 
         messages.push({
             ruleId: ruleId,
+            severity: severity,
             node: node,
             message: message,
             line: location.line,

--- a/lib/formatters/checkstyle.js
+++ b/lib/formatters/checkstyle.js
@@ -8,19 +8,12 @@
 // Helper Functions
 //------------------------------------------------------------------------------
 
-function getMessageType(message, rules) {
-    if (message.fatal) {
+function getMessageType(message) {
+    if (message.fatal || message.severity === 2) {
         return "error";
+    } else {
+        return "warning";
     }
-
-    var rule = rules[message.ruleId],
-        severity = rule && (rule[0] || rule);
-
-    if (severity === 2) {
-        return "error";
-    }
-
-    return "warning";
 }
 
 function xmlEscape(s) {
@@ -45,10 +38,9 @@ function xmlEscape(s) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results, config) {
+module.exports = function(results) {
 
-    var output = "",
-        rules = config.rules || {};
+    var output = "";
 
     output += "<?xml version=\"1.0\" encoding=\"utf-8\"?>";
     output += "<checkstyle version=\"4.3\">";
@@ -61,7 +53,7 @@ module.exports = function(results, config) {
         messages.forEach(function(message) {
             output += "<error line=\"" + xmlEscape(message.line) + "\" " +
                 "column=\"" + xmlEscape(message.column) + "\" " +
-                "severity=\"" + xmlEscape(getMessageType(message, rules)) + "\" " +
+                "severity=\"" + xmlEscape(getMessageType(message)) + "\" " +
                 "message=\"" + xmlEscape(message.message) +
                 (message.ruleId ? " (" + message.ruleId + ")" : "") + "\" />";
         });

--- a/lib/formatters/compact.js
+++ b/lib/formatters/compact.js
@@ -8,19 +8,12 @@
 // Helper Functions
 //------------------------------------------------------------------------------
 
-function getMessageType(message, rules) {
-    if (message.fatal) {
+function getMessageType(message) {
+    if (message.fatal || message.severity === 2) {
         return "Error";
+    } else {
+        return "Warning";
     }
-
-    var rule = rules[message.ruleId],
-        severity = rule && (rule[0] || rule);
-
-    if (severity === 2) {
-        return "Error";
-    }
-
-    return "Warning";
 }
 
 
@@ -28,11 +21,10 @@ function getMessageType(message, rules) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results, config) {
+module.exports = function(results) {
 
     var output = "",
-        total = 0,
-        rules = config.rules || {};
+        total = 0;
 
     results.forEach(function(result) {
 
@@ -42,9 +34,13 @@ module.exports = function(results, config) {
         messages.forEach(function(message) {
 
             output += result.filePath + ": ";
-            output += "line " + (message.line || 0) +  ", col " +
-                (message.column || 0) + ", " + getMessageType(message, rules);
-            output += " - " + message.message + (message.ruleId ? " (" + message.ruleId + ")" : "") + "\n";
+            output += "line " + (message.line || 0);
+            output += ", col " + (message.column || 0);
+            output += ", " + getMessageType(message);
+            output += " - " + message.message;
+            output += message.ruleId ? " (" + message.ruleId + ")" : "";
+            output += "\n";
+            
         });
 
     });

--- a/lib/formatters/junit.js
+++ b/lib/formatters/junit.js
@@ -10,19 +10,12 @@
 // Helper Functions
 //------------------------------------------------------------------------------
 
-function getMessageType(message, rules) {
-    if (message.fatal) {
+function getMessageType(message) {
+    if (message.fatal || message.severity === 2) {
         return "Error";
+    } else {
+        return "Warning";
     }
-
-    var rule = rules[message.ruleId],
-        severity = rule && (rule[0] || rule);
-
-    if (severity === 2) {
-        return "Error";
-    }
-
-    return "Warning";
 }
 
 /**
@@ -60,10 +53,9 @@ function escapeSpecialCharacters(message) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results, config) {
+module.exports = function(results) {
 
-    var output = "",
-        rules = config.rules || {};
+    var output = "";
 
     output += "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n";
     output += "<testsuites>\n";
@@ -82,7 +74,7 @@ module.exports = function(results, config) {
             output += "<" + type + " message=\"" + escapeSpecialCharacters(message.message) + "\">";
             output += "<![CDATA[";
             output += "line " + (message.line || 0) +  ", col ";
-            output += (message.column || 0) + ", " + getMessageType(message, rules);
+            output += (message.column || 0) + ", " + getMessageType(message);
             output += " - " + escapeSpecialCharacters(message.message);
             output += (message.ruleId ? " (" + message.ruleId + ")" : "");
             output += "]]>";

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -8,33 +8,13 @@ var chalk = require("chalk"),
     table = require("text-table");
 
 //------------------------------------------------------------------------------
-// Helper Functions
-//------------------------------------------------------------------------------
-
-function getMessageType(message, rules) {
-    if (message.fatal) {
-        return chalk.red("error");
-    }
-
-    var rule = rules[message.ruleId],
-        severity = rule && (rule[0] || rule);
-
-    if (severity === 2) {
-        return chalk.red("error");
-    }
-
-    return chalk.yellow("warning");
-}
-
-//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results, config) {
+module.exports = function(results) {
 
     var output = "\n",
         total = 0,
-        rules = config.rules || {},
         summaryColor = "yellow";
 
     results.forEach(function(result) {
@@ -49,10 +29,15 @@ module.exports = function(results, config) {
 
         output += table(
             messages.map(function(message) {
-                var messageType = getMessageType(message, rules);
-                if (chalk.stripColor(messageType) === "error") {
+                var messageType;
+
+                if (message.fatal || message.severity === 2) {
+                    messageType = chalk.red("error");
                     summaryColor = "red";
+                } else {
+                    messageType = chalk.yellow("warning");
                 }
+
                 return [
                     "",
                     message.line || 0,

--- a/lib/formatters/tap.js
+++ b/lib/formatters/tap.js
@@ -12,26 +12,15 @@ var yaml = require("js-yaml");
 
 /**
  * Returns a canonical error level string based upon the error message passed in.
- *     The rules setup in the config will determine if an issue is an error.
- *     Issues marked with message.fatal will be error level.
- *     All other issues will be a warning.
  * @param {object} message Individual error message provided by eslint
- * @param {object} rules Rules setup in the config via: config.rules
  * @returns {String} Error level string
  */
-function getMessageType(message, rules) {
-    if (message.fatal) {
+function getMessageType(message) {
+    if (message.fatal || message.severity === 2) {
         return "error";
+    } else {
+        return "warning";
     }
-
-    var rule = rules[message.ruleId],
-        severity = rule && (rule[0] || rule);
-
-    if (severity === 2) {
-        return "error";
-    }
-
-    return "warning";
 }
 
 /**
@@ -51,9 +40,8 @@ function outputDiagnostics(diagnostic) {
 // Public Interface
 //------------------------------------------------------------------------------
 
-module.exports = function(results, config) {
-    var output = "TAP version 13\n1.." + results.length + "\n",
-        rules = config.rules || {};
+module.exports = function(results) {
+    var output = "TAP version 13\n1.." + results.length + "\n";
 
     results.forEach(function(result, id) {
         var messages = result.messages;
@@ -66,7 +54,7 @@ module.exports = function(results, config) {
             messages.forEach(function(message) {
                 var diagnostic = {
                     message: message.message,
-                    severity: getMessageType(message, rules),
+                    severity: getMessageType(message),
                     data: {
                         line: message.line || 0,
                         column: message.column || 0,

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -35,9 +35,10 @@ var PASSTHROUGHS = [
  * @constructor
  * @param {string} ruleId The ID of the rule using this object.
  * @param {eslint} eslint The eslint object.
+ * @param {number} severity The configured severity level of the rule.
  * @param {array} options the configuration information to be added to the rule
  */
-function RuleContext(ruleId, eslint, options) {
+function RuleContext(ruleId, eslint, severity, options) {
 
     /**
      * The read-only ID of the rule.
@@ -70,7 +71,7 @@ function RuleContext(ruleId, eslint, options) {
      * @returns {void}
      */
     this.report = function(node, location, message, opts) {
-        eslint.report(ruleId, node, location, message, opts);
+        eslint.report(ruleId, severity, node, location, message, opts);
     };
 
 }

--- a/tests/lib/formatters/checkstyle.js
+++ b/tests/lib/formatters/checkstyle.js
@@ -20,32 +20,22 @@ describe("formatter:checkstyle", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
             }]
         }];
+
         it("should return a string in the format filename: line x, col y, Error - z for errors", function() {
-            var config = { rules: { foo: 2 } };
-            var result = formatter(code, config);
-
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
         });
+
         it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
-            var config = {
-                rules: { foo: 1 }
-            };
-
-            var result = formatter(code, config);
+            code[0].messages[0].severity = 1;
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"warning\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
-        });
-        it("should return a string in the format filename: line x, col y, Error - z for errors with options config", function() {
-            var config = {
-                rules: { foo: [2, "option"] }
-            };
-
-            var result = formatter(code, config);
-            assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
         });
     });
 
@@ -62,9 +52,7 @@ describe("formatter:checkstyle", function() {
         }];
 
         it("should return a string in the format filename: line x, col y, Error - z", function() {
-            var config = {};    // doesn't matter what's in the config for this test
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"&lt;&gt;&amp;&quot;&apos;.js\"><error line=\"&lt;\" column=\"&gt;\" severity=\"error\" message=\"Unexpected &lt;&gt;&amp;&quot;&apos;. (foo)\" /></file></checkstyle>");
         });
     });
@@ -82,9 +70,7 @@ describe("formatter:checkstyle", function() {
         }];
 
         it("should return a string in the format filename: line x, col y, Error - z", function() {
-            var config = {};    // doesn't matter what's in the config for this test
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file></checkstyle>");
         });
     });
@@ -94,11 +80,13 @@ describe("formatter:checkstyle", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
             }, {
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -106,11 +94,7 @@ describe("formatter:checkstyle", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" /></file></checkstyle>");
         });
     });
@@ -120,6 +104,7 @@ describe("formatter:checkstyle", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -128,6 +113,7 @@ describe("formatter:checkstyle", function() {
             filePath: "bar.js",
             messages: [{
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -135,11 +121,7 @@ describe("formatter:checkstyle", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><checkstyle version=\"4.3\"><file name=\"foo.js\"><error line=\"5\" column=\"10\" severity=\"error\" message=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><error line=\"6\" column=\"11\" severity=\"warning\" message=\"Unexpected bar. (bar)\" /></file></checkstyle>");
         });
     });

--- a/tests/lib/formatters/compact.js
+++ b/tests/lib/formatters/compact.js
@@ -22,11 +22,7 @@ describe("formatter:compact", function() {
         }];
 
         it("should return nothing", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "");
         });
     });
@@ -36,6 +32,7 @@ describe("formatter:compact", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -43,30 +40,14 @@ describe("formatter:compact", function() {
         }];
 
         it("should return a string in the format filename: line x, col y, Error - z for errors", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
 
         it("should return a string in the format filename: line x, col y, Warning - z for warnings", function() {
-            var config = {
-                rules: { foo: 1 }
-            };
-
-            var result = formatter(code, config);
+            code[0].messages[0].severity = 1;
+            var result = formatter(code);
             assert.equal(result, "foo.js: line 5, col 10, Warning - Unexpected foo. (foo)\n\n1 problem");
-        });
-
-        it("should return a string in the format filename: line x, col y, Error - z for errors with options config", function() {
-            var config = {
-                rules: { foo: [2, "option"] }
-            };
-
-            var result = formatter(code, config);
-            assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
     });
 
@@ -83,9 +64,7 @@ describe("formatter:compact", function() {
         }];
 
         it("should return a string in the format filename: line x, col y, Error - z", function() {
-            var config = {};    // doesn't matter what's in the config for this test
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\n\n1 problem");
         });
     });
@@ -95,11 +74,13 @@ describe("formatter:compact", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
             }, {
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -107,11 +88,7 @@ describe("formatter:compact", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nfoo.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
@@ -121,6 +98,7 @@ describe("formatter:compact", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -129,6 +107,7 @@ describe("formatter:compact", function() {
             filePath: "bar.js",
             messages: [{
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -136,11 +115,7 @@ describe("formatter:compact", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "foo.js: line 5, col 10, Error - Unexpected foo. (foo)\nbar.js: line 6, col 11, Warning - Unexpected bar. (bar)\n\n2 problems");
         });
     });
@@ -155,11 +130,7 @@ describe("formatter:compact", function() {
         }];
 
         it("should return a string without line and column", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "foo.js: line 0, col 0, Error - Couldn't find foo.js.\n\n1 problem");
         });
     });

--- a/tests/lib/formatters/jslint-xml.js
+++ b/tests/lib/formatters/jslint-xml.js
@@ -21,6 +21,7 @@ describe("formatter:jslint-xml", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo",
@@ -29,11 +30,7 @@ describe("formatter:jslint-xml", function() {
         }];
 
         it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
@@ -53,9 +50,7 @@ describe("formatter:jslint-xml", function() {
         }];
 
         it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
-            var config = {};    // doesn't matter what's in the config for this test
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });
@@ -65,12 +60,14 @@ describe("formatter:jslint-xml", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo",
                 source: "foo"
             }, {
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar",
@@ -79,11 +76,7 @@ describe("formatter:jslint-xml", function() {
         }];
 
         it("should return a string in JSLint XML format with 2 issues in 1 file", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
@@ -93,6 +86,7 @@ describe("formatter:jslint-xml", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo",
@@ -102,6 +96,7 @@ describe("formatter:jslint-xml", function() {
             filePath: "bar.js",
             messages: [{
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar",
@@ -110,11 +105,7 @@ describe("formatter:jslint-xml", function() {
         }];
 
         it("should return a string in JSLint XML format with 2 issues in 2 files", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected foo. (foo)\" /></file><file name=\"bar.js\"><issue line=\"6\" char=\"11\" evidence=\"bar\" reason=\"Unexpected bar. (bar)\" /></file></jslint>");
         });
     });
@@ -125,6 +116,7 @@ describe("formatter:jslint-xml", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected > foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo",
@@ -133,11 +125,7 @@ describe("formatter:jslint-xml", function() {
         }];
 
         it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"foo\" reason=\"Unexpected &gt; foo. (foo)\" /></file></jslint>");
         });
     });
@@ -148,6 +136,7 @@ describe("formatter:jslint-xml", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -155,11 +144,7 @@ describe("formatter:jslint-xml", function() {
         }];
 
         it("should return a string in JSLint XML format with 1 issue in 1 file", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "<?xml version=\"1.0\" encoding=\"utf-8\"?><jslint><file name=\"foo.js\"><issue line=\"5\" char=\"10\" evidence=\"\" reason=\"Unexpected foo. (foo)\" /></file></jslint>");
         });
     });

--- a/tests/lib/formatters/junit.js
+++ b/tests/lib/formatters/junit.js
@@ -21,8 +21,7 @@ describe("formatter:junit", function() {
         var code = [];
 
         it("should not complain about anything", function() {
-            var config = {}; // not needed for this test
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites></testsuites>");
         });
     });
@@ -32,6 +31,7 @@ describe("formatter:junit", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -39,30 +39,14 @@ describe("formatter:junit", function() {
         }];
 
         it("should return a single <testcase> with a message and the line and col number in the body (error)", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
 
         it("should return a single <testcase> with a message and the line and col number in the body (warning)", function() {
-            var config = {
-                rules: { foo: 1 }
-            };
-
-            var result = formatter(code, config);
+            code[0].messages[0].severity = 1;
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
-        });
-
-        it("should return a single <testcase> with a message and the line and col number in the body (error) with options config", function() {
-            var config = {
-                rules: { foo: [2, "option"] }
-            };
-
-            var result = formatter(code, config);
-            assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });
 
@@ -79,8 +63,7 @@ describe("formatter:junit", function() {
         }];
 
         it("should return a single <testcase> and an <error>", function() {
-            var config = {};
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><error message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></error></testcase></testsuite></testsuites>");
         });
     });
@@ -95,8 +78,7 @@ describe("formatter:junit", function() {
         }];
 
         it("should return a single <testcase> and an <error>", function() {
-            var config = {};
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"Unexpected foo.\"><![CDATA[line 0, col 0, Error - Unexpected foo.]]></error></testcase></testsuite></testsuites>");
         });
     });
@@ -110,8 +92,7 @@ describe("formatter:junit", function() {
         }];
 
         it("should return a single <testcase> and an <error>", function() {
-            var config = {};
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.unknown\"><error message=\"\"><![CDATA[line 0, col 0, Error - ]]></error></testcase></testsuite></testsuites>");
         });
     });
@@ -121,11 +102,13 @@ describe("formatter:junit", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
             }, {
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -133,11 +116,7 @@ describe("formatter:junit", function() {
         }];
 
         it("should return a multiple <testcase>'s", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"2\" errors=\"2\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Error - Unexpected foo. (foo)]]></failure></testcase><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Warning - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
@@ -147,6 +126,7 @@ describe("formatter:junit", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected <foo></foo>.",
+                severity: 1,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -154,11 +134,7 @@ describe("formatter:junit", function() {
         }];
 
         it("should make them go away", function() {
-            var config = {
-                rules: { foo: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected &lt;foo&gt;&lt;/foo&gt;.\"><![CDATA[line 5, col 10, Warning - Unexpected &lt;foo&gt;&lt;/foo&gt;. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });
@@ -168,6 +144,7 @@ describe("formatter:junit", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 1,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -176,6 +153,7 @@ describe("formatter:junit", function() {
             filePath: "bar.js",
             messages: [{
                 message: "Unexpected bar.",
+                severity: 2,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -183,11 +161,7 @@ describe("formatter:junit", function() {
         }];
 
         it("should return 2 <testsuite>'s", function() {
-            var config = {
-                rules: { foo: 1, bar: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"bar.js\"><testcase time=\"0\" name=\"org.eslint.bar\"><failure message=\"Unexpected bar.\"><![CDATA[line 6, col 11, Error - Unexpected bar. (bar)]]></failure></testcase></testsuite></testsuites>");
         });
     });
@@ -197,6 +171,7 @@ describe("formatter:junit", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 1,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -207,11 +182,7 @@ describe("formatter:junit", function() {
         }];
 
         it("should return 1 <testsuite>", function() {
-            var config = {
-                rules: { foo: 1, bar: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result.replace(/\n/g, ""), "<?xml version=\"1.0\" encoding=\"utf-8\"?><testsuites><testsuite package=\"org.eslint\" time=\"0\" tests=\"1\" errors=\"1\" name=\"foo.js\"><testcase time=\"0\" name=\"org.eslint.foo\"><failure message=\"Unexpected foo.\"><![CDATA[line 5, col 10, Warning - Unexpected foo. (foo)]]></failure></testcase></testsuite></testsuites>");
         });
     });

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -56,12 +56,8 @@ describe("formatter:stylish", function() {
             messages: []
         }];
 
-        it("should return message", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+        it("should not return message", function() {
+            var result = formatter(code);
             assert.equal(result, "");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 0);
@@ -73,6 +69,7 @@ describe("formatter:stylish", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -80,36 +77,18 @@ describe("formatter:stylish", function() {
         }];
 
         it("should return a string in the correct format for errors", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
 
         it("should return a string in the correct format for warnings", function() {
-            var config = {
-                rules: { foo: 1 }
-            };
-
-            var result = formatter(code, config);
+            code[0].messages[0].severity = 1;
+            var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 1);
             assert.equal(chalkStub.red.bold.callCount, 0);
-        });
-
-        it("should return a string in the correct format for errors with options config", function() {
-            var config = {
-                rules: { foo: [2, "option"] }
-            };
-
-            var result = formatter(code, config);
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
-            assert.equal(chalkStub.yellow.bold.callCount, 0);
-            assert.equal(chalkStub.red.bold.callCount, 1);
         });
     });
 
@@ -126,9 +105,7 @@ describe("formatter:stylish", function() {
         }];
 
         it("should return a string in the correct format", function() {
-            var config = {};    // doesn't matter what's in the config for this test
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
@@ -140,11 +117,13 @@ describe("formatter:stylish", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
             }, {
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -152,11 +131,7 @@ describe("formatter:stylish", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
@@ -168,6 +143,7 @@ describe("formatter:stylish", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -176,6 +152,7 @@ describe("formatter:stylish", function() {
             filePath: "bar.js",
             messages: [{
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -183,11 +160,7 @@ describe("formatter:stylish", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
@@ -204,11 +177,7 @@ describe("formatter:stylish", function() {
         }];
 
         it("should return a string without line and column", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);

--- a/tests/lib/formatters/tap.js
+++ b/tests/lib/formatters/tap.js
@@ -22,11 +22,7 @@ describe("formatter:tap", function() {
         }];
 
         it("should return nothing", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "TAP version 13\n1..1\nok 1 - foo.js\n");
         });
     });
@@ -36,6 +32,7 @@ describe("formatter:tap", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -43,34 +40,18 @@ describe("formatter:tap", function() {
         }];
 
         it("should return a string with YAML severity, line and column", function() {
-            var config = {
-                rules: { foo: 2 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.equal(result, "TAP version 13\n1..1\nnot ok 1 - foo.js\n  ---\n  message: Unexpected foo.\n  severity: error\n  data:\n    line: 5\n    column: 10\n    ruleId: foo\n  ...\n");
         });
 
         it("should return a string with line: x, column: y, severity: warning for warnings", function() {
-            var config = {
-                rules: { foo: 1 }
-            };
-
-            var result = formatter(code, config);
+            code[0].messages[0].severity = 1;
+            var result = formatter(code);
             assert.include(result, "line: 5");
             assert.include(result, "column: 10");
             assert.include(result, "ruleId: foo");
             assert.include(result, "severity: warning");
             assert.include(result, "1..1");
-        });
-
-        it("should return an error string", function() {
-            var config = {
-                rules: { foo: [2, "option"] }
-            };
-
-            var result = formatter(code, config);
-            assert.include(result, "severity: error");
         });
     });
 
@@ -87,9 +68,7 @@ describe("formatter:tap", function() {
         }];
 
         it("should return a an error string", function() {
-            var config = {};    // doesn't matter what's in the config for this test
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.include(result, "not ok");
             assert.include(result, "error");
         });
@@ -100,11 +79,13 @@ describe("formatter:tap", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
             }, {
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -112,11 +93,7 @@ describe("formatter:tap", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.include(result, "not ok");
             assert.include(result, "messages");
             assert.include(result, "Unexpected foo.");
@@ -133,6 +110,7 @@ describe("formatter:tap", function() {
             filePath: "foo.js",
             messages: [{
                 message: "Unexpected foo.",
+                severity: 2,
                 line: 5,
                 column: 10,
                 ruleId: "foo"
@@ -141,6 +119,7 @@ describe("formatter:tap", function() {
             filePath: "bar.js",
             messages: [{
                 message: "Unexpected bar.",
+                severity: 1,
                 line: 6,
                 column: 11,
                 ruleId: "bar"
@@ -148,11 +127,7 @@ describe("formatter:tap", function() {
         }];
 
         it("should return a string with multiple entries", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.include(result, "not ok 1");
             assert.include(result, "not ok 2");
         });
@@ -168,11 +143,7 @@ describe("formatter:tap", function() {
         }];
 
         it("should return a string without line and column", function() {
-            var config = {
-                rules: { foo: 2, bar: 1 }
-            };
-
-            var result = formatter(code, config);
+            var result = formatter(code);
             assert.include(result, "line: 0");
             assert.include(result, "column: 0");
             assert.include(result, "severity: error");


### PR DESCRIPTION
Fixes #984.

This stores the rule severity on the message objects created when a rule generates a report. This ensures that the severity is always what the rule gets at that instant, regardless of anything that's affected the config up to that point. It also removes all dependency on the config from the formatters, they now depend only on the messages.
