### PR TITLE
Fix: Add support for .eslintrc.yml config files (Fixes #992)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -21,7 +21,7 @@ var fs = require("fs"),
 // Constants
 //------------------------------------------------------------------------------
 
-var LOCAL_CONFIG_FILENAME = ".eslintrc";
+var LOCAL_CONFIG_FILENAMES = [ ".eslintrc", ".eslintrc.yml" ];
 var ESLINT_IGNORE_FILENAME = ".eslintignore";
 
 
@@ -217,7 +217,7 @@ Config.prototype.mergeConfigs = function (base, custom) {
  */
 Config.prototype.findLocalConfigFile = function (directory) {
     if (!this.localConfigFinder) {
-        this.localConfigFinder = new FileFinder(LOCAL_CONFIG_FILENAME);
+        this.localConfigFinder = new FileFinder(LOCAL_CONFIG_FILENAMES);
     }
     return this.localConfigFinder.findInDirectory(directory);
 };

--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -18,10 +18,10 @@ var fs = require("fs"),
 /**
  * FileFinder
  * @constructor
- * @param {string} fileName Name of file to find
+ * @param {string|array} fileName Name of file to find, or array of names
  */
 function FileFinder(fileName) {
-    this.fileName = fileName;
+    this.fileName = Array.isArray(fileName) ? fileName : [ fileName ];
     this.cache = {};
 }
 
@@ -36,6 +36,7 @@ FileFinder.prototype.findInDirectory = function(directory, directoriesToCache) {
     var lookInDirectory = directory || process.eslintCwd || process.cwd(),
         lookFor = this.fileName,
         files,
+        matchedNames,
         parentDirectory,
         resultFilePath,
         isFound = false;
@@ -52,9 +53,13 @@ FileFinder.prototype.findInDirectory = function(directory, directoriesToCache) {
 
     files = fs.readdirSync(lookInDirectory);
 
-    if (files.indexOf(lookFor) !== -1) {
+    matchedNames = lookFor.filter(function (name) {
+        return files.indexOf(name) !== -1;
+    });
+
+    if (matchedNames.length > 0) {
         isFound = true;
-        resultFilePath = path.resolve(lookInDirectory, lookFor);
+        resultFilePath = path.resolve(lookInDirectory, matchedNames[0]);
     } else {
 
         parentDirectory = path.resolve(lookInDirectory, "..");

--- a/tests/fixtures/configurations/yml-extension/.eslintrc.yml
+++ b/tests/fixtures/configurations/yml-extension/.eslintrc.yml
@@ -1,0 +1,7 @@
+env:
+    browser: true
+
+rules:
+    quotes: [ 1, single ]
+    no-new: 1
+

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -21,11 +21,20 @@ var assert = require("chai").assert,
 describe("config", function() {
     describe("findLocalConfigFile", function() {
         var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes");
+        var codeYaml = path.resolve(__dirname, "..", "fixtures", "configurations", "yml-extension");
 
-        it("should find local config file", function() {
+        it("should find local '.eslintrc' config file", function() {
             var configHelper = new Config(),
                 expected = path.resolve(code, ".eslintrc"),
                 actual = configHelper.findLocalConfigFile(code);
+
+            assert.equal(actual, expected);
+        });
+
+        it("should find local '.eslintrc.yml' config file", function() {
+            var configHelper = new Config(),
+                expected = path.resolve(codeYaml, ".eslintrc.yml"),
+                actual = configHelper.findLocalConfigFile(codeYaml);
 
             assert.equal(actual, expected);
         });


### PR DESCRIPTION
Now configs are searched both in `.eslintrc` and `.eslintrc.yml` files. This simplifies syntax highlight in editors and preserve compatibility.
