### PR TITLE
Brace-style default value doc innacuracy

### DIFF
--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -95,7 +95,7 @@ try {
 #### "stroustrup"
 
 
-This is the default setting for this rule and enforces Stroustrup style. While using this setting, the following patterns are considered warnings:
+This enforces Stroustrup style. While using this setting, the following patterns are considered warnings:
 
 ```js
 function foo()


### PR DESCRIPTION
The Stroustrup value section incorrectly stated that it was the default value for this setting.
