### PR TITLE
Docs: Removed reference to brace-style Stroustrup default (fixes #1000)

### DIFF
--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -95,7 +95,7 @@ try {
 #### "stroustrup"
 
 
-This is the default setting for this rule and enforces Stroustrup style. While using this setting, the following patterns are considered warnings:
+This enforces Stroustrup style. While using this setting, the following patterns are considered warnings:
 
 ```js
 function foo()


### PR DESCRIPTION
What it says on the tin. I removed a few words that said Stroustrup was the default value for the curly-brace rule.
