### PR TITLE
Breaking: CLIEngine abstraction for CLI operations

### DIFF
--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -16,15 +16,35 @@ This object's responsibilities include:
 
 * Interpreting command line arguments
 * Reading from the file system
-* Loading rule definitions
 * Outputting to the console
-* Reading configuration information from config files (including `.eslintrc`)
+* Outputting to the filesystem
+* Use a formatter
 * Returning the correct exit code
 
 This object may not:
 
 * Call `process.exit()` directly
 * Perform any asynchronous operations
+
+## The `CLIEngine` object
+
+The `CLIEngine` type represents the core functionality of the CLI except that it reads nothing from the command line and doesn't output anything by default. Instead, it accepts many (but not all) of the arguments that are passed into the CLI. It reads both configuration and source files as well as managing the environment that is passed into the `eslint` object.
+
+The main method of the `CLIEngine` is `executeOnFiles()`, which accepts an array of file and directory names to run the linter on.
+
+This object's responsibilities include:
+
+* Managing the execution environment for `eslint`
+* Reading from the file system
+* Loading rule definitions
+* Reading configuration information from config files (including `.eslintrc`)
+
+This object may not:
+
+* Call `process.exit()` directly
+* Perform any asynchronous operations
+* Output to the console
+* Use formatters
 
 ## The `eslint` object
 
@@ -49,7 +69,7 @@ This object may not:
 
 ## Rules
 
-Individual rules are the most specialized part of the ESLint architecture. Rules can do very little, they are simply a set of instructions executed against an AST that is provided. They do get some context information passed in, but the primary responsibility of a rule is to inspect the AST and report warnings. 
+Individual rules are the most specialized part of the ESLint architecture. Rules can do very little, they are simply a set of instructions executed against an AST that is provided. They do get some context information passed in, but the primary responsibility of a rule is to inspect the AST and report warnings.
 
 These objects' responsibilities are:
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -1,0 +1,199 @@
+/**
+ * @fileoverview Main CLI object.
+ * @author Nicholas C. Zakas
+ */
+
+"use strict";
+
+/*
+ * The CLI object should *not* call process.exit() directly. It should only return
+ * exit codes. This allows other programs to use the CLI object and still control
+ * when the program exits.
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var fs = require("fs"),
+    path = require("path"),
+
+    assign = require("object-assign"),
+    debug = require("debug"),
+
+    rules = require("./rules"),
+    eslint = require("./eslint"),
+    traverse = require("./util/traverse"),
+    IgnoredPaths = require("./ignored-paths"),
+    Config = require("./config");
+
+//------------------------------------------------------------------------------
+// Typedefs
+//------------------------------------------------------------------------------
+
+/**
+ * The options to configure a CLI engine with.
+ * @typedef {Object} CLIEngineOptions
+ * @property {string} configFile The configuration file to use.
+ * @property {boolean} reset True disables all default rules and environments.
+ * @property {boolean} ignore False disables use of .eslintignore.
+ * @property {string[]} rulePaths An array of directories to load custom rules from.
+ * @property {boolean} useEslintrc False disables looking for .eslintrc
+ * @property {string[]} envs An array of environments to load.
+ * @property {string[]} globals An array of global variables to declare.
+ * @property {Object<string,*>} rules An object of rules to use.
+ * @property {string} ignorePath The ignore file to use instead of .eslintignore.
+ */
+
+/**
+ * A linting warning or error.
+ * @typedef {Object} LintMessage
+ * @property {string} message The message to display to the user.
+ */
+
+/**
+ * A linting result.
+ * @typedef {Object} LintResult
+ * @property {string} filePath The path to the file that was linted.
+ * @property {LintMessage[]} messages All of the messages for the result.
+ */
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+debug = debug("eslint:cli-engine");
+
+/**
+ * Processes an individual file using ESLint.
+ * @param {string} filename The filename of the file being checked.
+ * @param {Object} configHelper The configuration options for ESLint.
+ * @returns {Result} The results for linting on this file.
+ * @private
+ */
+function processFile(filename, configHelper) {
+
+    // clear all existing settings for a new file
+    eslint.reset();
+
+    var filePath = path.resolve(filename),
+        config,
+        text,
+        messages;
+
+    if (fs.existsSync(filePath)) {
+        debug("Linting " + filePath);
+        config = configHelper.getConfig(filePath);
+        text = fs.readFileSync(path.resolve(filename), "utf8");
+        messages = eslint.verify(text, config, filename);
+    } else {
+        debug("Couldn't find " + filePath);
+        messages = [{
+            fatal: true,
+            message: "Could not find file at '" + filePath + "'."
+        }];
+    }
+
+    return {
+        filePath: filename,
+        messages: messages
+    };
+}
+
+//------------------------------------------------------------------------------
+// Private
+//------------------------------------------------------------------------------
+
+
+var defaultOptions = {
+    configFile: null,
+    reset: false,
+    rulePaths: [],
+    useEslintrc: true,
+    envs: [],
+    globals: [],
+    rules: {},
+    ignore: true,
+    ignorePath: null
+};
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * Creates a new instance of the core CLI engine.
+ * @param {CLIEngineOptions} options The options for this instance.
+ * @constructor
+ */
+function CLIEngine(options) {
+
+    /**
+     * Stored options for this instance
+     * @type {Object}
+     */
+    this.options = assign(Object.create(defaultOptions), options || {});
+
+    // load in additional rules
+    if (this.options.rulePaths) {
+        this.options.rulePaths.forEach(function(rulesdir) {
+            debug("Loading rules from " + rulesdir);
+            rules.load(rulesdir);
+        });
+    }
+}
+
+CLIEngine.prototype = {
+
+    constructor: CLIEngine,
+
+    /**
+     * Executes the current configuration on an array of file and directory names.
+     * @param {string[]} files An array of file and directory names.
+     * @returns {Object} The results for all files that were linted.
+     */
+    executeOnFiles: function(files) {
+
+        var results = [],
+            configHelper = new Config(this.options),
+            ignoredPaths = IgnoredPaths.load(this.options);
+
+        traverse({
+            files: files
+        }, function(filename) {
+
+            debug("Processing " + filename);
+
+            if (path.extname(filename) === ".js") {
+
+                var shouldIgnore = this.options.ignore ? ignoredPaths.contains(filename) : false;
+
+                if (!shouldIgnore) {
+                    results.push(processFile(filename, configHelper));
+                } else if (files.indexOf(filename) > -1) {
+
+                    debug("Ignoring " + filename);
+
+                    // only warn for files explicitly passes on the command line
+                    results.push({
+                        filePath: filename,
+                        messages: [
+                            {
+                                fatal: false,
+                                message: "File ignored because of your .eslintignore file. Use --no-ignore to override."
+                            }
+                        ]
+                    });
+                }
+            }
+
+        }.bind(this));
+
+        return {
+            results: results
+        };
+    }
+
+};
+
+module.exports = CLIEngine;

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -18,53 +18,62 @@
 var fs = require("fs"),
     path = require("path"),
 
-    options = require("./options"),
-    rules = require("./rules"),
-    eslint = require("./eslint"),
-    traverse = require("./util/traverse"),
     debug = require("debug"),
-    Config = require("./config"),
-    IgnoredPaths = require("./ignored-paths");
+
+    options = require("./options"),
+    CLIEngine = require("./cli-engine");
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
-var results = [];
 debug = debug("eslint:cli");
 
 /**
- * Stores the messages for a particular file.
- * @param {string} filename The name of the file.
- * @param {Object[]} messages The messages to store for the file.
- * @returns {void}
+ * Translates the CLI options into the options expected by the CLIEngine.
+ * @param {Object} cliOptions The CLI options to translate.
+ * @returns {CLIEngineOptions} The options object for the CLIEngine.
  * @private
  */
-function storeResults(filename, messages) {
-    results.push({filePath: filename, messages: messages});
+function translateOptions(cliOptions) {
+    return {
+        envs: cliOptions.env,
+        rules: cliOptions.rule,
+        globals: cliOptions.global,
+        ignore: cliOptions.ignore,
+        ignorePath: cliOptions.ignorePath,
+        configFile: cliOptions.config,
+        rulePaths: cliOptions.rulesdir,
+        reset: cliOptions.reset,
+        useEslintrc: cliOptions.eslintrc
+    };
 }
 
 /**
  * Outputs the results of the linting.
+ * @param {LintResult[]} results The results to print.
+ * @param {string} format The name of the formatter to use or the path to the formatter.
  * @param {Config} config The configuration options for the results.
  * @returns {boolean} True if the printing succeeds, false if not.
  * @private
  */
-function printResults(config) {
+function printResults(results, format, config) {
     var formatter,
         formatterPath,
         output;
-    if (fs.existsSync(path.resolve(process.cwd(), config.format))) {
-        formatterPath = path.resolve(process.cwd(), config.format);
+
+    if (fs.existsSync(path.resolve(process.cwd(), format))) {
+        formatterPath = path.resolve(process.cwd(), format);
     } else {
-        formatterPath = "./formatters/" + config.format;
+        formatterPath = "./formatters/" + format;
     }
     try {
         formatter = require(formatterPath);
     } catch (ex) {
-        console.error("Could not find formatter '%s'.", config.format);
+        console.error("Could not find formatter '%s'.", format);
         return false;
     }
+
     output = formatter(results, config);
     if (output) {
         console.log(output);
@@ -74,91 +83,18 @@ function printResults(config) {
 }
 
 /**
- * Processes an individual file using ESLint.
- * @param {string} filename The filename of the file being checked.
- * @param {Object} configHelper The configuration options for ESLint.
- * @returns {int} The total number of errors.
+ * Calculates the exit code for ESLint. If there is even one error then the
+ * exit code is 1.
+ * @param {LintResult[]} results The results to calculate from.
+ * @returns {int} The exit code to use.
+ * @private
  */
-function processFile(filename, configHelper) {
-
-    // clear all existing settings for a new file
-    eslint.reset();
-
-    var filePath = path.resolve(filename),
-        config,
-        text,
-        messages;
-
-    if (fs.existsSync(filePath)) {
-        debug("Linting " + filePath);
-        config = configHelper.getConfig(filePath);
-        text = fs.readFileSync(path.resolve(filename), "utf8");
-        messages = eslint.verify(text, config, filename);
-    } else {
-        debug("Couldn't find " + filePath);
-        messages = [{
-            fatal: true,
-            message: "Could not find file at '" + filePath + "'."
-        }];
-    }
-
-    // save the results for printing later
-    storeResults(filename, messages);
-
-    // count all errors and return the total
-    return messages.reduce(function(previous, message) {
-
-        if (message.fatal || message.severity === 2) {
-            return previous + 1;
-        }
-
-        return previous;
-        
-    }, 0);
-}
-
-/**
- * Processes all files from the command line.
- * @param {string[]} files All of the filenames to process.
- * @param {Object} configHelper The configuration options for ESLint.
- * @returns {int} The total number of errors.
- */
-function processFiles(files, configHelper) {
-
-    var errors = 0,
-        ignoredPaths = IgnoredPaths.load(configHelper.options);
-
-    traverse({
-        files: files
-    }, function(filename) {
-
-        debug("Processing " + filename);
-
-        if (path.extname(filename) === ".js") {
-
-            if (configHelper.options.force || !ignoredPaths.contains(filename)) {
-
-                errors += processFile(filename, configHelper);
-
-            } else if (files.indexOf(filename) > -1) {
-
-                debug("Ignoring " + filename);
-                // only warn for files explicitly passes on the command line
-                storeResults(filename, [{
-                    fatal: false,
-                    message: "File ignored because of your .eslintignore file. Use --no-ignore to override."
-                }]);
-
-            }
-
-        }
-
-    });
-
-    // If the formatter succeeds return validation errors count, otherwise
-    // return 1 for the formatter error.
-    return printResults(configHelper.getConfig()) ? errors : 1;
-
+function calculateExitCode(results) {
+    return results.some(function(result) {
+        return result.messages.some(function(message) {
+            return message.severity === 2;
+        });
+    }) ? 1 : 0;
 }
 
 //------------------------------------------------------------------------------
@@ -180,8 +116,8 @@ var cli = {
 
         var currentOptions,
             files,
-            configHelper,
-            result;
+            result,
+            engine;
 
         try {
             currentOptions = options.parse(args);
@@ -191,9 +127,6 @@ var cli = {
         }
 
         files = currentOptions._;
-
-        // Ensure results from previous execution are not printed.
-        results = [];
 
         if (currentOptions.version) { // version from package.json
 
@@ -205,21 +138,14 @@ var cli = {
 
         } else {
 
-            configHelper = new Config(currentOptions);
-
-            // TODO: Figure out correct option vs. config for this
-            // load rules
-            if (currentOptions.rulesdir) {
-                currentOptions.rulesdir.forEach(function(rulesdir) {
-                    debug("Loading rules from " + rulesdir);
-                    rules.load(rulesdir);
-                });
+            engine = new CLIEngine(translateOptions(currentOptions));
+            result = engine.executeOnFiles(files);
+            if (printResults(result.results, currentOptions.format)) {
+                return calculateExitCode(result.results);
+            } else {
+                return 1;
             }
 
-            result = processFiles(files, configHelper);
-
-            // result is the number of errors (not warnings)
-            return result > 0 ? 1 : 0;
         }
 
         return 0;

--- a/lib/config.js
+++ b/lib/config.js
@@ -95,15 +95,15 @@ function Config(options) {
     this.baseConfig = options.reset ? { rules: {} } :
             require(path.resolve(__dirname, "..", "conf", "eslint.json"));
     this.baseConfig.format = options.format;
-    this.useEslintrc = (options.eslintrc !== false);
-    this.env = options.env;
-    this.globals = (options.global || []).reduce(function (globals, def) {
+    this.useEslintrc = (options.useEslintrc !== false);
+    this.env = options.envs;
+    this.globals = options.globals ? options.globals.reduce(function (globals, def) {
         // Default "foo" to false and handle "foo:false" and "foo:true"
         var parts = def.split(":");
         globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
         return globals;
-    }, {});
-    useConfig = options.config;
+    }, {}) : [];
+    useConfig = options.configFile;
     this.options = options;
 
     if (useConfig) {
@@ -165,8 +165,8 @@ Config.prototype.getConfig = function (filePath) {
     config = this.mergeConfigs(config, userConfig);
     config = this.mergeConfigs(config, { globals: this.globals });
 
-    if (this.options.rule) {
-        config = this.mergeConfigs(config, { rules: this.options.rule });
+    if (this.options.rules) {
+        config = this.mergeConfigs(config, { rules: this.options.rules });
     }
 
     this.cache[directory] = config;

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "js-yaml": "~3.0.1",
     "doctrine": "~0.5.0",
     "minimatch": "^0.3.0",
-    "debug": "^0.8.1"
+    "debug": "^0.8.1",
+    "object-assign": "^0.3.1"
   },
   "devDependencies": {
     "sinon": "1.7.3",

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1,0 +1,424 @@
+/**
+ * @fileoverview Tests for cli.
+ * @author Ian Christian Myers
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    CLIEngine = require("../../lib/cli-engine"),
+    path = require("path");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("CLIEngine", function() {
+
+    describe("executeOnFiles", function() {
+
+        var engine;
+
+        afterEach(function() {
+            process.eslintCwd = null;
+        });
+
+        it("should report zero messages when given a config file and a valid file", function() {
+
+            engine = new CLIEngine({
+                configFile: path.join(__dirname, "..", ".eslintrc")
+            });
+
+            var report = engine.executeOnFiles(["lib/cli.js"]);
+
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+        it("should return one error message when given a config with rules with options and severity level set to error", function() {
+
+            engine = new CLIEngine({
+                configFile: "tests/fixtures/configurations/quotes-error.json",
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/single-quoted.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 1);
+            assert.equal(report.results[0].messages[0].ruleId, "quotes");
+            assert.equal(report.results[0].messages[0].severity, 2);
+        });
+
+        it("should return two messages when given a config file and a directory of files", function() {
+
+            engine = new CLIEngine({
+                configFile: "tests/fixtures/configurations/semi-error.json",
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/formatters"]);
+            assert.equal(report.results.length, 2);
+            assert.equal(report.results[0].messages.length, 0);
+            assert.equal(report.results[1].messages.length, 0);
+        });
+
+        it("should return zero messages when given a config with environment set to browser", function() {
+
+            engine = new CLIEngine({
+                configFile: "tests/fixtures/configurations/env-browser.json",
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/globals-browser.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+        it("should return zero messages when given a config with environment set to Node.js", function() {
+
+            engine = new CLIEngine({
+                configFile: "tests/fixtures/configurations/env-node.json",
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/globals-node.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+        it("should not return results from previous call when calling more than once", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                rules: {
+                    semi: 2
+                }
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/missing-semicolon.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "tests/fixtures/missing-semicolon.js");
+            assert.equal(report.results[0].messages.length, 1);
+            assert.equal(report.results[0].messages[0].ruleId, "semi");
+            assert.equal(report.results[0].messages[0].severity, 2);
+
+
+            report = engine.executeOnFiles(["tests/fixtures/passing.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "tests/fixtures/passing.js");
+            assert.equal(report.results[0].messages.length, 0);
+
+        });
+
+        it("should return zero messages when given a directory with eslint excluded files in the directory", function() {
+
+            engine = new CLIEngine({
+                ignorePath: "tests/fixtures/.eslintignore"
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/"]);
+            assert.equal(report.results.length, 0);
+        });
+
+        it("should return zero messages when given a file in excluded files list", function() {
+
+            engine = new CLIEngine({
+                ignorePath: "tests/fixtures/.eslintignore"
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/passing"]);
+            assert.equal(report.results.length, 0);
+
+        });
+
+        it("should return two messages when given a file in excluded files list while ignore is off", function() {
+
+            engine = new CLIEngine({
+                ignorePath: "tests/fixtures/.eslintignore",
+                ignore: false,
+                reset: true,
+                rules: {
+                    "no-undef": 2
+                }
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/undef.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "tests/fixtures/undef.js");
+            assert.equal(report.results[0].messages[0].ruleId, "no-undef");
+            assert.equal(report.results[0].messages[0].severity, 2);
+            assert.equal(report.results[0].messages[1].ruleId, "no-undef");
+            assert.equal(report.results[0].messages[1].severity, 2);
+        });
+
+        it("should return zero messages when executing a file with a shebang", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/shebang.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+
+        it("should thrown an error when loading a custom rule that doesn't exist", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                rulesPaths: ["./tests/fixtures/rules/wrong"],
+                configFile: "./tests/fixtures/rules/eslint.json"
+            });
+
+
+            assert.throws(function() {
+                engine.executeOnFiles(["tests/fixtures/rules/test/test-custom-rule.js"]);
+            }, /Definition for rule 'custom-rule' was not found/);
+
+        });
+
+        it("should thrown an error when loading a custom rule that doesn't exist", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                rulePaths: ["./tests/fixtures/rules/wrong"],
+                configFile: "./tests/fixtures/rules/eslint.json"
+            });
+
+
+            assert.throws(function() {
+                engine.executeOnFiles(["tests/fixtures/rules/test/test-custom-rule.js"]);
+            }, /Error while loading rule 'custom-rule'/);
+        });
+
+        it("should return one message when a custom rule matches a file", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                rulePaths: ["./tests/fixtures/rules/"],
+                configFile: "./tests/fixtures/rules/eslint.json"
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/rules/test/test-custom-rule.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "tests/fixtures/rules/test/test-custom-rule.js");
+            assert.equal(report.results[0].messages.length, 2);
+            assert.equal(report.results[0].messages[0].ruleId, "custom-rule");
+            assert.equal(report.results[0].messages[0].severity, 1);
+        });
+
+        it("should return messages when multiple custom rules match a file", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                rulePaths: [
+                    "./tests/fixtures/rules/dir1",
+                    "./tests/fixtures/rules/dir2"
+                ],
+                configFile: "./tests/fixtures/rules/multi-rulesdirs.json"
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/rules/test-multi-rulesdirs.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "tests/fixtures/rules/test-multi-rulesdirs.js");
+            assert.equal(report.results[0].messages.length, 2);
+            assert.equal(report.results[0].messages[0].ruleId, "no-literals");
+            assert.equal(report.results[0].messages[0].severity, 2);
+            assert.equal(report.results[0].messages[1].ruleId, "no-strings");
+            assert.equal(report.results[0].messages[1].severity, 2);
+        });
+
+        it("should return zero messages when executing with reset flag", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                useEslintrc: false
+            });
+
+            var report = engine.executeOnFiles(["./tests/fixtures/missing-semicolon.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "./tests/fixtures/missing-semicolon.js");
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+        it("should return zero messages when executing with reset flag in Node.js environment", function() {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                useEslintrc: false,
+                envs: ["node"]
+            });
+
+            var report = engine.executeOnFiles(["./tests/fixtures/process-exit.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "./tests/fixtures/process-exit.js");
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+
+        it("should return zero messages and ignore local config file when executing with no-eslintrc flag", function () {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true,
+                useEslintrc: false,
+                envs: ["node"]
+            });
+
+            var report = engine.executeOnFiles(["./tests/fixtures/eslintrc/quotes.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "./tests/fixtures/eslintrc/quotes.js");
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+        it("should return zero messages when executing with local config file", function () {
+
+            engine = new CLIEngine({
+                ignore: false,
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["./tests/fixtures/eslintrc/quotes.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "./tests/fixtures/eslintrc/quotes.js");
+            assert.equal(report.results[0].messages.length, 1);
+        });
+
+        // These tests have to do with https://github.com/eslint/eslint/issues/963
+
+        // it("should return zero messages when executing with global node flag", function () {
+
+        //     engine = new CLIEngine({
+        //         ignore: false,
+        //         reset: true,
+        //         useEslintrc: false,
+        //         configFile: "./conf/eslint.json",
+        //         envs: ["node"]
+        //     });
+
+        //     var files = [
+        //         "./tests/fixtures/globals-node.js"
+        //     ];
+
+        //     var report = engine.executeOnFiles(files);
+        //     console.dir(report.results[0].messages);
+        //     assert.equal(report.results.length, 1);
+        //     assert.equal(report.results[0].filePath, files[0]);
+        //     assert.equal(report.results[0].messages.length, 1);
+        // });
+
+        // it("should return zero messages when executing with global env flag", function () {
+
+        //     engine = new CLIEngine({
+        //         ignore: false,
+        //         reset: true,
+        //         useEslintrc: false,
+        //         configFile: "./conf/eslint.json",
+        //         envs: ["browser", "node"]
+        //     });
+
+        //     var files = [
+        //         "./tests/fixtures/globals-browser.js",
+        //         "./tests/fixtures/globals-node.js"
+        //     ];
+
+        //     var report = engine.executeOnFiles(files);
+        //     console.dir(report.results[1].messages);
+        //     assert.equal(report.results.length, 2);
+        //     assert.equal(report.results[0].filePath, files[0]);
+        //     assert.equal(report.results[0].messages.length, 1);
+        //     assert.equal(report.results[1].filePath, files[1]);
+        //     assert.equal(report.results[1].messages.length, 1);
+
+        // });
+
+        // it("should return zero messages when executing with env flag", function () {
+        //     var files = [
+        //         "./tests/fixtures/globals-browser.js",
+        //         "./tests/fixtures/globals-node.js"
+        //     ];
+
+        //     it("should allow environment-specific globals", function () {
+        //         cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --env browser,node --no-ignore " + files.join(" "));
+
+        //         assert.equal(console.log.args[0][0].split("\n").length, 9);
+        //     });
+
+        //     it("should allow environment-specific globals, with multiple flags", function () {
+        //         cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --env browser --env node --no-ignore " + files.join(" "));
+        //         assert.equal(console.log.args[0][0].split("\n").length, 9);
+        //     });
+        // });
+
+        // it("should return zero messages when executing without env flag", function () {
+        //     var files = [
+        //         "./tests/fixtures/globals-browser.js",
+        //         "./tests/fixtures/globals-node.js"
+        //     ];
+
+        //     it("should not define environment-specific globals", function () {
+        //         cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
+        //         assert.equal(console.log.args[0][0].split("\n").length, 12);
+        //     });
+        // });
+
+        // it("should return zero messages when executing with global flag", function () {
+        //     it("should default defined variables to read-only", function () {
+        //         var exit = cli.execute("--global baz,bat --no-ignore ./tests/fixtures/undef.js");
+
+        //         assert.isTrue(console.log.calledOnce);
+        //         assert.equal(exit, 1);
+        //     });
+
+        //     it("should allow defining writable global variables", function () {
+        //         var exit = cli.execute("--reset --global baz:false,bat:true --no-ignore ./tests/fixtures/undef.js");
+
+        //         assert.isTrue(console.log.notCalled);
+        //         assert.equal(exit, 0);
+        //     });
+
+        //     it("should allow defining variables with multiple flags", function () {
+        //         var exit = cli.execute("--reset --global baz --global bat:true --no-ignore ./tests/fixtures/undef.js");
+
+        //         assert.isTrue(console.log.notCalled);
+        //         assert.equal(exit, 0);
+        //     });
+        // });
+
+        it("should return zero messages when supplied with rule flag and severity level set to error", function() {
+
+            engine = new CLIEngine({
+                configFile: "tests/fixtures/configurations/env-browser.json",
+                reset: true,
+                rules: {
+                    quotes: [2, "double"]
+                }
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/single-quoted.js"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 1);
+            assert.equal(report.results[0].messages[0].ruleId, "quotes");
+            assert.equal(report.results[0].messages[0].severity, 2);
+        });
+
+
+
+
+
+    });
+
+
+
+});

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -59,9 +59,7 @@ describe("cli", function() {
         it("should exit with an error status (1)", function() {
             var exitStatus;
 
-            assert.doesNotThrow(function () {
-                exitStatus = cli.execute(code);
-            });
+            exitStatus = cli.execute(code);
 
             assert.equal(exitStatus, 1);
         });
@@ -173,7 +171,6 @@ describe("cli", function() {
     describe("when given a directory with eslint excluded files in the directory", function() {
         it("should not process any files", function() {
             var exit = cli.execute("--ignore-path tests/fixtures/.eslintignore tests/fixtures");
-
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
         });
@@ -337,9 +334,7 @@ describe("cli", function() {
         it("should exit with an error status (1)", function() {
             var exitStatus;
 
-            assert.doesNotThrow(function () {
-                exitStatus = cli.execute(code);
-            });
+            exitStatus = cli.execute(code);
 
             assert.equal(exitStatus, 1);
         });

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -49,7 +49,7 @@ describe("config", function() {
 
         it("should be no-global-strict off for node env", function() {
 
-            var configHelper = new Config({config: code}),
+            var configHelper = new Config({configFile: code}),
                 config = configHelper.getConfig(),
                 expected = 0,
                 actual = config.rules["no-global-strict"];
@@ -63,7 +63,7 @@ describe("config", function() {
                 "env-node-override.json");
 
         it("should be no-global-strict a warning", function() {
-            var configHelper = new Config({config: code}),
+            var configHelper = new Config({configFile: code}),
                 config = configHelper.getConfig(),
                 expected = 1,
                 actual = config.rules["no-global-strict"];
@@ -203,7 +203,7 @@ describe("config", function() {
     describe("Config with abitrarily named config file", function() {
         it("should load the config file", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "my-awesome-config"),
-                configHelper = new Config({config: configPath}),
+                configHelper = new Config({configFile: configPath}),
                 quotes = configHelper.useSpecificConfig.rules.quotes[0];
 
             assert.equal(quotes, 3);
@@ -213,7 +213,7 @@ describe("config", function() {
     describe("Config with comments", function() {
         it("should load the config file", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "comments.json"),
-                configHelper = new Config({config: configPath}),
+                configHelper = new Config({configFile: configPath}),
                 semi = configHelper.useSpecificConfig.rules.semi,
                 strict = configHelper.useSpecificConfig.rules.strict;
 
@@ -225,7 +225,7 @@ describe("config", function() {
     describe("YAML config", function() {
         it("should load the config file", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "env-browser.yaml"),
-                configHelper = new Config({config: configPath}),
+                configHelper = new Config({configFile: configPath}),
                 noAlert = configHelper.useSpecificConfig.rules["no-alert"],
                 noUndef = configHelper.useSpecificConfig.rules["no-undef"];
 


### PR DESCRIPTION
This PR is a first-pass at creating a mid-level programmatic API. This is intentionally not yet exposed publicly, as I'd like to test it in a release to catch bugs before encouraging developers to use it. Here's what the API looks like:

``` js
var engine = new CLIEngine({
    configFile: null,    // -c
    reset: false,   // --reset
    rulePaths: [],   // --rulesdir
    useEslintrc: true,  // --eslintrc
    envs: [],   // -env
    globals: [],    // --global
    rules: {},    // --rule
    ignore: true,    // --ignore
    ignorePath: null    // --ignore-path
});

var output = engine.executeOnFiles(["file1.js", "files/"]);
// output.results is the full results as passed to a formatter
```

My intention is to add an `executeOnText()` method at some point in the future.

This API exists between the high-level `cli` and the low-level `eslint`. Some things to know:
- It doesn't do any console output at all, the `cli` object is solely responsible for that.
- The return value of `executeOnFiles()` is an object with one property, `results`, which is the results that are passed to the formatter. I intentionally did this to allow us to add more properties if we find we need them (people have asked, in the past, for number of files linted, ignored, etc.).
- It does do all of the file system input for you.
- The options names are different than those on the CLI options object mostly due to plural and disambiguation issues.
- All current CLI tests pass.
- I ended up removing the ability to pass a config into a formatter. I wanted to deprecate it first, but with this refactor, it became hard to continue passing that data along.
