### PR TITLE
Add a couchdb environment

### DIFF
--- a/conf/environments.json
+++ b/conf/environments.json
@@ -400,5 +400,25 @@
             "suiteSetup": false,
             "suiteTeardown": false
         }
+    },
+
+    "couchdb": {
+        "globals": {
+            "emit": false,
+            "getRow": false,
+            "isArray": false,
+            "log": false,
+            "provides": false,
+            "registerType": false,
+            "require": false,
+            "send": false,
+            "start": false,
+            "sum": false,
+            "toJSON": false
+        },
+
+        "rules": {
+          "no-underscore-dangle": 0
+        }
     }
 }


### PR DESCRIPTION
This enables linting of CouchDB views which use a unique js environment specified here:
http://couchdb.readthedocs.org/en/latest/query-server/javascript.html.

"no-underscore-dangle" is explicitly disabled as couchdb natively exposes _id and _rev properties.
