### PR TITLE
New: Added no-mixed-spaces-and-tabs rule (fixes #1003)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -87,6 +87,7 @@
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 2,
         "no-wrap-func": 2,
+        "no-mixed-spaces-and-tabs": [2, false],
 
         "block-scoped-var": 0,
         "brace-style": [0, "1tbs"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -134,6 +134,7 @@ These rules are purely matters of style and are quite subjective.
 * [no-trailing-spaces](no-trailing-spaces.md) - disallow trailing whitespace at the end of lines (off by default)
 * [no-underscore-dangle](no-underscore-dangle.md) - disallow dangling underscores in identifiers
 * [no-wrap-func](no-wrap-func.md) - disallow wrapping of none IIFE statements in parents
+* [no-mixed-spaces-and-tabs](no-mixed-spaces-and-tabs.md) - disallow mixed spaces and tabs for indentation
 * [quotes](quotes.md) - specify whether double or single quotes should be used
 * [quote-props](quote-props.md) - require quotes around object literal property names (off by default)
 * [semi](semi.md)- require or disallow use of semicolons instead of ASI

--- a/docs/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/rules/no-mixed-spaces-and-tabs.md
@@ -1,0 +1,49 @@
+# Disallow mixed spaces and tabs for indentation (no-mixed-spaces-and-tabs)
+
+To ensure code is displayed correctly regardless of the viewer's tab size, this rule enforces only tabs or only spaces may be used for indenting code blocks.
+
+The following patterns are considered warnings:
+
+```js
+function add(x, y) {
+--->..return x + y;
+}
+
+function main() {
+--->var x = 5,
+--->....y = 7;
+}
+```
+
+The following patterns are not warnings:
+
+```js
+function add(x, y) {
+--->return x + y;
+}
+
+/* 
+ * When the SmartTabs option is enabled the following 
+ * does not produce a warning.
+ */
+function main() {
+--->var x = 5,
+--->....y = 7;
+}
+```
+
+### Options
+
+- SmartTabs
+
+This option suppresses warnings about mixed tabs and spaces when the latter are
+used for alignment only. This technique is called [SmartTabs](http://www.emacswiki.org/emacs/SmartTabs). The option is turned off by default.
+
+You can enable this option by using the following configuration:
+```json
+"no-mixed-spaces-and-tabs": [2, true]
+```
+
+## Further Reading
+
+[Click here](http://www.emacswiki.org/emacs/SmartTabs) to learn more about SmartTabs. 

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Disallow mixed spaces and tabs for indentation
+ * @author Jary Niebur
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var smartTabs = context.options[0];
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "Program": function(node) {
+            /* 
+             * At least one space followed by a tab
+             * or the reverse before non-tab/-space 
+             * characters begin.
+             */
+            var regex = /^(?=[\t ]*(\t | \t))/;
+
+            if (smartTabs) {
+                /*
+                 * At least one space followed by a tab 
+                 * before non-tab/-space characters begin.
+                 */
+                regex = /^(?=[\t ]* \t)/;
+            }
+
+            context.getSource()
+                .split(/\r?\n/g)
+                .forEach(function(line, i) {
+                    if (regex.exec(line)) {
+                        context.report(node, { line: i + 1 }, "Line " + (i + 1) + " has mixed spaces and tabs.");
+                    }
+                });
+        }
+
+    };
+
+};

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -17,10 +17,10 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/func-style", {
     valid: [
-    	{
-    		code: "function foo(){}\n function bar(){}",
-    		args: [1, "declaration"]
-    	},
+        {
+            code: "function foo(){}\n function bar(){}",
+            args: [1, "declaration"]
+        },
         {
             code: "foo.bar = function(){};",
             args: [1, "declaration"]
@@ -45,10 +45,10 @@ eslintTester.addRuleTest("lib/rules/func-style", {
             code: "foo.bar = function(){};",
             args: [1, "expression"]
         },
-		{
-    		code: "var foo = function(){};\n var bar = function(){};",
-    		args: [1, "expression"]
-    	}
+        {
+            code: "var foo = function(){};\n var bar = function(){};",
+            args: [1, "expression"]
+        }
     ],
 
     invalid: [

--- a/tests/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/tests/lib/rules/no-mixed-spaces-and-tabs.js
@@ -1,0 +1,72 @@
+/**
+ * @fileoverview Disallow mixed spaces and tabs for indentation
+ * @author Jary Niebur
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-mixed-spaces-and-tabs", {
+
+    valid: [
+        {
+            code: "\tvar x = 5;"
+        },
+        {
+            code: "    var x = 5;"
+        },
+        {
+            code: "\tvar x = 5,\n\t    y = 2;",
+            args: [2, true]
+        }
+    ],
+
+    invalid: [
+        {
+            code: "function add(x, y) {\n\t return x + y;\n}",
+            errors: [
+                {
+                    message: "Line 2 has mixed spaces and tabs.",
+                    type: "Program",
+                    line: 2
+                }
+            ]
+        },
+        {
+            code: "\t var x = 5, y = 2, z = 5;\n\n\t \tvar j =\t x + y;\nz *= j;",
+            errors: [
+                {
+                    message: "Line 1 has mixed spaces and tabs.",
+                    type: "Program",
+                    line: 1
+                }, 
+                {
+                    message: "Line 3 has mixed spaces and tabs.",
+                    type: "Program",
+                    line: 3
+                }
+            ]
+        },
+        {
+            code: "\tvar x = 5,\n  \t  y = 2;",
+            args: [2, true],
+            errors: [
+                {
+                    message: "Line 2 has mixed spaces and tabs.",
+                    type: "Program",
+                    line: 2
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
New rule disallows use of mixed spaces and tabs for indentation. Rule is enabled with a smart tabs option that is off by default.
