### PR TITLE
Breaking: Implement configuration hierarchy (fixes #963)

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -240,3 +240,40 @@ foo.js
 ```
 
 This message occurs because ESLint is unsure if you wanted to actually lint the file or not. As the message indicates, you can use `--no-eslintignore` to omit using the ignore rules.
+
+## Configuration Cascading and Hierarchy
+
+When you use `.eslintrc` files for configuration, you can take advantage of configuration cascading. For instance, suppose you have the following structure:
+
+```
+your-project
+├── .eslintrc
+├── lib
+│ └── source.js
+└─┬ tests
+  └─┬ .eslintrc
+    └── test.js
+```
+
+The configuration cascade works by using the closest `.eslintrc` file to the file being linted as the highest priority, then any configuration files in the parent directory, and so on. When you run ESLint on this project, all files in `lib/` will use the `.eslintrc` file at the root of the project as their configuration, so `your-project/lib/source.js` is only affected by `your-project/.eslintrc`. When ESLint traverses into the `tests/` directory, it will then use `your-project/tests/.eslintrc` in addition to `your-project/.eslintrc`. So `your-project/tests/test.js` is linted based on the combination of the two `.eslintrc` files in its directory hierarchy, with the closest one taking priority. In this way, you can have project-level ESLint settings and also have directory-specific overrides.
+
+The complete configuration hierarchy, from highest priority to lowest priority, is as follows:
+
+1. Inline configuration
+    a. `/*eslint-disable*/`
+    b. `/*global*/`
+    c. `/*eslint*/`
+    b. `/*eslint-env*/`
+2. Command line options:
+    -. `--global`
+    a. `--rule`
+    b. `--env`
+    c. `-c`, `--config`
+3. Project-level configuration:
+    a. `.eslintrc` file in same directory as linted file
+    b. Continue searching for `.eslintrc` in ancestor directories (parent has highest priority, then grandparent, etc.), up to and including the root directory.
+    c. XOR, in the absence of any defined `.eslintrc` rules in (a) and (b), fall back to `~/.eslintrc` - personal default configuration
+4. ESLint default configuration:
+    a. `environments.json`
+    b. `eslint.json`
+    c. Blank (no config)

--- a/lib/config.js
+++ b/lib/config.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Responsible for loading config files
  * @author Seth McLaughlin
+ * @copyright 2014 Nicholas C. Zakas. All rights reserved.
+ * @copyright 2013 Seth McLaughlin. All rights reserved.
  */
 "use strict";
 
@@ -14,6 +16,8 @@ var fs = require("fs"),
     util = require("./util"),
     FileFinder = require("./file-finder"),
     stripComments = require("strip-json-comments"),
+    assign = require("object-assign"),
+    debug = require("debug"),
     yaml = require("js-yaml");
 
 
@@ -21,12 +25,14 @@ var fs = require("fs"),
 // Constants
 //------------------------------------------------------------------------------
 
-var LOCAL_CONFIG_FILENAME = ".eslintrc";
-
+var CONFIG_FILENAME = ".eslintrc",
+    PERSONAL_CONFIG_PATH = path.resolve("~/" + CONFIG_FILENAME);
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+debug = debug("eslint:config");
 
 /**
  * Load and parse a JSON config object from a file.
@@ -49,6 +55,22 @@ function loadConfig(filePath) {
 }
 
 /**
+ * Get personal config object from ~/.eslintrc.
+ * @returns {Object} the personal config object (empty object if there is no personal config)
+ * @private
+ */
+function getPersonalConfig() {
+    var config = {};
+
+    if (fs.existsSync(PERSONAL_CONFIG_PATH)) {
+        debug("Using personal config");
+        config = loadConfig(PERSONAL_CONFIG_PATH);
+    }
+
+    return config;
+}
+
+/**
  * Get a local config object.
  * @param {Config} helper The configuration helper to use.
  * @param {string} directory the directory to start looking for a local config
@@ -57,21 +79,69 @@ function loadConfig(filePath) {
 function getLocalConfig(helper, directory) {
     var localConfigFile,
         config = {},
-        parentDirectory;
+        parentDirectory,
+        found = false;
 
     while ((localConfigFile = helper.findLocalConfigFile(directory))) {
+        found = true;
+
+        // don't automatically merge the personal config settings
+        if (localConfigFile === PERSONAL_CONFIG_PATH) {
+            break;
+        }
+
+        debug("Using " + localConfigFile);
         config = util.mergeConfigs(loadConfig(localConfigFile), config);
 
         parentDirectory = path.dirname(directory);
         if (directory === parentDirectory) {
             break;
         }
+
         directory = parentDirectory;
+    }
+
+    if (!found) {
+        config = util.mergeConfigs(config, getPersonalConfig());
     }
 
     return config;
 }
 
+/**
+ * Creates an environment config based on the specified environments.
+ * @param {Object<string,boolean>} envs The environment settings.
+ * @param {boolean} reset The value of the command line reset option. If true,
+ *      rules are not automatically merged into the config.
+ * @returns {Object} A configuration object with the appropriate rules and globals
+ *      set.
+ * @private
+ */
+function createEnvironmentConfig(envs, reset) {
+
+    var envConfig = {
+        globals: {},
+        env: envs || {},
+        rules: {}
+    };
+
+    if (envs) {
+        Object.keys(envs).forEach(function(name) {
+            var environment = environments[name];
+            if (environment) {
+                if (!reset && environment.rules) {
+                    assign(envConfig.rules, environment.rules);
+                }
+
+                if (environment.globals) {
+                    assign(envConfig.globals, environment.globals);
+                }
+            }
+        });
+    }
+
+    return envConfig;
+}
 
 //------------------------------------------------------------------------------
 // API
@@ -107,6 +177,7 @@ function Config(options) {
     this.options = options;
 
     if (useConfig) {
+        debug("Using command line config " + useConfig);
         this.useSpecificConfig = loadConfig(path.resolve(process.cwd(), useConfig));
     }
 }
@@ -118,71 +189,67 @@ function Config(options) {
  * @returns {Object} config object
  */
 Config.prototype.getConfig = function (filePath) {
+
     var config,
         userConfig,
-        envConfig = {},
-        directory = filePath ? path.dirname(filePath) : process.eslintCwd || process.cwd();
+        directory = filePath ? path.dirname(filePath) : process.cwd();
+
+    debug("Constructing config for " + filePath);
 
     config = this.cache[directory];
 
     if (config) {
+        debug("Using config from cache");
         return config;
     }
 
-    if (this.useSpecificConfig) {
-        userConfig = this.useSpecificConfig;
-    } else if (this.useEslintrc) {
+    // Step 1: Determine user-specified config from .eslintrc files
+    if (this.useEslintrc) {
+        debug("Using .eslintrc files");
         userConfig = getLocalConfig(this, directory);
     } else {
+        debug("Not using .eslintrc files");
         userConfig = {};
     }
 
-    // Add cli-supplied environments
-    if (this.env) {
-        if (!userConfig.env) {
-            userConfig.env = {};
+    // Step 2: Create a copy of the baseConfig
+    config = util.mergeConfigs({}, this.baseConfig);
+
+    // Step 3: Merge in environment-specific globals and rules from .eslintrc files
+    config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env, this.options.reset));
+
+    // Step 4: Merge in the user-specified configuration from .eslintrc files
+    config = util.mergeConfigs(config, userConfig);
+
+    // Step 5: Merge in command line config file
+    if (this.useSpecificConfig) {
+        debug("Merging command line config file");
+        config = util.mergeConfigs(config, this.useSpecificConfig);
+
+        if (this.useSpecificConfig.env) {
+            config = util.mergeConfigs(config, createEnvironmentConfig(this.useSpecificConfig.env, this.options.reset));
         }
-        this.env.forEach(function (env) {
-            userConfig.env[env] = true;
-        });
     }
 
-    if (userConfig.env && !this.options.reset) {
-        envConfig.rules = {};
-
-        Object.keys(userConfig.env).forEach(function (name) {
-            var environment = environments[name].rules;
-            if (userConfig.env[name] && environment) {
-                Object.keys(environment).forEach(function(name) {
-                    envConfig.rules[name] = environment[name];
-                });
-            }
-        });
+    // Step 6: Merge in command line environments
+    if (this.env) {
+        debug("Merging command line environment settings");
+        config = util.mergeConfigs(config, createEnvironmentConfig(this.env, this.options.reset));
     }
 
-    config = this.mergeConfigs({}, this.baseConfig);
-    config = this.mergeConfigs(config, envConfig);
-    config = this.mergeConfigs(config, userConfig);
-    config = this.mergeConfigs(config, { globals: this.globals });
-
+    // Step 7: Merge in command line rules
     if (this.options.rules) {
-        config = this.mergeConfigs(config, { rules: this.options.rules });
+        debug("Merging command line rules");
+        config = util.mergeConfigs(config, { rules: this.options.rules });
     }
+
+    // Step 8: Merge in command line globals
+    config = util.mergeConfigs(config, { globals: this.globals });
+
 
     this.cache[directory] = config;
 
     return config;
-};
-
-/**
- * Merge a base config with a custom config object. This allows for overriding base config values without needing to
- * specify all options in a custom config.
- * @param {Object} base the base config
- * @param {Object} custom the custom config
- * @returns {Object} the merged config
- */
-Config.prototype.mergeConfigs = function (base, custom) {
-    return util.mergeConfigs(base, custom);
 };
 
 /**
@@ -192,7 +259,7 @@ Config.prototype.mergeConfigs = function (base, custom) {
  */
 Config.prototype.findLocalConfigFile = function (directory) {
     if (!this.localConfigFinder) {
-        this.localConfigFinder = new FileFinder(LOCAL_CONFIG_FILENAME);
+        this.localConfigFinder = new FileFinder(CONFIG_FILENAME);
     }
     return this.localConfigFinder.findInDirectory(directory);
 };

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -12,6 +12,7 @@ var esprima = require("esprima"),
     estraverse = require("estraverse"),
     escope = require("escope"),
     environments = require("../conf/environments.json"),
+    assign = require("object-assign"),
     rules = require("./rules"),
     util = require("./util"),
     RuleContext = require("./rule-context"),
@@ -121,28 +122,19 @@ function addDeclaredGlobals(program, globalScope, config) {
         explicitGlobals = {},
         builtin = environments.builtin;
 
-    Object.keys(builtin).forEach(function(name) {
-        declaredGlobals[name] = builtin[name];
-    });
+    assign(declaredGlobals, builtin);
 
     Object.keys(config.env).forEach(function (name) {
         if (config.env[name]) {
             var environmentGlobals = environments[name] && environments[name].globals;
             if (environmentGlobals) {
-                Object.keys(environmentGlobals).forEach(function(name) {
-                    declaredGlobals[name] = environmentGlobals[name];
-                });
+                assign(declaredGlobals, environmentGlobals);
             }
         }
     });
 
-    Object.keys(config.globals).forEach(function(name) {
-        declaredGlobals[name] = config.globals[name];
-    });
-
-    Object.keys(config.astGlobals).forEach(function(name) {
-        explicitGlobals[name] = config.astGlobals[name];
-    });
+    assign(declaredGlobals, config.globals);
+    assign(explicitGlobals, config.astGlobals);
 
     Object.keys(declaredGlobals).forEach(function(name) {
         var variable = getVariable(globalScope, name);
@@ -537,6 +529,7 @@ module.exports = (function() {
             Object.keys(config.rules).filter(function(key) {
                 return getRuleSeverity(config.rules[key]) > 0;
             }).forEach(function(key) {
+
                 var ruleCreator = rules.get(key),
                     severity = getRuleSeverity(config.rules[key]),
                     options = getRuleOptions(config.rules[key]),

--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -33,7 +33,7 @@ function FileFinder(fileName) {
  */
 FileFinder.prototype.findInDirectory = function(directory, directoriesToCache) {
 
-    var lookInDirectory = directory || process.eslintCwd || process.cwd(),
+    var lookInDirectory = directory || process.cwd(),
         lookFor = this.fileName,
         files,
         parentDirectory,

--- a/tests/fixtures/config-hierarchy/broken/.eslintrc
+++ b/tests/fixtures/config-hierarchy/broken/.eslintrc
@@ -1,0 +1,4 @@
+env: 
+    node: true
+rules:
+    quotes: [2, "double"]

--- a/tests/fixtures/config-hierarchy/broken/add-conf.yaml
+++ b/tests/fixtures/config-hierarchy/broken/add-conf.yaml
@@ -1,0 +1,2 @@
+rules:
+    semi: [1, "never"]

--- a/tests/fixtures/config-hierarchy/broken/console-wrong-quotes-node.js
+++ b/tests/fixtures/config-hierarchy/broken/console-wrong-quotes-node.js
@@ -1,0 +1,4 @@
+
+/*eslint-env node*/
+
+console.log('bar');

--- a/tests/fixtures/config-hierarchy/broken/console-wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/broken/console-wrong-quotes.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/tests/fixtures/config-hierarchy/broken/override-conf.yaml
+++ b/tests/fixtures/config-hierarchy/broken/override-conf.yaml
@@ -1,0 +1,2 @@
+rules:
+    quotes: 0

--- a/tests/fixtures/config-hierarchy/broken/override-env-conf.yaml
+++ b/tests/fixtures/config-hierarchy/broken/override-env-conf.yaml
@@ -1,0 +1,4 @@
+env:
+    node: true
+rules:
+    quotes: 0

--- a/tests/fixtures/config-hierarchy/broken/process-exit.js
+++ b/tests/fixtures/config-hierarchy/broken/process-exit.js
@@ -1,0 +1,1 @@
+process.exit(0);

--- a/tests/fixtures/config-hierarchy/broken/subbroken/.eslintrc
+++ b/tests/fixtures/config-hierarchy/broken/subbroken/.eslintrc
@@ -1,0 +1,3 @@
+rules:
+    no-console: 1
+    quotes: [2, "single"]

--- a/tests/fixtures/config-hierarchy/broken/subbroken/console-wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/broken/subbroken/console-wrong-quotes.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/tests/fixtures/config-hierarchy/broken/subbroken/subsubbroken/.eslintrc
+++ b/tests/fixtures/config-hierarchy/broken/subbroken/subsubbroken/.eslintrc
@@ -1,0 +1,3 @@
+rules:
+    no-console: 0
+    quotes: [1, "double"]

--- a/tests/fixtures/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/tests/fixtures/config-hierarchy/broken/wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/broken/wrong-quotes.js
@@ -1,0 +1,7 @@
+// function is necessary to avoid any other errors
+function foo(bar) {
+    "use strict";
+    return bar;
+}
+
+foo('bar');

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -8,8 +8,11 @@
 //------------------------------------------------------------------------------
 
 var assert = require("chai").assert,
-    CLIEngine = require("../../lib/cli-engine"),
-    path = require("path");
+    CLIEngine = require("../../lib/cli-engine");
+
+require("shelljs/global");
+
+/*global tempdir, mkdir, rm, cp*/
 
 //------------------------------------------------------------------------------
 // Tests
@@ -17,22 +20,18 @@ var assert = require("chai").assert,
 
 describe("CLIEngine", function() {
 
-    describe("executeOnFiles", function() {
+    describe("executeOnFiles()", function() {
 
         var engine;
-
-        afterEach(function() {
-            process.eslintCwd = null;
-        });
 
         it("should report zero messages when given a config file and a valid file", function() {
 
             engine = new CLIEngine({
-                configFile: path.join(__dirname, "..", ".eslintrc")
+                // configFile: path.join(__dirname, "..", "..", ".eslintrc")
             });
 
             var report = engine.executeOnFiles(["lib/cli.js"]);
-
+            // console.dir(report.results[0].messages);
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].messages.length, 0);
         });
@@ -203,6 +202,7 @@ describe("CLIEngine", function() {
             engine = new CLIEngine({
                 ignore: false,
                 reset: true,
+                useEslintrc: false,
                 rulePaths: ["./tests/fixtures/rules/"],
                 configFile: "./tests/fixtures/rules/eslint.json"
             });
@@ -296,6 +296,248 @@ describe("CLIEngine", function() {
         });
 
         // These tests have to do with https://github.com/eslint/eslint/issues/963
+
+        describe("configuration hierarchy", function() {
+
+            var fixtureDir;
+
+            // copy into clean area so as not to get "infected" by this project's .eslintrc files
+            before(function() {
+                fixtureDir = tempdir() + "/eslint/fixtures";
+                mkdir("-p", fixtureDir);
+                cp("-r", "./tests/fixtures/config-hierarchy", fixtureDir);
+            });
+
+            after(function() {
+                rm("-r", fixtureDir);
+            });
+
+            // Default configuration - blank
+            it("should return zero messages when executing with reset and no .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    useEslintrc: false
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 0);
+            });
+
+            // Default configuration - conf/eslint.json
+            it("should return one message when executing with no .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    useEslintrc: false
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 3);
+                assert.equal(report.results[0].messages[0].ruleId, "no-undef");
+                assert.equal(report.results[0].messages[0].severity, 2);
+                assert.equal(report.results[0].messages[1].ruleId, "no-console");
+                assert.equal(report.results[0].messages[1].severity, 2);
+                assert.equal(report.results[0].messages[2].ruleId, "quotes");
+                assert.equal(report.results[0].messages[2].severity, 2);
+            });
+
+            // Default configuration - conf/environments.json (/*eslint-env node*/)
+            it("should return one message when executing with no .eslintrc in the Node.js environment", function () {
+
+                engine = new CLIEngine({
+                    useEslintrc: false
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes-node.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 2);
+            });
+
+            // Project configuration - first level .eslintrc
+            it("should return one message when executing with .eslintrc in the Node.js environment", function () {
+
+                engine = new CLIEngine();
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/process-exit.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "no-process-exit");
+                assert.equal(report.results[0].messages[0].severity, 2);
+            });
+
+            // Project configuration - first level .eslintrc
+            it("should return zero messages when executing with .eslintrc in the Node.js environment and reset", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/process-exit.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 0);
+            });
+
+            // Project configuration - first level .eslintrc
+            it("should return one message when executing with .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 2);
+            });
+
+            // Project configuration - first level package.json
+            it("should return one message when executing with package.json");
+
+            // Project configuration - second level .eslintrc
+            it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "no-console");
+                assert.equal(report.results[0].messages[0].severity, 1);
+            });
+
+            // Project configuration - third level .eslintrc
+            it("should return one message when executing with local .eslintrc that overrides parent and grandparent .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 1);
+            });
+
+            // Command line configuration - --config with first level .eslintrc
+            it("should return two messages when executing with config file that adds to local .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 2);
+                assert.equal(report.results[0].messages[0].ruleId, "semi");
+                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.equal(report.results[0].messages[1].ruleId, "quotes");
+                assert.equal(report.results[0].messages[1].severity, 2);
+            });
+
+            // Command line configuration - --config with first level .eslintrc
+            it("should return no messages when executing with config file that overrides local .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 0);
+            });
+
+            // Command line configuration - --config with second level .eslintrc
+            it("should return two messages when executing with config file that adds to local and parent .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 2);
+                assert.equal(report.results[0].messages[0].ruleId, "semi");
+                assert.equal(report.results[0].messages[0].severity, 1);
+                assert.equal(report.results[0].messages[1].ruleId, "no-console");
+                assert.equal(report.results[0].messages[1].severity, 1);
+            });
+
+            // Command line configuration - --config with second level .eslintrc
+            it("should return one message when executing with config file that overrides local and parent .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "no-console");
+                assert.equal(report.results[0].messages[0].severity, 1);
+            });
+
+            // Command line configuration - --config with first level .eslintrc
+            it("should return no messages when executing with config file that overrides local .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 0);
+            });
+
+            // Command line configuration - --rule with --config and first level .eslintrc
+            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml",
+                    rules: {
+                        quotes: [1, "double"]
+                    }
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 1);
+            });
+
+            // Command line configuration - --rule with --config and first level .eslintrc
+            it("should return one message when executing with command line rule and config file that overrides local .eslintrc", function () {
+
+                engine = new CLIEngine({
+                    reset: true,
+                    configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml",
+                    rules: {
+                        quotes: [1, "double"]
+                    }
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 1);
+            });
+
+        });
 
         // it("should return zero messages when executing with global node flag", function () {
 
@@ -395,27 +637,6 @@ describe("CLIEngine", function() {
         //         assert.equal(exit, 0);
         //     });
         // });
-
-        it("should return zero messages when supplied with rule flag and severity level set to error", function() {
-
-            engine = new CLIEngine({
-                configFile: "tests/fixtures/configurations/env-browser.json",
-                reset: true,
-                rules: {
-                    quotes: [2, "double"]
-                }
-            });
-
-            var report = engine.executeOnFiles(["tests/fixtures/single-quoted.js"]);
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].messages.length, 1);
-            assert.equal(report.results[0].messages[0].ruleId, "quotes");
-            assert.equal(report.results[0].messages[0].severity, 2);
-        });
-
-
-
-
 
     });
 

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -275,24 +275,6 @@ describe("cli", function() {
         });
     });
 
-    describe("when executing with env flag", function () {
-        var files = [
-            "./tests/fixtures/globals-browser.js",
-            "./tests/fixtures/globals-node.js"
-        ];
-
-        it("should allow environment-specific globals", function () {
-            cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --env browser,node --no-ignore " + files.join(" "));
-
-            assert.equal(console.log.args[0][0].split("\n").length, 9);
-        });
-
-        it("should allow environment-specific globals, with multiple flags", function () {
-            cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --env browser --env node --no-ignore " + files.join(" "));
-            assert.equal(console.log.args[0][0].split("\n").length, 9);
-        });
-    });
-
     describe("when executing without env flag", function () {
         var files = [
             "./tests/fixtures/globals-browser.js",

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -8,75 +8,118 @@
 //------------------------------------------------------------------------------
 
 var assert = require("chai").assert,
+    util = require("../../lib/util"),
     path = require("path"),
+    baseConfig = require("../../conf/eslint.json"),
+    environments = require("../../conf/environments.json"),
+
     fs = require("fs"),
     Config = require("../../lib/config"),
     sinon = require("sinon");
 
+require("shelljs/global");
+
+/*global tempdir, mkdir, rm, cp*/
+
+
+/**
+ * Asserts that two configs are equal. This is necessary because assert.deepEqual()
+ * gets confused when properties are in different orders.
+ * @param {Object} actual The config object to check.
+ * @param {Object} expected What the config object should look like.
+ * @returns {void}
+ * @private
+ */
+function assertConfigsEqual(actual, expected) {
+    if (actual.env && expected.env) {
+        assert.deepEqual(actual.env, expected.env);
+    }
+
+    if (actual.globals && expected.globals) {
+        assert.deepEqual(actual.globals, expected.globals);
+    }
+
+    if (actual.rules && expected.rules) {
+        assert.deepEqual(actual.rules, expected.rules);
+    }
+}
 
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
 
-describe("config", function() {
-    describe("findLocalConfigFile", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes");
+describe("Config", function() {
 
-        it("should find local config file", function() {
+    var fixtureDir,
+        sandbox;
+
+    /**
+     * Returns the path inside of the fixture directory.
+     * @returns {string} The path inside the fixture directory.
+     * @private
+     */
+    function getFixturePath() {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift("config-hierarchy");
+        args.unshift(fixtureDir);
+        return path.join.apply(path, args);
+    }
+
+    // copy into clean area so as not to get "infected" by this project's .eslintrc files
+    before(function() {
+        fixtureDir = tempdir() + "/eslint/fixtures";
+        mkdir("-p", fixtureDir);
+        cp("-r", "./tests/fixtures/config-hierarchy", fixtureDir);
+    });
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.verifyAndRestore();
+    });
+
+    after(function() {
+        rm("-r", fixtureDir);
+    });
+
+    describe("findLocalConfigFile()", function() {
+
+        it("should return the path when an .eslintrc file is found", function() {
             var configHelper = new Config(),
-                expected = path.resolve(code, ".eslintrc"),
-                actual = configHelper.findLocalConfigFile(code);
+                expected = getFixturePath("broken", ".eslintrc"),
+                actual = configHelper.findLocalConfigFile(getFixturePath("broken"));
 
             assert.equal(actual, expected);
         });
-    });
 
-    describe("mergeConfigs", function() {
-        var code = { person: { name: "Seth", car: "prius" }, town: "MV" };
-
-        it("should merge configs", function() {
+        it("should return an empty string when an .eslintrc file is not found", function() {
             var configHelper = new Config(),
-                expected = { person: { name: "Bob", car: "prius" }, town: "PA" },
-                actual = configHelper.mergeConfigs(code, { person: { name: "Bob" }, town: "PA" });
-
-            assert.deepEqual(expected, actual);
-        });
-    });
-
-    describe("getConfig with env rules", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations",
-                "env-node.json");
-
-        it("should be no-global-strict off for node env", function() {
-
-            var configHelper = new Config({configFile: code}),
-                config = configHelper.getConfig(),
-                expected = 0,
-                actual = config.rules["no-global-strict"];
+                expected = "",
+                actual = configHelper.findLocalConfigFile(getFixturePath());
 
             assert.equal(actual, expected);
         });
+
     });
 
-    describe("getConfig with env and user rules", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations",
-                "env-node-override.json");
+    describe("getConfig()", function() {
 
-        it("should be no-global-strict a warning", function() {
-            var configHelper = new Config({configFile: code}),
-                config = configHelper.getConfig(),
-                expected = 1,
-                actual = config.rules["no-global-strict"];
+        it("should return the project config when called in current working directory", function() {
+            var configHelper = new Config({ reset: true }),
+                expected = JSON.parse(fs.readFileSync("./.eslintrc", "utf8")),
+                actual = configHelper.getConfig();
 
-            assert.equal(actual, expected);
+            assertConfigsEqual(expected, actual);
+
         });
-    });
 
-    describe("getConfig", function() {
-        var firstpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", "subdir", ".eslintrc");
-        var secondpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
+        it("should not retain configs from previous directories when called multiple times", function() {
 
-        it("should not retain configs from previous directories", function() {
+            var firstpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", "subdir", ".eslintrc");
+            var secondpath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
+
             var configHelper = new Config(),
                 config;
 
@@ -86,132 +129,46 @@ describe("config", function() {
             config = configHelper.getConfig(secondpath);
             assert.equal(config.rules["dot-notation"], 2);
         });
-    });
 
-    describe("getLocalConfig with directory", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
-
-        it("should be single quotes config", function() {
-            var configHelper = new Config(),
-                config = configHelper.getConfig(code),
-                expected = [1, "single"],
-                actual = config.rules.quotes;
-
-            assert.deepEqual(expected, actual);
-        });
-    });
-
-    describe("getLocalConfig with nested directories", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", "subdir", ".eslintrc");
-
-        it("should be merged config", function() {
-            var configHelper = new Config(),
-                config = configHelper.getConfig(code);
-
-            assert.equal(config.rules["dot-notation"], 0);
-            assert.equal(config.rules["no-new"], 1);
-        });
-    });
-
-    describe("getLocalConfig with invalid directory", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "foobaz", ".eslintrc");
-
-        it("should throw error", function() {
+        it("should throw error when an invalid path is given", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "foobaz", ".eslintrc");
             var configHelper = new Config();
 
             assert.throws(function () {
-                configHelper.getConfig(code);
+                configHelper.getConfig(configPath);
             });
         });
-    });
 
-    describe("getLocalConfig with invalid file", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations", ".eslintrc");
-
-        it("should throw error", function() {
+        it("should throw error when an invalid configuration file is read", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", ".eslintrc");
             var configHelper = new Config();
 
-            sinon.stub(fs, "readFileSync", function() {
+            sandbox.stub(fs, "readFileSync", function() {
                 throw new Error();
             });
 
             assert.throws(function () {
-                configHelper.getConfig(code);
+                configHelper.getConfig(configPath);
             }, "Cannot read config file");
 
-            fs.readFileSync.restore();
         });
-    });
 
-    describe("getConfig", function() {
-        var code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
-
-        it("should cache config", function() {
+        it("should cache config when the same directory is passed twice", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
             var configHelper = new Config();
 
-            sinon.spy(configHelper, "findLocalConfigFile");
+            sandbox.spy(configHelper, "findLocalConfigFile");
 
             // If cached this should be called only once
-            configHelper.getConfig(code);
+            configHelper.getConfig(configPath);
             var callcount = configHelper.findLocalConfigFile.callcount;
-            configHelper.getConfig(code);
+            configHelper.getConfig(configPath);
 
             assert.equal(configHelper.findLocalConfigFile.callcount, callcount);
-
-            configHelper.findLocalConfigFile.restore();
         });
-    });
 
-    describe("getLocalConfig with current directory", function() {
-        it("should return false", function() {
-            var configHelper = new Config();
-
-            var output = configHelper.findLocalConfigFile("/");
-            assert.isFalse(output);
-        });
-    });
-
-    describe("getLocalConfig with no directory", function() {
-        it("should return global config", function() {
-            var configHelper = new Config();
-
-            var output = configHelper.findLocalConfigFile();
-            assert.include(output, ".eslintrc");
-        });
-    });
-
-    describe("getConfig with no directory", function() {
-        it("should return cwd config", function() {
-            var cwd = process.cwd();
-            process.chdir(path.resolve(__dirname, "..", "fixtures", "configurations", "cwd"));
-
-            try {
-                var configHelper = new Config(),
-                    code = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc"),
-                    expected = configHelper.getConfig(code),
-                    expectedQuotes = expected.rules.quotes[0],
-                    actual = configHelper.getConfig(),
-                    actualQuotes = actual.rules.quotes[0];
-
-                assert.notEqual(expectedQuotes, actualQuotes);
-            } finally {
-                process.chdir(cwd);
-            }
-        });
-    });
-
-    describe("Config with abitrarily named config file", function() {
-        it("should load the config file", function() {
-            var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "my-awesome-config"),
-                configHelper = new Config({configFile: configPath}),
-                quotes = configHelper.useSpecificConfig.rules.quotes[0];
-
-            assert.equal(quotes, 3);
-        });
-    });
-
-    describe("Config with comments", function() {
-        it("should load the config file", function() {
+        // make sure JS-style comments don't throw an error
+        it("should load the config file when there are JS-style comments in the text", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "comments.json"),
                 configHelper = new Config({configFile: configPath}),
                 semi = configHelper.useSpecificConfig.rules.semi,
@@ -220,10 +177,9 @@ describe("config", function() {
             assert.equal(semi, 1);
             assert.equal(strict, 0);
         });
-    });
 
-    describe("YAML config", function() {
-        it("should load the config file", function() {
+        // make sure YAML files work correctly
+        it("should load the config file when a YAML file is used", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "env-browser.yaml"),
                 configHelper = new Config({configFile: configPath}),
                 noAlert = configHelper.useSpecificConfig.rules["no-alert"],
@@ -232,6 +188,235 @@ describe("config", function() {
             assert.equal(noAlert, 0);
             assert.equal(noUndef, 2);
         });
+
+        // Configuration hierarchy ---------------------------------------------
+
+        // Default configuration - blank
+        it("should return a blank config when using reset and no .eslintrc", function() {
+
+            var configHelper = new Config({ reset: true, useEslintrc: false }),
+                file = getFixturePath("broken", "console-wrong-quotes.js"),
+                expected = {
+                    rules: {},
+                    globals: [],
+                    env: {}
+                },
+                actual = configHelper.getConfig(file);
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Default configuration - conf/eslint.json
+        it("should return the default config when not using .eslintrc", function () {
+
+            var configHelper = new Config({ useEslintrc: false }),
+                file = getFixturePath("broken", "console-wrong-quotes.js"),
+                expected = baseConfig,
+                actual = configHelper.getConfig(file);
+
+            assertConfigsEqual(expected, actual);
+
+        });
+
+        // Project configuration - conf/eslint.json + first level .eslintrc
+        it("should merge environment rules into config when using .eslintrc and the built-in defaults", function () {
+
+            var configHelper = new Config(),
+                file = getFixturePath("broken", "console-wrong-quotes.js"),
+                expected = baseConfig,
+                actual = configHelper.getConfig(file);
+
+            expected = util.mergeConfigs(expected, { rules: environments.node.rules });
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Project configuration - first level .eslintrc
+        it("should not merge environment rules into config when using .eslintrc and reset", function () {
+
+            var configHelper = new Config({ reset: true }),
+                file = getFixturePath("broken", "console-wrong-quotes.js"),
+                expected = {
+                    env: {
+                        node: true
+                    },
+                    rules: {
+                        quotes: [2, "double"]
+                    }
+                },
+                actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Project configuration - second level .eslintrc
+        it("should merge configs when local .eslintrc overrides parent .eslintrc", function () {
+
+            var configHelper = new Config({ reset: true }),
+                file = getFixturePath("broken", "subbroken", "console-wrong-quotes.js"),
+                expected = {
+                    env: {
+                        node: true
+                    },
+                    rules: {
+                        "no-console": 1,
+                        quotes: [2, "single"]
+                    }
+                },
+                actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Project configuration - third level .eslintrc
+        it("should merge configs when local .eslintrc overrides parent and grandparent .eslintrc", function () {
+
+            var configHelper = new Config({ reset: true }),
+                file = getFixturePath("broken", "subbroken", "subsubbroken", "console-wrong-quotes.js"),
+                expected = {
+                    env: {
+                        node: true
+                    },
+                    rules: {
+                        "no-console": 0,
+                        quotes: [1, "double"]
+                    }
+                },
+                actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Command line configuration - --config with first level .eslintrc
+        it("should merge command line config when config file adds to local .eslintrc", function () {
+
+            var configHelper = new Config({
+                    reset: true ,
+                    configFile: getFixturePath("broken", "add-conf.yaml")
+                }),
+                file = getFixturePath("broken", "console-wrong-quotes.js"),
+                expected = {
+                    env: {
+                        node: true
+                    },
+                    rules: {
+                        quotes: [2, "double"],
+                        semi: [1, "never"]
+                    }
+                },
+                actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Command line configuration - --config with first level .eslintrc
+        it("should merge command line config when config file overrides local .eslintrc", function () {
+
+            var configHelper = new Config({
+                    reset: true ,
+                    configFile: getFixturePath("broken", "override-conf.yaml")
+                }),
+                file = getFixturePath("broken", "console-wrong-quotes.js"),
+                expected = {
+                    env: {
+                        node: true
+                    },
+                    rules: {
+                        quotes: [0, "double"]
+                    }
+                },
+                actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Command line configuration - --config with second level .eslintrc
+        it("should merge command line config when config file adds to local and parent .eslintrc", function () {
+
+            var configHelper = new Config({
+                reset: true ,
+                configFile: getFixturePath("broken", "add-conf.yaml")
+            }),
+            file = getFixturePath("broken", "subbroken", "console-wrong-quotes.js"),
+            expected = {
+                env: {
+                    node: true
+                },
+                rules: {
+                    quotes: [2, "single"],
+                    "no-console": 1,
+                    semi: [1, "never"]
+                }
+            },
+            actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Command line configuration - --config with second level .eslintrc
+        it("should merge command line config when config file overrides local and parent .eslintrc", function () {
+
+            var configHelper = new Config({
+                reset: true ,
+                configFile: getFixturePath("broken", "override-conf.yaml")
+            }),
+            file = getFixturePath("broken", "subbroken", "console-wrong-quotes.js"),
+            expected = {
+                env: {
+                    node: true
+                },
+                rules: {
+                    quotes: [0, "single"],
+                    "no-console": 1
+                }
+            },
+            actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Command line configuration - --rule with --config and first level .eslintrc
+        it("should merge command line config and rule when rule and config file overrides local .eslintrc", function () {
+
+            var configHelper = new Config({
+                reset: true ,
+                configFile: getFixturePath("broken", "override-conf.yaml"),
+                rules: {
+                    quotes: [1, "double"]
+                }
+            }),
+            file = getFixturePath("broken", "console-wrong-quotes.js"),
+            expected = {
+                env: {
+                    node: true
+                },
+                rules: {
+                    quotes: [1, "double"]
+                }
+            },
+            actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+
     });
 
 });


### PR DESCRIPTION
Just want to get some eyes on this to see if I've missed anything. Some things to note:
1. I've not yet tackled the `package.json` piece of this.
2. Discovered that most of the CLI tests are really hard to figure out exactly what they're testing. As such, I'm never quite sure when something breaks if it means anything.
3. Some tests are breaking - not sure what that means given 2.
4. I ended up writing tests for the `CLIEngine` that really should be for `Config`. I'll spend some time translating that over.
5. Many tests are being infected by the `.eslintrc` file in the root directory. For the new tests, I copy over into a temp directory to avoid that effect.
6. I think the implementation is mostly correct - I just need to redo the tests to have a higher degree of confidence in that.
