### PR TITLE
New: report output to a file (fixes #1027)

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -26,6 +26,7 @@ Options:
   -c, --config path::String   Load configuration data from this file.
   --rulesdir [path::String]   Load additional rules from this directory.
   -f, --format String         Use a specific output format. - default: stylish
+  -o, --output-file           Outputs the output into a file.
   -v, --version               Outputs the version number.
   --reset                     Set all default rules to off.
   --eslintrc                  Enable loading .eslintrc configuration. -
@@ -65,6 +66,16 @@ When specified, the given format is output to the console. If you'd like to save
     eslint -f compact file.js > results.txt
 
 This saves the output into the `results.txt` file.
+
+### `-o`
+
+This option specifies the output file name which can be passes for the output of the task to be put into
+
+Example:
+
+    eslint -o ./test/test.html
+
+When specified, the given format is output into the provided file name.
 
 ### `--rulesdir`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -21,7 +21,8 @@ var fs = require("fs"),
     debug = require("debug"),
 
     options = require("./options"),
-    CLIEngine = require("./cli-engine");
+    CLIEngine = require("./cli-engine"),
+    mkdirp = require("mkdirp");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -53,14 +54,17 @@ function translateOptions(cliOptions) {
  * Outputs the results of the linting.
  * @param {LintResult[]} results The results to print.
  * @param {string} format The name of the formatter to use or the path to the formatter.
+ * @param {string} outputFile The path for the output file.
  * @param {Config} config The configuration options for the results.
  * @returns {boolean} True if the printing succeeds, false if not.
  * @private
  */
-function printResults(results, format, config) {
+function printResults(results, format, outputFile, config) {
     var formatter,
         formatterPath,
-        output;
+        output,
+        filePath,
+        made;
 
     if (fs.existsSync(path.resolve(process.cwd(), format))) {
         formatterPath = path.resolve(process.cwd(), format);
@@ -76,8 +80,19 @@ function printResults(results, format, config) {
 
     output = formatter(results, config);
     if (output) {
-        console.log(output);
+        if (outputFile) {
+            filePath = path.resolve(process.cwd(), outputFile);
+            made = mkdirp.sync(path.dirname(filePath));
+            if (made) {
+                fs.writeFileSync(filePath, output);
+            } else {
+                return false;
+            }
+        } else {
+            console.log(output);
+        }
     }
+
     return true;
 
 }
@@ -140,7 +155,7 @@ var cli = {
 
             engine = new CLIEngine(translateOptions(currentOptions));
             result = engine.executeOnFiles(files);
-            if (printResults(result.results, currentOptions.format)) {
+            if (printResults(result.results, currentOptions.format, currentOptions.outputFile)) {
                 return calculateExitCode(result.results);
             } else {
                 return 1;

--- a/lib/options.js
+++ b/lib/options.js
@@ -84,5 +84,11 @@ module.exports = optionator({
         type: "Boolean",
         default: "true",
         description: "Enable color in piped output."
+    },
+    {
+        option: "output-file",
+        alias: "o",
+        type: "path::String",
+        description: "Enable report to be written to a file."
     }]
 });

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "doctrine": "~0.5.0",
     "minimatch": "^0.3.0",
     "debug": "^0.8.1",
-    "object-assign": "^0.3.1"
+    "object-assign": "^0.3.1",
+    "mkdirp": "^0.5.0"
   },
   "devDependencies": {
     "sinon": "1.7.3",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -10,7 +10,8 @@
 var assert = require("chai").assert,
     cli = require("../../lib/cli"),
     path = require("path"),
-    sinon = require("sinon");
+    sinon = require("sinon"),
+    fs = require("fs");
 
 //------------------------------------------------------------------------------
 // Tests
@@ -337,6 +338,24 @@ describe("cli", function() {
             exitStatus = cli.execute(code);
 
             assert.equal(exitStatus, 1);
+        });
+    });
+
+    describe("when supplied with report output file path", function() {
+        it("should exit with an status (1) and file not exists", function() {
+            var code = "--o . tests/fixtures/single-quoted.js";
+            var exitStatus;
+            exitStatus = cli.execute(code);
+            assert.equal(exitStatus, 1);
+            assert.equal(fs.existsSync(path.resolve(process.cwd(),"./gstest/test/test.txt")), false);
+        });
+
+        it("should exit with an status (1) and file exits", function() {
+            var code = "--o ./gstest/test/test.txt tests/fixtures/single-quoted.js";
+            var exitStatus;
+            exitStatus = cli.execute(code);
+            assert.equal(exitStatus, 1);
+            assert.equal(fs.existsSync(path.resolve(process.cwd(),"./gstest/test/test.txt")), true);
         });
     });
 });


### PR DESCRIPTION
This merge would allow user to supply the reportOutput option with the specified file path and the output would be written to that file.
This would help us to generate pretty reports using HTML.
