### PR TITLE
New: Add getSourceLines() to core and rule context (fixed #1005)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -364,6 +364,7 @@ module.exports = (function() {
     var api = Object.create(new EventEmitter()),
         messages = [],
         currentText = null,
+        currentTextLines = [],
         currentConfig = null,
         currentTokens = null,
         currentScopes = null,
@@ -494,6 +495,7 @@ module.exports = (function() {
         messages = [];
         currentConfig = null;
         currentText = null;
+        currentTextLines = [];
         currentTokens = null;
         currentScopes = null;
         controller = null;
@@ -567,6 +569,16 @@ module.exports = (function() {
 
             // gather data that may be needed by the rules
             currentScopes = escope.analyze(ast, { ignoreEval: true }).scopes;
+
+            /*
+             * Split text here into array of lines so
+             * it's not being done repeatedly
+             * by individual rules.
+             */
+            currentTextLines = currentText.split(/\r?\n/g);
+
+            // Freezing so array isn't accidentally changed by a rule.
+            Object.freeze(currentTextLines);
 
             /* get all tokens from the ast and store them as a hashtable to
              * improve traversal speed when wanting to find tokens for a given
@@ -666,6 +678,14 @@ module.exports = (function() {
             return currentText;
         }
 
+    };
+
+    /**
+     * Gets the entire source text split into an array of lines.
+     * @returns {Array} The source text as an array of lines.
+     */
+    api.getSourceLines = function() {
+        return currentTextLines;
     };
 
     /**

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -10,6 +10,7 @@
 
 var PASSTHROUGHS = [
         "getSource",
+        "getSourceLines",
         "getTokens",
         "getTokensBefore",
         "getTokenBefore",

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -24,7 +24,8 @@ module.exports = function(context) {
              * or the reverse before non-tab/-space 
              * characters begin.
              */
-            var regex = /^(?=[\t ]*(\t | \t))/;
+            var regex = /^(?=[\t ]*(\t | \t))/,
+                match;
 
             if (smartTabs) {
                 /*
@@ -34,11 +35,13 @@ module.exports = function(context) {
                 regex = /^(?=[\t ]* \t)/;
             }
 
-            context.getSource()
-                .split(/\r?\n/g)
+            context
+                .getSourceLines()
                 .forEach(function(line, i) {
-                    if (regex.exec(line)) {
-                        context.report(node, { line: i + 1 }, "Line " + (i + 1) + " has mixed spaces and tabs.");
+                    match = regex.exec(line);
+                    
+                    if (match) {
+                        context.report(node, { line: i + 1, column: match.index + 1 }, "Mixed spaces and tabs.");
                     }
                 });
         }

--- a/tests/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/tests/lib/rules/no-mixed-spaces-and-tabs.js
@@ -36,7 +36,7 @@ eslintTester.addRuleTest("lib/rules/no-mixed-spaces-and-tabs", {
             code: "function add(x, y) {\n\t return x + y;\n}",
             errors: [
                 {
-                    message: "Line 2 has mixed spaces and tabs.",
+                    message: "Mixed spaces and tabs.",
                     type: "Program",
                     line: 2
                 }
@@ -46,12 +46,12 @@ eslintTester.addRuleTest("lib/rules/no-mixed-spaces-and-tabs", {
             code: "\t var x = 5, y = 2, z = 5;\n\n\t \tvar j =\t x + y;\nz *= j;",
             errors: [
                 {
-                    message: "Line 1 has mixed spaces and tabs.",
+                    message: "Mixed spaces and tabs.",
                     type: "Program",
                     line: 1
                 }, 
                 {
-                    message: "Line 3 has mixed spaces and tabs.",
+                    message: "Mixed spaces and tabs.",
                     type: "Program",
                     line: 3
                 }
@@ -62,7 +62,7 @@ eslintTester.addRuleTest("lib/rules/no-mixed-spaces-and-tabs", {
             args: [2, true],
             errors: [
                 {
-                    message: "Line 2 has mixed spaces and tabs.",
+                    message: "Mixed spaces and tabs.",
                     type: "Program",
                     line: 2
                 }


### PR DESCRIPTION
Added getSourceLines() to eslint.js; didn't include option to pass node and return only source lines of given node. Replaced getSource() with getSourceLines() where applicable.

Changed error message from no-mixed-spaces-and-tabs rule: removed "Line n has ..." because it's redundant.
