### PR TITLE
New: space-in-parens rule

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -120,6 +120,7 @@
         "sort-vars": 0,
         "space-after-keywords": [0, "always"],
         "space-in-brackets": [0, "never"],
+        "space-in-parens": [0, "never"],
         "space-infix-ops": 2,
         "space-return-throw-case": 2,
         "space-unary-word-ops": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -141,7 +141,8 @@ These rules are purely matters of style and are quite subjective.
 * [semi](semi.md)- require or disallow use of semicolons instead of ASI
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block (off by default)
 * [space-after-keywords](space-after-keywords.md) - require a space after certain keywords (off by default)
-* [space-in-brackets](space-in-brackets.md) - require or disallow spaces between brackets (off by default)
+* [space-in-brackets](space-in-brackets.md) - require or disallow spaces inside brackets (off by default)
+* [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses (off by default)
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators
 * [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`
 * [space-unary-word-ops](space-unary-word-ops.md) - require a space around word operators such as `typeof` (off by default)

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -154,3 +154,7 @@ Note that `"always"` has a special case where `{}` and `[]` are not considered w
 ## When Not To Use It
 
 You can turn this rule off if you are not concerned with the consistency of spacing between brackets.
+
+## Related Rules
+
+* [space-in-parens](space-in-parens.md)

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -1,0 +1,84 @@
+# Disallow or enforce spaces inside of parentheses (space-in-parens)
+
+Some style guides require or disallow spaces inside of parentheses:
+
+```js
+foo( 'bar' );
+var x = ( 1 + 2 ) * 3;
+
+foo('bar');
+var x = (1 + 2) * 3;
+```
+
+## Rule Details
+
+This rule will enforce consistency of spacing directly inside of parentheses, by disallowing or requiring one or more spaces to the right of `(` and to the left of `)`. In either case, `()` will still be allowed.
+
+### Options
+
+There are two options for this rule:
+
+* `"always"` enforces a space inside of parentheses
+* `"never"` enforces zero spaces inside of parentheses (default)
+
+Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+
+```json
+"space-in-brackets": [2, "always"]
+```
+
+#### always
+
+When `"always"` is set, the following patterns are considered warnings:
+
+```js
+foo( 'bar');
+foo('bar' );
+foo('bar');
+
+var foo = (1 + 2) * 3;
+(function () { return 'bar'; }());
+```
+
+The following patterns are not warnings:
+
+```js
+foo();
+
+foo( 'bar' );
+
+var foo = ( 1 + 2 ) * 3;
+( function () { return 'bar'; }() );
+```
+
+#### never
+
+When `"never"` is used, the following patterns are considered warnings:
+
+```js
+foo( 'bar');
+foo('bar' );
+foo( 'bar' );
+
+var foo = ( 1 + 2 ) * 3;
+( function () { return 'bar'; }() );
+```
+
+The following patterns are not warnings:
+
+```js
+foo();
+
+foo('bar');
+
+var foo = (1 + 2) * 3;
+(function () { return 'bar'; }());
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the consistency of spacing between parentheses.
+
+## Related Rules
+
+* [space-in-brackets](space-in-brackets.md)

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside of parentheses.
+ * @author Jonathan Rajavuori
+ * @copyright 2014 Jonathan Rajavuori. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var RE, MESSAGE;
+
+    if (context.options[0] === "always") {
+        RE = /\([^ \)]|[^ \(]\)/mg;
+        MESSAGE = "There must be a space inside this paren.";
+    } else {
+        RE = /\( | \)/mg;
+        MESSAGE = "There should be no spaces inside this paren.";
+    }
+
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    var skipRanges = [];
+
+    /**
+     * Adds the range of a node to the set to be skipped when checking parens
+     * @param {ASTNode} node The node to skip
+     * @returns {void}
+     * @private
+     */
+    function addSkipRange(node) {
+        skipRanges.push(node.range);
+    }
+
+    /**
+     * Sorts the skipRanges array. Must be called before shouldSkip
+     * @returns {void}
+     * @private
+     */
+    function sortSkipRanges() {
+        skipRanges.sort(function (a, b) {
+            return a[0] - b[0];
+        });
+    }
+
+    /**
+     * Checks if a certain position in the source should be skipped
+     * @param {Number} pos The 0-based index in the source
+     * @returns {boolean} whether the position should be skipped
+     * @private
+     */
+    function shouldSkip(pos) {
+        var i, len, range;
+        for (i = 0, len = skipRanges.length; i < len; i += 1) {
+            range = skipRanges[i];
+            if (pos < range[0]) {
+                break;
+            } else if (pos < range[1]) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "Program:exit": function checkParenSpaces(node) {
+
+            var match,
+                nextLine,
+                column,
+                line = 1,
+                source = context.getSource(),
+                pos = 0;
+
+            sortSkipRanges();
+
+            while ((match = RE.exec(source)) !== null) {
+                if (source.charAt(match.index) !== "(") {
+                    // Matched a closing paren pattern
+                    match.index += 1;
+                }
+
+                if (!shouldSkip(match.index)) {
+                    while ((nextLine = source.indexOf("\n", pos)) !== -1 && nextLine < match.index) {
+                        pos = nextLine + 1;
+                        line += 1;
+                    }
+                    column = match.index - pos;
+
+                    context.report(node, { line: line, column: column }, MESSAGE);
+                }
+            }
+
+        },
+
+
+        // These nodes can contain parentheses that this rule doesn't care about
+
+        LineComment: addSkipRange,
+
+        BlockComment: addSkipRange,
+
+        Literal: addSkipRange
+
+    };
+
+};

--- a/tests/lib/rules/space-in-parens.js
+++ b/tests/lib/rules/space-in-parens.js
@@ -1,0 +1,124 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside of parentheses.
+ * @author Jonathan Rajavuori
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/space-in-parens", {
+
+    valid: [
+        { code: "foo()", args: ["2", "always"] },
+        { code: "foo( bar )", args: ["2", "always"] },
+        { code: "var x = ( 1 + 2 ) * 3", args: ["2", "always"] },
+        { code: "var x = 'foo(bar)'", args: ["2", "always"] },
+
+        { code: "bar()", args: ["2", "never"] },
+        { code: "bar(baz)", args: ["2", "never"] },
+        { code: "var x = (4 + 5) * 6", args: ["2", "never"] },
+        { code: "var x = 'bar( baz )'", args: ["2", "always"] }
+    ],
+
+    invalid: [
+        {
+            code: "foo( bar)",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "There must be a space inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+        {
+            code: "foo(bar)",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "There must be a space inside this paren.",
+                    type: "Program"
+                },
+                {
+                    message: "There must be a space inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+        {
+            code: "var x = ( 1 + 2) * 3",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "There must be a space inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+        {
+            code: "var x = (1 + 2 ) * 3",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "There must be a space inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+
+        {
+            code: "bar(baz )",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no spaces inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+        {
+            code: "bar( baz )",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no spaces inside this paren.",
+                    type: "Program"
+                },
+                {
+                    message: "There should be no spaces inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+        {
+            code: "var x = ( 4 + 5) * 6",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no spaces inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+        {
+            code: "var x = (4 + 5 ) * 6",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no spaces inside this paren.",
+                    type: "Program"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Closes #627.

You'll notice that I set the rule to off by default. This is to be consistent with the existing `space-in-brackets` rule which seems closely related as more of a stylistic concern. I can easily switch it back to on by default as @nzakas originally said; however that will also require either setting it to off in eslint's .eslintrc or correcting the 20 or so files that currently fail it.
