### PR TITLE
Fix: Always make globals an object

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -167,12 +167,12 @@ function Config(options) {
     this.baseConfig.format = options.format;
     this.useEslintrc = (options.useEslintrc !== false);
     this.env = options.envs;
-    this.globals = options.globals ? options.globals.reduce(function (globals, def) {
+    this.globals = (options.globals || []).reduce(function (globals, def) {
         // Default "foo" to false and handle "foo:false" and "foo:true"
         var parts = def.split(":");
         globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
         return globals;
-    }, {}) : [];
+    }, {});
     useConfig = options.configFile;
     this.options = options;
 

--- a/tests/fixtures/globals/conf.yaml
+++ b/tests/fixtures/globals/conf.yaml
@@ -1,0 +1,5 @@
+{
+    "globals": {
+        "foo": true
+    }
+}

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -285,7 +285,7 @@ describe("cli", function() {
 
         it("should not define environment-specific globals", function () {
             cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
-            assert.equal(console.log.args[0][0].split("\n").length, 12);
+            assert.equal(console.log.args[0][0].split("\n").length, 9);
         });
     });
 

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -198,7 +198,7 @@ describe("Config", function() {
                 file = getFixturePath("broken", "console-wrong-quotes.js"),
                 expected = {
                     rules: {},
-                    globals: [],
+                    globals: {},
                     env: {}
                 },
                 actual = configHelper.getConfig(file);
@@ -414,6 +414,24 @@ describe("Config", function() {
             expected.env.node = true;
 
             assertConfigsEqual(expected, actual);
+        });
+
+
+        it("should load user config globals", function() {
+            var expected,
+                actual,
+                configPath = path.resolve(__dirname, "..", "fixtures", "globals", "conf.yaml"),
+                configHelper = new Config({ reset: true, configFile: configPath, useEslintrc: false });
+
+            expected = {
+                globals: {
+                    foo: true
+                }
+            };
+
+            actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(actual, expected);
         });
 
 


### PR DESCRIPTION
Fixes #1049.

Correct the recent configuration hierarchy change which changed this.globals' initialization to default to `[]` when options.globals is falsy, rather than `{}`. This caused later globals logic to fail,  most importantly [line 247](https://github.com/eslint/eslint/blob/v0.7.1/lib/config.js#L247) where that `[]` is merged into an object, overwriting the user config globals.

Also fixed tests that failed as a result of the correction and added a new test for the user config globals that were failing.
