### PR TITLE
Fix: Stringify before new-cap check

### DIFF
--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -59,7 +59,7 @@ module.exports = function(context) {
      * @returns {String} capitalization state: "non-alpha", "lower", or "upper"
      */
     function getCap(str) {
-        var firstChar = str.charAt(0);
+        var firstChar = String(str).charAt(0);
 
         var firstCharLower = firstChar.toLowerCase();
         var firstCharUpper = firstChar.toUpperCase();

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -38,6 +38,8 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         "var x = RegExp(42)",
         "var x = _();",
         "var x = $();",
+        "var o = { 1: function () {} }; o[1]();",
+        "var o = { 1: function () {} }; new o[1]();",
         {code: "var x = Foo(42)", args: [1, {"capIsNew": false}]},
         {code: "var x = bar.Foo(42)", args: [1, {"capIsNew": false}]},
         "var x = bar[Foo](42)",


### PR DESCRIPTION
Fixes #1053.

Added failing test replicating #1053 that passes with change.

Another approach would be to only allow string literals through `extractNameFromExpression`. I figured it made little difference since numbers are the only other literal we really need to worry about and they'll never begin with a character.
