### PR TITLE
Fix: Check envs for true/false

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -126,7 +126,9 @@ function createEnvironmentConfig(envs, reset) {
     };
 
     if (envs) {
-        Object.keys(envs).forEach(function(name) {
+        Object.keys(envs).filter(function (name) {
+            return envs[name];
+        }).forEach(function(name) {
             var environment = environments[name];
             if (environment) {
                 if (!reset && environment.rules) {

--- a/tests/fixtures/environments/disable.yaml
+++ b/tests/fixtures/environments/disable.yaml
@@ -1,0 +1,5 @@
+{
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -285,7 +285,7 @@ describe("cli", function() {
 
         it("should not define environment-specific globals", function () {
             cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
-            assert.equal(console.log.args[0][0].split("\n").length, 9);
+            assert.equal(console.log.args[0][0].split("\n").length, 12);
         });
     });
 

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -416,7 +416,6 @@ describe("Config", function() {
             assertConfigsEqual(expected, actual);
         });
 
-
         it("should load user config globals", function() {
             var expected,
                 actual,
@@ -434,6 +433,17 @@ describe("Config", function() {
             assertConfigsEqual(actual, expected);
         });
 
+        it("should not load disabled environments", function() {
+            var config, configPath, configHelper;
+
+            configPath = path.resolve(__dirname, "..", "fixtures", "environments", "disable.yaml");
+
+            configHelper = new Config({ reset: true, configFile: configPath, useEslintrc: false });
+
+            config = configHelper.getConfig(configPath);
+
+            assert.isUndefined(config.globals.window);
+        });
 
     });
 


### PR DESCRIPTION
Fixes #1059.

The environments passed to createEnvironmentConfig were not being checked for true/false - thus they were being merged in even if the user config disabled them.
