### PR TITLE
Docs: Change eol-last examples to <pre>

### DIFF
--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -10,26 +10,33 @@ empty or whitespace-only lines.
 
 The following patterns are considered warnings:
 
-```js
+<pre>
 function doSmth() {
   ...
 }
-```
+</pre>
 
-```js
+<pre>
 function doSmth() {
   ...
 }
 
 
 
-```
+</pre>
+
+<pre>
+function doSmth() {
+  ...
+}
+// spaces here
+</pre>
 
 The following patterns are not warnings:
 
-```js
+<pre>
 function doSmth() {
   ...
 }
 
-```
+</pre>


### PR DESCRIPTION
Fixes #1068. Also added trailing whitespace example.
