### PR TITLE
Docs: Fix 'lintinging' typo and ref links

### DIFF
--- a/docs/about/README.md
+++ b/docs/about/README.md
@@ -1,12 +1,15 @@
 # About
 
-ESLint is an open source JavaScript linting utility originally created by Nicholas C. Zakas in June 2013. Code [lintinging](http://en.wikipedia.org/wiki/Lint_(software)) is a type of static analysis that is frequently use to find problematic patterns or code that doesn't adhere to certain style guidelines. There are code linters for most programming languages, and compilers sometimes incorporate linting into the compilation process.
+ESLint is an open source JavaScript linting utility originally created by Nicholas C. Zakas in June 2013. Code [linting][] is a type of static analysis that is frequently use to find problematic patterns or code that doesn't adhere to certain style guidelines. There are code linters for most programming languages, and compilers sometimes incorporate linting into the compilation process.
 
 JavaScript, being a dynamic and loosely-typed language, is especially prone to developer error. Without the benefit of a compilation process, JavaScript code is typically executed in order to find syntax or other errors. Linting tools like ESLint allow developers to discover problems with their JavaScript code without executing it.
 
 The primary reason ESLint was created was to allow developers to create their own linting rules. ESLint is designed to have all rules completely pluggable. The default rules are written just like any plugin rules would be. They can all follow the same pattern, both for the rules themselves as well as tests. While ESLint will ship with some built-in rules to make it useful from the start, you'll be able to dynamically load rules at any point in time.
 
-ESLint is written using Node.js to provide a fast runtime environment and easy installation via [npm](http://npmjs.org/).
+ESLint is written using Node.js to provide a fast runtime environment and easy installation via [npm][].
+
+[linting]: http://en.wikipedia.org/wiki/Lint_(software)
+[npm]: http://npmjs.org/
 
 ## Philosophy
 


### PR DESCRIPTION
The [about page](http://eslint.org/docs/about/) currently renders 'Code lintinging)' (adds an extra `)`), so
switch to reference links (including npm for consistency).
