### PR TITLE
Fix: don't break node offsets if hasbang present (fixes #1078)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -517,7 +517,7 @@ module.exports = (function() {
             this.reset();
         }
 
-        ast = parse(text.replace(/^(#![^\r\n]+[\r\n]+)/, "//$1"));
+        ast = parse(text.replace(/^#!([^\r\n]+[\r\n]+)/, "//$1"));
 
         //if Esprima failed to parse the file, there's no sense in setting up rules
         if (ast) {

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -2107,4 +2107,21 @@ describe("eslint", function() {
         });
 
     });
+
+    describe("when evaluating code with hashbang", function() {
+        it("should comment hashbang without breaking offset", function() {
+
+            var code = "#!/usr/bin/env node\n'123';";
+
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("ExpressionStatement", function(node) {
+                assert.equal(eslint.getSource(node), "'123';");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+    });
 });


### PR DESCRIPTION
If hashbang exists in file, replace 2 first chars with `//` instead of adding `//`. That will keep all node src offsets intact.
