### PR TITLE
Fix: Speed up no-unreachable (fixes #1135)

### DIFF
--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -10,7 +10,24 @@
 
 
 function report(context, node, unreachableType) {
-    context.report(node, "Found unexpected statement after a {{type}}.", { type: unreachableType });
+    var keyword;
+    switch (unreachableType) {
+        case "BreakStatement":
+            keyword = "break";
+            break;
+        case "ContinueStatement":
+            keyword = "continue";
+            break;
+        case "ReturnStatement":
+            keyword = "return";
+            break;
+        case "ThrowStatement":
+            keyword = "throw";
+            break;
+        default:
+            return;
+    }
+    context.report(node, "Found unexpected statement after a {{type}}.", { type: keyword });
 }
 
 
@@ -19,21 +36,6 @@ function report(context, node, unreachableType) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    function checkForUnreachable(node) {
-        switch (node.type) {
-        case "ReturnStatement":
-            return "return";
-        case "ThrowStatement":
-            return "throw";
-        case "ContinueStatement":
-            return "continue";
-        case "BreakStatement":
-            return "break";
-        default:
-            return false;
-        }
-    }
 
     /**
      * Checks if a node is an exception for no-unreachable because of variable/function hoisting
@@ -49,31 +51,45 @@ module.exports = function(context) {
             });
     }
 
-    /**
-     * Loops through a field of a node and checks if its children fulfill conditions to trigger the unreachable report.
-     * @param {ASTNode} node The AST node to check.
-     * @param {string} field The field that represents the children of the node.
+    /*
+     * Verifies that the given node is the last node or followed exclusively by
+     * hoisted declarations
+     * @param {ASTNode} node Node that should be the last node
      * @returns {void}
      * @private
      */
-    function checkNodeFieldForUnreachable(node, field) {
-        var i, unreachableType = false;
-        for (i = 1; i < node[field].length; i++) {
-            unreachableType = unreachableType || checkForUnreachable(node[field][i - 1]);
-            if (unreachableType && !isUnreachableAllowed(node[field][i])) {
-                report(context, node[field][i], unreachableType);
+    function checkNode(node) {
+        var parent = context.getAncestors().pop();
+        var field, i, sibling;
+
+        switch (parent.type) {
+            case "SwitchCase":
+                field = "consequent";
+                break;
+            case "BlockStatement":
+                field = "body";
+                break;
+            default:
+                return;
+        }
+
+        for (i = parent[field].length - 1; i >= 0; i--) {
+            sibling = parent[field][i];
+            if (sibling === node) {
+                return; // Found the last reachable statement, all done
+            }
+
+            if (!isUnreachableAllowed(sibling)) {
+                report(context, sibling, node.type);
             }
         }
     }
 
     return {
-        "BlockStatement": function(node) {
-            checkNodeFieldForUnreachable(node, "body");
-        },
-
-        "SwitchCase": function(node) {
-            checkNodeFieldForUnreachable(node, "consequent");
-        }
+        "ReturnStatement": checkNode,
+        "ThrowStatement": checkNode,
+        "ContinueStatement": checkNode,
+        "BreakStatement": checkNode
     };
 
 };

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -26,7 +26,11 @@ eslintTester.addRuleTest("lib/rules/no-unreachable", {
         "while (true) { break; var x; }",
         "while (true) { continue; var x, y; }",
         "while (true) { throw 'message'; var x; }",
-        "switch (foo) { case 1: break; var x; }"
+        "while (true) { if (true) break; var x = 1; }",
+        "while (true) continue;",
+        "switch (foo) { case 1: break; var x; }",
+        "var x = 1; y = 2; throw 'uh oh'; var y;",
+        "var x = 1; throw 'uh oh'; var y = 2;"
     ],
     invalid: [
         { code: "function foo() { return x; var x = 1; }", errors: [{ message: "Found unexpected statement after a return.", type: "VariableDeclaration"}] },


### PR DESCRIPTION
Rather than iterating forward through every statement of a BlockStatement's body or SwitchCase's consequent, this change iterates backwards so that no nodes are checked unnecessarily. Starting at the end checks only hoisted declarations and the return/throw/break/continue itself, immediately reporting any unreachable statements without looping through every other child first.

`npm run perf` on `master`:

```
CPU Speed is 2200 with multiplier 7500000
Performance Run #1:  1990.606506ms
Performance Run #2:  1994.0910669999998ms
Performance Run #3:  1901.250357ms
Performance Run #4:  1992.7809849999999ms
Performance Run #5:  1918.564006ms
Performance budget ok:  1990.606506ms (limit: 3409.090909090909ms)
```

with this change:

```
CPU Speed is 2200 with multiplier 7500000
Performance Run #1:  797.273161ms
Performance Run #2:  819.342614ms
Performance Run #3:  790.95953ms
Performance Run #4:  793.833308ms
Performance Run #5:  791.022419ms
Performance budget ok:  793.833308ms (limit: 3409.090909090909ms)
```
