### PR TITLE
Update: ES3 `ReservedWord`s (fixes #1151)

### DIFF
--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -55,7 +55,24 @@ var keywords = [
     "super",
     "true",
     "false",
-    "null"
+    "null",
+    "abstract",
+    "boolean",
+    "byte",
+    "char",
+    "const",
+    "double",
+    "final",
+    "float",
+    "goto",
+    "int",
+    "long",
+    "native",
+    "short",
+    "synchronized",
+    "throws",
+    "transient",
+    "volatile"
 ];
 
 function canBeWrittenInDotNotation(node) {


### PR DESCRIPTION
This PR adds ES3 `ReservedWord`s to the list of keywords in the `dot-notation` rule
(fixes #1151)
