### PR TITLE
add; for-in support to no-empty-label rule

### DIFF
--- a/lib/rules/no-empty-label.js
+++ b/lib/rules/no-empty-label.js
@@ -14,7 +14,7 @@ module.exports = function(context) {
     return {
 
         "LabeledStatement": function(node) {
-            if (node.body.type !== "ForStatement" && node.body.type !== "WhileStatement" && node.body.type !== "DoWhileStatement" && node.body.type !== "SwitchStatement") {
+            if (node.body.type !== "ForStatement" && node.body.type !== "WhileStatement" && node.body.type !== "DoWhileStatement" && node.body.type !== "SwitchStatement" && node.body.type !== "ForInStatement") {
                 context.report(node, "Unexpected label {{l}}", {l: node.label.name});
             }
         }

--- a/tests/lib/rules/no-empty-label.js
+++ b/tests/lib/rules/no-empty-label.js
@@ -17,6 +17,7 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-empty-label", {
     valid: [
+        "labeled: for (var i in {}) { }",
         "labeled: for (var i=10; i; i--) { }",
         "labeled: while(i) {}",
         "labeled: do {} while (i)",


### PR DESCRIPTION
Labels on `for-in` loops were being marked as an error with the `no-empty-label` rule.  This fixes that.  Convo started in:

https://github.com/eslint/eslint/issues/1161
