### PR TITLE
New: Adds additional values to `environments.json` (fixes #1175, fixes #1176)

### DIFF
--- a/conf/environments.json
+++ b/conf/environments.json
@@ -400,5 +400,26 @@
             "suiteSetup": false,
             "suiteTeardown": false
         }
+    },
+
+    "jasmine": {
+        "globals": {
+            "afterEach": false,
+            "beforeEach": false,
+            "describe": false,
+            "expect": false,
+            "it": false,
+            "jasmine": false,
+            "pending": false,
+            "spyOn": false,
+            "waits": false,
+            "waitsFor": false,
+            "xdescribe": false,
+            "xit": false,
+
+            "beforeAll": false,
+            "afterAll": false,
+            "runs": false
+        }
     }
 }

--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -21,6 +21,7 @@ An environment defines both global variables that are predefined as well as whic
 * `node` - Node.js global variables and Node.js-specific rules.
 * `amd` - defines `require()` and `define()` as global variables.
 * `mocha` - adds all of the Mocha testing global variables.
+* `jasmine` - adds all of the Jasmine testing global variables for version 1.3 and 2.0.
 
 These environments are not mutually exclusive, so you can define more than one at a time.
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -2077,6 +2077,24 @@ describe("eslint", function() {
         });
 
         it("should not report a violation", function() {
+            var code = "/*eslint-env amd */ define();require();";
+
+            var config = { rules: { "no-undef" : 1} };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 0);
+        });
+
+        it("should not report a violation", function() {
+            var code = "/*eslint-env jasmine */ expect();spyOn();";
+
+            var config = { rules: { "no-undef" : 1} };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 0);
+        });
+
+        it("should not report a violation", function() {
             var code = "/*globals require: true */ /*eslint-env node */ require = 1;";
 
             var config = { rules: {"no-undef": 1} };


### PR DESCRIPTION
Adds support for a `jasmine` environment, as well as extending the `amd` environment definition.

As an avid user of [jasmine](http://jasmine.github.io/) for testing my [angular](http://angularjs.org) apps, specifically with [karma](http://karma-runner.github.io), this pull request adds support for defining a `jasmine` environment. This globals defined cover both 1.3 and 2.0.

As for requirejs, if you navigate to the requirejs [api](http://requirejs.org/docs/api.html#jsfiles), specifically about configuring requirejs, you can see an example where the `requirejs` Object is being used.
