### PR TITLE
Fix: Useless bind call in cli-engine (fixes #1181)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -172,7 +172,7 @@ CLIEngine.prototype = {
                 results.push(processFile(filename, configHelper));
             }
 
-        }.bind(this));
+        });
 
         // only warn for files explicitly passes on the command line
         if (this.options.ignore) {


### PR DESCRIPTION
Fixes #1181, caught by my new `no-extra-bind` rule (#1180)
