### PR TITLE
Fix: Correct a typo in the error message in tests

### DIFF
--- a/tests/fixtures/rules/custom-rule.js
+++ b/tests/fixtures/rules/custom-rule.js
@@ -5,7 +5,7 @@ module.exports = function(context) {
     return {
         "Identifier": function(node) {
             if (node.name === "foo") {
-                context.report(node, "Identifier cannot be names 'foo'.");
+                context.report(node, "Identifier cannot be named 'foo'.");
             }
         }
     };


### PR DESCRIPTION
I didn't create a ticket because this is trivial.
