### PR TITLE
"use strict" may not be the first expression

### DIFF
--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -12,9 +12,13 @@ module.exports = function(context) {
 
     function isPragma(expression, parent) {
 
+    	var parentBody = parent.body.filter(function(body) {
+    		return body.type === "ExpressionStatement" && body.expression.type === "Literal";
+    	});
+
         var isStrict = expression.type === "Literal" && expression.value === "use strict",
-            isGlobalStrict = isStrict && (parent.type === "Program" && parent.body[0].expression === expression),
-            isLocalStrict = isStrict && (parent.type === "BlockStatement" && parent.body[0].expression === expression);
+            isGlobalStrict = isStrict && (parent.type === "Program" && parentBody.length > 0 && parentBody[0].expression === expression),
+            isLocalStrict = isStrict && (parent.type === "BlockStatement" && parentBody.length > 0 && parentBody[0].expression === expression);
 
         return isGlobalStrict || isLocalStrict;
     }


### PR DESCRIPTION
This fixes Issue #1185.

We find the first Literal expression statement in the parent instead of just looking at the first expression since `"use strict"` may not be the first expression.
