### PR TITLE
One-line brace style

### DIFF
--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -31,10 +31,15 @@ This rule is aimed at enforcing a particular brace style in JavaScript. As such,
 
 ### Options
 
-The rule takes one option, a string which must be either "1tbs" or "stroustrup". The default is "1tbs". You can set the style in configuration like this:
+The rule takes two options:
+
+1. A string which must be either "1tbs" or "stroustrup". The default is "1tbs".
+2. An object that further controls the behaviour of this rule. Currently, the only available parameter is `allowSingleLine`, which indicates whether start and end braces may be on the same line.
+
+You can set the style in configuration like this:
 
 ```json
-"brace-style": [2, "stroustrup"]
+"brace-style": [2, "stroustrup", { allowSingleLine: true }]
 ```
 
 #### "1tbs"
@@ -92,6 +97,18 @@ try {
 }
 ```
 
+With one-line form enabled, the following is also valid:
+
+```js
+function nop() { return; }
+
+if (foo) { bar(); }
+
+if (foo) { bar(); } else { baz(); }
+
+try { somethingRisky(); } catch(e) { handleError(); }
+```
+
 #### "stroustrup"
 
 
@@ -147,6 +164,20 @@ try {
 catch(e) {
   handleError();
 }
+```
+
+With one-line form enabled, the following is also valid:
+
+```js
+function nop() { return; }
+
+if (foo) { bar(); }
+
+if (foo) { bar(); }
+else { baz(); }
+
+try { somethingRisky(); }
+catch(e) { handleError(); }
 ```
 
 ## When Not To Use It

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -11,10 +11,12 @@
 
 module.exports = function(context) {
     var style = context.options[0] || "1tbs";
+    var params = context.options[1] || {};
 
     var OPEN_MESSAGE = "Opening curly brace does not appear on the same line as controlling statement.",
         BODY_MESSAGE = "Statement inside of curly braces should be on next line.",
         CLOSE_MESSAGE = "Closing curly brace does not appear on the same line as the subsequent block.",
+        CLOSE_MESSAGE_SINGLE = "Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.",
         CLOSE_MESSAGE_STROUSTRUP = "Closing curly brace appears on the same line as the subsequent block.";
 
     //--------------------------------------------------------------------------
@@ -32,14 +34,22 @@ module.exports = function(context) {
         var blockProperties = arguments;
         return function(node) {
             [].forEach.call(blockProperties, function(blockProp) {
-                var block = node[blockProp], previousToken, curlyToken;
+                var block = node[blockProp], previousToken, curlyToken, curlyTokenEnd, curlyTokensOnSameLine;
                 block = node[blockProp];
                 if (block && block.type === "BlockStatement") {
                     previousToken = context.getTokenBefore(block);
                     curlyToken = context.getFirstToken(block);
+                    curlyTokenEnd = context.getLastToken(block);
+                    curlyTokensOnSameLine = curlyToken.loc.start.line === curlyTokenEnd.loc.start.line;
 
                     if (previousToken.loc.start.line !== curlyToken.loc.start.line) {
                         context.report(node, OPEN_MESSAGE);
+                    } else if (block.body.length && params.allowSingleLine) {
+                        if (curlyToken.loc.start.line === block.body[0].loc.start.line && !curlyTokensOnSameLine) {
+                            context.report(block.body[0], BODY_MESSAGE);
+                        } else if (curlyTokenEnd.loc.start.line === block.body[block.body.length - 1].loc.start.line && !curlyTokensOnSameLine) {
+                            context.report(block.body[block.body.length - 1], CLOSE_MESSAGE_SINGLE);
+                        }
                     } else if (block.body.length && curlyToken.loc.start.line === block.body[0].loc.start.line) {
                         context.report(block.body[0], BODY_MESSAGE);
                     }

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -12,6 +12,7 @@ var eslint = require("../../../lib/eslint"),
 var OPEN_MESSAGE = "Opening curly brace does not appear on the same line as controlling statement.",
     BODY_MESSAGE = "Statement inside of curly braces should be on next line.",
     CLOSE_MESSAGE = "Closing curly brace does not appear on the same line as the subsequent block.",
+    CLOSE_MESSAGE_SINGLE = "Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.",
     CLOSE_MESSAGE_STROUSTRUP = "Closing curly brace appears on the same line as the subsequent block.";
 
 //------------------------------------------------------------------------------
@@ -37,7 +38,26 @@ eslintTester.addRuleTest("lib/rules/brace-style", {
         "if (a &&\n b &&\n c) { \n }",
         "switch(0) {\n}",
         { code: "if (foo) {\n}\nelse {\n}", args: ["2", "stroustrup"] },
-        { code: "try { \n bar();\n }\ncatch (e) {\n baz(); \n }", args: ["2", "stroustrup"] }
+        { code: "try { \n bar();\n }\ncatch (e) {\n baz(); \n }", args: ["2", "stroustrup"] },
+        // allowSingleLine: true
+        { code: "function foo () { return; }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "function foo () { a(); b(); return; }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "function a(b,c,d) { }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "!function foo () { return; }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "!function a(b,c,d) { }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "if (foo) {  bar(); }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "if (a) { b(); } else { c(); }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "while (foo) {  bar(); }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "for (;;) {  bar(); }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "with (foo) {  bar(); }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "switch (foo) {  case \"bar\": break; }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "try {  bar(); } catch (e) { baz();  }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "do {  bar(); } while (true)", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "for (foo in bar) {  baz();  }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "if (a && b && c) {  }", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "switch(0) {}", args: ["2", "1tbs", { allowSingleLine: true }] },
+        { code: "if (foo) {}\nelse {}", args: ["2", "stroustrup", { allowSingleLine: true }] },
+        { code: "try {  bar(); }\ncatch (e) { baz();  }", args: ["2", "stroustrup", { allowSingleLine: true }] }
     ],
     invalid: [
         { code: "function foo() { return; }", errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}] },
@@ -59,6 +79,31 @@ eslintTester.addRuleTest("lib/rules/brace-style", {
         { code: "if (a) { \nb();\n } \n else { \nc();\n }", errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]},
         { code: "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "BlockStatement"}] },
         { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "CatchClause"}] },
-        { code: "if (a) { \nb();\n } else { \nc();\n }", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "BlockStatement" }]}
+        { code: "if (a) { \nb();\n } else { \nc();\n }", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "BlockStatement" }]},
+        // allowSingleLine: true
+        { code: "function foo() { return; \n}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}] },
+        { code: "function foo() { a(); b(); return; \n}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement"}] },
+        { code: "function foo() { \n return; }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
+        { code: "function foo() {\na();\nb();\nreturn; }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
+        { code: "!function foo() { \n return; }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
+        { code: "if (foo) \n { bar(); }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "IfStatement"}] },
+        { code: "if (a) { b();\n } else { c(); }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement"}] },
+        { code: "if (a) { b(); }\nelse { c(); }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }] },
+        { code: "while (foo) { \n bar(); }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}] },
+        { code: "for (;;) { bar(); \n }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement"}] },
+        { code: "with (foo) { bar(); \n }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement"}] },
+        { code: "switch (foo) \n { \n case \"bar\": break; }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement"}] },
+        { code: "switch (foo) \n { }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "SwitchStatement"}] },
+        { code: "try {  bar(); }\ncatch (e) { baz();  }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE, type: "CatchClause" }] },
+        { code: "try \n { \n bar(); \n } catch (e) {}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "TryStatement"}] },
+        { code: "try { \n bar(); \n } catch (e) \n {}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "CatchClause"}] },
+        { code: "do \n { \n bar(); \n} while (true)", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "DoWhileStatement"}] },
+        { code: "for (foo in bar) \n { \n baz(); \n }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "ForInStatement"}] },
+        { code: "try { \n bar(); \n }\ncatch (e) {\n}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE, type: "CatchClause"}] },
+        { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement"}] },
+        { code: "if (a) { \nb();\n } \n else { \nc();\n }", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]},
+        { code: "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}", args: ["2", "stroustrup", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "BlockStatement"}] },
+        { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", args: ["2", "stroustrup", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "CatchClause"}] },
+        { code: "if (a) { \nb();\n } else { \nc();\n }", args: ["2", "stroustrup", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "BlockStatement" }]}
     ]
 });


### PR DESCRIPTION
This adds a boolean parameter to `brace-style` for allowing single-line statements. For example, the following would be valid with one-line style enabled:

``` js
function nop() { return; }

if (foo) { bar(); }

if (foo) { bar(); } else { baz(); }

try { somethingRisky(); } catch(e) { handleError(); }
```

It is disabled by default.

This also adds a new error message for when the closing brace is on the last line of the block, but not on the first line of the block:

``` js
function bad() {
  return false; }
```

This would output `Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.`

Tests & docs updated.

Fixes #1089.
