### PR TITLE
Docs: Spell checking and one extra closing curly in code example

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -125,7 +125,7 @@ These rules are purely matters of style and are quite subjective.
 * [func-names](func-names.md) - require function expressions to have a name (off by default)
 * [func-style](func-style.md) - enforces use of function declarations or expressions (off by default)
 * [new-cap](new-cap.md) - require a capital letter for constructors
-* [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a contructor with no arguments
+* [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments
 * [no-nested-ternary](no-nested-ternary.md) - disallow nested ternary expressions (off by default)
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
 * [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block (off by default)

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -18,7 +18,7 @@ There are, however, some who prefer to only use braces when there is more than o
 
 ## Rule Details
 
-This rule is aimed at preventing bugs and increasing code clarity by ensuring that block statments are wrapped in curly braces. It will warn when it encounters blocks that omit curly braces.
+This rule is aimed at preventing bugs and increasing code clarity by ensuring that block statements are wrapped in curly braces. It will warn when it encounters blocks that omit curly braces.
 
 The following patterns are considered warnings:
 

--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -39,7 +39,7 @@ Once again, the intent here is to show that the developer intended for there to 
 
 ## Rule Details
 
-This rule aims to require `defaut` case in `switch` statements. You may optionally include a `// no default` after the last `case` if there is no `default` case.
+This rule aims to require `default` case in `switch` statements. You may optionally include a `// no default` after the last `case` if there is no `default` case.
 
 The following pattern is considered a warning:
 

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -9,7 +9,7 @@ var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficu
 
 ## Rule Details
 
-This rule is aimed at increading code readability and maintainability by enforcing a line length convention. As such it will warn on lines that exceed the configured maximum.
+This rule is aimed at increasing code readability and maintainability by enforcing a line length convention. As such it will warn on lines that exceed the configured maximum.
 
 The following patterns are considered warnings:
 

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -42,8 +42,6 @@ function foo() {
     return 42;
   };
 }
-
-}
 ```
 
 ## Related Rules

--- a/docs/rules/no-alert.md
+++ b/docs/rules/no-alert.md
@@ -8,7 +8,7 @@ alert("here!");
 
 ## Rule Details
 
-This rule is aimed at catching debugging code that should be removed and popup UI elements that should be replaced with less obtrustive, custom UIs. As such, it will warn when it encounters `alert`, `prompt`, and `confirm` function calls.
+This rule is aimed at catching debugging code that should be removed and popup UI elements that should be replaced with less obtrusive, custom UIs. As such, it will warn when it encounters `alert`, `prompt`, and `confirm` function calls.
 
 The following patterns are considered warnings:
 

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -62,7 +62,7 @@ for (i < 10; i += 1) {
 // line 2, col 20, Error - Unexpected token )
 ```
 
-So even though there is assignment ambiguity in the conditional expression, the parse error prevents the scenario from occuring.
+So even though there is assignment ambiguity in the conditional expression, the parse error prevents the scenario from occurring.
 
 ## Further Reading
 

--- a/docs/rules/no-empty-label.md
+++ b/docs/rules/no-empty-label.md
@@ -13,7 +13,6 @@ The following patterns are considered warnings:
 labeled: //Label for the following var statement
     var x = 10;
 };
-
 ```
 
 The following patterns are not considered warnings:
@@ -24,3 +23,4 @@ labeled:
         ...
     }
 };
+```

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -1,4 +1,4 @@
-# Disallow Function Assigment (no-func-assign)
+# Disallow Function Assignment (no-func-assign)
 
 JavaScript functions can be written as a FunctionDeclaration `function foo() { ... }` or as a FunctionExpression `var foo = function() { ... };`. While a JavaScript interpreter might tolerate it, overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
 

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -25,7 +25,7 @@ function anotherThing() {
 }
 ```
 
-A variable declaration is permitted anwhere a statement can go, even nested deeply inside other blocks. This is often undesirable due to variable hoisting, and moving declarations to the root of the program or function body can increase clarity.
+A variable declaration is permitted anywhere a statement can go, even nested deeply inside other blocks. This is often undesirable due to variable hoisting, and moving declarations to the root of the program or function body can increase clarity.
 
 ```js
 // Good

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -18,7 +18,7 @@ While convenient in some cases, labels tend to be used only rarely and are frown
 
 ## Rule Details
 
-This rule aims to elminate the use of labeled statements in JavaScript. It will warn whenever a labeled statement is encountered and whenever `break` or `continue` are used with a label.
+This rule aims to eliminate the use of labeled statements in JavaScript. It will warn whenever a labeled statement is encountered and whenever `break` or `continue` are used with a label.
 
 The following patterns are considered warnings:
 

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -44,7 +44,7 @@ if (foo) {
     }
 }
 
-functin bar() {
+function bar() {
     baz();
 }
 ```

--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -1,4 +1,4 @@
-# Disallow if as the Only Statmenent in an else Block (no-lonely-if)
+# Disallow if as the Only Statement in an else Block (no-lonely-if)
 
 If an `if` statement is the only statement in the `else` block of a parent `if` statement, it is often clearer to combine the two to using `else if` form.
 

--- a/docs/rules/no-new.md
+++ b/docs/rules/no-new.md
@@ -1,6 +1,6 @@
 # Disallow new For Side Effects (no-new)
 
-Calling contructors with the `new` keyword, without assigning the resulting object to a variable does is equivalent to simply calling the constructor without the `new` keyword. Thus, the constructor can be avoided and the function can be called directly.
+Calling constructors with the `new` keyword, without assigning the resulting object to a variable does is equivalent to simply calling the constructor without the `new` keyword. Thus, the constructor can be avoided and the function can be called directly.
 
 ```js
 new Person();

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -4,7 +4,7 @@
 
 ## Rule Details
 
-When object is created `__proto__` is set to the original prototype property of the object’s constructor function. `getPrototypeOf` is the prefered method of getting "the prototype".
+When object is created `__proto__` is set to the original prototype property of the object’s constructor function. `getPrototypeOf` is the preferred method of getting "the prototype".
 
 The following patterns are considered warnings:
 

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -2,7 +2,7 @@
 
 Any reference to an undeclared variable causes a warning, unless the variable is explicitly mentioned in a `/*global ...*/` comment. This rule provides compatibility with [JSHint](http://www.jshint.com)'s and [JSLint](http://www.jslint.com)'s treatment of global variables.
 
-This rule can help you locate potential ReferenceErrors resulting from mispellings of variable and parameter names, or accidental implicit globals (for example, from forgetting the `var` keyword in a `for` loop initializer).
+This rule can help you locate potential ReferenceErrors resulting from misspellings of variable and parameter names, or accidental implicit globals (for example, from forgetting the `var` keyword in a `for` loop initializer).
 
 ## Rule Details
 

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -52,7 +52,7 @@ These patterns would not be considered warnings with the same example configurat
 ...
 ```
 
-As mentationed above, patterns are matched when they match exactly to one of the terms specified (ignoring the case).
+As mentioned above, patterns are matched when they match exactly to one of the terms specified (ignoring the case).
 
 ## Rule Options
 ```js

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -1,6 +1,6 @@
 # Require Regex Literals to be Wrapped (wrap-regex)
 
-When a regular expression is used in certain situation, it can end up looking like a divison operator. For example:
+When a regular expression is used in certain situation, it can end up looking like a division operator. For example:
 
 ```js
 function a() {
@@ -10,7 +10,7 @@ function a() {
 
 ## Rule Details
 
-This is used to disambuguate the slash operator and facilitates in more readable code.
+This is used to disambiguate the slash operator and facilitates in more readable code.
 
 The following patterns are considered warnings:
 


### PR DESCRIPTION
As instructed via #1157, trying to follow contribution guidelines.
Closes #1157
