### PR TITLE
Add UTC to allowed capitalized functions

### DIFF
--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -78,6 +78,24 @@ module.exports = function(context) {
         }
     }
 
+    /**
+     * Check if capitalization is allowed for a CallExpression
+     * @param {ASTNode} node CallExpression node
+     * @param {String} calleeName Capitalized callee name from a CallExpression
+     * @returns {Boolean} Returns true if the callee may be capitalized
+     */
+    function isCapAllowed(node, calleeName) {
+        if (CAPS_ALLOWED.indexOf(calleeName) >= 0) {
+            return true;
+        }
+        if (calleeName === "UTC" && node.callee.type === "MemberExpression") {
+            // allow if callee is Date.UTC
+            return node.callee.object.type === "Identifier" &&
+                   node.callee.object.name === "Date";
+        }
+        return false;
+    }
+
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
@@ -96,7 +114,7 @@ module.exports = function(context) {
         listeners.CallExpression = function(node) {
 
             var calleeName = extractNameFromExpression(node);
-            if (calleeName && CAPS_ALLOWED.indexOf(calleeName) < 0 && getCap(calleeName) === "upper") {
+            if (calleeName && getCap(calleeName) === "upper" && !isCapAllowed(node, calleeName)) {
                 context.report(node, "A function with a name starting with an uppercase letter should only be used as a constructor.");
             }
         };

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -36,6 +36,7 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         "var x = Array(42)",
         "var x = String(42)",
         "var x = RegExp(42)",
+        "var x = Date.UTC(2000, 0)",
         "var x = _();",
         "var x = $();",
         {code: "var x = Foo(42)", args: [1, {"capIsNew": false}]},
@@ -54,6 +55,8 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         { code: "var x = new a.b['c'];", errors: [{ message: "A constructor name should not start with a lowercase letter.", type: "NewExpression"}] },
         { code: "var b = Foo();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
         { code: "var b = a.Foo();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
-        { code: "var b = a['Foo']();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] }
+        { code: "var b = a['Foo']();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
+        { code: "var b = a.Date.UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
+        { code: "var b = UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] }
     ]
 });


### PR DESCRIPTION
This commit adds `Date.UTC` to allowed capitalized functions in the `new-cap` rule.

This fixes a problem where the `Date.UTC` function is flagged because it begins with a capital letter.

Example code that was flagged by `new-cap` but should pass without a warning:

``` js
var timestamp = Date.UTC(2004, 02, 14);
```
