### PR TITLE
Fix: Speed up tokens API (refs #1212)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -508,7 +508,7 @@ module.exports = (function() {
      */
     api.verify = function(text, config, filename, saveState) {
 
-        var ast;
+        var ast, node;
 
         // set the current parsed filename
         currentFilename = filename;
@@ -573,13 +573,24 @@ module.exports = (function() {
             // Freezing so array isn't accidentally changed by a rule.
             Object.freeze(currentTextLines);
 
-            /* get all tokens from the ast and store them as a hashtable to
-             * improve traversal speed when wanting to find tokens for a given
-             * node
+            /*
+             * Store all of the tokens from the AST as a linked list for
+             * efficient sequential access, and index in a hash table based on
+             * the range's start for efficient random access.
              */
             currentTokens = [];
-            ast.tokens.forEach(function(token) {
-                currentTokens[token.range[0]] = token;
+            ast.tokens.forEach(function (token) {
+                node = {
+                    token: token,
+                    previous: node,
+                    next: null
+                };
+
+                if (node.previous) {
+                    node.previous.next = node;
+                }
+
+                currentTokens[token.range[0]] = node;
             });
 
             // augment global scope with declared global variables
@@ -771,14 +782,14 @@ module.exports = (function() {
      * @returns {[Token]} Array of objects representing tokens.
      */
     api.getTokensBefore = function(node, beforeCount) {
-        var beforeTokens = [], cursor = node.range[0] - 1;
-        while (beforeCount > 0 && cursor >= 0) {
-            if (currentTokens[cursor]) {
-                beforeTokens.unshift(currentTokens[cursor]);
-                --beforeCount;
-            }
-            --cursor;
+        var beforeTokens = [], cursor = currentTokens[node.range[0]];
+
+        cursor = cursor.previous;
+        while (beforeTokens.length < beforeCount && cursor) {
+            beforeTokens.unshift(cursor.token);
+            cursor = cursor.previous;
         }
+
         return beforeTokens;
     };
 
@@ -789,15 +800,15 @@ module.exports = (function() {
      * @returns {Token} An object representing the token.
      */
     api.getTokenBefore = function(node, skip) {
-        for (var cursor = node.range[0] - 1; cursor >= 0; --cursor) {
-            if (currentTokens[cursor]) {
-                if (skip > 0) {
-                    --skip;
-                } else {
-                    return currentTokens[cursor];
-                }
-            }
+        var cursor = currentTokens[node.range[0]], skipped = 0;
+
+        cursor = cursor.previous;
+        while (skipped < skip && cursor) {
+            cursor = cursor.previous;
+            ++skipped;
         }
+
+        return cursor && cursor.token;
     };
 
     /**
@@ -808,15 +819,17 @@ module.exports = (function() {
      */
     api.getTokensAfter = function(node, afterCount) {
         var afterTokens = [], cursor = node.range[1];
-        while (afterCount > 0 && cursor < currentTokens.length) {
-            if (currentTokens[cursor]) {
-                afterTokens.push(currentTokens[cursor]);
-                --afterCount;
-                cursor = currentTokens[cursor].range[1];
-            } else {
-                ++cursor;
-            }
+
+        while (!currentTokens[cursor] && cursor < currentTokens.length) {
+            ++cursor;
         }
+
+        cursor = currentTokens[cursor];
+        while (afterTokens.length < afterCount && cursor) {
+            afterTokens.push(cursor.token);
+            cursor = cursor.next;
+        }
+
         return afterTokens;
     };
 
@@ -827,15 +840,19 @@ module.exports = (function() {
      * @returns {Token} An object representing the token.
      */
     api.getTokenAfter = function(node, skip) {
-        for (var cursor = node.range[1]; cursor < currentTokens.length; ++cursor) {
-            if (currentTokens[cursor]) {
-                if (skip > 0) {
-                    --skip;
-                } else {
-                    return currentTokens[cursor];
-                }
-            }
+        var cursor = node.range[1], skipped = 0;
+
+        while (!currentTokens[cursor] && cursor < currentTokens.length) {
+            ++cursor;
         }
+
+        cursor = currentTokens[cursor];
+        while (skipped < skip && cursor) {
+            cursor = cursor.next;
+            ++skipped;
+        }
+
+        return cursor && cursor.token;
     };
 
     /**
@@ -849,15 +866,14 @@ module.exports = (function() {
         var beforeTokens = api.getTokensBefore(node, beforeCount),
             afterTokens = api.getTokensAfter(node, afterCount),
             tokens = [],
-            cursor = node.range[0];
-        while (cursor < node.range[1]) {
-            if (currentTokens[cursor]) {
-                tokens.push(currentTokens[cursor]);
-                cursor = currentTokens[cursor].range[1];
-            } else {
-                ++cursor;
-            }
+            cursor = currentTokens[node.range[0]],
+            endRange = node.range[1];
+
+        while (cursor && cursor.token.range[1] <= endRange) {
+            tokens.push(cursor.token);
+            cursor = cursor.next;
         }
+
         return beforeTokens.concat(tokens, afterTokens);
     };
 
@@ -868,16 +884,15 @@ module.exports = (function() {
      * @returns {[Token]} Array of objects representing tokens.
      */
     api.getFirstTokens = function(node, count) {
-        var tokens = [], cursor = node.range[0];
-        while (count > 0 && cursor < node.range[1]) {
-            if (currentTokens[cursor]) {
-                tokens.push(currentTokens[cursor]);
-                --count;
-                cursor = currentTokens[cursor].range[1];
-            } else {
-                ++cursor;
-            }
+        var cursor = currentTokens[node.range[0]],
+            endRange = node.range[1],
+            tokens = [];
+
+        while (tokens.length < count && cursor && cursor.token.range[1] <= endRange) {
+            tokens.push(cursor.token);
+            cursor = cursor.next;
         }
+
         return tokens;
     };
 
@@ -888,15 +903,16 @@ module.exports = (function() {
      * @returns {Token} An object representing the token.
      */
     api.getFirstToken = function(node, skip) {
-        for (var cursor = node.range[0]; cursor < node.range[1]; ++cursor) {
-            if (currentTokens[cursor]) {
-                if (skip > 0) {
-                    --skip;
-                } else {
-                    return currentTokens[cursor];
-                }
-            }
+        var cursor = currentTokens[node.range[0]],
+            endRange = node.range[1],
+            skipped = 0;
+
+        while (skipped < skip && cursor && cursor.token.range[1] <= endRange) {
+            cursor = cursor.next;
+            ++skipped;
         }
+
+        return cursor && cursor.token;
     };
 
     /**
@@ -906,14 +922,20 @@ module.exports = (function() {
      * @returns {[Token]} Array of objects representing tokens.
      */
     api.getLastTokens = function(node, count) {
-        var tokens = [], cursor = node.range[1] - 1;
-        while (count > 0 && cursor >= node.range[0]) {
-            if (currentTokens[cursor]) {
-                tokens.unshift(currentTokens[cursor]);
-                --count;
-            }
+        var beginRange = node.range[0],
+            cursor = node.range[1] - 1,
+            tokens = [];
+
+        while (!currentTokens[cursor] && cursor >= 0) {
             --cursor;
         }
+
+        cursor = currentTokens[cursor];
+        while (tokens.length < count && cursor && beginRange <= cursor.token.range[0]) {
+            tokens.unshift(cursor.token);
+            cursor = cursor.previous;
+        }
+
         return tokens;
     };
 
@@ -924,15 +946,21 @@ module.exports = (function() {
      * @returns {Token} An object representing the token.
      */
     api.getLastToken = function(node, skip) {
-        for (var cursor = node.range[1] - 1; cursor >= node.range[0]; --cursor) {
-            if (currentTokens[cursor]) {
-                if (skip > 0) {
-                    --skip;
-                } else {
-                    return currentTokens[cursor];
-                }
-            }
+        var beginRange = node.range[0],
+            cursor = node.range[1] - 1,
+            skipped = 0;
+
+        while (!currentTokens[cursor] && cursor >= 0) {
+            --cursor;
         }
+
+        cursor = currentTokens[cursor];
+        while (skipped < skip && cursor && beginRange <= cursor.token.range[0]) {
+            cursor = cursor.previous;
+            ++skipped;
+        }
+
+        return cursor && cursor.token;
     };
 
     /**

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -18,7 +18,10 @@ module.exports = function(context) {
     ];
 
     function isSpaced(left, right) {
-        var op, tokens = context.getTokens({range: [left.range[1], right.range[0]]}, 1, 1);
+        var op, tokens = context.getTokens({ range: [
+            context.getTokenAfter(left).range[0],
+            right.range[0]
+        ]}, 1, 1);
         for (var i = 1, l = tokens.length - 1; i < l; ++i) {
             op = tokens[i];
             if (
@@ -33,7 +36,10 @@ module.exports = function(context) {
     }
 
     function isRightSpaced(left, right) {
-        var op, tokens = context.getTokens({range: [left.range[1], right.range[0]]}, 1, 1);
+        var op, tokens = context.getTokens({ range: [
+            context.getTokenAfter(left).range[0],
+            right.range[0]
+        ]}, 1, 1);
         for (var i = 1, l = tokens.length - 1; i < l; ++i) {
             op = tokens[i];
             if (


### PR DESCRIPTION
Rather than storing tokens in a sparse array, I was able to achieve a slight but measurable speedup by storing them in a doubly linked list with references into the linked list from the hash table. This allows token-related methods to traverse directly between tokens rather than looking for the next extant index in the hash table.

I also tried storing tokens in a non-sparse array so I could do something like `return currentTokens.slice(begin, end);`, but that actually ended up being slower than the linked list method. I still have the code in another branch if someone wants to look at it.

This did require one external change in the `space-infix-ops` rule. It was fabricating an artificial `ASTNode` to pass to `getTokens`, and in some circumstances the mock node had invalid range indices. With the change, it still creates a fake node, but it ensures that the range is valid.

I suspect there are further gains either within the tokens API or in the rules that use it, which is why the commit message `refs` rather than `fixes`. I'll keep looking and update #1212 with progress.

`npm run perf` before and after:

```
Performance Run #1:  1913.754539ms
Performance Run #2:  1905.181409ms
Performance Run #3:  1899.0104489999999ms
Performance Run #4:  1910.490959ms
Performance Run #5:  1919.422015ms
Performance budget ok:  1910.490959ms (limit: 3409.090909090909ms)
```

```
Performance Run #1:  1865.762569ms
Performance Run #2:  1850.884799ms
Performance Run #3:  1864.212372ms
Performance Run #4:  1866.0704289999999ms
Performance Run #5:  1875.189211ms
Performance budget ok:  1865.762569ms (limit: 3409.090909090909ms)
```

In `npm run profile`, `getTokens` dropped from 5.62% of total time down to 2.13%.
