### PR TITLE
Fix: Speed up getScope() (refs #1212)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -360,6 +360,7 @@ module.exports = (function() {
         currentConfig = null,
         currentTokens = null,
         currentScopes = null,
+        scopeMap = null,
         currentFilename = null,
         controller = null,
         reportingConfig = [],
@@ -490,6 +491,7 @@ module.exports = (function() {
         currentTextLines = [];
         currentTokens = null;
         currentScopes = null;
+        scopeMap = null;
         controller = null;
         reportingConfig = [];
         commentLocsEnter = [];
@@ -562,6 +564,21 @@ module.exports = (function() {
 
             // gather data that may be needed by the rules
             currentScopes = escope.analyze(ast, { ignoreEval: true }).scopes;
+
+            /*
+             * Index the scopes by the start range of their block for efficient
+             * lookup in getScope.
+             */
+            scopeMap = [];
+            currentScopes.forEach(function (scope, index) {
+                var range = scope.block.range[0];
+
+                // Sometimes two scopes are returned for a given node. This is
+                // handled later in a known way, so just don't overwrite here.
+                if (!scopeMap[range]) {
+                    scopeMap[range] = index;
+                }
+            });
 
             /*
              * Split text here into array of lines so
@@ -977,8 +994,9 @@ module.exports = (function() {
      * @returns {Object} An object representing the current node's scope.
      */
     api.getScope = function() {
-        var parents = controller.parents().reverse(),
-            innerBlock = null;
+        var parents = controller.parents(),
+            innerBlock = null,
+            selectedScopeIndex;
 
         // Don't do this for Program nodes - they have no parents
         if (parents.length) {
@@ -986,11 +1004,11 @@ module.exports = (function() {
             // if current node is function declaration, add it to the list
             var current = controller.current();
             if (current.type === "FunctionDeclaration" || current.type === "FunctionExpression") {
-                parents.splice(0, 0, current);
+                parents.push(current);
             }
 
             // Ascend the current node's parents
-            for (var i = 0; i < parents.length; i++) {
+            for (var i = parents.length - 1; i >= 0; --i) {
 
                 // The first node that requires a scope is the node that will be
                 // our current node's innermost scope.
@@ -1000,24 +1018,17 @@ module.exports = (function() {
                 }
             }
 
-            // Loop through the scopes returned by escope to find the innermost
-            // scope and return that scope.
-            for (var j = 0; j < currentScopes.length; j++) {
-                if (innerBlock.type === currentScopes[j].block.type &&
-                    innerBlock.range[0] === currentScopes[j].block.range[0] &&
-                    innerBlock.range[1] === currentScopes[j].block.range[1]) {
+            // Find and return the innermost scope
+            selectedScopeIndex = scopeMap[innerBlock.range[0]];
 
-                    // Escope returns two similar scopes for named functional
-                    // expression, we should take the last
-                    if ((innerBlock.type === "FunctionExpression" && innerBlock.id && innerBlock.id.name)) {
-
-                        var nextScope = currentScopes[j + 1];
-                        return nextScope;
-                    }
-
-                    return currentScopes[j];
-                }
+            // Named function expressions create two nested scope objects. The
+            // outer scope contains only the function expression name. We return
+            // the inner scope.
+            if (innerBlock.type === "FunctionExpression" && innerBlock.id && innerBlock.id.name) {
+                ++selectedScopeIndex;
             }
+
+            return currentScopes[selectedScopeIndex];
         } else {
             return currentScopes[0];    // global scope
         }


### PR DESCRIPTION
Instead of `reverse`ing, iterates the `parents` list backwards. Indexes scopes for direct random lookup rather than searching through them linearly.

`npm run perf` before and after:

```
CPU Speed is 2200 with multiplier 7500000
Performance Run #1:  1883.021533ms
Performance Run #2:  1865.9190469999999ms
Performance Run #3:  1856.122294ms
Performance Run #4:  1871.876902ms
Performance Run #5:  1854.4841139999999ms
Performance budget ok:  1865.9190469999999ms (limit: 3409.090909090909ms)
```

```
CPU Speed is 2200 with multiplier 7500000
Performance Run #1:  1579.674679ms
Performance Run #2:  1637.630723ms
Performance Run #3:  1578.9458220000001ms
Performance Run #4:  1569.7571480000001ms
Performance Run #5:  1575.484874ms
Performance budget ok:  1578.9458220000001ms (limit: 3409.090909090909ms)
```

In `npm run profile`, `getScope` dropped from 6.23% of total time down to 0.38%.

In a separate local branch, I added some code to track processing time consumed by each rule. `no-unused-vars` is still the slowest rule by a large margin, but this change reduces it from 35% of total rule time down to 22% (those numbers on `tests/performance/jshint.js`).
