### PR TITLE
Fix: no-extra-strict behavior for named function expressions (fixes #1209)

### DIFF
--- a/lib/rules/no-extra-strict.js
+++ b/lib/rules/no-extra-strict.js
@@ -34,7 +34,7 @@ module.exports = function(context) {
     }
 
     function checkForUnnecessaryUseStrict(node) {
-        var useStrictDirectives, scope;
+        var useStrictDirectives, scope, upper;
         useStrictDirectives = directives(node).filter(isStrict);
 
         switch (useStrictDirectives.length) {
@@ -43,7 +43,13 @@ module.exports = function(context) {
 
             case 1:
                 scope = context.getScope();
-                if (scope.upper && scope.upper.isStrict) {
+                upper = scope.upper;
+
+                if (upper && upper.functionExpressionScope) {
+                    upper = upper.upper;
+                }
+
+                if (upper && upper.isStrict) {
                     context.report(useStrictDirectives[0], "Unnecessary 'use strict'.");
                 }
                 break;

--- a/tests/lib/rules/no-extra-strict.js
+++ b/tests/lib/rules/no-extra-strict.js
@@ -18,7 +18,10 @@ eslintTester.addRuleTest("lib/rules/no-extra-strict", {
         "function foo() { \"use strict\"; var bar = true; }",
         "function foo() { 'use strict'; var bar = true; }",
         "function foo() { 'use strict'; f('use strict'); }",
-        "function foo() { 'use strict'; { 'use strict'; } }"
+        "function foo() { 'use strict'; { 'use strict'; } }",
+        "a = function () { 'use strict'; return true; }",
+        "a = function foo() { 'use strict'; return true; }",
+        "this.a = function b() { 'use strict'; return 1; };"
     ],
     invalid: [
         { code: "\"use strict\"; function foo() { \"use strict\"; var bar = true; }",
@@ -30,6 +33,10 @@ eslintTester.addRuleTest("lib/rules/no-extra-strict", {
         { code: "'use strict'; (function foo() { function bar () { 'use strict'; } }());",
           errors: [{ message: "Unnecessary 'use strict'.", type: "Literal"}] },
         { code: "(function foo() { 'use strict'; 'use strict'; }());",
-          errors: [{ message: "Multiple 'use strict' directives.", type: "Literal"}] }
+          errors: [{ message: "Multiple 'use strict' directives.", type: "Literal"}] },
+        { code: "'use strict'; a = function foo() { 'use strict'; return true; }",
+          errors: [{ message: "Unnecessary 'use strict'.", type: "Literal"}]
+        }
+
     ]
 });


### PR DESCRIPTION
I don’t know if this is the best solution to fix #1209.

The problem is that `escope` creates a separate scope for named function expressions (see: [escope#7](https://github.com/Constellation/escope/issues/7)).
