### PR TITLE
Fix: rewrite no-spaced-func rule (refs #1212)

### DIFF
--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -11,37 +11,18 @@ module.exports = function(context) {
 
     "use strict";
 
-    function findOpenParen(tokens) {
-        var i, token, hasArgumentList = false, numOpen = 0;
-
-        // start at the end of the token stream; skip over argument list contents
-        for (i = tokens.length - 1; i >= 0; --i) {
-            token = tokens[i];
-            if (token.value === "(") {
-                --numOpen;
-            } else if (token.value === ")") {
-                hasArgumentList = true;
-                ++numOpen;
-            }
-            if (hasArgumentList && numOpen <= 0) {
-                return i;
-            }
-        }
-    }
-
     function detectOpenSpaces(node) {
-        var tokens = context.getTokens(node),
-            openParenIndex = findOpenParen(tokens),
-            openParen = tokens[openParenIndex],
-            callee = tokens[openParenIndex - 1];
-
-        // openParenIndex will be undefined for a NewExpression with no argument list
-        if (!openParenIndex) {
+        var lastCalleeToken = context.getLastToken(node.callee);
+        var tokens = context.getTokens(node);
+        var i = tokens.indexOf(lastCalleeToken), l = tokens.length;
+        while (i < l && tokens[i].value !== "(") {
+            ++i;
+        }
+        if (i >= l) {
             return;
         }
-
         // look for a space between the callee and the open paren
-        if (callee.range[1] !== openParen.range[0]) {
+        if (tokens[i - 1].range[1] !== tokens[i].range[0]) {
             context.report(node, "Unexpected space between function name and paren.");
         }
     }

--- a/tests/lib/rules/no-spaced-func.js
+++ b/tests/lib/rules/no-spaced-func.js
@@ -28,6 +28,7 @@ eslintTester.addRuleTest("lib/rules/no-spaced-func", {
         "f( (0) )",
         "( f )( 0 )",
         "( (f) )( (0) )",
+        "( f()() )(0)",
         "(function(){ if (foo) { bar(); } }());",
         "f(0, (1))"
     ],


### PR DESCRIPTION
Before:

```
$ npm run perf

> eslint@0.7.4 perf /Users/michael/projects/eslint
> node Makefile.js perf

CPU Speed is 2600 with multiplier 7500000
Performance Run #1:  1618.9791850000001ms
Performance Run #2:  1584.846229ms
Performance Run #3:  1643.8295779999999ms
Performance Run #4:  1608.190126ms
Performance Run #5:  1620.71616ms
Performance budget ok:  1618.9791850000001ms (limit: 2884.6153846153848ms)
```

After:

```
$ npm run perf

> eslint@0.7.4 perf /Users/michael/projects/eslint
> node Makefile.js perf

CPU Speed is 2600 with multiplier 7500000
Performance Run #1:  1577.5375589999999ms
Performance Run #2:  1616.653781ms
Performance Run #3:  1515.187082ms
Performance Run #4:  1508.76889ms
Performance Run #5:  1515.655062ms
Performance budget ok:  1515.655062ms (limit: 2884.6153846153848ms)
```
