### PR TITLE
Fix: rewrite no-unused-vars rule (refs #1212)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -25,211 +25,79 @@ module.exports = function(context) {
         }
     }
 
-    var allowUnusedGlobals = (config.vars !== "all"),
-        variables = {};
+    var MESSAGE = "{{name}} is defined but never used";
 
-
-    function lookupVariableName(name) {
-
-        // Convoluted check in case name is "hasOwnProperty"
-        if (!Object.prototype.hasOwnProperty.call(variables, name)) {
-            return null;
-        }
-        return variables[name];
-    }
-
-    function lookupVariable(variable) {
-        var candidates = lookupVariableName(variable.name);
-        if (candidates) {
-            return candidates.filter(function (candidate) {
-                return variable.identifiers.indexOf(candidate.node) > -1 || variable.eslintExplicitGlobal;
-            })[0];
-        }
-        return candidates;
+    /**
+     * @param {Reference} ref - an escope Reference
+     * @returns {Boolean} whether the given reference represents a read operation
+     */
+    function isReadRef(ref) {
+        return ref.isRead();
     }
 
     /**
-     * Check if funcNode has paramNode as an identifier of one of its params.
-     *
-     * @param {FunctionExpression|FunctionDeclaration} funcNode Node which to
-     *                                                          check for param
-     * @param {Identifier} paramNode Node which can be an identifier for a param
-     * @returns {boolean} If funcNode has paramNode as an identifier of one of
-     *                    its params
+     * @param {Scope} scope - an escope Scope object
+     * @returns {Variable[]} most of the local variables with no read references
      */
-    function functionHasParam(funcNode, paramNode) {
-        for (var i = 0, len = funcNode.params.length; i < len; i++) {
-            if (funcNode.params[i] === paramNode) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    function populateVariables(node) {
-        var scope = context.getScope(),
-            functionName = node && node.id && node.id.name;
-
-        scope.variables.forEach(function(variable) {
-
-            //filter out global variables that are part of default environment globals
-            if (variable.eslintExplicitGlobal || variable.identifiers.length > 0) {
-
-                //make sure that this variable is not already in the array
-                if (!lookupVariable(variable)) {
-
-                    if (!lookupVariableName(variable.name)) {
-                        variables[variable.name] = [];
-                    }
-                    variables[variable.name].push({
-                        name: variable.name,
-                        node: variable.identifiers[0] || node,
-                        used: (variable.name === functionName),
-                        ignorable: (config.args === "none") && node.params && functionHasParam(node, variable.identifiers[0])
-                    });
+    function unusedLocals(scope) {
+        var unused = [];
+        var variables = scope.variables;
+        if (scope.type !== "global") {
+            for (var i = 0, l = variables.length; i < l; ++i) {
+                // skip function expression names
+                if (scope.functionExpressionScope) {
+                    continue;
+                }
+                // skip implicit "arguments" variable
+                if (scope.type === "function" && variables[i].name === "arguments" && variables[i].identifiers.length === 0) {
+                    continue;
+                }
+                var type = variables[i].defs[0].type;
+                // skip catch variables
+                if (type === "CatchClause") {
+                    continue;
+                }
+                // if "args" option is "none", skip any parameter
+                if (config.args === "none" && type === "Parameter") {
+                    continue;
+                }
+                // if "args" option is "after-used", skip all but the last parameter
+                if (config.args === "after-used" && type === "Parameter" && variables[i].defs[0].index < variables[i].defs[0].node.params.length - 1) {
+                    continue;
+                }
+                if (variables[i].references.filter(isReadRef).length === 0) {
+                    unused.push(variables[i]);
                 }
             }
-        });
-    }
-
-    function populateGlobalVariables(node) {
-        if (!allowUnusedGlobals) {
-            populateVariables(node);
         }
-    }
-
-    function findVariable(name) {
-        var scope = context.getScope();
-        var scopeVariable = [];
-
-        function filter(variable) {
-            return variable.name === name;
-        }
-
-        while (scopeVariable.length === 0) {
-            scopeVariable = scope.variables.filter(filter);
-            if (scopeVariable.length === 0) {
-                if (!scope.upper) {
-                    return null;
-                }
-                scope = scope.upper;
-            }
-        }
-
-        return lookupVariable(scopeVariable[0]);
-    }
-
-    /**
-     * Determines if the given node represents a function.
-     * @param {ASTNode} node The node to check.
-     * @returns {boolean} True if the node represents a function, false if not.
-     * @private
-     */
-    function isFunction(node) {
-        return node && node.type && (node.type === "FunctionDeclaration" || node.type === "FunctionExpression");
-    }
-
-    function markIgnorableUnusedVariables(usedVariable) {
-
-        /* When variables are declared as parameters in a FunctionExpression or
-         * FunctionDeclaration, they can go unused so long as at least one
-         * to the right of them is used.
-         */
-
-        // Find the FunctionExpressions and FunctionDeclarations in which this used variable
-        // may be a parameter
-        var parent = usedVariable.node.parent;
-        if (isFunction(parent)) {
-
-            var ignorableVariables;
-            var fnParamNames;
-
-            if (config.args !== "all") {
-                // Get a list of the param names used in the ancestor Function
-                fnParamNames = parent.params.map(function(param){
-                    return param.name;
-                });
-            }
-
-            switch (config.args) {
-
-                case "all":
-                    break;
-
-                case "none":
-                    ignorableVariables = fnParamNames;
-                    break;
-
-                case "after-used":
-                default:
-
-                    // Check if the used variable exists among those params
-                    var variableIndex = fnParamNames.indexOf(usedVariable.name);
-
-                    // This will be true if this variable appears in the param list of an ancestor Function Expression
-                    // or FunctionDeclaration.
-                    if (variableIndex !== -1) {
-                        // All params left of the used variables are ignorable.
-                        ignorableVariables = fnParamNames.slice(0, variableIndex);
-                    }
-                    break;
-            }
-
-            if (ignorableVariables) {
-                // Mark them as ignorable.
-                ignorableVariables.forEach(function(ignorableVariable){
-
-                    lookupVariableName(ignorableVariable).forEach(function(variable){
-                        variable.ignorable = true;
-                    });
-                });
-            }
-        }
+        return [].concat.apply(unused, [].map.call(scope.childScopes, unusedLocals));
     }
 
     return {
-        "FunctionDeclaration": populateVariables,
-        "FunctionExpression": populateVariables,
-        "Program": populateGlobalVariables,
-        "Identifier": function(node) {
-            var ancestors = context.getAncestors(node);
-            var parent = ancestors.pop();
-            var grandparent = ancestors.pop();
+        "Program": function(programNode) {
+            var globalScope = context.getScope();
+            var unused = unusedLocals(globalScope);
+            var i, l;
 
-            /*
-             * if it's not an assignment expression find corresponding
-             * variable in the array and mark it as used
-             */
-            if ((parent.type !== "AssignmentExpression" || node !== parent.left || grandparent.type !== "ExpressionStatement" && parent.operator !== "=") &&
-                (parent.type !== "VariableDeclarator" || (parent.init && parent.init === node)) &&
-                parent.type !== "FunctionDeclaration" &&
-                !(parent.type === "MemberExpression" && parent.property === node && !parent.computed) &&
-                !(parent.type === "Property" && parent.kind === "init" && parent.key === node) &&
-                !(parent.type === "FunctionExpression" && functionHasParam(parent, node)) &&
-                (parent.type !== "FunctionExpression" ||
-                    (grandparent !== null &&
-                    (grandparent.type === "CallExpression" || grandparent.type === "AssignmentExpression")))) {
-
-                var variable = findVariable(node.name);
-
-                if (variable) {
-                    variable.used = true;
-                    markIgnorableUnusedVariables(variable, ancestors);
-                }
-
-            }
-        },
-
-        "Program:exit": function() {
-            Object.keys(variables)
-                .forEach(function (name) {
-                    variables[name].forEach(function (variable) {
-                        if (variable.used || variable.ignorable) {
-                            return;
-                        }
-                        context.report(variable.node, "{{var}} is defined but never used", {"var": variable.name});
-                    });
+            // determine unused globals
+            if (config.vars === "all") {
+                var unresolvedRefs = globalScope.through.filter(isReadRef).map(function(ref) {
+                    return ref.identifier.name;
                 });
+                for (i = 0, l = globalScope.variables.length; i < l; ++i) {
+                    if (unresolvedRefs.indexOf(globalScope.variables[i].name) < 0) {
+                        unused.push(globalScope.variables[i]);
+                    }
+                }
+            }
+
+            for (i = 0, l = unused.length; i < l; ++i) {
+                if (unused[i].eslintExplicitGlobal) {
+                    context.report(programNode, MESSAGE, unused[i]);
+                } else if (unused[i].defs.length > 0) {
+                    context.report(unused[i].identifiers[0], MESSAGE, unused[i]);
+                }
+            }
         }
     };
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -17,6 +17,7 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-unused-vars", {
     valid: [
+        { code: "a; var a;", args: [1, "all"] },
         { code: "var a=10; alert(a);", args: [1, "all"] },
         { code: "var a=10; (function() { alert(a); })();", args: [1, "all"] },
         { code: "var a=10; (function() { setTimeout(function() { alert(a); }, 0); })();", args: [1, "all"] },
@@ -35,6 +36,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});}; foo()",
         "(function() { var doSomething = function doSomething() {}; doSomething() }())",
         "function f() { var a = 1; return function(){ f(a *= 2); }; }",
+        "function f() { var a = 1; return function(){ f(++a); }; }",
+        "try {} catch(e) {}",
         "/*global a */ a;",
         { code: "var a=10; (function() { alert(a); })();", args: [1, {vars: "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all"}] },


### PR DESCRIPTION
Before:

```
$ npm run perf

> eslint@0.7.4 perf /Users/michael/projects/eslint
> node Makefile.js perf

CPU Speed is 2600 with multiplier 7500000
Performance Run #1:  1299.1717899999999ms
Performance Run #2:  1338.114744ms
Performance Run #3:  1288.453107ms
Performance Run #4:  1292.191793ms
Performance Run #5:  1307.2589520000001ms
Performance budget ok:  1299.1717899999999ms (limit: 2884.6153846153848ms)
```

After:

```
 npm run perf

> eslint@0.7.4 perf /Users/michael/projects/eslint
> node Makefile.js perf

CPU Speed is 2600 with multiplier 7500000
Performance Run #1:  1165.686332ms
Performance Run #2:  1185.946108ms
Performance Run #3:  1170.5925320000001ms
Performance Run #4:  1173.558406ms
Performance Run #5:  1189.729579ms
Performance budget ok:  1173.558406ms (limit: 2884.6153846153848ms)
```

Ref. #1212.
