### PR TITLE
Fix: Treat node.range as immutable in max-len (fixes #1224)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -41,22 +41,16 @@ module.exports = function(context) {
     // Helpers
     //--------------------------------------------------------------------------
     function checkProgramForMaxLength(node) {
-        // Esprima does not include leading whitespace on the first line, this
-        // sets the initial range to 80 for getSource
-        node.range[0] = 0;
-        var lines = context.getSource(node) || "";  // necessary for backwards compat
+        var lines = context.getSourceLines();
 
         // Replace the tabs
         // Split (honors line-ending)
         // Iterate
-        lines
-            .replace(/\t/g, tabString)
-            .split(/\r?\n/)
-            .forEach(function(line, i){
-                if (line.length > maxLength) {
-                    context.report(node, { line: i + 1, col: 1 }, "Line " + (i + 1) + " exceeds the maximum line length of " + maxLength + ".");
-                }
-            });
+        lines.forEach(function(line, i){
+            if (line.replace(/\t/g, tabString).length > maxLength) {
+                context.report(node, { line: i + 1, col: 1 }, "Line " + (i + 1) + " exceeds the maximum line length of " + maxLength + ".");
+            }
+        });
     }
 
 

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -26,6 +26,10 @@ eslintTester.addRuleTest("lib/rules/max-len", {
             code: "var i = 1;\r\nvar i = 1;\n",
             args: [1, 10, 4]
         },
+        {
+            code: "\n// Blank line on top\nvar foo = module.exports = {};\n",
+            args: [1, 80, 4]
+        },
         ""
     ],
 


### PR DESCRIPTION
AST nodes should not be modified by rules. Instead pass a new range to `getSource()`. Open question: what's the best way to test this? Such a test would not be rule-specific.
