### PR TITLE
Fix: strict should check function expressions (fixes #1244)

### DIFF
--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -35,7 +35,7 @@ module.exports = function(context) {
 
         var isStrict = false,
             isProgram = (node.type === "Program"),
-            isParentProgram = (!isProgram && node.parent.type === "Program"),
+            isParentGlobal = scopes.length === 1,
             isParentStrict = scopes.length ? scopes[scopes.length - 1] : false;
 
         // look for the "use strict" pragma
@@ -48,7 +48,7 @@ module.exports = function(context) {
         scopes.push(isStrict);
 
         // never warn if the parent is strict or the function is strict
-        if (!isParentStrict && !isStrict && isParentProgram) {
+        if (!isParentStrict && !isStrict && isParentGlobal) {
             context.report(node, "Missing \"use strict\" statement.");
         }
     }

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -18,7 +18,9 @@ eslintTester.addRuleTest("lib/rules/strict", {
         "'use strict'; function foo () {  return; }",
         "function foo () { \"use strict\"; return; }",
         "function foo () { \"use strict\"; function bar() {}; }",
-        "function foo () { 'use strict'; return; }"
+        "function foo () { 'use strict'; return; }",
+        "'use strict'; var foo = function () { bar(); };",
+        "var foo = function () { 'use strict'; bar(); return; };"
     ],
     invalid: [
         {
@@ -32,6 +34,10 @@ eslintTester.addRuleTest("lib/rules/strict", {
         {
             code: "function foo() { function bar() {} }",
             errors: [{ message: "Missing \"use strict\" statement.", type: "FunctionDeclaration"}]
+        },
+        {
+            code: "var foo = function () { return; };",
+            errors: [{ message: "Missing \"use strict\" statement.", type: "FunctionExpression"}]
         }
     ]
 });


### PR DESCRIPTION
Previously, `strict` only warned on nodes whose direct parent was the root `Program` node, therefore `FunctionDeclaration`s were checked, but `FunctionExpression`s, which typically get nested inside `VariableDeclaration`s or `CallExpression`s, were excluded. This changes the logic to check whether the parent _scope_ is the global `Program` scope.
