### PR TITLE
Docs: Changing NPM to npm

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -64,4 +64,4 @@ In order to make your plugin available to the community you have to publish it o
 
 ## Further Reading
 
-* [NPM Developer Guide](https://www.npmjs.org/doc/misc/npm-developers.html)
+* [npm Developer Guide](https://www.npmjs.org/doc/misc/npm-developers.html)


### PR DESCRIPTION
npm should be lowercased, per https://www.npmjs.org/doc/misc/npm-faq.html#if-npm-is-an-acronym-why-is-it-never-capitalized-
