### PR TITLE
New: Add sharable rule settings (fixes #1233)

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -198,6 +198,26 @@ console.log('bar');
 /*eslint-enable no-alert */
 ```
 
+## Adding Shared Settings
+
+ESLint supports adding shared settings into configuration file. You can add `settings` object to ESLint configuration file and it will be supplied to every rule that will be executed. This may be useful if you are adding custom rules and want them to have access to the same information and be easily configurable.
+
+In JSON:
+```json
+{
+    "settings": {
+        "sharedData": "Hello"
+    }
+}
+```
+
+And in YAML:
+```yaml
+---
+  settings:
+    sharedData: "Hello"
+```
+
 ## Using Configuration Files
 
 There are two ways to use configuration files. The first is to save the file wherever you would like an pass its location to the CLI using the `-c` option, such as:

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -339,7 +339,8 @@ function prepareConfig(config) {
     return {
         rules: copiedRules,
         globals: util.mergeConfigs({}, config.globals),
-        env: util.mergeConfigs({}, config.env || {})
+        env: util.mergeConfigs({}, config.env || {}),
+        settings: util.mergeConfigs({}, config.settings || {})
     };
 }
 
@@ -541,7 +542,7 @@ module.exports = (function() {
 
                 if (ruleCreator) {
                     try {
-                        rule = ruleCreator(new RuleContext(key, api, severity, options));
+                        rule = ruleCreator(new RuleContext(key, api, severity, options, config.settings));
 
                         // add all the node types as listeners
                         Object.keys(rule).forEach(function(nodeType) {

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -37,9 +37,10 @@ var PASSTHROUGHS = [
  * @param {string} ruleId The ID of the rule using this object.
  * @param {eslint} eslint The eslint object.
  * @param {number} severity The configured severity level of the rule.
- * @param {array} options the configuration information to be added to the rule
+ * @param {array} options The configuration information to be added to the rule.
+ * @param {object} settings The configuration settings passed from the config file.
  */
-function RuleContext(ruleId, eslint, severity, options) {
+function RuleContext(ruleId, eslint, severity, options, settings) {
 
     /**
      * The read-only ID of the rule.
@@ -53,6 +54,13 @@ function RuleContext(ruleId, eslint, severity, options) {
      */
     Object.defineProperty(this, "options", {
         value: options
+    });
+
+    /**
+     * The read-only settings shared between all rules
+     */
+    Object.defineProperty(this, "settings", {
+        value: settings
     });
 
     // copy over passthrough methods

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1174,6 +1174,49 @@ describe("eslint", function() {
         });
     });
 
+    describe("when config has shared settings for rules", function() {
+        var code = "test-rule";
+
+        it("should pass settings to all rules", function() {
+            eslint.reset();
+            eslint.defineRule(code, function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, context.settings.info);
+                    }
+                };
+            });
+
+            var config = { rules: {}, settings: { info: "Hello" } };
+            config.rules[code] = 1;
+
+            var messages = eslint.verify("0", config, filename);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].message, "Hello");
+        });
+
+        it("should not have any settings if they were not passed in", function() {
+            eslint.reset();
+            eslint.defineRule(code, function(context) {
+                return {
+                    "Literal": function(node) {
+                        if (Object.getOwnPropertyNames(context.settings).length !== 0) {
+                            context.report(node, "Settings should be empty");
+                        }
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules[code] = 1;
+
+            var messages = eslint.verify("0", config, filename);
+
+            assert.equal(messages.length, 0);
+        });
+    });
+
     describe("when passing in configuration values for rules", function() {
         var code = "var answer = 6 * 7";
 


### PR DESCRIPTION
This pull requests adds ability to specify shared settings in config file. Each rule will be able to access settings from `context` object.
