### PR TITLE
Fix bug in loading .eslintrc from home directory

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -18,7 +18,8 @@ var fs = require("fs"),
     stripComments = require("strip-json-comments"),
     assign = require("object-assign"),
     debug = require("debug"),
-    yaml = require("js-yaml");
+    yaml = require("js-yaml"),
+    userHome = require("user-home");
 
 
 //------------------------------------------------------------------------------
@@ -26,7 +27,7 @@ var fs = require("fs"),
 //------------------------------------------------------------------------------
 
 var CONFIG_FILENAME = ".eslintrc",
-    PERSONAL_CONFIG_PATH = path.resolve("~/" + CONFIG_FILENAME);
+    PERSONAL_CONFIG_PATH = path.join(userHome, CONFIG_FILENAME);
 
 //------------------------------------------------------------------------------
 // Helpers

--- a/package.json
+++ b/package.json
@@ -45,7 +45,8 @@
     "debug": "^2.0.0",
     "object-assign": "^1.0.0",
     "mkdirp": "^0.5.0",
-    "xml-escape": "~1.0.0"
+    "xml-escape": "~1.0.0",
+    "user-home": "^1.0.0"
   },
   "devDependencies": {
     "sinon": "1.7.3",


### PR DESCRIPTION
`path.resolve` doesn't expand the tilde character so let's use `user-home`
and `path.join` instead (which supports multiple operating systems).

Fixes eslint/eslint#1262.
