### PR TITLE
Fix: Load .eslintrc in directory with $HOME as an ancestor (fixes #1266)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -84,12 +84,12 @@ function getLocalConfig(helper, directory) {
         found = false;
 
     while ((localConfigFile = helper.findLocalConfigFile(directory))) {
-        found = true;
-
         // don't automatically merge the personal config settings
         if (localConfigFile === PERSONAL_CONFIG_PATH) {
             break;
         }
+
+        found = true;
 
         debug("Using " + localConfigFile);
         config = util.mergeConfigs(loadConfig(localConfigFile), config);


### PR DESCRIPTION
Very simple fix: We haven't found a config file if it's just the personal config (it gets merged in below `if (!found)`).
