### PR TITLE
Update "Configuring" page to fix fenced YAML block

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -203,6 +203,7 @@ console.log('bar');
 ESLint supports adding shared settings into configuration file. You can add `settings` object to ESLint configuration file and it will be supplied to every rule that will be executed. This may be useful if you are adding custom rules and want them to have access to the same information and be easily configurable.
 
 In JSON:
+
 ```json
 {
     "settings": {
@@ -212,6 +213,7 @@ In JSON:
 ```
 
 And in YAML:
+
 ```yaml
 ---
   settings:


### PR DESCRIPTION
Open http://eslint.org/docs/configuring/ and search for "sharedData". This proposed fix adds a blank line before the start of the fenced block for proper Markdown form and consistency with the rest of the file. (Unverified because GitHub displays it correctly even without the fix.)
