### PR TITLE
Docs: Update multiple pages to fix rendering of fenced code blocks

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -203,6 +203,7 @@ console.log('bar');
 ESLint supports adding shared settings into configuration file. You can add `settings` object to ESLint configuration file and it will be supplied to every rule that will be executed. This may be useful if you are adding custom rules and want them to have access to the same information and be easily configurable.
 
 In JSON:
+
 ```json
 {
     "settings": {
@@ -212,6 +213,7 @@ In JSON:
 ```
 
 And in YAML:
+
 ```yaml
 ---
   settings:

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -60,6 +60,7 @@ If the configured name of the error variable begins with a `^` it is considered 
 **Examples for valid configurations:**
 
 1. Rule configured to warn if an unhandled error is detected where the name of the error variable can be `err`, `error` or `anySpecificError`.
+
     ```js
     // ...
     "handle-callback-err": [2, "^(err|error|anySpecificError)$" ]
@@ -67,6 +68,7 @@ If the configured name of the error variable begins with a `^` it is considered 
     ```
 
 2. Rule configured to warn if an unhandled error is detected where the name of the error variable ends with `Error` (e. g. `connectionError` or `validationError` will match).
+
     ```js
     // ...
     "handle-callback-err": [2, "^.+Error$" ]
@@ -74,6 +76,7 @@ If the configured name of the error variable begins with a `^` it is considered 
     ```
 
 3. Rule configured to warn if an unhandled error is detected where the name of the error variable matches any string that contains `err` or `Err` (e. g. `err`, `error`, `anyError`, `some_err` will match).
+
     ```js
     // ...
     "handle-callback-err": [2, "^.*(e|E)rr" ]

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -11,6 +11,7 @@ function foo() {
     }
 }
 ```
+
 ## Rule Details
 
 This rule is aimed at highlighting an unnecessary block of code following an `if` containing a return statement. As such, it will warn when it encounters an `else` following an `if` containing a `return`.

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -23,6 +23,7 @@ function foo {
 ```
 
 Unlike the same rule in JSHint, the following pattern is also considered a warning:
+
 ```js
 foo = bar;
 function foo() {}

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -18,6 +18,7 @@ This rule comes with one boolean option called `grouping` which is turned off by
     "no-mixed-requires": [1, true]
 }
 ```
+
 If enabled, violations will be reported whenever a single `var` statement contains require declarations of mixed types (see the examples below).
 
 #### Nomenclature
@@ -32,6 +33,7 @@ This rule distinguishes between six kinds of variable declaration types:
 In this document, the first four types are summed up under the term *require declaration*.
 
 ###### Example
+
 ```javascript
 var fs = require('fs'),        // "core"     \
     async = require('async'),  // "module"   |- these are "require declaration"s

--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -49,6 +49,7 @@ The following patterns are considered warnings:
 ```js
 String = new Object();
 ```
+
 ```js
 var String;
 ```

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -19,6 +19,7 @@ The following patterns are considered okay and could be used alternatively:
 ```js
 var a = Object.getPrototypeOf(obj);
 ```
+
 ## When not to use
 
 If you need to support legacy browsers, you might want to turn this rule off, since support for `getPrototypeOf` is not yet universal.

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -52,6 +52,7 @@ setTimeout(function() {
 
 ### node
 Defines globals for Node.js development.
+
 ```js
 /*jshint node:true*/
 var fs = require("fs");

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -11,6 +11,7 @@ The following patterns are considered warnings:
 ```js
 var x = 10;
 ```
+
 ```js
 var x = 10; x = 5;
 ```

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -7,6 +7,7 @@ Often code is marked during development process for later work on it or with add
 This rule can be used to help finding these `warning-comments`. It can be configured with an array of terms you don't want to exist in your code. It will raise a warning when one or more of the configured `warning-comments` are present in the checked files.
 
 The default configuration has this rule disabled and looks like this:
+
 ```js
 ...
 "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }]
@@ -28,6 +29,7 @@ configures it to check the complete comment, not only the start:
 ```
 
 The following patterns are considered warnings with the example configuration from above:
+
 ```js
 // TODO: this
 // todo: this too
@@ -41,6 +43,7 @@ The following patterns are considered warnings with the example configuration fr
 ```
 
 These patterns would not be considered warnings with the same example configuration:
+
 ```js
 // This is to do
 // even not any other    term
@@ -55,11 +58,13 @@ These patterns would not be considered warnings with the same example configurat
 As mentioned above, patterns are matched when they match exactly to one of the terms specified (ignoring the case).
 
 ## Rule Options
+
 ```js
 ...
 "no-warning-comments": [<enabled>, { "terms": <terms>, "location": <location> }]
 ...
 ```
+
 * `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to `0`.
 * `terms`: optional array of terms to match. Terms are matched ignoring the case. Defaults to `["todo", "fixme", "xxx"]`.
 * `location`: optional string that configures where in your comments to check for matches. Defaults to `"start"`.
@@ -73,6 +78,7 @@ As mentioned above, patterns are matched when they match exactly to one of the t
 
 ### More examples of valid configurations
 1. Rule configured to warn on matches and search the complete comment, not only the start of it. Note that the `term` configuration is omitted to use the defaults terms.
+
    ```js
    ...
    "no-warning-comments": [1, { "location": "anywhere" }]
@@ -80,6 +86,7 @@ As mentioned above, patterns are matched when they match exactly to one of the t
    ```
 
 2. Rule configured to warn on matches of the term `bad string` at the start of comments. Note that the `location` configuration is omitted to use the default location.
+
    ```js
    ...
    "no-warning-comments": [1, { "terms": ["bad string"] }]
@@ -87,6 +94,7 @@ As mentioned above, patterns are matched when they match exactly to one of the t
    ```
 
 3. Rule configured to warn with error on matches of the default terms at the start of comments. Note that the complete configuration object (that normally holds `terms` and/or `location`) can be omitted for simplicity.
+
    ```js
    ...
    "no-warning-comments": [2]
@@ -94,6 +102,7 @@ As mentioned above, patterns are matched when they match exactly to one of the t
    ```
 
 4. Rule configured to warn on matches of the default terms at the start of comments. Note that the complete configuration object (as already seen in the example above) and even the square brackets can be omitted for simplicity.
+
    ```js
    ...
    "no-warning-comments": 1
@@ -101,6 +110,7 @@ As mentioned above, patterns are matched when they match exactly to one of the t
    ```
 
 5. Rule configured to warn on matches of the specified terms at the start of comments. Note that you can use as many terms as you want.
+
    ```js
    ...
    "no-warning-comments": [1, { "terms": ["any really", "interesting", "or even not", "term", "can be matched"] }]

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -10,6 +10,7 @@ var single = 'single';
 ```
 
 The third parameter enables an exception to the rule to avoid escaping quotes. For example, when `"single"` is the standard, this option allows the use of double quotes to avoid escaping single quotes. This option can have the value `"avoid-escape"` and is off by default.
+
 ```js
 [2, "single", "avoid-escape"]
 ```


### PR DESCRIPTION
I first noticed a problem on the "Configuring ESLint" page (http://eslint.org/docs/configuring/ and search for "sharedData") - the lack of a blank line above the fenced code block resulted in incorrect rendering.

After making that change, I searched for other instances of the problem and found a few (though their rendering issues are generally more subtle). This commit makes sure all fenced code blocks in the documentation have a blank line before and after the ``` fence. (The line after seems less necessary and is there more for consistency.)

If you'd like any changes to the proposed commit, please let me know!
