### PR TITLE
Update: Add missing environments and fix sorting/grouping of rules

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -2,7 +2,9 @@
     "env": {
         "browser": false,
         "node": false,
-        "amd": false
+        "amd": false,
+        "mocha": false,
+        "jasmine": false
     },
 
     "rules": {
@@ -61,6 +63,7 @@
         "no-octal-escape": 2,
         "no-path-concat": 0,
         "no-plusplus": 0,
+        "no-process-env": 0,
         "no-process-exit": 2,
         "no-proto": 2,
         "no-redeclare": 2,
@@ -107,12 +110,12 @@
         "func-style": [0, "declaration"],
         "global-strict": [2, "never"],
         "guard-for-in": 0,
+        "handle-callback-err": 0,
         "max-depth": [0, 4],
         "max-len": [0, 80, 4],
         "max-nested-callbacks": [0, 2],
         "max-params": [0, 3],
         "max-statements": [0, 10],
-        "handle-callback-err": 0,
         "new-cap": 2,
         "new-parens": 2,
         "one-var": 0,
@@ -134,7 +137,6 @@
         "vars-on-top": 0,
         "wrap-iife": 0,
         "wrap-regex": 0,
-        "yoda": [2, "never"],
-        "no-process-env": 0
+        "yoda": [2, "never"]
     }
 }


### PR DESCRIPTION
Mocha/Jasmine are present in environments.json and documented; I'm assuming they should be listed here as well.
