### PR TITLE
New: Add key-spacing rule (fixes #1280)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -256,7 +256,7 @@ target.changelog = function() {
     (rangeTags[1] + " - " + timestamp + "\n").to("CHANGELOG.tmp");
 
     // get log statements
-    var logs = exec("git log --pretty=format:\"* %s (%an)\" " + rangeTags.join(".."), {silent:true}).output.split(/\n/g);
+    var logs = exec("git log --pretty=format:\"* %s (%an)\" " + rangeTags.join(".."), {silent: true}).output.split(/\n/g);
     logs = logs.filter(function(line) {
         return line.indexOf("Merge pull request") === -1 && line.indexOf("Merge branch") === -1;
     });

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -114,6 +114,7 @@
         "global-strict": [2, "never"],
         "guard-for-in": 0,
         "handle-callback-err": 0,
+        "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
         "max-depth": [0, 4],
         "max-len": [0, 80, 4],
         "max-nested-callbacks": [0, 2],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -130,6 +130,7 @@ These rules are purely matters of style and are quite subjective.
 * [eol-last](eol-last.md) - enforce newline at the end of file, with no multiple empty lines
 * [func-names](func-names.md) - require function expressions to have a name (off by default)
 * [func-style](func-style.md) - enforces use of function declarations or expressions (off by default)
+* [key-spacing](key-spacing.md) - enforces spacing between keys and values in object literal properties
 * [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested (off by default)
 * [new-cap](new-cap.md) - require a capital letter for constructors
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -1,0 +1,132 @@
+# Enforce Property Spacing (key-spacing)
+
+Enforces spacing around the colon in object literal properties. It can verify each property individually, or it can ensure vertical alignment of all of the properties in an object literal.
+
+## Rule Details
+
+This rule will warn when spacing in properties does not match the specified options. There are three modes:
+
+### 1. Individual
+
+Use just the `beforeColon` and `afterColon` options to enforce having one space or zero spaces on each side, using `true` or `false`, respectively. The default is no whitespace between the key and the colon and one space between the colon and the value.
+
+The following patterns are considered valid:
+
+```js
+// DEFAULT
+// "key-spacing": [2, {
+//     beforeColon: false,
+//     afterColon: true
+// }]
+var obj = { "foo": (42) };
+
+// "key-spacing": [2, {
+//     "beforeColon": true,
+//     "afterColon": false
+// }]
+call({
+    foobar :42,
+    bat :(2 * 2)
+};
+```
+
+The follow patterns are considered warnings:
+
+```js
+// "key-spacing": [2, {
+//     beforeColon: false,
+//     afterColon: false
+// }]
+var obj = { foo : 42 }; // Extra space on both sides
+
+// "key-spacing": [2, {
+//     beforeColon: true,
+//     afterColon: true
+// }]
+function foo() {
+    return {
+        foobar: 42, // Missing space before colon
+        bat :"value" // Missing space after colon
+    };
+}
+```
+
+### 2. Vertically align values `"align": "value"`
+
+Use the `align` option to enforce vertical alignment of all values in an object literal. This mode still respects `beforeColon` and `afterColon` where possible, but it will pad with spaces after the colon where necessary.
+
+The following patterns are considered valid:
+
+```js
+// "key-spacing": [2, { "align": "value" }]
+// beforeColon and afterColon default to false and true, respectively
+var obj = {
+    a:    value,
+    bcde: 42,
+    fg:   foo()
+};
+
+// "key-spacing": [2, {
+//     "align": "value",
+//     "beforeColon": true,
+//     "afterColon": false
+// }]
+call({
+    'a' :[],
+    b :  []
+});
+```
+
+The following patterns are considered warnings:
+
+```js
+// "key-spacing": [2, { "align": "value" }]
+// beforeColon and afterColon default to false and true, respectively
+var obj = {
+    a: value, // Not enough space after colon
+    bcde:  42, // Extra space after colon
+    fg :   foo() // Extra space before colon
+};
+```
+
+### 3. Vertically align colons `"align": "colon"`
+
+The `align` option can also vertically align colons and values together. Whereas with `"value"` alignment, padding belongs right of the colon, with `"colon"` alignment, padding goes to the left of the colon. Except in the case of padding, it still respects `beforeColon` and `afterColon`.
+
+The following patterns are considered valid:
+```js
+// "key-spacing": [2, { "align": "colon" }]
+// beforeColon and afterColon default to false and true, respectively
+var obj = {
+    foobar   : 42,
+    bat      : (2 * 2),
+    "default": fn()
+};
+
+// "key-spacing": [2, {
+//     "align": "value",
+//     "beforeColon": true,
+//     "afterColon": false
+// }]
+obj = {
+    first  :1,
+    second :2,
+    third  :3
+};
+```
+
+The following patterns are considered warnings:
+
+```js
+// "key-spacing": [2, { "align": "value" }]
+// beforeColon and afterColon default to false and true, respectively
+var obj = {
+    one:   1, // Missing space before colon
+    "two": 2,
+    three:  3 // Extra space after colon
+};
+```
+
+## When Not To Use It
+
+If you have another convention for property spacing that might not be consistent with the available options, or if you want to permit multiple styles concurrently you can safely disable this rule.

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -1,0 +1,139 @@
+/**
+ * @fileoverview Rule to specify spacing of object literal keys and values
+ * @author Brandon Mills
+ * @copyright 2014 Brandon Mills. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets an object literal property's key as the identifier name or string value.
+ * @param {ASTNode} property Property node whose key to retrieve.
+ * @returns {string} The property's key.
+ */
+function getKey(property) {
+    return property.key.name || property.key.value;
+}
+
+/**
+ * Gets the number of characters in a key, including quotes around string keys.
+ * @param {ASTNode} property Property of on object literal.
+ * @returns {int} Width of the key, including string quotes where present.
+ */
+function getKeyWidth(property) {
+    var key = property.key;
+    return (key.type === "Identifier" ? key.name : key.raw).length;
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var messages = {
+    key: "{{error}} space after key \"{{key}}\".",
+    value: "{{error}} space before value for key \"{{key}}\"."
+};
+
+module.exports = function(context) {
+
+    /**
+     * OPTIONS
+     * "key-spacing": [2, {
+     *     beforeColon: false,
+     *     afterColon: true,
+     *     align: "colon" // Optional, or "value"
+     * }
+     */
+
+    var options = context.options[0] || {},
+        align = options.align,
+        beforeColon = +!!options.beforeColon, // Defaults to false
+        afterColon = +!(options.afterColon === false); // Defaults to true
+
+    /**
+     * Gets the spacing around the colon in an object literal property
+     * @param {ASTNode} property Property node from an object literal
+     * @returns {Object} Spacing before and after the property's colon
+     */
+    function getPropertySpacing(property) {
+        var whitespace = /^(\s*):(\s*)/.exec(context.getSource().slice(
+            property.key.range[1], property.value.range[0]
+        ));
+
+        if (whitespace) {
+            return {
+                beforeColon: whitespace[1].length,
+                afterColon: whitespace[2].length
+            };
+        }
+    }
+
+    /**
+     * Reports an appropriately-formatted error if spacing is incorrect on one
+     * side of the colon.
+     * @param {ASTNode} property Key-value pair in an object literal.
+     * @param {string} side Side being verified - either "key" or "value".
+     * @param {int} diff Difference between actual and expected spacing.
+     * @returns {void}
+     */
+    function report(property, side, diff) {
+        if (diff) {
+            context.report(property[side], messages[side], {
+                error: diff > 0 ? "Extra" : "Missing",
+                key: getKey(property)
+            });
+        }
+    }
+
+    if (align) { // Verify vertical alignment
+
+        return {
+            "ObjectExpression": function(node) {
+                var properties = node.properties,
+                    length = properties.length,
+                    widths = properties.map(getKeyWidth), // Width of keys, including quotes
+                    targetWidth = Math.max.apply(null, widths),
+                    i, property, spacing, width;
+
+                // Conditionally include one space before or after colon
+                targetWidth += (align === "colon" ? beforeColon : afterColon);
+
+                for (i = 0; i < length; i++) {
+                    property = properties[i];
+                    spacing = getPropertySpacing(property);
+
+                    if (!spacing) {
+                        continue; // Object literal getters/setters lack a colon
+                    }
+
+                    width = widths[i];
+
+                    if (align === "value") {
+                        report(property, "key", spacing.beforeColon - beforeColon);
+                        report(property, "value", (width + spacing.afterColon) - targetWidth);
+                    } else { // align = "colon"
+                        report(property, "key", (width + spacing.beforeColon) - targetWidth);
+                        report(property, "value", spacing.afterColon - afterColon);
+                    }
+                }
+            }
+        };
+
+    } else { // Strictly obey beforeColon and afterColon in each property
+
+        return {
+            "Property": function (node) {
+                var spacing = getPropertySpacing(node);
+                if (spacing) { // Object literal getters/setters lack colon spacing
+                    report(node, "key", spacing.beforeColon - beforeColon);
+                    report(node, "value", spacing.afterColon - afterColon);
+                }
+            }
+        };
+
+    }
+
+};

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -31,7 +31,7 @@ module.exports = function(context) {
                 lines = src.slice(0, re.lastIndex).split(/\r?\n/g);
 
                 location = {
-                    line:   lines.length,
+                    line: lines.length,
                     column: lines[lines.length - 1].length - match[0].length + 1
                 };
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1655,7 +1655,7 @@ describe("eslint", function() {
         var code = "/*eslint no-alert:0*/ alert('test');";
 
         it("should not report a violation", function() {
-            var config = { rules: { "no-alert" : 1 } };
+            var config = { rules: { "no-alert": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -1680,7 +1680,7 @@ describe("eslint", function() {
     describe("when evaluating code with comments to enable and disable multiple rules", function() {
         var code = "/*eslint no-alert:1 no-console:0*/ alert('test'); console.log('test');";
         it("should report a violation", function() {
-            var config = { rules: { "no-console" : 1, "no-alert" : 0 } };
+            var config = { rules: { "no-console": 1, "no-alert": 0 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -1712,7 +1712,7 @@ describe("eslint", function() {
 
         it("should not report a violation", function() {
             var code = "/*eslint test-plugin/test-rule:0*/ var a = \"trigger violation\"";
-            var config = { rules: { "test-plugin/test-rule" : 1 } };
+            var config = { rules: { "test-plugin/test-rule": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -1741,7 +1741,7 @@ describe("eslint", function() {
                 "/*eslint-enable */",
                 "alert('test');"
             ].join("\n");
-            var config = { rules: { "no-alert" : 1 } };
+            var config = { rules: { "no-alert": 1 } };
 
             var messages = eslint.verify(code, config, filename);
 
@@ -1758,7 +1758,7 @@ describe("eslint", function() {
                 "alert('test');",
                 "alert('test');"
             ].join("\n");
-            var config = { rules: { "no-alert" : 1 } };
+            var config = { rules: { "no-alert": 1 } };
 
             var messages = eslint.verify(code, config, filename);
 
@@ -1772,7 +1772,7 @@ describe("eslint", function() {
                 "                                         alert('test');\n",
                 "/*eslint-enable */alert('test2');"
             ].join("");
-            var config = { rules: { "no-alert" : 1 } };
+            var config = { rules: { "no-alert": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 2);
@@ -1792,7 +1792,7 @@ describe("eslint", function() {
                 "/*eslint-enable*/"
             ].join("\n");
 
-            var config = { rules: { "no-alert" : 1 } };
+            var config = { rules: { "no-alert": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -1806,7 +1806,7 @@ describe("eslint", function() {
                 "/*eslint-enable */;any();"
             ].join("\n");
 
-            var config = { rules: { "no-unused-vars" : 1 } };
+            var config = { rules: { "no-unused-vars": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -1818,7 +1818,7 @@ describe("eslint", function() {
                 "/*eslint-enable */;any();"
             ].join("\n");
 
-            var config = { rules: { "no-unused-vars" : 1 } };
+            var config = { rules: { "no-unused-vars": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -1833,7 +1833,7 @@ describe("eslint", function() {
                     "alert('test');",
                     "console.log('test');" // here
             ].join("\n");
-            var config = { rules: { "no-alert" : 1, "no-console": 1 } };
+            var config = { rules: { "no-alert": 1, "no-console": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -1851,7 +1851,7 @@ describe("eslint", function() {
                 "alert('test');", // here
                 "console.log('test');" // here
             ].join("\n");
-            var config = { rules: { "no-alert" : 1, "no-console": 1 } };
+            var config = { rules: { "no-alert": 1, "no-console": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 2);
@@ -1871,7 +1871,7 @@ describe("eslint", function() {
 
                 "alert('test');" // here
             ].join("\n");
-            var config = { rules: { "no-alert" : 1, "no-console": 1 } };
+            var config = { rules: { "no-alert": 1, "no-console": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -1890,7 +1890,7 @@ describe("eslint", function() {
                 "alert('test');", // here
                 "console.log('test');"
             ].join("\n");
-            var config = { rules: { "no-alert" : 1, "no-console": 1 } };
+            var config = { rules: { "no-alert": 1, "no-console": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -1919,7 +1919,7 @@ describe("eslint", function() {
 
                 "/*eslint-enable*/"
             ].join("\n");
-            var config = { rules: { "no-alert" : 1, "no-console": 1 } };
+            var config = { rules: { "no-alert": 1, "no-console": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 3);
@@ -1952,7 +1952,7 @@ describe("eslint", function() {
                     "console.log('test');", // here
                 "/*eslint-enable no-console */"
             ].join("\n");
-            var config = { rules: { "no-alert" : 1, "no-console": 1 } };
+            var config = { rules: { "no-alert": 1, "no-console": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 3);
@@ -1973,7 +1973,7 @@ describe("eslint", function() {
         var code = "/*eslint no-alert:1, no-console:0*/ alert('test'); console.log('test');";
 
         it("should report a violation", function() {
-            var config = { rules: { "no-console" : 1, "no-alert" : 0 } };
+            var config = { rules: { "no-console": 1, "no-alert": 0 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -1987,7 +1987,7 @@ describe("eslint", function() {
         var code = "/*eslint quotes:[2, \"double\"]*/ alert('test');";
 
         it("should report a violation", function() {
-            var config = { rules: { "quotes" : [2, "single"] } };
+            var config = { rules: { "quotes": [2, "single"] } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -2001,7 +2001,7 @@ describe("eslint", function() {
         it("should report a violation", function() {
             var code = "/*eslint no-alert:'1'*/ alert('test');";
 
-            var config = { rules: { "no-alert" : 1} };
+            var config = { rules: { "no-alert": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -2013,7 +2013,7 @@ describe("eslint", function() {
         it("should report a violation", function() {
             var code = "/*eslint no-alert:abc*/ alert('test');";
 
-            var config = { rules: { "no-alert" : 1} };
+            var config = { rules: { "no-alert": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -2025,7 +2025,7 @@ describe("eslint", function() {
         it("should report a violation", function() {
             var code = "/*eslint no-alert:0 2*/ alert('test');";
 
-            var config = { rules: { "no-alert" : 1} };
+            var config = { rules: { "no-alert": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -2084,7 +2084,7 @@ describe("eslint", function() {
         it("should not support legacy config", function() {
             var code = "/*jshint mocha:true */ describe();";
 
-            var config = { rules: { "no-undef" : 1} };
+            var config = { rules: { "no-undef": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 1);
@@ -2097,7 +2097,7 @@ describe("eslint", function() {
         it("should not report a violation when using typed array", function() {
             var code = "var array = new Uint8Array();";
 
-            var config = { rules: { "no-undef" : 1} };
+            var config = { rules: { "no-undef": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -2106,7 +2106,7 @@ describe("eslint", function() {
         it("should not report a violation", function() {
             var code = "/*eslint-env mocha,node */ require();describe();";
 
-            var config = { rules: { "no-undef" : 1} };
+            var config = { rules: { "no-undef": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -2115,7 +2115,7 @@ describe("eslint", function() {
         it("should not report a violation", function() {
             var code = "/*eslint-env mocha */ suite();test();";
 
-            var config = { rules: { "no-undef" : 1} };
+            var config = { rules: { "no-undef": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -2124,7 +2124,7 @@ describe("eslint", function() {
         it("should not report a violation", function() {
             var code = "/*eslint-env amd */ define();require();";
 
-            var config = { rules: { "no-undef" : 1} };
+            var config = { rules: { "no-undef": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);
@@ -2133,7 +2133,7 @@ describe("eslint", function() {
         it("should not report a violation", function() {
             var code = "/*eslint-env jasmine */ expect();spyOn();";
 
-            var config = { rules: { "no-undef" : 1} };
+            var config = { rules: { "no-undef": 1} };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -1,0 +1,226 @@
+/**
+ * @fileoverview Tests for key-spacing rule.
+ * @author Brandon Mills
+ * @copyright 2014 Brandon Mills. All rights reserved.
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/key-spacing", {
+
+    valid: [{
+        code: "var obj = { key: value };",
+        args: {}
+    }, {
+        code: "var foo = { a:bar };",
+        args: [2, {
+            beforeColon: false,
+            afterColon: false
+        }]
+    }, {
+        code: "var foo = { a: bar };",
+        args: [2, {
+            beforeColon: false,
+            afterColon: true
+        }]
+    }, {
+        code: "foo({ 'default': function(){}});",
+        args: [2, {
+            beforeColon: false,
+            afterColon: true
+        }]
+    }, {
+        code: "function foo() { return {\n    key: (foo === 4)\n}; }",
+        args: [2, {
+            beforeColon: false,
+            afterColon: true
+        }]
+    }, {
+        code: "var obj = {'key' :42 };",
+        args: [2, {
+            beforeColon: true,
+            afterColon: false
+        }]
+    }, {
+        code: "({a : foo, b : bar})['a'];",
+        args: [2, {
+            beforeColon: true,
+            afterColon: true
+        }]
+    }, {
+        code: [
+            "var obj = {",
+            "    'a'   : (42 - 12),",
+            "    foobar: 'value'",
+            "};"
+        ].join("\n"),
+        args: [2, {
+            align: "colon"
+        }]
+    }, {
+        code: [
+            "callExpr(arg, {",
+            "    key       :val,",
+            "    'another' :false,",
+            "});"
+        ].join("\n"),
+        args: [2, {
+            align: "colon",
+            beforeColon: true,
+            afterColon: false
+        }]
+    }, {
+        code: [
+            "var obj = {",
+            "    a:        (42 - 12),",
+            "    'foobar': 'value',",
+            "    bat:      []",
+            "};"
+        ].join("\n"),
+        args: [2, {
+            align: "value"
+        }]
+    }, {
+        code: [
+            "callExpr(arg, {",
+            "    'asdf' :val,",
+            "    foobar :false,",
+            "    key :   value",
+            "});"
+        ].join("\n"),
+        args: [2, {
+            align: "value",
+            beforeColon: true,
+            afterColon: false
+        }]
+    }, {
+        code: "var obj = { get fn() { return 42; } };",
+        args: [2, {}]
+    }],
+
+    invalid: [{
+        code: "var bat = function() { return { foo:bar, 'key': value }; };",
+        args: [2, {
+            beforeColon: false,
+            afterColon: false
+        }],
+        errors: [{ message: "Extra space before value for key \"key\".", type: "Identifier"}]
+    }, {
+        code: "fn({ foo:bar, 'key' :value });",
+        args: [2, {
+            beforeColon: false,
+            afterColon: false
+        }],
+        errors: [{ message: "Extra space after key \"key\".", type: "Literal"}]
+    }, {
+        code: "var obj = {prop :(42)};",
+        args: [2, {
+            beforeColon: true,
+            afterColon: true
+        }],
+        errors: [{ message: "Missing space before value for key \"prop\".", type: "Literal"}]
+    }, {
+        code: "({'a' : foo, b: bar() }).b();",
+        args: [2, {
+            beforeColon: true,
+            afterColon: true
+        }],
+        errors: [{ message: "Missing space after key \"b\".", type: "Identifier"}]
+    }, {
+        code: "({'a'  :foo(), b:  bar() }).b();",
+        args: [2, {
+            beforeColon: true,
+            afterColon: true
+        }],
+        errors: [
+            { message: "Extra space after key \"a\".", type: "Literal" },
+            { message: "Missing space before value for key \"a\".", type: "CallExpression" },
+            { message: "Missing space after key \"b\".", type: "Identifier"},
+            { message: "Extra space before value for key \"b\".", type: "CallExpression" }
+        ]
+    }, {
+        code: "bar = { key:value };",
+        args: [2, {
+            beforeColon: false,
+            afterColon: true
+        }],
+        errors: [{ message: "Missing space before value for key \"key\".", type: "Identifier" }]
+    }, {
+        code: [
+            "obj = {",
+            "    key:   value,",
+            "    foobar:fn(),",
+            "    'a'   : (2 * 2)",
+            "};"
+        ].join("\n"),
+        args: [2, {
+            align: "colon"
+        }],
+        errors: [
+            { message: "Missing space after key \"key\".", type: "Identifier" },
+            { message: "Extra space before value for key \"key\".", type: "Identifier" },
+            { message: "Missing space before value for key \"foobar\".", type: "CallExpression" }
+        ]
+    }, {
+        code: [
+            "({",
+            "    'a' : val,",
+            "    foo:fn(),",
+            "    b    :[42],",
+            "    c   :call()",
+            "}).a();"
+        ].join("\n"),
+        args: [2, {
+            align: "colon",
+            beforeColon: true,
+            afterColon: false
+        }],
+        errors: [
+            { message: "Extra space before value for key \"a\".", type: "Identifier" },
+            { message: "Missing space after key \"foo\".", type: "Identifier" },
+            { message: "Extra space after key \"b\".", type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = {",
+            "    a:    fn(),",
+            "    'b' : 42,",
+            "    foo:(bar),",
+            "    bat: 'valid'",
+            "};"
+        ].join("\n"),
+        args: [2, {
+            align: "value"
+        }],
+        errors: [
+            { message: "Extra space before value for key \"a\".", type: "CallExpression" },
+            { message: "Extra space after key \"b\".", type: "Literal" },
+            { message: "Missing space before value for key \"foo\".", type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "foo = {",
+            "    a:  value,",
+            "    b :  42,",
+            "    foo :['a'],",
+            "    bar : call()",
+            "};"
+        ].join("\n"),
+        args: [2, {
+            align: "value",
+            beforeColon: true,
+            afterColon: false
+        }],
+        errors: [
+            { message: "Missing space after key \"a\".", type: "Identifier" },
+            { message: "Extra space before value for key \"bar\".", type: "CallExpression" }
+        ]
+    }]
+
+});

--- a/tests/lib/rules/vars-on-top.js
+++ b/tests/lib/rules/vars-on-top.js
@@ -21,370 +21,356 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new EslintTester(eslint);
 eslintTester.addRuleTest("lib/rules/vars-on-top", {
 
-    valid:
+    valid: [
         [
-            [
+            "var first = 0;",
+            "function foo() {",
+            "    first = 2;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   if (true) {",
+            "       first = true;",
+            "   } else {",
+            "       first = 1;",
+            "   }",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   var second = 1;",
+            "   var third;",
+            "   var fourth = 1, fifth, sixth = third;",
+            "   var seventh;",
+            "   if (true) {",
+            "       third = true;",
+            "   }",
+            "   first = second;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var i;",
+            "   for (i = 0; i < 10; i++) {",
+            "       alert(i);",
+            "   }",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var outer;",
+            "   function inner() {",
+            "       var inner = 1;",
+            "       var outer = inner;",
+            "   }",
+            "   outer = 1;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   //Hello",
+            "   var second = 1;",
+            "   first = second;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   /*",
+            "       Hello Clarice",
+            "   */",
+            "   var second = 1;",
+            "   first = second;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   var second = 1;",
+            "   function bar(){",
+            "       var first;",
+            "       first = 5;",
+            "   }",
+            "   first = second;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   var second = 1;",
+            "   function bar(){",
+            "       var third;",
+            "       third = 5;",
+            "   }",
+            "   first = second;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   var bar = function(){",
+            "       var third;",
+            "       third = 5;",
+            "   }",
+            "   first = 5;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var first;",
+            "   first.onclick(function(){",
+            "       var third;",
+            "       third = 5;",
+            "   });",
+            "   first = 5;",
+            "}"
+        ].join("\n"),
+        [
+            "function foo() {",
+            "   var i = 0;",
+            "   for (let j = 0; j < 10; j++) {",
+            "       alert(j);",
+            "   }",
+            "   i = i + 1;",
+            "}"
+        ].join("\n"),
+        "'use strict'; var x; f();",
+        "'use strict'; 'directive'; var x; var y; f();",
+        "function f() { 'use strict'; var x; f(); }",
+        "function f() { 'use strict'; 'directive'; var x; var y; f(); }"
+    ],
+
+    invalid: [
+        {
+            code: [
                 "var first = 0;",
                 "function foo() {",
                 "    first = 2;",
-                "}"
+                "    second = 2;",
+                "}",
+                "var second = 0;"
             ].join("\n"),
-            [
-                "function foo() {",
-                "}"
-            ].join("\n"),
-            [
-                "function foo() {",
-                "   var first;",
-                "   if (true) {",
-                "       first = true;",
-                "   } else {",
-                "       first = 1;",
-                "   }",
-                "}"
-            ].join("\n"),
-            [
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
                 "function foo() {",
                 "   var first;",
+                "   first = 1;",
+                "   first = 2;",
+                "   first = 3;",
+                "   first = 4;",
                 "   var second = 1;",
-                "   var third;",
-                "   var fourth = 1, fifth, sixth = third;",
-                "   var seventh;",
+                "   second = 2;",
+                "   first = second;",
+                "}"
+            ].join("\n"),
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
+                "function foo() {",
+                "   var first;",
                 "   if (true) {",
-                "       third = true;",
+                "       var second = true;",
                 "   }",
                 "   first = second;",
                 "}"
             ].join("\n"),
-            [
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
                 "function foo() {",
-                "   var i;",
-                "   for (i = 0; i < 10; i++) {",
+                "   for (var i = 0; i < 10; i++) {",
                 "       alert(i);",
                 "   }",
                 "}"
             ].join("\n"),
-            [
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
                 "function foo() {",
-                "   var outer;",
-                "   function inner() {",
-                "       var inner = 1;",
-                "       var outer = inner;",
+                "   var first = 10;",
+                "   var i;",
+                "   for (i = 0; i < first; i ++) {",
+                "       var second = i;",
                 "   }",
-                "   outer = 1;",
                 "}"
             ].join("\n"),
-            [
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
                 "function foo() {",
-                "   var first;",
-                "   //Hello",
-                "   var second = 1;",
-                "   first = second;",
-                "}"
-            ].join("\n"),
-            [
-                "function foo() {",
-                "   var first;",
-                "   /*",
-                "       Hello Clarice",
-                "   */",
-                "   var second = 1;",
-                "   first = second;",
-                "}"
-            ].join("\n"),
-            [
-                "function foo() {",
-                "   var first;",
-                "   var second = 1;",
-                "   function bar(){",
-                "       var first;",
-                "       first = 5;",
+                "   var first = 10;",
+                "   var i;",
+                "   switch (first) {",
+                "       case 10:",
+                "           var hello = 1;",
+                "           break;",
                 "   }",
-                "   first = second;",
                 "}"
             ].join("\n"),
-            [
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
                 "function foo() {",
-                "   var first;",
-                "   var second = 1;",
-                "   function bar(){",
-                "       var third;",
-                "       third = 5;",
+                "   var first = 10;",
+                "   var i;",
+                "   try {",
+                "       var hello = 1;",
+                "   } catch (e) {",
+                "       alert('error');",
                 "   }",
-                "   first = second;",
                 "}"
             ].join("\n"),
-            [
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
                 "function foo() {",
-                "   var first;",
-                "   var bar = function(){",
-                "       var third;",
-                "       third = 5;",
+                "   var first = 10;",
+                "   var i;",
+                "   try {",
+                "       asdf;",
+                "   } catch (e) {",
+                "       var hello = 1;",
                 "   }",
-                "   first = 5;",
                 "}"
             ].join("\n"),
-            [
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
                 "function foo() {",
-                "   var first;",
-                "   first.onclick(function(){",
-                "       var third;",
-                "       third = 5;",
-                "   });",
-                "   first = 5;",
-                "}"
-            ].join("\n"),
-            [
-                "function foo() {",
-                "   var i = 0;",
-                "   for (let j = 0; j < 10; j++) {",
-                "       alert(j);",
+                "   var first = 10;",
+                "   while (first) {",
+                "       var hello = 1;",
                 "   }",
-                "   i = i + 1;",
                 "}"
             ].join("\n"),
-            "'use strict'; var x; f();",
-            "'use strict'; 'directive'; var x; var y; f();",
-            "function f() { 'use strict'; var x; f(); }",
-            "function f() { 'use strict'; 'directive'; var x; var y; f(); }"
-        ],
-
-    invalid:
-        [
-            {
-                code:
-                    [
-                        "var first = 0;",
-                        "function foo() {",
-                        "    first = 2;",
-                        "    second = 2;",
-                        "}",
-                        "var second = 0;"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first;",
-                        "   first = 1;",
-                        "   first = 2;",
-                        "   first = 3;",
-                        "   first = 4;",
-                        "   var second = 1;",
-                        "   second = 2;",
-                        "   first = second;",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first;",
-                        "   if (true) {",
-                        "       var second = true;",
-                        "   }",
-                        "   first = second;",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   for (var i = 0; i < 10; i++) {",
-                        "       alert(i);",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = 10;",
-                        "   var i;",
-                        "   for (i = 0; i < first; i ++) {",
-                        "       var second = i;",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = 10;",
-                        "   var i;",
-                        "   switch (first) {",
-                        "       case 10:",
-                        "           var hello = 1;",
-                        "           break;",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = 10;",
-                        "   var i;",
-                        "   try {",
-                        "       var hello = 1;",
-                        "   } catch (e) {",
-                        "       alert('error');",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = 10;",
-                        "   var i;",
-                        "   try {",
-                        "       asdf;",
-                        "   } catch (e) {",
-                        "       var hello = 1;",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = 10;",
-                        "   while (first) {",
-                        "       var hello = 1;",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = 10;",
-                        "   do {",
-                        "       var hello = 1;",
-                        "   } while (first == 10);",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = [1,2,3];",
-                        "   for (var item in first) {",
-                        "       item++;",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code:
-                    [
-                        "function foo() {",
-                        "   var first = [1,2,3];",
-                        "   var item;",
-                        "   for (item in first) {",
-                        "       var hello = item;",
-                        "   }",
-                        "}"
-                    ].join("\n"),
-                errors: [
-                    {
-                        message: "All \"var\" declarations must be at the top of the function scope.",
-                        type: "VariableDeclaration"
-                    }
-                ]
-            },
-            {
-                code: "'use strict'; 0; var x; f();",
-                errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
-            },
-            {
-                code: "'use strict'; var x; 'directive'; var y; f();",
-                errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
-            },
-            {
-                code: "function f() { 'use strict'; 0; var x; f(); }",
-                errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
-            },
-            {
-                code: "function f() { 'use strict'; var x; 'directive';  var y; f(); }",
-                errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
-            }
-        ]
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
+                "function foo() {",
+                "   var first = 10;",
+                "   do {",
+                "       var hello = 1;",
+                "   } while (first == 10);",
+                "}"
+            ].join("\n"),
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
+                "function foo() {",
+                "   var first = [1,2,3];",
+                "   for (var item in first) {",
+                "       item++;",
+                "   }",
+                "}"
+            ].join("\n"),
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: [
+                "function foo() {",
+                "   var first = [1,2,3];",
+                "   var item;",
+                "   for (item in first) {",
+                "       var hello = item;",
+                "   }",
+                "}"
+            ].join("\n"),
+            errors: [
+                {
+                    message: "All \"var\" declarations must be at the top of the function scope.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "'use strict'; 0; var x; f();",
+            errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: "'use strict'; var x; 'directive'; var y; f();",
+            errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: "function f() { 'use strict'; 0; var x; f(); }",
+            errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: "function f() { 'use strict'; var x; 'directive';  var y; f(); }",
+            errors: [{message: "All \"var\" declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        }
+    ]
 });


### PR DESCRIPTION
I had a couple questions about this in [#1280 (comment)](https://github.com/eslint/eslint/issues/1280#issuecomment-57680914), but I went ahead with what I already had and can change it based on feedback:
- On by default, no space between key and colon, one space between colon and value
- Options are in order for after key and before value, with possible values being `"always"` or `"never"`.

Adds a new method, `getTokensBetween`, to the tokens API. I believe this can be used in a couple other rules, so if this gets merged, I'll look for other rules that implement the same thing and switch them to use the new method.

This does not include the idea brought up by @lo1tuma in [#1280 (comment)](https://github.com/eslint/eslint/issues/1280#issuecomment-57683287), which would add additional options for vertically aligning multiple properties. I'm totally amenable to adding that to this PR if that's desirable.

There were changes to `Makefile.js`, `lib/rules/no-trailing-spaces.js`, `tests/lib/eslint.js`, and `tests/lib/rules/vars-on-top.js` required whitespace changes because this is on by default. If that's the wrong choice, I'll revert those changes.
