### PR TITLE
Docs: Remove moot integration plugins

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -16,9 +16,7 @@
 ## Build Systems
 
 * **Grunt:**
-    * [eslint-grunt](https://npmjs.org/package/eslint-grunt)
     * [grunt-eslint](https://npmjs.org/package/grunt-eslint)
-    * [grunt-contrib-eslint](https://www.npmjs.org/package/grunt-contrib-eslint)
 * **Gulp:**
     * [gulp-eslint](https://npmjs.org/package/gulp-eslint)
 * **Mimosa:**


### PR DESCRIPTION
`eslint-grunt` isn't maintained and `grunt-contrib-eslint` is breaking the grunt naming rules and is just a duplicate of `grunt-eslint`.
