### PR TITLE
Fix: space-in-parens should not throw for multiline statements (fixes #1351)

### DIFF
--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -14,10 +14,10 @@ module.exports = function(context) {
     var RE, MESSAGE;
 
     if (context.options[0] === "always") {
-        RE = /\([^ \)]|[^ \(]\)/mg;
+        RE = /\([^ \)\r\n]|[^ \(\r\n]\)/mg;
         MESSAGE = "There must be a space inside this paren.";
     } else {
-        RE = /\( | \)/mg;
+        RE = /\( +[^ \r\n]|[^ \r\n] +\)/mg;
         MESSAGE = "There should be no spaces inside this paren.";
     }
 

--- a/tests/lib/rules/space-in-parens.js
+++ b/tests/lib/rules/space-in-parens.js
@@ -21,12 +21,20 @@ eslintTester.addRuleTest("lib/rules/space-in-parens", {
     valid: [
         { code: "foo()", args: ["2", "always"] },
         { code: "foo( bar )", args: ["2", "always"] },
+        { code: "foo\n(\nbar\n)\n", args: ["2", "always"] },
+        { code: "foo\n(  \nbar\n )\n", args: ["2", "always"] },
+        { code: "foo\n(\n bar  \n)\n", args: ["2", "always"] },
+        { code: "foo\n( \n  bar \n  )\n", args: ["2", "always"] },
         { code: "var x = ( 1 + 2 ) * 3", args: ["2", "always"] },
         { code: "var x = 'foo(bar)'", args: ["2", "always"] },
 
         { code: "bar()", args: ["2", "never"] },
         { code: "bar(baz)", args: ["2", "never"] },
         { code: "var x = (4 + 5) * 6", args: ["2", "never"] },
+        { code: "foo\n(\nbar\n)\n", args: ["2", "never"] },
+        { code: "foo\n(  \nbar\n )\n", args: ["2", "never"] },
+        { code: "foo\n(\n bar  \n)\n", args: ["2", "never"] },
+        { code: "foo\n( \n  bar \n  )\n", args: ["2", "never"] },
         { code: "var x = 'bar( baz )'", args: ["2", "always"] }
     ],
 
@@ -75,7 +83,16 @@ eslintTester.addRuleTest("lib/rules/space-in-parens", {
                 }
             ]
         },
-
+        {
+            code: "foo\n(bar\n)\n",
+            args: ["2", "always"],
+            errors: [
+                {
+                    message: "There must be a space inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
         {
             code: "bar(baz )",
             args: ["2", "never"],
@@ -112,6 +129,16 @@ eslintTester.addRuleTest("lib/rules/space-in-parens", {
         },
         {
             code: "var x = (4 + 5 ) * 6",
+            args: ["2", "never"],
+            errors: [
+                {
+                    message: "There should be no spaces inside this paren.",
+                    type: "Program"
+                }
+            ]
+        },
+        {
+            code: "foo\n(\nbar )\n",
             args: ["2", "never"],
             errors: [
                 {


### PR DESCRIPTION
Changed regex in rule and added tests.
