### PR TITLE
Update: Add support for plugin default configuration (fixes #1358)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -18,6 +18,25 @@ module.exports = {
 };
 ```
 
+### Default Configuration for Plugins
+
+You can provide default configuration for the rules included in your plugin by modifying
+exported object to include `rulesConfig` property. `rulesConfig` follows the same pattern as
+you would use in your .eslintrc config `rules` property, but without plugin name as a prefix.
+
+```js
+module.exports = {
+    rules: {
+        "myFirstRule": require("./lib/rules/my-first-rule"),
+        "mySecondRule": require("./lib/rules/my-second-rule")
+    },
+    rulesConfig: {
+        "myFirstRule": 1,
+        "mySecondRule": [2, "on"]
+    }
+};
+```
+
 ### Peer Dependency
 
 To make clear that the plugin requires eslint to work correctly you have to declare eslint as a `peerDependency` in your `package.json`.

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -25,7 +25,8 @@ var fs = require("fs"),
     eslint = require("./eslint"),
     traverse = require("./util/traverse"),
     IgnoredPaths = require("./ignored-paths"),
-    Config = require("./config");
+    Config = require("./config"),
+    util = require("./util");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -59,12 +60,6 @@ var fs = require("fs"),
  */
 
 //------------------------------------------------------------------------------
-// Constants
-//------------------------------------------------------------------------------
-
-var PLUGIN_NAME_PREFIX = "eslint-plugin-";
-
-//------------------------------------------------------------------------------
 // Private
 //------------------------------------------------------------------------------
 
@@ -89,23 +84,6 @@ var defaultOptions = {
 debug = debug("eslint:cli-engine");
 
 /**
- * Removes the prefix `eslint-plugin-` from a plugin name.
- * @param {string} pluginName The name of the plugin which may has the prefix.
- * @returns {string} The name of the plugin without prefix.
- */
-function removePluginPrefix(pluginName) {
-    var nameWithoutPrefix;
-
-    if (pluginName.indexOf(PLUGIN_NAME_PREFIX) === 0) {
-        nameWithoutPrefix = pluginName.substring(PLUGIN_NAME_PREFIX.length);
-    } else {
-        nameWithoutPrefix = pluginName;
-    }
-
-    return nameWithoutPrefix;
-}
-
-/**
  * Load the given plugins if they are not loaded already.
  * @param {string[]} pluginNames An array of plugin names which should be loaded.
  * @returns {void}
@@ -113,13 +91,13 @@ function removePluginPrefix(pluginName) {
 function loadPlugins(pluginNames) {
     if (pluginNames) {
         pluginNames.forEach(function (pluginName) {
-            var pluginNameWithoutPrefix = removePluginPrefix(pluginName),
+            var pluginNameWithoutPrefix = util.removePluginPrefix(pluginName),
                 plugin;
 
             if (!loadedPlugins[pluginNameWithoutPrefix]) {
                 debug("Load plugin " + pluginNameWithoutPrefix);
 
-                plugin = require(PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+                plugin = require(util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
                 rules.import(plugin.rules, pluginNameWithoutPrefix);
 
                 loadedPlugins[pluginNameWithoutPrefix] = true;

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,13 +21,18 @@ var fs = require("fs"),
     yaml = require("js-yaml"),
     userHome = require("user-home");
 
-
 //------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
 
 var CONFIG_FILENAME = ".eslintrc",
     PERSONAL_CONFIG_PATH = path.join(userHome, CONFIG_FILENAME);
+
+//------------------------------------------------------------------------------
+// Private
+//------------------------------------------------------------------------------
+
+var loadedPlugins = Object.create(null);
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -53,6 +58,40 @@ function loadConfig(filePath) {
     }
 
     return config;
+}
+
+/**
+ * Load configuration for all plugins provided.
+ * @param {string[]} pluginNames An array of plugin names which should be loaded.
+ * @returns {Object} all plugin configurations merged together
+ */
+function getPluginsConfig(pluginNames) {
+    var pluginConfig = {};
+    if (pluginNames) {
+        pluginNames.forEach(function (pluginName) {
+            var pluginNameWithoutPrefix = util.removePluginPrefix(pluginName),
+                plugin = {},
+                rules = {};
+            if (!loadedPlugins[pluginNameWithoutPrefix]) {
+                try {
+                    plugin = require(util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+                    loadedPlugins[pluginNameWithoutPrefix] = plugin;
+                } catch(err) {
+                    debug("Failed to load plugin configuration for " + pluginNameWithoutPrefix + ". Proceeding without it.");
+                    plugin = { rulesConfig: {}};
+                }
+            } else {
+                plugin = loadedPlugins[pluginNameWithoutPrefix];
+            }
+            Object.keys(plugin.rulesConfig).forEach(function(item) {
+                rules[pluginNameWithoutPrefix + "/" + item] = plugin.rulesConfig[item];
+            });
+
+            pluginConfig = util.mergeConfigs(pluginConfig, rules);
+        });
+    }
+
+    return {rules: pluginConfig};
 }
 
 /**
@@ -198,7 +237,8 @@ Config.prototype.getConfig = function (filePath) {
 
     var config,
         userConfig,
-        directory = filePath ? path.dirname(filePath) : process.cwd();
+        directory = filePath ? path.dirname(filePath) : process.cwd(),
+        pluginConfig;
 
     debug("Constructing config for " + filePath);
 
@@ -252,6 +292,12 @@ Config.prototype.getConfig = function (filePath) {
     // Step 8: Merge in command line globals
     config = util.mergeConfigs(config, { globals: this.globals });
 
+
+    // Step 9: Merge in plugin specific rules in reverse
+    if (config.plugins) {
+        pluginConfig = getPluginsConfig(config.plugins);
+        config = util.mergeConfigs(pluginConfig, config);
+    }
 
     this.cache[directory] = config;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var PLUGIN_NAME_PREFIX = "eslint-plugin-";
+
+//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 /**
@@ -59,3 +65,22 @@ exports.mergeConfigs = function mergeConfigs(base, custom) {
 
     return base;
 };
+
+/**
+ * Removes the prefix `eslint-plugin-` from a plugin name.
+ * @param {string} pluginName The name of the plugin which may has the prefix.
+ * @returns {string} The name of the plugin without prefix.
+ */
+exports.removePluginPrefix = function removePluginPrefix(pluginName) {
+    var nameWithoutPrefix;
+
+    if (pluginName.indexOf(PLUGIN_NAME_PREFIX) === 0) {
+        nameWithoutPrefix = pluginName.substring(PLUGIN_NAME_PREFIX.length);
+    } else {
+        nameWithoutPrefix = pluginName;
+    }
+
+    return nameWithoutPrefix;
+};
+
+exports.PLUGIN_NAME_PREFIX = PLUGIN_NAME_PREFIX;

--- a/tests/fixtures/config-hierarchy/broken/plugins/.eslintrc
+++ b/tests/fixtures/config-hierarchy/broken/plugins/.eslintrc
@@ -1,0 +1,3 @@
+plugins: 
+    ["example"]
+    

--- a/tests/fixtures/config-hierarchy/broken/plugins/console-wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/broken/plugins/console-wrong-quotes.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/tests/fixtures/config-hierarchy/broken/plugins2/.eslintrc
+++ b/tests/fixtures/config-hierarchy/broken/plugins2/.eslintrc
@@ -1,0 +1,3 @@
+plugins: 
+    ["example", "eslint-plugin-test"]
+    

--- a/tests/fixtures/config-hierarchy/broken/plugins2/console-wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/broken/plugins2/console-wrong-quotes.js
@@ -1,0 +1,1 @@
+console.log('bar');

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -36,6 +36,18 @@ describe("util", function() {
         });
     });
 
+    describe("when calling removePluginPrefix", function() {
+        it("should remove common prefix", function() {
+            var pluginName = util.removePluginPrefix("eslint-plugin-test");
+            assert.equal(pluginName, "test");
+        });
+
+        it("should not modify plugin name", function() {
+            var pluginName = util.removePluginPrefix("test");
+            assert.equal(pluginName, "test");
+        });
+    });
+
     describe("when calling mergeConfigs()", function() {
         var code = [
             { env: { browser: true } },


### PR DESCRIPTION
As discussed in #1358 
Everything seems to be working currently. I do not like that we are loading plugins twice every time, once in CLIEngine and once in Config, but couldn't come up with a better way to do this. Also, since plugin return object already uses `rules` property for a different purpose then .eslintrc, I assumed another property on the returned object called `rulesConfig`. Maybe that's not the right way to do this, not sure.
