### PR TITLE
Change no-mixed-spaces-and-tabs option type (fixes #1374)

### DIFF
--- a/docs/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/rules/no-mixed-spaces-and-tabs.md
@@ -45,7 +45,7 @@ This option suppresses warnings about mixed tabs and spaces when the latter are 
 You can enable this option by using the following configuration:
 
 ```json
-"no-mixed-spaces-and-tabs": [2, true]
+"no-mixed-spaces-and-tabs": [2, "smart-tabs"]
 ```
 
 ## Further Reading

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -12,7 +12,16 @@
 
 module.exports = function(context) {
 
-    var smartTabs = context.options[0];
+    var smartTabs;
+
+    switch (context.options[0]) {
+        case true: // Support old syntax, maybe add deprecation warning here
+        case "smart-tabs":
+            smartTabs = true;
+            break;
+        default:
+            smartTabs = false;
+    }
 
     var COMMENT_START = /^\s*\/\*/,
         MAYBE_COMMENT = /^\s*\*/;

--- a/tests/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/tests/lib/rules/no-mixed-spaces-and-tabs.js
@@ -31,6 +31,10 @@ eslintTester.addRuleTest("lib/rules/no-mixed-spaces-and-tabs", {
         {
             code: "\tvar x = 5,\n\t    y = 2;",
             args: [2, true]
+        },
+        {
+            code: "\tvar x = 5,\n\t    y = 2;",
+            args: [2, "smart-tabs"]
         }
     ],
 
@@ -63,6 +67,17 @@ eslintTester.addRuleTest("lib/rules/no-mixed-spaces-and-tabs", {
         {
             code: "\tvar x = 5,\n  \t  y = 2;",
             args: [2, true],
+            errors: [
+                {
+                    message: "Mixed spaces and tabs.",
+                    type: "Program",
+                    line: 2
+                }
+            ]
+        },
+        {
+            code: "\tvar x = 5,\n  \t  y = 2;",
+            args: [2, "smart-tabs"],
             errors: [
                 {
                     message: "Mixed spaces and tabs.",


### PR DESCRIPTION
Instead of using a boolean, this pull request changes it to use a string constant like the rest of the rules. This is to be more consistent across the options for the various builtin rules.
