### PR TITLE
New: Allow reading from STDIN (fixes #368)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -1,11 +1,22 @@
 #!/usr/bin/env node
-var cli = require("../lib/cli");
-var exitCode = cli.execute(process.argv);
+var concat = require("concat-stream"),
+    cli = require("../lib/cli");
+
+var exitCode = 0,
+    useStdIn = (process.argv.indexOf("--stdin") > -1);
+
+if (useStdIn) {
+    process.stdin.pipe(concat({ encoding: "string" }, function(text) {
+        exitCode = cli.execute(process.argv, text);
+    }));
+} else {
+    exitCode = cli.execute(process.argv);
+}
 
 /*
  * Wait for the stdout buffer to drain.
  * See https://github.com/eslint/eslint/issues/317
  */
-process.on('exit', function() {
+process.on("exit", function() {
     process.exit(exitCode);
 });

--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -26,7 +26,6 @@ Options:
   -c, --config path::String   Load configuration data from this file.
   --rulesdir [path::String]   Load additional rules from this directory.
   -f, --format String         Use a specific output format. - default: stylish
-  -o, --output-file           Outputs the output into a file.
   -v, --version               Outputs the version number.
   --reset                     Set all default rules to off.
   --eslintrc                  Enable loading .eslintrc configuration. -
@@ -39,6 +38,9 @@ Options:
                               to ignore.
   --ignore                    Enable loading of .eslintignore. - default: true
   --quiet                     Report errors only. - default false
+  --color                     Enable color in piped output. - default: true
+  -o, --output-file path::String  Enable report to be written to a file.
+  --stdin                     Lint code provided on <STDIN>. - default: false
 ```
 
 ### `-h`, `--help`
@@ -162,6 +164,14 @@ Example:
 
   eslint --ignore false file.js
   eslint --no-ignore file.js
+
+### `--stdin`
+
+This option tells ESLint to read and lint source code from STDIN instead files. You can use this to pipe code to ESLint, such as:
+
+```
+cat myfile.js | eslint --stdin
+```
 
 ### `-v`, `--version`
 

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -176,6 +176,27 @@ var config = cli.getConfigForFile("myfile.js");
 var messages = linter.verify('var foo;', config);
 ```
 
+### executeOnText()
+
+If you already have some text to lint, then you can use the `executeOnText()` method to lint that text. The linter will assume that the text is a file in the current working directory, and so will still obey any `.eslintrc` and `.eslintignore` files that may be present. Here's an example:
+
+```js
+var CLIEngine = require("eslint").CLIEngine;
+
+var cli = new CLIEngine({
+    envs: ["browser", "mocha"],
+    useEslintrc: false,
+    rules: {
+        semi: 2
+    }
+});
+
+// lint myfile.js and all files in lib/
+var report = cli.executeOnText("var foo = 'bar';");
+```
+
+The `report` returned from `executeOnText()` is in the same format as from `executeOnFiles()`, but there is only ever one result in `report.results`.
+
 ## Deprecated APIs
 
 * `cli` - the `cli` object has been deprecated in favor of `CLIEngine`. It will be removed at some point in the future.

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -143,6 +143,32 @@ function processFile(filename, configHelper) {
     };
 }
 
+/**
+ * Processes an source code using ESLint.
+ * @param {string} text The source code to check.
+ * @param {Object} configHelper The configuration options for ESLint.
+ * @returns {Result} The results for linting on this text.
+ * @private
+ */
+function processText(text, configHelper) {
+
+    // clear all existing settings for a new file
+    eslint.reset();
+
+    var config,
+        messages;
+
+    debug("Linting <text>");
+    config = configHelper.getConfig();
+    loadPlugins(config.plugins);
+    messages = eslint.verify(text, config, "<text>");
+
+    return {
+        filePath: "<text>",
+        messages: messages
+    };
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -218,6 +244,23 @@ CLIEngine.prototype = {
                 }
             });
         }
+
+        return {
+            results: results
+        };
+    },
+
+    /**
+     * Executes the current configuration on text.
+     * @param {string} text A string of JavaScript code to lint.
+     * @returns {Object} The results for the linting.
+     */
+    executeOnText: function(text) {
+
+        var configHelper = new Config(this.options),
+            results = [];
+
+        results.push(processText(text, configHelper));
 
         return {
             results: results

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -162,9 +162,10 @@ var cli = {
     /**
      * Executes the CLI based on an array of arguments that is passed in.
      * @param {string|Array|Object} args The arguments to process.
+     * @param {string} [text] The text to lint (used for TTY).
      * @returns {int} The exit code for the operation.
      */
-    execute: function(args) {
+    execute: function(args, text) {
 
         var currentOptions,
             files,
@@ -184,15 +185,16 @@ var cli = {
 
             console.log("v" + require("../package.json").version);
 
-        } else if (currentOptions.help || !files.length) {
+        } else if (currentOptions.help || (!files.length && !text)) {
 
             console.log(options.generateHelp());
 
         } else {
 
             engine = new CLIEngine(translateOptions(currentOptions));
-            result = engine.executeOnFiles(files);
+            debug("Running on " + (text ? "text" : "files"));
 
+            result = text ? engine.executeOnText(text) : engine.executeOnFiles(files);
             if (currentOptions.quiet) {
                 result.results = getErrorResults(result.results);
             }

--- a/lib/options.js
+++ b/lib/options.js
@@ -100,5 +100,11 @@ module.exports = optionator({
         type: "Boolean",
         default: "false",
         description: "Report errors only."
+    },
+    {
+        option: "stdin",
+        type: "Boolean",
+        default: "false",
+        description: "Lint code provided on <STDIN>."
     }]
 });

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
     "chalk": "~0.5.1",
+    "concat-stream": "^1.4.6",
     "debug": "^2.0.0",
     "doctrine": "^0.5.2",
     "escope": "~1.0.0",

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1,6 +1,7 @@
 /**
- * @fileoverview Tests for cli.
- * @author Ian Christian Myers
+ * @fileoverview Tests for CLIEngine.
+ * @author Nicholas C. Zakas
+ * @copyright 2014 Nicholas C. Zakas. All rights reserved.
  */
 
 //------------------------------------------------------------------------------
@@ -35,6 +36,37 @@ describe("CLIEngine", function() {
         CLIEngine = proxyquire("../../lib/cli-engine", requireStubs);
     });
 
+    describe("executeOnText()", function() {
+
+        var engine;
+
+        it("should report three messages when using local cwd .eslintrc", function() {
+
+            engine = new CLIEngine();
+
+            var report = engine.executeOnText("var foo = 'bar';");
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 3);
+            assert.equal(report.results[0].messages[0].ruleId, "eol-last");
+            assert.equal(report.results[0].messages[1].ruleId, "no-unused-vars");
+            assert.equal(report.results[0].messages[2].ruleId, "quotes");
+        });
+
+        it("should report one message when using specific config file", function() {
+
+            engine = new CLIEngine({
+                configFile: "tests/fixtures/configurations/quotes-error.json",
+                reset: true
+            });
+
+            var report = engine.executeOnText("var foo = 'bar';");
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 1);
+            assert.equal(report.results[0].messages[0].ruleId, "quotes");
+        });
+
+    });
+
     describe("executeOnFiles()", function() {
 
         var engine;
@@ -46,7 +78,6 @@ describe("CLIEngine", function() {
             });
 
             var report = engine.executeOnFiles(["lib/cli.js"]);
-            // console.dir(report.results[0].messages);
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].messages.length, 0);
         });
@@ -425,8 +456,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].severity, 2);
             });
 
-            // Project configuration - first level package.json
-            it("should return one message when executing with package.json");
+            // Project configuration - package.json (TODO)
 
             // Project configuration - second level .eslintrc
             it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", function () {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -30,6 +30,13 @@ describe("cli", function() {
         console.error.restore();
     });
 
+    describe("execute()", function() {
+        it("should lint text when passed as argument", function() {
+            var result = cli.execute("-c " + path.join(__dirname, "..", "..", ".eslintrc"), "var foo = 'bar';");
+            assert.equal(result, 1);
+        });
+    });
+
     describe("when given a config file", function() {
         it("should load the specified config file", function() {
             assert.doesNotThrow(function () {

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -115,6 +115,13 @@ describe("options", function() {
         });
     });
 
+    describe("when passed --stdin", function() {
+        it("should return true for .stdin", function() {
+            var currentOptions = options.parse("--stdin");
+            assert.isTrue(currentOptions.stdin);
+        });
+    });
+
     describe("when passed --global", function() {
         it("should return an array for a single occurrence", function () {
             var currentOptions = options.parse("--global foo");


### PR DESCRIPTION
This adds a few things:
1. `--stdin` flag to the CLI to indicate that input should be read from STDIN
2. `executeOnText()` method to `CLIEngine`
3. Documentation for each
