### PR TITLE
[BUGFIX] Fix else return for nested issue reporting

### DIFF
--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -36,6 +36,19 @@ function foo() {
 
     return t;
 }
+
+// Two warnings for nested occurrences
+function foo() {
+    if (x) {
+        if (y) {
+            return y;
+        } else {
+            return x;
+        }
+    } else {
+        return z;
+    }
+}
 ```
 
 The follow patterns are not considered warnings:

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -8,17 +8,74 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
     "use strict";
 
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
-    function checkForReturnStatement(node, alternate) {
-        if (node.type === "ReturnStatement") {
-            context.report(alternate, "Unexpected 'else' after 'return'.");
+    /**
+     * Display the context report when this rule is violated
+     *
+     * @param {object} node The node containing the 'else' statement
+     * @returns {void}
+     */
+    function displayReport(node) {
+        context.report(node, "Unexpected 'else' after 'return'.");
+    }
+
+    /**
+     * Check the consequent for a return statement to see if the rule is violated
+     *
+     * @param {object} consequent The consequent of the if-statement node
+     * @param {object} alternate The alternate of the if-statement node
+     * @param {boolean} noReport If true, do not display report, just report nested violation
+     * @returns {boolean} True if nested else-return has been found
+     */
+    function checkForReturnStatement(consequent, alternate, noReport) {
+        if (consequent.type === "ReturnStatement") {
+            if (noReport) {
+                return true;
+            }
+            displayReport(alternate);
         }
+        return false;
+    }
+
+    /**
+     * Check the node to see if it has an unexpected else after a return in the consequent
+     *
+     * @param {object} node The node being checked for violations
+     * @param {boolean} noReport If true, do not display report, just report nested violation
+     * @returns {boolean} True if nested else-return has been found
+     */
+    function checkIfForReturn(node, noReport) {
+        var nestedReturn = false;
+        // Don't bother finding a ReturnStatement, if there's no `else`
+        // or if the alternate is also an if (indicating an else if).
+        if (node.alternate && node.consequent && node.alternate.type !== "IfStatement") {
+            // If we have a BlockStatement, check each consequent body node.
+            if (node.consequent.type === "BlockStatement") {
+                node.consequent.body.forEach(function (bodyNode) {
+                    var hadReturn;
+                    if (bodyNode.type === "IfStatement") {
+                        hadReturn = checkIfForReturn(bodyNode, true);
+                        if (hadReturn && !noReport) { // Suppress recursive reports
+                            displayReport(node.alternate);
+                        }
+                    } else {
+                        hadReturn = checkForReturnStatement(bodyNode, node.alternate, noReport);
+                    }
+                    if (hadReturn) {
+                        nestedReturn = true;
+                    }
+                });
+                // If not a block or if statement, make sure the consequent isn't a ReturnStatement
+            } else {
+                nestedReturn = checkForReturnStatement(node.consequent, node.alternate, noReport);
+            }
+        }
+        return nestedReturn;
     }
 
     //--------------------------------------------------------------------------
@@ -27,25 +84,7 @@ module.exports = function(context) {
 
     return {
 
-        "IfStatement": function(node) {
-
-            // Don't bother finding a ReturnStatement, if there's no `else`
-            // or if the alternate is also an if (indicating an else if).
-            if (node.alternate && node.consequent && node.alternate.type !== "IfStatement") {
-
-                // If we have a BlockStatement, check each consequent body node.
-                if (node.consequent.type === "BlockStatement") {
-                    node.consequent.body.forEach(function (bodyNode) {
-                        checkForReturnStatement(bodyNode, node.alternate);
-                    });
-
-                // If not a block statement, make sure the consequent isn't a
-                // ReturnStatement
-                } else {
-                    checkForReturnStatement(node.consequent, node.alternate);
-                }
-            }
-        }
+        "IfStatement": checkIfForReturn
 
     };
 

--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -26,6 +26,12 @@ eslintTester.addRuleTest("lib/rules/no-else-return", {
     invalid: [
         { code: "function foo() { if (true) { return x; } else { return y; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}] },
         { code: "function foo() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}] },
-        { code: "function foo() { if (true) return x; else return y; }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"}] }
+        { code: "function foo() { if (true) return x; else return y; }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"}] },
+        { code: "function foo() { if (true) { if (false) return x; else return y; } else { return z; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"}, { message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}] },
+        { code: "function foo() { if (true) { if (false) { if (true) return x; else return y; } else { return w; } } else { return z; } }", errors: [
+            { message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"},
+            { message: "Unexpected 'else' after 'return'.", type: "BlockStatement"},
+            { message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}
+        ]}
     ]
 });


### PR DESCRIPTION
Reference: #1380 

Updates the no-else-return rule to display multiple errors in cases of nested violations of this rule, where before it was only showing the most interior violation and would not display the others until that one was fixed.

@nzakas Please review, thanks! I'm not convinced this is the best implementation, but it seems to satisfy all the use-cases I could think of.

Fixes #1369
