### PR TITLE
[BUGFIX] Fix no-else-return for nested issue reporting

### DIFF
--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -36,6 +36,19 @@ function foo() {
 
     return t;
 }
+
+// Two warnings for nested occurrences
+function foo() {
+    if (x) {
+        if (y) {
+            return y;
+        } else {
+            return x;
+        }
+    } else {
+        return z;
+    }
+}
 ```
 
 The follow patterns are not considered warnings:

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -8,16 +8,84 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
     "use strict";
 
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
-    function checkForReturnStatement(node, alternate) {
-        if (node.type === "ReturnStatement") {
-            context.report(alternate, "Unexpected 'else' after 'return'.");
+    /**
+     * Display the context report if rule is violated
+     *
+     * @param {Node} node The 'else' node
+     * @returns {void}
+     */
+    function displayReport(node) {
+        context.report(node, "Unexpected 'else' after 'return'.");
+    }
+
+    /**
+     * Check to see if the node is a ReturnStatement
+     *
+     * @param {Node} node The node being evaluated
+     * @returns {boolean} True if node is a return
+     */
+    function checkForReturn(node) {
+        return node.type === "ReturnStatement";
+    }
+
+    /**
+     * Naive return checking, does not iterate through the whole
+     * BlockStatement because we make the assumption that the ReturnStatement
+     * will be the last node in the body of the BlockStatement.
+     *
+     * @param {Node} node The consequent/alternate node
+     * @returns {boolean} True if it has a return
+     */
+    function naiveHasReturn(node) {
+        if (node.type === "BlockStatement") {
+            var body = node.body;
+            return checkForReturn(body[body.length - 1]);
+        }
+        return checkForReturn(node);
+    }
+
+    /**
+     * Check to see if the node is valid for evaluation,
+     * meaning it has an else and not an else-if
+     *
+     * @param {Node} node The node being evaluated
+     * @returns {boolean} True if the node is valid
+     */
+    function hasElse(node) {
+        return node.alternate && node.consequent && node.alternate.type !== "IfStatement";
+    }
+
+    /**
+     * If the consequent is an IfStatement, check to see if it has an else
+     * and both its consequent and alternate path return, meaning this is
+     * a nested case of rule violation.  If-Else not considered currently.
+     *
+     * @param {Node} node The consequent node
+     * @returns {boolean} True if this is a nested rule violation
+     */
+    function checkForIf(node) {
+        return node.type === "IfStatement" && hasElse(node) &&
+            naiveHasReturn(node.alternate) && naiveHasReturn(node.consequent);
+    }
+
+    /**
+     * Check the consequent/body node to make sure it is not
+     * a ReturnStatement or an IfStatement that returns on both
+     * code paths.  If it is, display the context report.
+     *
+     * @param {Node} node The consequent or body node
+     * @param {Node} alternate The alternate node
+     * @returns {void}
+     */
+    function checkForReturnOrIf(node, alternate) {
+        if (checkForReturn(node) || checkForIf(node)) {
+            displayReport(alternate);
         }
     }
 
@@ -27,22 +95,22 @@ module.exports = function(context) {
 
     return {
 
-        "IfStatement": function(node) {
-
+        "IfStatement": function (node) {
             // Don't bother finding a ReturnStatement, if there's no `else`
             // or if the alternate is also an if (indicating an else if).
-            if (node.alternate && node.consequent && node.alternate.type !== "IfStatement") {
-
+            if (hasElse(node)) {
+                var consequent = node.consequent,
+                    alternate = node.alternate;
                 // If we have a BlockStatement, check each consequent body node.
-                if (node.consequent.type === "BlockStatement") {
-                    node.consequent.body.forEach(function (bodyNode) {
-                        checkForReturnStatement(bodyNode, node.alternate);
+                if (consequent.type === "BlockStatement") {
+                    var body = consequent.body;
+                    body.forEach(function (bodyNode) {
+                        checkForReturnOrIf(bodyNode, alternate);
                     });
-
-                // If not a block statement, make sure the consequent isn't a
-                // ReturnStatement
+                // If not a block statement, make sure the consequent isn't a ReturnStatement
+                // or an IfStatement with returns on both paths
                 } else {
-                    checkForReturnStatement(node.consequent, node.alternate);
+                    checkForReturnOrIf(consequent, alternate);
                 }
             }
         }

--- a/tests/lib/rules/no-else-return.js
+++ b/tests/lib/rules/no-else-return.js
@@ -26,6 +26,17 @@ eslintTester.addRuleTest("lib/rules/no-else-return", {
     invalid: [
         { code: "function foo() { if (true) { return x; } else { return y; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}] },
         { code: "function foo() { if (true) { var x = bar; return x; } else { var y = baz; return y; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}] },
-        { code: "function foo() { if (true) return x; else return y; }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"}] }
+        { code: "function foo() { if (true) return x; else return y; }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"}] },
+        { code: "function foo() { if (true) { if (false) return x; else return y; } else { return z; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"}, { message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}] },
+        { code: "function foo() { if (true) { if (false) { if (true) return x; else w = y; } else { w = x; } } else { return z; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ExpressionStatement"}] },
+        { code: "function foo() { if (true) { if (false) { if (true) return x; else return y; } } else { return z; } }", errors: [{ message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"}] },
+        { code: "function foo() { if (true) { if (false) { if (true) return x; else return y; } return w; } else { return z; } }", errors: [
+            { message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"},
+            { message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}
+        ] },
+        { code: "function foo() { if (true) { if (false) { if (true) return x; else return y; } else { w = x; } } else { return z; } }", errors: [
+            { message: "Unexpected 'else' after 'return'.", type: "ReturnStatement"},
+            { message: "Unexpected 'else' after 'return'.", type: "BlockStatement"}
+        ] }
     ]
 });


### PR DESCRIPTION
Reference: #1381

Updates the no-else-return rule to display multiple errors in cases of nested violations of this rule, where before it was only showing the most interior violation and would not display the others until that one was fixed.

Note: Per discussion with @nzakas, this solution does not go down the rabbit hole of infinite nesting...it checks one layer deep on each if-statement to make sure that there isn't a nested if-else with 2 return paths inside the consequent.

Fixes #1369
