### PR TITLE
Document the functionality to load a custom formatter from a file

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -65,6 +65,12 @@ Example:
 
     eslint -f compact file.js
 
+You can also use a custom formatter from the command line by specifying a path to the custom formatter file.
+
+Example:
+
+    eslint -f customformat.js file.js
+
 When specified, the given format is output to the console. If you'd like to save that output into a file, you can do so on the command line like so:
 
     eslint -f compact file.js > results.txt


### PR DESCRIPTION
I noticed that the option to load a custom formatter from a path was not documented. Hopefully this saves someone else the trouble I had.
