### PR TITLE
Fix: let fs.stat throw if a file does not exist (fixes #1296)

### DIFF
--- a/lib/util/traverse.js
+++ b/lib/util/traverse.js
@@ -31,12 +31,7 @@ function walk(name, exclude, callback) {
 
     var stat, basename;
 
-    try {
-        stat = fs.statSync(name);
-    } catch (ex) {
-        /* istanbul ignore next too hard to make fs.stat fail */
-        return;
-    }
+    stat = fs.statSync(name);
 
     function traverse(dir, stack) {
         stack.push(dir);

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -183,15 +183,25 @@ describe("CLIEngine", function() {
             assert.equal(report.results.length, 0);
         });
 
-        it("should return zero messages when given a file in excluded files list", function() {
-
+        it("should return zero messages when all given files are ignored", function () {
             engine = new CLIEngine({
                 ignorePath: "tests/fixtures/.eslintignore"
             });
 
-            var report = engine.executeOnFiles(["tests/fixtures/passing"]);
+            var report = engine.executeOnFiles(["tests/fixtures/"]);
             assert.equal(report.results.length, 0);
+        });
 
+        it("should return a warning when an explicitly given file is ignored", function () {
+            engine = new CLIEngine({
+                ignorePath: "tests/fixtures/.eslintignore"
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/passing.js"]);
+
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].filePath, "tests/fixtures/passing.js");
+            assert.equal(report.results[0].messages[0].message, "File ignored because of your .eslintignore file. Use --no-ignore to override.");
         });
 
         it("should return two messages when given a file in excluded files list while ignore is off", function() {

--- a/tests/lib/traverse.js
+++ b/tests/lib/traverse.js
@@ -8,6 +8,8 @@
 
 var assert = require("chai").assert,
     path = require("path"),
+    fs = require("fs"),
+    sinon = require("sinon"),
     traverse = require("../../lib/util/traverse");
 
 
@@ -56,5 +58,19 @@ describe("traverse", function() {
 
         assert.notEqual(files.length, 0);
     });
+
+    it("should throw if fs.statSync throws", sinon.test(function () {
+        var error = new Error("anyError"),
+            options = {
+                files: [ "/any/file.js" ],
+                exclude: false
+            },
+            callback = this.spy();
+
+        this.stub(fs, "statSync").throws(error);
+
+        assert.throws(traverse.bind(null, options, callback), "anyError");
+        sinon.assert.notCalled(callback);
+    }));
 
 });


### PR DESCRIPTION
This fixes #1296.

There was a failing test, which tested the ignoring-feature on a non-existing fixture file (the file extension was missing).

I’ve also noticed that the "file ignored"-warning [doesn’t specify the `severity` property](https://github.com/eslint/eslint/blob/master/lib/cli-engine.js#L239)
