### PR TITLE
Fix: ! negates .eslintignore patterns (fixes #1093)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -48,10 +48,6 @@ function loadIgnoreFile(filepath) {
         }
     }
 
-    ignorePatterns.forEach(function (pattern) {
-        ignorePatterns.push(pattern + "/**");
-    });
-
     return ignorePatterns;
 }
 
@@ -114,11 +110,18 @@ IgnoredPaths.prototype.contains = function (filepath) {
     }
 
     filepath = filepath.replace("\\", "/");
-    return this.patterns.some(function (pattern) {
-        var result = minimatch(filepath, pattern);
-        debug("Minimatch " + result);
-        return result;
-    });
+    return this.patterns.reduce(function(ignored, pattern) {
+        var negated = pattern[0] === "!",
+            matches;
+
+        if (negated) {
+            pattern = pattern.slice(1);
+        }
+
+        matches = minimatch(filepath, pattern) || minimatch(filepath, pattern + "/**");
+
+        return matches ? !negated : ignored;
+    }, false);
 };
 
 module.exports = IgnoredPaths;

--- a/tests/fixtures/.eslintignore4
+++ b/tests/fixtures/.eslintignore4
@@ -1,0 +1,2 @@
+/dir
+!/dir/foo.js

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -53,12 +53,6 @@ describe("IgnoredPaths", function() {
             assert.notEqual(ignoredPaths.patterns.length, 0);
         });
 
-        it("should add a second children pattern", function() {
-            var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
-            assert.ok(ignoredPaths.patterns[1]);
-            assert.equal(ignoredPaths.patterns[1], ignoredPaths.patterns[0] + "/**");
-        });
-
     });
 
     describe("initialization with invalid file", function() {
@@ -110,9 +104,23 @@ describe("IgnoredPaths", function() {
 
         it("should ignore comments", function() {
             var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
-            // get 2 lines, because loader autoadd '/**' rule to each
-            // change to 1 if loader updated
-            assert.equal(ignoredPaths.patterns.length, 2);
+            assert.equal(ignoredPaths.patterns.length, 1);
+        });
+
+    });
+
+    describe("initialization with negations", function() {
+
+        var filepath = path.resolve(__dirname, "..", "fixtures", ".eslintignore4");
+
+        it("should ignore a normal pattern", function() {
+            var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
+            assert.ok(ignoredPaths.contains("/dir/bar.js"));
+        });
+
+        it("should not ignore a negated pattern", function() {
+            var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
+            assert.notOk(ignoredPaths.contains("/dir/foo.js"));
         });
 
     });


### PR DESCRIPTION
For example, given the following .eslintignore, `/dir/bar.js` would be ignored, but `/dir/foo.js` would still be included.

```
/dir
!/dir/foo.js
```

I moved the logic that duplicated patterns by adding `/**` because the duplicate patterns were breaking the negation logic, so instead I just check each pattern twice.
