### PR TITLE
Fix: Keep sinon at ~1.10.3 (fixes #1406)

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "proxyquire": "^1.0.0",
     "shelljs": "^0.3.0",
     "shelljs-nodecli": "~0.1.0",
-    "sinon": "^1.10.3",
+    "sinon": "~1.10.3",
     "through": "^2.3.6"
   },
   "keywords": [


### PR DESCRIPTION
Note that this only further specifies the `sinon` version; it does not do any shrinkwrapping on the assumption that doing so would be a separate discussion, especially because `sinon` is a dev dependency, which means it wouldn't normally be shrinkwrapped.
