### PR TITLE
Fix: Allow line breaks in key-spacing rule (fixes #1407)

### DIFF
--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -4,7 +4,7 @@ Enforces spacing around the colon in object literal properties. It can verify ea
 
 ## Rule Details
 
-This rule will warn when spacing in properties does not match the specified options. There are three modes:
+This rule will warn when spacing in properties does not match the specified options. In the case of long lines, it is acceptable to add a new line wherever whitespace is allowed. There are three modes:
 
 ### 1. Individual
 
@@ -30,6 +30,14 @@ call({
 };
 ```
 
+// "key-spacing": [2, {
+//     "beforeColon": false,
+//     "afterColon": true
+// }]
+foo = { thisLineWouldBeTooLong:
+    soUseAnotherLine };
+```
+
 The follow patterns are considered warnings:
 
 ```js
@@ -49,6 +57,13 @@ function foo() {
         bat :"value" // Missing space after colon
     };
 }
+
+// "key-spacing": [2, {
+//     "beforeColon": false,
+//     "afterColon": false
+// }]
+foo = { thisLineWouldBeTooLong:
+    soUseAnotherLine };
 ```
 
 ### 2. Vertically align values `"align": "value"`

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -10,6 +10,16 @@
 //------------------------------------------------------------------------------
 
 /**
+ * Checks whether a string contains a line terminator as defined in
+ * http://www.ecma-international.org/ecma-262/5.1/#sec-7.3
+ * @param {string} str String to test.
+ * @returns {boolean} True if str contains a line terminator.
+ */
+function containsLineTerminator(str) {
+    return /[\n\r\u2028\u2029]/.test(str);
+}
+
+/**
  * Gets an object literal property's key as the identifier name or string value.
  * @param {ASTNode} property Property node whose key to retrieve.
  * @returns {string} The property's key.
@@ -54,19 +64,19 @@ module.exports = function(context) {
         afterColon = +!(options.afterColon === false); // Defaults to true
 
     /**
-     * Gets the spacing around the colon in an object literal property
-     * @param {ASTNode} property Property node from an object literal
-     * @returns {Object} Spacing before and after the property's colon
+     * Gets the whitespace around the colon in an object literal property.
+     * @param {ASTNode} property Property node from an object literal.
+     * @returns {Object} Whitespace before and after the property's colon.
      */
-    function getPropertySpacing(property) {
+    function getPropertyWhitespace(property) {
         var whitespace = /^(\s*):(\s*)/.exec(context.getSource().slice(
             property.key.range[1], property.value.range[0]
         ));
 
         if (whitespace) {
             return {
-                beforeColon: whitespace[1].length,
-                afterColon: whitespace[2].length
+                beforeColon: whitespace[1],
+                afterColon: whitespace[2]
             };
         }
     }
@@ -76,11 +86,14 @@ module.exports = function(context) {
      * side of the colon.
      * @param {ASTNode} property Key-value pair in an object literal.
      * @param {string} side Side being verified - either "key" or "value".
-     * @param {int} diff Difference between actual and expected spacing.
+     * @param {string} whitespace Actual whitespace string.
+     * @param {int} expected Expected whitespace length.
      * @returns {void}
      */
-    function report(property, side, diff) {
-        if (diff) {
+    function report(property, side, whitespace, expected) {
+        var diff = whitespace.length - expected;
+
+        if (diff && !(expected && containsLineTerminator(whitespace))) {
             context.report(property[side], messages[side], {
                 error: diff > 0 ? "Extra" : "Missing",
                 key: getKey(property)
@@ -96,27 +109,27 @@ module.exports = function(context) {
                     length = properties.length,
                     widths = properties.map(getKeyWidth), // Width of keys, including quotes
                     targetWidth = Math.max.apply(null, widths),
-                    i, property, spacing, width;
+                    i, property, whitespace, width;
 
                 // Conditionally include one space before or after colon
                 targetWidth += (align === "colon" ? beforeColon : afterColon);
 
                 for (i = 0; i < length; i++) {
                     property = properties[i];
-                    spacing = getPropertySpacing(property);
+                    whitespace = getPropertyWhitespace(property);
 
-                    if (!spacing) {
+                    if (!whitespace) {
                         continue; // Object literal getters/setters lack a colon
                     }
 
                     width = widths[i];
 
                     if (align === "value") {
-                        report(property, "key", spacing.beforeColon - beforeColon);
-                        report(property, "value", (width + spacing.afterColon) - targetWidth);
+                        report(property, "key", whitespace.beforeColon, beforeColon);
+                        report(property, "value", whitespace.afterColon, targetWidth - width);
                     } else { // align = "colon"
-                        report(property, "key", (width + spacing.beforeColon) - targetWidth);
-                        report(property, "value", spacing.afterColon - afterColon);
+                        report(property, "key", whitespace.beforeColon, targetWidth - width);
+                        report(property, "value", whitespace.afterColon, afterColon);
                     }
                 }
             }
@@ -126,10 +139,10 @@ module.exports = function(context) {
 
         return {
             "Property": function (node) {
-                var spacing = getPropertySpacing(node);
-                if (spacing) { // Object literal getters/setters lack colon spacing
-                    report(node, "key", spacing.beforeColon - beforeColon);
-                    report(node, "value", spacing.afterColon - afterColon);
+                var whitespace = getPropertyWhitespace(node);
+                if (whitespace) { // Object literal getters/setters lack colons
+                    report(node, "key", whitespace.beforeColon, beforeColon);
+                    report(node, "value", whitespace.afterColon, afterColon);
                 }
             }
         };

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -100,6 +100,16 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             afterColon: false
         }]
     }, {
+        code: [
+            "obj = { key ",
+            " : ",
+            " longName };"
+        ].join("\n"),
+        args: [2, {
+            beforeColon: true,
+            afterColon: true
+        }]
+    }, {
         code: "var obj = { get fn() { return 42; } };",
         args: [2, {}]
     }],
@@ -220,6 +230,23 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
         errors: [
             { message: "Missing space after key \"a\".", type: "Identifier" },
             { message: "Extra space before value for key \"bar\".", type: "CallExpression" }
+        ]
+    }, {
+        code: [
+            "foo = {",
+            "    key:",
+            "        longValueName,",
+            "    key2",
+            "        :anotherLongValue",
+            "};"
+        ].join("\n"),
+        args: [2, {
+            beforeColon: false,
+            afterColon: false
+        }],
+        errors: [
+            { message: "Extra space before value for key \"key\".", type: "Identifier" },
+            { message: "Extra space after key \"key2\".", type: "Identifier" }
         ]
     }]
 


### PR DESCRIPTION
With this logic change, a newline is permitted anywhere whitespace is allowed.
