### PR TITLE
New rule: lines-around-comment

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -117,6 +117,7 @@
         "guard-for-in": 0,
         "handle-callback-err": 0,
         "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
+        "lines-around-comment": 0,
         "max-depth": [0, 4],
         "max-len": [0, 80, 4],
         "max-nested-callbacks": [0, 2],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -133,6 +133,7 @@ These rules are purely matters of style and are quite subjective.
 * [func-names](func-names.md) - require function expressions to have a name (off by default)
 * [func-style](func-style.md) - enforces use of function declarations or expressions (off by default)
 * [key-spacing](key-spacing.md) - enforces spacing between keys and values in object literal properties
+* [lines-around-comment](lines-around-comment.md) - (dis)allow empty lines around comments (off by default)
 * [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested (off by default)
 * [new-cap](new-cap.md) - require a capital letter for constructors
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -22,8 +22,9 @@ generates a warning with `{afterLineComment: true}`, but none on `false`.
 Block comments are completely separate from single-line rules, and are affected by the `afterBlockComment` configuration:
 
 ```js
-// multi-line block
-// comment
+/*
+ * multi-line block comment
+ */
 
 doSomething();
 ```
@@ -31,9 +32,17 @@ doSomething();
 generates a warning under `{afterBlockComment: false}`, and:
 
 ```js
-// multi-line block
-// comment
+/* block comments can also be single line */
 doSomething();
 ```
 
 generates a warning under `{afterBlockComment: true}`.
+
+Each `after...` option has an analogous `before...` option. For example:
+
+```js
+doSomething();
+// Line comment here
+```
+
+generates a warning under `{beforeLineComment: true}`.

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -1,0 +1,39 @@
+# (Dis)allow empty lines around comments (lines-around-comment)
+
+The `lines-around-comment` rule forces or prohibits empty lines around single-line comments or blocks.
+
+## Rule Details
+
+```js
+// Single-line comment
+
+doSomething();
+```
+
+generates a warning when configured with `{afterLineComment: false}`, but is fine when it is set to `true`. Conversely:
+
+```js
+// Single-line comment
+doSomething();
+```
+
+generates a warning with `{afterLineComment: true}`, but none on `false`.
+
+Block comments are completely separate from single-line rules, and are affected by the `afterBlockComment` configuration:
+
+```js
+// multi-line block
+// comment
+
+doSomething();
+```
+
+generates a warning under `{afterBlockComment: false}`, and:
+
+```js
+// multi-line block
+// comment
+doSomething();
+```
+
+generates a warning under `{afterBlockComment: true}`.

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -49,44 +49,49 @@ module.exports = function(context) {
     /**
      * False iff a string contains a non-whitespace character.
      *
-     * @param {string} txt  Text to scan
+     * @param {string} text Text to scan
      * @returns {boolean}   False iff txt contains a non-whitespace character
      */
-    function isEmpty(txt) {
-        return txt.trim() === "";
+    function isEmpty(text) {
+        return text.trim() === "";
     }
 
     /**
      * True iff a string contains a non-whitespace character.
      *
-     * @param {string} txt  Text to scan
+     * @param {string} text Text to scan
      * @returns {boolean}   True iff txt contains a non-whitespace character
      */
-    function isNotEmpty(txt) {
-        return !isEmpty(txt);
+    function isNotEmpty(text) {
+        return !isEmpty(text);
     }
 
     return {
+
         "LineComment": function (node) {
+
             // Ignore end-of-line comments
             var before = getLineUntil(node);
             if (before.trim() !== "") {
                 return;
             }
-            // Esprina line indexes are 1-offset
+
+            // Esprima line indexes are 1-offset
             lines[node.loc.start.line - 1].isLineComment = true;
         },
 
         "BlockComment": function (node) {
+
             // Ignore inline comments
             var rest = getLineUntil(node) + getLineFrom(node);
             if (rest.trim() !== "") {
                 return;
             }
+
             // Correct for 1-offset
-            var startidx = node.loc.start.line - 1;
-            var endidx = node.loc.end.line - 1;
-            for (var i = startidx; i <= endidx; i++) {
+            var startIndex = node.loc.start.line - 1;
+            var endIndex = node.loc.end.line - 1;
+            for (var i = startIndex; i <= endIndex; i++) {
                 lines[i].isBlockComment = true;
             }
         },
@@ -98,18 +103,21 @@ module.exports = function(context) {
         },
 
         "Program:exit": function (node) {
-            // Default behaviour for all rules is to accept
+
+            // Default behavior for all rules is to accept
             var opts = context.options[0] || {};
+
             // Pre-index all lines following comments
-            var afterLineIdxs = [];
-            var afterBlockIdxs = [];
+            var afterLineIndexes = [];
+            var afterBlockIndexes = [];
+
             for (var i = 1; i < lines.length; i++) {
                 var line = lines[i];
                 var prevLine = lines[i - 1];
                 if (!line.isLineComment && prevLine.isLineComment) {
-                    afterLineIdxs.push(i);
+                    afterLineIndexes.push(i);
                 } else if (!line.isBlockComment && prevLine.isBlockComment) {
-                    afterBlockIdxs.push(i);
+                    afterBlockIndexes.push(i);
                 }
             }
 
@@ -121,49 +129,58 @@ module.exports = function(context) {
              * string, "%s" is substituted for the line number that violates the
              * rule.
              *
-             * The line numbers in idxs should be at 0 offset (they are indices
-             * into an array of lines), but %s will be substituted for
+             * The line numbers in indexes should be at 0 offset (they are
+             * indices into an array of lines), but %s will be substituted for
              * human-readable, 1 offset line numbers.
              *
-             * @param {number[]} idxs  Line indexes to test for conformance
-             * @param {function} rule  Callback to test every line (string) with
-             * @param {string} fmt     Format string for error message
+             * @param {number[]} indexes  Line indexes to test for conformance
+             * @param {function} rule     Callback to test every line (string) with
+             * @param {string} format     Format string for error message
              * @returns {void}
              */
-            function forbid(idxs, rule, fmt) {
-                idxs.forEach(function (idx) {
-                    if (rule(lines[idx].src)) {
+            function forbid(indexes, rule, format) {
+                indexes.forEach(function (index) {
+                    if (rule(lines[index].src)) {
+
                         // Human line numbers start at 1
-                        context.report(node, fmt.replace("%s", idx + 1));
+                        context.report(node, format.replace("%s", index + 1));
                     }
                 });
             }
 
             // Single line comments
             switch (opts.afterLineComment) {
+
                 case true:
-                    forbid(afterLineIdxs, isNotEmpty,
+                    forbid(afterLineIndexes, isNotEmpty,
                            "Line comment must be followed by empty line (line %s)");
                     break;
+
                 case false:
-                    forbid(afterLineIdxs, isEmpty,
+                    forbid(afterLineIndexes, isEmpty,
                            "Line comment cannot be followed by empty line (line %s)");
                     break;
+
                 // no default
             }
 
             // Block comments
             switch (opts.afterBlockComment) {
+
                 case true:
-                    forbid(afterBlockIdxs, isNotEmpty,
+                    forbid(afterBlockIndexes, isNotEmpty,
                            "Block comment must be followed by empty line (line %s)");
                     break;
+
                 case false:
-                    forbid(afterBlockIdxs, isEmpty,
+                    forbid(afterBlockIndexes, isEmpty,
                            "Block comment cannot be followed by empty line (line %s)");
                     break;
+
                 // no default
             }
+
         }
+
     };
 };

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -107,17 +107,28 @@ module.exports = function(context) {
             // Default behavior for all rules is to accept
             var opts = context.options[0] || {};
 
-            // Pre-index all lines following comments
+            // Pre-index all lines surrounding comments
+            var beforeLineIndexes = [];
+            var beforeBlockIndexes = [];
             var afterLineIndexes = [];
             var afterBlockIndexes = [];
 
-            for (var i = 1; i < lines.length; i++) {
-                var line = lines[i];
-                var prevLine = lines[i - 1];
-                if (!line.isLineComment && prevLine.isLineComment) {
-                    afterLineIndexes.push(i);
-                } else if (!line.isBlockComment && prevLine.isBlockComment) {
-                    afterBlockIndexes.push(i);
+            for (var ia = 0, ib = 1; ib < lines.length; ia++, ib++) {
+                var lineA = lines[ia];
+                var lineB = lines[ib];
+
+                // Check if line A is a line preceding a comment
+                if (!lineA.isLineComment && lineB.isLineComment) {
+                    beforeLineIndexes.push(ia);
+                } else if (!lineA.isBlockComment && lineB.isBlockComment) {
+                    beforeBlockIndexes.push(ia);
+                }
+
+                // Check if line B is a line following a comment
+                else if (lineA.isLineComment && !lineB.isLineComment) {
+                    afterLineIndexes.push(ib);
+                } else if (lineA.isBlockComment && !lineB.isBlockComment) {
+                    afterBlockIndexes.push(ib);
                 }
             }
 
@@ -149,6 +160,20 @@ module.exports = function(context) {
             }
 
             // Single line comments
+            switch (opts.beforeLineComment) {
+
+                case true:
+                    forbid(beforeLineIndexes, isNotEmpty,
+                           "Line comment must be preceded by empty line (line %s)");
+                    break;
+
+                case false:
+                    forbid(beforeLineIndexes, isEmpty,
+                           "Line comment cannot be preceded by empty line (line %s)");
+                    break;
+
+                // no default
+            }
             switch (opts.afterLineComment) {
 
                 case true:
@@ -165,6 +190,20 @@ module.exports = function(context) {
             }
 
             // Block comments
+            switch (opts.beforeBlockComment) {
+
+                case true:
+                    forbid(beforeBlockIndexes, isNotEmpty,
+                           "Block comment must be preceded by empty line (line %s)");
+                    break;
+
+                case false:
+                    forbid(beforeBlockIndexes, isEmpty,
+                           "Block comment cannot be preceded by empty line (line %s)");
+                    break;
+
+                // no default
+            }
             switch (opts.afterBlockComment) {
 
                 case true:

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -1,0 +1,169 @@
+/**
+ * @fileoverview Rule to (dis)allow empty lines around comments
+ * @author Hraban Luyat
+ * @copyright 2014 Hraban Luyat. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    /**
+     * List of line object for each line in the source code:
+     *
+     * {
+     *     src: <string containing source code for this line>,
+     *     isLineComment: <optional: true iff this is line comment>,
+     *     isBlockComment: <optional: true iff block comment>
+     * }
+     *
+     * The optional attributes are true if specified, otherwise they are just
+     * not defined on this object.
+     */
+    var lines = {};
+
+    /**
+     * Get everything on the same line as this node, preceding it
+     *
+     * @param {Node} node  node up to which you want the source
+     * @returns {string}   source code line leading up to node
+     */
+    function getLineUntil(node) {
+        var src = lines[node.loc.start.line - 1].src;
+        return src.slice(0, node.loc.start.column);
+    }
+
+    /**
+     * Get everything on the same line as this node, following it
+     *
+     * @param {Node} node  node after which you want the source
+     * @returns {string}   source code from this node to end of line
+     */
+    function getLineFrom(node) {
+        var src = lines[node.loc.end.line - 1].src;
+        return src.slice(node.loc.end.column);
+    }
+
+    /**
+     * False iff a string contains a non-whitespace character.
+     *
+     * @param {string} txt  Text to scan
+     * @returns {boolean}   False iff txt contains a non-whitespace character
+     */
+    function isEmpty(txt) {
+        return txt.trim() === "";
+    }
+
+    /**
+     * True iff a string contains a non-whitespace character.
+     *
+     * @param {string} txt  Text to scan
+     * @returns {boolean}   True iff txt contains a non-whitespace character
+     */
+    function isNotEmpty(txt) {
+        return !isEmpty(txt);
+    }
+
+    return {
+        "LineComment": function (node) {
+            // Ignore end-of-line comments
+            var before = getLineUntil(node);
+            if (before.trim() !== "") {
+                return;
+            }
+            // Esprina line indexes are 1-offset
+            lines[node.loc.start.line - 1].isLineComment = true;
+        },
+
+        "BlockComment": function (node) {
+            // Ignore inline comments
+            var rest = getLineUntil(node) + getLineFrom(node);
+            if (rest.trim() !== "") {
+                return;
+            }
+            // Correct for 1-offset
+            var startidx = node.loc.start.line - 1;
+            var endidx = node.loc.end.line - 1;
+            for (var i = startidx; i <= endidx; i++) {
+                lines[i].isBlockComment = true;
+            }
+        },
+
+        "Program": function () {
+            lines = context.getSourceLines().map(function (src) {
+                return {src: src};
+            });
+        },
+
+        "Program:exit": function (node) {
+            // Default behaviour for all rules is to accept
+            var opts = context.options[0] || {};
+            // Pre-index all lines following comments
+            var afterLineIdxs = [];
+            var afterBlockIdxs = [];
+            for (var i = 1; i < lines.length; i++) {
+                var line = lines[i];
+                var prevLine = lines[i - 1];
+                if (!line.isLineComment && prevLine.isLineComment) {
+                    afterLineIdxs.push(i);
+                } else if (!line.isBlockComment && prevLine.isBlockComment) {
+                    afterBlockIdxs.push(i);
+                }
+            }
+
+            /**
+             * Scan all lines at these indexes for conformance to given rule.
+             *
+             * If one of the given lines does not adhere to the given rule,
+             * generate an error message using the given format string. In that
+             * string, "%s" is substituted for the line number that violates the
+             * rule.
+             *
+             * The line numbers in idxs should be at 0 offset (they are indices
+             * into an array of lines), but %s will be substituted for
+             * human-readable, 1 offset line numbers.
+             *
+             * @param {number[]} idxs  Line indexes to test for conformance
+             * @param {function} rule  Callback to test every line (string) with
+             * @param {string} fmt     Format string for error message
+             * @returns {void}
+             */
+            function forbid(idxs, rule, fmt) {
+                idxs.forEach(function (idx) {
+                    if (rule(lines[idx].src)) {
+                        // Human line numbers start at 1
+                        context.report(node, fmt.replace("%s", idx + 1));
+                    }
+                });
+            }
+
+            // Single line comments
+            switch (opts.afterLineComment) {
+                case true:
+                    forbid(afterLineIdxs, isNotEmpty,
+                           "Line comment must be followed by empty line (line %s)");
+                    break;
+                case false:
+                    forbid(afterLineIdxs, isEmpty,
+                           "Line comment cannot be followed by empty line (line %s)");
+                    break;
+                // no default
+            }
+
+            // Block comments
+            switch (opts.afterBlockComment) {
+                case true:
+                    forbid(afterBlockIdxs, isNotEmpty,
+                           "Block comment must be followed by empty line (line %s)");
+                    break;
+                case false:
+                    forbid(afterBlockIdxs, isEmpty,
+                           "Block comment cannot be followed by empty line (line %s)");
+                    break;
+                // no default
+            }
+        }
+    };
+};

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -24,53 +24,80 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
         // Default: everything goes
         "// line comment\n\ndefaultConfig();",
         "// line comment\ndefaultConfig();",
-        "// block\n// comment\n\ndefaultConfig();",
-        "// block\n// comment\ndefaultConfig();",
+        "/* block\n * comment\n */\n\ndefaultConfig();",
+        "/* block\n * comment\n */\ndefaultConfig();",
         // Line comment styles that conform to the rules
         {
-            code: "// single line comment\n\nafterSingleLineComment: true",
+            code: "// single line comment\n\nafterLineComment: true",
             args: [1, {afterLineComment: true}]
         },
         {
-            code: "// single line comment\nafterSingleLineComment: false",
+            code: "// single line comment\nafterLineComment: false",
             args: [1, {afterLineComment: false}]
         },
         {
-            code: "// multi line\n// comment\n\nafterMultiLineComment: true",
+            code: "// multi line\n// comment\n\nafterLineComment: true",
             args: [1, {afterLineComment: true}]
         },
         {
-            code: "// multi line\n// comment\nafterMultiComment: false",
+            code: "// multi line\n// comment\nafterLineComment: false",
             args: [1, {afterLineComment: false}]
+        },
+        {
+            code: "var x = 5; // end of line comment\nafterLineComment: true",
+            args: [1, {afterLineComment: true}]
         },
         // Block comment styles that conform to the rules
         {
-            code: "/* single line block comment */\n\nafterSingleBlockComment: true",
+            code: "/* single line block comment */\n\nafterBlockComment: true",
             args: [1, {afterBlockComment: true}]
         },
         {
-            code: "/* single line block comment */\nafterSingleBlockComment: false",
+            code: "/* single line block comment */\nafterBlockComment: false",
             args: [1, {afterBlockComment: false}]
         },
         {
-            code: "/* multi line\n * block comment */\n\nafterMultiBlockComment: true",
+            code: "/* multi line\n * block comment */\n\nafterBlockComment: true",
             args: [1, {afterBlockComment: true}]
         },
         {
-            code: "/* multi line\n * block comment */\nafterMultiBlockComment: false",
+            code: "/* multi line\n * block comment */\nafterBlockComment: false",
             args: [1, {afterBlockComment: false}]
         },
+        {
+            code: "var x = /* inline comment */ 5;\nafterBlockComment: true",
+            args: [1, {afterBlockComment: true}]
+        },
+
+        // These are considered in-line comments, and thus completely ignored
+        {
+            code: "/* two block comments */ /* on one line */\nafterBlockComment: true",
+            args: [1, {afterBlockComment: true}]
+        },
+        {
+            code: "/* two block comments */ /* on one line */\nafterBlockComment: false",
+            args: [1, {afterBlockComment: false}]
+        },
+        {
+            code: "/* block comment */ // and line comment\nafterBlockComment: true",
+            args: [1, {afterBlockComment: true}]
+        },
+        {
+            code: "/* block comment */ // and line comment\nafterBlockComment: false",
+            args: [1, {afterBlockComment: false}]
+        },
+
         // String literals should be ignored
         {
-            code: "'\\\n// string, not a comment\\\n'",
+            code: "'\\\n// string, not a comment\\\nafterLineComment: true'",
             args: [1, {afterLineComment: true}]
         },
         {
-            code: "\"\\\n// string, not a comment\\\n\"",
+            code: "\"\\\n// string, not a comment\\\nafterLineComment: true\"",
             args: [1, {afterLineComment: true}]
         },
         {
-            code: "/regexp literal looks like block comment.*/\n;",
+            code: "/regexp literal looks like block comment.*/\nafterBlockComment: true",
             args: [1, {afterBlockComment: true}]
         }
     ],
@@ -92,7 +119,14 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
             ]
         },
         {
-            code: "/* block\n * comment\n */\n\nafterBlockComment: false",
+            code: "/* single-line block comment */\n\nafterBlockComment: false",
+            args: [1, {afterBlockComment: false}],
+            errors: [
+                { message: "Block comment cannot be followed by empty line (line 2)" }
+            ]
+        },
+        {
+            code: "/* multi-line\n * block comment\n */\n\nafterBlockComment: false",
             args: [1, {afterBlockComment: false}],
             errors: [
                 { message: "Block comment cannot be followed by empty line (line 4)" }

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -1,0 +1,123 @@
+/**
+ * @fileoverview Tests for lines-around-comments rule.
+ * @author Hraban Luyat
+ * @copyright 2014 Hraban Luyat. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/lines-around-comment", {
+
+    // Examples of code that should not trigger the rule
+    valid: [
+        // Default: everything goes
+        "// line comment\n\ndefaultConfig();",
+        "// line comment\ndefaultConfig();",
+        "// block\n// comment\n\ndefaultConfig();",
+        "// block\n// comment\ndefaultConfig();",
+        // Line comment styles that conform to the rules
+        {
+            code: "// single line comment\n\nafterSingleLineComment: true",
+            args: [1, {afterLineComment: true}]
+        },
+        {
+            code: "// single line comment\nafterSingleLineComment: false",
+            args: [1, {afterLineComment: false}]
+        },
+        {
+            code: "// multi line\n// comment\n\nafterMultiLineComment: true",
+            args: [1, {afterLineComment: true}]
+        },
+        {
+            code: "// multi line\n// comment\nafterMultiComment: false",
+            args: [1, {afterLineComment: false}]
+        },
+        // Block comment styles that conform to the rules
+        {
+            code: "/* single line block comment */\n\nafterSingleBlockComment: true",
+            args: [1, {afterBlockComment: true}]
+        },
+        {
+            code: "/* single line block comment */\nafterSingleBlockComment: false",
+            args: [1, {afterBlockComment: false}]
+        },
+        {
+            code: "/* multi line\n * block comment */\n\nafterMultiBlockComment: true",
+            args: [1, {afterBlockComment: true}]
+        },
+        {
+            code: "/* multi line\n * block comment */\nafterMultiBlockComment: false",
+            args: [1, {afterBlockComment: false}]
+        },
+        // String literals should be ignored
+        {
+            code: "'\\\n// string, not a comment\\\n'",
+            args: [1, {afterLineComment: true}]
+        },
+        {
+            code: "\"\\\n// string, not a comment\\\n\"",
+            args: [1, {afterLineComment: true}]
+        },
+        {
+            code: "/regexp literal looks like block comment.*/\n;",
+            args: [1, {afterBlockComment: true}]
+        }
+    ],
+
+    // Examples of code that should trigger the rule
+    invalid: [
+        {
+            code: "// line comment\n\nafterLineComment: false",
+            args: [1, {afterLineComment: false}],
+            errors: [
+                { message: "Line comment cannot be followed by empty line (line 2)" }
+            ]
+        },
+        {
+            code: "// line comment\nafterLineComment: true",
+            args: [1, {afterLineComment: true}],
+            errors: [
+                { message: "Line comment must be followed by empty line (line 2)" }
+            ]
+        },
+        {
+            code: "/* block\n * comment\n */\n\nafterBlockComment: false",
+            args: [1, {afterBlockComment: false}],
+            errors: [
+                { message: "Block comment cannot be followed by empty line (line 4)" }
+            ]
+        },
+        {
+            code: "/* block\n * comment\n */\nafterBlockComment: true",
+            args: [1, {afterBlockComment: true}],
+            errors: [
+                { message: "Block comment must be followed by empty line (line 4)" }
+            ]
+        },
+        {
+            code: "/* block\n * comment\n with last-line noise */\nfoo;",
+            args: [1, {afterBlockComment: true}],
+            errors: [
+                { message: "Block comment must be followed by empty line (line 4)" }
+            ]
+        },
+        {
+            code: "// CRLF instead of LF\r\n\r\nafterLineComment: false",
+            args: [1, {afterLineComment: false}],
+            errors: [
+                { message: "Line comment cannot be followed by empty line (line 2)" }
+            ]
+        }
+    ]
+});

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -21,12 +21,26 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
 
     // Examples of code that should not trigger the rule
     valid: [
+
         // Default: everything goes
         "// line comment\n\ndefaultConfig();",
         "// line comment\ndefaultConfig();",
+        "defaultConfig();\n\n// line comment",
+        "defaultConfig();\n// line comment",
         "/* block\n * comment\n */\n\ndefaultConfig();",
         "/* block\n * comment\n */\ndefaultConfig();",
+        "defaultConfig();\n\n/* block\n * comment\n */",
+        "defaultConfig();\n/* block\n * comment\n */",
+
         // Line comment styles that conform to the rules
+        {
+            code: "beforeLineComment: true\n\n// single line comment",
+            args: [1, {beforeLineComment: true}]
+        },
+        {
+            code: "beforeLineComment: false\n// single line comment",
+            args: [1, {beforeLineComment: false}]
+        },
         {
             code: "// single line comment\n\nafterLineComment: true",
             args: [1, {afterLineComment: true}]
@@ -47,7 +61,16 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
             code: "var x = 5; // end of line comment\nafterLineComment: true",
             args: [1, {afterLineComment: true}]
         },
+
         // Block comment styles that conform to the rules
+        {
+            code: "beforeBlockComment: true;\n\n/* single line block comment */",
+            args: [1, {beforeBlockComment: true}]
+        },
+        {
+            code: "beforeBlockComment: false;\n/* single line block comment */",
+            args: [1, {beforeBlockComment: false}]
+        },
         {
             code: "/* single line block comment */\n\nafterBlockComment: true",
             args: [1, {afterBlockComment: true}]
@@ -55,6 +78,10 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
         {
             code: "/* single line block comment */\nafterBlockComment: false",
             args: [1, {afterBlockComment: false}]
+        },
+        {
+            code: "beforeBlockComment: false;\n/* multi line\n * block comment */",
+            args: [1, {beforeBlockComment: false}]
         },
         {
             code: "/* multi line\n * block comment */\n\nafterBlockComment: true",
@@ -105,6 +132,20 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
     // Examples of code that should trigger the rule
     invalid: [
         {
+            code: "beforeLineComment: false;\n\n// line comment",
+            args: [1, {beforeLineComment: false}],
+            errors: [
+                { message: "Line comment cannot be preceded by empty line (line 2)" }
+            ]
+        },
+        {
+            code: "beforeLineComment: true;\n// line comment",
+            args: [1, {beforeLineComment: true}],
+            errors: [
+                { message: "Line comment must be preceded by empty line (line 1)" }
+            ]
+        },
+        {
             code: "// line comment\n\nafterLineComment: false",
             args: [1, {afterLineComment: false}],
             errors: [
@@ -116,6 +157,27 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
             args: [1, {afterLineComment: true}],
             errors: [
                 { message: "Line comment must be followed by empty line (line 2)" }
+            ]
+        },
+        {
+            code: "// line comment\nafterLineComment: true",
+            args: [1, {afterLineComment: true}],
+            errors: [
+                { message: "Line comment must be followed by empty line (line 2)" }
+            ]
+        },
+        {
+            code: "beforeBlockComment: false;\n\n/* single-line block comment */",
+            args: [1, {beforeBlockComment: false}],
+            errors: [
+                { message: "Block comment cannot be preceded by empty line (line 2)" }
+            ]
+        },
+        {
+            code: "beforeBlockComment: true;\n/* single-line block comment */",
+            args: [1, {beforeBlockComment: true}],
+            errors: [
+                { message: "Block comment must be preceded by empty line (line 1)" }
             ]
         },
         {
@@ -137,6 +199,14 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
             args: [1, {afterBlockComment: true}],
             errors: [
                 { message: "Block comment must be followed by empty line (line 4)" }
+            ]
+        },
+        {
+            code: "beforeBlockComment: true\n/* block comment */\nafterBlockComment: true",
+            args: [1, {beforeBlockComment: true, afterBlockComment: true}],
+            errors: [
+                { message: "Block comment must be preceded by empty line (line 1)" },
+                { message: "Block comment must be followed by empty line (line 3)" }
             ]
         },
         {


### PR DESCRIPTION
(Dis)allow empty lines around comments. This patch only implements the
lines /after/ a comment line or block. If it is accepted I will adapt it
to consider preceding lines.

The implementation is fully text-based. There is no reliable access to
comments through the official AST API, so I had to resort to manual
parsing. Luckily, JS has some quirks that make it doable.

See https://github.com/eslint/eslint/issues/1344