### PR TITLE
Revert "Fix: '.md' to '.html' with anchors (fixes #1415)"

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -250,7 +250,7 @@ target.gensite = function() {
 
             text = "---\ntitle: ESLint\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n" + text;
 
-            text = text.replace(/(\(.+)(.md)(.+\))/g, "$1.html$3").replace("README.html", "index.html");
+            text = text.replace(/.md\)/g, ".html)").replace("README.html", "index.html");
 
             if (filename.indexOf("rules/") !== -1 && baseName !== "README.md") {
                 var version = getFirstVersionOfFile(path.join("lib/rules", sourceBaseName));


### PR DESCRIPTION
Reverts eslint/eslint#1417 due to site generation problems. 
