### PR TITLE
Fix ESlint.getSource() clamping

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -710,7 +710,7 @@ module.exports = (function() {
      */
     api.getSource = function(node, beforeCount, afterCount) {
         if (node) {
-            return (currentText !== null) ? currentText.slice(node.range[0] - (beforeCount || 0),
+            return (currentText !== null) ? currentText.slice(Math.max(node.range[0] - (beforeCount || 0), 0),
                 node.range[1] + (afterCount || 0)) : null;
         } else {
             return currentText;

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -116,6 +116,22 @@ describe("eslint", function() {
             assert(spy.calledOnce);
         });
 
+        it("should clamp to valid range when retrieving characters before start of source", function() {
+            function handler(node) {
+                var source = eslint.getSource(node, 2, 0);
+                assert.equal(source, TEST_CODE);
+            }
+
+            var config = { rules: {} },
+                spy = sandbox.spy(handler);
+
+            eslint.reset();
+            eslint.on("Program", spy);
+
+            eslint.verify(code, config, filename, true);
+            assert(spy.calledOnce);
+        });
+
         it("should retrieve all text for binary expression", function() {
             var config = { rules: {} };
 
@@ -163,6 +179,7 @@ describe("eslint", function() {
 
             eslint.verify(code, config, filename, true);
         });
+
     });
 
     describe("when calling getTokens", function() {


### PR DESCRIPTION
Only adding clamping to the beforeCount to avoid it going negative. afterCount should work as expected since very large values are handled by slice.
