### PR TITLE
New: Add ability to time individual rules (fixes #1437)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -226,7 +226,70 @@ invalid: [
 
 ### Write Many Tests
 
-You must have at least one valid and one invalid case for the rule tests to pass.Provide as many unit tests as possible. Your pull request will never be turned down for having too many tests submitted with it!
+You must have at least one valid and one invalid case for the rule tests to pass. Provide as many unit tests as possible. Your pull request will never be turned down for having too many tests submitted with it!
+
+## Performance Testing
+
+To keep the linting process efficient and unobtrusive, it is useful to verify the performance impact of new rules or modifications to existing rules.
+
+### Overall Performance
+
+The `npm run perf` command gives a high-level overview of ESLint running time.
+
+```bash
+$ git checkout master
+Switched to branch 'master'
+
+$ npm run perf
+CPU Speed is 2200 with multiplier 7500000
+Performance Run #1:  1394.689313ms
+Performance Run #2:  1423.295351ms
+Performance Run #3:  1385.09515ms
+Performance Run #4:  1382.406982ms
+Performance Run #5:  1409.68566ms
+Performance budget ok:  1394.689313ms (limit: 3409.090909090909ms)
+
+$ git checkout my-rule-branch
+Switched to branch 'my-rule-branch'
+
+$ npm run perf
+CPU Speed is 2200 with multiplier 7500000
+Performance Run #1:  1443.736547ms
+Performance Run #2:  1419.193291ms
+Performance Run #3:  1436.018228ms
+Performance Run #4:  1473.605485ms
+Performance Run #5:  1457.455283ms
+Performance budget ok:  1443.736547ms (limit: 3409.090909090909ms)
+```
+
+### Per-rule Performance
+
+ESLint has a built-in method to track performance of individual rules. Setting the `TIMING` environment variable will trigger the display, upon linting completion, of the ten longest-running rules, along with their individual running time and relative performance impact as a percentage of total rule processing time.
+
+```bash
+$ TIMING=1 eslint lib
+Rule                    | Time (ms) | Relative
+:-----------------------|----------:|--------:
+no-multi-spaces         |    52.472 |     6.1%
+camelcase               |    48.684 |     5.7%
+no-irregular-whitespace |    43.847 |     5.1%
+valid-jsdoc             |    40.346 |     4.7%
+handle-callback-err     |    39.153 |     4.6%
+space-infix-ops         |    35.444 |     4.1%
+no-undefined            |    25.693 |     3.0%
+no-shadow               |    22.759 |     2.7%
+no-empty-class          |    21.976 |     2.6%
+semi                    |    19.359 |     2.3%
+```
+
+To test one rule explicitly, combine the `--reset`, `--no-eslintrc`, and `--rule` options:
+
+```
+$ TIMING=1 eslint --reset --no-eslintrc --rule "quotes: [2, 'double']" lib
+Rule   | Time (ms) | Relative
+:------|----------:|--------:
+quotes |    18.066 |   100.0%
+```
 
 ## Rule Naming Conventions
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -16,6 +16,7 @@ var esprima = require("esprima"),
     rules = require("./rules"),
     util = require("./util"),
     RuleContext = require("./rule-context"),
+    timing = require("./timing"),
     EventEmitter = require("events").EventEmitter;
 
 //------------------------------------------------------------------------------
@@ -553,7 +554,10 @@ module.exports = (function() {
 
                         // add all the node types as listeners
                         Object.keys(rule).forEach(function(nodeType) {
-                            api.on(nodeType, rule[nodeType]);
+                            api.on(nodeType, timing.enabled
+                                ? timing.time(key, rule[nodeType])
+                                : rule[nodeType]
+                            );
                         });
                     } catch(ex) {
                         ex.message = "Error while loading rule '" + key + "': " + ex.message;

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -1,0 +1,109 @@
+/**
+ * @fileoverview Tracks performance of individual rules.
+ * @author Brandon Mills
+ * @copyright 2014 Brandon Mills. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/* istanbul ignore next */
+function alignLeft(str, len, ch) {
+    return str + new Array(len - str.length + 1).join(ch || " ");
+}
+
+/* istanbul ignore next */
+function alignRight(str, len, ch) {
+    return new Array(len - str.length + 1).join(ch || " ") + str;
+}
+
+//------------------------------------------------------------------------------
+// Module definition
+//------------------------------------------------------------------------------
+
+var enabled = !!process.env.TIMING;
+
+var HEADERS = ["Rule", "Time (ms)", "Relative"];
+var ALIGN = [alignLeft, alignRight, alignRight];
+
+/* istanbul ignore next */
+function display(data) {
+    var total = 0;
+    var rows = Object.keys(data)
+        .map(function(key) {
+            var time = data[key];
+            total += time;
+            return [key, time];
+        })
+        .sort(function(a, b) {
+            return b[1] - a[1];
+        })
+        .slice(0, 10);
+
+    rows.forEach(function(row) {
+        row.push((row[1] * 100 / total).toFixed(1) + "%");
+        row[1] = row[1].toFixed(3);
+    });
+
+    rows.unshift(HEADERS);
+
+    var widths = [];
+    rows.forEach(function(row) {
+        var len = row.length, i, n;
+        for (i = 0; i < len; i++) {
+            n = row[i].length;
+            if (!widths[i] || n > widths[i]) {
+                widths[i] = n;
+            }
+        }
+    });
+
+    var table = rows.map(function(row) {
+        return row.map(function(cell, index) {
+            return ALIGN[index](cell, widths[index]);
+        }).join(" | ");
+    });
+    table.splice(1, 0, widths.map(function(w, index) {
+        if (index !== 0 && index !== widths.length - 1) {
+            w++;
+        }
+
+        return ALIGN[index](":", w + 1, "-");
+    }).join("|"));
+
+    console.log(table.join("\n"));
+}
+
+/* istanbul ignore next */
+module.exports = (function() {
+
+    var data = Object.create(null);
+
+    function time(key, fn) {
+        if (typeof data[key] === "undefined") {
+            data[key] = 0;
+        }
+
+        return function() {
+            var t = process.hrtime();
+            fn.apply(null, Array.prototype.slice.call(arguments));
+            t = process.hrtime(t);
+            data[key] += t[0] * 1e3 + t[1] / 1e6;
+        };
+    }
+
+    if (enabled) {
+        process.on("exit", function() {
+            display(data);
+        });
+    }
+
+    return {
+        time: time,
+        enabled: enabled
+    };
+
+}());


### PR DESCRIPTION
My timing branch is to the point where I'd like some input and feedback before this gets merged. Right now the output format is a listing of the ten most expensive rules, their running time, and relative performance cost as a percentage of total rule processing time. I have three major questions that I'd like to open up to the community:
1. I'm not sure if this is the right format. Should it be an ASCII table? Generate an HTML file with full data?
2. How does one test a specific rule? Right now, if I'm trying to test a rule that doesn't appear in the top (or bottom?) ten, I don't see its performance data.
3. Timing is triggered by the `TIMING` environment variable. Should it be a CLI option, a differently-named environment variable, something else entirely...?

``` bash
$ TIMING=1 eslint lib
no-irregular-whitespace: 54ms(7.2%)
camelcase: 42ms(5.6%)
valid-jsdoc: 41ms(5.4%)
no-multi-spaces: 37ms(5.0%)
handle-callback-err: 28ms(3.7%)
no-undefined: 22ms(2.9%)
space-infix-ops: 20ms(2.7%)
no-spaced-func: 20ms(2.6%)
no-empty-class: 18ms(2.4%)
semi: 17ms(2.2%)
```
