### PR TITLE
Update: Add no-cond-assign option to disallow nested assignments in conditionals (fixes #1444)

### DIFF
--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -1,70 +1,123 @@
-# Disallow Assignment in Conditional Expressions (no-cond-assign)
+# Disallow Assignment in Conditional Statements (no-cond-assign)
 
-It is uncommon to use an assignment operator inside of a conditional statement, such as:
+In conditional statements, it is very easy to mistype a comparison operator (such as `==`) as an assignment operator (such as `=`). For example:
 
 ```js
-if (c = "f") {
-    // ...
+// Check the user's job title
+if (user.jobTitle = "manager") {
+    // user.jobTitle is now incorrect
 }
 ```
 
-As such, assignment operators used in this context are frequently errors, where the developer meant to use a comparison operator instead.
+There are valid reasons to use assignment operators in conditional statements. However, it can be difficult to tell whether a specific assignment was intentional.
 
 ## Rule Details
 
-This rule is aimed at eliminating ambiguous assignment operators found in `if`, `while`, and `do...while` conditional expressions.
+This rule is aimed at eliminating ambiguous assignments in `for`, `if`, `while`, and `do...while` conditional statements.
+
+### Options
+
+The rule takes one option, a string, which must contain one of the following values:
+
++ `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
++ `always`: Disallow all assignments.
+
+#### "except-parens"
+
+This is the default option. It disallows assignments unless they are enclosed in parentheses. This option makes it possible to use common patterns, such as reassigning a value in the condition of a `while` or `do...while` loop, without causing a warning.
 
 The following patterns are considered warnings:
 
 ```js
+// Unintentional assignment
 var x;
 if (x = 0) {
     var b = 1;
 }
 
-// Practical example
+// Practical example that is similar to an error
 function setHeight(someNode) {
     "use strict";
     do {
-        someNode.height = '100px';
+        someNode.height = "100px";
     } while (someNode = someNode.parentNode);
 }
-
 ```
 
 The following patterns are considered okay and do not cause warnings:
 
 ```js
+// Assignment replaced by comparison
 var x;
 if (x === 0) {
     var b = 1;
 }
 
-// Practical example
+// Practical example that wraps the assignment in parentheses
 function setHeight(someNode) {
     "use strict";
     do {
-        someNode.height = '100px';
+        someNode.height = "100px";
+    } while ((someNode = someNode.parentNode));
+}
+
+// Practical example that wraps the assignment and tests for 'null'
+function setHeight(someNode) {
+    "use strict";
+    do {
+        someNode.height = "100px";
     } while ((someNode = someNode.parentNode) !== null);
-} 
+}
 ```
 
-## Notes
+#### "always"
 
-The evaluation of `for` statements was excluded in this rule. Presently,
-`esprima` will fire an error when parsing the following code:
+This option disallows all assignments in conditional statement tests. All assignments are treated as warnings.
+
+The following patterns are considered warnings:
 
 ```js
-var i = 0, foo;
-for (i < 10; i += 1) {
-    foo += i;
+// Unintentional assignment
+var x;
+if (x = 0) {
+    var b = 1;
 }
-// line 2, col 20, Error - Unexpected token )
+
+// Practical example that is similar to an error
+function setHeight(someNode) {
+    "use strict";
+    do {
+        someNode.height = "100px";
+    } while (someNode = someNode.parentNode);
+}
+
+// Practical example that wraps the assignment in parentheses
+function setHeight(someNode) {
+    "use strict";
+    do {
+        someNode.height = "100px";
+    } while ((someNode = someNode.parentNode));
+}
+
+// Practical example that wraps the assignment and tests for 'null'
+function setHeight(someNode) {
+    "use strict";
+    do {
+        someNode.height = "100px";
+    } while ((someNode = someNode.parentNode) !== null);
+}
 ```
 
-So even though there is assignment ambiguity in the conditional expression, the parse error prevents the scenario from occurring.
+The following pattern does not cause warnings:
+
+```js
+// Assignment replaced by comparison
+var x;
+if (x === 0) {
+    var b = 1;
+}
+```
 
 ## Further Reading
 
-* [JSLint -- Expected a conditional expression and instead saw an assignment.](http://jslinterrors.com/expected-a-conditional-expression-and-saw-an-assignment/)
 * [JSLint -- Unexpected assignment expression](http://jslinterrors.com/unexpected-assignment-expression/)

--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -1,8 +1,15 @@
 /**
- * @fileoverview Rule to flag assignment in a conditional expression
+ * @fileoverview Rule to flag assignment in a conditional statement's test expression
  * @author Stephen Murray <spmurrayzzz>
  */
 "use strict";
+
+var NODE_DESCRIPTIONS = {
+    "DoWhileStatement": "a 'do...while' statement",
+    "ForStatement": "a 'for' statement",
+    "IfStatement": "an 'if' statement",
+    "WhileStatement": "a 'while' statement"
+};
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -10,6 +17,41 @@
 
 module.exports = function(context) {
 
+    var prohibitAssign = (context.options[0] || "except-parens");
+
+    /**
+     * Check whether an AST node is the test expression for a conditional statement.
+     * @param {!Object} node The node to test.
+     * @returns {boolean} `true` if the node is the text expression for a conditional statement; otherwise, `false`.
+     */
+    function isConditionalTestExpression(node) {
+        return node.parent &&
+            node.parent.test &&
+            node === node.parent.test;
+    }
+
+    /**
+     * Given an AST node, perform a bottom-up search for the first ancestor that represents a conditional statement.
+     * @param {!Object} node The node to use at the start of the search.
+     * @returns {?Object} The closest ancestor node that represents a conditional statement.
+     */
+    function findConditionalAncestor(node) {
+        var currentAncestor = node;
+
+        while ((currentAncestor = currentAncestor.parent)) {
+            if (isConditionalTestExpression(currentAncestor)) {
+                return currentAncestor.parent;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Check whether the code represented by an AST node is enclosed in parentheses.
+     * @param {!Object} node The node to test.
+     * @returns {boolean} `true` if the code is enclosed in parentheses; otherwise, `false`.
+     */
     function isParenthesised(node) {
         var previousToken = context.getTokenBefore(node),
             nextToken = context.getTokenAfter(node);
@@ -18,6 +60,11 @@ module.exports = function(context) {
             nextToken.value === ")" && nextToken.range[0] >= node.range[1];
     }
 
+    /**
+     * Check whether the code represented by an AST node is enclosed in two sets of parentheses.
+     * @param {!Object} node The node to test.
+     * @returns {boolean} `true` if the code is enclosed in two sets of parentheses; otherwise, `false`.
+     */
     function isParenthesisedTwice(node) {
         var previousToken = context.getTokenBefore(node, 1),
             nextToken = context.getTokenAfter(node, 1);
@@ -27,17 +74,44 @@ module.exports = function(context) {
             nextToken.value === ")" && nextToken.range[0] >= node.range[1];
     }
 
+    /**
+     * Check a conditional statement's test expression for top-level assignments that are not enclosed in parentheses.
+     * @param {!Object} node The node for the conditional statement.
+     * @returns {void}
+     */
     function testForAssign(node) {
         if (node.test && (node.test.type === "AssignmentExpression") && !isParenthesisedTwice(node.test)) {
+            // must match JSHint's error message
             context.report(node, "Expected a conditional expression and instead saw an assignment.");
         }
     }
 
+    /**
+     * Check whether an assignment expression is descended from a conditional statement's test expression.
+     * @param {!Object} node The node for the assignment expression.
+     * @returns {void}
+     */
+    function testForConditionalAncestor(node) {
+        var ancestor = findConditionalAncestor(node);
+
+        if (ancestor) {
+            context.report(ancestor, "Unexpected assignment within {{type}}.", {
+                type: NODE_DESCRIPTIONS[ancestor.type] || ancestor.type
+            });
+        }
+    }
+
+    if (prohibitAssign === "always") {
+        return {
+            "AssignmentExpression": testForConditionalAncestor
+        };
+    }
+
     return {
-        "IfStatement": testForAssign,
-        "WhileStatement": testForAssign,
         "DoWhileStatement": testForAssign,
-        "ForStatement": testForAssign
+        "ForStatement": testForAssign,
+        "IfStatement": testForAssign,
+        "WhileStatement": testForAssign
     };
 
 };

--- a/tests/lib/rules/no-cond-assign.js
+++ b/tests/lib/rules/no-cond-assign.js
@@ -9,6 +9,7 @@
 
 var eslint = require("../../../lib/eslint"),
     ESLintTester = require("eslint-tester");
+var ERROR_MESSAGE = "Expected a conditional expression and instead saw an assignment.";
 
 //------------------------------------------------------------------------------
 // Tests
@@ -18,17 +19,28 @@ var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-cond-assign", {
     valid: [
         "var x = 0; if (x == 0) { var b = 1; }",
+        { code: "var x = 0; if (x == 0) { var b = 1; }", args: ["2", "always"] },
         "var x = 5; while (x < 5) { x = x + 1; }",
         "var x = 0; if (x == 0) { var b = 1; }",
         "if ((someNode = someNode.parentNode) !== null) { }",
+        { code: "if ((someNode = someNode.parentNode) !== null) { }", args: ["2", "except-parens"] },
         "if ((a = b));",
-        "for (;;) {}"
+        "for (;;) {}",
+        "if (someNode || (someNode = parentNode)) { }",
+        "while (someNode || (someNode = parentNode)) { }",
+        "do { } while (someNode || (someNode = parentNode));",
+        "if ((function(node) { return (node = parentNode); })(someNode)) { }"
     ],
     invalid: [
-        { code: "var x; if (x = 0) { var b = 1; }", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "IfStatement"}] },
-        { code: "var x; while (x = 0) { var b = 1; }", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "WhileStatement"}] },
-        { code: "var x = 0, y; do { y = x; } while (x = x + 1);", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "DoWhileStatement"}] },
-        { code: "var x; for(; x+=1 ;){};", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "ForStatement"}] },
-        { code: "var x; if ((x) = (0));", errors: [{ message: "Expected a conditional expression and instead saw an assignment.", type: "IfStatement"}] }
+        { code: "var x; if (x = 0) { var b = 1; }", errors: [{ message: ERROR_MESSAGE, type: "IfStatement"}] },
+        { code: "var x; while (x = 0) { var b = 1; }", errors: [{ message: ERROR_MESSAGE, type: "WhileStatement"}] },
+        { code: "var x = 0, y; do { y = x; } while (x = x + 1);", errors: [{ message: ERROR_MESSAGE, type: "DoWhileStatement"}] },
+        { code: "var x; for(; x+=1 ;){};", errors: [{ message: ERROR_MESSAGE, type: "ForStatement"}] },
+        { code: "var x; if ((x) = (0));", errors: [{ message: ERROR_MESSAGE, type: "IfStatement"}] },
+        { code: "if (someNode || (someNode = parentNode)) { }", args: ["2", "always"], errors: [{ message: "Unexpected assignment within an 'if' statement.", type: "IfStatement"}] },
+        { code: "while (someNode || (someNode = parentNode)) { }", args: ["2", "always"], errors: [{ message: "Unexpected assignment within a 'while' statement.", type: "WhileStatement"}] },
+        { code: "do { } while (someNode || (someNode = parentNode));", args: ["2", "always"], errors: [{ message: "Unexpected assignment within a 'do...while' statement.", type: "DoWhileStatement"}] },
+        { code: "for (; (typeof l === 'undefined' ? (l = 0) : l); i++) { }", args: ["2", "always"], errors: [{ message: "Unexpected assignment within a 'for' statement.", type: "ForStatement"}] },
+        { code: "if ((function(node) { return (node = parentNode); })(someNode)) { }", args: ["2", "always"], errors: [{ message: "Unexpected assignment within an 'if' statement.", type: "IfStatement"}] }
     ]
 });


### PR DESCRIPTION
For now, the options are named `parens` (only allow assignments in parentheses) or `never` (never allow assignments). I'm happy to change the names.

I tried to clarify the `no-cond-assign` docs in the course of updating them. A few not-so-obvious doc changes:
- Standardized on "conditional statements," which is consistent with the [ES 5.1 spec](http://www.ecma-international.org/ecma-262/5.1/#sec-12), rather than "conditional expressions."
- Removed a large section about how Esprima parses `for` statements, because it seemed more distracting than helpful.
- Removed a bad link to jslinterrors.com.
