### PR TITLE
ignore unreadable directories

### DIFF
--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -50,7 +50,11 @@ FileFinder.prototype.findInDirectory = function(directory, directoriesToCache) {
 
     directoriesToCache = directoriesToCache.concat(lookInDirectory);
 
-    files = fs.readdirSync(lookInDirectory);
+    try {
+        files = fs.readdirSync(lookInDirectory);
+    } catch (e) {
+        files = [];
+    }
 
     if (files.indexOf(lookFor) !== -1) {
         isFound = true;


### PR DESCRIPTION
I'm not sure if this is the best fix, but the issue that happens is that eslint tries to find eslintrc, and traverses up the directory tree.  If it encounters a directory that it cannot read, then eslint will crash.  For example, this happens with flycheck in emacs with pam_tmpdir (since flycheck saves the file to a temporary directory, and pam_tmpdir manages secure per-user temporary directories), but I suppose this could also happen if the user only has execute permissions on /home.
