### PR TITLE
Fix: Unexpect action when declare variables in switch-case (fixes #1453)

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -151,6 +151,17 @@ module.exports = function(context) {
         },
         "ForInStatement:exit": popScope,
 
+        "SwitchCase": function(node) {
+            pushScope();
+            node.consequent.forEach(function(stmt) {
+
+                if (stmt.type === "VariableDeclaration") {
+                    variableDeclarationHandler(stmt);
+                }
+            });
+        },
+        "SwitchCase:exit": popScope,
+
         "Identifier": function(node) {
             var ancestor = context.getAncestors().pop();
             if (isDeclaration(node, ancestor) || isProperty(node, ancestor)) {

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -42,7 +42,8 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         "var a = f; function f() { };",
         "function f(){ for(var i; i; i) i; }",
         "function f(){ for(var a=0, b=1; a; b) a, b; }",
-        "function f(){ for(var a in {}) a; }"
+        "function f(){ for(var a in {}) a; }",
+        "function f(a){ switch(a) { case 1: var b = 2; b; break; } }"
     ],
     invalid: [
         { code: "function f(){ x; }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
@@ -60,6 +61,7 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         { code: "function x(){}; var a = arguments;", errors: [{ message: "\"arguments\" used outside of binding context.", type: "Identifier" }] },
         { code: "function z(b){}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
         { code: "function z(){var b;}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function f(){ try{}catch(e){} e }", errors: [{ message: "\"e\" used outside of binding context.", type: "Identifier" }] }
+        { code: "function f(){ try{}catch(e){} e }", errors: [{ message: "\"e\" used outside of binding context.", type: "Identifier" }] },
+        { code: "function f(a){ switch(a) { case 1: var b = 2; break;} b; }", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] }
     ]
 });


### PR DESCRIPTION
When declare variables in case statement and use it after, block-scoped-var will report an error  "xxx used outside of binding context".

See #1453.
