### PR TITLE
Fix: message for numeric property names in quote-props (fixes #1459)

### DIFF
--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -1,55 +1,66 @@
 /**
  * @fileoverview Rule to flag non-quoted property names in object literals.
  * @author Mathias Bynens <http://mathiasbynens.be/>
+ * @copyright 2014 Brandon Mills. All rights reserved.
  */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var esprima = require("esprima");
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-var esprima = require("esprima");
-
 module.exports = function(context) {
-
-    "use strict";
 
     var MODE = context.options[0];
 
-    switch (MODE) {
+    /**
+     * Ensures that a property's key is quoted only when necessary
+     * @param   {ASTNode} node Property AST node
+     * @returns {void}
+     */
+    function asNeeded(node) {
+        var key = node.key,
+            tokens;
 
-        case "as-needed":
-            return {
-                Property: function(node) {
-                    var key = node.key;
-                    // Ensure that any quoted property names required quoting
-                    if (key.type === "Literal" && typeof key.value === "string") {
-                        try {
-                            var tokens = esprima.tokenize(key.value);
-                            if (tokens.length !== 1) {
-                                return;
-                            }
-                            var t = tokens[0];
-                        } catch(e) {
-                            return;
-                        }
-                        if (t.type === "Identifier" || t.type === "Null" || t.type === "Boolean" || t.type === "Numeric" && "" + +t.value === t.value) {
-                            context.report(node, "Unnecessarily quoted property `{{name}}` found.", key);
-                        }
-                    }
-                }
-            };
+        if (key.type === "Literal" && typeof key.value === "string") {
+            try {
+                tokens = esprima.tokenize(key.value);
+            } catch (e) {
+                return;
+            }
 
-        default:
-            return {
-                Property: function(node) {
-                    var key = node.key;
-                    // Ensure all property names are quoted
-                    if (key.type !== "Literal" || typeof key.value !== "string") {
-                        context.report(node, "Unquoted property `{{name}}` found.", key);
-                    }
-                }
-            };
-
+            if (tokens.length === 1 &&
+                (["Identifier", "Null", "Boolean"].indexOf(tokens[0].type) >= 0 ||
+                (tokens[0].type === "Numeric" && "" + +tokens[0].value === tokens[0].value))
+            ) {
+                context.report(node, "Unnecessarily quoted property `{{value}}` found.", key);
+            }
+        }
     }
+
+    /**
+     * Ensures that a property's key is quoted
+     * @param   {ASTNode} node Property AST node
+     * @returns {void}
+     */
+    function always(node) {
+        var key = node.key;
+
+        if (!(key.type === "Literal" && typeof key.value === "string")) {
+            context.report(node, "Unquoted property `{{key}}` found.", {
+                key: key.name || key.value
+            });
+        }
+    }
+
+    return {
+        "Property": MODE === "as-needed" ? asNeeded : always
+    };
 
 };

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -31,12 +31,39 @@ eslintTester.addRuleTest("lib/rules/quote-props", {
         { code: "({ a: 0, 0: 0 })", args: [2, "as-needed"] },
         { code: "({ a: 0, '0x0': 0 })", args: [2, "as-needed"] }
     ],
-    invalid: [
-        {
-            code: "({ a: 0 })",
-            errors: [
-                { message: "Unquoted property `a` found.", type: "Property"}
-            ]
-        }
-    ]
+    invalid: [{
+        code: "({ a: 0 })",
+        errors: [{
+            message: "Unquoted property `a` found.", type: "Property"
+        }]
+    }, {
+        code: "({ 0: '0' })",
+        errors: [{
+            message: "Unquoted property `0` found.", type: "Property"
+        }]
+    }, {
+        code: "({ 'a': 0 })",
+        args: [2, "as-needed"],
+        errors: [{
+            message: "Unnecessarily quoted property `a` found.", type: "Property"
+        }]
+    }, {
+        code: "({ 'null': 0 })",
+        args: [2, "as-needed"],
+        errors: [{
+            message: "Unnecessarily quoted property `null` found.", type: "Property"
+        }]
+    }, {
+        code: "({ 'true': 0 })",
+        args: [2, "as-needed"],
+        errors: [{
+            message: "Unnecessarily quoted property `true` found.", type: "Property"
+        }]
+    }, {
+        code: "({ '0': 0 })",
+        args: [2, "as-needed"],
+        errors: [{
+            message: "Unnecessarily quoted property `0` found.", type: "Property"
+        }]
+    }]
 });


### PR DESCRIPTION
Added a few test cases to hit some previously uncovered code. Coverage is now at 100% for `lib/rules/quote-props.js`. Also refactored a bit to reduce complexity and nesting.
