### PR TITLE
Fix: env rules merging for command line config (fixes #1271)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -275,11 +275,11 @@ Config.prototype.getConfig = function (filePath) {
     // Step 5: Merge in command line config file
     if (this.useSpecificConfig) {
         debug("Merging command line config file");
-        config = util.mergeConfigs(config, this.useSpecificConfig);
-
         if (this.useSpecificConfig.env) {
             config = util.mergeConfigs(config, createEnvironmentConfig(this.useSpecificConfig.env, this.options.reset));
         }
+
+        config = util.mergeConfigs(config, this.useSpecificConfig);
     }
 
     // Step 6: Merge in command line environments

--- a/tests/fixtures/config-hierarchy/broken/override-env-conf.yaml
+++ b/tests/fixtures/config-hierarchy/broken/override-env-conf.yaml
@@ -1,4 +1,4 @@
 env:
     node: true
 rules:
-    quotes: 0
+    no-mixed-requires: 0

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -296,7 +296,6 @@ describe("Config", function() {
 
             assertConfigsEqual(expected, actual);
         });
-
         // Command line configuration - --config with first level .eslintrc
         it("should merge command line config when config file adds to local .eslintrc", function () {
 
@@ -389,6 +388,22 @@ describe("Config", function() {
             actual = configHelper.getConfig(file);
 
             expected.env.node = true;
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Command line configuration - --config with first level .eslintrc
+        it("should merge command line config when config file adds environment to local .eslintrc", function () {
+
+            var configHelper = new Config({
+                    configFile: getFixturePath("broken", "override-env-conf.yaml")
+                }),
+                file = getFixturePath("broken", "console-wrong-quotes.js"),
+                expected = util.mergeConfigs(baseConfig, environments.node),
+                actual = configHelper.getConfig(file);
+
+            expected.env.node = true;
+            expected.rules["no-mixed-requires"] = [0, false];
 
             assertConfigsEqual(expected, actual);
         });


### PR DESCRIPTION
The rules for environments specified in a command line config file are now merged properly _before_ any explicit rule from the same file.

I added one extra text for this particular behaviour. I'm not sure whether it would be more logical to rewrite the rest of the `config file` tests to check that the environment merging is done properly. It may not be worth it if the `-c` flag is to be dreprecated in the future.
