### PR TITLE
Add test for single quotes only while using JSX.

### DIFF
--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -2337,6 +2337,13 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
+        it("should not report an error when JSX code with text is encountered and single quotes is enabled", function() {
+            var code = "<div>Foo</div>";
+            var messages = eslint.verify(code, { settings: { jsx: true }, rules: { quotes: [1, "single"]}}, "filename");
+
+            assert.equal(messages.length, 0);
+        });
+        
         // More ES6/JSX parsing tests go here
 
     });


### PR DESCRIPTION
The JSX transforms currently use double quotes when converting JSX nodes. This conflicts with the single quote rule. This is a test case (which currently fails) for this scenario.
