### PR TITLE
Update: Remove shebang workaround in spaced-line-comment (fixes #1433)

### DIFF
--- a/lib/rules/spaced-line-comment.js
+++ b/lib/rules/spaced-line-comment.js
@@ -38,19 +38,6 @@ module.exports = function(context) {
 
         "LineComment": function checkCommentForSpace(node) {
 
-            if (node.loc.start.line === 1 && /^#!/.test(context.getSourceLines()[0])) {
-
-                /*
-                 * HACK: return if we are on the first line and
-                 * encounter a shebang at the beginning.
-                 * It seems the parser will return this as a
-                 * comment and filter out the # so we must fetch
-                 * the actual source line. Is this being caused
-                 * by esprima or eslint? Something else?
-                 */
-                return;
-            }
-
             if (requireSpace) {
 
                 // Space expected and not found


### PR DESCRIPTION
Credit to @ilovejary for the original PR (#1435) (https://github.com/ilovejary/eslint/commit/27fc2f617b2ed6b29dba0cb7c8612ec0dd8be8c0).
