### PR TITLE
Fix: crash in no-multi-spaces on empty array elements (fixes #1418)

### DIFF
--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -2,8 +2,44 @@
  * @fileoverview Disallow use of multiple spaces.
  * @author Vignesh Anand aka vegetableman.
  * @copyright 2014 Vignesh Anand. All rights reserved.
+ * @copyright 2014 Brandon Mills. All rights reserved.
  */
 "use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var OPERATORS = [
+    "*", "/", "%", "+", "-", "<<", ">>", ">>>", "<", "<=", ">", ">=", "in",
+    "instanceof", "==", "!=", "===", "!==", "&", "^", "|", "&&", "||", "=",
+    "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|=",
+    "?", ":", ","
+];
+
+/**
+ * Checks whether the operator is in same line as two adjacent tokens.
+ * @param {ASTNode} left The token left to the operator.
+ * @param {ASTNode} right The token right to the operator.
+ * @param {ASTNode} operator The operator.
+ * @returns {boolean} Whether the operator is in same line as two adjacent tokens.
+ */
+function isSameLine(left, right, operator) {
+    return operator.loc.end.line === left.loc.end.line &&
+                    operator.loc.end.line === right.loc.start.line;
+}
+
+/**
+ * Check whether there are multiple spaces around the operator.
+ * @param {ASTNode} left The token left to the operator.
+ * @param {ASTNode} right The token right to the operator.
+ * @param {ASTNode} operator The operator.
+ * @returns {boolean} Whether there are multiple spaces.
+ */
+function isMultiSpaced(left, right, operator) {
+    return operator.range[0] - left.range[1] > 1 ||
+            right.range[0] - operator.range[1] > 1;
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -11,62 +47,29 @@
 
 module.exports = function(context) {
 
-    var OPERATORS = [
-        "*", "/", "%", "+", "-", "<<", ">>", ">>>", "<", "<=", ">", ">=", "in",
-        "instanceof", "==", "!=", "===", "!==", "&", "^", "|", "&&", "||", "=",
-        "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|=",
-        "?", ":", ","
-    ], errOps = [];
-
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
-
     /**
      * Reports an AST node as a rule violation.
      * @param {ASTNode} node The node to report.
+     * @param {String} operator The operator near the spacing error.
      * @returns {void}
      * @private
      */
-    function report(node) {
-        context.report(node, "Multiple spaces found around '" + errOps.shift() + "'.");
-    }
-
-    /**
-     * Checks whether the operator is in same line as two adjacent tokens.
-     * @param {ASTNode} left The token left to the operator.
-     * @param {ASTNode} right The token right to the operator.
-     * @param {ASTNode} operator The operator.
-     * @returns {boolean} Whether the operator is in same line as two adjacent tokens.
-     * @private
-     */
-    function isSameLine(left, right, operator) {
-        return operator.loc.end.line === left.loc.end.line &&
-                        operator.loc.end.line === right.loc.start.line;
-    }
-
-    /**
-     * Check whether there are multiple spaces around the operator.
-     * @param {ASTNode} left The token left to the operator.
-     * @param {ASTNode} right The token right to the operator.
-     * @param {ASTNode} operator The operator.
-     * @returns {boolean} Whether there are multiple spaces.
-     * @private
-     */
-    function isMultiSpaced(left, right, operator) {
-        return operator.range[0] - left.range[1] > 1 ||
-                right.range[0] - operator.range[1] > 1;
+    function report(node, operator) {
+        context.report(node, "Multiple spaces found around '" + operator + "'.");
     }
 
     /**
      * Get tokens and validate the spacing.
-     * @param {ASTNode} left The token left to the operator.
-     * @param {ASTNode} right The token right to the operator.
-     * @returns {boolean} Whether multiple spaces were found.
+     * @param {ASTNode} node The parent node, used for reporting.
+     * @param {String} leftName Child node left of the operator.
+     * @param {String} rightName Child node right of the operator.
+     * @returns {void}
      * @private
      */
-    function validateSpacing(left, right) {
-        var tokens = context.getTokens({range: [left.range[1], right.range[0]]}, 1, 1),
+    function validateSpacing(node, leftName, rightName) {
+        var left = node[leftName],
+            right = node[rightName],
+            tokens = context.getTokens({range: [left.range[1], right.range[0]]}, 1, 1),
             operator;
 
         for (var i = 1, l = tokens.length - 1; i < l; ++i) {
@@ -75,15 +78,12 @@ module.exports = function(context) {
             right = tokens[i + 1];
 
             if (operator && operator.type === "Punctuator" && OPERATORS.indexOf(operator.value) >= 0 &&
-                isSameLine(left, right, operator) && isMultiSpaced(left, right, operator)) {
-                errOps.push(operator.value);
-                return true;
+                isSameLine(left, right, operator) && isMultiSpaced(left, right, operator)
+            ) {
+                report(node, operator.value);
             }
         }
-
-        return false;
     }
-
 
     /**
      * Report if there are multiple spaces on the expression.
@@ -92,9 +92,7 @@ module.exports = function(context) {
      * @private
      */
     function checkExpression(node) {
-        if (validateSpacing(node.left, node.right)) {
-            report(node);
-        }
+        validateSpacing(node, "left", "right");
     }
 
     /**
@@ -104,12 +102,8 @@ module.exports = function(context) {
      * @private
      */
     function checkConditional(node) {
-        if (validateSpacing(node.test, node.consequent)) {
-            report(node);
-        }
-        if (validateSpacing(node.consequent, node.alternate)) {
-            report(node);
-        }
+        validateSpacing(node, "test", "consequent");
+        validateSpacing(node, "consequent", "alternate");
     }
 
     /**
@@ -119,34 +113,112 @@ module.exports = function(context) {
      * @private
      */
     function checkVar(node) {
-        if (node.init && validateSpacing(node.id, node.init)) {
-            report(node);
+        if (node.init) {
+            validateSpacing(node, "id", "init");
         }
     }
 
     /**
-     * Report if there are multiple spaces around list of items in objects, arrays,
-     * function parameters, sequences and declarations.
-     * @param {ASTNode} node The node to check.
-     * @param {string} property The property of node.
-     * @returns {void}
+     * Generates a function to check object literals and other list-like nodes.
+     * @param {String} property Name of the node's collection property.
+     * @returns {Function} A function that checks spacing within list-like node.
      * @private
      */
-    function checkList(node, property) {
-        var items = node[property];
+    function checkList(property) {
+        /**
+         * Report if there are multiple spaces around list of items in objects,
+         * function parameters, sequences and declarations.
+         * @param {ASTNode} node The node to check.
+         * @param {string} property The property of node.
+         * @returns {void}
+         * @private
+         */
+        return function(node) {
+            var items = node[property];
 
-        for (var i = 0, l = items.length; i < l; i++) {
-            var left = items[i - 1],
-                right = items[i],
-                operator = context.getTokenBefore(right);
+            for (var i = 0, l = items.length; i < l; i++) {
+                var left = items[i - 1],
+                    right = items[i],
+                    operator = context.getTokenBefore(right);
 
-            if (operator && operator.type === "Punctuator" && operator.value === ",") {
-                if (isSameLine(left, right, operator) && isMultiSpaced(left, right, operator)) {
-                    errOps.push(operator.value);
-                    report(right);
+                if (operator && operator.type === "Punctuator" && operator.value === ",") {
+                    if (isSameLine(left, right, operator) && isMultiSpaced(left, right, operator)) {
+                        report(right, operator.value);
+                    }
                 }
             }
+        };
+    }
+
+    /**
+     * Checks arrays literals, allowing that some elements may be empty.
+     * @param {ASTNode} node An ArrayExpression.
+     * @returns {void}
+     */
+    function checkArray(node) {
+        var elements = node.elements,
+            last = context.getLastToken(node),
+            length = elements.length,
+            missing = 0,
+            previous = context.getFirstToken(node),
+            ranges = [],
+            el, i, tokens;
+
+        /**
+         * Pushes another range and sets the new previous token.
+         * @param {Token} token The token on the right side of the range.
+         * @returns {void}
+         */
+        function pushNext(token) {
+            ranges.push([previous, token]);
+            previous = token;
         }
+
+        // Collect every element that might be multi-spaced into a list of range
+        // pairs. For example, `[1, , 2 + 3]` becomes:
+        // ```
+        // [ ["[", "1"],
+        //   ["1", ","],
+        //   [",", ","],
+        //   [",", "2"],
+        //   ["3", "]"] ]
+        // ```
+        for (i = 0; i < length; i++) {
+            el = elements[i];
+
+            if (el) {
+                tokens = context.getTokens(el, missing, 1);
+
+                tokens.slice(0, missing).forEach(pushNext);
+                ranges.push([previous, tokens[missing]]);
+                ranges.push(tokens.slice(-2));
+
+                previous = tokens[tokens.length - 1];
+                missing = 0;
+            } else {
+                ++missing;
+            }
+        }
+
+        if (!ranges.length) {
+            // If the array had no child elements, fill ranges directly from its
+            // tokens - the square brackets with any commas in between
+            context.getTokens(node).slice(1).forEach(pushNext);
+        } else if (ranges[ranges.length - 1][1] !== last) {
+            // Ensure the last range ends with the array"s closing bracket
+            ranges.push([previous, context.getLastToken(node)]);
+        }
+
+        ranges.forEach(function(range) {
+            var left = range[0],
+                right = range[1];
+
+            if (left.loc.end.line === right.loc.start.line &&
+                    right.range[0] - left.range[1] > 1) {
+                report(left.type === "Punctuator" && left.value === ","
+                    ? left : right, ",");
+            }
+        });
     }
 
     //--------------------------------------------------------------------------
@@ -159,24 +231,12 @@ module.exports = function(context) {
         "LogicalExpression": checkExpression,
         "ConditionalExpression": checkConditional,
         "VariableDeclarator": checkVar,
-        "ArrayExpression": function(node) {
-            checkList(node, "elements");
-        },
-        "ObjectExpression": function(node) {
-            checkList(node, "properties");
-        },
-        "SequenceExpression": function(node) {
-            checkList(node, "expressions");
-        },
-        "FunctionExpression": function(node) {
-            checkList(node, "params");
-        },
-        "FunctionDeclaration": function(node) {
-            checkList(node, "params");
-        },
-        "VariableDeclaration": function(node) {
-            checkList(node, "declarations");
-        }
+        "ArrayExpression": checkArray,
+        "ObjectExpression": checkList("properties"),
+        "SequenceExpression": checkList("expressions"),
+        "FunctionExpression": checkList("params"),
+        "FunctionDeclaration": checkList("params"),
+        "VariableDeclaration": checkList("declarations")
     };
 
 };

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -38,9 +38,11 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
         "function foo(a,b) {}",
         "function foo(a, b) {}",
         "if ( a === 3 && b === 4) {}",
-        "if ( a === 3||b === 4) {}",
+        "if ( a === 3||b === 4 ) {}",
         "if ( a <= 4) {}",
-        "var foo = bar === 1 ? 2: 3"
+        "var foo = bar === 1 ? 2: 3",
+        "[1, , 3]",
+        "[1, ]"
     ],
 
     invalid: [
@@ -100,20 +102,33 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
             code: "var a = [1,  2,  3,  4]",
             errors: [{
                 message: "Multiple spaces found around ','.",
-                type: "Literal"
+                type: "Punctuator"
             }, {
                 message: "Multiple spaces found around ','.",
-                type: "Literal"
+                type: "Punctuator"
             }, {
                 message: "Multiple spaces found around ','.",
-                type: "Literal"
+                type: "Punctuator"
             }]
         },
         {
             code: "var arr = [1,  2];",
             errors: [{
                 message: "Multiple spaces found around ','.",
-                type: "Literal"
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "[  , 1,  , 3,  ]",
+            errors: [{
+                message: "Multiple spaces found around ','.",
+                type: "Punctuator"
+            }, {
+                message: "Multiple spaces found around ','.",
+                type: "Punctuator"
+            }, {
+                message: "Multiple spaces found around ','.",
+                type: "Punctuator"
             }]
         },
         {


### PR DESCRIPTION
Part of this is refactoring to clean up some unnecessary state and repetitive code. The interesting part, however, is the new `checkArray` method. It is designed to handle possibly-empty elements, so it detects the error in the second case below, even though everything except the second comma is in the same place.

```
[1, , 3]; // Valid
[1,  ,3]; // Invalid
```

With a little bit more effort, I could generalize `checkArray` to be able to replace `checkList` entirely, but I haven't yet because the logic for allowing empty elements does make it much more complex. I also noticed that the more general `checkList` doesn't check for multiple spaces at the beginning or end of lists, but `checkArray` does:

```
({  hello: world  }); // Valid (incorrectly?)
([  hello, world  ]); // Invalid
```
