### PR TITLE
Fix: no-fallthrough should work when semis are missing (fixes #1447)

### DIFF
--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -40,8 +40,15 @@ module.exports = function(context) {
                 comments = context.getComments(switchData.lastCase).trailing;
                 comment = comments[comments.length - 1];
 
+                // unless the user doesn't like semicolons, in which case it's first leading comment of this case
+                if (!comment) {
+                    comments = context.getComments(node).leading;
+                    comment = comments[comments.length - 1];
+                }
+
                 // check for comment
                 if (!comment || !FALLTHROUGH_COMMENT.test(comment.value)) {
+
                     context.report(switchData.lastCase,
                         "Expected a \"break\" statement before \"{{code}}\".",
                         { code: node.test ? "case" : "default" });

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -20,6 +20,7 @@ var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-fallthrough", {
     valid: [
         "switch(foo) { case 0: a(); /* falls through */ case 1: b(); }",
+        "switch(foo) { case 0: a()\n /* falls through */ case 1: b(); }",
         "function foo() { switch(foo) { case 0: a(); return; case 1: b(); }; }",
         "switch(foo) { case 0: a(); throw 'foo'; case 1: b(); }",
         "while (a) { switch(foo) { case 0: a(); continue; case 1: b(); } }",


### PR DESCRIPTION
As I suspected, comments are attached in a different spot when semicolons are missing.
