### PR TITLE
Fix: Don't explode on directory traversal (fixes #1452)

### DIFF
--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -12,6 +12,27 @@ var fs = require("fs"),
     path = require("path");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Returns an array of entries for a directory. If there's an error, then an
+ * empty array is returned instead. The try-catch is moved out here to avoid
+ * performance penalty of having it in the findInDirectory() method.
+ * @param {string} directory The directory to search in.
+ * @returns {string[]} The filenames in the directory or an empty array on error.
+ * @private
+ */
+function getDirectoryEntries(directory) {
+    try {
+        return fs.readdirSync(directory);
+    } catch (ex) {
+        return [];
+    }
+}
+
+
+//------------------------------------------------------------------------------
 // API
 //------------------------------------------------------------------------------
 
@@ -50,7 +71,8 @@ FileFinder.prototype.findInDirectory = function(directory, directoriesToCache) {
 
     directoriesToCache = directoriesToCache.concat(lookInDirectory);
 
-    files = fs.readdirSync(lookInDirectory);
+
+    files = getDirectoryEntries(lookInDirectory);
 
     if (files.indexOf(lookFor) !== -1) {
         isFound = true;

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -133,22 +133,20 @@ describe("Config", function() {
             assert.equal(config.rules["dot-notation"], 2);
         });
 
-        it("should throw error when an invalid path is given", function() {
+        it("should return a default config when an invalid path is given", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "foobaz", ".eslintrc");
             var configHelper = new Config();
 
-            assert.throws(function () {
-                configHelper.getConfig(configPath);
-            });
+            sandbox.stub(fs, "readdirSync").throws(new Error());
+
+            assert.isObject(configHelper.getConfig(configPath));
         });
 
         it("should throw error when an invalid configuration file is read", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", ".eslintrc");
             var configHelper = new Config();
 
-            sandbox.stub(fs, "readFileSync", function() {
-                throw new Error();
-            });
+            sandbox.stub(fs, "readFileSync").throws(new Error());
 
             assert.throws(function () {
                 configHelper.getConfig(configPath);


### PR DESCRIPTION
Unsure how to test this. Basically, if a directory is unreadable while searching for `.eslintrc` files, then don't throw an error.
