### PR TITLE
Fix: crash in no-multi-spaces on empty array elements (fixes #1418)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -985,6 +985,57 @@ module.exports = (function() {
     };
 
     /**
+     * Gets all of the tokens between two non-overlapping nodes.
+     * @param {ASTNode} left Node before the desired token range.
+     * @param {ASTNode} right Node after the desired token range.
+     * @param {int} [padding=0] Number of extra tokens on either side of center.
+     * @returns {Token[]} Tokens between left and right plus padding.
+     */
+    api.getTokensBetween = function(left, right, padding) {
+        var count,
+            cursor,
+            token,
+            tokens = [];
+
+        padding = padding || 0; // Defaults to 0
+
+        left = left.range[1];
+        right = right.range[0];
+
+        // Get {{padding}} tokens before first
+        for (cursor = left - 1, count = 0; count < padding && cursor >= 0; --cursor) {
+            token = currentTokens[cursor];
+            if (token) {
+                tokens.unshift(token);
+                ++count;
+            }
+        }
+
+        // Get the tokens between left and right
+        cursor = left;
+        while (cursor < right) {
+            token = currentTokens[cursor];
+            if (token) {
+                tokens.push(token);
+                cursor = token.range[1];
+            } else {
+                ++cursor;
+            }
+        }
+
+        // Get {{padding}} tokens after last
+        for (count = 0; count < padding && cursor < currentTokens.length; ++cursor) {
+            token = currentTokens[cursor];
+            if (token) {
+                tokens.push(token);
+                ++count;
+            }
+        }
+
+        return tokens;
+    };
+
+    /**
      * Gets nodes that are ancestors of current node.
      * @returns {ASTNode[]} Array of objects representing ancestors.
      */

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -20,6 +20,7 @@ var PASSTHROUGHS = [
         "getFirstToken",
         "getLastTokens",
         "getLastToken",
+        "getTokensBetween",
         "getComments",
         "getAncestors",
         "getScope",

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -2,8 +2,57 @@
  * @fileoverview Disallow use of multiple spaces.
  * @author Vignesh Anand aka vegetableman.
  * @copyright 2014 Vignesh Anand. All rights reserved.
+ * @copyright 2014 Brandon Mills. All rights reserved.
  */
 "use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var OPERATORS = {
+    "Punctuator": {
+        "*": true, "/": true, "%": true, "+": true, "-": true, "<<": true,
+        ">>": true, ">>>": true, "<": true, "<=": true, ">": true, ">=": true,
+        "==": true, "!=": true, "===": true, "!==": true, "&": true, "^": true,
+        "|": true, "&&": true, "||": true, "=": true, "+=": true, "-=": true,
+        "*=": true, "/=": true, "%=": true, "<<=": true, ">>=": true,
+        ">>>=": true, "&=": true, "^=": true, "|=": true, "?": true, ":": true,
+        ",": true
+    },
+    "Keyword": {
+        "in": true,
+        "instanceof": true
+    }
+};
+
+/**
+ * Determines whether a token is a binary operator.
+ * @param   {Token}   token The token.
+ * @returns {Boolean}       Whether the token is a binary operator.
+ */
+function isOperator(token) {
+    var type = OPERATORS[token.type];
+    return (type && type[token.value]) || false;
+}
+
+/**
+ * Gets the index of the first element of an array that satisfies a predicate.
+ * Like Array.prototype.indexOf(), but with a predicate instead of equality.
+ * @param   {Array}    array     An array to search.
+ * @param   {Function} predicate A function returning true if its argument
+ *                               satisfies a condition.
+ * @returns {Number}             The index of the first element that satisifies
+ *                               the predicate, or -1 if no elements match.
+ */
+function findIndex(array, predicate) {
+    for (var i = 0, l = array.length; i < l; i++) {
+        if (predicate(array[i])) {
+            return i;
+        }
+    }
+    return -1;
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -11,79 +60,41 @@
 
 module.exports = function(context) {
 
-    var OPERATORS = [
-        "*", "/", "%", "+", "-", "<<", ">>", ">>>", "<", "<=", ">", ">=", "in",
-        "instanceof", "==", "!=", "===", "!==", "&", "^", "|", "&&", "||", "=",
-        "+=", "-=", "*=", "/=", "%=", "<<=", ">>=", ">>>=", "&=", "^=", "|=",
-        "?", ":", ","
-    ], errOps = [];
-
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
-
     /**
-     * Reports an AST node as a rule violation.
-     * @param {ASTNode} node The node to report.
+     * Validates that two adjacent tokens are separated by less than two spaces.
+     * @param   {Token} left  Token on the left side.
+     * @param   {Token} right Token on the right side.
      * @returns {void}
-     * @private
      */
-    function report(node) {
-        context.report(node, "Multiple spaces found around '" + errOps.shift() + "'.");
-    }
+    function validate(left, right) {
+        var op;
 
-    /**
-     * Checks whether the operator is in same line as two adjacent tokens.
-     * @param {ASTNode} left The token left to the operator.
-     * @param {ASTNode} right The token right to the operator.
-     * @param {ASTNode} operator The operator.
-     * @returns {boolean} Whether the operator is in same line as two adjacent tokens.
-     * @private
-     */
-    function isSameLine(left, right, operator) {
-        return operator.loc.end.line === left.loc.end.line &&
-                        operator.loc.end.line === right.loc.start.line;
-    }
-
-    /**
-     * Check whether there are multiple spaces around the operator.
-     * @param {ASTNode} left The token left to the operator.
-     * @param {ASTNode} right The token right to the operator.
-     * @param {ASTNode} operator The operator.
-     * @returns {boolean} Whether there are multiple spaces.
-     * @private
-     */
-    function isMultiSpaced(left, right, operator) {
-        return operator.range[0] - left.range[1] > 1 ||
-                right.range[0] - operator.range[1] > 1;
-    }
-
-    /**
-     * Get tokens and validate the spacing.
-     * @param {ASTNode} left The token left to the operator.
-     * @param {ASTNode} right The token right to the operator.
-     * @returns {boolean} Whether multiple spaces were found.
-     * @private
-     */
-    function validateSpacing(left, right) {
-        var tokens = context.getTokens({range: [left.range[1], right.range[0]]}, 1, 1),
-            operator;
-
-        for (var i = 1, l = tokens.length - 1; i < l; ++i) {
-            left = tokens[i - 1];
-            operator = tokens[i];
-            right = tokens[i + 1];
-
-            if (operator && operator.type === "Punctuator" && OPERATORS.indexOf(operator.value) >= 0 &&
-                isSameLine(left, right, operator) && isMultiSpaced(left, right, operator)) {
-                errOps.push(operator.value);
-                return true;
-            }
+        if (
+            left.loc.end.line === right.loc.start.line &&
+            right.range[0] - left.range[1] > 1
+        ) {
+            op = isOperator(left) ? left : right;
+            context.report(op, "Multiple spaces found {{side}} '{{op}}'.", {
+                side: op === right ? "before" : "after",
+                op: op.value
+            });
         }
-
-        return false;
     }
 
+    /**
+     * Validates the spacing of two nodes with an operator between them.
+     * @param   {ASTNode} left  Node left of the operator.
+     * @param   {ASTNode} right Node right of the operator.
+     * @returns {void}
+     */
+    function validateBetween(left, right) {
+        var tokens = context.getTokensBetween(left, right, 1),
+            operatorIndex = findIndex(tokens, isOperator),
+            op = tokens[operatorIndex];
+
+        validate(tokens[operatorIndex - 1], op);
+        validate(op, tokens[operatorIndex + 1]);
+    }
 
     /**
      * Report if there are multiple spaces on the expression.
@@ -92,9 +103,7 @@ module.exports = function(context) {
      * @private
      */
     function checkExpression(node) {
-        if (validateSpacing(node.left, node.right)) {
-            report(node);
-        }
+        validateBetween(node.left, node.right);
     }
 
     /**
@@ -104,12 +113,8 @@ module.exports = function(context) {
      * @private
      */
     function checkConditional(node) {
-        if (validateSpacing(node.test, node.consequent)) {
-            report(node);
-        }
-        if (validateSpacing(node.consequent, node.alternate)) {
-            report(node);
-        }
+        validateBetween(node.test, node.consequent);
+        validateBetween(node.consequent, node.alternate);
     }
 
     /**
@@ -119,32 +124,72 @@ module.exports = function(context) {
      * @private
      */
     function checkVar(node) {
-        if (node.init && validateSpacing(node.id, node.init)) {
-            report(node);
+        if (node.init) {
+            validateBetween(node.id, node.init);
         }
     }
 
     /**
-     * Report if there are multiple spaces around list of items in objects, arrays,
-     * function parameters, sequences and declarations.
-     * @param {ASTNode} node The node to check.
-     * @param {string} property The property of node.
+     * Generates a function to check object literals and other list-like nodes.
+     * @param {String} property Name of the node's collection property.
+     * @returns {Function} A function that checks spacing within list-like node.
+     * @private
+     */
+    function checkList(property) {
+        /**
+         * Report if there are multiple spaces around list of items in objects,
+         * function parameters, sequences and declarations.
+         * @param {ASTNode} node The node to check.
+         * @returns {void}
+         * @private
+         */
+        return function(node) {
+            var items = node[property];
+
+            for (var i = 0, l = items.length; i < l - 1; i++) {
+                validateBetween(items[i], items[i + 1]);
+            }
+        };
+    }
+
+    /**
+     * Checks arrays literals, allowing that some elements may be empty.
+     * @param {ASTNode} node An ArrayExpression.
      * @returns {void}
      * @private
      */
-    function checkList(node, property) {
-        var items = node[property];
+    function checkArray(node) {
+        var elements = node.elements,
+            elementIndex = 0,
+            tokens = context.getTokens(node),
+            tokenIndex = 0,
+            length = tokens.length,
+            dest;
 
-        for (var i = 0, l = items.length; i < l; i++) {
-            var left = items[i - 1],
-                right = items[i],
-                operator = context.getTokenBefore(right);
+        // Check spacing at the beginning, around commas, and at the end
+        while (tokenIndex < length - 1) {
+            validate(tokens[tokenIndex], tokens[++tokenIndex]);
 
-            if (operator && operator.type === "Punctuator" && operator.value === ",") {
-                if (isSameLine(left, right, operator) && isMultiSpaced(left, right, operator)) {
-                    errOps.push(operator.value);
-                    report(right);
+            // Don't advance to the next element until both sides of the comma
+            // have been checked
+            if (tokens[tokenIndex].value !== ",") {
+                // Skip to just before the end of the array or the next comma
+                if (elements[elementIndex]) {
+                    dest = elements[elementIndex].range[1];
+                    // Move to the end of the element
+                    while (tokens[tokenIndex].range[1] < dest) {
+                        ++tokenIndex;
+                    }
+                    // Move past anything (like closing parens) between the end
+                    // of the node and the following comma or end brace.
+                    while (
+                        tokenIndex + 1 < tokens.length &&
+                        tokens[tokenIndex + 1].value !== ","
+                    ) {
+                        ++tokenIndex;
+                    }
                 }
+                ++elementIndex;
             }
         }
     }
@@ -159,24 +204,12 @@ module.exports = function(context) {
         "LogicalExpression": checkExpression,
         "ConditionalExpression": checkConditional,
         "VariableDeclarator": checkVar,
-        "ArrayExpression": function(node) {
-            checkList(node, "elements");
-        },
-        "ObjectExpression": function(node) {
-            checkList(node, "properties");
-        },
-        "SequenceExpression": function(node) {
-            checkList(node, "expressions");
-        },
-        "FunctionExpression": function(node) {
-            checkList(node, "params");
-        },
-        "FunctionDeclaration": function(node) {
-            checkList(node, "params");
-        },
-        "VariableDeclaration": function(node) {
-            checkList(node, "declarations");
-        }
+        "ArrayExpression": checkArray,
+        "ObjectExpression": checkList("properties"),
+        "SequenceExpression": checkList("expressions"),
+        "FunctionExpression": checkList("params"),
+        "FunctionDeclaration": checkList("params"),
+        "VariableDeclaration": checkList("declarations")
     };
 
 };

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -608,6 +608,69 @@ describe("eslint", function() {
         });
     });
 
+    describe("when calling getTokensBetween", function() {
+        var code = "typeof foo;";
+
+        it("should retrieve zero tokens between adjacent nodes", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("UnaryExpression", function(node) {
+                var tokens = eslint.getTokensBetween(node.operator, node.argument);
+                assert.equal(tokens.length, 0);
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        code = TEST_CODE;
+
+        it("should retrieve one token between nodes", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("BinaryExpression", function(node) {
+                var tokens = eslint.getTokensBetween(node.left, node.right);
+                assert.equal(tokens.length, 1);
+                assert.equal(tokens[0].value, "*");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should retrieve multiple tokens between non-adjacent nodes", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("VariableDeclarator", function(node) {
+                var tokens = eslint.getTokensBetween(node.id, node.init.right);
+                assert.equal(tokens.length, 3);
+                assert.equal(tokens[0].value, "=");
+                assert.equal(tokens[1].value, "6");
+                assert.equal(tokens[2].value, "*");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should retrieve surrounding tokens when asked for padding", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("VariableDeclarator", function(node) {
+                var tokens = eslint.getTokensBetween(node.id, node.init.left, 2);
+                assert.equal(tokens.length, 5);
+                assert.equal(tokens[0].value, "var");
+                assert.equal(tokens[1].value, "answer");
+                assert.equal(tokens[2].value, "=");
+                assert.equal(tokens[3].value, "6");
+                assert.equal(tokens[4].value, "*");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+    });
+
     describe("getJSDocComment()", function() {
         var sandbox;
 

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -24,103 +24,151 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
         "var a=1;",
         "var a = 1, b = 2;",
         "var arr = [1, 2];",
-        "var arr = {'a': 1, 'b': 2};",
+        "var arr = [ (1), (2) ];",
+        "var obj = {'a': 1, 'b': (2)};",
         "a, b",
         "a >>> b",
         "a ^ b",
-        "a | b",
+        "(a) | (b)",
         "a & b",
         "a << b",
-        "a >> b",
-        "a |= b",
-        "a &= b",
+        "a !== b",
+        "a >>>= b",
         "if (a & b) { }",
         "function foo(a,b) {}",
         "function foo(a, b) {}",
         "if ( a === 3 && b === 4) {}",
-        "if ( a === 3||b === 4) {}",
+        "if ( a === 3||b === 4 ) {}",
         "if ( a <= 4) {}",
-        "var foo = bar === 1 ? 2: 3"
+        "var foo = bar === 1 ? 2: 3",
+        "[1, , 3]",
+        "[1, ]",
+        "[ (  1  ) , (  2  ) ]",
+        "a = 1, b = 2;",
+        "(function(a, b){})"
     ],
 
     invalid: [
         {
             code: "var a =  1",
             errors: [{
-                message: "Multiple spaces found around '='.",
-                type: "VariableDeclarator"
+                message: "Multiple spaces found after '='.",
+                type: "Punctuator"
             }]
         },
         {
             code: "var a = 1,  b = 2;",
             errors: [{
-                message: "Multiple spaces found around ','.",
-                type: "VariableDeclarator"
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
             }]
         },
         {
             code: "a <<  b",
             errors: [{
-                message: "Multiple spaces found around '<<'.",
-                type: "BinaryExpression"
+                message: "Multiple spaces found after '<<'.",
+                type: "Punctuator"
             }]
         },
         {
             code: "var arr = {'a': 1,  'b': 2};",
             errors: [{
-                message: "Multiple spaces found around ','.",
-                type: "Property"
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
             }]
         },
         {
             code: "if (a &  b) { }",
             errors: [{
-                message: "Multiple spaces found around '&'.",
-                type: "BinaryExpression"
+                message: "Multiple spaces found after '&'.",
+                type: "Punctuator"
             }]
         },
         {
             code: "if ( a === 3  &&  b === 4) {}",
             errors: [{
-                message: "Multiple spaces found around '&&'.",
-                type: "LogicalExpression"
+                message: "Multiple spaces found before '&&'.",
+                type: "Punctuator"
+            }, {
+                message: "Multiple spaces found after '&&'.",
+                type: "Punctuator"
             }]
         },
         {
             code: "var foo = bar === 1 ?  2:  3",
             errors: [{
-                message: "Multiple spaces found around '?'.",
-                type: "ConditionalExpression"
+                message: "Multiple spaces found after '?'.",
+                type: "Punctuator"
             }, {
-                message: "Multiple spaces found around ':'.",
-                type: "ConditionalExpression"
+                message: "Multiple spaces found after ':'.",
+                type: "Punctuator"
             }]
         },
         {
             code: "var a = [1,  2,  3,  4]",
             errors: [{
-                message: "Multiple spaces found around ','.",
-                type: "Literal"
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
             }, {
-                message: "Multiple spaces found around ','.",
-                type: "Literal"
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
             }, {
-                message: "Multiple spaces found around ','.",
-                type: "Literal"
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
             }]
         },
         {
             code: "var arr = [1,  2];",
             errors: [{
-                message: "Multiple spaces found around ','.",
-                type: "Literal"
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "[  , 1,  , 3,  ,  ]",
+            errors: [{
+                message: "Multiple spaces found before ','.",
+                type: "Punctuator"
+            }, {
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
+            }, {
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
+            }, {
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
             }]
         },
         {
             code: "a >>>  b",
             errors: [{
-                message: "Multiple spaces found around '>>>'.",
-                type: "BinaryExpression"
+                message: "Multiple spaces found after '>>>'.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "a = 1,  b =  2;",
+            errors: [{
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
+            }, {
+                message: "Multiple spaces found after '='.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "(function(a,  b){})",
+            errors: [{
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function foo(a,  b){}",
+            errors: [{
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
             }]
         }
     ]


### PR DESCRIPTION
Turns out I was unable to reopen #1491.

In addition to fixing the crash, this handles a few new cases with arrays that weren't handled previously, including extra spacing at the beginning and the end of the array.

I also changed the reporting messages to specify whether the extra space is before or after the reported token.
