### PR TITLE
New: Allow other file extensions (fixes #801)

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -22,25 +22,26 @@ The command line utility has several options. You can view the options by runnin
 eslint [options] file.js [file.js] [dir]
 
 Options:
-  -h, --help                  Show help.
-  -c, --config path::String   Load configuration data from this file.
-  --rulesdir [path::String]   Load additional rules from this directory.
-  -f, --format String         Use a specific output format. - default: stylish
-  -v, --version               Outputs the version number.
-  --reset                     Set all default rules to off.
-  --eslintrc                  Enable loading .eslintrc configuration. -
-                              default: true
-  --env [String]              Specify environments.
-  --plugin [String]           Specify plugins.
-  --global [String]           Define global variables.
-  --rule Object               Specify rules.
+  -h, --help                 Show help.
+  -c, --config path::String  Load configuration data from this file.
+  --rulesdir [path::String]  Load additional rules from this directory.
+  -f, --format String        Use a specific output format. - default: stylish
+  -v, --version              Outputs the version number.
+  --reset                    Set all default rules to off.
+  --eslintrc                 Enable loading .eslintrc configuration. -
+                             default: true
+  --env [String]             Specify environments.
+  --ext [String]             Specify JavaScript file extensions. - default: .js
+  --plugin [String]          Specify plugins.
+  --global [String]          Define global variables.
+  --rule Object              Specify rules.
   --ignore-path path::String  Specify the file that contains patterns of files
                               to ignore.
-  --ignore                    Enable loading of .eslintignore. - default: true
-  --quiet                     Report errors only. - default false
-  --color                     Enable color in piped output. - default: true
+  --ignore                   Enable loading of .eslintignore. - default: true
+  --color                    Enable color in piped output. - default: true
   -o, --output-file path::String  Enable report to be written to a file.
-  --stdin                     Lint code provided on <STDIN>. - default: false
+  --quiet                    Report errors only. - default: false
+  --stdin                    Lint code provided on <STDIN>. - default: false
 ```
 
 ### `-h`, `--help`
@@ -56,6 +57,21 @@ Example:
     eslint -c ~/my-eslint.json file.js
 
 This example uses the configuration file at `~/my-eslint.json` instead of the default.
+
+### `--ext`
+
+This option allows you to specify which file extensions ESLint will use when searching for JavaScript files. By default, it uses `.js` as the only file extension.
+
+Examples:
+
+  # Use only .js2 extension
+  eslint --ext .js2
+
+  # Use both .js and .js2
+  eslint --ext .js --ext .js2
+
+  # Also use both .js and .js2
+  eslint --ext .js,.js2
 
 ### `-f`, `--format`
 

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -69,6 +69,7 @@ The `CLIEngine` is a constructor, and you can create a new instance by passing i
 
 * `configFile` - The configuration file to use (default: null). Corresponds to `-c`.
 * `envs` - An array of environments to load (default: empty array). Corresponds to `--env`.
+* `extensions` - An array of filename extensions that should be checked for code. The default is an array containing just `".js"`. Corresponds to `--ext`.
 * `globals` - An array of global variables to declare (default: empty array). Corresponds to `--global`.
 * `ignore` - False disables use of `.eslintignore` (default: true). Corresponds to `--no-ignore`.
 * `ignorePath` - The ignore file to use instead of `.eslintignore` (default: null). Corresponds to `--ignore-path`.

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Main CLI object.
  * @author Nicholas C. Zakas
+ * @copyright 2014 Nicholas C. Zakas. All rights reserved.
  */
 
 "use strict";
@@ -42,6 +43,7 @@ var fs = require("fs"),
  * @property {boolean} useEslintrc False disables looking for .eslintrc
  * @property {string[]} envs An array of environments to load.
  * @property {string[]} globals An array of global variables to declare.
+ * @property {string[]} extensions An array of file extensions to check.
  * @property {Object<string,*>} rules An object of rules to use.
  * @property {string} ignorePath The ignore file to use instead of .eslintignore.
  */
@@ -72,6 +74,7 @@ var defaultOptions = {
         envs: [],
         globals: [],
         rules: {},
+        extensions: [".js"],
         ignore: true,
         ignorePath: null
     },
@@ -210,18 +213,21 @@ CLIEngine.prototype = {
 
         var results = [],
             processed = [],
-            configHelper = new Config(this.options),
-            ignoredPaths = IgnoredPaths.load(this.options),
+            options = this.options,
+            configHelper = new Config(options),
+            ignoredPaths = IgnoredPaths.load(options),
             exclude = ignoredPaths.contains.bind(ignoredPaths);
 
         traverse({
             files: files,
-            exclude: this.options.ignore ? exclude : false
+            extensions: options.extensions,
+            exclude: options.ignore ? exclude : false
         }, function(filename) {
 
             debug("Processing " + filename);
 
-            if (path.extname(filename) === ".js") {
+            // only use validated extensions
+            if (options.extensions.indexOf(path.extname(filename)) > -1) {
                 processed.push(filename);
                 results.push(processFile(filename, configHelper));
             }
@@ -229,9 +235,10 @@ CLIEngine.prototype = {
         });
 
         // only warn for files explicitly passes on the command line
-        if (this.options.ignore) {
+        if (options.ignore) {
             files.forEach(function(file) {
-                if (path.extname(file) === ".js" && processed.indexOf(file) === -1) {
+                if (options.extensions.indexOf(path.extname(file)) > -1 &&
+                        processed.indexOf(file) === -1) {
                      results.push({
                          filePath: file,
                          messages: [

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -39,6 +39,7 @@ debug = debug("eslint:cli");
 function translateOptions(cliOptions) {
     return {
         envs: cliOptions.env,
+        extensions: cliOptions.ext,
         rules: cliOptions.rule,
         plugins: cliOptions.plugin,
         globals: cliOptions.global,

--- a/lib/options.js
+++ b/lib/options.js
@@ -60,6 +60,11 @@ module.exports = optionator({
         type: "[String]",
         description: "Specify environments."
     }, {
+        option: "ext",
+        type: "[String]",
+        default: ".js",
+        description: "Specify JavaScript file extensions."
+    }, {
         option: "plugin",
         type: "[String]",
         description: "Specify plugins."

--- a/tests/fixtures/files/.eslintrc
+++ b/tests/fixtures/files/.eslintrc
@@ -1,0 +1,2 @@
+settings:
+    jsx: true

--- a/tests/fixtures/files/foo.js
+++ b/tests/fixtures/files/foo.js
@@ -1,0 +1,1 @@
+var foo = "<div>Hello world!</div>";

--- a/tests/fixtures/files/foo.js2
+++ b/tests/fixtures/files/foo.js2
@@ -1,0 +1,1 @@
+var foo = "<div>Hello world!</div>";

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -82,6 +82,31 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
+        it("should report zero messages when given a directory with a .js2 file", function() {
+
+            engine = new CLIEngine({
+                extensions: [".js2"],
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/files/"]);
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 0);
+        });
+
+        it("should report zero messages when given a directory with a .js and a .js2 file", function() {
+
+            engine = new CLIEngine({
+                extensions: [".js", ".js2"],
+                reset: true
+            });
+
+            var report = engine.executeOnFiles(["tests/fixtures/files/"]);
+            assert.equal(report.results.length, 2);
+            assert.equal(report.results[0].messages.length, 0);
+            assert.equal(report.results[1].messages.length, 0);
+        });
+
         it("should return one error message when given a config with rules with options and severity level set to error", function() {
 
             engine = new CLIEngine({

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -31,10 +31,16 @@ describe("cli", function() {
     });
 
     describe("execute()", function() {
-        it("should lint text when passed as argument", function() {
+        it("should return error when text with incorrect quotes is passed as argument", function() {
             var result = cli.execute("-c " + path.join(__dirname, "..", "..", ".eslintrc"), "var foo = 'bar';");
             assert.equal(result, 1);
         });
+
+        it("should return no error when --ext .js2 is specified", function() {
+            var result = cli.execute("--ext .js2 --reset ./tests/fixtures/files/");
+            assert.equal(result, 0);
+        });
+
     });
 
     describe("when given a config file", function() {

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -19,110 +19,144 @@ var assert = require("chai").assert,
  */
 
 describe("options", function() {
-    describe("when passed --help", function() {
-        it("should return true for .help", function() {
+    describe("--help", function() {
+        it("should return true for .help when passed", function() {
             var currentOptions = options.parse("--help");
             assert.isTrue(currentOptions.help);
         });
     });
 
-    describe("when passed -h", function() {
-        it("should return true for .help", function() {
+    describe("-h", function() {
+        it("should return true for .help when passed", function() {
             var currentOptions = options.parse("-h");
             assert.isTrue(currentOptions.help);
         });
     });
 
-    describe("when passed --config", function() {
-        it("should return a string for .config", function() {
+    describe("--config", function() {
+        it("should return a string for .config when passed a string", function() {
             var currentOptions = options.parse("--config file");
             assert.isString(currentOptions.config);
             assert.equal(currentOptions.config, "file");
         });
     });
 
-    describe("when passed -c", function() {
-        it("should return a string for .config", function() {
+    describe("-c", function() {
+        it("should return a string for .config when passed a string", function() {
             var currentOptions = options.parse("-c file");
             assert.isString(currentOptions.config);
             assert.equal(currentOptions.config, "file");
         });
     });
 
-    describe("when passed --rulesdir", function() {
-        it("should return a string for .rulesdir", function() {
+    describe("--ext", function() {
+        it("should return an array with one item when passed .jsx", function() {
+            var currentOptions = options.parse("--ext .jsx");
+            assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext[0], ".jsx");
+        });
+
+        it("should return an array with two items when passed .js and .jsx", function() {
+            var currentOptions = options.parse("--ext .jsx --ext .js");
+            assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext[0], ".jsx");
+            assert.equal(currentOptions.ext[1], ".js");
+        });
+
+        it("should return an array with two items when passed .jsx,.js", function() {
+            var currentOptions = options.parse("--ext .jsx,.js");
+            assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext[0], ".jsx");
+            assert.equal(currentOptions.ext[1], ".js");
+        });
+
+        it("should return an array one item when not passed", function() {
+            var currentOptions = options.parse("");
+            assert.isArray(currentOptions.ext);
+            assert.equal(currentOptions.ext[0], ".js");
+        });
+    });
+
+    describe("--rulesdir", function() {
+        it("should return a string for .rulesdir when passed a string", function() {
             var currentOptions = options.parse("--rulesdir /morerules");
             assert.isArray(currentOptions.rulesdir);
             assert.equal(currentOptions.rulesdir, "/morerules");
         });
     });
 
-    describe("when passed --format", function() {
-        it("should return a string for .format", function() {
+    describe("--format", function() {
+        it("should return a string for .format when passed a string", function() {
             var currentOptions = options.parse("--format compact");
             assert.isString(currentOptions.format);
             assert.equal(currentOptions.format, "compact");
         });
+
+        it("should return stylish for .format when not passed", function() {
+            var currentOptions = options.parse("");
+            assert.isString(currentOptions.format);
+            assert.equal(currentOptions.format, "stylish");
+        });
     });
 
-    describe("when passed -f", function() {
-        it("should return a string for .format", function() {
+    describe("-f", function() {
+        it("should return a string for .format when passed a string", function() {
             var currentOptions = options.parse("-f compact");
             assert.isString(currentOptions.format);
             assert.equal(currentOptions.format, "compact");
         });
     });
 
-    describe("when passed --version", function() {
-        it("should return true for .version", function() {
+    describe("--version", function() {
+        it("should return true for .version when passed", function() {
             var currentOptions = options.parse("--version");
             assert.isTrue(currentOptions.version);
         });
     });
 
-    describe("when passed -v", function() {
-        it("should return true for .version", function() {
+    describe("-v", function() {
+        it("should return true for .version when passed", function() {
             var currentOptions = options.parse("-v");
             assert.isTrue(currentOptions.version);
         });
     });
 
     describe("when asking for help", function() {
-        it("should return string of help text", function() {
+        it("should return string of help text when called", function() {
             var helpText = options.generateHelp();
             assert.isString(helpText);
         });
     });
 
-    describe("when passed --no-ignore", function() {
-        it("should return false for .ignore", function() {
+    describe("--no-ignore", function() {
+        it("should return false for .ignore when passed", function() {
             var currentOptions = options.parse("--no-ignore");
             assert.isFalse(currentOptions.ignore);
         });
     });
 
-    describe("when passed --ignore-path", function() {
-        it("should return a string for .ignorePath", function() {
+    describe("--ignore-path", function() {
+        it("should return a string for .ignorePath when passed", function() {
             var currentOptions = options.parse("--ignore-path .gitignore");
             assert.equal(currentOptions.ignorePath, ".gitignore");
         });
     });
 
-    describe("when passed --color", function() {
-        it("should return true for .color", function() {
+    describe("--color", function() {
+        it("should return true for .color when passed", function() {
             var currentOptions = options.parse("--color");
             assert.isTrue(currentOptions.color);
         });
     });
 
-    describe("when passed --stdin", function() {
-        it("should return true for .stdin", function() {
+    describe("--stdin", function() {
+        it("should return true for .stdin when passed", function() {
             var currentOptions = options.parse("--stdin");
             assert.isTrue(currentOptions.stdin);
         });
     });
 
-    describe("when passed --global", function() {
+    describe("--global", function() {
         it("should return an array for a single occurrence", function () {
             var currentOptions = options.parse("--global foo");
             assert.isArray(currentOptions.global);
@@ -155,15 +189,15 @@ describe("options", function() {
         });
     });
 
-    describe("when passed --plugin", function() {
-        it("should return an array for a single occurrence", function () {
+    describe("--plugin", function() {
+        it("should return an array when passed a single occurrence", function () {
             var currentOptions = options.parse("--plugin single");
             assert.isArray(currentOptions.plugin);
             assert.equal(currentOptions.plugin.length, 1);
             assert.equal(currentOptions.plugin[0], "single");
         });
 
-        it("should split variable names using commas", function() {
+        it("should return an array when passed a comma-delimiated string", function() {
             var currentOptions = options.parse("--plugin foo,bar");
             assert.isArray(currentOptions.plugin);
             assert.equal(currentOptions.plugin.length, 2);
@@ -171,7 +205,7 @@ describe("options", function() {
             assert.equal(currentOptions.plugin[1], "bar");
         });
 
-        it("should concatenate successive occurrences", function() {
+        it("should return an array when passed multiple times", function() {
             var currentOptions = options.parse("--plugin foo --plugin bar");
             assert.isArray(currentOptions.plugin);
             assert.equal(currentOptions.plugin.length, 2);
@@ -180,8 +214,8 @@ describe("options", function() {
         });
     });
 
-    describe("when passed --quiet", function () {
-        it("should return true for .quiet", function() {
+    describe("--quiet", function () {
+        it("should return true for .quiet when passed", function() {
             var currentOptions = options.parse("--quiet");
             assert.isTrue(currentOptions.quiet);
         });


### PR DESCRIPTION
Allows you to pass `--ext` to specify the file extensions to search.
