### PR TITLE
Build: Fix md to html conversion regex (fixes #1525)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -264,7 +264,7 @@ target.gensite = function() {
 
             text = "---\ntitle: ESLint\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n" + text;
 
-            text = text.replace(/\.md(.*)\)/g, ".html$1").replace("README.html", "index.html");
+            text = text.replace(/\.md(.*\))/g, ".html$1").replace("README.html", "index.html");
 
             if (filename.indexOf("rules/") !== -1 && baseName !== "README.md") {
                 var version = getFirstVersionOfFile(path.join("lib/rules", sourceBaseName));


### PR DESCRIPTION
Hopefully the problem is as simple as swapping the escape. It seemed to do the trick on the files I checked after I re-ran `npm run gensite`.
