### PR TITLE
Build: make the "gensite" target work when DOCS_DIR does not exist (fixes #1530)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -248,8 +248,10 @@ target.gensite = function() {
 
     echo("Generating eslint.org");
 
-    rm("-r", DOCS_DIR);
-    mkdir(DOCS_DIR);
+    if (test("-d", DOCS_DIR)) {
+        rm("-r", DOCS_DIR);
+    }
+    mkdir("-p", DOCS_DIR);
     cp("-rf", "docs/*", DOCS_DIR);
 
     find(DOCS_DIR).forEach(function(filename) {


### PR DESCRIPTION
With this patch, `Makefile.js` checks to see if `DOCS_DIR` exists before deleting it, then uses `mkdir -p` to create `DOCS_DIR`.
