### PR TITLE
Fix: comma-spacing has false positive when paranthesis are used (fixes #1457)

### DIFF
--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -26,7 +26,8 @@ module.exports = function(context) {
      * @returns {boolean} Whether or not there is space between the tokens.
      */
     function isSpaced(left, right) {
-        return left.range[1] < right.range[0];
+        var punctuationLength = context.getTokensBetween(left, right).length; // the length of any parenthesis
+        return (left.range[1] + punctuationLength) < right.range[0];
     }
 
     /**

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -30,6 +30,18 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
         "var a = (1 + 2, 2);",
         "a(b, c)",
         "new A(b, c)",
+        "foo((a), b)",
+        "var b = ((1 + 2), 2);",
+        "parseInt((a + b), 10)",
+        "go.boom((a + b), 10)",
+        "go.boom((a + b), 10, (4))",
+        "var x = [ (a + c), (b + b) ]",
+        "['  ,  ']",
+        "foo(/,/, 'a')",
+        "var x = ',,,,,';",
+        "var code = 'var foo = 1, bar = 3;',",
+        "['apples', \n 'oranges'];",
+        "{x: 'var x,y,z'}",
         {code: "var obj = {'foo':\n'bar' ,'baz':\n'qur'};", args: [2, {before: true, after: false}]},
         {code: "var a = 1 ,b = 2;", args: [2, {before: true, after: false}]},
         {code: "var arr = [1 ,2];", args: [2, {before: true, after: false}]},
@@ -100,6 +112,15 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
                     message: "A space is required after ','.",
                     type: "Literal"
                 },
+                {
+                    message: "There should be no space before ','.",
+                    type: "Literal"
+                }
+            ]
+        },
+        {
+            code: "var arr = [(1) , 2];",
+            errors: [
                 {
                     message: "There should be no space before ','.",
                     type: "Literal"


### PR DESCRIPTION
Added an additional check to make sure that we take into account any additional tokens between the comma and the nearest value (such as parenthesis).
