### PR TITLE
Fix: wrong op index in no-multi-spaces (fixes #1547)

### DIFF
--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -89,7 +89,7 @@ module.exports = function(context) {
      */
     function validateBetween(left, right) {
         var tokens = context.getTokensBetween(left, right, 1),
-            operatorIndex = findIndex(tokens, isOperator),
+            operatorIndex = findIndex(tokens.slice(1, -1), isOperator) + 1,
             op = tokens[operatorIndex];
 
         validate(tokens[operatorIndex - 1], op);

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -45,7 +45,8 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
         "[1, ]",
         "[ (  1  ) , (  2  ) ]",
         "a = 1, b = 2;",
-        "(function(a, b){})"
+        "(function(a, b){})",
+        "x.in = 0;"
     ],
 
     invalid: [


### PR DESCRIPTION
In the previously-failing test case `x.in = 0;`, the tokens from `getTokensBetween` were `['in', '=', '0'], and 'in' was coming back as the operator. This PR drops the first and last tokens that are just padding in order to find the actual operator.
