### PR TITLE
Enhancement: Add new-cap exception configurations. (Closes #1487)

### DIFF
--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -26,7 +26,7 @@ var colleague = person();
 
 ## Options
 
-By default all options are set to `true`.
+By default both `newIsCap` and `capIsNew` options are set to `true`.
 
 ### newIsCap
 
@@ -36,6 +36,26 @@ When `true`, rule checks if all `new` operators are called only with uppercase-s
 
 When `true`, rule checks if all uppercase-started functions are called only with `new` operator.
 
+### newIsCapExceptions
+
+Array of lowercase function names that are permitted to be used with the `new` operator.
+If provided, it must be an `Array`.
+
+### capIsNewExceptions
+
+Array of uppercase-starting function names that are permitted to be used without the `new` operator.
+If provided, it must be an `Array`.
+If not provided, `capIsNewExceptions` defaults to the following:
+ - `Object`
+ - `Function`
+ - `Number`
+ - `String`
+ - `Boolean`
+ - `Date`
+ - `Array`
+ - `Symbol`
+ - `RegExp`
+
 ## When Not To Use It
 
-If you have conventions that don't require an uppercase letter for constructors, turn this rule off.
+If you have conventions that don't require an uppercase letter for constructors, or don't require capitalized functions be only used as constructors, turn this rule off.

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Rule to flag use of constructors without capital letters
  * @author Nicholas C. Zakas
+ * @copyright 2014 Jordan Harband. All rights reserved.
  * @copyright 2013-2014 Nicholas C. Zakas. All rights reserved.
  */
 
@@ -18,6 +19,31 @@ var CAPS_ALLOWED = [
     "RegExp"
 ];
 
+/**
+ * Ensure that if the key is provided, it must be an array.
+ * @param {Object} obj Object to check with `key`.
+ * @param {string} key Object key to check on `obj`.
+ * @param {*} fallback If obj[key] is not present, this will be returned.
+ * @returns {string[]} Returns obj[key] if it's an Array, otherwise `fallback`
+ */
+function checkArray(obj, key, fallback) {
+    if (Object.prototype.hasOwnProperty.call(obj, key) && !Array.isArray(obj[key])) {
+        throw new TypeError(key + ", if provided, must be an Array");
+    }
+    return obj[key] || fallback;
+}
+
+/**
+ * A reducer function to invert an array to an Object mapping the string form of the key, to `true`.
+ * @param {Object} map Accumulator object for the reduce.
+ * @param {string} key Object key to set to `true`.
+ * @returns {Object} Returns the updated Object for further reduction.
+ */
+function invert(map, key) {
+    map[key] = true;
+    return map;
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -28,6 +54,10 @@ module.exports = function(context) {
     config.newIsCap = config.newIsCap === false ? false : true;
     config.capIsNew = config.capIsNew === false ? false : true;
 
+    var newIsCapExceptions = checkArray(config, "newIsCapExceptions", []).reduce(invert, {});
+
+    var capIsNewExceptions = checkArray(config, "capIsNewExceptions", CAPS_ALLOWED).reduce(invert, {});
+
     var listeners = {};
 
     //--------------------------------------------------------------------------
@@ -37,7 +67,7 @@ module.exports = function(context) {
     /**
      * Get exact callee name from expression
      * @param {ASTNode} node CallExpression or NewExpression node
-     * @returns {String} name
+     * @returns {string} name
      */
     function extractNameFromExpression(node) {
 
@@ -61,8 +91,8 @@ module.exports = function(context) {
     /**
      * Returns the capitalization state of the string -
      * Whether the first character is uppercase, lowercase, or non-alphabetic
-     * @param {String} str String
-     * @returns {String} capitalization state: "non-alpha", "lower", or "upper"
+     * @param {string} str String
+     * @returns {string} capitalization state: "non-alpha", "lower", or "upper"
      */
     function getCap(str) {
         var firstChar = str.charAt(0);
@@ -82,12 +112,13 @@ module.exports = function(context) {
 
     /**
      * Check if capitalization is allowed for a CallExpression
+     * @param {Object} allowedMap Object mapping calleeName to a Boolean
      * @param {ASTNode} node CallExpression node
-     * @param {String} calleeName Capitalized callee name from a CallExpression
+     * @param {string} calleeName Capitalized callee name from a CallExpression
      * @returns {Boolean} Returns true if the callee may be capitalized
      */
-    function isCapAllowed(node, calleeName) {
-        if (CAPS_ALLOWED.indexOf(calleeName) >= 0) {
+    function isCapAllowed(allowedMap, node, calleeName) {
+        if (allowedMap[calleeName]) {
             return true;
         }
         if (calleeName === "UTC" && node.callee.type === "MemberExpression") {
@@ -106,8 +137,12 @@ module.exports = function(context) {
         listeners.NewExpression = function(node) {
 
             var constructorName = extractNameFromExpression(node);
-            if (constructorName && getCap(constructorName) === "lower") {
-                context.report(node, "A constructor name should not start with a lowercase letter.");
+            if (constructorName) {
+                var capitalization = getCap(constructorName);
+                var isAllowed = capitalization !== "lower" || isCapAllowed(newIsCapExceptions, node, constructorName);
+                if (!isAllowed) {
+                    context.report(node, "A constructor name should not start with a lowercase letter.");
+                }
             }
         };
     }
@@ -116,8 +151,12 @@ module.exports = function(context) {
         listeners.CallExpression = function(node) {
 
             var calleeName = extractNameFromExpression(node);
-            if (calleeName && getCap(calleeName) === "upper" && !isCapAllowed(node, calleeName)) {
-                context.report(node, "A function with a name starting with an uppercase letter should only be used as a constructor.");
+            if (calleeName) {
+                var capitalization = getCap(calleeName);
+                var isAllowed = capitalization !== "upper" || isCapAllowed(capIsNewExceptions, node, calleeName);
+                if (!isAllowed) {
+                    context.report(node, "A function with a name starting with an uppercase letter should only be used as a constructor.");
+                }
             }
         };
     }

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -41,14 +41,16 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         "var x = Function('return 0')",
         "var x = _();",
         "var x = $();",
-        {code: "var x = Foo(42)", args: [1, {"capIsNew": false}]},
-        {code: "var x = bar.Foo(42)", args: [1, {"capIsNew": false}]},
+        { code: "var x = Foo(42)", args: [1, {"capIsNew": false}] },
+        { code: "var x = bar.Foo(42)", args: [1, {"capIsNew": false}] },
         "var x = bar[Foo](42)",
-        {code: "var x = bar['Foo'](42)", args: [1, {"capIsNew": false}]},
+        {code: "var x = bar['Foo'](42)", args: [1, {"capIsNew": false}] },
         "var x = Foo.bar(42)",
-        {code: "var x = new foo(42)", args: [1, {"newIsCap": false}]},
+        { code: "var x = new foo(42)", args: [1, {"newIsCap": false}] },
         "var o = { 1: function () {} }; o[1]();",
-        "var o = { 1: function () {} }; new o[1]();"
+        "var o = { 1: function () {} }; new o[1]();",
+        { code: "var x = Foo(42);", args: [1, { capIsNew: true, capIsNewExceptions: ["Foo"] }] },
+        { code: "var x = new foo(42);", args: [1, { newIsCap: true, newIsCapExceptions: ["foo"] }] }
     ],
     invalid: [
         { code: "var x = new c();", errors: [{ message: "A constructor name should not start with a lowercase letter.", type: "NewExpression"}] },
@@ -59,6 +61,7 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         { code: "var b = a.Foo();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
         { code: "var b = a['Foo']();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
         { code: "var b = a.Date.UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
-        { code: "var b = UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] }
+        { code: "var b = UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
+        { code: "var x = Object(42);", args: [1, { capIsNew: true, capIsNewExceptions: [] }], errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression" }] }
     ]
 });


### PR DESCRIPTION
Add the following two options for the `new-cap` rule:
- `newCapsAllowed`
- `nonNewCapsAllowed`

Fixes #1487.
