### PR TITLE
Rule: space-after-function-name (fixes #1340)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@ rules:
     no-nested-ternary: 2
     no-undefined: 2
     radix: 2
+    space-after-function-name: [2, "never"]
     space-after-keywords: [2, "always"]
     space-before-blocks: 2
     spaced-line-comment: [2, "always", { exceptions: ["-"]}]

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -133,6 +133,7 @@
         "radix": 0,
         "semi": 2,
         "sort-vars": 0,
+        "space-after-function-name": [0, "never"],
         "space-after-keywords": [0, "always"],
         "space-before-blocks": [0, "always"],
         "space-in-brackets": [0, "never"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -156,6 +156,7 @@ These rules are purely matters of style and are quite subjective.
 * [quotes](quotes.md) - specify whether double or single quotes should be used
 * [semi](semi.md) - require or disallow use of semicolons instead of ASI
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block (off by default)
+* [space-after-function-name](space-after-function-name.md) - require a space after function names (off by default)
 * [space-after-keywords](space-after-keywords.md) - require a space after certain keywords (off by default)
 * [space-before-blocks](space-before-blocks.md) - require or disallow space before blocks (off by default)
 * [space-in-brackets](space-in-brackets.md) - require or disallow spaces inside brackets (off by default)

--- a/docs/rules/space-after-function-name.md
+++ b/docs/rules/space-after-function-name.md
@@ -1,0 +1,50 @@
+# Require or disallow spaces following function names (space-after-function-name)
+
+Whitespace between a function name and its parameter list is optional.
+
+```js
+function withoutSpace(x) {
+	// ...
+}
+
+function withSpace (x) {
+	// ...
+}
+```
+
+Some style guides may require a consistent spacing for function names.
+
+## Rule Details
+
+This rule aims to enforce a consistent spacing after function names. It takes one argument. If it is `"always"` then all function names must be followed by at least one space. If `"never"` then there should be no spaces between the name and the parameter list. The default is `"never"`.
+
+
+The following patterns are considered warnings:
+
+```js
+function foo (x) {
+	// ...
+}
+
+var x = function named (x) {};
+
+// When [1, "always"]
+function bar(x) {
+	// ...
+}
+```
+
+The following patterns are not warnings:
+
+```js
+function foo(x) {
+	// ...
+}
+
+var x = function named(x) {};
+
+// When [1, "always"]
+function bar (x) {
+	// ...
+}
+```

--- a/lib/rules/space-after-function-name.js
+++ b/lib/rules/space-after-function-name.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview Rule to enforce consistent spacing after function names
+ * @author Roberto Vidal
+ * @copyright 2014 Roberto Vidal. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var requiresSpace = context.options[0] === "always";
+
+    /**
+     * Reports if the give named function node has the correct spacing after its name
+     *
+     * @param {ASTNode} node  The node to which the potential problem belongs.
+     * @returns {void}
+     */
+    function check(node) {
+        var tokens = context.getFirstTokens(node, 3),
+            hasSpace = tokens[1].range[1] < tokens[2].range[0];
+
+        if (hasSpace !== requiresSpace) {
+            context.report(node, "Function name \"{{name}}\" must {{not}}be followed by whitespace.", {
+                name: node.id.name,
+                not: requiresSpace ? "" : "not "
+            });
+        }
+    }
+
+    return {
+        "FunctionDeclaration": check,
+        "FunctionExpression": function (node) {
+            if (node.id) {
+                check(node);
+            }
+        }
+    };
+
+};

--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -33,7 +33,7 @@ module.exports = function (context) {
      * @param {ASTNode[]} statements - collection of ASTNodes for the parent node block
      * @returns {Boolean} True if var is on top otherwise false
      */
-    function isVarOnTop (node, statements) {
+    function isVarOnTop(node, statements) {
         var i = 0, l = statements.length;
 
         // skip over directives
@@ -59,7 +59,7 @@ module.exports = function (context) {
      * @param {ASTNode} parent - Parent of the node
      * @returns {void}
      */
-    function globalVarCheck (node, parent) {
+    function globalVarCheck(node, parent) {
         if (!isVarOnTop(node, parent.body)) {
             context.report(node, errorMessage);
         }
@@ -72,7 +72,7 @@ module.exports = function (context) {
      * @param {ASTNode} grandParent - Parent of the node's parent
      * @returns {void}
      */
-    function blockScopeVarCheck (node, parent, grandParent) {
+    function blockScopeVarCheck(node, parent, grandParent) {
         if (!((grandParent.type === "FunctionDeclaration"
             || grandParent.type === "FunctionExpression")
             && parent.type === "BlockStatement"

--- a/tests/lib/rules/space-after-function-name.js
+++ b/tests/lib/rules/space-after-function-name.js
@@ -1,0 +1,83 @@
+/**
+ * @fileoverview Rule to enforce consistent spacing after function names
+ * @author Roberto Vidal
+ * @copyright 2014 Roberto Vidal. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/space-after-function-name", {
+
+    valid: [
+        { args: [2, "never"], code: "function foo() {}" },
+        { args: [2, "never"], code: "var x = function foo() {}" },
+        { args: 2, code: "function foo() {}" },
+        { args: 2, code: "var x = function foo() {}" },
+        { args: [2, "always"], code: "var x = function foo () {}" },
+        { args: [2, "always"], code: "function foo () {}" },
+        { args: [2, "always"], code: "var x = function() {}" },
+        { args: [2, "never"], code: "var x = function () {}" }
+    ],
+
+    invalid: [
+        {
+            args: [2, "never"],
+            code: "function foo (x) {}",
+            errors: [{
+                message: "Function name \"foo\" must not be followed by whitespace.",
+                type: "FunctionDeclaration"
+            }]
+        },
+        {
+            args: [2, "never"],
+            code: "var x = function bar (x) {}",
+            errors: [{
+                message: "Function name \"bar\" must not be followed by whitespace.",
+                type: "FunctionExpression"
+            }]
+        },
+        {
+            args: 2,
+            code: "function foo (x) {}",
+            errors: [{
+                message: "Function name \"foo\" must not be followed by whitespace.",
+                type: "FunctionDeclaration"
+            }]
+        },
+        {
+            args: 2,
+            code: "var x = function bar (x) {}",
+            errors: [{
+                message: "Function name \"bar\" must not be followed by whitespace.",
+                type: "FunctionExpression"
+            }]
+        },
+        {
+            args: [2, "always"],
+            code: "function baz(x) {}",
+            errors: [{
+                message: "Function name \"baz\" must be followed by whitespace.",
+                type: "FunctionDeclaration"
+            }]
+        },
+        {
+            args: [2, "always"],
+            code: "var x = function qux(x) {}",
+            errors: [{
+                message: "Function name \"qux\" must be followed by whitespace.",
+                type: "FunctionExpression"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
Adds a new rule, `space-after-function-name`, that enforces consistent spacing between a function name and its parameters. The rule is off by default. If activated, it defaults to "never": no space between name and parameters.
