### PR TITLE
Fix: simplify comma-spacing logic (fixes #1562)

### DIFF
--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -52,34 +52,16 @@ module.exports = function(context) {
     }
 
     /**
-     * Run report.
-     * @param {ASTNode} node The binary expression node to check.
-     * @param {string} msg The error msg to show.
-     * @private
+     * Reports a spacing error with an appropriate message.
+     * @param {ASTNode} node The binary expression node to report.
+     * @param {string} dir Is the error "before" or "after" the comma?
      * @returns {void}
-     */
-    function report(node, msg) {
-        context.report(node, msg);
-    }
-
-    /**
-     * Show space required message.
-     * @param {string} dir The location of spacing.
      * @private
-     * @returns {string} The spacing error msg.
      */
-    function getSpaceReqMsg(dir) {
-        return "A space is required " + dir + " ','.";
-    }
-
-    /**
-     * Show no space message.
-     * @param {string} dir The location of spacing
-     * @private
-     * @returns {string} The spacing error msg.
-     */
-    function getNoSpaceMsg(dir) {
-        return "There should be no space " + dir + " ','.";
+    function report(node, dir) {
+        context.report(node, options[dir] ?
+            "A space is required " + dir + " ','." :
+            "There should be no space " + dir + " ','.");
     }
 
     /**
@@ -95,34 +77,11 @@ module.exports = function(context) {
         if (isSameLine(previousItemToken, commaToken) &&
                 isSameLine(commaToken, currentItemToken)) {
 
-            if (options.before && options.after) {
-                if (!isSpaced(previousItemToken, commaToken)) {
-                    report(reportItem, getSpaceReqMsg("before"));
-                }
-                if (!isSpaced(commaToken, currentItemToken)) {
-                    report(reportItem, getSpaceReqMsg("after"));
-                }
-            } else if (options.before) {
-                if (!isSpaced(previousItemToken, commaToken)) {
-                    report(reportItem, getSpaceReqMsg("before"));
-                }
-                if (isSpaced(commaToken, currentItemToken)) {
-                    report(reportItem, getNoSpaceMsg("after"));
-                }
-            } else if (options.after) {
-                if (!isSpaced(commaToken, currentItemToken)) {
-                    report(reportItem, getSpaceReqMsg("after"));
-                }
-                if (isSpaced(previousItemToken, commaToken)) {
-                    report(reportItem, getNoSpaceMsg("before"));
-                }
-            } else {
-                if (isSpaced(previousItemToken, commaToken)) {
-                    report(reportItem, getNoSpaceMsg("before"));
-                }
-                if (isSpaced(commaToken, currentItemToken)) {
-                    report(reportItem, getNoSpaceMsg("after"));
-                }
+            if (options.before !== isSpaced(previousItemToken, commaToken)) {
+                report(reportItem, "before");
+            }
+            if (options.after !== isSpaced(commaToken, currentItemToken)) {
+                report(reportItem, "after");
             }
         }
     }

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -89,11 +89,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             code: "var a = 1 ,b = 2;",
             errors: [
                 {
-                    message: "A space is required after ','.",
+                    message: "There should be no space before ','.",
                     type: "VariableDeclarator"
                 },
                 {
-                    message: "There should be no space before ','.",
+                    message: "A space is required after ','.",
                     type: "VariableDeclarator"
                 }
             ]
@@ -139,11 +139,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             code: "var arr = [1 ,2];",
             errors: [
                 {
-                    message: "A space is required after ','.",
+                    message: "There should be no space before ','.",
                     type: "Literal"
                 },
                 {
-                    message: "There should be no space before ','.",
+                    message: "A space is required after ','.",
                     type: "Literal"
                 }
             ]
@@ -242,11 +242,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             args: [2, {before: false, after: true}],
             errors: [
                 {
-                    message: "A space is required after ','.",
+                    message: "There should be no space before ','.",
                     type: "Identifier"
                 },
                 {
-                    message: "There should be no space before ','.",
+                    message: "A space is required after ','.",
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
Three of the tests had the "after" error coming before the "before" error. The altered code always checks before the comma before it checks after the comma, so I swapped the expected error messages around, resulting in what to me seems like a more natural ordering.
