### PR TITLE
Fix: operator-assignment is not commutative (fixes #1556)

### DIFF
--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -2,19 +2,21 @@
 
 JavaScript provides shorthand operators that combine variable assignment and some simple mathematical operations. For example, `x = x + 4` can be shortened to `x += 4`. The supported shorthand forms are as follows:
 
-Shorthand|Separate
----------|--------
-`x += y`|`x = x + y`
-`x -= y`|`x = x - y`
-`x *= y`|`x = x * y`
-`x /= y`|`x = x / y`
-`x %= y`|`x = x % y`
-`x <<= y`|`x = x << y`
-`x >>= y`|`x = x >> y`
-`x >>>= y`|`x = x >>> y`
-`x &= y`|`x = x & y`
-`x ^= y`|`x = x ^ y`
-`x |= y`|`x = x | y`
+```plain
+ Shorthand | Separate
+-----------|------------
+ x += y    | x = x + y
+ x -= y    | x = x - y
+ x *= y    | x = x * y
+ x /= y    | x = x / y
+ x %= y    | x = x % y
+ x <<= y   | x = x << y
+ x >>= y   | x = x >> y
+ x >>>= y  | x = x >>> y
+ x &= y    | x = x & y
+ x ^= y    | x = x ^ y
+ x |= y    | x = x | y
+```
 
 ## Rule Details
 
@@ -35,6 +37,7 @@ x = y * z;
 x = (x * y) * z;
 x[0] /= y;
 x[foo()] = x[foo()] % 2;
+x = y + x; // `+` is not always commutative (e.g. x = "abc")
 ```
 
 The following patterns are considered warnings and should be replaced by their shorthand equivalents:

--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -17,7 +17,7 @@
  *     shorthand form.
  */
 function isCommutativeOperatorWithShorthand(operator) {
-    return ["+", "*", "&", "^", "|"].indexOf(operator) >= 0;
+    return ["*", "&", "^", "|"].indexOf(operator) >= 0;
 }
 
 /**
@@ -28,7 +28,7 @@ function isCommutativeOperatorWithShorthand(operator) {
  *     a shorthand form.
  */
 function isNonCommutativeOperatorWithShorthand(operator) {
-    return ["-", "/", "%", "<<", ">>", ">>>"].indexOf(operator) >= 0;
+    return ["+", "-", "/", "%", "<<", ">>", ">>>"].indexOf(operator) >= 0;
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/operator-assignment.js
+++ b/tests/lib/rules/operator-assignment.js
@@ -11,11 +11,16 @@
 var eslint = require("../../../lib/eslint"),
     ESLintTester = require("eslint-tester");
 
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/operator-assignment", {
 
     valid: [
         "x = y",
+        "x = y + x",
         "x += x + y",
         "x = (x + y) - z",
         "x -= y",
@@ -46,6 +51,7 @@ eslintTester.addRuleTest("lib/rules/operator-assignment", {
         "x = x !== y",
         "x[y] = x['y'] + z",
         "x.y = x['y'] / z",
+        "x.y = z + x.y",
         "x[fn()] = x[fn()] + y",
         {
             code: "x += x + y",
@@ -74,12 +80,6 @@ eslintTester.addRuleTest("lib/rules/operator-assignment", {
             type: "AssignmentExpression"
         }]
     }, {
-        code: "x = y + x",
-        errors: [{
-            message: "Assignment can be replaced with operator assignment.",
-            type: "AssignmentExpression"
-        }]
-    }, {
         code: "x = x - y",
         errors: [{
             message: "Assignment can be replaced with operator assignment.",
@@ -87,6 +87,12 @@ eslintTester.addRuleTest("lib/rules/operator-assignment", {
         }]
     }, {
         code: "x = x * y",
+        errors: [{
+            message: "Assignment can be replaced with operator assignment.",
+            type: "AssignmentExpression"
+        }]
+    }, {
+        code: "x = y * x",
         errors: [{
             message: "Assignment can be replaced with operator assignment.",
             type: "AssignmentExpression"
@@ -141,12 +147,6 @@ eslintTester.addRuleTest("lib/rules/operator-assignment", {
         }]
     }, {
         code: "x = x | y",
-        errors: [{
-            message: "Assignment can be replaced with operator assignment.",
-            type: "AssignmentExpression"
-        }]
-    }, {
-        code: "x.y = z + x.y",
         errors: [{
             message: "Assignment can be replaced with operator assignment.",
             type: "AssignmentExpression"


### PR DESCRIPTION
I also noticed that the table on http://eslint.org/docs/rules/operator-assignment.html wasn't getting rendered properly (I'm guessing it's another issue with the renderer because it seems to render properly elsewhere), so I put the whole table in a fenced code block.
