### PR TITLE
Update: add yoda exception for range tests (fixes #1561)

### DIFF
--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -53,6 +53,12 @@ if (color == "blue") {
 }
 ```
 
+```js
+if (0 <= x && x < 1) {
+    // ...
+}
+```
+
 The following patterns are not considered warnings:
 
 ```js
@@ -74,6 +80,33 @@ if ("blue" == value) {
 }
 ```
 
+### Range Tests
+
+"Range" comparisons test whether a variable is inside or outside the range between two literals. When configured with the `exceptRange` option, range tests are allowed when the comparison itself is wrapped directly in parentheses, such as those of an `if` or `while` condition.
+
+```json
+"yoda": [2, "never", { "exceptRange": true }]
+```
+
+With the `exceptRange` option enabled, the following patterns become valid:
+
+```js
+function isRedish(color) {
+    return (color.hue < 60 || 300 < color.hue);
+}
+```
+
+```js
+if (count < 10 && (0 <= rand && rand < 1)) {
+    // ...
+}
+```
+
+```js
+function howLong(arr) {
+    return (0 <= arr.length && arr.length < 10) ? "short" : "long";
+}
+```
 
 ## Further Reading
 

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -1,8 +1,63 @@
 /**
  * @fileoverview Rule to require or disallow yoda comparisons
  * @author Nicholas C. Zakas
+ * @copyright 2014 Nicholas C. Zakas. All rights reserved.
+ * @copyright 2014 Brandon Mills. All rights reserved.
  */
 "use strict";
+
+//--------------------------------------------------------------------------
+// Helpers
+//--------------------------------------------------------------------------
+
+/**
+ * Determines whether an operator is a comparison operator.
+ * @param {String} operator The operator to check.
+ * @returns {Boolean} Whether or not it is a comparison operator.
+ */
+function isComparisonOperator(operator) {
+    return (/^(==|===|!=|!==|<|>|<=|>=)$/).test(operator);
+}
+
+/**
+ * Determines whether an operator is one used in a range test.
+ * Allowed operators are `<` and `<=`.
+ * @param {String} operator The operator to check.
+ * @returns {Boolean} Whether the operator is used in range tests.
+ */
+function isRangeTestOperator(operator) {
+    return ["<", "<="].indexOf(operator) >= 0;
+}
+
+/**
+ * Checks whether two expressions reference the same value. For example:
+ *     a = a
+ *     a.b = a.b
+ *     a[0] = a[0]
+ *     a['b'] = a['b']
+ * @param   {ASTNode} a Left side of the comparison.
+ * @param   {ASTNode} b Right side of the comparison.
+ * @returns {Boolean}   True if both sides match and reference the same value.
+ */
+function same(a, b) {
+    if (a.type !== b.type) {
+        return false;
+    }
+
+    switch (a.type) {
+        case "Identifier":
+            return a.name === b.name;
+        case "Literal":
+            return a.value === b.value;
+        case "MemberExpression":
+            // x[0] = x[0]
+            // x[y] = x[y]
+            // x.y = x.y
+            return same(a.object, b.object) && same(a.property, b.property);
+        default:
+            return false;
+    }
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -11,20 +66,69 @@
 module.exports = function (context) {
 
     // Default to "never" (!always) if no option
-
     var always = (context.options[0] === "always");
-
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
+    var exceptRange = (context.options[1] && context.options[1].exceptRange);
 
     /**
-     * Determines whether an operator is a comparison operator.
-     * @param {String} operator The operator to check.
-     * @returns {Boolean} Whether or not it is a comparison operator.
+     * Determines whether node represents a range test.
+     * A range test is a "between" test like `(0 <= x && x < 1)` or an "outside"
+     * test like `(x < 0 || 1 <= x)`. It must be wrapped in parentheses, and
+     * both operators must be `<` or `<=`. Finally, the literal on the left side
+     * must be less than or equal to the literal on the right side so that the
+     * test makes any sense.
+     * @param {ASTNode} node LogicalExpression node to test.
+     * @returns {Boolean} Whether node is a range test.
      */
-    function isComparisonOperator(operator) {
-        return (/^(==|===|!=|!==|<|>|<=|>=)$/).test(operator);
+    function isRangeTest(node) {
+        var left = node.left,
+            right = node.right;
+
+        /**
+         * Determines whether node is of the form `0 <= x && x < 1`.
+         * @returns {Boolean} Whether node is a "between" range test.
+         */
+        function isBetweenTest() {
+            return (node.operator === "&&" &&
+                left.left.type === "Literal" &&
+                right.right.type === "Literal" &&
+                left.left.value <= right.right.value &&
+                same(left.right, right.left));
+        }
+
+        /**
+         * Determines whether node is of the form `x < 0 || 1 <= x`.
+         * @returns {Boolean} Whether node is an "outside" range test.
+         */
+        function isOutsideTest() {
+            return (node.operator === "||" &&
+                left.right.type === "Literal" &&
+                right.left.type === "Literal" &&
+                left.right.value <= right.left.value &&
+                same(left.left, right.right));
+        }
+
+        /**
+         * Determines whether node is wrapped in parentheses.
+         * @returns {Boolean} Whether node is preceded immediately by an open
+         *                    paren token and followed immediately by a close
+         *                    paren token.
+         */
+        function isParenWrapped() {
+            var tokenBefore, tokenAfter;
+
+            return ((tokenBefore = context.getTokenBefore(node)) &&
+                tokenBefore.value === "(" &&
+                (tokenAfter = context.getTokenAfter(node)) &&
+                tokenAfter.value === ")");
+        }
+
+        return (node.type === "LogicalExpression" &&
+            left.type === "BinaryExpression" &&
+            right.type === "BinaryExpression" &&
+            isRangeTestOperator(left.operator) &&
+            isRangeTestOperator(right.operator) &&
+            (isBetweenTest() || isOutsideTest()) &&
+            isParenWrapped());
     }
 
     //--------------------------------------------------------------------------
@@ -32,29 +136,29 @@ module.exports = function (context) {
     //--------------------------------------------------------------------------
 
     return {
+        "BinaryExpression": always ? function(node) {
 
-        "BinaryExpression": function (node) {
+            // Comparisons must always be yoda-style: if ("blue" === color)
+            if (
+                node.right.type === "Literal" &&
+                isComparisonOperator(node.operator) &&
+                !(exceptRange && isRangeTest(context.getAncestors().pop()))
+            ) {
+                context.report(node, "Expected literal to be on the left side of " + node.operator + ".");
+            }
 
-            if (always) {
+        } : function(node) {
 
-                // Comparisons must always be yoda-style: if ("blue" === color)
-
-                if (node.right.type === "Literal" && isComparisonOperator(node.operator)) {
-                    context.report(node, "Expected literal to be on the left side of " + node.operator + ".");
-                }
-
-            } else {
-
-                // Comparisons must never be yoda-style (default)
-
-                if (node.left.type === "Literal" && isComparisonOperator(node.operator)) {
-                    context.report(node, "Expected literal to be on the right side of " + node.operator + ".");
-                }
-
+            // Comparisons must never be yoda-style (default)
+            if (
+                node.left.type === "Literal" &&
+                isComparisonOperator(node.operator) &&
+                !(exceptRange && isRangeTest(context.getAncestors().pop()))
+            ) {
+                context.report(node, "Expected literal to be on the right side of " + node.operator + ".");
             }
 
         }
-
     };
 
 };

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -16,20 +16,53 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/yoda", {
     valid: [
-        { code: "if (value === \"red\") {}", args: ["2", "never"] },
-        { code: "if (value === value) {}", args: ["2", "never"] },
-        { code: "if (value != 5) {}", args: ["2", "never"] },
-        { code: "if (5 & foo) {}", args: ["2", "never"] },
-        { code: "if (\"blue\" === value) {}", args: ["2", "always"] },
-        { code: "if (value === value) {}", args: ["2", "always"] },
-        { code: "if (4 != value) {}", args: ["2", "always"] },
-        { code: "if (foo & 4) {}", args: ["2", "always"] }
+        // "never" mode
+        { code: "if (value === \"red\") {}", args: [2, "never"] },
+        { code: "if (value === value) {}", args: [2, "never"] },
+        { code: "if (value != 5) {}", args: [2, "never"] },
+        { code: "if (5 & foo) {}", args: [2, "never"] },
+
+        // "always" mode
+        { code: "if (\"blue\" === value) {}", args: [2, "always"] },
+        { code: "if (value === value) {}", args: [2, "always"] },
+        { code: "if (4 != value) {}", args: [2, "always"] },
+        { code: "if (foo & 4) {}", args: [2, "always"] },
+
+        // Range exception
+        {
+            code: "if (0 < x && x <= 1) {}",
+            args: [2, "never", { exceptRange: true }]
+        }, {
+            code: "if (x < 0 || 1 <= x) {}",
+            args: [2, "never", { exceptRange: true }]
+        }, {
+            code: "if (0 <= x && x < 1) {}",
+            args: [2, "always", { exceptRange: true }]
+        }, {
+            code: "if (x <= 'bar' || 'foo' < x) {}",
+            args: [2, "always", { exceptRange: true }]
+        }, {
+            code: "if ('blue' < x.y && x.y < 'green') {}",
+            args: [2, "never", { exceptRange: true }]
+        }, {
+            code: "if (0 <= x['y'] && x['y'] <= 100) {}",
+            args: [2, "never", { exceptRange: true }]
+        }, {
+            code: "if (a < 0 && (0 < b && b < 1)) {}",
+            args: [2, "never", { exceptRange: true }]
+        }, {
+            code: "if ((0 < a && a < 1) && b < 0) {}",
+            args: [2, "never", { exceptRange: true }]
+        }, {
+            code: "if (a < 4 || (b[c[0]].d['e'] < 0 || 1 <= b[c[0]].d['e'])) {}",
+            args: [2, "never", { exceptRange: true }]
+        }
     ],
     invalid: [
 
         {
             code: "if (\"red\" == value) {}",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of ==.",
@@ -39,7 +72,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "if (true === value) {}",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of ===.",
@@ -49,7 +82,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "if (5 != value) {}",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of !=.",
@@ -59,7 +92,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "if (null !== value) {}",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of !==.",
@@ -69,7 +102,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "if (\"red\" <= value) {}",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of <=.",
@@ -79,7 +112,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "if (true >= value) {}",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of >=.",
@@ -89,7 +122,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "var foo = (5 < value) ? true : false",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of <.",
@@ -99,7 +132,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "function foo() { return (null > value); }",
-            args: ["2", "never"],
+            args: [2, "never"],
             errors: [
                 {
                     message: "Expected literal to be on the right side of >.",
@@ -109,7 +142,7 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "if (value == \"red\") {}",
-            args: ["2", "always"],
+            args: [2, "always"],
             errors: [
                 {
                     message: "Expected literal to be on the left side of ==.",
@@ -119,10 +152,79 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         },
         {
             code: "if (value === true) {}",
-            args: ["2", "always"],
+            args: [2, "always"],
             errors: [
                 {
                     message: "Expected literal to be on the left side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (a < 0 && 0 <= b && b < 1) {}",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (0 <= a && a < 1 && b < 1) {}",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (1 < a && a < 0) {}",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "0 < a && a < 1",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "var a = b < 0 || 1 <= b;",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "var a = (b < 0 && 0 <= b);",
+            args: [2, "always", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the left side of <.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (0 <= x && x < 1) {}",
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
                     type: "BinaryExpression"
                 }
             ]


### PR DESCRIPTION
This is a possible implementation of #1561 to see whether it's worth pursuing. This is the most restrictive version I could imagine being reasonable, on the assumption that we can drop restrictions if it's too complex. In order to qualify for the exception, a BinaryExpression's parent must be:
- A `LogicalExpression`...
- ...containing two `BinaryExpression`s...
- ...whose tests are both `<` or `<=`...
- ...either an `&&` "between" test...
  - ...with literals describing a range on the exterior...
  - ...and the same expression on the interior...
- ...or an `||` "outside" test...
  - ...with literals describing a range on the interior...
  - ...and the same expression on the exterior...
- ...that is wrapped in parens.

For example:
- `var a = 0 < b && b < 1 ? "between" : "outside";` would fail, but `var a = (0 < b && b < 1) ? "between" : "outside";` would pass.
- "Outside" tests such as `if (x < 0 || 1 <= x) {}` would pass.
- `if (1 <= x && x < 0) {}` makes no sense, so it would fail, but `if (0 <= x && x < 1) {}` would pass.
- `if (a < 1 && 1 < x && x < 10) {}` would fail, but wrapping it in parens `if (a < 1 && (a < x && x < 10)) {}` would let it pass.
- "Backwards" tests `if (6 > x && x > 5) {}` are not included in this exception.

_Edit: Add "outside" exception._
