### PR TITLE
New: Configuration via package.json (fixes #698)

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -22,26 +22,24 @@ The command line utility has several options. You can view the options by runnin
 eslint [options] file.js [file.js] [dir]
 
 Options:
-  -h, --help                 Show help.
-  -c, --config path::String  Load configuration data from this file.
-  --rulesdir [path::String]  Load additional rules from this directory.
-  -f, --format String        Use a specific output format. - default: stylish
-  -v, --version              Outputs the version number.
-  --reset                    Set all default rules to off.
-  --eslintrc                 Enable loading .eslintrc configuration. -
-                             default: true
-  --env [String]             Specify environments.
-  --ext [String]             Specify JavaScript file extensions. - default: .js
-  --plugin [String]          Specify plugins.
-  --global [String]          Define global variables.
-  --rule Object              Specify rules.
-  --ignore-path path::String  Specify the file that contains patterns of files
-                              to ignore.
-  --ignore                   Enable loading of .eslintignore. - default: true
-  --color                    Enable color in piped output. - default: true
-  -o, --output-file path::String  Enable report to be written to a file.
-  --quiet                    Report errors only. - default: false
-  --stdin                    Lint code provided on <STDIN>. - default: false
+  -h, --help                 Show help
+  -c, --config path::String  Use configuration from this file
+  --rulesdir [path::String]  Use additional rules from this directory
+  -f, --format String        Use a specific output format - default: stylish
+  -v, --version              Outputs the version number
+  --reset                    Set all default rules to off
+  --eslintrc                 Use configuration from .eslintrc - default: true
+  --env [String]             Specify environments
+  --ext [String]             Specify JavaScript file extensions - default: .js
+  --plugin [String]          Specify plugins
+  --global [String]          Define global variables
+  --rule Object              Specify rules
+  --ignore-path path::String  Specify path of ignore file
+  --ignore                   Use .eslintignore - default: true
+  --color                    Use color in piped output - default: true
+  -o, --output-file path::String  Specify file to write report to
+  --quiet                    Report errors only - default: false
+  --stdin                    Lint code provided on <STDIN> - default: false
 ```
 
 ### `-h`, `--help`
@@ -125,7 +123,7 @@ Example:
 
 ### `--eslintrc`
 
-This option, on by default, enables automatically loading `.eslintrc` configuration files. Use as `--no-eslintrc` to disable.
+This option, on by default, specifies whether to use configuration from `.eslintrc` and `package.json` files. Use as `--no-eslintrc` to disable.
 
 Example
 

--- a/docs/developer-guide/architecture.md
+++ b/docs/developer-guide/architecture.md
@@ -37,7 +37,7 @@ This object's responsibilities include:
 * Managing the execution environment for `eslint`
 * Reading from the file system
 * Loading rule definitions
-* Reading configuration information from config files (including `.eslintrc`)
+* Reading configuration information from config files (including `.eslintrc` and `package.json`)
 
 This object may not:
 

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -92,7 +92,7 @@ var cli = new CLIEngine({
 });
 ```
 
-In this code, a new `CLIEngine` instance is created that sets two environments, `"browser"` and `"mocha"`, disables loading of `.eslintrc` files, and enables the `semi` rule as an error. You can then call methods on `cli` and these options will be used to perform the correct action.
+In this code, a new `CLIEngine` instance is created that sets two environments, `"browser"` and `"mocha"`, disables loading of `.eslintrc` and `package.json` files, and enables the `semi` rule as an error. You can then call methods on `cli` and these options will be used to perform the correct action.
 
 ### executeOnFiles()
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -3,6 +3,7 @@
  * @author Seth McLaughlin
  * @copyright 2014 Nicholas C. Zakas. All rights reserved.
  * @copyright 2013 Seth McLaughlin. All rights reserved.
+ * @copyright 2014 Michael McLaughlin. All rights reserved.
  */
 "use strict";
 
@@ -25,8 +26,10 @@ var fs = require("fs"),
 // Constants
 //------------------------------------------------------------------------------
 
-var CONFIG_FILENAME = ".eslintrc",
-    PERSONAL_CONFIG_PATH = path.join(userHome, CONFIG_FILENAME);
+var PACKAGE_CONFIG_FILENAME = "package.json",
+    PACKAGE_CONFIG_FIELD_NAME = "eslintConfig",
+    LOCAL_CONFIG_FILENAME = ".eslintrc",
+    PERSONAL_CONFIG_PATH = path.join(userHome, LOCAL_CONFIG_FILENAME);
 
 //------------------------------------------------------------------------------
 // Private
@@ -67,11 +70,13 @@ function loadConfig(filePath) {
  */
 function getPluginsConfig(pluginNames) {
     var pluginConfig = {};
+
     if (pluginNames) {
         pluginNames.forEach(function (pluginName) {
             var pluginNameWithoutPrefix = util.removePluginPrefix(pluginName),
                 plugin = {},
                 rules = {};
+
             if (!loadedPlugins[pluginNameWithoutPrefix]) {
                 try {
                     plugin = require(util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
@@ -117,40 +122,52 @@ function getPersonalConfig() {
 
 /**
  * Get a local config object.
- * @param {Config} helper The configuration helper to use.
- * @param {string} directory the directory to start looking for a local config
- * @returns {Object} the local config object (empty object if there is no local config)
+ * @param {Object} thisConfig A Config object.
+ * @param {string} directory The directory to start looking in for a local config file.
+ * @returns {Object} The local config object, or an empty object if there is no local config.
  */
-function getLocalConfig(helper, directory) {
-    var localConfigFile,
-        config = {},
+function getLocalConfig(thisConfig, directory) {
+    var found,
+        i,
+        localConfig,
+        localConfigFile,
+        localConfigFiles = thisConfig.findLocalConfigFiles(directory),
+        localConfigFilesCount = localConfigFiles.length,
         parentDirectory,
-        found = false;
+        config = {};
 
-    while ((localConfigFile = helper.findLocalConfigFile(directory))) {
-        // don't automatically merge the personal config settings
-        if (localConfigFile === PERSONAL_CONFIG_PATH) {
-            break;
+    while (localConfigFilesCount) {
+
+        // Iterate through the files and merge the found config.
+        for (i = 0; i < localConfigFilesCount; i++) {
+            localConfigFile = localConfigFiles[i];
+            localConfig = loadConfig(localConfigFile);
+
+            if (path.basename(localConfigFile) !== LOCAL_CONFIG_FILENAME) {
+
+                // Don't consider a local config file found if the package.json doesn't have the eslintConfig field.
+                if (!localConfig.hasOwnProperty(PACKAGE_CONFIG_FIELD_NAME)) {
+                    continue;
+                }
+                localConfig = localConfig[PACKAGE_CONFIG_FIELD_NAME] || {};
+            }
+            found = true;
+            debug("Using " + localConfigFile);
+            config = util.mergeConfigs(localConfig, config);
         }
 
-        found = true;
-
-        debug("Using " + localConfigFile);
-        config = util.mergeConfigs(loadConfig(localConfigFile), config);
-
         parentDirectory = path.dirname(directory);
+
         if (directory === parentDirectory) {
             break;
         }
-
         directory = parentDirectory;
+        localConfigFiles = thisConfig.findLocalConfigFiles(directory);
+        localConfigFilesCount = localConfigFiles.length;
     }
 
-    if (!found) {
-        config = util.mergeConfigs(config, getPersonalConfig());
-    }
-
-    return config;
+    // Use the personal config file if there are no other local config files found.
+    return found ? config : util.mergeConfigs(config, getPersonalConfig());
 }
 
 /**
@@ -175,7 +192,9 @@ function createEnvironmentConfig(envs, reset) {
             return envs[name];
         }).forEach(function(name) {
             var environment = environments[name];
+
             if (environment) {
+
                 if (!reset && environment.rules) {
                     assign(envConfig.rules, environment.rules);
                 }
@@ -207,22 +226,26 @@ function Config(options) {
 
     this.ignore = options.ignore;
     this.ignorePath = options.ignorePath;
-
     this.cache = {};
+
     this.baseConfig = options.reset ? { rules: {} } :
             require(path.resolve(__dirname, "..", "conf", "eslint.json"));
+
     this.baseConfig.format = options.format;
     this.useEslintrc = (options.useEslintrc !== false);
+
     this.env = (options.envs || []).reduce(function (envs, name) {
         envs[name] = true;
         return envs;
     }, {});
+
     this.globals = (options.globals || []).reduce(function (globals, def) {
         // Default "foo" to false and handle "foo:false" and "foo:true"
         var parts = def.split(":");
         globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
         return globals;
     }, {});
+
     useConfig = options.configFile;
     this.options = options;
 
@@ -239,7 +262,6 @@ function Config(options) {
  * @returns {Object} config object
  */
 Config.prototype.getConfig = function (filePath) {
-
     var config,
         userConfig,
         directory = filePath ? path.dirname(filePath) : process.cwd(),
@@ -254,12 +276,12 @@ Config.prototype.getConfig = function (filePath) {
         return config;
     }
 
-    // Step 1: Determine user-specified config from .eslintrc files
+    // Step 1: Determine user-specified config from .eslintrc and package.json files
     if (this.useEslintrc) {
-        debug("Using .eslintrc files");
+        debug("Using .eslintrc and package.json files");
         userConfig = getLocalConfig(this, directory);
     } else {
-        debug("Not using .eslintrc files");
+        debug("Not using .eslintrc or package.json files");
         userConfig = {};
     }
 
@@ -269,7 +291,7 @@ Config.prototype.getConfig = function (filePath) {
     // Step 3: Merge in environment-specific globals and rules from .eslintrc files
     config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env, this.options.reset));
 
-    // Step 4: Merge in the user-specified configuration from .eslintrc files
+    // Step 4: Merge in the user-specified configuration
     config = util.mergeConfigs(config, userConfig);
 
     // Step 5: Merge in command line config file
@@ -310,14 +332,16 @@ Config.prototype.getConfig = function (filePath) {
 };
 
 /**
- * Find a local config file, relative to a specified directory.
+ * Find a local config file or files, relative to a specified directory.
  * @param {string} directory the directory to start searching from
- * @returns {string|boolean} path of config file if found, or false if no config is found
+ * @returns {string[]} paths of files found
  */
-Config.prototype.findLocalConfigFile = function (directory) {
+Config.prototype.findLocalConfigFiles = function (directory) {
+
     if (!this.localConfigFinder) {
-        this.localConfigFinder = new FileFinder(CONFIG_FILENAME);
+        this.localConfigFinder = new FileFinder(LOCAL_CONFIG_FILENAME, PACKAGE_CONFIG_FILENAME);
     }
+
     return this.localConfigFinder.findInDirectory(directory);
 };
 

--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Util class to find config files.
  * @author Aliaksei Shytkin
+ * @copyright 2014 Michael McLaughlin. All rights reserved.
  */
 "use strict";
 
@@ -20,7 +21,7 @@ var fs = require("fs"),
  * empty array is returned instead. The try-catch is moved out here to avoid
  * performance penalty of having it in the findInDirectory() method.
  * @param {string} directory The directory to search in.
- * @returns {string[]} The filenames in the directory or an empty array on error.
+ * @returns {string[]} The file names in the directory or an empty array on error.
  * @private
  */
 function getDirectoryEntries(directory) {
@@ -39,59 +40,62 @@ function getDirectoryEntries(directory) {
 /**
  * FileFinder
  * @constructor
- * @param {string} fileName Name of file to find
+ * @param {...string} arguments The basename(s) of the file(s) to find.
  */
-function FileFinder(fileName) {
-    this.fileName = fileName;
+function FileFinder() {
+    this.fileNames = Array.prototype.slice.call(arguments);
     this.cache = {};
 }
 
 /**
- * Look file in directory and its parents, cache result
- * @param  {string} directory The path of directory to start
- * @param  {string[]} directoriesToCache    Array of directories, found file will be cached for
- * @returns {string|boolean}           Path of file or false if no file is found
+ * Look for files in directory and its parents, cache result.
+ * @param  {string} directory The path of the directory to start the search in.
+ * @param  {string[]} [directoriesToCache] Array of directories, found file will be cached.
+ * @returns {string[]} Paths of found files.
  */
 FileFinder.prototype.findInDirectory = function(directory, directoriesToCache) {
-
-    var lookInDirectory = directory || process.cwd(),
-        lookFor = this.fileName,
-        files,
+    var cache = this.cache,
+        directoryEntries,
+        fileName,
+        fileNames,
+        found,
+        i,
+        len,
         parentDirectory,
-        resultFilePath,
-        isFound = false;
+        resultFilePaths;
 
-    if (this.cache.hasOwnProperty(lookInDirectory)) {
-        return this.cache[lookInDirectory];
+    if (!directory) {
+        directory = process.cwd();
+    }
+
+    if (cache.hasOwnProperty(directory)) {
+        return cache[directory];
     }
 
     if (!directoriesToCache) {
         directoriesToCache = [];
     }
 
-    directoriesToCache = directoriesToCache.concat(lookInDirectory);
+    directoriesToCache.push(directory);
+    directoryEntries = getDirectoryEntries(directory);
+    resultFilePaths = [];
+    fileNames = this.fileNames;
 
+    for (i = 0, len = fileNames.length; i < len; i++) {
+        fileName = fileNames[i];
 
-    files = getDirectoryEntries(lookInDirectory);
-
-    if (files.indexOf(lookFor) !== -1) {
-        isFound = true;
-        resultFilePath = path.resolve(lookInDirectory, lookFor);
-    } else {
-
-        parentDirectory = path.resolve(lookInDirectory, "..");
-        if (parentDirectory === lookInDirectory) {
-            isFound = true;
-            resultFilePath = false;
+        if (directoryEntries.indexOf(fileName) !== -1) {
+            resultFilePaths.push(path.resolve(directory, fileName));
+            found = true;
         }
     }
 
-    if (isFound) {
+    if (found || (parentDirectory = path.dirname(directory)) === directory) {
 
-        directoriesToCache.forEach(function(dir) {
-            this.cache[dir] = resultFilePath;
-        }.bind(this));
-        return resultFilePath;
+        for (i = 0, len = directoriesToCache.length; i < len; i++) {
+            cache[directoriesToCache[i]] = resultFilePaths;
+        }
+        return resultFilePaths;
     }
 
     return this.findInDirectory(parentDirectory, directoriesToCache);

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -62,7 +62,7 @@ function findIgnoreFile() {
         ignoreFileFinder = new FileFinder(ESLINT_IGNORE_FILENAME);
     }
 
-    return ignoreFileFinder.findInDirectory();
+    return ignoreFileFinder.findInDirectory()[0] || false;
 }
 
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -25,91 +25,91 @@ module.exports = optionator({
         option: "help",
         alias: "h",
         type: "Boolean",
-        description: "Show help."
+        description: "Show help"
     }, {
         option: "config",
         alias: "c",
         type: "path::String",
-        description: "Load configuration data from this file."
+        description: "Use configuration from this file"
     }, {
         option: "rulesdir",
         type: "[path::String]",
-        description: "Load additional rules from this directory."
+        description: "Use additional rules from this directory"
     }, {
         option: "format",
         alias: "f",
         type: "String",
         default: "stylish",
-        description: "Use a specific output format."
+        description: "Use a specific output format"
     }, {
         option: "version",
         alias: "v",
         type: "Boolean",
-        description: "Outputs the version number."
+        description: "Outputs the version number"
     }, {
         option: "reset",
         type: "Boolean",
-        description: "Set all default rules to off."
+        description: "Set all default rules to off"
     }, {
         option: "eslintrc",
         type: "Boolean",
         default: "true",
-        description: "Enable loading .eslintrc configuration."
+        description: "Use configuration from .eslintrc"
     }, {
         option: "env",
         type: "[String]",
-        description: "Specify environments."
+        description: "Specify environments"
     }, {
         option: "ext",
         type: "[String]",
         default: ".js",
-        description: "Specify JavaScript file extensions."
+        description: "Specify JavaScript file extensions"
     }, {
         option: "plugin",
         type: "[String]",
-        description: "Specify plugins."
+        description: "Specify plugins"
     }, {
         option: "global",
         type: "[String]",
-        description: "Define global variables."
+        description: "Define global variables"
     }, {
         option: "rule",
         type: "Object",
-        description: "Specify rules."
+        description: "Specify rules"
     },
     {
         option: "ignore-path",
         type: "path::String",
-        description: "Specify the file that contains patterns of files to ignore."
+        description: "Specify path of ignore file"
     },
     {
         option: "ignore",
         type: "Boolean",
         default: "true",
-        description: "Enable loading of .eslintignore."
+        description: "Use .eslintignore"
     },
     {
         option: "color",
         type: "Boolean",
         default: "true",
-        description: "Enable color in piped output."
+        description: "Use color in piped output"
     },
     {
         option: "output-file",
         alias: "o",
         type: "path::String",
-        description: "Enable report to be written to a file."
+        description: "Specify file to write report to"
     },
     {
         option: "quiet",
         type: "Boolean",
         default: "false",
-        description: "Report errors only."
+        description: "Report errors only"
     },
     {
         option: "stdin",
         type: "Boolean",
         default: "false",
-        description: "Lint code provided on <STDIN>."
+        description: "Lint code provided on <STDIN>"
     }]
 });

--- a/tests/fixtures/config-hierarchy/broken/package.json
+++ b/tests/fixtures/config-hierarchy/broken/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "",
+  "version": "",
+  "eslintConfig": {}
+}

--- a/tests/fixtures/config-hierarchy/packagejson/.eslintrc
+++ b/tests/fixtures/config-hierarchy/packagejson/.eslintrc
@@ -1,0 +1,2 @@
+rules:
+    quotes: [2, "double"]

--- a/tests/fixtures/config-hierarchy/packagejson/package.json
+++ b/tests/fixtures/config-hierarchy/packagejson/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "",
+  "version": "",
+  "eslintConfig": {
+    "rules": {
+      "quotes": [1, "single"]
+    }
+  }
+}

--- a/tests/fixtures/config-hierarchy/packagejson/subdir/package.json
+++ b/tests/fixtures/config-hierarchy/packagejson/subdir/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "",
+  "version": "",
+  "eslintConfig": {
+    "rules": {
+      "quotes": [1, "double"]
+    }
+  }
+}

--- a/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/package.json
+++ b/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "",
+  "version": "",
+  "eslintConfig": {
+    "rules": {
+      "quotes": [2, "single"]
+    }
+  }
+}

--- a/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/package.json
+++ b/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "",
+  "version": "",
+  "eslintConfig": {
+    "rules": {
+      "quotes": [2, "double"]
+    }
+  }
+}

--- a/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js
@@ -1,0 +1,1 @@
+var str = 'quotes';

--- a/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js
@@ -1,0 +1,1 @@
+var str = 'quotes';

--- a/tests/fixtures/config-hierarchy/packagejson/subdir/wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/packagejson/subdir/wrong-quotes.js
@@ -1,0 +1,1 @@
+var str = 'quotes';

--- a/tests/fixtures/config-hierarchy/packagejson/wrong-quotes.js
+++ b/tests/fixtures/config-hierarchy/packagejson/wrong-quotes.js
@@ -1,0 +1,1 @@
+var str = 'quotes';

--- a/tests/fixtures/packagejson/package.json
+++ b/tests/fixtures/packagejson/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "",
+  "version": "",
+  "eslintConfig": {
+    "rules": {
+      "quotes": [1, "single"]
+    }
+  }
+}

--- a/tests/fixtures/packagejson/quotes.js
+++ b/tests/fixtures/packagejson/quotes.js
@@ -1,0 +1,1 @@
+var str = "quotes!";

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -364,7 +364,7 @@ describe("CLIEngine", function() {
         });
 
 
-        it("should return zero messages and ignore local config file when executing with no-eslintrc flag", function () {
+        it("should return zero messages and ignore .eslintrc files when executing with no-eslintrc flag", function () {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -379,17 +379,19 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages when executing with local config file", function () {
+        it("should return zero messages and ignore package.json files when executing with no-eslintrc flag", function () {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true
+                reset: true,
+                useEslintrc: false,
+                envs: ["node"]
             });
 
-            var report = engine.executeOnFiles(["./tests/fixtures/eslintrc/quotes.js"]);
+            var report = engine.executeOnFiles(["./tests/fixtures/packagejson/quotes.js"]);
             assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].filePath, "./tests/fixtures/eslintrc/quotes.js");
-            assert.equal(report.results[0].messages.length, 1);
+            assert.equal(report.results[0].filePath, "./tests/fixtures/packagejson/quotes.js");
+            assert.equal(report.results[0].messages.length, 0);
         });
 
         // These tests have to do with https://github.com/eslint/eslint/issues/963
@@ -492,8 +494,6 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].severity, 2);
             });
 
-            // Project configuration - package.json (TODO)
-
             // Project configuration - second level .eslintrc
             it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", function () {
 
@@ -520,6 +520,60 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
                 assert.equal(report.results[0].messages[0].severity, 1);
+            });
+
+            // Project configuration - first level package.json
+            it("should return one message when executing with package.json", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 1);
+            });
+
+             // Project configuration - second level package.json
+            it("should return zero messages when executing with local package.json that overrides parent package.json", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 0);
+            });
+
+            // Project configuration - third level package.json
+            it("should return one message when executing with local package.json that overrides parent and grandparent package.json", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 2);
+            });
+
+            // Project configuration - .eslintrc overrides package.json in same directory
+            it("should return one message when executing with .eslintrc that overrides a package.json in the same directory", function () {
+
+                engine = new CLIEngine({
+                    reset: true
+                });
+
+                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/wrong-quotes.js"]);
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 1);
+                assert.equal(report.results[0].messages[0].ruleId, "quotes");
+                assert.equal(report.results[0].messages[0].severity, 2);
             });
 
             // Command line configuration - --config with first level .eslintrc

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -87,24 +87,40 @@ describe("Config", function() {
         rm("-r", fixtureDir);
     });
 
-    describe("findLocalConfigFile()", function() {
+    describe("findLocalConfigFiles()", function() {
 
         it("should return the path when an .eslintrc file is found", function() {
             var configHelper = new Config(),
                 expected = getFixturePath("broken", ".eslintrc"),
-                actual = configHelper.findLocalConfigFile(getFixturePath("broken"));
+                actual = configHelper.findLocalConfigFiles(getFixturePath("broken"))[0];
 
             assert.equal(actual, expected);
         });
 
-        it("should return an empty string when an .eslintrc file is not found", function() {
+        it("should return an empty array when an .eslintrc file is not found", function() {
             var configHelper = new Config(),
-                expected = "",
-                actual = configHelper.findLocalConfigFile(getFixturePath());
+                actual = configHelper.findLocalConfigFiles(getFixturePath());
+
+            assert.isArray(actual);
+            assert.lengthOf(actual, 0);
+        });
+
+         it("should return the path when a package.json file is found", function() {
+            var configHelper = new Config(),
+                expected = getFixturePath("broken", "package.json"),
+                // The first element of the array is the .eslintrc in the same directory.
+                actual = configHelper.findLocalConfigFiles(getFixturePath("broken"))[1];
 
             assert.equal(actual, expected);
         });
 
+        it("should return an empty array when a package.json file is not found", function() {
+            var configHelper = new Config(),
+                actual = configHelper.findLocalConfigFiles(getFixturePath());
+
+            assert.isArray(actual);
+            assert.lengthOf(actual, 0);
+        });
     });
 
     describe("getConfig()", function() {
@@ -158,14 +174,14 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "single-quotes", ".eslintrc");
             var configHelper = new Config();
 
-            sandbox.spy(configHelper, "findLocalConfigFile");
+            sandbox.spy(configHelper, "findLocalConfigFiles");
 
             // If cached this should be called only once
             configHelper.getConfig(configPath);
-            var callcount = configHelper.findLocalConfigFile.callcount;
+            var callcount = configHelper.findLocalConfigFiles.callcount;
             configHelper.getConfig(configPath);
 
-            assert.equal(configHelper.findLocalConfigFile.callcount, callcount);
+            assert.equal(configHelper.findLocalConfigFiles.callcount, callcount);
         });
 
         // make sure JS-style comments don't throw an error


### PR DESCRIPTION
> In terms of behavior, I think it should act like a .eslintrc would in the same directory.

Yes.

> The only questions in my mind;
> How would ESLint know to look in package.json? Would it always do so by default?

I added a `packagejson` option which follows the behaviour of the `eslintrc` option, and so is turned on by default.

> What is the expectation if there is config in both package.json and .eslintrc in the same directory?
> 
> There is a hierarchy followed by JSHint and JCSC for this. The package.json would be looked for first, and if found with ESLint config used. Failing that the .eslintrcwould be looked for and used if available.

I chose to instead use both, with the .eslintrc file having the higher precendence. To me, that seems more consistent with current behaviour and more flexible.

> We will stick with eslintConfig to match other tools doing similar things. 

I used `eslint` as the field name to look for in the package.json.

I'm looking for feedback in terms of questions about the new behaviour, changes that need to be made, preferences for the field and option names etc.

There are further tests still to be added to tests/lib/config.js and I will update this request with them presently.

---

Edited cli options descriptions so they fit 80 character width. 

I'm now thinking it would be better to stop looking for package.json files on finding the first one, instead of following .eslintrc behaviour and looking in all parent directories up to the file system root.

Also, perhaps it's unnecessary to have a packagejson cli option as it would be simpler for the eslintrc option setting to apply to both, otherwise its quite long-winded to turn both off. The package.json field could perhaps then be named `eslintrc`.

---

Okay, I have amended the commit so that only the first package.json file found is used. As before, all .eslintrc files in successive parent directories are used. This means that users who don't want to have higher directories searched for configuration data can just use a package.json file. 

I have left the packagejson cli option in, as now it seems necessary because the behaviour of package.json and .eslintrc files differs as just desribed.
