### PR TITLE
Fix: yoda treats negative numbers as literals (fixes #1571)

### DIFF
--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -47,6 +47,12 @@ if (5 > count) {
 ```
 
 ```js
+if (-1 < str.indexOf(substr)) {
+    // ...
+}
+```
+
+```js
 // When ["always"]
 if (color == "blue") {
 	// ...
@@ -80,6 +86,13 @@ if ("blue" == value) {
 }
 ```
 
+```js
+// When ["always"]
+if (-1 < str.indexOf(substr)) {
+    // ...
+}
+```
+
 ### Range Tests
 
 "Range" comparisons test whether a variable is inside or outside the range between two literals. When configured with the `exceptRange` option, range tests are allowed when the comparison itself is wrapped directly in parentheses, such as those of an `if` or `while` condition.
@@ -91,8 +104,14 @@ if ("blue" == value) {
 With the `exceptRange` option enabled, the following patterns become valid:
 
 ```js
-function isRedish(color) {
+function isReddish(color) {
     return (color.hue < 60 || 300 < color.hue);
+}
+```
+
+```js
+if (x < -1 || 1 < x) {
+    // ...
 }
 ```
 

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -13,7 +13,7 @@
 /**
  * Determines whether an operator is a comparison operator.
  * @param {String} operator The operator to check.
- * @returns {Boolean} Whether or not it is a comparison operator.
+ * @returns {boolean} Whether or not it is a comparison operator.
  */
 function isComparisonOperator(operator) {
     return (/^(==|===|!=|!==|<|>|<=|>=)$/).test(operator);
@@ -23,10 +23,50 @@ function isComparisonOperator(operator) {
  * Determines whether an operator is one used in a range test.
  * Allowed operators are `<` and `<=`.
  * @param {String} operator The operator to check.
- * @returns {Boolean} Whether the operator is used in range tests.
+ * @returns {boolean} Whether the operator is used in range tests.
  */
 function isRangeTestOperator(operator) {
     return ["<", "<="].indexOf(operator) >= 0;
+}
+
+/**
+ * Determines whether a non-Literal node is a negative number that should be
+ * treated as if it were a single Literal node.
+ * @param {ASTNode} node Node to test.
+ * @returns {boolean} True if the node is a negative number that looks like a
+ *                    real literal and should be treated as such.
+ */
+function looksLikeLiteral(node) {
+    return (node.type === "UnaryExpression" &&
+        node.operator === "-" &&
+        node.prefix &&
+        node.argument.type === "Literal" &&
+        typeof node.argument.value === "number");
+}
+
+/**
+ * Attempts to derive a Literal node from nodes that are treated like literals.
+ * @param {ASTNode} node Node to normalize.
+ * @returns {ASTNode} The original node if the node is already a Literal, or a
+ *                    normalized Literal node with the negative number as the
+ *                    value if the node represents a negative number literal,
+ *                    otherwise null if the node cannot be converted to a
+ *                    normalized literal.
+ */
+function getNormalizedLiteral(node) {
+    if (node.type === "Literal") {
+        return node;
+    }
+
+    if (looksLikeLiteral(node)) {
+        return {
+            type: "Literal",
+            value: -node.argument.value,
+            raw: "-" + node.argument.value
+        };
+    }
+
+    return null;
 }
 
 /**
@@ -37,7 +77,7 @@ function isRangeTestOperator(operator) {
  *     a['b'] = a['b']
  * @param   {ASTNode} a Left side of the comparison.
  * @param   {ASTNode} b Right side of the comparison.
- * @returns {Boolean}   True if both sides match and reference the same value.
+ * @returns {boolean}   True if both sides match and reference the same value.
  */
 function same(a, b) {
     if (a.type !== b.type) {
@@ -88,10 +128,12 @@ module.exports = function (context) {
          * @returns {Boolean} Whether node is a "between" range test.
          */
         function isBetweenTest() {
+            var leftLiteral, rightLiteral;
+
             return (node.operator === "&&" &&
-                left.left.type === "Literal" &&
-                right.right.type === "Literal" &&
-                left.left.value <= right.right.value &&
+                (leftLiteral = getNormalizedLiteral(left.left)) &&
+                (rightLiteral = getNormalizedLiteral(right.right)) &&
+                leftLiteral.value <= rightLiteral.value &&
                 same(left.right, right.left));
         }
 
@@ -100,10 +142,12 @@ module.exports = function (context) {
          * @returns {Boolean} Whether node is an "outside" range test.
          */
         function isOutsideTest() {
+            var leftLiteral, rightLiteral;
+
             return (node.operator === "||" &&
-                left.right.type === "Literal" &&
-                right.left.type === "Literal" &&
-                left.right.value <= right.left.value &&
+                (leftLiteral = getNormalizedLiteral(left.right)) &&
+                (rightLiteral = getNormalizedLiteral(right.left)) &&
+                leftLiteral.value <= rightLiteral.value &&
                 same(left.left, right.right));
         }
 
@@ -140,7 +184,7 @@ module.exports = function (context) {
 
             // Comparisons must always be yoda-style: if ("blue" === color)
             if (
-                node.right.type === "Literal" &&
+                (node.right.type === "Literal" || looksLikeLiteral(node.right)) &&
                 isComparisonOperator(node.operator) &&
                 !(exceptRange && isRangeTest(context.getAncestors().pop()))
             ) {
@@ -151,7 +195,7 @@ module.exports = function (context) {
 
             // Comparisons must never be yoda-style (default)
             if (
-                node.left.type === "Literal" &&
+                (node.left.type === "Literal" || looksLikeLiteral(node.left)) &&
                 isComparisonOperator(node.operator) &&
                 !(exceptRange && isRangeTest(context.getAncestors().pop()))
             ) {

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -56,6 +56,9 @@ eslintTester.addRuleTest("lib/rules/yoda", {
         }, {
             code: "if (a < 4 || (b[c[0]].d['e'] < 0 || 1 <= b[c[0]].d['e'])) {}",
             args: [2, "never", { exceptRange: true }]
+        }, {
+            code: "if (-1 < x && x < 0) {}",
+            args: [2, "never", { exceptRange: true }]
         }
     ],
     invalid: [
@@ -141,6 +144,16 @@ eslintTester.addRuleTest("lib/rules/yoda", {
             ]
         },
         {
+            code: "if (-1 < str.indexOf(substr)) {}",
+            args: [2, "never"],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "if (value == \"red\") {}",
             args: [2, "always"],
             errors: [
@@ -211,11 +224,41 @@ eslintTester.addRuleTest("lib/rules/yoda", {
             ]
         },
         {
+            code: "if (0 <= x && x < -1) {}",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
             code: "var a = (b < 0 && 0 <= b);",
             args: [2, "always", { exceptRange: true }],
             errors: [
                 {
                     message: "Expected literal to be on the left side of <.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (0 <= a[b] && a['b'] < 1) {}",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (0 <= a[b()] && a[b()] < 1) {}",
+            args: [2, "never", { exceptRange: true }],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <=.",
                     type: "BinaryExpression"
                 }
             ]


### PR DESCRIPTION
Negative numbers like `-1` are represented in the AST as a numeric `Literal` node with positive one as the value, wrapped in a `UnaryExpression` node with `-` as the prefix operator to negate the literal. This PR treats both positive and negative numbers as normal literals.

Because the range test exception validates ranges to ensure that the left end of the range <= the right end of the range, it was necessary to combine the negating wrapper and literal into a single negative literal node rather than simply checking for the presence of the negating wrapper so that the actual negative value is available.

This brings test coverage of `lib/rules/yoda.js` back up to 100%.

It also fixes a spelling error in the docs pointed out by @ljharb.
