### PR TITLE
Fix: check if next statement is on newline when warning against extra semicolons. (fixes #1580)

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -18,6 +18,24 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
 
     /**
+     * Check if a semicolon is unnecessary, only true if:
+     *   - next token is on a new line and is not one of the opt-out tokens
+     *   - next token is a valid statement divider
+     * @param {Token} lastToken last token of current node.
+     * @param {Token} nextToken next token after current node.
+     * @returns {boolean} whether the semicolon is unnecessary.
+     */
+    function isUnnecessarySemicolon(lastToken, nextToken) {
+
+        var lastTokenLine = lastToken.loc.end.line,
+            nextTokenLine = nextToken && nextToken.loc.start.line,
+            isOptOutToken = nextToken && OPT_OUT_PATTERN.test(nextToken.value),
+            isDivider = nextToken && (nextToken.value === "}" || nextToken.value === ";");
+
+        return (lastTokenLine !== nextTokenLine && !isOptOutToken) || isDivider;
+    }
+
+    /**
      * Checks a node to see if it's followed by a semicolon.
      * @param {ASTNode} node The node to check.
      * @returns {void}
@@ -31,12 +49,11 @@ module.exports = function(context) {
                 context.report(node, lastToken.loc.end, "Missing semicolon.");
             }
         } else {
-            if (lastToken.type === "Punctuator" && lastToken.value === ";") {
-
-                if (!nextToken || !(OPT_OUT_PATTERN.test(nextToken.value))) {
-                    context.report(node, node.loc.end, "Extra semicolon.");
-                }
-
+            if (lastToken.type === "Punctuator" &&
+                lastToken.value === ";" &&
+                isUnnecessarySemicolon(lastToken, nextToken)
+            ) {
+                context.report(node, node.loc.end, "Extra semicolon.");
             }
         }
     }
@@ -72,12 +89,13 @@ module.exports = function(context) {
         "BreakStatement": checkForSemicolon,
         "ContinueStatement": checkForSemicolon,
         "EmptyStatement": function (node) {
-            var nextToken;
+            var lastToken, nextToken;
 
             if (!always) {
+                lastToken = context.getLastToken(node);
                 nextToken = context.getTokenAfter(node) || context.getLastToken(node);
 
-                if (!(OPT_OUT_PATTERN.test(nextToken.value))) {
+                if (isUnnecessarySemicolon(lastToken, nextToken)) {
                     context.report(node, "Extra semicolon.");
                 }
             }

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -33,7 +33,9 @@ eslintTester.addRuleTest("lib/rules/semi", {
         { code: "(function bar() {})\n;(function foo(){})", args: [1, "never"] },
         { code: ";/foo/.test('bar')", args: [1, "never"] },
         { code: ";+5", args: [1, "never"] },
-        { code: ";-foo()", args: [1, "never"] }
+        { code: ";-foo()", args: [1, "never"] },
+        { code: "a++\nb++", args: [1, "never"] },
+        { code: "a++; b++", args: [1, "never"] }
     ],
     invalid: [
         { code: "function foo() { return [] }", errors: [{ message: "Missing semicolon.", type: "ReturnStatement"}] },


### PR DESCRIPTION
Details are explained in #1580.

Added two test cases (the second one, `a++; b++` fails before this patch). All tests pass after the patch.
