### PR TITLE
Fix: Update optionator, --no in help (fixes #1134)

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -22,29 +22,25 @@ The command line utility has several options. You can view the options by runnin
 eslint [options] file.js [file.js] [dir]
 
 Options:
-  -h, --help                 Show help
-  -c, --config path::String  Use configuration from this file
-  --rulesdir [path::String]  Use additional rules from this directory
-  -f, --format String        Use a specific output format - default: stylish
-  -v, --version              Outputs the version number
-  --reset                    Set all default rules to off
-  --eslintrc                 Use configuration from .eslintrc - default: true
-  --env [String]             Specify environments
-  --ext [String]             Specify JavaScript file extensions - default: .js
-  --plugin [String]          Specify plugins
-  --global [String]          Define global variables
-  --rule Object              Specify rules
+  -h, --help                  Show help
+  -c, --config path::String   Use configuration from this file
+  --rulesdir [path::String]   Use additional rules from this directory
+  -f, --format String         Use a specific output format - default: stylish
+  -v, --version               Outputs the version number
+  --reset                     Set all default rules to off - default: false
+  --no-eslintrc               Disable use of configuration from .eslintrc
+  --env [String]              Specify environments
+  --ext [String]              Specify JavaScript file extensions - default: .js
+  --plugin [String]           Specify plugins
+  --global [String]           Define global variables
+  --rule Object               Specify rules
   --ignore-path path::String  Specify path of ignore file
-  --ignore                   Use .eslintignore - default: true
-  --color                    Use color in piped output - default: true
+  --no-ignore                 Disable use of .eslintignore
+  --no-color                  Disable color in piped output
   -o, --output-file path::String  Specify file to write report to
-  --quiet                    Report errors only - default: false
-  --stdin                    Lint code provided on <STDIN> - default: false
+  --quiet                     Report errors only - default: false
+  --stdin                     Lint code provided on <STDIN> - default: false
 ```
-
-### `-h`, `--help`
-
-This option outputs the help menu, displaying all of the available options. All other flags are ignored when this is present.
 
 ### `-c`, `--config`
 
@@ -56,20 +52,29 @@ Example:
 
 This example uses the configuration file at `~/my-eslint.json` instead of the default.
 
+### `--env`
+
+This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](../configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the flag multiple times.
+
+Examples:
+
+    eslint --env browser,node file.js
+    eslint --env browser --env node file.js
+
 ### `--ext`
 
 This option allows you to specify which file extensions ESLint will use when searching for JavaScript files. By default, it uses `.js` as the only file extension.
 
 Examples:
 
-  # Use only .js2 extension
-  eslint --ext .js2
+    # Use only .js2 extension
+    eslint --ext .js2
 
-  # Use both .js and .js2
-  eslint --ext .js --ext .js2
+    # Use both .js and .js2
+    eslint --ext .js --ext .js2
 
-  # Also use both .js and .js2
-  eslint --ext .js,.js2
+    # Also use both .js and .js2
+    eslint --ext .js,.js2
 
 ### `-f`, `--format`
 
@@ -91,15 +96,97 @@ When specified, the given format is output to the console. If you'd like to save
 
 This saves the output into the `results.txt` file.
 
-### `-o`
+### `--global`
 
-This option specifies the output file name which can be passes for the output of the task to be put into
+This option defines global variables so that they will not be flagged as undefined by the `no-undef` rule. Global variables are read-only by default, but appending `:true` to a variable's name makes it writable. To define multiple variables, separate them using commas, or use the flag multiple times.
+
+Examples:
+
+    eslint --global require,exports:true file.js
+    eslint --global require --global exports:true
+
+### `-h`, `--help`
+
+This option outputs the help menu, displaying all of the available options. All other flags are ignored when this is present.
+
+### `--ignore-path`
+
+This option allows you to specify the file to use as your `.eslintignore`. By default, ESLint looks in the current working directory for `.eslintignore`. You can override this behavior by providing a path to a different file.
+
+Example:
+
+    eslint --ignore-path tmp/.eslintignore file.js
+
+### `--no-color`
+
+Disable color in piped output.
+
+Example:
+
+    eslint --no-color file.js
+
+### `--no-eslintrc`
+
+Disables use of configuration from `.eslintrc` and `package.json` files.
+
+Example:
+
+    eslint --no-eslintrc file.js
+
+### `--no-ignore`
+
+Disable use of configuration from `.eslintrc` and `package.json` files.
+
+Example:
+
+    eslint --no-ignore file.js
+
+### `-o`, `--output-file`
+
+Enable report to be written to a file.
 
 Example:
 
     eslint -o ./test/test.html
 
 When specified, the given format is output into the provided file name.
+
+### `--plugin`
+
+This option specifies a plugin to load. You can omit the prefix `eslint-plugin-` from the plugin name.
+Before using the plugin you have to install it using npm.
+
+Examples:
+
+    eslint --plugin jquery file.js
+    eslint --plugin eslint-plugin-mocha file.js
+
+### `--quiet`
+
+This option allows you to disable reporting on warnings. If you enable this option only errors are reported by ESLint.
+
+Example:
+
+    eslint --quiet file.js
+
+### `--reset`
+
+This option turns off all rules enabled in ESLint's default configuration file located at `conf/eslint.json`. ESLint will still report syntax errors.
+
+Example:
+
+    eslint --reset file.js
+
+### `--rule`
+
+This option specifies rules to be used. They will be merged into any previously defined rules. To start fresh, simply combine with the `--reset` flag. To define multiple rules, separate them using commas, or use the flag multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
+If the rule is defined within a plugin you have to prefix the rule ID with the plugin name and a `/`.
+
+Examples:
+
+    eslint --rule 'quotes: [2, double]'
+    eslint --rule 'guard-for-in: 2' --rule 'brace-style: [2, 1tbs]'
+    eslint --rule 'jquery/dollar-sign: 2'
 
 ### `--rulesdir`
 
@@ -113,85 +200,13 @@ The rules in your custom rules directory must follow the same format as bundled 
 
     eslint --rulesdir my-rules/ --rulesdir my-other-rules/ file.js
 
-### `--reset`
-
-This option turns off all rules enabled in ESLint's default configuration file located at `conf/eslint.json`. ESLint will still report syntax errors.
-
-Example:
-
-    eslint --reset file.js
-
-### `--eslintrc`
-
-This option, on by default, specifies whether to use configuration from `.eslintrc` and `package.json` files. Use as `--no-eslintrc` to disable.
-
-Example
-
-    eslint --no-eslintrc file.js
-
-### `--env`
-
-This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](../configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the flag multiple times.
-
-Example
-
-    eslint --env browser,node file.js
-    eslint --env browser --env node file.js
-
-### `--plugin`
-
-This option specifies a plugin to load. You can omit the prefix `eslint-plugin-` from the plugin name.
-Before using the plugin you have to install it using npm.
-
-Example
-
-    eslint --plugin jquery file.js
-    eslint --plugin eslint-plugin-mocha file.js
-
-### `--global`
-
-This option defines global variables so that they will not be flagged as undefined by the `no-undef` rule. Global variables are read-only by default, but appending `:true` to a variable's name makes it writable. To define multiple variables, separate them using commas, or use the flag multiple times.
-
-Example:
-
-    eslint --global require,exports:true file.js
-    eslint --global require --global exports:true
-
-### `--rule`
-
-This option specifies rules to be used. They will be merged into any previously defined rules. To start fresh, simply combine with the `--reset` flag. To define multiple rules, separate them using commas, or use the flag multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
-If the rule is defined within a plugin you have to prefix the rule ID with the plugin name and a `/`.
-
-Example:
-
-    eslint --rule 'quotes: [2, double]'
-    eslint --rule 'guard-for-in: 2' --rule 'brace-style: [2, 1tbs]'
-    eslint --rule 'jquery/dollar-sign: 2'
-
-### `--ignore-path`
-
-This option allows you to specify the file to use as your `.eslintignore`. By default, ESLint looks in the current working directory for `.eslintignore`. You can override this behavior by providing a path to a different file.
-
-Example:
-
-  eslint --ignore-path tmp/.eslintignore file.js
-
-### `--ignore`, `--no-ignore`
-
-This options tells ESLint whether it should automatically load an `.eslintignore` file from the current working directory. When set to `false`, or when using `--no-ignore`, no files or directories will be ignored.
-
-Example:
-
-  eslint --ignore false file.js
-  eslint --no-ignore file.js
-
 ### `--stdin`
 
-This option tells ESLint to read and lint source code from STDIN instead files. You can use this to pipe code to ESLint, such as:
+This option tells ESLint to read and lint source code from STDIN instead files. You can use this to pipe code to ESLint.
 
-```
-cat myfile.js | eslint --stdin
-```
+Example
+
+    cat myfile.js | eslint --stdin
 
 ### `-v`, `--version`
 
@@ -200,15 +215,6 @@ This option outputs the current ESLint version onto the console. All other optio
 Example:
 
     eslint -v
-
-### `--quiet`
-
-This option allows you to disable reporting on warnings. If you enable this option only errors are reported by ESLint.
-
-Example:
-
-    eslint --quiet file.js
-
 
 ## Ignoring files from linting
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -49,12 +49,13 @@ module.exports = optionator({
     }, {
         option: "reset",
         type: "Boolean",
+        default: "false",
         description: "Set all default rules to off"
     }, {
         option: "eslintrc",
         type: "Boolean",
         default: "true",
-        description: "Use configuration from .eslintrc"
+        description: "Disable use of configuration from .eslintrc"
     }, {
         option: "env",
         type: "[String]",
@@ -86,13 +87,13 @@ module.exports = optionator({
         option: "ignore",
         type: "Boolean",
         default: "true",
-        description: "Use .eslintignore"
+        description: "Disable use of .eslintignore"
     },
     {
         option: "color",
         type: "Boolean",
         default: "true",
-        description: "Use color in piped output"
+        description: "Disable color in piped output"
     },
     {
         option: "output-file",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "minimatch": "^1.0.0",
     "mkdirp": "^0.5.0",
     "object-assign": "^1.0.0",
-    "optionator": "^0.4.0",
+    "optionator": "^0.5.0",
     "strip-json-comments": "~1.0.1",
     "text-table": "~0.2.0",
     "user-home": "^1.0.0",


### PR DESCRIPTION
- Updated optionator to 0.5.0
Boolean options with 'default: true' now display their negated variant
in help. eg. --no-eslintrc, --no-ignore, --no-color
- Updated help messages work with that eg. 'disable' rather than
  'enable'
- Updated command line interface docs with new help output
- Rearrange docs to be in alphabetical order
- Fixed various formatting issues with the docs
- Added option 'color' to docs, was missing before