### PR TITLE
brace-style stroustrup should report on cuddled elseif

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -64,11 +64,12 @@ module.exports = function(context) {
      * @returns {void}
      */
     function checkIfStatement(node) {
-        var tokens;
+        var tokens,
+            checkedTypes = ["BlockStatement", "IfStatement"];
 
         checkBlock("consequent", "alternate")(node);
 
-        if (node.alternate && node.alternate.type === "BlockStatement") {
+        if (node.alternate && checkedTypes.indexOf(node.alternate.type) > -1) {
             tokens = context.getTokensBefore(node.alternate, 2);
             if (style === "1tbs") {
                 if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -80,6 +80,8 @@ eslintTester.addRuleTest("lib/rules/brace-style", {
         { code: "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "BlockStatement"}] },
         { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "CatchClause"}] },
         { code: "if (a) { \nb();\n } else { \nc();\n }", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "BlockStatement" }]},
+        { code: "if (foo) {\nbaz();\n} else if (bar) {\nbaz();\n}\nelse {\nqux();\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "IfStatement" }] },
+        { code: "if (foo) {\npoop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}", args: ["2", "stroustrup"], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP, type: "IfStatement" }] },
         // allowSingleLine: true
         { code: "function foo() { return; \n}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}] },
         { code: "function foo() { a(); b(); return; \n}", args: ["2", "1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement"}] },


### PR DESCRIPTION
The `brace-style` rule with the `"stroustrup"` option on was failing to report cuddled `elseif`s because of a check to make sure the `alternate` type was `BlockStatement`. For `elseif`s, the `alternate` type is `IfStatement`.

```
if (foo) {
  baz();
} else if (bar) {
  baz();
}
else {
  qux();
}
```

The above code will now report correctly.

Fixes #1583
