### PR TITLE
Fix: padded-blocks incorrectly complained on comments (fixes #1416)

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "debug": "^2.0.0",
     "doctrine": "^0.6.2",
     "escope": "~1.0.0",
-    "espree": "^1.3.1",
+    "espree": "^1.4.0",
     "estraverse": "~1.5.1",
     "globals": "^4.0.0",
     "js-yaml": "~3.2.2",

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -33,7 +33,9 @@ eslintTester.addRuleTest("lib/rules/padded-blocks", {
         { code: "{a();\n}", args: [1, "never"]},
         { code: "{a();}", args: [1, "never"]},
         { code: "{//comment\na();}", args: [1, "never"]},
-        { code: "{a();//comment\n}", args: [1, "never"]}
+        { code: "{a();//comment\n}", args: [1, "never"]},
+        { code: "function a() {\n/* comment */\nreturn;\n/* comment*/\n}", args: [1, "never"] },
+        { code: "{\n// comment\ndebugger;\n// comment\n}", args: [1, "never"] }
     ],
     invalid: [
         { code: "{\n//comment\na();\n\n}", errors: [expectedPaddingError] },


### PR DESCRIPTION
This bug is fixed in espree 1.4.0. I’ve added some tests to ensure that the
rule works as expected.
