### PR TITLE
Fix: Adding regexp literal exception (fixes #1589)

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -32,7 +32,12 @@ The following patterns are not considered warnings:
 (function(){} ? a() : b())
 ```
 
+```js
+(/^a$/).test(var)
+```
+
 IIFEs are excluded from this requirement, so the `(function(){}())` pattern is allowed in any position.
+RegExp literals are also excluded from this requirement, so the `(/abc/).test(var)` pattern is allowed in any position as well.
 
 
 ## Further Reading

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -210,9 +210,12 @@ module.exports = function(context) {
                 (
                     node.computed ||
                     !(
-                        node.object.type === "Literal" &&
+                        (node.object.type === "Literal" &&
                         typeof node.object.value === "number" &&
-                        /^[0-9]+$/.test(context.getFirstToken(node.object).value)
+                        /^[0-9]+$/.test(context.getFirstToken(node.object).value))
+                        ||
+                        // RegExp literal is allowed to have parens (#1589)
+                        (node.object.type === "Literal" && node.object.regex)
                     )
                 )
             ) {
@@ -229,7 +232,9 @@ module.exports = function(context) {
             });
         },
         "ReturnStatement": function(node) {
-            if (node.argument && isParenthesised(node.argument)) {
+            if (node.argument && isParenthesised(node.argument) &&
+                    // RegExp literal is allowed to have parens (#1589)
+                    !(node.argument.type === "Literal" && node.argument.regex)) {
                 report(node.argument);
             }
         },
@@ -258,7 +263,10 @@ module.exports = function(context) {
         "UnaryExpression": dryUnaryUpdate,
         "UpdateExpression": dryUnaryUpdate,
         "VariableDeclarator": function(node) {
-            if (node.init && isParenthesised(node.init) && precedence(node.init) >= precedence({type: "AssignmentExpression"})) {
+            if (node.init && isParenthesised(node.init) &&
+                    precedence(node.init) >= precedence({type: "AssignmentExpression"}) &&
+                    // RegExp literal is allowed to have parens (#1589)
+                    !(node.init.type === "Literal" && node.init.regex)) {
                 report(node.init);
             }
         },

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -103,6 +103,12 @@ eslintTester.addRuleTest("lib/rules/no-extra-parens", {
         "({a: function(){}}.a());",
         "({a:0}.a ? b : c)",
 
+        // RegExp literal is allowed to have parens (#1589)
+        "var isA = (/^a$/).test('a');",
+        "var regex = (/^a$/);",
+        "function a(){ return (/^a$/); }",
+        "function a(){ return (/^a$/).test('a'); }",
+
         // IIFE is allowed to have parens in any position (#655)
         "var foo = (function() { return bar(); }())",
         "var o = { foo: (function() { return bar(); }()) };",


### PR DESCRIPTION
Took longer than expected due to the holidays and the fact that my `~/.eslintrc` was throwing off eslint's validation step in `npm test`.
