### PR TITLE
Fix: Allow individual newlines in space-in-brackets (fixes #1614)

### DIFF
--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -14,7 +14,7 @@ foo['bar'];
 
 ## Rule Details
 
-This rule aims to maintain consistency around the spacing inside of square brackets, either by disallowing spaces inside of brackets between the brackets and other tokens or enforcing spaces. Multi-line array and object literals with no values on the same line as the brackets are excepted from this rule as this is a common pattern.  Object literals that are used as the first or last element in an array are also ignored.
+This rule aims to maintain consistency around the spacing inside of square brackets, either by disallowing spaces inside of brackets between the brackets and other tokens or enforcing spaces. Brackets that are separated from the adjacent value by a new line are excepted from this rule, as this is a common pattern.  Object literals that are used as the first or last element in an array are also ignored.
 
 ### Options
 
@@ -36,9 +36,6 @@ When `"never"` is set, the following patterns are considered warnings:
 ```js
 foo[ 'bar' ];
 foo['bar' ];
-foo[
-    'bar'
-];
 
 var arr = [ 'foo', 'bar' ];
 var arr = ['foo', 'bar' ];
@@ -48,19 +45,10 @@ var arr = ['foo',
   'bar'
 ];
 
-var arr = [
-  'foo',
-  'bar'];
-
 var obj = { 'foo': 'bar' };
 var obj = {'foo': 'bar' };
 var obj = { baz: {'foo': 'qux'}, 'bar'};
 var obj = {baz: { 'foo': 'qux' }, 'bar'};
-var obj = {'foo': 'bar'
-};
-
-var obj = {
-  'foo':'bar'};
 ```
 
 The following patterns are not warnings:
@@ -69,6 +57,11 @@ The following patterns are not warnings:
 // When options are [2, "never"]
 
 foo['bar'];
+foo[
+  'bar'
+];
+foo[
+  'bar'];
 
 var arr = [];
 var arr = ['foo', 'bar', 'baz'];
@@ -79,6 +72,10 @@ var arr = [
   'baz'
 ];
 
+var arr = [
+  'foo',
+  'bar'];
+
 var obj = {'foo': 'bar'};
 
 var obj = {'foo': {'bar': 'baz'}, 'qux': 'quxx'};
@@ -86,6 +83,10 @@ var obj = {'foo': {'bar': 'baz'}, 'qux': 'quxx'};
 var obj = {
   'foo': 'bar'
 };
+var obj = {'foo': 'bar'
+};
+var obj = {
+  'foo':'bar'};
 
 var obj = {};
 ```

--- a/lib/rules/space-in-brackets.js
+++ b/lib/rules/space-in-brackets.js
@@ -124,18 +124,24 @@ module.exports = function(context) {
             var propertyNameMustBeSpaced = options.propertyNameException ?
                                     !options.spaced : options.spaced;
 
-            if (isSameLine(before, first) || isSameLine(last, after)) {
+            if (isSameLine(before, first)) {
                 if (propertyNameMustBeSpaced) {
                     if (!isSpaced(before, first) && isSameLine(before, first)) {
                         reportRequiredBeginningSpace(node, before);
-                    }
-                    if (!isSpaced(last, after) && isSameLine(last, after)) {
-                        reportRequiredEndingSpace(node, after);
                     }
                 } else {
                     if (isSpaced(before, first)) {
                         reportNoBeginningSpace(node, before);
                     }
+                }
+            }
+
+            if (isSameLine(last, after)) {
+                if (propertyNameMustBeSpaced) {
+                    if (!isSpaced(last, after) && isSameLine(last, after)) {
+                        reportRequiredEndingSpace(node, after);
+                    }
+                } else {
                     if (isSpaced(last, after)) {
                         reportNoEndingSpace(node, after);
                     }
@@ -165,13 +171,16 @@ module.exports = function(context) {
                 options.singleElementException && node.elements.length === 1
                 ? !options.spaced : options.spaced;
 
-            if (isSameLine(first, second) || isSameLine(penultimate, last)) {
+            if (isSameLine(first, second)) {
                 if (openingBracketMustBeSpaced && !isSpaced(first, second)) {
                     reportRequiredBeginningSpace(node, first);
                 }
                 if (!openingBracketMustBeSpaced && isSpaced(first, second)) {
                     reportNoBeginningSpace(node, first);
                 }
+            }
+
+            if (isSameLine(penultimate, last)) {
                 if (closingBracketMustBeSpaced && !isSpaced(penultimate, last)) {
                     reportRequiredEndingSpace(node, last);
                 }
@@ -196,13 +205,16 @@ module.exports = function(context) {
                 options.objectsInObjectsException && penultimate.value === "}"
                 ? !options.spaced : options.spaced;
 
-            if (isSameLine(first, second) || isSameLine(penultimate, last)) {
+            if (isSameLine(first, second)) {
                 if (options.spaced && !isSpaced(first, second)) {
                     reportRequiredBeginningSpace(node, first);
                 }
                 if (!options.spaced && isSpaced(first, second)) {
                     reportNoBeginningSpace(node, first);
                 }
+            }
+
+            if (isSameLine(penultimate, last)) {
                 if (closingCurlyBraceMustBeSpaced && !isSpaced(penultimate, last)) {
                     reportRequiredEndingSpace(node, last);
                 }

--- a/tests/lib/rules/space-in-brackets.js
+++ b/tests/lib/rules/space-in-brackets.js
@@ -97,6 +97,14 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
         { code: "obj[ obj2[ foo ] ]", args: [2, "never", {"propertyName": true}] },
         { code: "obj['for' + 'Each'](function (item) { return [\n1,\n2,\n3,\n4\n]; })", args: [2, "never"] },
 
+
+        { code: "obj[\nfoo]", args: [2, "never"] },
+        { code: "obj[foo\n]", args: [2, "never"] },
+        { code: "var obj = {foo: bar,\nbaz: qux\n};", args: [2, "never"] },
+        { code: "var obj = {\nfoo: bar,\nbaz: qux};", args: [2, "never"] },
+        { code: "var arr = [1,\n2,\n3,\n4\n];", args: [2, "never"] },
+        { code: "var arr = [\n1,\n2,\n3,\n4];", args: [2, "never"] },
+
         // never - singleValue
         { code: "var foo = [ 'foo' ]", args: [2, "never", {singleValue: true}] },
         { code: "var foo = [ 2 ]", args: [2, "never", {singleValue: true}] },
@@ -556,26 +564,6 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
             ]
         },
         {
-            code: "var obj = {foo: bar,\nbaz: qux\n};",
-            args: [2, "never"],
-            errors: [
-                {
-                    message: "There should be no space before '}'",
-                    type: "ObjectExpression"
-                }
-            ]
-        },
-        {
-            code: "var obj = {\nfoo: bar,\nbaz: qux};",
-            args: [2, "never"],
-            errors: [
-                {
-                    message: "There should be no space after '{'",
-                    type: "ObjectExpression"
-                }
-            ]
-        },
-        {
             code: "var arr = [1, 2, 3, 4];",
             args: [2, "always"],
             errors: [
@@ -667,26 +655,6 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
                 },
                 {
                     message: "There should be no space before ']'",
-                    type: "ArrayExpression"
-                }
-            ]
-        },
-        {
-            code: "var arr = [1,\n2,\n3,\n4\n];",
-            args: [2, "never"],
-            errors: [
-                {
-                    message: "There should be no space before ']'",
-                    type: "ArrayExpression"
-                }
-            ]
-        },
-        {
-            code: "var arr = [\n1,\n2,\n3,\n4];",
-            args: [2, "never"],
-            errors: [
-                {
-                    message: "There should be no space after '['",
                     type: "ArrayExpression"
                 }
             ]


### PR DESCRIPTION
Previously, spacing was enforced unless both brackets were separated from values by new lines. This change allows a new line on one side while still enforcing the spacing on the other.