### PR TITLE
Fix: Find JSXIdentifier refs in no-unused-vars (fixes #1534)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -44,8 +44,9 @@ module.exports = function(context) {
         var variables = scope.variables;
         if (scope.type !== "global") {
             for (var i = 0, l = variables.length; i < l; ++i) {
+
                 // skip function expression names
-                if (scope.functionExpressionScope) {
+                if (scope.functionExpressionScope || variables[i].eslintJSXUsed) {
                     continue;
                 }
                 // skip implicit "arguments" variable
@@ -74,7 +75,7 @@ module.exports = function(context) {
     }
 
     return {
-        "Program": function(programNode) {
+        "Program:exit": function(programNode) {
             var globalScope = context.getScope();
             var unused = unusedLocals(globalScope);
             var i, l;
@@ -96,6 +97,21 @@ module.exports = function(context) {
                     context.report(programNode, MESSAGE, unused[i]);
                 } else if (unused[i].defs.length > 0) {
                     context.report(unused[i].identifiers[0], MESSAGE, unused[i]);
+                }
+            }
+        },
+
+        "JSXIdentifier": function(node) {
+            var scope = context.getScope(),
+                variables = scope.variables,
+                i,
+                len;
+
+            // mark JSXIdentifiers with a special flag
+            for (i = 0, len = variables.length; i < len; i++) {
+                if (variables[i].name === node.name) {
+                    variables[i].eslintJSXUsed = true;
+                    break;
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "chai": "^1.9.1",
     "coveralls": "2.11.2",
     "dateformat": "^1.0.8",
-    "eslint-tester": "^0.2.1",
+    "eslint-tester": "^0.5.0",
     "istanbul": "^0.3.5",
     "jsonlint": "^1.6.2",
     "mocha": "~1.13.0",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -39,6 +39,7 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "function f() { var a = 1; return function(){ f(++a); }; }",
         "try {} catch(e) {}",
         "/*global a */ a;",
+        { code: "function foo() { var App; var bar = React.render(<App/>); return bar; }; foo()", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var a=10; (function() { alert(a); })();", args: [1, {vars: "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all", "args": "after-used"}] },


### PR DESCRIPTION
Bringing in this fix from the es6jsx branch.