### PR TITLE
Fix: Don't warn on JSX literals with newlines (fixes #1533)

### DIFF
--- a/lib/rules/no-multi-str.js
+++ b/lib/rules/no-multi-str.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Rule to flag when using multiline strings
  * @author Ilya Volodin
+ * @copyright 2014 Nicholas C. Zakas. All rights reserved.
+ * @copyright 2013 Ilya Volodin. All rights reserved.
  */
 
 //------------------------------------------------------------------------------
@@ -10,11 +12,26 @@
 module.exports = function(context) {
     "use strict";
 
+    /**
+     * Determines if a given node is part of JSX syntax.
+     * @param {ASTNode} node The node to check.
+     * @returns {boolean} True if the node is a JSX node, false if not.
+     * @private
+     */
+    function isJSXElement(node) {
+        return node.type.indexOf("JSX") === 0;
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
     return {
 
         "Literal": function(node) {
             var lineBreak = /\n/;
-            if (lineBreak.test(node.raw)) {
+
+            if (lineBreak.test(node.raw) && !isJSXElement(node.parent)) {
                 context.report(node, "Multiline support is limited to browsers supporting ES5 only.");
             }
         }

--- a/tests/lib/rules/no-multi-str.js
+++ b/tests/lib/rules/no-multi-str.js
@@ -17,7 +17,8 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-multi-str", {
     valid: [
-        "var a = 'Line 1 Line 2';"
+        "var a = 'Line 1 Line 2';",
+        { code: "var a = <div>\n<h1>Wat</h1>\n</div>;", ecmaFeatures: { jsx: true }}
     ],
     invalid: [
         { code: "var x = 'Line 1 \\\n Line 2'", errors: [{ message: "Multiline support is limited to browsers supporting ES5 only.", type: "Literal"}] },


### PR DESCRIPTION
Pulling in from es6jsx branch.