### PR TITLE
new rule: no-var

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -96,6 +96,7 @@
         "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],
         "no-use-before-define": 2,
         "no-void": 0,
+        "no-var": 0,
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 2,
         "no-wrap-func": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -167,6 +167,12 @@ These rules are purely matters of style and are quite subjective.
 * [spaced-line-comment](spaced-line-comment.md) - require or disallow a space immediately following the `//` in a line comment (off by default)
 * [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses (off by default)
 
+## ECMAScript 6
+
+These rules are only relevant to ES6 environments and are off by default.
+
+* [no-var](no-var.md) - require `let` or `const` instead of `var` (off by default)
+
 ## Legacy
 
 The following rules are included for compatibility with [JSHint](http://jshint.com/) and [JSLint](http://jslint.com/). While the names of the rules may not match up with the JSHint/JSLint counterpart, the functionality is the same.

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -1,0 +1,44 @@
+# require `let` or `const` instead of `var` (no-var)
+
+ECMAScript 6 allows programmers to create variables with block scope instead of function scope using the `let`
+and `const` keywords. Block scope is common in many other programming languages and helps programmers avoid mistakes
+such as:
+
+```js
+var count = people.length;
+var enoughFood = count > sandwhiches.length;
+
+if (enoughFood) {
+    var count = sandwhiches.length; // accidently overriding the count variable
+    console.log("We have " + count + " sandwhiches for everyone. Plenty for all!");
+}
+
+// our count variable is no longer accurate
+console.log("We have " + count + " people and " + sandwhiches.length + " sandwhiches!");
+```
+
+## Rule Details
+
+This rule is aimed at discouraging the use of `var` and encouraging the use of `const` or `let` instead.
+
+The following patterns are considered warnings:
+
+```js
+var x = "y";
+var CONFIG = {};
+```
+
+The following patterns are not considered warnings:
+
+```js
+let x = "y";
+const CONFIG = {};
+```
+
+If you intend to use this rule, you must set `blockBindings` to `true` in the `ecmaFeatures` configuration object,
+which will give ESLint the ability to read `let` and `const` variables.
+
+## When Not To Use It
+
+In addition to non-ES6 environments, existing JavaScript projects that are beginning to introduce ES6 into their
+codebase may not want to apply this rule if the cost of migrating from `var` to `let` is too costly.

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -1,0 +1,24 @@
+/**
+ * @fileoverview Rule to check for the usage of var.
+ * @author Jamund Ferguson
+ * @copyright 2014 Jamund Ferguson. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "VariableDeclaration": function (node) {
+            if (node.kind === "var") {
+                context.report(node, "Unexpected var, use let or const instead.");
+            }
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Tests for no-var rule.
+ * @author Jamund Ferguson
+ * @copyright 2014 Jamund Ferguson. All rights reserved.
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-var", {
+    valid: [
+        {
+            code: "const JOE = 'schmoe';",
+            ecmaFeatures: { blockBindings: true }
+        },
+        {
+            code: "let moo = 'car';",
+            ecmaFeatures: { blockBindings: true }
+        }
+    ],
+
+    invalid: [
+        {
+            code: "var foo = bar;",
+            ecmaFeatures: { blockBindings: true },
+            errors: [
+                {
+                    message: "Unexpected var, use let or const instead.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "var foo = bar, toast = most;",
+            ecmaFeatures: { blockBindings: true },
+            errors: [
+                {
+                    message: "Unexpected var, use let or const instead.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "var foo = bar; let toast = most;",
+            ecmaFeatures: { blockBindings: true },
+            errors: [
+                {
+                    message: "Unexpected var, use let or const instead.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Requires `const` or `let` instead of `var` when defining variables. Only applicable in ES6 environments.