### PR TITLE
Docs: Add angularjs-eslint link into the integration doc

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -27,3 +27,7 @@
 ## Source Control
 
 * [Git Precommit Hook](https://coderwall.com/p/zq8jlq)
+
+## Source Control
+
+* [Git Precommit Hook](https://coderwall.com/p/zq8jlq)


### PR DESCRIPTION
It can be interesting to add links to external ESLint rules. I have just added a specific block in the integration MD file with some rules for AngularJS-based application