### PR TITLE
Fix: no-multi-spaces should allow comments (fixes #1659)

### DIFF
--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -42,6 +42,10 @@ var arr = [1,  2];
 a ?  b: c
 ```
 
+```js
+function(a,  /*b, */ c){ }
+```
+
 The following patterns are not warnings:
 
 ```js
@@ -62,6 +66,10 @@ var arr = [1, 2];
 
 ```js
 a ? b: c
+```
+
+```js
+function(a, /*b, */ c){ }
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -92,6 +92,19 @@ module.exports = function(context) {
             operatorIndex = findIndex(tokens.slice(1, -1), isOperator) + 1,
             op = tokens[operatorIndex];
 
+        if (right.leadingComments) {
+
+            if (right.leadingComments[right.leadingComments.length - 1].range[1] === tokens[operatorIndex + 1].range[0]) {
+
+                // gulp the comments into the token range
+                tokens[operatorIndex + 1].range[0] = right.leadingComments[right.leadingComments.length - 1].range[0];
+            } else if (right.leadingComments[right.leadingComments.length - 1].range[1] + 1 === tokens[operatorIndex + 1].range[0]) {
+
+                // gulp the comments plus one space into the token range
+                tokens[operatorIndex + 1].range[0] = right.leadingComments[right.leadingComments.length - 1].range[0];
+            }
+        }
+
         validate(tokens[operatorIndex - 1], op);
         validate(op, tokens[operatorIndex + 1]);
     }

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -46,6 +46,18 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
         "[ (  1  ) , (  2  ) ]",
         "a = 1, b = 2;",
         "(function(a, b){})",
+        "(function(/*a, b, */c){})",
+        "(function(/*a, */b, c){})",
+        "(function(a,/* b, */c){})",
+        "(function(a,/*b,*/c){})",
+        "(function(a, /*b,*/c){})",
+        "(function(a,/*b,*/ c){})",
+        "(function(a, /*b,*/ c){})",
+        "(function(a, b/*, c*/){})",
+        "(function(a, b/*,c*/){})",
+        "(function(a, b /*,c*/){})",
+        "(function(a/*, b ,c*/){})",
+        "(function(a /*, b ,c*/){})",
         "x.in = 0;"
     ],
 
@@ -167,6 +179,20 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
         },
         {
             code: "function foo(a,  b){}",
+            errors: [{
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "(function(a,  /*b,*/ c){})",
+            errors: [{
+                message: "Multiple spaces found after ','.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "(function(a,  /*b,*/  c){})",
             errors: [{
                 message: "Multiple spaces found after ','.",
                 type: "Punctuator"


### PR DESCRIPTION
Comments offset the tokens for function params, but are not taken into
account when checking for spaces. This fixes that issue by adding the
comment's range to the token's range. Fixes #1659