### PR TITLE
Docs: Add angularjs-eslint link into the integration doc

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -28,6 +28,6 @@
 
 * [Git Precommit Hook](https://coderwall.com/p/zq8jlq)
 
-## Source Control
+## External ESLint rules
 
-* [Git Precommit Hook](https://coderwall.com/p/zq8jlq)
+* [AngularJS Rules](https://github.com/Gillespie59/angularjs-eslint)


### PR DESCRIPTION
Update previous commit. Bad copy/paste