### PR TITLE
Fix no-unused-vars for JSX

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -74,6 +74,30 @@ module.exports = function(context) {
         return [].concat.apply(unused, [].map.call(scope.childScopes, unusedLocals));
     }
 
+    /**
+     * @param {String} nodeName - Name of the node to check.
+     * @returns {void}
+     */
+    function flagVariableAsUsedInJSX(nodeName) {
+        var scope = context.getScope(),
+            variables = scope.variables,
+            i,
+            len;
+
+        while (scope.type !== "global") {
+            scope = scope.upper;
+            variables = [].concat.apply(scope.variables, variables);
+        }
+
+        // mark JSXIdentifiers with a special flag
+        for (i = 0, len = variables.length; i < len; i++) {
+            if (variables[i].name === nodeName) {
+                variables[i].eslintJSXUsed = true;
+                break;
+            }
+        }
+    }
+
     return {
         "Program:exit": function(programNode) {
             var globalScope = context.getScope();
@@ -102,19 +126,14 @@ module.exports = function(context) {
             }
         },
 
-        "JSXIdentifier": function(node) {
-            var scope = context.getScope(),
-                variables = scope.variables,
-                i,
-                len;
-
-            // mark JSXIdentifiers with a special flag
-            for (i = 0, len = variables.length; i < len; i++) {
-                if (variables[i].name === node.name) {
-                    variables[i].eslintJSXUsed = true;
-                    break;
-                }
+        "JSXExpressionContainer": function(node) {
+            if (node.expression.type === "Identifier") {
+                flagVariableAsUsedInJSX(node.expression.name);
             }
+        },
+
+        "JSXIdentifier": function(node) {
+            flagVariableAsUsedInJSX(node.name);
         }
     };
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -41,6 +41,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "/*global a */ a;",
         { code: "function foo() { var App; var bar = React.render(<App/>); return bar; }; foo()", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var App; React.render(<App/>);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
+        { code: "var a=1; React.render(<img src={a} />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
+        { code: "var App; function f() { return <App />; } f();", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var a=10; (function() { alert(a); })();", args: [1, {vars: "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all", "args": "after-used"}] },


### PR DESCRIPTION
This patch should fix 2 issues with the no-unused-vars rule and the recent JSX support:

- no-unused-vars doesn’t recognize used vars within JSXExpressionContainer (#1673)
- when handling JSXIdentifier, the rule only use the current scope to find the defined variables. So if we use a variable defined in a upper scope, this one will not be flagged as used (#1534).

For this I made a new `flagJSXAsUsed` function used for `JSXExpressionContainer` and `JSXIdentifier`.

I also added 2 additional tests to confirm the fix.

(I am not very comfortable with AST yet, hope the fix in lib/rules/no-unused-vars.js:83-86 is correct)
