### PR TITLE
Fix: generator-star should allow params (fixes #1677)

### DIFF
--- a/lib/rules/generator-star.js
+++ b/lib/rules/generator-star.js
@@ -15,16 +15,23 @@ module.exports = function(context) {
     var position = context.options[0] || "end";
 
     /**
-     * Check the position of the start compared to the expected position.
-     * @param {Object} node - the entire function node
-     * @param {Object} starToken - the star token
+     * Check the position of the star compared to the expected position.
+     * @param {ASTNode} node - the entire function node
      * @returns {void}
      */
-    function checkStarPosition(node, starToken) {
+    function checkStarPosition(node) {
+        var starToken;
 
         if (!node.generator) {
             return;
         }
+
+        // Blocked, pending decision to fix or work around in eslint/espree#36
+        if (context.getAncestors().pop().method) {
+            return;
+        }
+
+        starToken = context.getFirstToken(node, 1);
 
         // check for function *name() {}
         if (position === "end") {
@@ -38,7 +45,7 @@ module.exports = function(context) {
         // check for function* name() {}
         if (position === "start") {
 
-            // * ends where the previous identifier ends
+            // * begins where the previous identifier ends
             if (starToken.range[0] !== context.getTokenBefore(starToken).range[1]) {
                 context.report(node, "Expected no space before *.");
             }
@@ -46,18 +53,8 @@ module.exports = function(context) {
     }
 
     return {
-
-        "FunctionDeclaration": function (node) {
-            var starToken = context.getTokenBefore(node.id);
-            checkStarPosition(node, starToken);
-        },
-
-        "FunctionExpression": function (node) {
-
-            // count back an extra token if you have a named anonymous function
-            var starToken = context.getTokenBefore(node.body, node.id ? 3 : 2);
-            checkStarPosition(node, starToken);
-        }
+        "FunctionDeclaration": checkStarPosition,
+        "FunctionExpression": checkStarPosition
     };
 
 };

--- a/tests/lib/rules/generator-star.js
+++ b/tests/lib/rules/generator-star.js
@@ -73,12 +73,27 @@ eslintTester.addRuleTest("lib/rules/generator-star", {
             ecmaFeatures: { "generators": true, "objectLiteralShorthandMethods": true }
         },
         {
+            code: "var x = {\n    *foo(){} }",
+            args: [1, "start"],
+            ecmaFeatures: { "generators": true, "objectLiteralShorthandMethods": true }
+        },
+        {
             code: "var foo = function*(){}",
             args: [1, "start"],
             ecmaFeatures: { "generators": true }
         },
         {
             code: "var foo = function*(){}",
+            args: [1, "end"],
+            ecmaFeatures: { "generators": true }
+        },
+        {
+            code: "var foo = function* ( arg1 ){};",
+            args: [1, "start"],
+            ecmaFeatures: { "generators": true }
+        },
+        {
+            code: "var foo = function *( arg1 ){};",
             args: [1, "end"],
             ecmaFeatures: { "generators": true }
         }


### PR DESCRIPTION
The previous implementation worked backwards from the function body to get to the asterisk. While I suspect that that was done as a workaround for eslint/espree#36, it didn't account for function params. With rest params, default values, and destructuring coming, this approach will become increasingly complex, so I'd like to find another way if at all possible. For now, starting from the beginning works for everything except object literal shorthand generator methods.

This PR fixes the issue as described and bails on the edge case. That way it fixes the bigger issue immediately and won't break anything, but we could also wait for a decision on eslint/espree#36 to revise this PR before merging.