### PR TITLE
Fix: Missing undeclared variables in JSX (fixes #1676)

### DIFF
--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -45,11 +45,49 @@ function hasTypeOfOperator(node) {
     return parent.type === "UnaryExpression" && parent.operator === "typeof";
 }
 
+/**
+ * Checks if a node name match the JSX tag convention.
+ * @param {String} name - Name of the node to check.
+ * @returns {boolean} Whether or not the node name match the JSX tag convention.
+ */
+var tagConvention = /^[a-z]|\-/;
+function isTagName(name) {
+    return tagConvention.test(name);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
+    var NOT_DEFINED_MESSAGE = "'{{name}}' is not defined.",
+        READ_ONLY_MESSAGE = "'{{name}}' is read only.";
+
+    /**
+     * Compare an identifier with the variables declared in the scope
+     * @param {ASTNode} node - Identifier or JSXIdentifier node
+     * @returns {void}
+     */
+    function checkIdentifierInJSX(node) {
+        var scope = context.getScope(),
+            variables = scope.variables,
+            i,
+            len;
+
+        while (scope.type !== "global") {
+            scope = scope.upper;
+            variables = scope.variables.concat(variables);
+        }
+
+        for (i = 0, len = variables.length; i < len; i++) {
+            if (variables[i].name === node.name) {
+                return;
+            }
+        }
+
+        context.report(node, NOT_DEFINED_MESSAGE, { name: node.name });
+    }
 
     return {
 
@@ -66,12 +104,25 @@ module.exports = function(context) {
                 }
 
                 if (!variable) {
-                    context.report(ref.identifier, "'{{name}}' is not defined.", { name: name });
+                    context.report(ref.identifier, NOT_DEFINED_MESSAGE, { name: name });
                 } else if (ref.isWrite() && variable.writeable === false) {
-                    context.report(ref.identifier, "'{{name}}' is read only.", { name: name });
+                    context.report(ref.identifier, READ_ONLY_MESSAGE, { name: name });
                 }
             });
+        },
+
+        "JSXExpressionContainer": function(node) {
+            if (node.expression.type === "Identifier") {
+                checkIdentifierInJSX(node.expression);
+            }
+        },
+
+        "JSXOpeningElement": function(node) {
+            if (!isTagName(node.name.name)) {
+                checkIdentifierInJSX(node.name);
+            }
         }
+
     };
 
 };

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -38,7 +38,11 @@ eslintTester.addRuleTest("lib/rules/no-undef", {
         "typeof (a)",
         "var b = typeof a",
         "typeof a === 'undefined'",
-        "if (typeof a === 'undefined') {}"
+        "if (typeof a === 'undefined') {}",
+        { code: "var React, App; React.render(<App />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
+        { code: "var React; React.render(<img />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
+        { code: "var React; React.render(<x-gif />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
+        { code: "var React, App, a=1; React.render(<App attr={a} />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } }
     ],
     invalid: [
         { code: "a = 1;", errors: [{ message: "'a' is not defined.", type: "Identifier"}] },
@@ -51,6 +55,9 @@ eslintTester.addRuleTest("lib/rules/no-undef", {
         { code: "/*global b:false*/ var b = 1;", errors: [{ message: "'b' is read only.", type: "Identifier"}] },
         { code: "window;", errors: [{ message: "'window' is not defined.", type: "Identifier"}] },
         { code: "require(\"a\");", errors: [{ message: "'require' is not defined.", type: "Identifier"}] },
-        { code: "Array = 1;", errors: [{ message: "'Array' is read only.", type: "Identifier"}] }
+        { code: "Array = 1;", errors: [{ message: "'Array' is read only.", type: "Identifier"}] },
+        { code: "var React; React.render(<App />);", args: [1, {vars: "all"}], errors: [{ message: "'App' is not defined." }], ecmaFeatures: { jsx: true } },
+        { code: "var React; React.render(<img attr={a} />);", args: [1, {vars: "all"}], errors: [{ message: "'a' is not defined." }], ecmaFeatures: { jsx: true } },
+        { code: "var React, App; React.render(<App attr={a} />);", args: [1, {vars: "all"}], errors: [{ message: "'a' is not defined." }], ecmaFeatures: { jsx: true } }
     ]
 });


### PR DESCRIPTION
My fix attempt for #1676.

For the JSXExpressionContainer and JSXOpeningElement nodes, I go through the upper scopes (as in my previous fix #1675) and get the declared variables, then I compare them to the current node name. If I cannot find a matching variable the node is reported as not defined.

For the JSXOpeningElement nodes, [the tags supported by React](https://github.com/facebook/react/blob/master/docs/docs/ref-04-tags-and-attributes.md#supported-tags) are whitelisted to not be marked as not defined.

The report messages were moved in the `NOT_DEFINED_MESSAGE` and `READ_ONLY_MESSAGE` variables to avoid the duplication of the string.

I also added 6 additional tests to confirm the fix.
