### PR TITLE
Fix: disregards leading './' in ignore pattern or file name (fixes #1685)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -110,12 +110,18 @@ IgnoredPaths.prototype.contains = function (filepath) {
     }
 
     filepath = filepath.replace("\\", "/");
+    filepath = filepath.replace(/^\.\//, "");
     return this.patterns.reduce(function(ignored, pattern) {
         var negated = pattern[0] === "!",
             matches;
 
         if (negated) {
             pattern = pattern.slice(1);
+        }
+
+        // Remove leading "current folder" prefix
+        if (pattern.indexOf("./") === 0) {
+            pattern = pattern.slice(2);
         }
 
         matches = minimatch(filepath, pattern) || minimatch(filepath, pattern + "/**");

--- a/tests/fixtures/.eslintignore2
+++ b/tests/fixtures/.eslintignore2
@@ -1,1 +1,3 @@
 undef.js
+./undef2.js
+undef3.js

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -78,6 +78,16 @@ describe("IgnoredPaths", function() {
             assert.ok(ignoredPaths.contains("undef.js"));
         });
 
+        it("should return true for file matching an ignore pattern with leading './'", function() {
+            var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
+            assert.ok(ignoredPaths.contains("undef2.js"));
+        });
+
+        it("should return true for file with leading './' matching an ignore pattern without leading './'", function() {
+            var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
+            assert.ok(ignoredPaths.contains("./undef3.js"));
+        });
+
         it("should return true for file matching a child of an ignore pattern", function() {
             var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
             assert.ok(ignoredPaths.contains("undef.js/subdir/grandsubdir"));


### PR DESCRIPTION
This PR fixes a bug in the logic that determines whether a file name matches a given ignore pattern. It allows file names and/or ignore patterns to contain the "current directory" path prefix (`./`).

Fixes #1685.