### PR TITLE
Update: Combine strict mode rules (fixes #1246)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -89,9 +89,9 @@ These are rules designed to prevent you from making mistakes. They either prescr
 
 These rules relate to using strict mode.
 
-* [global-strict](global-strict.md) - require or disallow the `"use strict"` pragma in the global scope (off by default in the node environment)
-* [no-extra-strict](no-extra-strict.md) - disallow unnecessary use of `"use strict";` when already in strict mode
-* [strict](strict.md) - require that all functions are run in strict mode
+* [global-strict](global-strict.md) - **(deprecated)** require or disallow the `"use strict"` pragma in the global scope (off by default in the node environment)
+* [no-extra-strict](no-extra-strict.md) - **(deprecated)** disallow unnecessary use of `"use strict";` when already in strict mode
+* [strict](strict.md) - controls location of Use Strict Directives
 
 ## Variables
 

--- a/docs/rules/global-strict.md
+++ b/docs/rules/global-strict.md
@@ -1,5 +1,7 @@
 # Global Strict Mode (global-strict)
 
+**Deprecation notice**: This rule is deprecated and has been superseded by the [strict](strict.md) rule. It will be removed in ESLint v1.0. `"global"` mode in the strict rule is most similar to this rule.
+
 Strict mode is enabled by using the following pragma in your code:
 
 ```js

--- a/docs/rules/no-extra-strict.md
+++ b/docs/rules/no-extra-strict.md
@@ -1,5 +1,7 @@
 # Disallow Unnecessary Strict Pragma (no-extra-strict)
 
+**Deprecation notice**: This rule is deprecated and has been superseded by the [strict](strict.md) rule. It will be removed in ESLint v1.0. Both `"global"` and `"function"` mode in the strict rule implement this rule's behavior.
+
 The `"use strict";` directive applies to the scope in which it appears and all inner scopes contained within that scope. Therefore, using the `"use strict";` directive in one of these inner scopes is unnecessary.
 
 ```js

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -1,23 +1,171 @@
-# Require Function Strict Mode (strict)
+# Strict Mode (strict)
 
-Strict mode is enabled by using the following pragma in your code:
+A Use Strict Directive at the beginning of a script or function body enables strict mode semantics:
 
 ```js
 "use strict";
 ```
 
-When used globally, as in this example, the strict mode pragma applies to all code within a single file. That means all functions defined within the file will run in strict mode.
+When used globally, as in the preceding example, the entire script, including all contained functions, are strict mode code. It is also possible to specify function-level strict mode, such that strict mode applies only to the function in which the directive occurs:
 
-It's also possible to specify function-level strict mode, such that strict mode applies just to that function. This is the preferred way of applying strict mode so that you know the extent to which strict mode will be used.
+```js
+function foo() {
+    "use strict";
+    return;
+}
+
+var bar = function() {
+    "use strict";
+    return;
+};
+```
 
 ## Rule Details
 
-This rule is aimed at ensuring all functions are executed in strict mode.
+This rule is aimed at controlling how Use Strict Directives are used in code. It has three modes, each enabled by a single string argument:
 
+### "never" mode
+
+This mode forbids any occurrence of a Use Strict Directive.
 
 The following patterns are considered warnings:
 
 ```js
+// "strict": [2, "never"]
+
+"use strict";
+
+function foo() {
+    "use strict";
+    return;
+}
+
+var bar = function() {
+    "use strict";
+    return;
+};
+
+foo();
+bar();
+```
+
+The following patterns are considered valid:
+
+```js
+// "strict": [2, "never"]
+
+function foo() {
+    return;
+}
+
+var bar = function() {
+    return;
+};
+
+foo();
+bar();
+```
+
+### "global" mode
+
+This mode ensures that all code is in strict mode and that there are no extraneous Use Srict Directives at the top level or in nested functions, which are themselves already strict by virtue of being contained in strict global code. It requires that global code contains exactly one Use Strict Directive. Use Strict Directives inside functions are considered unnecessary. Multiple Use Strict Directives at any level also trigger warnings.
+
+The following patterns are considered warnings:
+
+```js
+// "strict": [2, "global"]
+
+"use strict";
+"use strict"; // Multiple Use Strict Directives
+
+function foo() {
+    "use strict"; // Unnecessary; already nested in strict mode code
+
+    return function() {
+        "use strict"; // Unnecessary; already nested in strict mode code
+        "use strict"; // Multiple Use Strict Directives
+
+        return;
+    };
+}
+
+foo();
+```
+
+The following patterns are considered valid:
+
+```js
+// "strict": [2, "global"]
+
+"use strict";
+
+function foo() {
+    return function() {
+        return;
+    };
+}
+
+foo();
+```
+
+### "function" mode
+
+This mode ensures that all function bodies are strict mode code, while global code is not. Particularly if a build step concatenates multiple scripts, a Use Strict Directive in global code of one script could unintentionally enable strict mode in another script that was not intended to be strict code. It forbids any occurrence of a Use Strict Directive in global code. It requires exactly one Use Strict Directive in each function declaration or expression whose parent is global code. Use Strict Directives inside nested functions are considered unnecessary. Multiple Use Strict Directives at any level also trigger warnings.
+
+The following patterns are considered warnings:
+
+```js
+// "strict": [2, "function"]
+
+"use strict"; // Use function form
+
+function foo() {
+    // Missing Use Strict Directive
+
+    return function() {
+        "use strict"; // Unnecessary; parent should contain a Strict Mode Directive
+        "use strict"; // Multiple Use Strict Directives
+
+        return;
+    };
+}
+
+foo();
+```
+
+The following patterns are considered valid:
+
+```js
+// "strict": [2, "function"]
+
+function foo() {
+    "use strict";
+
+    return function() {
+        return;
+    };
+}
+
+(function() {
+    "use strict";
+
+    return;
+}());
+
+foo();
+```
+
+### deprecated mode (default)
+
+**Deprecation notice**: This mode, enabled by turning on the rule without specifying a mode, is deprecated and remains for backward compatibility. It will be removed entirely in ESLint v1.0, at which point this rule will require a mode option. `"function"` mode is most similar to the deprecated behavior.
+
+This mode ensures that all functions are executed in strict mode. A Use Strict Directive must be present in global code or in every top-level function declaration or expression. It does not concern itself with unnecessary Use Strict Directives in nested functions that are already strict, nor with multiple Use Strict Directives at the same level.
+
+The following patterns are considered warnings:
+
+```js
+// "strict": 2
+
 function foo() {
     return true;
 }
@@ -26,10 +174,12 @@ function foo() {
 The following patterns do not cause a warning:
 
 ```js
+// "strict": 2
+
 "use strict";
 
 function foo() {
-	return true;
+    return true;
 }
 
 // ----------------
@@ -52,4 +202,4 @@ function foo() {
 
 ## When Not To Use It
 
-If you have functions that you specifically want to run in non-strict mode (due to use of strict mode prohibited properties such as `arguments.callee`), then you should turn this rule off.
+In a codebase that has both strict and non-strict code, either turn this rule off, or [selectively disable it](http://eslint.org/docs/configuring/) where necessary. For example, functions referencing `arguments.callee` are invalid in strict mode. A [full list of strict mode differences](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode/Transitioning_to_strict_mode#Differences_from_non-strict_to_strict) is available on MDN.

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -1,9 +1,51 @@
 /**
- * @fileoverview Rule to ensure code is running in strict mode.
- * @author Nicholas C. Zakas
+ * @fileoverview Rule to control usage of strict mode directives.
+ * @author Brandon Mills
+ * @copyright 2015 Brandon Mills. All rights reserved.
  * @copyright 2013-2014 Nicholas C. Zakas. All rights reserved.
+ * @copyright 2013 Ian Christian Myers. All rights reserved.
  */
+
 "use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var messages = {
+    function: "Use the function form of \"use strict\".",
+    global: "Use the global form of \"use strict\".",
+    multiple: "Multiple \"use strict\" directives.",
+    never: "Strict mode is not permitted.",
+    unnecessary: "Unnecessary \"use strict\" directive."
+};
+
+/**
+ * Gets all of the Use Strict Directives in the Directive Prologue of a group of
+ * statements.
+ * @param {ASTNode[]} statements Statements in the program or function body.
+ * @returns {ASTNode[]} All of the Use Strict Directives.
+ */
+function getUseStrictDirectives(statements) {
+    var directives = [],
+        i, statement;
+
+    for (i = 0; i < statements.length; i++) {
+        statement = statements[i];
+
+        if (
+            statement.type === "ExpressionStatement" &&
+            statement.expression.type === "Literal" &&
+            statement.expression.value === "use strict"
+        ) {
+            directives[i] = statement;
+        } else {
+            break;
+        }
+    }
+
+    return directives;
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -11,7 +53,31 @@
 
 module.exports = function(context) {
 
-    var scopes = [];
+    var mode = context.options[0],
+        modes = {},
+        scopes = [];
+
+    /**
+     * Report a node or array of nodes with a given message.
+     * @param {(ASTNode|ASTNode[])} nodes Node or nodes to report.
+     * @param {string} message Message to display.
+     * @returns {void}
+     */
+    function report(nodes, message) {
+        var i;
+
+        if (Array.isArray(nodes)) {
+            for (i = 0; i < nodes.length; i++) {
+                context.report(nodes[i], message);
+            }
+        } else {
+            context.report(nodes, message);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // "deprecated" mode (default)
+    //--------------------------------------------------------------------------
 
     /**
      * Determines if a given node is "use strict".
@@ -63,8 +129,7 @@ module.exports = function(context) {
         scopes.pop();
     }
 
-    return {
-
+    modes.deprecated = {
         "Program": enterScope,
         "FunctionDeclaration": enterScope,
         "FunctionExpression": enterScope,
@@ -73,5 +138,92 @@ module.exports = function(context) {
         "FunctionDeclaration:exit": exitScope,
         "FunctionExpression:exit": exitScope
     };
+
+    //--------------------------------------------------------------------------
+    // "never" mode
+    //--------------------------------------------------------------------------
+
+    modes.never = {
+        "Program": function(node) {
+            report(getUseStrictDirectives(node.body), messages.never);
+        },
+        "FunctionDeclaration": function(node) {
+            report(getUseStrictDirectives(node.body.body), messages.never);
+        },
+        "FunctionExpression": function(node) {
+            report(getUseStrictDirectives(node.body.body), messages.never);
+        }
+    };
+
+    //--------------------------------------------------------------------------
+    // "global" mode
+    //--------------------------------------------------------------------------
+
+    modes.global = {
+        "Program": function(node) {
+            var useStrictDirectives = getUseStrictDirectives(node.body);
+
+            if (node.body.length && useStrictDirectives.length < 1) {
+                report(node, messages.global);
+            } else {
+                report(useStrictDirectives.slice(1), messages.multiple);
+            }
+        },
+        "FunctionDeclaration": function(node) {
+            report(getUseStrictDirectives(node.body.body), messages.global);
+        },
+        "FunctionExpression": function(node) {
+            report(getUseStrictDirectives(node.body.body), messages.global);
+        }
+    };
+
+    //--------------------------------------------------------------------------
+    // "function" mode
+    //--------------------------------------------------------------------------
+
+    /**
+     * Entering a function pushes a new nested scope onto the stack. The new
+     * scope is true if the nested function is strict mode code.
+     * @param {ASTNode} node The function declaration or expression.
+     * @returns {void}
+     */
+    function enterFunction(node) {
+        var useStrictDirectives = getUseStrictDirectives(node.body.body),
+            isParentGlobal = scopes.length === 0,
+            isParentStrict = scopes.length && scopes[scopes.length - 1],
+            isStrict = useStrictDirectives.length > 0;
+
+        if (isStrict) {
+            if (isParentStrict) {
+                report(useStrictDirectives[0], messages.unnecessary);
+            }
+
+            report(useStrictDirectives.slice(1), messages.multiple);
+        } else if (isParentGlobal) {
+            report(node, messages.function);
+        }
+
+        scopes.push(isParentStrict || isStrict);
+    }
+
+    /**
+     * Exiting a function pops its scope off the stack.
+     * @returns {void}
+     */
+    function exitFunction() {
+        scopes.pop();
+    }
+
+    modes.function = {
+        "Program": function(node) {
+            report(getUseStrictDirectives(node.body), messages.function);
+        },
+        "FunctionDeclaration": enterFunction,
+        "FunctionExpression": enterFunction,
+        "FunctionDeclaration:exit": exitFunction,
+        "FunctionExpression:exit": exitFunction
+    };
+
+    return modes[mode || "deprecated"];
 
 };

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -14,30 +14,212 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/strict", {
     valid: [
+
+        // "deprecated" mode (default)
         "\"use strict\"; function foo () {  return; }",
         "'use strict'; function foo () {  return; }",
         "function foo () { \"use strict\"; return; }",
         "function foo () { \"use strict\"; function bar() {}; }",
         "function foo () { 'use strict'; return; }",
         "'use strict'; var foo = function () { bar(); };",
-        "var foo = function () { 'use strict'; bar(); return; };"
+        "var foo = function () { 'use strict'; bar(); return; };",
+
+        // "never" mode
+        { code: "foo();", args: [2, "never"] },
+        { code: "function foo() { return; }", args: [2, "never"] },
+        { code: "var foo = function() { return; };", args: [2, "never"] },
+        { code: "foo(); 'use strict';", args: [2, "never"] },
+        { code: "function foo() { bar(); 'use strict'; return; }", args: [2, "never"] },
+        { code: "var foo = function() { { 'use strict'; } return; };", args: [2, "never"] },
+        { code: "(function() { bar('use strict'); return; }());", args: [2, "never"] },
+
+        // "global" mode
+        { code: "// Intentionally empty", args: [2, "global"] },
+        { code: "\"use strict\"; foo();", args: [2, "global"] },
+        { code: "'use strict'; function foo() { return; }", args: [2, "global"] },
+        { code: "'use strict'; var foo = function() { return; };", args: [2, "global"] },
+        { code: "'use strict'; function foo() { bar(); 'use strict'; return; }", args: [2, "global"] },
+        { code: "'use strict'; var foo = function() { bar(); 'use strict'; return; };", args: [2, "global"] },
+        { code: "'use strict'; function foo() { return function() { bar(); 'use strict'; return; }; }", args: [2, "global"] },
+
+        // "function" mode
+        { code: "function foo() { 'use strict'; return; }", args: [2, "function"] },
+        { code: "var foo = function() { 'use strict'; return; }", args: [2, "function"] },
+        { code: "function foo() { 'use strict'; return; } var bar = function() { 'use strict'; bar(); };", args: [2, "function"] },
+        { code: "var foo = function() { 'use strict'; function bar() { return; } bar(); };", args: [2, "function"] }
+
     ],
     invalid: [
+
+        // "deprecated" mode (default)
         {
             code: "function foo() \n { \n return; }",
-            errors: [{ message: "Missing \"use strict\" statement.", type: "FunctionDeclaration"}]
-        },
-        {
+            errors: [
+                { message: "Missing \"use strict\" statement.", type: "FunctionDeclaration" }
+            ]
+        }, {
             code: "function foo() { function bar() { 'use strict'; } }",
-            errors: [{ message: "Missing \"use strict\" statement.", type: "FunctionDeclaration"}]
-        },
-        {
+            errors: [
+                { message: "Missing \"use strict\" statement.", type: "FunctionDeclaration" }
+            ]
+        }, {
             code: "function foo() { function bar() {} }",
-            errors: [{ message: "Missing \"use strict\" statement.", type: "FunctionDeclaration"}]
-        },
-        {
+            errors: [
+                { message: "Missing \"use strict\" statement.", type: "FunctionDeclaration" }
+            ]
+        }, {
             code: "var foo = function () { return; };",
-            errors: [{ message: "Missing \"use strict\" statement.", type: "FunctionExpression"}]
+            errors: [
+                { message: "Missing \"use strict\" statement.", type: "FunctionExpression" }
+            ]
+        },
+
+        // "never" mode
+        {
+            code: "\"use strict\"; foo();",
+            args: [2, "never"],
+            errors: [
+                { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "function foo() { 'use strict'; return; }",
+            args: [2, "never"],
+            errors: [
+                { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "var foo = function() { 'use strict'; return; };",
+            args: [2, "never"],
+            errors: [
+                { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "function foo() { return function() { 'use strict'; return; }; }",
+            args: [2, "never"],
+            errors: [
+                { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { \"use strict\"; return; }",
+            args: [2, "never"],
+            errors: [
+                { message: "Strict mode is not permitted.", type: "ExpressionStatement" },
+                { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
+            ]
+        },
+
+        // "global" mode
+        {
+            code: "foo();",
+            args: [2, "global"],
+            errors: [
+                { message: "Use the global form of \"use strict\".", type: "Program" }
+            ]
+        }, {
+            code: "function foo() { 'use strict'; return; }",
+            args: [2, "global"],
+            errors: [
+                { message: "Use the global form of \"use strict\".", type: "Program" },
+                { message: "Use the global form of \"use strict\".", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "var foo = function() { 'use strict'; return; }",
+            args: [2, "global"],
+            errors: [
+                { message: "Use the global form of \"use strict\".", type: "Program" },
+                { message: "Use the global form of \"use strict\".", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            args: [2, "global"],
+            errors: [
+                { message: "Use the global form of \"use strict\".", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; var foo = function() { 'use strict'; return; };",
+            args: [2, "global"],
+            errors: [
+                { message: "Use the global form of \"use strict\".", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; 'use strict'; foo();",
+            args: [2, "global"],
+            errors: [
+                { message: "Multiple \"use strict\" directives.", type: "ExpressionStatement" }
+            ]
+        },
+
+        // "function" mode
+        {
+            code: "'use strict'; foo();",
+            args: [2, "function"],
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "(function() { return true; }());",
+            args: [2, "function"],
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "FunctionExpression" }
+            ]
+        }, {
+            code: "var foo = function() { foo(); 'use strict'; return; }; function bar() { foo(); 'use strict'; }",
+            args: [2, "function"],
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "FunctionExpression" },
+                { message: "Use the function form of \"use strict\".", type: "FunctionDeclaration" }
+            ]
+        }, {
+            code: "function foo() { 'use strict'; 'use strict'; return; }",
+            args: [2, "function"],
+            errors: [
+                { message: "Multiple \"use strict\" directives.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "var foo = function() { 'use strict'; 'use strict'; return; }",
+            args: [2, "function"],
+            errors: [
+                { message: "Multiple \"use strict\" directives.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "function foo() { return function() { 'use strict'; return; }; }",
+            args: [2, "function"],
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "FunctionDeclaration" }
+            ]
+        }, {
+            code: "var foo = function() { function bar() { 'use strict'; return; } return; }",
+            args: [2, "function"],
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "FunctionExpression" }
+            ]
+        }, {
+            code: "function foo() { 'use strict'; return; } var bar = function() { return; };",
+            args: [2, "function"],
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "FunctionExpression" }
+            ]
+        }, {
+            code: "var foo = function() { 'use strict'; return; }; function bar() { return; };",
+            args: [2, "function"],
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "FunctionDeclaration" }
+            ]
+        }, {
+            code: "function foo() { 'use strict'; return function() { 'use strict'; 'use strict'; return; }; }",
+            args: [2, "function"],
+            errors: [
+                { message: "Unnecessary \"use strict\" directive.", type: "ExpressionStatement" },
+                { message: "Multiple \"use strict\" directives.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "var foo = function() { 'use strict'; function bar() { 'use strict'; 'use strict'; return; } }",
+            args: [2, "function"],
+            errors: [
+                { message: "Unnecessary \"use strict\" directive.", type: "ExpressionStatement" },
+                { message: "Multiple \"use strict\" directives.", type: "ExpressionStatement" }
+            ]
         }
+
     ]
 });


### PR DESCRIPTION
This combines the three existing strict mode rules, global-strict, no-extra-strict, and strict, into a single strict rule. The combined rule has three modes:

- `"never"` forbids any occurrence of a Use Strict Directive.
- `"global"` ensures that global code contains exactly one Use Strict
  Directive. Use Strict Directives inside functions are considered
  unnecessary. Multiple Use Strict Directives at any level also
  trigger warnings.
- `"function"` forbids any occurrence of a Use Strict Directive in
  global code. It requires exactly one Use Strict Directive in each
  function declaration or expression whose parent is global code. Use
  Strict Directives inside nested functions are considered
  unnecessary. Multiple Use Strict Directives at any level also
  trigger warnings.

Note that a `"use strict";` statement that occurs outside of the Directive Prologue will be flagged by `no-unused-expressions` and not by this rule.

In addition to the three modes described above, the existing behavior of the rule is preserved as the default mode so that this change is a backward-compatible update. Deprecation notices are included in the documentation for the default mode as well as the global-strict and no-extra strict rules. All three notices include suggestions for migrating to the new behavior.

This PR does not move the ESLint codebase onto the new rule. This is a large enough diff as it is, and the change is backward compatible, so I'll open a separate issue for that once this is finalized.