### PR TITLE
Add allowPattern option to dot-notation rule

### DIFF
--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -24,6 +24,19 @@ var x = foo.bar;
 var x = foo[bar];    // Property name is a variable, square-bracket notation required
 ```
 
+### Options
+
+This rule accepts a single options argument with the following defaults:
+```js
+{
+    "rules": {
+        "dot-notation": [2, {"allowKeywords": true, "allowPattern": ""}]
+    }
+}
+```
+
+#### `allowKeywords`
+
 Set the `allowKeywords` option to `false` (default is `true`) to follow ECMAScript version 3 compatible style, avoiding dot notation for reserved word properties.
 
 ```
@@ -33,4 +46,34 @@ Set the `allowKeywords` option to `false` (default is `true`) to follow ECMAScri
 ```js
 var foo = { "class": "CS 101" }
 var x = foo["class"]; // Property name is a reserved word, square-bracket notation required
+```
+
+#### `allowPattern`
+
+Set the `allowPattern` option to a regular expression string to allow bracket notation for property names that match a pattern (by default, no pattern is tested).
+
+For example, when preparing data to be sent to an external API, it is often required to use property names that include underscores.  If the `camelcase` rule is in effect, these [snake case](http://en.wikipedia.org/wiki/Snake_case) properties would not be allowed.  By providing an `allowPattern` to the `dot-notation` rule, these snake case properties can be accessed with bracket notation.
+
+Example configuration:
+
+```js
+{
+    "rules": {
+        "camelcase": 2
+        "dot-notation": [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}]
+    }
+}
+```
+
+Example code patterns:
+
+```js
+var data = {};
+data.foo_bar = 42; // warning from camelcase
+
+var data = {};
+data["fooBar"] = 42; // warning from dot-notation
+
+var data = {};
+data["foo_bar"] = 42; // no warning
 ```

--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -79,6 +79,11 @@ module.exports = function(context) {
     var options = context.options[0] || {};
     var allowKeywords = options.allowKeywords === void 0 || !!options.allowKeywords;
 
+    var allowPattern;
+    if (options.allowPattern) {
+        allowPattern = new RegExp(options.allowPattern);
+    }
+
     return {
         "MemberExpression": function(node) {
             if (
@@ -87,7 +92,9 @@ module.exports = function(context) {
                 validIdentifier.test(node.property.value) &&
                 (allowKeywords || keywords.indexOf("" + node.property.value) === -1)
             ) {
-                context.report(node, "[" + JSON.stringify(node.property.value) + "] is better written in dot notation.");
+                if (!(allowPattern && allowPattern.test(node.property.value))) {
+                    context.report(node, "[" + JSON.stringify(node.property.value) + "] is better written in dot notation.");
+                }
             }
             if (
                 !allowKeywords &&

--- a/tests/lib/rules/dot-notation.js
+++ b/tests/lib/rules/dot-notation.js
@@ -31,6 +31,8 @@ eslintTester.addRuleTest("lib/rules/dot-notation", {
         { code: "a[null];", args: [2, {allowKeywords: false}] },
         { code: "a.true;", args: [2, {allowKeywords: true}] },
         { code: "a.null;", args: [2, {allowKeywords: true}] },
+        { code: "a['snake_case'];", args: [2, {allowPattern: "^[a-z]+(_[a-z]+)+$"}] },
+        { code: "a['lots_of_snake_case'];", args: [2, {allowPattern: "^[a-z]+(_[a-z]+)+$"}] },
         "a.true;",
         "a.null;",
         "a[undefined];",
@@ -42,6 +44,8 @@ eslintTester.addRuleTest("lib/rules/dot-notation", {
         { code: "a['true'];", errors: [{ message: "[\"true\"] is better written in dot notation." }] },
         { code: "a[null];", errors: [{ message: "[null] is better written in dot notation." }] },
         { code: "a['b'];", errors: [{ message: "[\"b\"] is better written in dot notation." }] },
-        { code: "a.b['c'];", errors: [{ message: "[\"c\"] is better written in dot notation." }] }
+        { code: "a.b['c'];", errors: [{ message: "[\"c\"] is better written in dot notation." }] },
+        { code: "a['_dangle'];", args: [2, {allowPattern: "^[a-z]+(_[a-z]+)+$"}], errors: [{ message: "[\"_dangle\"] is better written in dot notation." }] },
+        { code: "a['SHOUT_CASE'];", args: [2, {allowPattern: "^[a-z]+(_[a-z]+)+$"}], errors: [{ message: "[\"SHOUT_CASE\"] is better written in dot notation." }] }
     ]
 });


### PR DESCRIPTION
This adds an `allowPattern` option to the `dot-notation` rule for allowing exceptions to the rule.  If a string pattern is provided, it will be used to create a RegExp for testing property names.  In member expressions where the property name matches the `allowPattern`, bracket notation will be allowed.

For example, with this rule configuration:
```js
  "rules": {
    "dot-notation": [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}]
  }
```

The following would not be treated as an error:
```js
var data = {};
data['foo_bar'] = 42;
```

While the following would be treated as an error:
```js
var data = {};
data['fooBar'] = 42; // better written as data.fooBar
```

The example above allows the `dot-notation` rule to be used in conjunction with the `camelcase` rule - allowing snake_case properties to be assigned with bracket notation (for example when generating data to be sent to an external service).

Fixes #1679.
