### PR TITLE
Update: Added globals for: phantom,jquery, prototypejs, shelljs (fixes #1704)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 npm-debug.log
 .DS_Store
 tmp/
+.idea

--- a/conf/environments.js
+++ b/conf/environments.js
@@ -33,5 +33,17 @@ module.exports = {
     },
     jasmine: {
         globals: globals.jasmine
+    },
+    phantomjs: {
+        globals: globals.phantom
+    },
+    jquery: {
+        globals: globals.jquery
+    },
+    prototypejs: {
+        globals: globals.prototypejs
+    },
+    shelljs: {
+        globals: globals.shelljs
     }
 };

--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -58,6 +58,11 @@ An environment defines both global variables that are predefined as well as whic
 * `amd` - defines `require()` and `define()` as global variables as per the [amd](https://github.com/amdjs/amdjs-api/wiki/AMD) spec.
 * `mocha` - adds all of the Mocha testing global variables.
 * `jasmine` - adds all of the Jasmine testing global variables for version 1.3 and 2.0.
+* `phantomjs` - phantomjs global variables.
+* `jquery` - jquery global variables.
+* `prototypejs` - prototypejs global variables.
+* `shelljs` - shelljs global variables.
+
 
 These environments are not mutually exclusive, so you can define more than one at a time.
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "escope": "~1.0.0",
     "espree": "^1.6.0",
     "estraverse": "^1.9.1",
-    "globals": "^5.0.0",
+    "globals": "^5.1.0",
     "js-yaml": "^3.2.5",
     "minimatch": "^2.0.1",
     "mkdirp": "^0.5.0",


### PR DESCRIPTION
Added environment configuration options to enable `phantom`, `jquery`, `prototypejs`, `shelljs`

@sindresorhus @es128 
refs to globals package update 5.1.0 
https://github.com/sindresorhus/globals/pull/18

ps: CLA signed