### PR TITLE
Docs: Fixed example for the quotes rule

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -45,8 +45,8 @@ var double = "double";
 var single = 'single';
 
 // When [1, "double", "avoid-escape"]
-var single = "a string containing 'double' quotes";
+var double = "a string containing 'double' quotes";
 
 // When [1, "single", "avoid-escape"]
-var double = 'a string containing "single" quotes';
+var single = 'a string containing "single" quotes';
 ```

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -45,8 +45,8 @@ var double = "double";
 var single = 'single';
 
 // When [1, "double", "avoid-escape"]
-var single = 'a string containing "double" quotes';
+var single = "a string containing 'double' quotes";
 
 // When [1, "single", "avoid-escape"]
-var double = "a string containing 'single' quotes";
+var double = 'a string containing "single" quotes';
 ```


### PR DESCRIPTION
Edit:
Example for the "quotes" rule and its "avoid-escape" argument, changed to match the comments.

the first commit (343bfdc) is wrong - 405511a is ok