### PR TITLE
Docs: Fixed example for the space-return-throw-case rule

### DIFF
--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -29,5 +29,5 @@ function f(){ return -a; }
 ```
 
 ```js
-function f(){ return; }
+switch(a){ case 'a': break; }
 ```


### PR DESCRIPTION
Edit:
Instead of having two "non-warning" examples for the `return` keyword, the last one changed, to include the `case` keyword and to match the last "warning" example.