### PR TITLE
Breaking: Update escope (fixes #1642)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -365,6 +365,7 @@ module.exports = (function() {
         currentTokens = null,
         currentScopes = null,
         scopeMap = null,
+        scopeManager = null,
         currentFilename = null,
         controller = null,
         reportingConfig = [],
@@ -500,6 +501,7 @@ module.exports = (function() {
         currentTokens = null;
         currentScopes = null;
         scopeMap = null;
+        scopeManager = null;
         controller = null;
         reportingConfig = [];
         commentLocsEnter = [];
@@ -581,7 +583,8 @@ module.exports = (function() {
             controller = new estraverse.Controller();
 
             // gather data that may be needed by the rules
-            currentScopes = escope.analyze(ast, { ignoreEval: true }).scopes;
+            scopeManager = escope.analyze(ast, { ignoreEval: true });
+            currentScopes = scopeManager.scopes;
 
             /*
              * Index the scopes by the start range of their block for efficient
@@ -830,8 +833,7 @@ module.exports = (function() {
      */
     api.getScope = function() {
         var parents = controller.parents(),
-            innerBlock = null,
-            selectedScopeIndex;
+            scope = currentScopes[0];
 
         // Don't do this for Program nodes - they have no parents
         if (parents.length) {
@@ -845,28 +847,16 @@ module.exports = (function() {
             // Ascend the current node's parents
             for (var i = parents.length - 1; i >= 0; --i) {
 
-                // The first node that requires a scope is the node that will be
-                // our current node's innermost scope.
-                if (escope.Scope.isScopeRequired(parents[i])) {
-                    innerBlock = parents[i];
-                    break;
+                scope = scopeManager.acquire(parents[i]);
+                if (scope) {
+                    return scope;
                 }
+
             }
 
-            // Find and return the innermost scope
-            selectedScopeIndex = scopeMap[innerBlock.range[0]];
-
-            // Named function expressions create two nested scope objects. The
-            // outer scope contains only the function expression name. We return
-            // the inner scope.
-            if (innerBlock.type === "FunctionExpression" && innerBlock.id && innerBlock.id.name) {
-                ++selectedScopeIndex;
-            }
-
-            return currentScopes[selectedScopeIndex];
-        } else {
-            return currentScopes[0];    // global scope
         }
+
+        return currentScopes[0];
     };
 
     /**

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Rule to flag references to undeclared variables.
  * @author Mark Macdonald
+ * @copyright 2015 Nicholas C. Zakas. All rights reserved.
+ * @copyright 2013 Mark Macdonald. All rights reserved.
  */
 "use strict";
 
@@ -81,6 +83,7 @@ module.exports = function(context) {
         }
 
         for (i = 0, len = variables.length; i < len; i++) {
+
             if (variables[i].name === node.name) {
                 return;
             }
@@ -109,12 +112,6 @@ module.exports = function(context) {
                     context.report(ref.identifier, READ_ONLY_MESSAGE, { name: name });
                 }
             });
-        },
-
-        "JSXExpressionContainer": function(node) {
-            if (node.expression.type === "Identifier") {
-                checkIdentifierInJSX(node.expression);
-            }
         },
 
         "JSXOpeningElement": function(node) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "debug": "^2.1.1",
     "doctrine": "^0.6.2",
     "escape-string-regexp": "^1.0.2",
-    "escope": "~1.0.0",
+    "escope": "^2.0.3",
     "espree": "^1.7.1",
     "estraverse": "^1.9.1",
     "globals": "^5.1.0",


### PR DESCRIPTION
This updates escope but does not implement ES6 scoping. Marking as breaking because the scope calculation is done differently and we may run into problems. We should wait until 3.0.0 of escope to turn on ES6 scoping.