### PR TITLE
Update: no-warning-comments matches on whole word only (fixes #1709)

### DIFF
--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -18,6 +18,7 @@ This preconfigures
 
 * the rule is disabled because it is set to `0`. Changing this to `1` for warn or `2` for error mode activates it (this works exactly the same as everywhere else in `ESLint`).
 * the `terms` array is set to `todo`, `fixme` and `xxx` as `warning-comments`. `terms` has to be an array. It can hold any terms you might want to warn about in your comments - they do not have to be single words. E.g. `really bad idea` is as valid as `attention`.
+* the `terms` are case-insensitive and are matched as whole words. E.g. `fix` would not match `fixing`.
 * the `location`-option set to `start` configures the rule to check only the start of comments. E.g. `// TODO` would be matched, `// This is a TODO` not. You can change this to `anywhere` to check your complete comments.
 
 As already seen above, the configuration is quite simple. Example that enables the rule and configures it to check the complete comment, not only the start:
@@ -47,6 +48,7 @@ These patterns would not be considered warnings with the same example configurat
 ```js
 // This is to do
 // even not any other    term
+// any other terminal
 /*
  * The same goes for block comments
  * with any other interesting term
@@ -54,8 +56,6 @@ These patterns would not be considered warnings with the same example configurat
  */
 ...
 ```
-
-As mentioned above, patterns are matched when they match exactly to one of the terms specified (ignoring the case).
 
 ## Rule Options
 
@@ -109,10 +109,10 @@ As mentioned above, patterns are matched when they match exactly to one of the t
    ...
    ```
 
-5. Rule configured to warn on matches of the specified terms at the start of comments. Note that you can use as many terms as you want.
+5. Rule configured to warn on matches of the specified terms at any location in the comments. Note that you can use as many terms as you want.
 
    ```js
    ...
-   "no-warning-comments": [1, { "terms": ["any really", "interesting", "or even not", "term", "can be matched"] }]
+   "no-warning-comments": [1, { "terms": ["really any", "term", "can be matched"], "location": "anywhere" }]
    ...
    ```

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -13,42 +13,38 @@ module.exports = function (context) {
 
     var configuration = context.options[0] || {},
         warningTerms = configuration.terms || ["todo", "fixme", "xxx"],
-        location = configuration.location || "start";
+        location = configuration.location || "start",
+        warningRegExps;
 
     /**
-     * Prepares a specified comment for being checked.
-     * @param {String} comment The comment to prepare.
-     * @returns {String} The specified comment prepared for being checked.
+     * Convert a warning term into a RegExp which will match a comment containing that whole word in the specified
+     * location ("start" or "anywhere"). If the term starts or ends with non word characters, then the match will not
+     * require word boundaries on that side.
+     *
+     * @param {String} term A term to convert to a RegExp
+     * @returns {RegExp} The term converted to a RegExp
      */
-    function prepareCommentForChecking(comment) {
-        var commentToCheck;
+    function convertToRegExp(term) {
+        var escaped = term.replace(/[-\/\\$\^*+?.()|\[\]{}]/g, "\\$&"),
+            // If the term ends in a word character (a-z0-9_), ensure a word boundary at the end, so that substrings do
+            // not get falsely matched. eg "todo" in a string such as "mastodon".
+            // If the term ends in a non-word character, then \b won't match on the boundary to the next non-word
+            // character, which would likely be a space. For example `/\bFIX!\b/.test('FIX! blah') === false`.
+            // In these cases, use no bounding match. Same applies for the prefix, handled below.
+            suffix = /\w$/.test(term) ? "\\b" : "",
+            prefix;
 
-        commentToCheck = comment.toLowerCase();
-        commentToCheck = commentToCheck.trim();
+        if (location === "start") {
+            // When matching at the start, ignore leading whitespace, and there's no need to worry about word boundaries
+            prefix = "^\\s*";
+        } else if (/^\w/.test(term)) {
+            prefix = "\\b";
+        } else {
+            prefix = "";
+        }
 
-        return commentToCheck;
+        return new RegExp(prefix + escaped + suffix, "i");
     }
-
-    /**
-     * Checks if the specified comment starts with a specified term.
-     * @param {String} commentToCheck The comment to check.
-     * @param {String} lowerCaseTerm The term to search for.
-     * @returns {Boolean} True if the comment started with the specified term, else false.
-     */
-    function commentStartsWithTerm(commentToCheck, lowerCaseTerm) {
-        return commentToCheck.indexOf(lowerCaseTerm) === 0;
-    }
-
-    /**
-     * Checks if the specified comment contains a specified term at any location.
-     * @param {String} commentToCheck The comment to check.
-     * @param {String} lowerCaseTerm The term to search for.
-     * @returns {Boolean} True if the term was contained in the comment, else false.
-     */
-    function commentContainsTerm(commentToCheck, lowerCaseTerm) {
-        return commentToCheck.indexOf(lowerCaseTerm) !== -1;
-    }
-
 
     /**
      * Checks the specified comment for matches of the configured warning terms and returns the matches.
@@ -58,18 +54,9 @@ module.exports = function (context) {
     function commentContainsWarningTerm(comment) {
         var matches = [];
 
-        warningTerms.forEach(function (term) {
-            var lowerCaseTerm = term.toLowerCase(),
-                commentToCheck = prepareCommentForChecking(comment);
-
-            if (location === "start") {
-                if (commentStartsWithTerm(commentToCheck, lowerCaseTerm)) {
-                    matches.push(term);
-                }
-            } else if (location === "anywhere") {
-                if (commentContainsTerm(commentToCheck, lowerCaseTerm)) {
-                    matches.push(term);
-                }
+        warningRegExps.forEach(function (regex, index) {
+            if (regex.test(comment)) {
+                matches.push(warningTerms[index]);
             }
         });
 
@@ -89,6 +76,7 @@ module.exports = function (context) {
         });
     }
 
+    warningRegExps = warningTerms.map(convertToRegExp);
     return {
         "BlockComment": checkComment,
         "LineComment": checkComment

--- a/tests/lib/rules/no-warning-comments.js
+++ b/tests/lib/rules/no-warning-comments.js
@@ -32,7 +32,10 @@ eslintTester.addRuleTest("lib/rules/no-warning-comments", {
         { code: "/* any block comment */", args: [1, { "location": "anywhere" } ] },
         { code: "/* any block comment with TODO, FIXME or XXX */", args: [1, { "location": "start" } ] },
         { code: "/* any block comment with TODO, FIXME or XXX */", args: [1] },
-        { code: "/* any block comment with TODO, FIXME or XXX */", args: 1 }
+        { code: "/* any block comment with TODO, FIXME or XXX */", args: 1 },
+        { code: "/* any block comment with (TODO, FIXME's or XXX!) */", args: 1 },
+        { code: "// comments containing terms as substrings like TodoMVC", args: [1, { "terms": ["todo"], "location": "anywhere" } ] },
+        { code: "// special regex characters don't cause problems", args: [1, { "terms": ["[aeiou]"], "location": "anywhere" } ] }
     ],
     invalid: [
         { code: "// fixme", args: [1], errors: [ { message: "Unexpected fixme comment." } ] },
@@ -47,6 +50,8 @@ eslintTester.addRuleTest("lib/rules/no-warning-comments", {
         { code: "/* any fixme or todo */", args: [1, { "terms": ["fixme", "todo"], "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." }, { message: "Unexpected todo comment." } ] },
         { code: "/* any fixme or todo */", args: [1, { "location": "anywhere" } ], errors: [ { message: "Unexpected todo comment." }, { message: "Unexpected fixme comment." } ] },
         { code: "/* fixme and todo */", args: [1], errors: [ { message: "Unexpected fixme comment." } ] },
-        { code: "/* any fixme */", args: [1, { "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." } ] }
+        { code: "/* any fixme */", args: [1, { "location": "anywhere" } ], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "/* fixme! */", args: [1, { "terms": ["fixme"] } ], errors: [ { message: "Unexpected fixme comment." } ] },
+        { code: "// regex [litera|$]", args: [1, { "terms": ["[litera|$]"], "location": "anywhere" } ], errors: [ { message: "Unexpected [litera|$] comment." } ] }
     ]
 });


### PR DESCRIPTION
Description from #1709:
> The no-warning-comments rule just does an indexOf check to find the specified terms in the comments, which means it matches on parts of words. This isn't such a problem for terms such as "todo", "fixme", etc, but if you want to use other words in there, then you can get a lot of false positives. For example, the term "he" is found in "the". Surrounding the term with spaces doesn't help either, since it might be followed by punctuation.

Using a regex search simplified the flow quite considerably, since the location logic and leading whitespace handling could all be encoded in the regex very simply.