### PR TITLE
Support eslint.json as local configuration file name

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -26,10 +26,9 @@ var fs = require("fs"),
 // Constants
 //------------------------------------------------------------------------------
 
-var LOCAL_CONFIG_FILENAME = ".eslintrc",
+var LOCAL_CONFIG_FILENAMES = ["eslint.json", ".eslintrc"],
     PACKAGE_CONFIG_FILENAME = "package.json",
-    PACKAGE_CONFIG_FIELD_NAME = "eslintConfig",
-    PERSONAL_CONFIG_PATH = path.join(userHome, LOCAL_CONFIG_FILENAME);
+    PACKAGE_CONFIG_FIELD_NAME = "eslintConfig";
 
 //------------------------------------------------------------------------------
 // Private
@@ -112,10 +111,15 @@ function getPluginsConfig(pluginNames) {
 function getPersonalConfig() {
     var config = {};
 
-    if (fs.existsSync(PERSONAL_CONFIG_PATH)) {
-        debug("Using personal config");
-        config = loadConfig(PERSONAL_CONFIG_PATH);
-    }
+    LOCAL_CONFIG_FILENAMES.every(function(LOCAL_CONFIG_FILENAME) {
+        var personalConfigPath = path.join(userHome, LOCAL_CONFIG_FILENAME);
+
+        if (fs.existsSync(personalConfigPath)) {
+            debug("Using personal config");
+            config = loadConfig(personalConfigPath);
+            return false; // break
+        }
+    });
 
     return config;
 }
@@ -139,7 +143,7 @@ function getLocalConfig(thisConfig, directory) {
         localConfigFile = localConfigFiles[i];
         localConfig = loadConfig(localConfigFile);
 
-        if (path.basename(localConfigFile) !== LOCAL_CONFIG_FILENAME) {
+        if (LOCAL_CONFIG_FILENAMES.indexOf(path.basename(localConfigFile)) === -1) {
 
             // Don't consider a local config file found if the package.json doesn't have the eslintConfig field.
             if (!localConfig.hasOwnProperty(PACKAGE_CONFIG_FIELD_NAME)) {
@@ -327,7 +331,7 @@ Config.prototype.getConfig = function (filePath) {
 Config.prototype.findLocalConfigFiles = function (directory) {
 
     if (!this.localConfigFinder) {
-        this.localConfigFinder = new FileFinder(LOCAL_CONFIG_FILENAME, PACKAGE_CONFIG_FILENAME);
+        this.localConfigFinder = new FileFinder(LOCAL_CONFIG_FILENAMES, PACKAGE_CONFIG_FILENAME);
     }
 
     return this.localConfigFinder.findAllInDirectoryAndParents(directory);

--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -41,7 +41,20 @@ function getDirectoryEntries(directory) {
  * @param {...string} arguments The basename(s) of the file(s) to find.
  */
 function FileFinder() {
-    this.fileNames = Array.prototype.slice.call(arguments);
+    var self = this,
+        extractedFileNames = [];
+
+    self.fileNames = Array.prototype.slice.call(arguments);
+
+    self.fileNames.forEach(function(fileName, i) {
+        if (Array.isArray(fileName)) {
+            extractedFileNames = extractedFileNames.concat(fileName);
+            self.fileNames.splice(i, 1);
+        }
+    });
+
+    self.fileNames = self.fileNames.concat(extractedFileNames);
+
     this.cache = {};
 }
 


### PR DESCRIPTION
Some editors and IDEs don't treat .eslintrc as JSON file because of its file extension.
Highlights and code formatting is not available.

With this change, `eslint.json` is also accepted as a ESLint configuration file and those editors treat it as JSON.