### PR TITLE
Update: spaced-line-comment now also allows tab (fixes #1713)

### DIFF
--- a/docs/rules/spaced-line-comment.md
+++ b/docs/rules/spaced-line-comment.md
@@ -1,16 +1,16 @@
-# Requires or disallows a space beginning a single-line comment (spaced-line-comment)
+# Requires or disallows a whitespace (space or tab) beginning a single-line comment (spaced-line-comment)
 
-Some style guides require or disallow a space immediately after the initial `//` of a line comment.
+Some style guides require or disallow a whitespace immediately after the initial `//` of a line comment.
 Whitespace after the `//` makes it easier to read text in comments.
-On the other hand, commenting out code is easier without having to put a space right after the `//`.
+On the other hand, commenting out code is easier without having to put a whitespace right after the `//`.
 
 
 ## Rule Details
 
 This rule will enforce consistency of spacing after the start of a line comment `//`.
 
-This rule takes two arguments. If the first is `"always"` then the `//` must be followed by at least once space. 
-If `"never"` then there should be no space following.
+This rule takes two arguments. If the first is `"always"` then the `//` must be followed by at least once whitespace. 
+If `"never"` then there should be no whitespace following.
 The default is `"always"`.
 
 The second argument is an object with one key, `"exceptions"`. 
@@ -22,12 +22,12 @@ The following patterns are considered warnings:
 
 ```js
 // When ["never"]
-// This is a comment with a space at the beginning
+// This is a comment with a whitespace at the beginning
 ```
 
 ```js
 //When ["always"]
-//This is a comment with no space at the beginning
+//This is a comment with no whitespace at the beginning
 var foo = 5;  
 ```
 
@@ -42,13 +42,13 @@ The following patterns are not warnings:
 
 ```js
 // When ["always"]
-// This is a comment with a space at the beginning
+// This is a comment with a whitespace at the beginning
 var foo = 5;  
 ```
 
 ```js
 //When ["never"]
-//This is a comment with no space at the beginning
+//This is a comment with no whitespace at the beginning
 var foo = 5;  
 ```
 

--- a/lib/rules/spaced-line-comment.js
+++ b/lib/rules/spaced-line-comment.js
@@ -46,23 +46,23 @@ module.exports = function(context) {
                 }
 
                 // Space expected and not found
-                if (node.value.indexOf(" ") !== 0) {
+                if (node.value.indexOf(" ") !== 0 && node.value.indexOf("\t") !== 0) {
 
                     /*
                      * Do two tests; one for space starting the line,
                      * and one for a comment comprised only of exceptions
                      */
                     if (hasExceptions && !exceptionMatcher.test(node.value)) {
-                        context.report(node, "Expected exception block or space after // in comment.");
+                        context.report(node, "Expected exception block, space or tab after // in comment.");
                     } else if (!hasExceptions) {
-                        context.report(node, "Expected space after // in comment.");
+                        context.report(node, "Expected space or tab after // in comment.");
                     }
                 }
 
             } else {
 
-                if (node.value.indexOf(" ") === 0) {
-                    context.report(node, "Unexpected space after // in comment.");
+                if (node.value.indexOf(" ") === 0 || node.value.indexOf("\t") === 0) {
+                    context.report(node, "Unexpected space or tab after // in comment.");
                 }
             }
         }

--- a/tests/lib/rules/spaced-line-comment.js
+++ b/tests/lib/rules/spaced-line-comment.js
@@ -18,7 +18,7 @@ var eslint = require("../../../lib/eslint"),
 
 var eslintTester = new ESLintTester(eslint),
     alwaysError = {
-        messsage: "Expected space after // in comment.",
+        messsage: "Expected space or tab after // in comment.",
         type: "Line"
     },
     alwaysArgs = [
@@ -31,11 +31,11 @@ var eslintTester = new ESLintTester(eslint),
         {exceptions: ["-", "=", "*", "#", "!@#"] }
     ],
     alwaysExceptionError = {
-        message: "Expected exception block or space after // in comment.",
+        message: "Expected exception block, space or tab after // in comment.",
         type: "Line"
     },
     neverError = {
-        message: "Unexpected space after // in comment.",
+        message: "Unexpected space or tab after // in comment.",
         type: "Line"
     },
     neverArgs = [
@@ -50,6 +50,10 @@ eslintTester.addRuleTest("lib/rules/spaced-line-comment", {
     valid: [
         {
             code: "// A valid comment starting with space\nvar a = 1;",
+            args: alwaysArgs
+        },
+        {
+            code: "//   A valid comment starting with tab\nvar a = 1;",
             args: alwaysArgs
         },
         {
@@ -94,6 +98,11 @@ eslintTester.addRuleTest("lib/rules/spaced-line-comment", {
         },
         {
             code: "// An invalid comment starting with space\nvar a = 2;",
+            errors: [ neverError ],
+            args: neverArgs
+        },
+        {
+            code: "//   An invalid comment starting with tab\nvar a = 2;",
             errors: [ neverError ],
             args: neverArgs
         },


### PR DESCRIPTION
The spaced-line-comment rule now also allows tab and not only space. (fixes #1713)

PS: This is my first pull request for eslint.I read the documentation and hope to not have forgotten anything.