### PR TITLE
Docs: add Jasmine rules and eslintplugin npm links

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -30,4 +30,7 @@
 
 ## External ESLint rules
 
-* [AngularJS Rules](https://github.com/Gillespie59/angularjs-eslint)
+* [AngularJS](https://github.com/Gillespie59/angularjs-eslint)
+* [Jasmine](https://github.com/tlvince/eslint-plugin-jasmine)
+
+… and many more published on npm with the [eslintplugin](https://www.npmjs.com/search?q=eslintplugin) tag.


### PR DESCRIPTION
Following #1660 (#1668), I've just overhauled [eslint-plugin-jasmine](https://github.com/tlvince/eslint-plugin-jasmine) (previously eslint-plugin-no-exclusive-tests) and thought I'd do a bit of shameless self-promotion :wink:

It might also be nice to start highlighting others' efforts. I've also added a link to the eslintplugin tag on npm.