### PR TITLE
Fix: Make no-multi-spaces work for every case (fixes #1603, fixes #1659)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -370,7 +370,8 @@ module.exports = (function() {
         controller = null,
         reportingConfig = [],
         commentLocsEnter = [],
-        commentLocsExit = [];
+        commentLocsExit = [],
+        currentAST = null;
 
     /**
      * Parses text into an AST. Moved out here because the try-catch prevents
@@ -495,6 +496,7 @@ module.exports = (function() {
     api.reset = function() {
         this.removeAllListeners();
         messages = [];
+        currentAST = null;
         currentConfig = null;
         currentText = null;
         currentTextLines = [];
@@ -537,6 +539,9 @@ module.exports = (function() {
 
         // if espree failed to parse the file, there's no sense in setting up rules
         if (ast) {
+
+            currentAST = ast;
+
             // process initial config to make it safe to extend
             config = prepareConfig(config);
 
@@ -736,6 +741,14 @@ module.exports = (function() {
      */
     api.getSourceLines = function() {
         return currentTextLines;
+    };
+
+    /**
+     * Retrieves an array containing all comments in the source code.
+     * @returns {ASTNode[]} An array of comment nodes.
+     */
+    api.getAllComments = function() {
+        return currentAST.comments;
     };
 
     /**

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -25,7 +25,9 @@ var PASSTHROUGHS = [
         "getAncestors",
         "getScope",
         "getJSDocComment",
-        "getFilename"
+        "getFilename",
+        "getTokenByRangeIndex",
+        "getAllComments"
     ];
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -1,58 +1,9 @@
 /**
  * @fileoverview Disallow use of multiple spaces.
- * @author Vignesh Anand aka vegetableman.
- * @copyright 2014 Vignesh Anand. All rights reserved.
- * @copyright 2014 Brandon Mills. All rights reserved.
+ * @author Nicholas C. Zakas
+ * @copyright 2015 Nicholas C. Zakas. All rights reserved.
  */
 "use strict";
-
-//------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-var OPERATORS = {
-    "Punctuator": {
-        "*": true, "/": true, "%": true, "+": true, "-": true, "<<": true,
-        ">>": true, ">>>": true, "<": true, "<=": true, ">": true, ">=": true,
-        "==": true, "!=": true, "===": true, "!==": true, "&": true, "^": true,
-        "|": true, "&&": true, "||": true, "=": true, "+=": true, "-=": true,
-        "*=": true, "/=": true, "%=": true, "<<=": true, ">>=": true,
-        ">>>=": true, "&=": true, "^=": true, "|=": true, "?": true, ":": true,
-        ",": true
-    },
-    "Keyword": {
-        "in": true,
-        "instanceof": true
-    }
-};
-
-/**
- * Determines whether a token is a binary operator.
- * @param   {Token}   token The token.
- * @returns {Boolean}       Whether the token is a binary operator.
- */
-function isOperator(token) {
-    var type = OPERATORS[token.type];
-    return (type && type[token.value]) || false;
-}
-
-/**
- * Gets the index of the first element of an array that satisfies a predicate.
- * Like Array.prototype.indexOf(), but with a predicate instead of equality.
- * @param   {Array}    array     An array to search.
- * @param   {Function} predicate A function returning true if its argument
- *                               satisfies a condition.
- * @returns {Number}             The index of the first element that satisifies
- *                               the predicate, or -1 if no elements match.
- */
-function findIndex(array, predicate) {
-    for (var i = 0, l = array.length; i < l; i++) {
-        if (predicate(array[i])) {
-            return i;
-        }
-    }
-    return -1;
-}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -60,138 +11,38 @@ function findIndex(array, predicate) {
 
 module.exports = function(context) {
 
-    /**
-     * Validates that two adjacent tokens are separated by less than two spaces.
-     * @param   {Token} left  Token on the left side.
-     * @param   {Token} right Token on the right side.
-     * @returns {void}
-     */
-    function validate(left, right) {
-        var op;
-
-        if (
-            left.loc.end.line === right.loc.start.line &&
-            right.range[0] - left.range[1] > 1
-        ) {
-            op = isOperator(left) ? left : right;
-            context.report(op, "Multiple spaces found {{side}} '{{op}}'.", {
-                side: op === right ? "before" : "after",
-                op: op.value
-            });
-        }
-    }
+    // the index of the last comment that was checked
+    var lastCommentIndex = 0;
 
     /**
-     * Validates the spacing of two nodes with an operator between them.
-     * @param   {ASTNode} left  Node left of the operator.
-     * @param   {ASTNode} right Node right of the operator.
-     * @returns {void}
-     */
-    function validateBetween(left, right) {
-        var tokens = context.getTokensBetween(left, right, 1),
-            operatorIndex = findIndex(tokens.slice(1, -1), isOperator) + 1,
-            op = tokens[operatorIndex];
-
-        validate(tokens[operatorIndex - 1], op);
-        validate(op, tokens[operatorIndex + 1]);
-    }
-
-    /**
-     * Report if there are multiple spaces on the expression.
-     * @param {ASTNode} node The node to check.
-     * @returns {void}
+     * Determines if a given source index is in a comment or not by checking
+     * the index against the comment range. Since the check goes straight
+     * through the file, once an index is passed a certain comment, we can
+     * go to the next comment to check that.
+     * @param {int} index The source index to check.
+     * @param {ASTNode[]} comments An array of comment nodes.
+     * @returns {boolean} True if the index is within a comment, false if not.
      * @private
      */
-    function checkExpression(node) {
-        validateBetween(node.left, node.right);
-    }
+    function isIndexInComment(index, comments) {
 
-    /**
-     * Report if there are multiple spaces around conditional ternary operators.
-     * @param {ASTNode} node The node to check.
-     * @returns {void}
-     * @private
-     */
-    function checkConditional(node) {
-        validateBetween(node.test, node.consequent);
-        validateBetween(node.consequent, node.alternate);
-    }
+        var comment;
 
-    /**
-     * Report if there are multiple spaces around equal operator in variable declaration.
-     * @param {ASTNode} node The node to check.
-     * @returns {void}
-     * @private
-     */
-    function checkVar(node) {
-        if (node.init) {
-            validateBetween(node.id, node.init);
-        }
-    }
+        while (lastCommentIndex < comments.length) {
 
-    /**
-     * Generates a function to check object literals and other list-like nodes.
-     * @param {String} property Name of the node's collection property.
-     * @returns {Function} A function that checks spacing within list-like node.
-     * @private
-     */
-    function checkList(property) {
-        /**
-         * Report if there are multiple spaces around list of items in objects,
-         * function parameters, sequences and declarations.
-         * @param {ASTNode} node The node to check.
-         * @returns {void}
-         * @private
-         */
-        return function(node) {
-            var items = node[property];
+            comment = comments[lastCommentIndex];
 
-            for (var i = 0, l = items.length; i < l - 1; i++) {
-                validateBetween(items[i], items[i + 1]);
+            if (comment.range[0] <= index && index <= comment.range[1]) {
+                return true;
+            } else if (index > comment.range[1]) {
+                lastCommentIndex++;
+            } else {
+                break;
             }
-        };
-    }
 
-    /**
-     * Checks arrays literals, allowing that some elements may be empty.
-     * @param {ASTNode} node An ArrayExpression.
-     * @returns {void}
-     * @private
-     */
-    function checkArray(node) {
-        var elements = node.elements,
-            elementIndex = 0,
-            tokens = context.getTokens(node),
-            tokenIndex = 0,
-            length = tokens.length,
-            dest;
-
-        // Check spacing at the beginning, around commas, and at the end
-        while (tokenIndex < length - 1) {
-            validate(tokens[tokenIndex], tokens[++tokenIndex]);
-
-            // Don't advance to the next element until both sides of the comma
-            // have been checked
-            if (tokens[tokenIndex].value !== ",") {
-                // Skip to just before the end of the array or the next comma
-                if (elements[elementIndex]) {
-                    dest = elements[elementIndex].range[1];
-                    // Move to the end of the element
-                    while (tokens[tokenIndex].range[1] < dest) {
-                        ++tokenIndex;
-                    }
-                    // Move past anything (like closing parens) between the end
-                    // of the node and the following comma or end brace.
-                    while (
-                        tokenIndex + 1 < tokens.length &&
-                        tokens[tokenIndex + 1].value !== ","
-                    ) {
-                        ++tokenIndex;
-                    }
-                }
-                ++elementIndex;
-            }
         }
+
+        return false;
     }
 
     //--------------------------------------------------------------------------
@@ -199,17 +50,33 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
 
     return {
-        "AssignmentExpression": checkExpression,
-        "BinaryExpression": checkExpression,
-        "LogicalExpression": checkExpression,
-        "ConditionalExpression": checkConditional,
-        "VariableDeclarator": checkVar,
-        "ArrayExpression": checkArray,
-        "ObjectExpression": checkList("properties"),
-        "SequenceExpression": checkList("expressions"),
-        "FunctionExpression": checkList("params"),
-        "FunctionDeclaration": checkList("params"),
-        "VariableDeclaration": checkList("declarations")
+        "Program": function() {
+
+            var source = context.getSource(),
+                allComments = context.getAllComments(),
+                pattern = /[^\n\r\u2028\u2029 ] {2,}/g,  // note: repeating space
+                prevToken,
+                token;
+
+            while (pattern.test(source)) {
+
+                // do not flag anything inside of comments
+                if (!isIndexInComment(pattern.lastIndex, allComments)) {
+
+                    token = context.getTokenByRangeIndex(pattern.lastIndex);
+
+                    // see if there's a token that contains the whitespace, might be a string
+                    prevToken = context.getTokenByRangeIndex(pattern.lastIndex - 1);
+
+                    if (!prevToken || (prevToken.type !== "String" && prevToken.type !== "Template")) {
+                        context.report(token, token.loc.start,
+                            "Multiple spaces found before '{{value}}'.",
+                            { value: token.value });
+                    }
+
+                }
+            }
+        }
     };
 
 };

--- a/lib/token-store.js
+++ b/lib/token-store.js
@@ -14,6 +14,7 @@ module.exports = function(tokens) {
     var api = {},
         starts = Object.create(null),
         ends = Object.create(null),
+        ranges = Object.create(null),
         index, length, range;
 
     /**
@@ -64,6 +65,11 @@ module.exports = function(tokens) {
         range = tokens[index].range;
         starts[range[0]] = index;
         ends[range[1]] = index;
+
+        // allows fast lookup of any source index
+        for (var j = range[0]; j < range[1]; j++) {
+            ranges[j] = index;
+        }
     }
 
     /**
@@ -180,6 +186,15 @@ module.exports = function(tokens) {
             lastTokenIndex(left) + 1 - padding,
             starts[right.range[0]] + padding
         );
+    };
+
+    /**
+     * Returns the token within with the given source index occurs.
+     * @param {int} rangeIndex The index at which to look for the token.
+     * @returns {Token} The token at that position or null if not found.
+     */
+    api.getTokenByRangeIndex = function(rangeIndex) {
+        return tokens[ranges[rangeIndex]] || null;
     };
 
     return api;

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -43,46 +43,68 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
         "var foo = bar === 1 ? 2: 3",
         "[1, , 3]",
         "[1, ]",
-        "[ (  1  ) , (  2  ) ]",
+        "[ ( 1 ) , ( 2 ) ]",
         "a = 1, b = 2;",
         "(function(a, b){})",
-        "x.in = 0;"
+        "x.in = 0;",
+        "(function(a,/* b, */c){})",
+        "(function(a,/*b,*/c){})",
+        "(function(a, /*b,*/c){})",
+        "(function(a,/*b,*/ c){})",
+        "(function(a, /*b,*/ c){})",
+        "(function(/*a, b, */c){})",
+        "(function(/*a, */b, c){})",
+        "(function(a, b/*, c*/){})",
+        "(function(a, b/*,c*/){})",
+        "(function(a, b /*,c*/){})",
+        "(function(a/*, b ,c*/){})",
+        "(function(a /*, b ,c*/){})",
+        "(function(a /*, b        ,c*/){})",
+        "/**\n * hello\n * @param {foo} int hi\n *      set.\n * @private\n*/",
+        "/**\n * hello\n * @param {foo} int hi\n *      set.\n *      set.\n * @private\n*/",
+        "var a,/* b,*/c;",
+        "var foo = [1,/* 2,*/3];",
+        "var bar = {a: 1,/* b: 2*/c: 3};",
+        "var foo = \"hello     world\";",
+        "function foo() {\n    return;\n}",
+        "function foo() {\n    if (foo) {\n        return;\n    }\n}",
+        { code: "var foo = `hello     world`;", ecmaFeatures: { templateStrings: true }}
     ],
 
     invalid: [
         {
             code: "var a =  1",
             errors: [{
-                message: "Multiple spaces found after '='.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '1'.",
+                type: "Numeric"
             }]
         },
         {
             code: "var a = 1,  b = 2;",
             errors: [{
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
             }]
         },
         {
             code: "a <<  b",
             errors: [{
-                message: "Multiple spaces found after '<<'.",
-                type: "Punctuator"
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
             }]
         },
         {
             code: "var arr = {'a': 1,  'b': 2};",
             errors: [{
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before ''b''.",
+                type: "String"
             }]
         },
         {
             code: "if (a &  b) { }",
             errors: [{
-                message: "Multiple spaces found after '&'.",
-                type: "Punctuator"
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
             }]
         },
         {
@@ -91,38 +113,38 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
                 message: "Multiple spaces found before '&&'.",
                 type: "Punctuator"
             }, {
-                message: "Multiple spaces found after '&&'.",
-                type: "Punctuator"
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
             }]
         },
         {
             code: "var foo = bar === 1 ?  2:  3",
             errors: [{
-                message: "Multiple spaces found after '?'.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '2'.",
+                type: "Numeric"
             }, {
-                message: "Multiple spaces found after ':'.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '3'.",
+                type: "Numeric"
             }]
         },
         {
             code: "var a = [1,  2,  3,  4]",
             errors: [{
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '2'.",
+                type: "Numeric"
             }, {
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '3'.",
+                type: "Numeric"
             }, {
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '4'.",
+                type: "Numeric"
             }]
         },
         {
             code: "var arr = [1,  2];",
             errors: [{
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '2'.",
+                type: "Numeric"
             }]
         },
         {
@@ -131,46 +153,131 @@ eslintTester.addRuleTest("lib/rules/no-multi-spaces", {
                 message: "Multiple spaces found before ','.",
                 type: "Punctuator"
             }, {
-                message: "Multiple spaces found after ','.",
+                message: "Multiple spaces found before ','.",
                 type: "Punctuator"
             }, {
-                message: "Multiple spaces found after ','.",
+                message: "Multiple spaces found before ','.",
                 type: "Punctuator"
             }, {
-                message: "Multiple spaces found after ','.",
+                message: "Multiple spaces found before ']'.",
                 type: "Punctuator"
             }]
         },
         {
             code: "a >>>  b",
             errors: [{
-                message: "Multiple spaces found after '>>>'.",
-                type: "Punctuator"
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
             }]
         },
         {
             code: "a = 1,  b =  2;",
             errors: [{
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
             }, {
-                message: "Multiple spaces found after '='.",
-                type: "Punctuator"
+                message: "Multiple spaces found before '2'.",
+                type: "Numeric"
             }]
         },
         {
             code: "(function(a,  b){})",
             errors: [{
-                message: "Multiple spaces found after ','.",
-                type: "Punctuator"
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
             }]
         },
         {
             code: "function foo(a,  b){}",
             errors: [{
-                message: "Multiple spaces found after ','.",
+                message: "Multiple spaces found before 'b'.",
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "var o = { fetch: function    () {} };",
+            errors: [{
+                message: "Multiple spaces found before '('.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "var o = { fetch: function    () {} };",
+            errors: [{
+                message: "Multiple spaces found before '('.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function foo      () {}",
+            errors: [{
+                message: "Multiple spaces found before '('.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "if (foo)      {}",
+            errors: [{
+                message: "Multiple spaces found before '{'.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function    foo(){}",
+            errors: [{
+                message: "Multiple spaces found before 'foo'.",
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "if    (foo) {}",
+            errors: [{
+                message: "Multiple spaces found before '('.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "try    {} catch(ex) {}",
+            errors: [{
+                message: "Multiple spaces found before '{'.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "try {} catch    (ex) {}",
+            errors: [{
+                message: "Multiple spaces found before '('.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "var o = { fetch: function    () {} };",
+            errors: [{
+                message: "Multiple spaces found before '('.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "throw  error;",
+            errors: [{
+                message: "Multiple spaces found before 'error'.",
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo() { return      bar; }",
+            errors: [{
+                message: "Multiple spaces found before 'bar'.",
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "switch   (a) {default: foo(); break;}",
+            errors: [{
+                message: "Multiple spaces found before '('.",
                 type: "Punctuator"
             }]
         }
+
     ]
 });

--- a/tests/lib/token-store.js
+++ b/tests/lib/token-store.js
@@ -346,4 +346,27 @@ describe("TokenStore", function() {
 
     });
 
+    describe("when calling getTokenByRangeIndex", function() {
+
+        it("should return identifier token", function() {
+            var result = store.getTokenByRangeIndex(4);
+
+            assert.equal(result.type, "Identifier");
+            assert.equal(result.value, "answer");
+        });
+
+        it("should return identifier token", function() {
+            var result = store.getTokenByRangeIndex(5);
+
+            assert.equal(result.type, "Identifier");
+            assert.equal(result.value, "answer");
+        });
+
+        it("should return null when token doesn't exist", function() {
+            var result = store.getTokenByRangeIndex(3);
+            assert.isNull(result);
+        });
+
+    });
+
 });


### PR DESCRIPTION
This was an absolute monster to work through and it's still not quite there. One edge case remaining. Just posting to share.

I had to create a map of where all tokens are, and that subsequently slowed things down a bit. I think the slowdown is worth it for the tradeoff.

$ npm run perf

> eslint@0.12.0 perf c:\Users\Nicholas\projects\personal\jscheck
> node Makefile.js perf

```
# Before

CPU Speed is 3093 with multiplier 7500000
Performance Run #1:  1501.513292ms
Performance Run #2:  1516.6144359999998ms
Performance Run #3:  1522.233913ms
Performance Run #4:  1537.468143ms
Performance Run #5:  1510.7205079999999ms
Performance budget ok:  1516.6144359999998ms (limit: 2424.8302618816683ms)

# After

CPU Speed is 3093 with multiplier 7500000
Performance Run #1:  1573.712675ms
Performance Run #2:  1545.923181ms
Performance Run #3:  1556.752278ms
Performance Run #4:  1558.050048ms
Performance Run #5:  1550.235287ms
Performance budget ok:  1556.752278ms (limit: 2424.8302618816683ms)
```