### PR TITLE
Docs: use npm's keyword route

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -33,4 +33,4 @@
 * [AngularJS](https://github.com/Gillespie59/angularjs-eslint)
 * [Jasmine](https://github.com/tlvince/eslint-plugin-jasmine)
 
-… and many more published on npm with the [eslintplugin](https://www.npmjs.com/search?q=eslintplugin) tag.
+… and many more published on npm with the [eslintplugin](https://www.npmjs.com/browse/keyword/eslintplugin) keyword.


### PR DESCRIPTION
Use the purpose-built `/browse/keyword/[keyword]` route than a generic search term.