### PR TITLE
Breaking: remove implied eval check from no-eval (fixes #1202)

### DIFF
--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -8,18 +8,9 @@ var obj = { x: "foo" },
     value = eval("obj." + key);
 ```
 
-Additionally, there are some other methods that act similar to `eval()`. Both `setTimeout()` and `setInterval()` allow the first argument to be a string, which evaluates the string in the global scope, such as:
-
-```js
-setTimeout("count = 5", 10);
-setInterval("foo = bar", 10);
-```
-
-These are considered implied `eval()` and it's typically recommended to use functions for the first argument instead of a string.
-
 ## Rule Details
 
-This rule is aimed at preventing potentially dangerous, unnecessary, and slow code by disallowing the use of the `eval()` function. As such, it will warn whenever the `eval()` function is used or when either `setTimeout()` or `setInterval()` are used with a string argument.
+This rule is aimed at preventing potentially dangerous, unnecessary, and slow code by disallowing the use of the `eval()` function. As such, it will warn whenever the `eval()` function is used.
 
 The following patterns are considered warnings:
 
@@ -27,11 +18,6 @@ The following patterns are considered warnings:
 var obj = { x: "foo" },
     key = "x",
     value = eval("obj." + key);
-
-setTimeout("count = 5", 10);
-setInterval("foo = bar", 10);
-window.setTimeout("count = 5", 10);
-window.setInterval("foo = bar", 10);
 ```
 
 The following patterns are not considered warnings:
@@ -40,15 +26,6 @@ The following patterns are not considered warnings:
 var obj = { x: "foo" },
     key = "x",
     value = obj[key];
-
-setTimeout(function() {
-    count = 5;
-}, 10);
-
-setInterval(function() {
-    foo = bar;
-}, 10);
-
 ```
 
 ## Further Reading

--- a/docs/rules/no-implied-eval.md
+++ b/docs/rules/no-implied-eval.md
@@ -29,6 +29,10 @@ The following patterns are considered warnings:
 setTimeout("alert('Hi!');", 100);
 
 setInterval("alert('Hi!');", 100);
+
+window.setTimeout("count = 5", 10);
+
+window.setInterval("foo = bar", 10);
 ```
 
 The following patterns are not warnings:

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Rule to flag use of eval() statement
  * @author Nicholas C. Zakas
+ * @copyright 2015 Mathias Schreck. All rights reserved.
+ * @copyright 2013 Nicholas C. Zakas. All rights reserved.
  */
 
 "use strict";
@@ -11,44 +13,10 @@
 
 module.exports = function(context) {
 
-    var IMPLIED_EVAL = /set(?:Timeout|Interval)/;
-
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
-
-    /**
-     * Determines if a node represents a call to setTimeout/setInterval with
-     * a string argument.
-     * @param {ASTNode} node The node to check.
-     * @returns {boolean} True if the node matches, false if not.
-     * @private
-     */
-    function isImpliedEval(node) {
-
-        var isMemberExpression = (node.callee.type === "MemberExpression"),
-            isIdentifier = (node.callee.type === "Identifier"),
-            isSetMethod = (isIdentifier && IMPLIED_EVAL.test(node.callee.name)) ||
-                (isMemberExpression && node.callee.object.name === "window" &&
-                IMPLIED_EVAL.test(node.callee.property.name)),
-            hasStringArgument = node.arguments.length && (typeof node.arguments[0].value === "string");
-
-        return isSetMethod && hasStringArgument;
-    }
-
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
-
     return {
         "CallExpression": function(node) {
             if (node.callee.name === "eval") {
                 context.report(node, "eval can be harmful.");
-            } else if (isImpliedEval(node)) {
-                if (node.arguments.length && (typeof node.arguments[0].value === "string")) {
-                    context.report(node, "Implied eval can be harmful. Pass a function instead of a string.");
-                }
             }
         }
     };

--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Rule to flag use of implied eval via setTimeout and setInterval
  * @author James Allardice
+ * @copyright 2015 Mathias Schreck. All rights reserved.
+ * @copyright 2013 James Allardice. All rights reserved.
  */
 
 "use strict";
@@ -10,19 +12,61 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var IMPLIED_EVAL = /set(?:Timeout|Interval)/;
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Checks if the first argument of a given CallExpression node is a string literal.
+     * @param {ASTNode} node The CallExpression node the check.
+     * @returns {boolean} True if the first argument is a string literal, false if not.
+     */
+    function hasStringLiteralArgument(node) {
+        var firstArgument = node.arguments[0];
+
+        return firstArgument && firstArgument.type === "Literal" && typeof firstArgument.value === "string";
+    }
+
+    /**
+     * Checks if the given MemberExpression node is window.setTimeout or window.setInterval.
+     * @param {ASTNode} node The MemberExpression node to check.
+     * @returns {boolean} Whether or not the given node is window.set*.
+     */
+    function isSetMemberExpression(node) {
+        var object = node.object,
+            property = node.property,
+            hasSetPropertyName = IMPLIED_EVAL.test(property.name) || IMPLIED_EVAL.test(property.value);
+
+        return object.name === "window" && hasSetPropertyName;
+
+    }
+
+    /**
+     * Determines if a node represents a call to setTimeout/setInterval with
+     * a string argument.
+     * @param {ASTNode} node The node to check.
+     * @returns {boolean} True if the node matches, false if not.
+     * @private
+     */
+    function isImpliedEval(node) {
+        var isMemberExpression = (node.callee.type === "MemberExpression"),
+            isIdentifier = (node.callee.type === "Identifier"),
+            isSetMethod = (isIdentifier && IMPLIED_EVAL.test(node.callee.name)) ||
+                (isMemberExpression && isSetMemberExpression(node.callee));
+
+        return isSetMethod && hasStringLiteralArgument(node);
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
 
     return {
         "CallExpression": function(node) {
-
-            if (node.callee.type === "Identifier") {
-                var callee = node.callee.name;
-
-                if (callee === "setTimeout" || callee === "setInterval") {
-                    var argument = node.arguments[0];
-                    if (argument && argument.type === "Literal" && typeof argument.value === "string") {
-                        context.report(node, "Implied eval. Consider passing a function instead of a string.");
-                    }
-                }
+            if (isImpliedEval(node)) {
+                context.report(node, "Implied eval. Consider passing a function instead of a string.");
             }
         }
     };

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -20,18 +20,14 @@ var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-eval", {
     valid: [
         "Eval(foo)",
-        "foo.setTimeout('hi')",
-        "setTimeout(foo, 10)",
-        "setTimeout(function() {}, 10)",
-        "foo.setInterval('hi')",
-        "setInterval(foo, 10)",
-        "setInterval(function() {}, 10)"
+        "setTimeout('foo')",
+        "setInterval('foo')",
+        "window.setTimeout('foo')",
+        "window.setInterval('foo')"
     ],
+
     invalid: [
         { code: "eval(foo)", errors: [{ message: "eval can be harmful.", type: "CallExpression"}] },
-        { code: "setTimeout('foo')", errors: [{ message: "Implied eval can be harmful. Pass a function instead of a string.", type: "CallExpression"}] },
-        { code: "setInterval('foo')", errors: [{ message: "Implied eval can be harmful. Pass a function instead of a string.", type: "CallExpression"}] },
-        { code: "window.setTimeout('foo')", errors: [{ message: "Implied eval can be harmful. Pass a function instead of a string.", type: "CallExpression"}] },
-        { code: "window.setInterval('foo')", errors: [{ message: "Implied eval can be harmful. Pass a function instead of a string.", type: "CallExpression"}] }
+        { code: "eval('foo')", errors: [{ message: "eval can be harmful.", type: "CallExpression"}] }
     ]
 });

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -16,14 +16,28 @@ var eslint = require("../../../lib/eslint"),
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new ESLintTester(eslint);
+var eslintTester = new ESLintTester(eslint),
+    expectedErrorMessage = "Implied eval. Consider passing a function instead of a string.",
+    expectedError = { message: expectedErrorMessage, type: "CallExpression" };
+
 eslintTester.addRuleTest("lib/rules/no-implied-eval", {
     valid: [
-        "setInterval(function () { x = 1; }, 100);"
+        "setInterval(function () { x = 1; }, 100);",
+        "foo.setTimeout('hi')",
+        "setTimeout(foo, 10)",
+        "setTimeout(function() {}, 10)",
+        "foo.setInterval('hi')",
+        "setInterval(foo, 10)",
+        "setInterval(function() {}, 10)"
     ],
+
     invalid: [
-        { code: "setTimeout(\"x = 1;\");", errors: [{ message: "Implied eval. Consider passing a function instead of a string.", type: "CallExpression"}] },
-        { code: "setTimeout(\"x = 1;\", 100);", errors: [{ message: "Implied eval. Consider passing a function instead of a string.", type: "CallExpression"}] },
-        { code: "setInterval(\"x = 1;\");", errors: [{ message: "Implied eval. Consider passing a function instead of a string.", type: "CallExpression"}] }
+        { code: "setTimeout(\"x = 1;\");", errors: [expectedError] },
+        { code: "setTimeout(\"x = 1;\", 100);", errors: [expectedError] },
+        { code: "setInterval(\"x = 1;\");", errors: [expectedError] },
+        { code: "window.setTimeout('foo')", errors: [expectedError] },
+        { code: "window.setInterval('foo')", errors: [expectedError] },
+        { code: "window['setTimeout']('foo')", errors: [expectedError] },
+        { code: "window['setInterval']('foo')", errors: [expectedError] }
     ]
 });


### PR DESCRIPTION
This removes the implied eval check from `no-eval` because this functionality is already covered by `no-implied-eval`.

`no-implied-eval` now checks also for `window['setTimeout']('foo')` and `window['setInterval']('foo')`.