### PR TITLE
Update: Add getNodeByRangeIndex method (refs #1721)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -81,6 +81,7 @@ Additionally, the `context` object has the following methods:
 * `getJSDocComment(node)` - returns the JSDoc comment for a given node or `null` if there is none.
 * `getLastToken(node)` - returns the last token representing the given node.
 * `getLastTokens(node, count)` - returns the last `count` tokens representing the given node.
+* `getNodeByRangeIndex(index)` - returns the deepest node in the AST containing the given source index.
 * `getScope()` - returns the current scope.
 * `getSource(node)` - returns the source code for the given node. Omit `node` to get the whole source.
 * `getSourceLines()` - returns the entire source code split into an array of string lines.

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -848,6 +848,31 @@ module.exports = (function() {
         return controller.parents();
     };
 
+    /**
+     * Gets the deepest node containing a range index.
+     * @param {int} index Range index of the desired node.
+     * @returns {ASTNode} [description]
+     */
+    api.getNodeByRangeIndex = function(index) {
+        var result = null;
+
+        estraverse.traverse(controller.root, {
+            enter: function (node) {
+                if (node.range[0] <= index && index < node.range[1]) {
+                    result = node;
+                } else {
+                    this.skip();
+                }
+            },
+            leave: function (node) {
+                if (node === result) {
+                    this.break();
+                }
+            }
+        });
+
+        return result;
+    };
 
     /**
      * Gets the scope for the current node.

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -18,6 +18,7 @@ var PASSTHROUGHS = [
         "getJSDocComment",
         "getLastToken",
         "getLastTokens",
+        "getNodeByRangeIndex",
         "getScope",
         "getSource",
         "getSourceLines",

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -643,6 +643,90 @@ describe("eslint", function() {
         });
     });
 
+    describe("when calling getNodeByRangeIndex", function() {
+        var code = TEST_CODE;
+
+        it("should retrieve a node starting at the given index", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var node = eslint.getNodeByRangeIndex(4);
+                assert.equal(node.type, "Identifier");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should retrieve a node containing the given index", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var node = eslint.getNodeByRangeIndex(6);
+                assert.equal(node.type, "Identifier");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should retrieve a node that is exactly the given index", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var node = eslint.getNodeByRangeIndex(13);
+                assert.equal(node.type, "Literal");
+                assert.equal(node.value, 6);
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should retrieve a node ending with the given index", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var node = eslint.getNodeByRangeIndex(9);
+                assert.equal(node.type, "Identifier");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should retrieve the deepest node containing the given index", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var node = eslint.getNodeByRangeIndex(14);
+                assert.equal(node.type, "BinaryExpression");
+                node = eslint.getNodeByRangeIndex(3);
+                assert.equal(node.type, "VariableDeclaration");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should return null if the index is outside the range of any node", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var node = eslint.getNodeByRangeIndex(-1);
+                assert.isNull(node);
+                node = eslint.getNodeByRangeIndex(-99);
+                assert.isNull(node);
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+    });
+
+
+
     describe("when calling getScope", function() {
         var code = "function foo() { q: for(;;) { break q; } } function bar () { var q = t; }";
 


### PR DESCRIPTION
This spawned from the [discussion in #1721](https://github.com/eslint/eslint/pull/1721#issuecomment-71755084) about a possible way to prevent the changes to no-multi-spaces from making it and key-spacing mutually exclusive.

According to my theory, one could except nodes of type `Property` from no-multi-spaces. Then in the following example, it would check the double space between the property's key and value using `getNodeByRangeIndex`, and, finding that the whitespace belongs to the property, obey the exception and disregard the error.

```js
({
    a:  b
})
```

I thought about adding this as a comment on that discussion, but then I decided a PR would be a whole lot easier to understand.