### PR TITLE
Breaking: Show error and warning counts in stylish summary (fixes #1746)

### DIFF
--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -8,6 +8,20 @@ var chalk = require("chalk"),
     table = require("text-table");
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Given a word and a count, append an s if count is not one.
+ * @param {string} word A word in its singular form.
+ * @param {int} count A number controlling whether word should be pluralized.
+ * @returns {string} The original word with an s on the end if count is not one.
+ */
+function pluralize(word, count) {
+    return (count === 1 ? word : word + "s");
+}
+
+//------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
 
@@ -15,6 +29,8 @@ module.exports = function(results) {
 
     var output = "\n",
         total = 0,
+        errors = 0,
+        warnings = 0,
         summaryColor = "yellow";
 
     results.forEach(function(result) {
@@ -34,8 +50,10 @@ module.exports = function(results) {
                 if (message.fatal || message.severity === 2) {
                     messageType = chalk.red("error");
                     summaryColor = "red";
+                    errors++;
                 } else {
                     messageType = chalk.yellow("warning");
+                    warnings++;
                 }
 
                 return [
@@ -61,7 +79,11 @@ module.exports = function(results) {
     });
 
     if (total > 0) {
-        output += chalk[summaryColor].bold("\u2716 " + total + " problem" + (total === 1 ? "" : "s") + "\n");
+        output += chalk[summaryColor].bold([
+            "\u2716 ", total, pluralize(" problem", total),
+            " (", errors, pluralize(" error", errors), ", ",
+            warnings, pluralize(" warning", warnings), ")\n"
+        ].join(""));
     }
 
     return total > 0 ? output : "";

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -83,7 +83,7 @@ describe("formatter:stylish", function() {
 
         it("should return a string in the correct format for errors", function() {
             var result = formatter(code);
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
+            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -91,7 +91,7 @@ describe("formatter:stylish", function() {
         it("should return a string in the correct format for warnings", function() {
             code[0].messages[0].severity = 1;
             var result = formatter(code);
-            assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem\n");
+            assert.equal(result, "\nfoo.js\n  5:10  warning  Unexpected foo  foo\n\n\u2716 1 problem (0 errors, 1 warning)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 1);
             assert.equal(chalkStub.red.bold.callCount, 0);
         });
@@ -111,7 +111,7 @@ describe("formatter:stylish", function() {
 
         it("should return a string in the correct format", function() {
             var result = formatter(code);
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem\n");
+            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\n\u2716 1 problem (1 error, 0 warnings)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -137,7 +137,7 @@ describe("formatter:stylish", function() {
 
         it("should return a string with multiple entries", function() {
             var result = formatter(code);
-            assert.equal(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n");
+            assert.equal(result, "\nfoo.js\n  5:10  error    Unexpected foo  foo\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -166,7 +166,7 @@ describe("formatter:stylish", function() {
 
         it("should return a string with multiple entries", function() {
             var result = formatter(code);
-            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems\n");
+            assert.equal(result, "\nfoo.js\n  5:10  error  Unexpected foo  foo\n\nbar.js\n  6:11  warning  Unexpected bar  bar\n\n\u2716 2 problems (1 error, 1 warning)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });
@@ -183,7 +183,7 @@ describe("formatter:stylish", function() {
 
         it("should return a string without line and column", function() {
             var result = formatter(code);
-            assert.equal(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem\n");
+            assert.equal(result, "\nfoo.js\n  0:0  error  Couldn't find foo.js\n\n\u2716 1 problem (1 error, 0 warnings)\n");
             assert.equal(chalkStub.yellow.bold.callCount, 0);
             assert.equal(chalkStub.red.bold.callCount, 1);
         });


### PR DESCRIPTION
Before: `✖ 3 problems`
After: `✖ 3 problems (2 errors, 1 warning)`

This could break code that scrapes CLI output.