### PR TITLE
Update: Replace getTokenBy(Range->Start)Index (refs #1721)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -72,8 +72,9 @@ The `context` object contains additional functionality that is helpful for rules
 
 Additionally, the `context` object has the following methods:
 
+* `getAllComments()` - returns an array of all comments in the source.
 * `getAncestors()` - returns an array of ancestor nodes based on the current traversal.
-* `getComments()` - returns an array of all comments in the source.
+* `getComments(node)` - returns the leading and trailing comments arrays for the given node.
 * `getFilename()` - returns the filename associated with the source.
 * `getFirstToken(node)` - returns the first token representing the given node.
 * `getFirstTokens(node, count)` - returns the first `count` tokens representing the given node.
@@ -85,6 +86,7 @@ Additionally, the `context` object has the following methods:
 * `getSourceLines()` - returns the entire source code split into an array of string lines.
 * `getTokenAfter(node)` - returns the first token after the given node.
 * `getTokenBefore(node)` - returns the first token before the given node.
+* `getTokenByRangeStart(index)` - returns the token whose range starts at the given index in the source.
 * `getTokens(node)` - returns all tokens for the given node.
 * `getTokensAfter(node, count)` - returns `count` tokens after the given node.
 * `getTokensBefore(node, count)` - returns `count` tokens before the given node.

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -9,25 +9,25 @@
 //------------------------------------------------------------------------------
 
 var PASSTHROUGHS = [
+        "getAllComments",
+        "getAncestors",
+        "getComments",
+        "getFilename",
+        "getFirstToken",
+        "getFirstTokens",
+        "getJSDocComment",
+        "getLastToken",
+        "getLastTokens",
+        "getScope",
         "getSource",
         "getSourceLines",
-        "getTokens",
-        "getTokensBefore",
-        "getTokenBefore",
-        "getTokensAfter",
         "getTokenAfter",
-        "getFirstTokens",
-        "getFirstToken",
-        "getLastTokens",
-        "getLastToken",
-        "getTokensBetween",
-        "getComments",
-        "getAncestors",
-        "getScope",
-        "getJSDocComment",
-        "getFilename",
-        "getTokenByRangeIndex",
-        "getAllComments"
+        "getTokenBefore",
+        "getTokenByRangeStart",
+        "getTokens",
+        "getTokensAfter",
+        "getTokensBefore",
+        "getTokensBetween"
     ];
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -32,7 +32,7 @@ module.exports = function(context) {
 
             comment = comments[lastCommentIndex];
 
-            if (comment.range[0] <= index && index <= comment.range[1]) {
+            if (comment.range[0] <= index && index < comment.range[1]) {
                 return true;
             } else if (index > comment.range[1]) {
                 lastCommentIndex++;
@@ -55,7 +55,6 @@ module.exports = function(context) {
             var source = context.getSource(),
                 allComments = context.getAllComments(),
                 pattern = /[^\n\r\u2028\u2029 ] {2,}/g,  // note: repeating space
-                prevToken,
                 token;
 
             while (pattern.test(source)) {
@@ -63,12 +62,9 @@ module.exports = function(context) {
                 // do not flag anything inside of comments
                 if (!isIndexInComment(pattern.lastIndex, allComments)) {
 
-                    token = context.getTokenByRangeIndex(pattern.lastIndex);
+                    token = context.getTokenByRangeStart(pattern.lastIndex);
 
-                    // see if there's a token that contains the whitespace, might be a string
-                    prevToken = context.getTokenByRangeIndex(pattern.lastIndex - 1);
-
-                    if (!prevToken || (prevToken.type !== "String" && prevToken.type !== "Template")) {
+                    if (token) {
                         context.report(token, token.loc.start,
                             "Multiple spaces found before '{{value}}'.",
                             { value: token.value });

--- a/lib/token-store.js
+++ b/lib/token-store.js
@@ -14,7 +14,6 @@ module.exports = function(tokens) {
     var api = {},
         starts = Object.create(null),
         ends = Object.create(null),
-        ranges = Object.create(null),
         index, length, range;
 
     /**
@@ -65,11 +64,6 @@ module.exports = function(tokens) {
         range = tokens[index].range;
         starts[range[0]] = index;
         ends[range[1]] = index;
-
-        // allows fast lookup of any source index
-        for (var j = range[0]; j < range[1]; j++) {
-            ranges[j] = index;
-        }
     }
 
     /**
@@ -189,12 +183,12 @@ module.exports = function(tokens) {
     };
 
     /**
-     * Returns the token within with the given source index occurs.
-     * @param {int} rangeIndex The index at which to look for the token.
-     * @returns {Token} The token at that position or null if not found.
+     * Gets the token starting at the specified index.
+     * @param {int} startIndex Index of the start of the token's range.
+     * @returns {Token} The token starting at index, or null if no such token.
      */
-    api.getTokenByRangeIndex = function(rangeIndex) {
-        return tokens[ranges[rangeIndex]] || null;
+    api.getTokenByRangeStart = function(startIndex) {
+        return (tokens[starts[startIndex]] || null);
     };
 
     return api;

--- a/tests/lib/token-store.js
+++ b/tests/lib/token-store.js
@@ -346,24 +346,17 @@ describe("TokenStore", function() {
 
     });
 
-    describe("when calling getTokenByRangeIndex", function() {
+    describe("when calling getTokenByRangeStart", function() {
 
         it("should return identifier token", function() {
-            var result = store.getTokenByRangeIndex(4);
-
-            assert.equal(result.type, "Identifier");
-            assert.equal(result.value, "answer");
-        });
-
-        it("should return identifier token", function() {
-            var result = store.getTokenByRangeIndex(5);
+            var result = store.getTokenByRangeStart(4);
 
             assert.equal(result.type, "Identifier");
             assert.equal(result.value, "answer");
         });
 
         it("should return null when token doesn't exist", function() {
-            var result = store.getTokenByRangeIndex(3);
+            var result = store.getTokenByRangeStart(5);
             assert.isNull(result);
         });
 


### PR DESCRIPTION
The idea for this originated in [a comment on #1721](https://github.com/eslint/eslint/pull/1721#issuecomment-72157629).

The `getTokenByRangeIndex` and the expensive `ranges` array aren't necessary. A space sequence can end one of five ways:

1. It reaches the end of the line.
This rule is not designed to handle end-of-line spaces. Nothing should be reported.

1. It reaches the start of a comment.
The isIndexInComment check will find that pattern.lastIndex is the starting index of the comment. Nothing will be reported.

1. The space sequence is within a comment.
Again, isIndexInComment will prevent reporting.

1. The space sequence is within a string or template literal.
Nothing should be reported.

1. It encounters the start of a token.
In this case, pattern.lastIndex will be exactly the starting index of some token. The rule should report an error.

If I'm not missing anything, then the rule should only report when it encounters a token starting at pattern.lastIndex. Therefore, we replace `getTokenByRangeIndex` with a new method, `getTokenByStartIndex`, consisting simply of `return tokens[starts[index]] || null;`. The rule warns if and only if `getTokenStartingAtIndex(pattern.lastIndex)` returns a token. No more retrieval from the middle of a token's range, and no more need to assemble the map of ranges.

Since this PR builds on #1721, merge that, I'll rebase this so it can be merged, then get #1738 ready and merged?