### PR TITLE
New: Add predefined Meteor globals (fixes #1763)

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -45,5 +45,8 @@ module.exports = {
     },
     shelljs: {
         globals: globals.shelljs
+    },
+    meteor: {
+        globals: globals.meteor
     }
 };

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "escope": "^2.0.3",
     "espree": "^1.7.1",
     "estraverse": "^1.9.1",
-    "globals": "^5.1.0",
+    "globals": "^6.1.0",
     "estraverse-fb": "^1.3.0",
     "js-yaml": "^3.2.5",
     "minimatch": "^2.0.1",


### PR DESCRIPTION
This PR adds support for [Meteor](http://meteor.com/) globals in the form of introducing a `meteor` environment. This fixes warnings/errors regarding Meteor globals such as `Template`, `Meteor`, etc.