### PR TITLE
Docs: Added `eslint-enable` inline

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -323,7 +323,7 @@ If there is an `.eslintrc` and a `package.json` file found in the same directory
 The complete configuration hierarchy, from highest precedence to lowest precedence, is as follows:
 
 1. Inline configuration
-    1. `/*eslint-disable*/`
+    1. `/*eslint-disable*/` and `/*eslint-enable*/`
     1. `/*global*/`
     1. `/*eslint*/`
     1. `/*eslint-env*/`


### PR DESCRIPTION
When I checked the configuration docs page I wasn't sure that `/*eslint-enable*/` existed, I tried to know that eslint does not complain and moreover it parses it and applies.

I think that it must be included in the list as a pair of `/*eslint-disable*/` because it's clearer.