### PR TITLE
Fix: Ensure template string references count (fixes #1542)

### DIFF
--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -57,7 +57,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "function g(bar, baz) { return bar + baz; }; g();", args: [1, {"vars": "locals", "args": "all"}] },
         { code: "var g = function (bar, baz) { return 2; }; g();", args: [1, {"vars": "all", "args": "none"}] },
         "(function z() { z(); })();",
-        { code: " ", globals: {a: true} }
+        { code: " ", globals: {a: true} },
+        { code: "var who = \"Paul\";\nmodule.exports = `Hello ${who}!`;", ecmaFeatures: { templateStrings: true }}
     ],
     invalid: [
         { code: "var a=10", errors: [{ message: "a is defined but never used", type: "Identifier"}] },


### PR DESCRIPTION
Already fixed with Espree and escope, just adding a test.