### PR TITLE
Fix: comma-spacing for template literals (fixes #1736)

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "doctrine": "^0.6.2",
     "escape-string-regexp": "^1.0.2",
     "escope": "^2.0.4",
-    "espree": "^1.8.0",
+    "espree": "^1.8.1",
     "estraverse": "^1.9.1",
     "estraverse-fb": "^1.3.0",
     "globals": "^6.1.0",

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -55,7 +55,8 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
         {code: "var arr = [1 , 2];", args: [2, {before: true, after: true}]},
         {code: "a , b", args: [2, {before: true, after: true}]},
         {code: "var arr = [1,2];", args: [2, {before: false, after: false}]},
-        {code: "var a = (1 + 2,2)", args: [2, {before: false, after: false}]}
+        {code: "var a = (1 + 2,2)", args: [2, {before: false, after: false}]},
+        { code: "var a; console.log(`${a}`, \"a\");", ecmaFeatures: { templateStrings: true } }
     ],
 
     invalid: [


### PR DESCRIPTION
Espree upgrade magically fixes rule without further changes. :)