### PR TITLE
Refactor RuleContext.report() to take all optional args via a hash as th...

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -102,7 +102,7 @@ The main method you'll use is `context.report()`, which publishes a warning or e
 
 or
 
-    context.report(node, "`{{identifier}}` is unexpected!", { identifier: node.name });
+    context.report(node, "`{{identifier}}` is unexpected!", {substitutions: { identifier: node.name }});
 
 The node contains all of the information necessary to figure out the line and column number of the offending text as well the source text representing the node.
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -704,26 +704,25 @@ module.exports = (function() {
      * @param {string} ruleId The ID of the rule causing the message.
      * @param {number} severity The severity level of the rule as configured.
      * @param {ASTNode} node The AST node that the message relates to.
-     * @param {Object=} location An object containing the error line and column
+     * @param {string} message The actual message.
+     * @param {(Object|undefined)} substitutions Optional template data which produces a formatted message
+     *     with symbols being replaced by this object's values.
+     * @param {({line: number, column: number}|undefined)} location An object containing the error line and column
      *      numbers. If location is not provided the node's start location will
      *      be used.
-     * @param {string} message The actual message.
-     * @param {Object} opts Optional template data which produces a formatted message
-     *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    api.report = function(ruleId, severity, node, location, message, opts) {
-
-        if (typeof location === "string") {
-            opts = message;
-            message = location;
+    api.report = function(ruleId, severity, node, message, substitutions, location) {
+        if (location === void 0) {
             location = node.loc.start;
         }
 
-        Object.keys(opts || {}).forEach(function (key) {
-            var rx = new RegExp("{{" + escapeRegExp(key) + "}}", "g");
-            message = message.replace(rx, opts[key]);
-        });
+        if (substitutions) {
+            Object.keys(substitutions).forEach(function (key) {
+                var rx = new RegExp("{{" + escapeRegExp(key) + "}}", "g");
+                message = message.replace(rx, substitutions[key]);
+            });
+        }
 
         if (isDisabledByReportingConfig(reportingConfig, ruleId, location)) {
             return;

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -86,14 +86,19 @@ function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) 
     /**
      * Passthrough to eslint.report() that automatically assigns the rule ID and severity.
      * @param {ASTNode} node The AST node related to the message.
-     * @param {Object=} location The location of the error.
      * @param {string} message The message to display to the user.
-     * @param {Object} opts Optional template data which produces a formatted message
-     *     with symbols being replaced by this object's values.
+     * @param {{substitutions: (Object|undefined), location: ({line: number, column: number}|undefined)}=} opts
+     *     Additional optional parameters that can include the following:
+     *     - substitutions Optional template data that produces a formatted
+     *       message with symbols being replaced by this object's values.
+     *     - location The location of the error. If location is not provided the
+     *       node's start location will be used.
      * @returns {void}
      */
-    this.report = function(node, location, message, opts) {
-        eslint.report(ruleId, severity, node, location, message, opts);
+    this.report = function(node, message, opts) {
+        var substitutions = opts && opts.substitutions;
+        var location = opts && opts.location;
+        eslint.report(ruleId, severity, node, message, substitutions, location);
     };
 
 }

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -34,7 +34,7 @@ module.exports = function(context) {
      * @private
      */
     function report(node) {
-        context.report(node, "Identifier '{{name}}' is not in camel case.", { name: node.name });
+        context.report(node, "Identifier '{{name}}' is not in camel case.", {substitutions: { name: node.name }});
     }
 
     return {

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -60,10 +60,14 @@ module.exports = function(context) {
                 !isSameLine(previousItemToken, commaToken)) {
 
             // lone comma
-            context.report(reportItem, {
-                line: commaToken.loc.end.line,
-                column: commaToken.loc.start.column
-            }, "Bad line breaking before and after ','.");
+            context.report(reportItem,
+                "Bad line breaking before and after ','.",
+                {
+                    location: {
+                        line: commaToken.loc.end.line,
+                        column: commaToken.loc.start.column
+                    }
+                });
 
         } else if (style === "first" && !isSameLine(commaToken, currentItemToken)) {
 
@@ -71,10 +75,14 @@ module.exports = function(context) {
 
         } else if (style === "last" && isSameLine(commaToken, currentItemToken)) {
 
-            context.report(reportItem, {
-                line: commaToken.loc.end.line,
-                column: commaToken.loc.end.column
-            }, "',' should be placed last.");
+            context.report(reportItem,
+              "',' should be placed last.",
+              {
+                  location: {
+                      line: commaToken.loc.end.line,
+                      column: commaToken.loc.end.column
+                  }
+              });
         }
     }
 

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -33,7 +33,9 @@ module.exports = function(context) {
             name = node.id.name;
         }
         if (complexity > THRESHOLD) {
-            context.report(node, "Function '{{name}}' has a complexity of {{complexity}}.", { name: name, complexity: complexity });
+            context.report(node,
+                "Function '{{name}}' has a complexity of {{complexity}}.",
+                {substitutions: { name: name, complexity: complexity }});
         }
     }
 

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -21,7 +21,7 @@ module.exports = function(context) {
     function reportBadAssignment(node) {
         context.report(node,
             "Designated alias '{{alias}}' is not assigned to 'this'.",
-            { alias: alias });
+            {substitutions: { alias: alias }});
     }
 
     /**
@@ -41,7 +41,8 @@ module.exports = function(context) {
             }
         } else if (isThis) {
             context.report(node,
-                "Unexpected alias '{{name}}' for 'this'.", { name: name });
+                "Unexpected alias '{{name}}' for 'this'.",
+                {substitutions: { name: name }});
         }
     }
 

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -32,8 +32,10 @@ module.exports = function(context) {
             if (hasBlock && body.body.length === 1) {
                 context.report(node, "Unnecessary { after '{{name}}'{{suffix}}.",
                     {
-                        name: name,
-                        suffix: (suffix ? " " + suffix : "")
+                        substitutions: {
+                            name: name,
+                            suffix: (suffix ? " " + suffix : "")
+                        }
                     }
                 );
             }
@@ -41,8 +43,10 @@ module.exports = function(context) {
             if (!hasBlock) {
                 context.report(node, "Expected { after '{{name}}'{{suffix}}.",
                     {
-                        name: name,
-                        suffix: (suffix ? " " + suffix : "")
+                        substitutions: {
+                            name: name,
+                            suffix: (suffix ? " " + suffix : "")
+                        }
                     }
                 );
             }

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -27,11 +27,11 @@ module.exports = function(context) {
             if (src[src.length - 1] !== "\n") {
                 // file is not newline-terminated
                 location.line = src.split(/\n/g).length;
-                context.report(node, location, "Newline required at end of file but not found.");
+                context.report(node, "Newline required at end of file but not found.", {location: location});
             } else if (/\n\s*\n$/.test(src)) {
                 // last line is empty
                 location.line = src.split(/\n/g).length - 1;
-                context.report(node, location, "Unexpected blank line at end of file.");
+                context.report(node, "Unexpected blank line at end of file.", {location: location});
             }
         }
 

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -80,9 +80,9 @@ module.exports = function(context) {
             }
 
             context.report(
-                node, getOperatorLocation(node),
+                node,
                 "Expected '{{op}}=' and instead saw '{{op}}'.",
-                {op: node.operator}
+                {substitutions: {op: node.operator}, location: getOperatorLocation(node)}
             );
         }
     };

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -290,8 +290,8 @@ module.exports = function (context) {
 
                 if (actualIndentation !== expectedIndentation) {
                     context.report(node,
-                        {line: i + 1, column: expectedIndentation},
-                        "Expected indentation of " + expectedIndentation + " characters.");
+                        "Expected indentation of " + expectedIndentation + " characters.",
+                        {location: {line: i + 1, column: expectedIndentation}});
                     // correct the indentation so that future lines
                     // can be validated appropriately
                     actualIndentation = expectedIndentation;

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -141,10 +141,14 @@ module.exports = function(context) {
             location = side === "key" ? key.loc.start : firstTokenAfterColon.loc.start;
 
         if (diff && !(expected && containsLineTerminator(whitespace))) {
-            context.report(property[side], location, messages[side], {
-                error: diff > 0 ? "Extra" : "Missing",
-                key: getKey(property)
-            });
+            context.report(property[side], messages[side],
+                {
+                    substitutions: {
+                        error: diff > 0 ? "Extra" : "Missing",
+                        key: getKey(property)
+                    },
+                    location: location
+                });
         }
     }
 

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -32,7 +32,7 @@ module.exports = function(context) {
 
         if (len > maxDepth) {
             context.report(node, "Blocks are nested too deeply ({{depth}}).",
-                    { depth: len });
+                    {substitutions: { depth: len }});
         }
     }
 

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -48,7 +48,7 @@ module.exports = function(context) {
         // Iterate
         lines.forEach(function(line, i) {
             if (line.replace(/\t/g, tabString).length > maxLength) {
-                context.report(node, { line: i + 1, col: 1 }, "Line " + (i + 1) + " exceeds the maximum line length of " + maxLength + ".");
+                context.report(node, "Line " + (i + 1) + " exceeds the maximum line length of " + maxLength + ".", {location: { line: i + 1, col: 1 }});
             }
         });
     }

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -39,7 +39,7 @@ module.exports = function(context) {
 
         if (callbackStack.length > THRESHOLD) {
             var opts = {num: callbackStack.length, max: THRESHOLD};
-            context.report(node, "Too many nested callbacks ({{num}}). Maximum allowed is {{max}}.", opts);
+            context.report(node, "Too many nested callbacks ({{num}}). Maximum allowed is {{max}}.", {substitutions: opts});
         }
     }
 

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -23,10 +23,10 @@ module.exports = function(context) {
      */
     function checkFunction(node) {
         if (node.params.length > numParams) {
-            context.report(node, "This function has too many parameters ({{count}}). Maximum allowed is {{max}}.", {
+            context.report(node, "This function has too many parameters ({{count}}). Maximum allowed is {{max}}.", {substitutions: {
                 count: node.params.length,
                 max: numParams
-            });
+            }});
         }
     }
 

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
 
         if (count > maxStatements) {
             context.report(node, "This function has too many statements ({{count}}). Maximum allowed is {{max}}.",
-                    { count: count, max: maxStatements });
+                    {substitutions: { count: count, max: maxStatements }});
         }
     }
 

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -13,7 +13,7 @@ function matchProhibited(name) {
 }
 
 function report(context, node, result) {
-    context.report(node, "Unexpected {{name}}.", { name: result[1] });
+    context.report(node, "Unexpected {{name}}.", {substitutions: { name: result[1] }});
 }
 
 

--- a/lib/rules/no-bitwise.js
+++ b/lib/rules/no-bitwise.js
@@ -23,7 +23,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function report(node) {
-        context.report(node, "Unexpected use of '{{operator}}'.", { operator: node.operator });
+        context.report(node, "Unexpected use of '{{operator}}'.", {substitutions: { operator: node.operator }});
     }
 
     /**

--- a/lib/rules/no-caller.js
+++ b/lib/rules/no-caller.js
@@ -18,7 +18,7 @@ module.exports = function(context) {
                 propertyName = node.property.name;
 
             if (objectName === "arguments" && !node.computed && propertyName && propertyName.match(/^calle[er]$/)) {
-                context.report(node, "Avoid arguments.{{property}}.", { property: propertyName });
+                context.report(node, "Avoid arguments.{{property}}.", {substitutions: { property: propertyName }});
             }
 
         }

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -42,7 +42,7 @@ module.exports = function(context) {
 
             if (paramIsShadowing(scope, node.param.name)) {
                 context.report(node, "Value of '{{name}}' may be overwritten in IE 8 and earlier.",
-                        { name: node.param.name });
+                        {substitutions: { name: node.param.name }});
             }
         }
     };

--- a/lib/rules/no-comma-dangle.js
+++ b/lib/rules/no-comma-dangle.js
@@ -25,7 +25,7 @@ module.exports = function(context) {
             if (lastItem) {
                 penultimateToken = context.getLastToken(node, 1);
                 if (penultimateToken.value === ",") {
-                    context.report(lastItem, penultimateToken.loc.start, "Trailing comma.");
+                    context.report(lastItem, "Trailing comma.", {location: penultimateToken.loc.start});
                 }
             }
         }

--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -95,9 +95,9 @@ module.exports = function(context) {
         var ancestor = findConditionalAncestor(node);
 
         if (ancestor) {
-            context.report(ancestor, "Unexpected assignment within {{type}}.", {
+            context.report(ancestor, "Unexpected assignment within {{type}}.", {substitutions: {
                 type: NODE_DESCRIPTIONS[ancestor.type] || ancestor.type
-            });
+            }});
         }
     }
 

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
 
                 if (checkProperty) {
                     if (nodeProps[key]) {
-                        context.report(node, "Duplicate key '{{key}}'.", { key: keyName });
+                        context.report(node, "Duplicate key '{{key}}'.", {substitutions: { key: keyName }});
                     } else {
                         nodeProps[key] = true;
                     }

--- a/lib/rules/no-empty-label.js
+++ b/lib/rules/no-empty-label.js
@@ -15,7 +15,7 @@ module.exports = function(context) {
 
         "LabeledStatement": function(node) {
             if (node.body.type !== "ForStatement" && node.body.type !== "WhileStatement" && node.body.type !== "DoWhileStatement" && node.body.type !== "SwitchStatement" && node.body.type !== "ForInStatement") {
-                context.report(node, "Unexpected label {{l}}", {l: node.label.name});
+                context.report(node, "Unexpected label {{l}}", {substitutions: {l: node.label.name}});
             }
         }
     };

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -51,7 +51,7 @@ module.exports = function(context) {
 
                     context.report(switchData.lastCase,
                         "Expected a \"break\" statement before \"{{code}}\".",
-                        { code: node.test ? "case" : "default" });
+                        {substitutions: { code: node.test ? "case" : "default" }});
                 }
             }
 

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -71,7 +71,7 @@ module.exports = function(context) {
                 name = node.left.name;
 
             if (checkIfIdentifierIsFunction(scope, name)) {
-                context.report(node, "'{{name}}' is a function.", { name: name });
+                context.report(node, "'{{name}}' is a function.", {substitutions: { name: name }});
             }
 
         }

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -47,12 +47,12 @@ module.exports = function(context) {
 
         if (!valid) {
             context.report(node, "Move {{type}} declaration to {{body}} root.",
-                {
+                {substitutions: {
                     type: (node.type === "FunctionDeclaration" ?
                         "function" : "variable"),
                     body: (body.type === "Program" ?
                         "program" : "function body")
-                }
+                }}
             );
         }
     }

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -28,7 +28,7 @@ module.exports = function(context) {
         var locEnd = node.loc.end;
 
         errors = errors.filter(function (error) {
-            var errorLoc = error[1];
+            var errorLoc = error[2].location;
             if (errorLoc.line >= locStart.line && errorLoc.line <= locEnd.line) {
                 if (errorLoc.column >= locStart.column && errorLoc.column <= locEnd.column) {
                     return false;
@@ -73,7 +73,7 @@ module.exports = function(context) {
                         column: match.index
                     };
 
-                    errors.push([node, location, "Irregular whitespace not allowed"]);
+                    errors.push([node, "Irregular whitespace not allowed", {location: location}]);
                 }
             });
         },

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -56,7 +56,7 @@ module.exports = function(context) {
                 if (match) {
 
                     if (!MAYBE_COMMENT.test(line) && !COMMENT_START.test(lines[i - 1])) {
-                        context.report(node, { line: i + 1, column: match.index + 1 }, "Mixed spaces and tabs.");
+                        context.report(node, "Mixed spaces and tabs.", {location: { line: i + 1, column: match.index + 1 }});
                     }
 
                 }

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -87,9 +87,9 @@ module.exports = function(context) {
                         }
 
                         if (!parent || !exceptions[parent.type]) {
-                            context.report(token, token.loc.start,
+                            context.report(token,
                                 "Multiple spaces found before '{{value}}'.",
-                                { value: token.value });
+                                {substitutions: { value: token.value }, location: token.loc.start});
                         }
                     }
 

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -47,7 +47,7 @@ module.exports = function(context) {
                             line: lastLocation + 1,
                             column: lines[lastLocation].length
                         };
-                        context.report(node, location, "Multiple blank lines not allowed.");
+                        context.report(node, "Multiple blank lines not allowed.", {location: location});
                     }
 
                     // Finally, reset the blank counter

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -29,7 +29,7 @@ module.exports = function(context) {
 
         "VariableDeclarator": function(node) {
             if (nativeObjects.indexOf(node.id.name) >= 0) {
-                context.report(node, "Redefinition of '{{nativeObject}}'.", { nativeObject: node.id.name });
+                context.report(node, "Redefinition of '{{nativeObject}}'.", {substitutions: { nativeObject: node.id.name }});
             }
         }
     };

--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -16,7 +16,7 @@ module.exports = function(context) {
         "NewExpression": function(node) {
             var wrapperObjects = ["String", "Number", "Boolean", "Math", "JSON"];
             if (wrapperObjects.indexOf(node.callee.name) > -1) {
-                context.report(node, "Do not use {{fn}} as a constructor.", { fn: node.callee.name });
+                context.report(node, "Do not use {{fn}} as a constructor.", {substitutions: { fn: node.callee.name }});
             }
         }
     };

--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
             if (node.callee.type === "Identifier") {
                 var name = node.callee.name;
                 if (name === "Math" || name === "JSON") {
-                    context.report(node, "'{{name}}' is not a function.", { name: name });
+                    context.report(node, "'{{name}}' is not a function.", {substitutions: { name: name }});
                 }
             }
         }

--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -23,7 +23,7 @@ module.exports = function(context) {
             if (match) {
                 octalDigit = match[2];
                 context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
-                        { octalDigit: octalDigit });
+                        {substitutions: { octalDigit: octalDigit }});
             }
         }
 

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -21,7 +21,7 @@ module.exports = function(context) {
                 });
 
                 for (var i = 1, l = variable.identifiers.length; i < l; i++) {
-                    context.report(variable.identifiers[i], "{{a}} is already defined", {a: variable.name});
+                    context.report(variable.identifiers[i], "{{a}} is already defined", {substitutions: {a: variable.name}});
                 }
             }
         });

--- a/lib/rules/no-reserved-keys.js
+++ b/lib/rules/no-reserved-keys.js
@@ -42,7 +42,7 @@ module.exports = function(context) {
                     var keyName = property.key.name;
 
                     if (reservedWords.indexOf("" + keyName) !== -1) {
-                        context.report(node, MESSAGE, { key: keyName });
+                        context.report(node, MESSAGE, {substitutions: { key: keyName }});
                     }
                 }
 

--- a/lib/rules/no-restricted-modules.js
+++ b/lib/rules/no-restricted-modules.js
@@ -62,9 +62,9 @@ module.exports = function (context) {
                 var restrictedModuleName = getRestrictedModuleName(node);
 
                 if (restrictedModuleName) {
-                    context.report(node, "'{{moduleName}}' module is restricted from being used.", {
+                    context.report(node, "'{{moduleName}}' module is restricted from being used.", {substitutions: {
                         moduleName: restrictedModuleName
-                    });
+                    }});
                 }
             }
         }

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -40,7 +40,7 @@ module.exports = function(context) {
                     variable.identifiers.length > 0
             ) {
 
-                context.report(variable.identifiers[0], "{{a}} is already declared in the upper scope.", {a: variable.name});
+                context.report(variable.identifiers[0], "{{a}} is already declared in the upper scope.", {substitutions: {a: variable.name}});
             }
         });
     }

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -38,7 +38,7 @@ module.exports = function(context) {
                 // Passing node is a bit dirty, because message data will contain
                 // big text in `source`. But... who cares :) ?
                 // One more kludge will not make worse the bloody wizardry of this plugin.
-                context.report(node, location, "Trailing spaces not allowed.");
+                context.report(node, "Trailing spaces not allowed.", {location: location});
             }
         }
 

--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -18,7 +18,7 @@ module.exports = function(context) {
             var init = node.init && node.init.name;
 
             if (init === "undefined") {
-                context.report(node, "It's not necessary to initialize '{{name}}' to undefined.", { name: name });
+                context.report(node, "It's not necessary to initialize '{{name}}' to undefined.", {substitutions: { name: name }});
             }
         }
     };

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -89,7 +89,7 @@ module.exports = function(context) {
             }
         }
 
-        context.report(node, NOT_DEFINED_MESSAGE, { name: node.name });
+        context.report(node, NOT_DEFINED_MESSAGE, {substitutions: { name: node.name }});
     }
 
     return {
@@ -107,9 +107,9 @@ module.exports = function(context) {
                 }
 
                 if (!variable) {
-                    context.report(ref.identifier, NOT_DEFINED_MESSAGE, { name: name });
+                    context.report(ref.identifier, NOT_DEFINED_MESSAGE, {substitutions: { name: name }});
                 } else if (ref.isWrite() && variable.writeable === false) {
-                    context.report(ref.identifier, READ_ONLY_MESSAGE, { name: name });
+                    context.report(ref.identifier, READ_ONLY_MESSAGE, {substitutions: { name: name }});
                 }
             });
         },

--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -27,7 +27,7 @@ function report(context, node, unreachableType) {
         default:
             return;
     }
-    context.report(node, "Found unexpected statement after a {{type}}.", { type: keyword });
+    context.report(node, "Found unexpected statement after a {{type}}.", {substitutions: { type: keyword }});
 }
 
 

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -126,9 +126,9 @@ module.exports = function(context) {
 
             for (i = 0, l = unused.length; i < l; ++i) {
                 if (unused[i].eslintExplicitGlobal) {
-                    context.report(programNode, MESSAGE, unused[i]);
+                    context.report(programNode, MESSAGE, {substitutions: unused[i]});
                 } else if (unused[i].defs.length > 0) {
-                    context.report(unused[i].identifiers[0], MESSAGE, unused[i]);
+                    context.report(unused[i].identifiers[0], MESSAGE, {substitutions: unused[i]});
                 }
             }
         },

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -38,7 +38,7 @@ module.exports = function(context) {
         function checkLocationAndReport(reference, declaration) {
             if (typeOption !== NO_FUNC || declaration.defs[0].type !== "FunctionName") {
                 if (declaration.identifiers[0].range[1] > reference.identifier.range[1]) {
-                    context.report(reference.identifier, "{{a}} was used before it was defined", {a: reference.identifier.name});
+                    context.report(reference.identifier, "{{a}} was used before it was defined", {substitutions: {a: reference.identifier.name}});
                 }
             }
         }

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -39,7 +39,7 @@ module.exports = function(context) {
                 (["Identifier", "Null", "Boolean"].indexOf(tokens[0].type) >= 0 ||
                 (tokens[0].type === "Numeric" && "" + +tokens[0].value === tokens[0].value))
             ) {
-                context.report(node, "Unnecessarily quoted property `{{value}}` found.", key);
+                context.report(node, "Unnecessarily quoted property `{{value}}` found.", {substitutions: key});
             }
         }
     }
@@ -53,9 +53,9 @@ module.exports = function(context) {
         var key = node.key;
 
         if (!(key.type === "Literal" && typeof key.value === "string")) {
-            context.report(node, "Unquoted property `{{key}}` found.", {
+            context.report(node, "Unquoted property `{{key}}` found.", {substitutions: {
                 key: key.name || key.value
-            });
+            }});
         }
     }
 

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -46,14 +46,14 @@ module.exports = function(context) {
 
         if (always) {
             if (lastToken.type !== "Punctuator" || lastToken.value !== ";") {
-                context.report(node, lastToken.loc.end, "Missing semicolon.");
+                context.report(node, "Missing semicolon.", {location: lastToken.loc.end});
             }
         } else {
             if (lastToken.type === "Punctuator" &&
                 lastToken.value === ";" &&
                 isUnnecessarySemicolon(lastToken, nextToken)
             ) {
-                context.report(node, node.loc.end, "Extra semicolon.");
+                context.report(node, "Extra semicolon.", {location: node.loc.end});
             }
         }
     }

--- a/lib/rules/space-after-function-name.js
+++ b/lib/rules/space-after-function-name.js
@@ -24,10 +24,10 @@ module.exports = function(context) {
             hasSpace = tokens[1].range[1] < tokens[2].range[0];
 
         if (hasSpace !== requiresSpace) {
-            context.report(node, "Function name \"{{name}}\" must {{not}}be followed by whitespace.", {
+            context.report(node, "Function name \"{{name}}\" must {{not}}be followed by whitespace.", {substitutions: {
                 name: node.id.name,
                 not: requiresSpace ? "" : "not "
-            });
+            }});
         }
     }
 

--- a/lib/rules/space-after-keywords.js
+++ b/lib/rules/space-after-keywords.js
@@ -28,10 +28,10 @@ module.exports = function(context) {
             value = left.value;
 
         if (hasSpace !== requiresSpace) {
-            context.report(node, "Keyword \"{{value}}\" must {{not}}be followed by whitespace.", {
+            context.report(node, "Keyword \"{{value}}\" must {{not}}be followed by whitespace.", {substitutions: {
                 value: value,
                 not: requiresSpace ? "" : "not "
-            });
+            }});
         }
     }
 

--- a/lib/rules/space-in-brackets.js
+++ b/lib/rules/space-in-brackets.js
@@ -66,8 +66,9 @@ module.exports = function(context) {
     * @returns {void}
     */
     function reportNoBeginningSpace(node, token) {
-        context.report(node, token.loc.start,
-            "There should be no space after '" + token.value + "'");
+        context.report(node,
+            "There should be no space after '" + token.value + "'",
+            {location: token.loc.start});
     }
 
     /**
@@ -77,8 +78,9 @@ module.exports = function(context) {
     * @returns {void}
     */
     function reportNoEndingSpace(node, token) {
-        context.report(node, token.loc.start,
-            "There should be no space before '" + token.value + "'");
+        context.report(node,
+            "There should be no space before '" + token.value + "'",
+            {location: token.loc.start});
     }
 
     /**
@@ -88,8 +90,9 @@ module.exports = function(context) {
     * @returns {void}
     */
     function reportRequiredBeginningSpace(node, token) {
-        context.report(node, token.loc.start,
-            "A space is required after '" + token.value + "'");
+        context.report(node,
+            "A space is required after '" + token.value + "'",
+            {location: token.loc.start});
     }
 
     /**
@@ -99,8 +102,9 @@ module.exports = function(context) {
     * @returns {void}
     */
     function reportRequiredEndingSpace(node, token) {
-        context.report(node, token.loc.start,
-                    "A space is required before '" + token.value + "'");
+        context.report(node,
+                    "A space is required before '" + token.value + "'",
+                    {location: token.loc.start});
     }
 
 

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -232,7 +232,7 @@ module.exports = function(context) {
                     }
                     column = match.index - pos;
 
-                    context.report(node, { line: line, column: column }, message);
+                    context.report(node, message, {location: { line: line, column: column }});
                 }
             }
 

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -94,15 +94,15 @@ module.exports = function(context) {
 
                     case "param":
                         if (!tag.type) {
-                            context.report(jsdocNode, "Missing JSDoc parameter type for '{{name}}'.", { name: tag.name });
+                            context.report(jsdocNode, "Missing JSDoc parameter type for '{{name}}'.", {substitutions: { name: tag.name }});
                         }
 
                         if (!tag.description && requireParamDescription) {
-                            context.report(jsdocNode, "Missing JSDoc parameter description for '{{name}}'.", { name: tag.name });
+                            context.report(jsdocNode, "Missing JSDoc parameter description for '{{name}}'.", {substitutions: { name: tag.name }});
                         }
 
                         if (params[tag.name]) {
-                            context.report(jsdocNode, "Duplicate JSDoc parameter '{{name}}'.", { name: tag.name });
+                            context.report(jsdocNode, "Duplicate JSDoc parameter '{{name}}'.", {substitutions: { name: tag.name }});
                         } else if (tag.name.indexOf(".") === -1) {
                             params[tag.name] = 1;
                         }
@@ -136,7 +136,7 @@ module.exports = function(context) {
 
                 // check tag preferences
                 if (prefer.hasOwnProperty(tag.title)) {
-                    context.report(jsdocNode, "Use @{{name}} instead.", { name: prefer[tag.title] });
+                    context.report(jsdocNode, "Use @{{name}} instead.", {substitutions: { name: prefer[tag.title] }});
                 }
 
             });
@@ -155,14 +155,14 @@ module.exports = function(context) {
                 var name = param.name;
 
                 if (jsdocParams[i] && (name !== jsdocParams[i])) {
-                    context.report(jsdocNode, "Expected JSDoc for '{{name}}' but found '{{jsdocName}}'.", {
+                    context.report(jsdocNode, "Expected JSDoc for '{{name}}' but found '{{jsdocName}}'.", {substitutions: {
                         name: name,
                         jsdocName: jsdocParams[i]
-                    });
+                    }});
                 } else if (!params[name]) {
-                    context.report(jsdocNode, "Missing JSDoc for parameter '{{name}}'.", {
+                    context.report(jsdocNode, "Missing JSDoc for parameter '{{name}}'.", {substitutions: {
                         name: name
-                    });
+                    }});
                 }
             });
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -799,7 +799,10 @@ describe("eslint", function() {
             eslint.defineRule("test-rule", function(context) {
                 return {
                     "Literal": function(node) {
-                        context.report(node, node.loc.end, "hello {{dynamic}}", {dynamic: node.type});
+                        context.report(node, "hello {{dynamic}}", {
+                            substitutions: {dynamic: node.type},
+                            location: node.loc.end
+                        });
                     }
                 };
             });
@@ -816,7 +819,7 @@ describe("eslint", function() {
             eslint.defineRule("test-rule", function(context) {
                 return {
                     "Literal": function(node) {
-                        context.report(node, {line: 42, column: 13}, "hello world");
+                        context.report(node, "hello world", {location: {line: 42, column: 13}});
                     }
                 };
             });


### PR DESCRIPTION
...e final param.

Previously, RuleContext took the following four parameters:

```
{ASTNode} node
{Object=} location
{string} message
{Object} opts
```

I found it odd to have one optional parameter in the middle of the
list (`location`) in addition to another optional parameter at the
end of the list (`opts`). I believe this also makes it difficult
to cleanly introduce any future optional parameters, which is something
I would like to do in an upcoming pull request.

As such, I moved `location` and `opts` into a hash of their own,
which is now its own optional argument. This changes the params to:

```
{ASTNode} node
{string} message
{{substitutions: (Object|undefined), location: ({line: number, column: number}|undefined)}=} opts
```

I updated all of the call sites to use this new API and verified that
all tests pass. Fortunately, the majority of the call sites did not
specify either of the optional params, so those did not have to be updated.

Cleaning up this API also made it possible to clean up `eslint.report()` so
it no longer has to do `typeof` checks to figure out which parameters map to
which values.

I also tightened up the type expression for what constitutes a `location`,
changing it from `Object` to `{line: number, column: number}`.

The documentation in `working-with-rules.md` was also updated to
reflect the changes in this commit.