### PR TITLE
Update: Backslashes in path (fixes #1818)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -374,7 +374,7 @@ CLIEngine.prototype = {
         if (typeof format === "string") {
 
             // if there's a slash, then it's a file
-            if (format.indexOf("/") > -1) {
+            if (format.indexOf("/") > -1 || format.indexOf("\\") > -1) {
                 formatterPath = path.resolve(process.cwd(), format);
             } else {
                 formatterPath = "./formatters/" + format;

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -842,6 +842,13 @@ describe("CLIEngine", function() {
             assert.isFunction(formatter);
         });
 
+        it("should return a function when a custom formatter is requested, also if the path has backslashes", function() {
+            var engine = new CLIEngine(),
+                formatter = engine.getFormatter(".\\tests\\fixtures\\formatters\\simple.js");
+
+            assert.isFunction(formatter);
+        });
+
         it("should return null when a customer formatter doesn't exist", function() {
             var engine = new CLIEngine(),
                 formatter = engine.getFormatter("./tests/fixtures/formatters/doesntexist.js");


### PR DESCRIPTION
When using the tool standard on Windows 7, the following error
occured:
Could not find formatter
'C:\Users\Jan\AppData\Roaming\npm\
node_modules\standard\lib\eslint-reporter.js'.
This
was because standard passes a path with backslashes to eslint
as the
formatter param; and eslint only looked for forward slashes.

This fixes #1818.
I'm not sure if this should be classified as _fix_ or _update_.