### PR TITLE
Docs: fix typo in configuring docs

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -60,7 +60,7 @@ Setting language options helps ESLint determine what is a parsing error. All lan
 By default, ESLint uses [Espree](https://github.com/eslint/espree) as its parser. You can optionally specify that a different parser should be used in your configuration file so long as the parser meets the following requirements:
 
 1. It must be an npm module installed locally.
-1. It must have an Esprima-compatible interface (it must exports a `parse()` method).
+1. It must have an Esprima-compatible interface (it must export a `parse()` method).
 1. It must produce Esprima-compatible AST and token objects.
 
 Note that even with these compatibilities, there are no guarantees that an external parser will work correctly with ESLint and ESLint will not fix bugs related to incompatibilities with other parsers.
@@ -448,4 +448,3 @@ foo.js
 ```
 
 This message occurs because ESLint is unsure if you wanted to actually lint the file or not. As the message indicates, you can use `--no-eslintignore` to omit using the ignore rules.
-


### PR DESCRIPTION
Found this minor typo while reading through.
This may be referring to the `exports` global. In that case, perhaps we should surround it with backticks to indicate it being code, so that the reader doesn't read it as regular English.