### PR TITLE
WIP Support for custom loaders

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -78,7 +78,8 @@ var defaultOptions = {
         ignore: true,
         ignorePath: null
     },
-    loadedPlugins = Object.create(null);
+    loadedPlugins = Object.create(null),
+    loadedLoaders = Object.create(null);
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -104,6 +105,29 @@ function loadPlugins(pluginNames) {
                 rules.import(plugin.rules, pluginNameWithoutPrefix);
 
                 loadedPlugins[pluginNameWithoutPrefix] = true;
+            }
+        });
+    }
+}
+
+/**
+ * Load the format loader
+ * @param {Object} loadersConfig A list of supported extension with names of loaders assigned to them.
+ * @returns {void}
+ */
+function loadLoaders(loadersConfig) {
+    if (loadersConfig) {
+        Object.keys(loadersConfig).forEach(function (extension) {
+            var loaderName = loadersConfig[extension];
+            var loaderNameWithoutPrefix = util.removeLoaderPrefix(loaderName),
+                loader;
+
+            if (!loadedLoaders[loaderNameWithoutPrefix]) {
+                debug("Load loader " + loaderNameWithoutPrefix);
+
+                loader = require(util.LOADER_NAME_PREFIX + loaderNameWithoutPrefix);
+
+                loadedLoaders[extension] = loader;
             }
         });
     }
@@ -162,14 +186,25 @@ function processFile(filename, configHelper) {
         config,
         text,
         messages,
-        stats;
+        stats,
+        fileExtension = path.extname(filename).substring(1);
 
     if (fs.existsSync(filePath)) {
         debug("Linting " + filePath);
         config = configHelper.getConfig(filePath);
         loadPlugins(config.plugins);
+        loadLoaders(config.loaders);
         text = fs.readFileSync(path.resolve(filename), "utf8");
-        messages = eslint.verify(text, config, filename);
+        if (loadedLoaders[fileExtension]) {
+            var parsedBlocks = loadedLoaders[fileExtension].preprocess(text);
+            var unprocessedMessages = [];
+            parsedBlocks.forEach(function(block) {
+                unprocessedMessages.push(eslint.verify(block, config, filename));
+            });
+            messages = loadedLoaders[fileExtension].postprocess(unprocessedMessages);
+        } else {
+            messages = eslint.verify(text, config, filename);
+        }
     } else {
         debug("Couldn't find " + filePath);
         messages = [{

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 var PLUGIN_NAME_PREFIX = "eslint-plugin-";
+var LOADER_NAME_PREFIX = "eslint-loader-";
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -66,21 +67,34 @@ exports.mergeConfigs = function mergeConfigs(base, custom) {
     return base;
 };
 
+
+/**
+ * Removes prefix from a given name
+ * @param {string} name Value to remove prefix from
+ * @param {string} prefix Value of the prefix to be removed
+ * @returns {string} Result name without prefix
+ */
+function removePrefix(name, prefix) {
+    return name.indexOf(prefix) === 0 ? name.substring(prefix.length) : name;
+}
+
 /**
  * Removes the prefix `eslint-plugin-` from a plugin name.
- * @param {string} pluginName The name of the plugin which may has the prefix.
+ * @param {string} pluginName The name of the plugin which may have the prefix.
  * @returns {string} The name of the plugin without prefix.
  */
 exports.removePluginPrefix = function removePluginPrefix(pluginName) {
-    var nameWithoutPrefix;
+    return removePrefix(pluginName, PLUGIN_NAME_PREFIX);
+};
 
-    if (pluginName.indexOf(PLUGIN_NAME_PREFIX) === 0) {
-        nameWithoutPrefix = pluginName.substring(PLUGIN_NAME_PREFIX.length);
-    } else {
-        nameWithoutPrefix = pluginName;
-    }
-
-    return nameWithoutPrefix;
+/**
+ * Remove the prefix 'eslint-loader-' from a loader name.
+ * @param {string} loaderName The name of the plugin which may have the prefix.
+ * @returns {string} The name of the loader without prefix.
+ */
+exports.removeLoaderPrefix = function removeLoaderPrefix(loaderName) {
+    return removePrefix(loaderName, LOADER_NAME_PREFIX);
 };
 
 exports.PLUGIN_NAME_PREFIX = PLUGIN_NAME_PREFIX;
+exports.LOADER_NAME_PREFIX = LOADER_NAME_PREFIX;


### PR DESCRIPTION
This is related to #1817 This would add support for custom file loaders. In retrospect, I really dislike name `loader`, but I didn't want to use `preprocessor` since that's usually reserved for transpilers. I would also like to merge caches for loaders and plugins, and probably refactor the functions related to loading plugins. It's also doesn't support native loaders, only plugins, but I think that's fine. Eslint is javascript linter, everything else is extra - hence plugins. Missing tests and docs can be added if the direction is correct.