### PR TITLE
Fix: new-cap should allow defining exceptions (fixes #1424)

### DIFF
--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -44,7 +44,6 @@ If provided, it must be an `Array`.
 ### capIsNewExceptions
 
 Array of uppercase-starting function names that are permitted to be used without the `new` operator.
-If provided, it must be an `Array`.
 If not provided, `capIsNewExceptions` defaults to the following:
  - `Object`
  - `Function`
@@ -55,6 +54,8 @@ If not provided, `capIsNewExceptions` defaults to the following:
  - `Array`
  - `Symbol`
  - `RegExp`
+
+If provided, it must be an `Array`. The default values will continue to be excluded when `capIsNewExceptions` is provided.
 
 ## When Not To Use It
 

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -44,6 +44,21 @@ function invert(map, key) {
     return map;
 }
 
+/**
+ * Creates an object with the cap is new exceptions as its keys and true as their values.
+ * @param {Object} config Rule configuration
+ * @returns {Object} Object with cap is new exceptions.
+ */
+function calculateCapIsNewExceptions(config) {
+    var capIsNewExceptions = checkArray(config, "capIsNewExceptions", CAPS_ALLOWED);
+
+    if (capIsNewExceptions !== CAPS_ALLOWED) {
+        capIsNewExceptions = capIsNewExceptions.concat(CAPS_ALLOWED);
+    }
+
+    return capIsNewExceptions.reduce(invert, {});
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -56,7 +71,7 @@ module.exports = function(context) {
 
     var newIsCapExceptions = checkArray(config, "newIsCapExceptions", []).reduce(invert, {});
 
-    var capIsNewExceptions = checkArray(config, "capIsNewExceptions", CAPS_ALLOWED).reduce(invert, {});
+    var capIsNewExceptions = calculateCapIsNewExceptions(config);
 
     var listeners = {};
 

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -52,7 +52,8 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         "var o = { 1: function () {} }; o[1]();",
         "var o = { 1: function () {} }; new o[1]();",
         { code: "var x = Foo(42);", args: [1, { capIsNew: true, capIsNewExceptions: ["Foo"] }] },
-        { code: "var x = new foo(42);", args: [1, { newIsCap: true, newIsCapExceptions: ["foo"] }] }
+        { code: "var x = new foo(42);", args: [1, { newIsCap: true, newIsCapExceptions: ["foo"] }] },
+        { code: "var x = Object(42);", args: [1, { capIsNewExceptions: ["Foo"] }] }
     ],
     invalid: [
         { code: "var x = new c();", errors: [{ message: "A constructor name should not start with a lowercase letter.", type: "NewExpression"}] },
@@ -63,7 +64,6 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
         { code: "var b = a.Foo();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
         { code: "var b = a['Foo']();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
         { code: "var b = a.Date.UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
-        { code: "var b = UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] },
-        { code: "var x = Object(42);", args: [1, { capIsNew: true, capIsNewExceptions: [] }], errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression" }] }
+        { code: "var b = UTC();", errors: [{ message: "A function with a name starting with an uppercase letter should only be used as a constructor.", type: "CallExpression"}] }
     ]
 });


### PR DESCRIPTION
When exceptions are provided the defaults shouldn't be dropped.