### PR TITLE
New: rule no-throw-literal added (fixes #1791)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -88,6 +88,7 @@
         "no-sync": 0,
         "no-ternary": 0,
         "no-trailing-spaces": 2,
+        "no-throw-literal": 0,
         "no-undef": 2,
         "no-undef-init": 2,
         "no-undefined": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -76,6 +76,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
 * [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same (off by default)
 * [no-sequences](no-sequences.md) - disallow use of comma operator
+* [no-throw-literal](no-throw-literal.md) - restrict what can be thrown as an exception (off by default)
 * [no-unused-expressions](no-unused-expressions.md) - disallow usage of expressions in statement position
 * [no-void](no-void.md) - disallow use of `void` operator (off by default)
 * [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME` (off by default)

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -1,0 +1,38 @@
+# Restrict what can be thrown as an exception (no-throw-literal)
+
+It is considered good practice to only `throw` the `Error`object itself or an object using the `Error` object as base objects for user-defined exceptions.
+The fundamental benefit of `Error` objects is that they automatically keep track of where they were built and originated.
+This rule restrict what can be thrown as an exception by preventing to throw literals.
+
+## Rule Details
+
+This rule is aimed at maintaining consistency when throwing exception by disallowing to throw literals.
+
+The following patterns are considered warnings:
+
+```js
+throw "error";
+
+throw 0;
+
+throw undefined;
+
+throw null;
+```
+
+The following patterns are not considered warnings:
+
+```js
+throw new Error();
+
+throw new Error("error");
+
+var e = new Error("error");
+throw e;
+
+try {
+	throw new Error("error");
+} catch (e) {
+	throw e;
+}
+```

--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -1,0 +1,31 @@
+/**
+ * @fileoverview Rule to restrict what can be thrown as an exception.
+ * @author Dieter Oberkofler
+ * @copyright 2015 Dieter Oberkofler. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "ThrowStatement": function(node) {
+
+            if (node.argument.type === "Literal") {
+                context.report(node, "Do not throw a literal.");
+            } else if (node.argument.type === "Identifier") {
+                if (node.argument.name === "undefined") {
+                    context.report(node, "Do not throw undefined.");
+                }
+            }
+
+        }
+
+    };
+
+};

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Tests for no-throw-literal rule.
+ * @author Dieter Oberkofler
+ * @copyright 2015 Dieter Oberkofler. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-throw-literal", {
+    valid: [
+        "throw new Error();",
+        "throw new Error('error');",
+        "throw Error('error');",
+        "throw {};",
+        "throw [];",
+        "var e = new Error(); throw e;",
+        "try {throw new Error();} catch (e) {throw e;};"
+    ],
+    invalid: [
+        {
+            code: "throw 'error';",
+            errors: [{
+                message: "Do not throw a literal.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw 0;",
+            errors: [{
+                message: "Do not throw a literal.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw false;",
+            errors: [{
+                message: "Do not throw a literal.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw null;",
+            errors: [{
+                message: "Do not throw a literal.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw undefined;",
+            errors: [{
+                message: "Do not throw undefined.",
+                type: "ThrowStatement"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
The new rule `no-throw-literal` is based on the suggestion of @nzakas and tries to only prevent from throwing a literal.

PS: Please be patient with my first attempt to create a new rule from scratch.
