### PR TITLE
New: Adding Support for "// eslint-disable-line rule" style comments

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -282,6 +282,18 @@ console.log('bar');
 /*eslint-enable no-alert */
 ```
 
+To disable warnings on a specific line
+
+```js
+alert('foo'); // eslint-disable-line
+```
+
+To disable a specific rule on a specific line
+
+```js
+alert('foo'); // eslint-disable-line no-alert
+```
+
 ## Adding Shared Settings
 
 ESLint supports adding shared settings into configuration file. You can add `settings` object to ESLint configuration file and it will be supplied to every rule that will be executed. This may be useful if you are adding custom rules and want them to have access to the same information and be easily configurable.

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -218,7 +218,6 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
     }
 }
 
-
 /**
  * Parses comments in file to extract file-specific config of rules, globals
  * and environments and merges them with global config; also code blocks
@@ -238,14 +237,14 @@ function modifyConfigsFromComments(ast, config, reportingConfig) {
     var commentRules = {};
 
     ast.comments.forEach(function(comment) {
-        if (comment.type === "Block") {
 
-            var value = comment.value.trim();
-            var match = /^(eslint-\w+|eslint|globals?)(\s|$)/.exec(value);
+        var value = comment.value.trim();
+        var match = /^(eslint-\w+|eslint-\w+-\w+|eslint|globals?)(\s|$)/.exec(value);
 
-            if (match) {
-                value = value.substring(match.index + match[1].length);
+        if (match) {
+            value = value.substring(match.index + match[1].length);
 
+            if (comment.type === "Block") {
                 switch (match[1]) {
                     case "globals":
                     case "global":
@@ -275,6 +274,12 @@ function modifyConfigsFromComments(ast, config, reportingConfig) {
                         break;
 
                     // no default
+                }
+            } else {
+                // comment.type === "Line"
+                if (match[1] === "eslint-disable-line") {
+                    disableReporting(reportingConfig, { "line": comment.loc.start.line, "column": 0 }, Object.keys(parseListConfig(value)));
+                    enableReporting(reportingConfig, comment.loc.end, Object.keys(parseListConfig(value)));
                 }
             }
         }

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1549,6 +1549,79 @@ describe("eslint", function() {
         });
     });
 
+    describe("when evaluating code with comments to ignore reporting on of specific rules on a specific line", function() {
+
+        it("should report a violation", function() {
+            var code = [
+                "alert('test'); // eslint-disable-line no-alert",
+                "console.log('test');" // here
+            ].join("\n");
+            var config = {
+                rules: {
+                    "no-alert": 1,
+                    "no-console": 1
+                }
+            };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 1);
+
+            assert.equal(messages[0].ruleId, "no-console");
+        });
+
+        it("should report a violation", function() {
+            var code = [
+                "alert('test'); // eslint-disable-line no-alert",
+                "console.log('test'); // eslint-disable-line no-console",
+                "alert('test');" // here
+            ].join("\n");
+            var config = {
+                rules: {
+                    "no-alert": 1,
+                    "no-console": 1
+                }
+            };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 1);
+
+            assert.equal(messages[0].ruleId, "no-alert");
+        });
+
+        it("should report a violation", function() {
+            var code = [
+                "alert('test'); // eslint-disable-line no-alert",
+                "alert('test'); /*eslint-disable-line no-alert*/" // here
+            ].join("\n");
+            var config = {
+                rules: {
+                    "no-alert": 1
+                }
+            };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 1);
+
+            assert.equal(messages[0].ruleId, "no-alert");
+        });
+
+        it("should not report a violation", function() {
+            var code = [
+                "alert('test'); // eslint-disable-line no-alert",
+                "console('test'); // eslint-disable-line no-console"
+            ].join("\n");
+            var config = {
+                rules: {
+                    "no-alert": 1,
+                    "no-console": 1
+                }
+            };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 0);
+        });
+    });
+
     describe("when evaluating code with comments to enable and disable reporting of specific rules", function() {
 
         it("should report a violation", function() {


### PR DESCRIPTION
As discussed on eslint@googlegroups.com, this pull requests enables support for a trailing comment to "mute" or "ignore" a single line. For example, previously accomplishing this would have required something like:

```javascript
/*eslint-disable no-eval*/
var value = eval(value);
/*eslint-enable*/
``` 
Whereas now with `eslint-ignore` you can accomplish this more easily with a simple trailing comment:

```javascript
var value = eval(value);  /*eslint-ignore no-eval*/
```

Making it simpler and easier to mute known rule violations when necessary.