### PR TITLE
New add requireJsDoc to valid-jsdoc (fixes #1842)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -20,10 +20,13 @@ module.exports = function(context) {
     var options = context.options[0] || {},
         prefer = options.prefer || {},
 
-        // these both default to true, so you have to explicitly make them false
-        requireReturn = options.requireReturn === false ? false : true,
+        // these three default to true, so you have to explicitly make them false
+        requireReturn = options.requireReturn !== false,
         requireParamDescription = options.requireParamDescription !== false,
-        requireReturnDescription = options.requireReturnDescription !== false;
+        requireReturnDescription = options.requireReturnDescription !== false,
+
+        // defaults to false
+        requireJsDoc = options.requireJsDoc || false;
 
     //--------------------------------------------------------------------------
     // Helpers
@@ -167,6 +170,8 @@ module.exports = function(context) {
                 }
             });
 
+        } else if (!jsdocNode && requireJsDoc) {
+            context.report(node, "Missing JSDoc.");
         }
 
     }

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -213,6 +213,14 @@ eslintTester.addRuleTest("lib/rules/valid-jsdoc", {
                 message: "Unexpected @returns tag; function has no return statement.",
                 type: "Block"
             }]
+        },
+        {
+            code: "function foo(){}",
+            args: [1, {requireJsDoc: true}],
+            errors: [{
+                message: "Missing JSDoc.",
+                type: "FunctionDeclaration"
+            }]
         }
     ]
 });


### PR DESCRIPTION
This is to have a check if a function has a jsDoc at all.