### PR TITLE
Docs: Fix typo in wrap-iife rule doc title

### DIFF
--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -1,4 +1,4 @@
-# Require IFFEs to be Wrapped (wrap-iife)
+# Require IIFEs to be Wrapped (wrap-iife)
 
 Require immediate function invocation to be wrapped in parentheses.
 


### PR DESCRIPTION
Changes "IFFE" to "IIFE" in the `wrap-iife` rule documentation title.