### PR TITLE
Docs: Change customformat value to path

### DIFF
--- a/docs/command-line-interface/README.md
+++ b/docs/command-line-interface/README.md
@@ -88,7 +88,7 @@ You can also use a custom formatter from the command line by specifying a path t
 
 Example:
 
-    eslint -f customformat.js file.js
+    eslint -f ./customformat.js file.js
 
 When specified, the given format is output to the console. If you'd like to save that output into a file, you can do so on the command line like so:
 


### PR DESCRIPTION
I try use custom format with `eslint -f customformat.js file.js` but that got error `Could not find formatter`
and retry to `eslint -f ./customformat.js file.js` and got success.

I think documentation's command is a trap and not so friendly.