### PR TITLE
Fix: make rules work with for-of statements (fixes #1859)

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -160,6 +160,14 @@ module.exports = function(context) {
         },
         "ForInStatement:exit": popScope,
 
+        "ForOfStatement": function(node) {
+            pushScope();
+            if (node.left.type === "VariableDeclaration") {
+                variableDeclarationHandler(node.left);
+            }
+        },
+        "ForOfStatement:exit": popScope,
+
         "Identifier": function(node) {
             var ancestor = context.getAncestors().pop();
             if (isDeclaration(node, ancestor) || isProperty(node, ancestor) || ancestor.type === "LabeledStatement") {

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -197,6 +197,7 @@ module.exports = function(context) {
         "WithStatement": checkBlock("body"),
         "ForStatement": checkBlock("body"),
         "ForInStatement": checkBlock("body"),
+        "ForOfStatement": checkBlock("body"),
         "SwitchStatement": checkSwitchStatement
     };
 

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -74,6 +74,7 @@ module.exports = function(context) {
         "LogicalExpression": increaseLogicalComplexity,
         "ForStatement": increaseComplexity,
         "ForInStatement": increaseComplexity,
+        "ForOfStatement": increaseComplexity,
         "IfStatement": increaseComplexity,
         "SwitchCase": increaseSwitchComplexity,
         "WhileStatement": increaseComplexity,

--- a/lib/rules/no-empty-label.js
+++ b/lib/rules/no-empty-label.js
@@ -14,7 +14,9 @@ module.exports = function(context) {
     return {
 
         "LabeledStatement": function(node) {
-            if (node.body.type !== "ForStatement" && node.body.type !== "WhileStatement" && node.body.type !== "DoWhileStatement" && node.body.type !== "SwitchStatement" && node.body.type !== "ForInStatement") {
+            var type = node.body.type;
+
+            if (type !== "ForStatement" && type !== "WhileStatement" && type !== "DoWhileStatement" && type !== "SwitchStatement" && type !== "ForInStatement" && type !== "ForOfStatement") {
                 context.report(node, "Unexpected label {{l}}", {l: node.label.name});
             }
         }

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -186,6 +186,11 @@ module.exports = function(context) {
                 report(node.right);
             }
         },
+        "ForOfStatement": function(node) {
+            if (isParenthesised(node.right)) {
+                report(node.right);
+            }
+        },
         "ForStatement": function(node) {
             if (node.init && isParenthesised(node.init)) {
                 report(node.init);

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -11,14 +11,32 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var loopNodeTypes = [
+        "ForStatement",
+        "WhileStatement",
+        "ForInStatement",
+        "ForOfStatement",
+        "DoWhileStatement"
+    ];
 
+    /**
+     * Checks if the given node is a loop.
+     * @param {ASTNode} node The AST node to check.
+     * @returns {boolean} Whether or not the node is a loop.
+     */
+    function isLoop(node) {
+        return loopNodeTypes.indexOf(node.type) > -1;
+    }
+
+    /**
+     * Reports if the given node has an ancestor node which is a loop.
+     * @param {ASTNode} node The AST node to check.
+     * @returns {boolean} Whether or not the node is within a loop.
+     */
     function checkForLoops(node) {
         var ancestors = context.getAncestors();
 
-        if (ancestors.some(function(ancestor) {
-            return ancestor.type === "ForStatement" || ancestor.type === "ForInStatement" ||
-                ancestor.type === "WhileStatement" || ancestor.type === "DoWhileStatement";
-        })) {
+        if (ancestors.some(isLoop)) {
             context.report(node, "Don't make functions within a loop");
         }
     }

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -67,6 +67,15 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         { code: "function z(b){}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
         { code: "function z(){var b;}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
         { code: "function f(){ try{}catch(e){} e }", errors: [{ message: "\"e\" used outside of binding context.", type: "Identifier" }] },
-        { code: "a:b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] }
+        { code: "a:b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
+        {
+            code: "function a() { for(var b in {}) { var c = b; } c; }",
+            errors: [{ message: "\"c\" used outside of binding context.", type: "Identifier" }]
+        },
+        {
+            code: "function a() { for(var b of {}) { var c = b;} c; }",
+            ecmaFeatures: { forOf: true },
+            errors: [{ message: "\"c\" used outside of binding context.", type: "Identifier" }]
+        }
     ]
 });

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -79,6 +79,7 @@ eslintTester.addRuleTest("lib/rules/brace-style", {
         { code: "try { \n bar(); \n } catch (e) \n {}", errors: [{ message: OPEN_MESSAGE, type: "CatchClause"}] },
         { code: "do \n { \n bar(); \n} while (true)", errors: [{ message: OPEN_MESSAGE, type: "DoWhileStatement"}] },
         { code: "for (foo in bar) \n { \n baz(); \n }", errors: [{ message: OPEN_MESSAGE, type: "ForInStatement"}] },
+        { code: "for (foo of bar) \n { \n baz(); \n }", ecmaFeatures: { forOf: true }, errors: [{ message: OPEN_MESSAGE, type: "ForOfStatement"}] },
         { code: "try { \n bar(); \n }\ncatch (e) {\n}", errors: [{ message: CLOSE_MESSAGE, type: "CatchClause"}] },
         { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement"}] },
         { code: "if (a) { \nb();\n } \n else { \nc();\n }", errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]},

--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -49,6 +49,7 @@ eslintTester.addRuleTest("lib/rules/complexity", {
         { code: "function a(x) {if (true) {return x;} else if (false) {return x+1;} else {return 4;}}", args: [1, 2], errors: 1 },
         { code: "function a(x) {for(var i = 0; i < 5; i ++) {x ++;} return x;}", args: [1, 1], errors: 1 },
         { code: "function a(obj) {for(var i in obj) {obj[i] = 3;}}", args: [1, 1], errors: 1 },
+        { code: "function a(obj) {for(var i of obj) {obj[i] = 3;}}", ecmaFeatures: { forOf: true }, args: [1, 1], errors: 1 },
         { code: "function a(x) {for(var i = 0; i < 5; i ++) {if(i % 2 === 0) {x ++;}} return x;}", args: [1, 2], errors: 1 },
         { code: "function a(obj) {if(obj){ for(var x in obj) {try {x.getThis();} catch (e) {x.getThat();}}} else {return false;}}", args: [1, 3], errors: 1 },
         { code: "function a(x) {try {x.getThis();} catch (e) {x.getThat();}}", args: [1, 1], errors: 1 },

--- a/tests/lib/rules/no-empty-label.js
+++ b/tests/lib/rules/no-empty-label.js
@@ -20,6 +20,7 @@ var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-empty-label", {
     valid: [
         "labeled: for (var i in {}) { }",
+        { code: "labeled: for (var i of {}) { }", ecmaFeatures: { forOf: true } },
         "labeled: for (var i=10; i; i--) { }",
         "labeled: while(i) {}",
         "labeled: do {} while (i)",

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -13,9 +13,10 @@
 var eslint = require("../../../lib/eslint"),
     ESLintTester = require("eslint-tester");
 
-function invalid(code, type, line) {
+function invalid(code, type, line, ecmaFeatures) {
     var result = {
             code: code,
+            ecmaFeatures: ecmaFeatures,
             errors: [
                 {
                     message: "Gratuitous parentheses around expression.",
@@ -155,6 +156,7 @@ eslintTester.addRuleTest("lib/rules/no-extra-parens", {
         invalid("while((0));", "Literal"),
         invalid("do; while((0))", "Literal"),
         invalid("for(a in (0));", "Literal"),
+        invalid("for(a of (0));", "Literal", 1, { forOf: true }),
         invalid("f((0))", "Literal"),
         invalid("f(0, (1))", "Literal"),
         invalid("!(0)", "Literal"),

--- a/tests/lib/rules/no-loop-func.js
+++ b/tests/lib/rules/no-loop-func.js
@@ -17,19 +17,48 @@ var eslint = require("../../../lib/eslint"),
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new ESLintTester(eslint);
+var eslintTester = new ESLintTester(eslint),
+    expectedErrorMessage = "Don't make functions within a loop";
+
 eslintTester.addRuleTest("lib/rules/no-loop-func", {
     valid: [
         "string = 'function a() {}';",
         "for (var i=0; i<l; i++) { } var a = function() { };"
     ],
     invalid: [
-        { code: "for (var i=0; i<l; i++) { (function() {}) }", errors: [{ message: "Don't make functions within a loop", type: "FunctionExpression"}] },
-        { code: "for (var i in {}) { (function() {}) }", errors: [{ message: "Don't make functions within a loop", type: "FunctionExpression"}] },
-        { code: "for (var i=0; i<l; i++) { (() => {}) }", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "Don't make functions within a loop", type: "ArrowFunctionExpression"}] },
-        { code: "for (var i=0; i<l; i++) { var a = function() {} }", errors: [{ message: "Don't make functions within a loop", type: "FunctionExpression"}] },
-        { code: "for (var i=0; i<l; i++) { function a() {}; a(); }", errors: [{ message: "Don't make functions within a loop", type: "FunctionDeclaration"}] },
-        { code: "while(i) { (function() {}) }", errors: [{ message: "Don't make functions within a loop", type: "FunctionExpression"}] },
-        { code: "do { (function() {}) } while (i)", errors: [{ message: "Don't make functions within a loop", type: "FunctionExpression"}] }
+        {
+            code: "for (var i=0; i<l; i++) { (function() {}) }",
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "for (var i in {}) { (function() {}) }",
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "for (var i of {}) { (function() {}) }",
+            ecmaFeatures: { forOf: true },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "for (var i=0; i < l; i++) { (() => {}) }",
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [ { message: expectedErrorMessage, type: "ArrowFunctionExpression" } ]
+        },
+        {
+            code: "for (var i=0; i < l; i++) { var a = function() {} }",
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "for (var i=0; i < l; i++) { function a() {}; a(); }",
+            errors: [ { message: expectedErrorMessage, type: "FunctionDeclaration" } ]
+        },
+        {
+            code: "while(i) { (function() {}) }",
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "do { (function() {}) } while (i)",
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        }
     ]
 });


### PR DESCRIPTION
I’ve searched for every occurrence of `"ForInStatement"` and added a check for `"ForOfStatement"` if necessary.