### PR TITLE
Upgrade: `chalk` to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   "homepage": "http://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "chalk": "~0.5.1",
+    "chalk": "^1.0.0",
     "concat-stream": "^1.4.6",
     "debug": "^2.1.1",
     "doctrine": "^0.6.2",


### PR DESCRIPTION
It's now finally stable and bumping it would help with deduping.

https://github.com/sindresorhus/chalk/releases/tag/v1.0.0