### PR TITLE
Fix: Allow globalReturn in consistent-return (fixes #1868)

### DIFF
--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -42,9 +42,12 @@ module.exports = function(context) {
 
     return {
 
+        "Program": enterFunction,
         "FunctionDeclaration": enterFunction,
         "FunctionExpression": enterFunction,
         "ArrowFunctionExpression": enterFunction,
+
+        "Program:exit": exitFunction,
         "FunctionDeclaration:exit": exitFunction,
         "FunctionExpression:exit": exitFunction,
         "ArrowFunctionExpression:exit": exitFunction,

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -27,7 +27,8 @@ eslintTester.addRuleTest("lib/rules/consistent-return", {
         "f(function() { if (true) return true; else return false; })",
         "function foo() { function bar() { return true; } return; }",
         "function foo() { function bar() { return; } return false; }",
-        { code: "var x = () => {  return {}; };", ecmaFeatures: { arrowFunctions: true } }
+        { code: "var x = () => {  return {}; };", ecmaFeatures: { arrowFunctions: true } },
+        { code: "if (true) { return 1; } return 0;", ecmaFeatures: { globalReturn: true } }
     ],
 
     invalid: [
@@ -83,6 +84,16 @@ eslintTester.addRuleTest("lib/rules/consistent-return", {
             errors: [
                 {
                     message: "Expected no return value.",
+                    type: "ReturnStatement"
+                }
+            ]
+        },
+        {
+            code: "if (true) { return 1; } return;",
+            ecmaFeatures: { globalReturn: true },
+            errors: [
+                {
+                    message: "Expected a return value.",
                     type: "ReturnStatement"
                 }
             ]


### PR DESCRIPTION
When the rule saw a global `ReturnStatement`, it was attempting to get `returnInfo` for a function which didn't exist in global scope. This PR treats the `Program` node as a function as well, since it is in fact a function body in Node.js. When `globalReturn` is not enabled, this will change nothing because the parser will have already caught any erroneous top-level returns.