### PR TITLE
Fix: Refactor comma-spacing (#1587, #1845)

### DIFF
--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -43,7 +43,8 @@ The following patterns are not warnings:
 
 ```js
 
-    var foo = 1, bar = 2;
+    var foo = 1, bar = 2
+        , baz = 3;
     var arr = [1, 2];
     var obj = {"foo": "bar", "baz": "qur"};
     foo(a, b);
@@ -72,7 +73,8 @@ The following patterns are not warnings:
 
 ```js
 
-    var foo = 1 ,bar = 2;
+    var foo = 1 ,bar = 2 ,
+        baz = true;
     var arr = [1 ,2];
     var obj = {"foo": "bar" ,"baz": "qur"};
     foo(a ,b);

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     var options = {
         before: context.options[0] ? !!context.options[0].before : false,
         after: context.options[0] ? !!context.options[0].after : true
@@ -18,6 +19,9 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
+
+    // the index of the last comment that was checked
+    var lastCommentIndex = 0;
 
     /**
      * Determines whether two adjacent tokens have whitespace between them.
@@ -65,92 +69,57 @@ module.exports = function(context) {
     }
 
     /**
-     * Validates the spacing around single items in lists.
-     * @param {Token} previousItemToken The last token from the previous item.
-     * @param {Token} commaToken The token representing the comma.
-     * @param {Token} currentItemToken The first token of the current item.
-     * @param {Token} reportItem The item to use when reporting an error.
+     * Validates the spacing around a comma token.
+     * @param {Object} tokens - The tokens to be validated.
+     * @param {Token} tokens.comma The token representing the comma.
+     * @param {Token} [tokens.left] The last token before the comma.
+     * @param {Token} [tokens.right] The first token after the comma.
+     * @param {Token|ASTNode} reportItem The item to use when reporting an error.
      * @returns {void}
      * @private
      */
-    function validateCommaItemSpacing(previousItemToken, commaToken, currentItemToken, reportItem) {
-        if (isSameLine(previousItemToken, commaToken) &&
-                isSameLine(commaToken, currentItemToken)) {
-
-            if (options.before !== isSpaced(previousItemToken, commaToken)) {
-                report(reportItem, "before");
-            }
-            if (options.after !== isSpaced(commaToken, currentItemToken)) {
-                report(reportItem, "after");
-            }
+    function validateCommaItemSpacing(tokens, reportItem) {
+        if (tokens.left && isSameLine(tokens.left, tokens.comma) &&
+                (options.before !== isSpaced(tokens.left, tokens.comma))
+        ) {
+            report(reportItem, "before");
+        }
+        if (tokens.right && isSameLine(tokens.comma, tokens.right) &&
+                (options.after !== isSpaced(tokens.comma, tokens.right))
+        ) {
+            report(reportItem, "after");
         }
     }
 
     /**
-     * Validates the spacing before and after commas.
-     * @param {ASTNode} node The binary expression node to check.
-     * @param {string} property The property of the node.
-     * @returns {void}
+     * Determines if a given source index is in a comment or not by checking
+     * the index against the comment range. Since the check goes straight
+     * through the file, once an index is passed a certain comment, we can
+     * go to the next comment to check that.
+     * @param {int} index The source index to check.
+     * @param {ASTNode[]} comments An array of comment nodes.
+     * @returns {boolean} True if the index is within a comment, false if not.
      * @private
      */
-    function validateCommaSpacing(node, property) {
-        var items = node[property],
-            previousItemToken,
-            arrayLiteral = (node.type === "ArrayExpression");
+    function isIndexInComment(index, comments) {
 
-        if (items && (items.length > 1 || arrayLiteral)) {
+        var comment;
 
-            // seed as opening [
-            previousItemToken = context.getFirstToken(node);
+        while (lastCommentIndex < comments.length) {
 
-            items.forEach(function(item) {
-                var commaToken = item ? context.getTokenBefore(item) : previousItemToken,
-                    currentItemToken = item ? context.getFirstToken(item) : context.getTokenAfter(commaToken),
-                    reportItem = item || currentItemToken;
+            comment = comments[lastCommentIndex];
 
-                /*
-                 * This works by comparing three token locations:
-                 * - previousItemToken is the last token of the previous item
-                 * - commaToken is the location of the comma before the current item
-                 * - currentItemToken is the first token of the current item
-                 *
-                 * These values get switched around if item is undefined.
-                 * previousItemToken will refer to the last token not belonging
-                 * to the current item, which could be a comma or an opening
-                 * square bracket. currentItemToken could be a comma.
-                 *
-                 * All comparisons are done based on these tokens directly, so
-                 * they are always valid regardless of an undefined item.
-                 */
-                if (isComma(commaToken)) {
-                    validateCommaItemSpacing(previousItemToken, commaToken,
-                            currentItemToken, reportItem);
-                }
-
-                previousItemToken = item ? context.getLastToken(item) : previousItemToken;
-            });
-
-            /*
-             * Special case for array literals that have empty last items, such
-             * as [ 1, 2, ]. These arrays only have two items show up in the
-             * AST, so we need to look at the token to verify that there's no
-             * dangling comma.
-             */
-            if (arrayLiteral) {
-
-                var lastToken = context.getLastToken(node),
-                    nextToLastToken = context.getTokenBefore(lastToken);
-
-                if (isComma(nextToLastToken)) {
-                    validateCommaItemSpacing(
-                        context.getTokenBefore(nextToLastToken),
-                        nextToLastToken,
-                        lastToken,
-                        lastToken
-                    );
-                }
+            if (comment.range[0] <= index && index < comment.range[1]) {
+                return true;
+            } else if (index > comment.range[1]) {
+                lastCommentIndex++;
+            } else {
+                break;
             }
+
         }
+
+        return false;
     }
 
     //--------------------------------------------------------------------------
@@ -158,32 +127,32 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
 
     return {
-        "VariableDeclaration": function(node) {
-            validateCommaSpacing(node, "declarations");
-        },
-        "ObjectExpression": function(node) {
-            validateCommaSpacing(node, "properties");
-        },
-        "ArrayExpression": function(node) {
-            validateCommaSpacing(node, "elements");
-        },
-        "SequenceExpression": function(node) {
-            validateCommaSpacing(node, "expressions");
-        },
-        "ArrowFunctionExpression": function(node) {
-            validateCommaSpacing(node, "params");
-        },
-        "FunctionExpression": function(node) {
-            validateCommaSpacing(node, "params");
-        },
-        "FunctionDeclaration": function(node) {
-            validateCommaSpacing(node, "params");
-        },
-        "CallExpression": function(node) {
-            validateCommaSpacing(node, "arguments");
-        },
-        "NewExpression": function(node) {
-            validateCommaSpacing(node, "arguments");
+        "Program": function() {
+
+            var source = context.getSource(),
+                allComments = context.getAllComments(),
+                pattern = /,/g,
+                commaToken,
+                previousToken,
+                nextToken;
+
+            while (pattern.test(source)) {
+
+                // do not flag anything inside of comments
+                if (!isIndexInComment(pattern.lastIndex, allComments)) {
+                    commaToken = context.getTokenByRangeStart(pattern.lastIndex - 1);
+
+                    if (commaToken) {
+                        previousToken = context.getTokenBefore(commaToken);
+                        nextToken = context.getTokenAfter(commaToken);
+                        validateCommaItemSpacing({
+                            comma: commaToken,
+                            left: isComma(previousToken) ? null : previousToken,
+                            right: isComma(nextToken) ? null : nextToken
+                        }, commaToken);
+                    }
+                }
+            }
         }
     };
 

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -317,7 +317,7 @@ describe("Config", function() {
         it("should merge command line config when config file adds to local .eslintrc", function () {
 
             var configHelper = new Config({
-                    reset: true ,
+                    reset: true,
                     configFile: getFixturePath("broken", "add-conf.yaml")
                 }),
                 file = getFixturePath("broken", "console-wrong-quotes.js"),
@@ -341,7 +341,7 @@ describe("Config", function() {
         it("should merge command line config when config file overrides local .eslintrc", function () {
 
             var configHelper = new Config({
-                    reset: true ,
+                    reset: true,
                     configFile: getFixturePath("broken", "override-conf.yaml")
                 }),
                 file = getFixturePath("broken", "console-wrong-quotes.js"),
@@ -364,7 +364,7 @@ describe("Config", function() {
         it("should merge command line config when config file adds to local and parent .eslintrc", function () {
 
             var configHelper = new Config({
-                reset: true ,
+                reset: true,
                 configFile: getFixturePath("broken", "add-conf.yaml")
             }),
             file = getFixturePath("broken", "subbroken", "console-wrong-quotes.js"),
@@ -389,7 +389,7 @@ describe("Config", function() {
         it("should merge command line config when config file overrides local and parent .eslintrc", function () {
 
             var configHelper = new Config({
-                reset: true ,
+                reset: true,
                 configFile: getFixturePath("broken", "override-conf.yaml")
             }),
             file = getFixturePath("broken", "subbroken", "console-wrong-quotes.js"),
@@ -429,7 +429,7 @@ describe("Config", function() {
         it("should merge command line config and rule when rule and config file overrides local .eslintrc", function () {
 
             var configHelper = new Config({
-                reset: true ,
+                reset: true,
                 configFile: getFixturePath("broken", "override-conf.yaml"),
                 rules: {
                     quotes: [1, "double"]

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -21,14 +21,28 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
 
     valid: [
         "var a = 1, b = 2;",
-        "var arr = [1, 2];",
-        "var arr = [, 2];",
+        "var arr = [, ];",
         "var arr = [1, ];",
+        "var arr = [, 2];",
+        "var arr = [1, 2];",
+        "var arr = [, , ];",
+        "var arr = [1, , ];",
+        "var arr = [, 2, ];",
+        "var arr = [, , 3];",
+        "var arr = [1, 2, ];",
+        "var arr = [, 2, 3];",
+        "var arr = [1, , 3];",
+        "var arr = [1, 2, 3];",
         "var obj = {'foo':'bar', 'baz':'qur'};",
         "var obj = {'foo':'bar', 'baz':\n'qur'};",
         "var obj = {'foo':\n'bar', 'baz':\n'qur'};",
         "function foo(a, b){}",
+        {code: "function foo(a, b = 1){}", ecmaFeatures: {defaultParams: true}},
+        {code: "function foo(a = 1, b, c){}", ecmaFeatures: {defaultParams: true}},
         { code: "var foo = (a, b) => {}", ecmaFeatures: { arrowFunctions: true } },
+        { code: "var foo = (a=1, b) => {}", ecmaFeatures: {
+            arrowFunctions: true, defaultParams: true
+        } },
         { code: "var foo = a => a + 2", ecmaFeatures: { arrowFunctions: true } },
         "a, b",
         "var a = (1 + 2, 2);",
@@ -41,6 +55,8 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
         "go.boom((a + b), 10, (4))",
         "var x = [ (a + c), (b + b) ]",
         "['  ,  ']",
+        {code: "[`  ,  `]", ecmaFeatures: {templateStrings: true}},
+        {code: "`${[1, 2]}`", ecmaFeatures: {templateStrings: true}},
         "foo(/,/, 'a')",
         "var x = ',,,,,';",
         "var code = 'var foo = 1, bar = 3;',",
@@ -48,15 +64,51 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
         "{x: 'var x,y,z'}",
         {code: "var obj = {'foo':\n'bar' ,'baz':\n'qur'};", args: [2, {before: true, after: false}]},
         {code: "var a = 1 ,b = 2;", args: [2, {before: true, after: false}]},
-        {code: "var arr = [1 ,2];", args: [2, {before: true, after: false}]},
         {code: "function foo(a ,b){}", args: [2, {before: true, after: false}]},
+        {code: "var arr = [ ,];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [1 ,];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [ ,2];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [1 ,2];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [ , ,];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [1 , ,];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [ ,2 ,];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [ , ,3];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [1 ,2 ,];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [ ,2 ,3];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [1 , ,3];", args: [2, {before: true, after: false}]},
+        {code: "var arr = [1 ,2 ,3];", args: [2, {before: true, after: false}]},
         {code: "var obj = {'foo':'bar' , 'baz':'qur'};", args: [2, {before: true, after: true}]},
         {code: "var a = 1 , b = 2;", args: [2, {before: true, after: true}]},
+        {code: "var arr = [ , ];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [1 , ];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [ , 2];", args: [2, {before: true, after: true}]},
         {code: "var arr = [1 , 2];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [ , , ];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [1 , , ];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [ , 2 , ];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [ , , 3];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [1 , 2 , ];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [ , 2 , 3];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [1 , , 3];", args: [2, {before: true, after: true}]},
+        {code: "var arr = [1 , 2 , 3];", args: [2, {before: true, after: true}]},
         {code: "a , b", args: [2, {before: true, after: true}]},
+        {code: "var arr = [,];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [1,];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [,2];", args: [2, {before: false, after: false}]},
         {code: "var arr = [1,2];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [,,];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [1,,];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [,2,];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [,,3];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [1,2,];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [,2,3];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [1,,3];", args: [2, {before: false, after: false}]},
+        {code: "var arr = [1,2,3];", args: [2, {before: false, after: false}]},
         {code: "var a = (1 + 2,2)", args: [2, {before: false, after: false}]},
-        { code: "var a; console.log(`${a}`, \"a\");", ecmaFeatures: { templateStrings: true } }
+        { code: "var a; console.log(`${a}`, \"a\");", ecmaFeatures: { templateStrings: true } },
+        { code: "var [a, b] = [1, 2];", ecmaFeatures: { destructuring: true } },
+        { code: "var [a, b, ] = [1, 2];", ecmaFeatures: { destructuring: true } },
+        { code: "var [a, , b] = [1, 2, 3];", ecmaFeatures: { destructuring: true } }
     ],
 
     invalid: [
@@ -66,11 +118,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -80,11 +132,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -93,11 +145,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "There should be no space before ','.",
-                    type: "VariableDeclarator"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "VariableDeclarator"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -106,7 +158,7 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "There should be no space before ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -115,7 +167,7 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "There should be no space before ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -143,11 +195,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "There should be no space before ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -156,7 +208,7 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "There should be no space before ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -166,11 +218,31 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 },
                 {
                     message: "There should be no space after ','.",
-                    type: "Literal"
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "var arr = [1\n  , 2];",
+            args: [2, {before: false, after: false}],
+            errors: [
+                {
+                    message: "There should be no space after ','.",
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "var arr = [1,\n  2];",
+            args: [2, {before: true, after: false}],
+            errors: [
+                {
+                    message: "A space is required before ','.",
+                    type: "Punctuator"
                 }
             ]
         },
@@ -180,11 +252,31 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Property"
+                    type: "Punctuator"
                 },
                 {
                     message: "There should be no space after ','.",
-                    type: "Property"
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "var obj = {a: 1\n  ,b: 2};",
+            args: [2, {before: false, after: true}],
+            errors: [
+                {
+                    message: "A space is required after ','.",
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "var obj = {a: 1 ,\n  b: 2};",
+            args: [2, {before: false, after: false}],
+            errors: [
+                {
+                    message: "There should be no space before ','.",
+                    type: "Punctuator"
                 }
             ]
         },
@@ -194,7 +286,7 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required after ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -204,11 +296,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -218,11 +310,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Property"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Property"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -232,11 +324,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "There should be no space before ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 },
                 {
                     message: "There should be no space after ','.",
-                    type: "Literal"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -246,11 +338,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "There should be no space before ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -260,11 +352,11 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 }
             ]
         },
@@ -275,11 +367,41 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
             errors: [
                 {
                     message: "A space is required before ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
                 },
                 {
                     message: "A space is required after ','.",
-                    type: "Identifier"
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "var foo = (a = 1,b) => {}",
+            ecmaFeatures: { arrowFunctions: true, defaultParams: true },
+            args: [2, {before: true, after: true}],
+            errors: [
+                {
+                    message: "A space is required before ','.",
+                    type: "Punctuator"
+                },
+                {
+                    message: "A space is required after ','.",
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "function foo(a = 1 ,b = 2) {}",
+            ecmaFeatures: { defaultParams: true },
+            args: [2, {before: false, after: true}],
+            errors: [
+                {
+                    message: "There should be no space before ','.",
+                    type: "Punctuator"
+                },
+                {
+                    message: "A space is required after ','.",
+                    type: "Punctuator"
                 }
             ]
         }


### PR DESCRIPTION
The `comma-spacing` rule now searches for the comma tokens directly at the "Program" level, in the same fashion as `no-multi-spaces`. This handles a few corner cases: default parameters (#1845), sparse arrays (#1587), line breaks and destructuring.