### PR TITLE
Fix: check all semicolons in no-space-before-semi (fixes #1885)

### DIFF
--- a/lib/rules/no-space-before-semi.js
+++ b/lib/rules/no-space-before-semi.js
@@ -1,6 +1,8 @@
 /**
- * @fileoverview Rule to require variables declared without whitespace before the lines semicolon
+ * @fileoverview Rule to disallow whitespace before the semicolon
  * @author Jonathan Kingston
+ * @copyright 2015 Mathias Schreck
+ * @copyright 2014 Jonathan Kingston
  */
 
 "use strict";
@@ -11,19 +13,83 @@
 
 module.exports = function(context) {
 
-    var semicolonWhitespace = /\s;$/;
+    /**
+     * Determines whether two adjacent tokens are have whitespace between them.
+     * @param {Object} left - The left token object.
+     * @param {Object} right - The right token object.
+     * @returns {boolean} Whether or not there is space between the tokens.
+     */
+    function isSpaced(left, right) {
+        return left.range[1] < right.range[0];
+    }
+
+    /**
+     * Checks whether two tokens are on the same line.
+     * @param {Object} left The leftmost token.
+     * @param {Object} right The rightmost token.
+     * @returns {boolean} True if the tokens are on the same line, false if not.
+     * @private
+     */
+    function isSameLine(left, right) {
+        return left.loc.end.line === right.loc.start.line;
+    }
+
+    /**
+     * Checks if a given token has leading whitespace.
+     * @param {Object} token The token to check.
+     * @returns {boolean} True if the given token has leading space, false if not.
+     */
+    function hasLeadingSpace(token) {
+        var tokenBefore = context.getTokenBefore(token);
+        return isSameLine(tokenBefore, token) && isSpaced(tokenBefore, token);
+    }
+
+    /**
+     * Checks if the given token is a semicolon.
+     * @param {Token} token The token to check.
+     * @returns {boolean} Whether or not the given token is a semicolon.
+     */
+    function isSemicolon(token) {
+        return token.type === "Punctuator" && token.value === ";";
+    }
+
+    /**
+     * Reports if the given token has leading space.
+     * @param {Token} token The semicolon token to check.
+     * @param {ASTNode} node The corresponding node of the token.
+     * @returns {void}
+     */
+    function checkSemiTokenForLeadingSpace(token, node) {
+        if (isSemicolon(token) && hasLeadingSpace(token)) {
+            context.report(node, token.loc.start, "Unexpected whitespace before semicolon.");
+        }
+    }
+
+    /**
+     * Checks leading space before the semicolon with the assumption that the last token is the semicolon.
+     * @param {ASTNode} node The node to check.
+     * @returns {void}
+     */
+    function checkNode(node) {
+        var token = context.getLastToken(node);
+        checkSemiTokenForLeadingSpace(token, node);
+    }
 
     return {
-        "VariableDeclaration": function(node) {
-            var source = context.getSource(node);
-            if (semicolonWhitespace.test(source)) {
-                context.report(node, "Variable declared with trailing whitespace before semicolon");
+        "VariableDeclaration": checkNode,
+        "ExpressionStatement": checkNode,
+        "BreakStatement": checkNode,
+        "ContinueStatement": checkNode,
+        "DebuggerStatement": checkNode,
+        "ReturnStatement": checkNode,
+        "ThrowStatement": checkNode,
+        "ForStatement": function (node) {
+            if (node.init) {
+                checkSemiTokenForLeadingSpace(context.getTokenAfter(node.init), node);
             }
-        },
-        "ExpressionStatement": function(node) {
-            var source = context.getSource(node);
-            if (semicolonWhitespace.test(source)) {
-                context.report(node, "Expression called with trailing whitespace before semicolon");
+
+            if (node.test) {
+                checkSemiTokenForLeadingSpace(context.getTokenAfter(node.test), node);
             }
         }
     };

--- a/tests/lib/rules/no-space-before-semi.js
+++ b/tests/lib/rules/no-space-before-semi.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Tests for no-space-before-semi rule.
  * @author Jonathan Kingston
+ * @copyright 2015 Mathias Schreck
+ * @copyright 2014 Jonathan Kingston
  */
 
 "use strict";
@@ -16,7 +18,9 @@ var eslint = require("../../../lib/eslint"),
 // Tests
 //------------------------------------------------------------------------------
 
-var eslintTester = new ESLintTester(eslint);
+var eslintTester = new ESLintTester(eslint),
+    expectedErrorMessage = "Unexpected whitespace before semicolon.";
+
 eslintTester.addRuleTest("lib/rules/no-space-before-semi", {
     valid: [
         "var thing = 'test';",
@@ -24,15 +28,70 @@ eslintTester.addRuleTest("lib/rules/no-space-before-semi", {
         "var thing = \"test ; thing\";",
         "var thing = function () {};",
         "var thing = function () {\n var thing = 'test ; '; };",
-        ";(function(){}());"
+        ";(function(){}());",
+        "while (true) { break; }",
+        "while (true) { continue; }",
+        "debugger;",
+        "function foo() { return; }",
+        "throw new Error('foo');",
+        "for (var i = 0; i < 10; i++) {}",
+        "for (;;) {}"
     ],
     invalid: [
-        { code: "var foo = \"bar\" ;", errors: [{ message: "Variable declared with trailing whitespace before semicolon", type: "VariableDeclaration"}] },
-        { code: "var foo = function() {} ;", errors: [{ message: "Variable declared with trailing whitespace before semicolon", type: "VariableDeclaration"}] },
-        { code: "var foo = function() {\n} ;", errors: [{ message: "Variable declared with trailing whitespace before semicolon", type: "VariableDeclaration"}] },
-        { code: "var thing = 'test' ;", errors: [{ message: "Variable declared with trailing whitespace before semicolon", type: "VariableDeclaration"}] },
-        { code: "var foo = 1 + 2 ;", errors: [{ message: "Variable declared with trailing whitespace before semicolon", type: "VariableDeclaration"}] },
-        { code: "/^thing$/.test('thing') ;", errors: [{ message: "Expression called with trailing whitespace before semicolon", type: "ExpressionStatement"}] },
-        { code: ";(function(){}()) ;", errors: [{ message: "Expression called with trailing whitespace before semicolon", type: "ExpressionStatement"}] }
+        {
+            code: "var foo = \"bar\" ;",
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 16 } ]
+        },
+        {
+            code: "var foo = function() {} ;",
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 24 } ]
+        },
+        {
+            code: "var foo = function() {\n} ;",
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 2, column: 2 } ]
+        },
+        {
+            code: "var thing = 'test' ;",
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 19 } ]
+        },
+        {
+            code: "var foo = 1 + 2 ;",
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 16 } ]
+        },
+        {
+            code: "/^thing$/.test('thing') ;",
+            errors: [{ message: expectedErrorMessage, type: "ExpressionStatement", line: 1, column: 24 } ]
+        },
+        {
+            code: ";(function(){}()) ;",
+            errors: [ { message: expectedErrorMessage, type: "ExpressionStatement", line: 1, column: 18 } ]
+        },
+        {
+            code: "while (true) { break ; }",
+            errors: [ { message: expectedErrorMessage, type: "BreakStatement", line: 1, column: 21 } ]
+        },
+        {
+            code: "while (true) { continue ; }",
+            errors: [ { message: expectedErrorMessage, type: "ContinueStatement", line: 1, column: 24 } ]
+        },
+        {
+            code: "debugger ;",
+            errors: [ { message: expectedErrorMessage, type: "DebuggerStatement", line: 1, column: 9 } ]
+        },
+        {
+            code: "function foo() { return ; }",
+            errors: [ { message: expectedErrorMessage, type: "ReturnStatement", line: 1, column: 24 } ]
+        },
+        {
+            code: "throw new Error('foo') ;",
+            errors: [ { message: expectedErrorMessage, type: "ThrowStatement", line: 1, column: 23 } ]
+        },
+        {
+            code: "for (var i = 0 ; i < 10 ; i++) {}",
+            errors: [
+                { message: expectedErrorMessage, type: "ForStatement", line: 1, column: 15 },
+                { message: expectedErrorMessage, type: "ForStatement", line: 1, column: 24 }
+            ]
+        }
     ]
 });


### PR DESCRIPTION
This adds checks for several nodes where a semicolon can appear.
Additionally, I changed the error message to `"Unexpected whitespace before semicolon."` and the reported location of the error is now the location of the semicolon token.