### PR TITLE
Support ExportDeclaration in no-unused-vars rule

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -37,6 +37,31 @@ module.exports = function(context) {
     }
 
     /**
+     * Checks whether the given definition is exported or not.
+     * @param  {DefEntry}  def - an escope definition entry.
+     * @returns {Boolean}  true if the definition is exported.
+     */
+    function isExportedDeclaration(def) {
+        if (def.node.type === "VariableDeclarator" && def.node.parent.type === "VariableDeclaration" && def.node.parent.parent.type === "ExportDeclaration") {
+            return true;
+        } else if (def.node.type === "FunctionDeclaration" && def.node.parent.type === "ExportDeclaration") {
+            return true;
+        } else if (def.node.type === "ClassDeclaration" && def.node.parent.type === "ExportDeclaration") {
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    /**
+     * @param  {Variable}  ref - an escope Variable object
+     * @returns {Boolean}  true if the variable is exported
+     */
+    function isExported(ref) {
+        return ref.defs.filter(isExportedDeclaration).length > 0;
+    }
+
+    /**
      * Gets an array of local variables without read references.
      * @param {Scope} scope - an escope Scope object
      * @returns {Variable[]} most of the local variables with no read references
@@ -72,7 +97,7 @@ module.exports = function(context) {
                     continue;
                 }
 
-                if (variables[i].references.filter(isReadRef).length === 0) {
+                if (variables[i].references.filter(isReadRef).length === 0 && !isExported(variables[i])) {
                     unused.push(variables[i]);
                 }
             }


### PR DESCRIPTION
Without this, each of the following will be consider `foo` to be unused.

```js
export var foo = 123;
export function foo () {}
export class foo {}
```

Unfortunately I wasn't able to create tests for this as this relies on the parser from [babel-eslint](/babel/babel-eslint), until https://github.com/eslint/espree/pull/43 lands. 