### PR TITLE
Fix: getScope and no-use-before-define for arrow functions (fixes #1895)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -914,7 +914,8 @@ module.exports = (function() {
 
             // if current node is function declaration, add it to the list
             var current = controller.current();
-            if (current.type === "FunctionDeclaration" || current.type === "FunctionExpression") {
+            if (["FunctionDeclaration", "FunctionExpression",
+                    "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
                 parents.push(current);
             }
 

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -61,6 +61,7 @@ module.exports = function(context) {
     return {
         "Program": findVariables,
         "FunctionExpression": findVariables,
-        "FunctionDeclaration": findVariables
+        "FunctionDeclaration": findVariables,
+        "ArrowFunctionExpression": findVariables
     };
 };

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -753,7 +753,7 @@ describe("eslint", function() {
 
 
     describe("when calling getScope", function() {
-        var code = "function foo() { q: for(;;) { break q; } } function bar () { var q = t; }";
+        var code = "function foo() { q: for(;;) { break q; } } function bar () { var q = t; } var baz = (() => { return 1; });";
 
         it("should retrieve the global scope correctly from a Program", function() {
             var config = { rules: {} };
@@ -787,6 +787,19 @@ describe("eslint", function() {
                 var scope = eslint.getScope();
                 assert.equal(scope.type, "function");
                 assert.equal(scope.block.id.name, "foo");
+            });
+
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("should retrieve the function scope correctly from within an ArrowFunctionExpression", function() {
+            var config = { rules: {}, ecmaFeatures: { arrowFunctions: true } };
+
+            eslint.reset();
+            eslint.on("ReturnStatement", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "function");
+                assert.equal(scope.block.type, "ArrowFunctionExpression");
             });
 
             eslint.verify(code, config, filename, true);

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -24,13 +24,16 @@ eslintTester.addRuleTest("lib/rules/no-use-before-define", {
         "function b(a) { alert(a); }",
         "Object.hasOwnProperty.call(a);",
         "function a() { alert(arguments);}",
-        { code: "a(); function a() { alert(arguments); }", args: [1, "nofunc"] }
+        { code: "a(); function a() { alert(arguments); }", args: [1, "nofunc"] },
+        { code: "(() => { var a = 42; alert(a); })();", ecmaFeatures: { arrowFunctions: true } }
     ],
     invalid: [
         { code: "a++; var a=19;", errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
         { code: "a(); var a=function() {};", errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
         { code: "alert(a[1]); var a=[1,3];", errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
         { code: "a(); function a() { alert(b); var b=10; a(); }", errors: [{ message: "a was used before it was defined", type: "Identifier"}, { message: "b was used before it was defined", type: "Identifier"}] },
-        { code: "a(); var a=function() {};", args: [1, "nofunc"], errors: [{ message: "a was used before it was defined", type: "Identifier"}] }
+        { code: "a(); var a=function() {};", args: [1, "nofunc"], errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
+        { code: "(() => { alert(a); var a = 42; })();", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "(() => a())(); function a() { }", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] }
     ]
 });


### PR DESCRIPTION
There were two problems here. First, `no-use-before-define` wasn't calling `findVariables` for `ArrowFunctionExpression`s. Second, `getScope()` skipped `ArrowFunctionExpression` nodes when looking for the appropriate parent node.