### PR TITLE
Docs: no-plusplus.md - auto semicolon insertion

### DIFF
--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -7,8 +7,6 @@ var foo = 0;
 foo++;
 ```
 
-## Automatic Semicolon Insertion
-
 The `++` and `--` operators are subject to automatic semicolon insertion. When their use is allowed, introducing whitespace may change semantics of source code. Enabling the rule may prevent this kind of errors.
 
 ```js

--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -7,6 +7,29 @@ var foo = 0;
 foo++;
 ```
 
+## Automatic Semicolon Insertion
+
+The `++` and `--` operators are subject to automatic semicolon insertion. When their use is allowed, introducing whitespace may change semantics of source code. Enabling the rule may prevent this kind of errors.
+
+```js
+var i = 10;
+var j = 20;
+
+i ++
+j
+// i = 11, j = 20
+```
+
+```js
+var i = 10;
+var j = 20;
+
+i
+++
+j
+// i = 10, j = 21
+```
+
 ## Rule Details
 
 This rule is aimed at flagging the use of `++` and `--`. Some believe that the use of these unary operators reduces code quality and clarity. There are some programming languages that completely exclude these operators.


### PR DESCRIPTION
The way this rule is presented in the documentation sounds as if it's just a matter of taste regarding code readability. On the other hand, due to automatic semicolon insertion, this may be considered an important rule. Of course, no one will write the code like in these examples, but some of us do not prefer whitespace affecting semantics of the source code, and that's why I believe this rule should be on by default.

Recall the famous example function which returns `undefined`:
```js
function returningUndefined() {
  return
  {
    value: 42
  }
}
```