### PR TITLE
don't count lowercase JSX tags as variable use

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -6,6 +6,20 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks if a node name match the JSX tag convention.
+ * @param {String} name - Name of the node to check.
+ * @returns {boolean} Whether or not the node name match the JSX tag convention.
+ */
+var tagConvention = /^[a-z]|\-/;
+function isTagName(name) {
+    return tagConvention.test(name);
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -90,6 +104,10 @@ module.exports = function(context) {
             variables = scope.variables,
             i,
             len;
+
+        if (isTagName(nodeName)) {
+            return;
+        }
 
         while (scope.type !== "global") {
             scope = scope.upper;

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -84,6 +84,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "(function(foo, baz, bar) { return baz; })();", args: [1, {"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]},
         { code: "(function z(foo) { var bar = 33; })();", args: [1, {"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]},
         { code: "(function z(foo) { z(); })();", args: [1, {}], errors: [{ message: "foo is defined but never used" }]},
-        { code: "function f() { var a = 1; return function(){ f(a = 2); }; }", args: [1, {}], errors: [{ message: "a is defined but never used" }]}
+        { code: "function f() { var a = 1; return function(){ f(a = 2); }; }", args: [1, {}], errors: [{ message: "a is defined but never used" }]},
+        { code: "var div = 1; React.render(<div />);", args: [1, {vars: "all"}], errors: [{ message: "div is defined but never used" }], ecmaFeatures: { jsx: true } },
+        { code: "var y = 1; React.render(<y />);", args: [1, {vars: "all"}], errors: [{ message: "y is defined but never used" }], ecmaFeatures: { jsx: true } }
     ]
 });


### PR DESCRIPTION
I've not raised a separate issue, as it took me as long to make the patch as it would to raise an issue in the first place (and I read the contributing docs a bit late!) - this is somewhat related to https://github.com/eslint/eslint/issues/1905

React is in the process of removing the tag whitelist in JSX - it's slated to land in React 0.13 (https://github.com/facebook/react/issues/2746)

The current rule is that JSX tags beginning with a lowercase character will transform to a string, and others will transform to a variable.

This logic already exists in the `no-undef` rule, this patch includes the same logic in `no-unused-vars`.