### PR TITLE
Fix: don't crash when given null as rule config (fixes #1760)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -330,6 +330,9 @@ function prepareConfig(config) {
     if (typeof config.rules === "object") {
         Object.keys(config.rules).forEach(function(k) {
             var rule = config.rules[k];
+            if (rule === null) {
+                throw new Error("Invalid config for rule '" + k + "'\.");
+            }
             if (Array.isArray(rule)) {
                 copiedRules[k] = rule.slice();
             } else {

--- a/lib/util.js
+++ b/lib/util.js
@@ -55,7 +55,7 @@ exports.mergeConfigs = function mergeConfigs(base, custom) {
             return;
         }
 
-        if (typeof property === "object" && !Array.isArray(property)) {
+        if (typeof property === "object" && !Array.isArray(property) && property !== null) {
             // base[key] might not exist, so be careful with recursion here
             base[key] = mergeConfigs(base[key] || {}, custom[key]);
         } else {

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1834,6 +1834,16 @@ describe("eslint", function() {
         });
     });
 
+    describe("when using invalid rule config", function() {
+        var code = TEST_CODE;
+
+        it("should throw an error", function() {
+            assert.throws(function() {
+                eslint.verify(code, { rules: {foobar: null } });
+            }, /Invalid config for rule 'foobar'\./);
+        });
+    });
+
     describe("when calling defaults", function() {
         it("should return back config object", function() {
             var config = eslint.defaults();

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -65,6 +65,18 @@ describe("util", function() {
             assert.isTrue(result.env.browser);
         });
 
+        it("should combine without blowing up on null values", function() {
+            var code = [
+                        { env: { browser: true } },
+                        { env: { node: null } }
+                    ];
+
+            var result = util.mergeConfigs(code[0], code[1]);
+
+            assert.equal(result.env.node, null);
+            assert.isTrue(result.env.browser);
+        });
+
         it("should combine two objects with parser when passed two objects with different top-level properties", function() {
             var code = [
                         { env: { browser: true }, parser: "espree" },


### PR DESCRIPTION
I'm a bit unsure about this, rather than error when passed null in the rule config, I'm treating it as if the key was never there.

This avoids the crash reported in the original issue, but might be a bit confusing as the key has no effect.
