### PR TITLE
Breaking: made eol-last less strict (fixes #1460)

### DIFF
--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -3,8 +3,12 @@
 Trailing newlines in non-empty files are a common UNIX idiom. Benefits of
 trailing newlines include the ability to concatenate or append to files as well
 as output files to the terminal without interfering with shell prompts. This
-rule enforces newlines for all non-empty programs and disallows trailing
-empty or whitespace-only lines.
+rule enforces newlines for all non-empty programs.
+
+Prior to v0.16.0 this rule also enforced that there was only a single line at
+the end of the file. If you still want this behaviour, consider enabling
+[no-multiple-empty-lines](no-multiple-empty-lines.md) and/or
+[no-trailing-spaces](no-trailing-spaces.md).
 
 ## Rule Details
 
@@ -16,14 +20,7 @@ function doSmth() {
 }
 </pre>
 
-<pre>
-function doSmth() {
-  ...
-}
-
-
-
-</pre>
+The following patterns are not warnings:
 
 <pre>
 function doSmth() {
@@ -32,11 +29,18 @@ function doSmth() {
 // spaces here
 </pre>
 
-The following patterns are not warnings:
+<pre>
+function doSmth() {
+  ...
+}
+
+</pre>
 
 <pre>
 function doSmth() {
   ...
 }
+
+
 
 </pre>

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -28,10 +28,6 @@ module.exports = function(context) {
                 // file is not newline-terminated
                 location.line = src.split(/\n/g).length;
                 context.report(node, location, "Newline required at end of file but not found.");
-            } else if (/\n\s*\n$/.test(src)) {
-                // last line is empty
-                location.line = src.split(/\n/g).length - 1;
-                context.report(node, location, "Unexpected blank line at end of file.");
             }
         }
 

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -21,7 +21,9 @@ eslintTester.addRuleTest("lib/rules/eol-last", {
     valid: [
         "",
         "\n",
-        "var a = 123;\n"
+        "var a = 123;\n",
+        "var a = 123;\n\n",
+        "var a = 123;\n   \n"
     ],
 
     invalid: [
@@ -30,12 +32,8 @@ eslintTester.addRuleTest("lib/rules/eol-last", {
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }]
         },
         {
-            code: "var a = 123;\n\n",
-            errors: [{ message: "Unexpected blank line at end of file.", type: "Program" }]
-        },
-        {
-            code: "var a = 123;\n   \n",
-            errors: [{ message: "Unexpected blank line at end of file.", type: "Program" }]
+            code: "var a = 123;\n   ",
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }]
         }
     ]
 });


### PR DESCRIPTION
I've implemented what was suggested in https://github.com/eslint/eslint/issues/1460#issuecomment-63178505

I've also updated the docs to point people at the rules which can be used to enforce the previous behaviour - I'm unsure if this is necessary.

I marked this as breaking, as it will cause some builds to pass which would previously have failed - let me know if this needs changing.