### PR TITLE
Update: no-empty to check TryStatement.handler (fixes #1930)

### DIFF
--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -17,10 +17,11 @@ module.exports = function(context) {
             var ancestors = context.getAncestors(),
                 parent = ancestors[ancestors.length - 1],
                 parentType = parent.type,
+                hasHandler = !!(parent.handler || (parent.handlers && parent.handlers.length)),
                 isFinallyBlock = (parentType === "TryStatement") && (parent.finalizer === node);
 
             if (/Function|CatchClause/.test(parentType) ||
-                    (isFinallyBlock && !parent.handlers.length)) {
+                    (isFinallyBlock && !hasHandler)) {
                 return;
             }
 


### PR DESCRIPTION
I filed a PR for `TryStatement.handler` in eslint/espree#70, but without that I'm not sure we have a way to test this automatically yet. I did, however, verify it manually with babel-eslint.