### PR TITLE
Fix: Comment configuration of rule doesn't work (fixes #1792)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -56,14 +56,26 @@ function parseBooleanConfig(string) {
 /**
  * Parses a JSON-like config.
  * @param {string} string The string to parse.
+ * @param {Object} location Start line and column of comments for potential error message.
+ * @param {Object[]} messages The messages queue for potential error message.
  * @returns {Object} Result map object
  */
-function parseJsonConfig(string) {
+function parseJsonConfig(string, location, messages) {
     var items = {};
-    string = string.replace(/([a-z0-9\-\/]+):/g, "\"$1\":").replace(/(\]|[0-9])\s+(?=")/, "$1,");
+    string = string.replace(/([a-zA-Z0-9\-\/]+):/g, "\"$1\":").replace(/(\]|[0-9])\s+(?=")/, "$1,");
     try {
         items = JSON.parse("{" + string + "}");
-    } catch(e) { }
+    } catch(ex) {
+
+        messages.push({
+            fatal: true,
+            severity: 2,
+            message: "Failed to parse JSON from '" + string + "': " + ex.message,
+            line: location.start.line,
+            column: location.start.column
+        });
+
+    }
 
     return items;
 }
@@ -225,9 +237,10 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
  * @param {ASTNode} ast The top node of the AST.
  * @param {Object} config The existing configuration data.
  * @param {Object[]} reportingConfig The existing reporting configuration data.
+ * @param {Object[]} messages The messages queue.
  * @returns {void}
  */
-function modifyConfigsFromComments(ast, config, reportingConfig) {
+function modifyConfigsFromComments(ast, config, reportingConfig, messages) {
 
     var commentConfig = {
         astGlobals: {},
@@ -264,7 +277,7 @@ function modifyConfigsFromComments(ast, config, reportingConfig) {
                         break;
 
                     case "eslint":
-                        var items = parseJsonConfig(value);
+                        var items = parseJsonConfig(value, comment.loc, messages);
                         Object.keys(items).forEach(function(name) {
                             var ruleValue = items[name];
                             if (typeof ruleValue === "number" || (Array.isArray(ruleValue) && typeof ruleValue[0] === "number")) {
@@ -586,7 +599,7 @@ module.exports = (function() {
             currentAST = ast;
 
             // parse global comments and modify config
-            modifyConfigsFromComments(ast, config, reportingConfig);
+            modifyConfigsFromComments(ast, config, reportingConfig, messages);
 
             // enable appropriate rules
             Object.keys(config.rules).filter(function(key) {

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1814,10 +1814,20 @@ describe("eslint", function() {
             var config = { rules: { "no-alert": 1} };
 
             var messages = eslint.verify(code, config, filename);
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
-            assert.include(messages[0].nodeType, "CallExpression");
+            assert.equal(messages.length, 2);
+
+            // Incorrectly formatted comment threw error;
+            // message from caught exception
+            // may differ amongst UAs, so verifying
+            // first part only as defined in the
+            // parseJsonConfig function in lib/eslint.js
+            assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":'1'':/);
+            assert.equal(messages[0].line, 1);
+            assert.equal(messages[0].column, 0);
+
+            assert.equal(messages[1].ruleId, "no-alert");
+            assert.equal(messages[1].message, "Unexpected alert.");
+            assert.include(messages[1].nodeType, "CallExpression");
         });
 
         it("should report a violation", function() {
@@ -1826,10 +1836,20 @@ describe("eslint", function() {
             var config = { rules: { "no-alert": 1} };
 
             var messages = eslint.verify(code, config, filename);
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
-            assert.include(messages[0].nodeType, "CallExpression");
+            assert.equal(messages.length, 2);
+
+            // Incorrectly formatted comment threw error;
+            // message from caught exception
+            // may differ amongst UAs, so verifying
+            // first part only as defined in the
+            // parseJsonConfig function in lib/eslint.js
+            assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":abc':/);
+            assert.equal(messages[0].line, 1);
+            assert.equal(messages[0].column, 0);
+
+            assert.equal(messages[1].ruleId, "no-alert");
+            assert.equal(messages[1].message, "Unexpected alert.");
+            assert.include(messages[1].nodeType, "CallExpression");
         });
 
         it("should report a violation", function() {
@@ -1838,10 +1858,20 @@ describe("eslint", function() {
             var config = { rules: { "no-alert": 1} };
 
             var messages = eslint.verify(code, config, filename);
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-alert");
-            assert.equal(messages[0].message, "Unexpected alert.");
-            assert.include(messages[0].nodeType, "CallExpression");
+            assert.equal(messages.length, 2);
+
+            // Incorrectly formatted comment threw error;
+            // message from caught exception
+            // may differ amongst UAs, so verifying
+            // first part only as defined in the
+            // parseJsonConfig function in lib/eslint.js
+            assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":0 2':/);
+            assert.equal(messages[0].line, 1);
+            assert.equal(messages[0].column, 0);
+
+            assert.equal(messages[1].ruleId, "no-alert");
+            assert.equal(messages[1].message, "Unexpected alert.");
+            assert.include(messages[1].nodeType, "CallExpression");
         });
     });
 


### PR DESCRIPTION
Added errors to messages queue if parsing fails. Also, JSON parse-function actually checks for whether or not double quotes are used and adds them if not, however, camel-cased rule-names wouldn't be recognized.