### PR TITLE
Breaking: Stop checking JSX variable use, expose API instead (fixes #1911)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -92,6 +92,7 @@ Additionally, the `context` object has the following methods:
 * `getTokensAfter(nodeOrToken, count)` - returns `count` tokens after the given node or token.
 * `getTokensBefore(nodeOrToken, count)` - returns `count` tokens before the given node or token.
 * `getTokensBetween(node1, node2)` - returns the tokens between two nodes.
+* `markVariableAsUsed(name)` - marks the named variable in scope as used. This affects the [no-unused-vars](../rules/no-unused-vars.md) rule.
 * `report(node, message)` - reports an error in the code.
 
 ### context.report()

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -935,6 +935,28 @@ module.exports = (function() {
     };
 
     /**
+     * Record that a particular variable has been used in code
+     * @param {string} name The name of the variable to mark as used
+     * @returns {void}
+     */
+    api.markVariableAsUsed = function(name) {
+        var scope = this.getScope(),
+            variables,
+            i,
+            len;
+
+        do {
+            variables = scope.variables;
+            for (i = 0, len = variables.length; i < len; i++) {
+                if (variables[i].name === name) {
+                    variables[i].eslintNodeHasBeenUsed = true;
+                    return;
+                }
+            }
+        } while ( (scope = scope.upper) );
+    };
+
+    /**
      * Gets the filename for the currently parsed source.
      * @returns {string} The filename associated with the source being parsed.
      *     Defaults to "<input>" if no filename info is present.

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -28,7 +28,9 @@ var PASSTHROUGHS = [
         "getTokens",
         "getTokensAfter",
         "getTokensBefore",
-        "getTokensBetween"
+        "getTokensBetween",
+        "markVariableAsUsed",
+        "isMarkedAsUsed"
     ];
 
 //------------------------------------------------------------------------------

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -49,7 +49,7 @@ module.exports = function(context) {
             for (var i = 0, l = variables.length; i < l; ++i) {
 
                 // skip function expression names
-                if (scope.functionExpressionScope || variables[i].eslintJSXUsed) {
+                if (scope.functionExpressionScope || variables[i].eslintNodeHasBeenUsed) {
                     continue;
                 }
                 // skip implicit "arguments" variable
@@ -81,30 +81,6 @@ module.exports = function(context) {
         return [].concat.apply(unused, scope.childScopes.map(getUnusedLocals));
     }
 
-    /**
-     * @param {String} nodeName - Name of the node to check.
-     * @returns {void}
-     */
-    function flagVariableAsUsedInJSX(nodeName) {
-        var scope = context.getScope(),
-            variables = scope.variables,
-            i,
-            len;
-
-        while (scope.type !== "global") {
-            scope = scope.upper;
-            variables = [].concat.apply(scope.variables, variables);
-        }
-
-        // mark JSXIdentifiers with a special flag
-        for (i = 0, len = variables.length; i < len; i++) {
-            if (variables[i].name === nodeName) {
-                variables[i].eslintJSXUsed = true;
-                break;
-            }
-        }
-    }
-
     return {
         "Program:exit": function(programNode) {
             var globalScope = context.getScope();
@@ -118,7 +94,7 @@ module.exports = function(context) {
                 });
                 for (i = 0, l = globalScope.variables.length; i < l; ++i) {
                     if (unresolvedRefs.indexOf(globalScope.variables[i].name) < 0 &&
-                            !globalScope.variables[i].eslintJSXUsed) {
+                            !globalScope.variables[i].eslintNodeHasBeenUsed) {
                         unused.push(globalScope.variables[i]);
                     }
                 }
@@ -131,16 +107,6 @@ module.exports = function(context) {
                     context.report(unused[i].identifiers[0], MESSAGE, unused[i]);
                 }
             }
-        },
-
-        "JSXExpressionContainer": function(node) {
-            if (node.expression.type === "Identifier") {
-                flagVariableAsUsedInJSX(node.expression.name);
-            }
-        },
-
-        "JSXIdentifier": function(node) {
-            flagVariableAsUsedInJSX(node.name);
         }
     };
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -17,6 +17,15 @@ var eslint = require("../../../lib/eslint"),
 //------------------------------------------------------------------------------
 
 var eslintTester = new ESLintTester(eslint);
+eslint.defineRule("use-every-a", function(context) {
+    function useA() {
+        context.markVariableAsUsed("a");
+    }
+    return {
+        "VariableDeclaration": useA,
+        "ReturnStatement": useA
+    };
+});
 eslintTester.addRuleTest("lib/rules/no-unused-vars", {
     valid: [
         "var foo = 5;\n\nlabel: while (true) {\n  console.log(foo);\n  break label;\n}",
@@ -45,10 +54,6 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "function f() { var a = 1; return function(){ f(++a); }; }",
         "try {} catch(e) {}",
         "/*global a */ a;",
-        { code: "function foo() { var App; var bar = React.render(<App/>); return bar; }; foo()", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
-        { code: "var App; React.render(<App/>);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
-        { code: "var a=1; React.render(<img src={a} />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
-        { code: "var App; function f() { return <App />; } f();", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var a=10; (function() { alert(a); })();", args: [1, {vars: "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all"}] },
         { code: "function g(bar, baz) { return baz; }; g();", args: [1, {"vars": "all", "args": "after-used"}] },
@@ -58,7 +63,12 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "var g = function (bar, baz) { return 2; }; g();", args: [1, {"vars": "all", "args": "none"}] },
         "(function z() { z(); })();",
         { code: " ", globals: {a: true} },
-        { code: "var who = \"Paul\";\nmodule.exports = `Hello ${who}!`;", ecmaFeatures: { templateStrings: true }}
+        { code: "var who = \"Paul\";\nmodule.exports = `Hello ${who}!`;", ecmaFeatures: { templateStrings: true }},
+
+        // Can mark variables as used via context.markVariableAsUsed()
+        { code: "/*eslint use-every-a:1*/ var a;"},
+        { code: "/*eslint use-every-a:1*/ !function(a) { return 1; }"},
+        { code: "/*eslint use-every-a:1*/ !function() { var a; return 1 }"}
     ],
     invalid: [
         { code: "var a=10", errors: [{ message: "a is defined but never used", type: "Identifier"}] },


### PR DESCRIPTION
Should the APIs be in the documentation somewhere? I was going to add into `no-unused-vars`, but it seems like the audience is a little different?

Perhaps the introduction of the new API and the removal of the JSX checking should be done separately?