### PR TITLE
Docs: Minor grammar edit for `curly`

### DIFF
--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -1,6 +1,6 @@
 # Require Following Curly Brace Conventions (curly)
 
-JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to _never_ omit curly braces around blocks, even when they optional, because it can lead to bugs and reduces code clarity. So the following:
+JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to _never_ omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity. So the following:
 
 ```js
 if (foo) return;


### PR DESCRIPTION
This just adds a missing word to the documentation. I will probably send some more patches shortly :-)
