### PR TITLE
Fix: Ensure class names are marked as used (fixes #1967)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -138,6 +138,7 @@ module.exports = function(context) {
                 var unresolvedRefs = globalScope.through.filter(isReadRef).map(function(ref) {
                     return ref.identifier.name;
                 });
+
                 for (i = 0, l = globalScope.variables.length; i < l; ++i) {
                     if (unresolvedRefs.indexOf(globalScope.variables[i].name) < 0 &&
                             !globalScope.variables[i].eslintJSXUsed && !isExported(globalScope.variables[i])) {
@@ -150,6 +151,12 @@ module.exports = function(context) {
                 if (unused[i].eslintExplicitGlobal) {
                     context.report(programNode, MESSAGE, unused[i]);
                 } else if (unused[i].defs.length > 0) {
+
+                    // TODO: Remove when https://github.com/estools/escope/issues/49 is resolved
+                    if (unused[i].defs[0].type === "ClassName") {
+                        continue;
+                    }
+
                     context.report(unused[i].identifiers[0], MESSAGE, unused[i]);
                 }
             }

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -61,7 +61,9 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "var who = \"Paul\";\nmodule.exports = `Hello ${who}!`;", ecmaFeatures: { templateStrings: true }},
         { code: "export var foo = 123;", ecmaFeatures: { modules: true }},
         { code: "export function foo () {}", ecmaFeatures: { modules: true }},
-        { code: "export class foo {}", ecmaFeatures: { modules: true, classes: true }}
+        { code: "export class foo {}", ecmaFeatures: { modules: true, classes: true }},
+        { code: "class Foo{}; var x = new Foo(); x.foo()", ecmaFeatures: { classes: true }},
+        "function Foo(){}; var x = new Foo(); x.foo()"
     ],
     invalid: [
         { code: "var a=10", errors: [{ message: "a is defined but never used", type: "Identifier"}] },


### PR DESCRIPTION
This is a stop-gap measure until escope is fixed.