### PR TITLE
Feature comma dangle allow multiline

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -16,6 +16,8 @@ On the other hand, trailing commas can be useful because if you add or remove it
 This rule is aimed to forbid or enforce trailing commas in object literals and array literals.
 
 This rule takes one argument. If it is `"always"` then it warns whenever a missing comma is detected.
+If `"always-multiline"` then it warns if there is a missing trailing comma on arrays or objects that
+span multiple lines, and warns if there is a trailing comma present on single line arrays or objects.
 If `"never"` then it warns whenever an trailing comma is detected.
 The default value of this option is `"never"`.
 
@@ -76,6 +78,51 @@ var foo = {
 };
 
 var arr = [1,2,];
+
+foo({
+  bar: "baz",
+  qux: "quux",
+});
+```
+
+The following patterns are considered warnings when configured `"always-multiline"`:
+
+```js
+var foo = {
+    bar: "baz",
+    qux: "quux"
+};
+
+var foo = { bar: "baz", qux: "quux", };
+
+var arr = [1,2,];
+
+var arr = [
+    1,
+    2
+];
+
+foo({
+  bar: "baz",
+  qux: "quux"
+});
+```
+
+The following patterns are not considered warnings when configured `"always-multiline"`:
+
+```js
+var foo = {
+    bar: "baz",
+    qux: "quux",
+};
+
+var foo = {bar: "baz", qux: "quux"};
+var arr = [1,2];
+
+var arr = [
+    1,
+    2,
+];
 
 foo({
   bar: "baz",

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -12,7 +12,10 @@
 //------------------------------------------------------------------------------
 
 module.exports = function (context) {
-    var forbidDanglingComma = context.options[0] !== "always";
+    var allowDangle = context.options[0];
+    var forbidDangle = allowDangle !== "always-multiline" && allowDangle !== "always";
+    var UNEXPECTED_MESSAGE = "Unexpected trailing comma.";
+    var MISSING_MESSAGE = "Missing trailing comma.";
 
     /**
      * Checks the given node for trailing comma and reports violations.
@@ -22,22 +25,27 @@ module.exports = function (context) {
     function checkForTrailingComma(node) {
         var items = node.properties || node.elements,
             length = items.length,
+            nodeIsMultiLine = node.loc.start.line !== node.loc.end.line,
             lastItem,
-            penultimateToken;
+            penultimateToken,
+            hasDanglingComma;
 
         if (length) {
             lastItem = items[length - 1];
             if (lastItem) {
                 penultimateToken = context.getLastToken(node, 1);
+                hasDanglingComma = penultimateToken.value === ",";
 
-                if (forbidDanglingComma) {
-                    if (penultimateToken.value === ",") {
-                        context.report(lastItem, penultimateToken.loc.start, "Unexpected trailing comma.");
+                if (forbidDangle && hasDanglingComma) {
+                    context.report(lastItem, penultimateToken.loc.start, UNEXPECTED_MESSAGE);
+                } else if (allowDangle === "always-multiline") {
+                    if (hasDanglingComma && !nodeIsMultiLine) {
+                        context.report(lastItem, penultimateToken.loc.start, UNEXPECTED_MESSAGE);
+                    } else if (!hasDanglingComma && nodeIsMultiLine) {
+                        context.report(lastItem, penultimateToken.loc.end, MISSING_MESSAGE);
                     }
-                } else {
-                    if (penultimateToken.value !== ",") {
-                        context.report(lastItem, lastItem.loc.end, "Missing trailing comma.");
-                    }
+                } else if (allowDangle === "always" && !hasDanglingComma) {
+                    context.report(lastItem, lastItem.loc.end, MISSING_MESSAGE);
                 }
             }
         }

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -23,16 +23,43 @@ var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/comma-dangle", {
     valid: [
         "var foo = { bar: 'baz' }",
+        "var foo = {\nbar: 'baz'\n}",
         "var foo = [ 'baz' ]",
+        "var foo = [\n'baz'\n]",
         "[,,]",
+        "[\n,\n,\n]",
         "[,]",
+        "[\n,\n]",
         "[]",
+        "[\n]",
+
+        { code: "var foo = { bar: 'baz' }", options: ["foo"] },
+        { code: "var foo = {\nbar: 'baz'\n}", options: ["bar"] },
+        { code: "var foo = [ 'baz' ]", options: ["baz"] },
 
         { code: "var foo = { bar: 'baz', }", options: [ "always" ] },
+        { code: "var foo = {\nbar: 'baz',\n}", options: [ "always" ] },
+        { code: "var foo = {\nbar: 'baz'\n,}", options: [ "always" ] },
         { code: "var foo = [ 'baz', ]", options: [ "always" ] },
+        { code: "var foo = [\n'baz',\n]", options: [ "always" ] },
+        { code: "var foo = [\n'baz'\n,]", options: [ "always" ] },
         { code: "[,,]", options: [ "always" ] },
+        { code: "[\n,\n,\n]", options: [ "always" ] },
         { code: "[,]", options: [ "always" ] },
-        { code: "[]", options: [ "always" ] }
+        { code: "[\n,\n]", options: [ "always" ] },
+        { code: "[]", options: [ "always" ] },
+        { code: "[\n]", options: [ "always" ] },
+
+        { code: "var foo = { bar: 'baz' }", options: [ "always-multiline" ] },
+        { code: "var foo = {\nbar: 'baz',\n}", options: [ "always-multiline" ] },
+        { code: "var foo = [ 'baz' ]", options: [ "always-multiline" ] },
+        { code: "var foo = [\n'baz',\n]", options: [ "always-multiline" ] },
+        { code: "[,,]", options: [ "always" ] },
+        { code: "[\n,\n,\n]", options: [ "always" ] },
+        { code: "[,]", options: [ "always" ] },
+        { code: "[\n,\n]", options: [ "always" ] },
+        { code: "[]", options: [ "always" ] },
+        { code: "[\n]", options: [ "always" ] }
     ],
     invalid: [
         {
@@ -43,6 +70,17 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     type: "Property",
                     line: 1,
                     column: 22
+                }
+            ]
+        },
+        {
+            code: "var foo = {\nbar: 'baz',\n}",
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 2,
+                    column: 10
                 }
             ]
         },
@@ -58,7 +96,29 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
             ]
         },
         {
+            code: "foo({\nbar: 'baz',\nqux: 'quux',\n});",
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 3,
+                    column: 11
+                }
+            ]
+        },
+        {
             code: "var foo = [ 'baz', ]",
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Literal",
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: "var foo = [ 'baz',\n]",
             errors: [
                 {
                     message: "Unexpected trailing comma.",
@@ -80,6 +140,44 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
             ]
         },
 
+
+        {
+            code: "var foo = { bar: 'baz', }",
+            options: [ "foo" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 22
+                }
+            ]
+        },
+        {
+            code: "var foo = {\nbar: 'baz',\n}",
+            options: [ "bar" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 2,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "foo({ bar: 'baz', qux: 'quux', });",
+            options: [ "baz" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 29
+                }
+            ]
+        },
+
         {
             code: "var foo = { bar: 'baz' }",
             options: [ "always" ],
@@ -89,6 +187,18 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     type: "Property",
                     line: 1,
                     column: 22
+                }
+            ]
+        },
+        {
+            code: "var foo = {\nbar: 'baz'\n}",
+            options: [ "always" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Property",
+                    line: 2,
+                    column: 10
                 }
             ]
         },
@@ -105,7 +215,31 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
             ]
         },
         {
+            code: "foo({\nbar: 'baz',\nqux: 'quux'\n});",
+            options: [ "always" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Property",
+                    line: 3,
+                    column: 11
+                }
+            ]
+        },
+        {
             code: "var foo = [ 'baz' ]",
+            options: [ "always" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Literal",
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: "var foo = [ 'baz'\n]",
             options: [ "always" ],
             errors: [
                 {
@@ -119,6 +253,91 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
         {
             code: "var foo = { bar:\n\n'bar' }",
             options: [ "always" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Property",
+                    line: 3,
+                    column: 5
+                }
+            ]
+        },
+
+        {
+            code: "var foo = {\nbar: 'baz'\n}",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Property",
+                    line: 2,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "var foo = { bar: 'baz', }",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 22
+                }
+            ]
+        },
+        {
+            code: "foo({\nbar: 'baz',\nqux: 'quux'\n});",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Property",
+                    line: 3,
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "foo({ bar: 'baz', qux: 'quux', });",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 29
+                }
+            ]
+        },
+        {
+            code: "var foo = [\n'baz'\n]",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Literal",
+                    line: 2,
+                    column: 5
+                }
+            ]
+        },
+        {
+            code: "var foo = ['baz',]",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Literal",
+                    line: 1,
+                    column: 16
+                }
+            ]
+        },
+        {
+            code: "var foo = { bar:\n\n'bar' }",
+            options: [ "always-multiline" ],
             errors: [
                 {
                     message: "Missing trailing comma.",


### PR DESCRIPTION
Fixes #1984 

Adds option for `"allow-multiline"` to the comma-dangle rule, which fails if single-line objects/arrays have a dangling comma, or multiline objects/arrays are missing a dangling comma.