### PR TITLE
Adding ignore config to no-unused-vars rule

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -15,7 +15,8 @@ module.exports = function(context) {
 
     var config = {
         vars: "all",
-        args: "after-used"
+        args: "after-used",
+        ignore: []
     };
 
     if (context.options[0]) {
@@ -24,6 +25,7 @@ module.exports = function(context) {
         } else {
             config.vars = context.options[0].vars || config.vars;
             config.args = context.options[0].args || config.args;
+            config.ignore = context.options[0].ignore || config.ignore;
         }
     }
 
@@ -91,6 +93,10 @@ module.exports = function(context) {
 
                 // if "args" option is "after-used", skip all but the last parameter
                 if (config.args === "after-used" && type === "Parameter" && variables[i].defs[0].index < variables[i].defs[0].node.params.length - 1) {
+                    continue;
+                }
+
+                if (config.ignore.indexOf(variables[i].name) > -1) {
                     continue;
                 }
 


### PR DESCRIPTION
This change adds a configuration option to the `no-unused-vars` rule that allows you to explicitly ignore variables when validating usage.

Something like this is required to allow React projects to pass without either:

* disabling the `no-unused-vars` rule
* littering every JSX file with `/*eslint-disable no-unused-vars*/` exceptions
* living with a bunch of false-positives

Example config:

```
"no-unused-vars": [2, { ignore: ["React"] }]
```

Causes this to be valid:

```
var React = require('react');
module.exports = <div>Hello World</div>;
```

I've read #1867 and understand that ESLint doesn't want any library-specific exceptions, however *something* is needed here to make it viable for React users, so this seems like a good compromise.

I also understand the inherent danger of creating exceptions (in case, in another file, having `React` unused really were an issue) however in my project I'm willing to live with it, as the other option is to go without `no-unused-vars` entirely, which is much worse.

I haven't updated the docs or written tests yet because I'm not sure if the PR will be accepted. If it will be, please let me know and I'll add them. (I have tested it locally in my project and it is a significant improvement)