### PR TITLE
Docs: Add quotes around object key

### DIFF
--- a/docs/rules/spaced-line-comment.md
+++ b/docs/rules/spaced-line-comment.md
@@ -32,7 +32,7 @@ var foo = 5;
 ```
 
 ```js
-// When ["always",{exceptions:["-","+"]}]
+// When ["always",{"exceptions":["-","+"]}]
 //------++++++++
 // Comment block
 //------++++++++
@@ -53,14 +53,14 @@ var foo = 5;
 ```
 
 ```js
-// When ["always",{exceptions:["-"]}]
+// When ["always",{"exceptions":["-"]}]
 //--------------
 // Comment block
 //--------------
 ```
 
 ```js
-// When ["always",{exceptions:["-+"]}]
+// When ["always",{"exceptions":["-+"]}]
 //-+-+-+-+-+-+-+
 // Comment block
 //-+-+-+-+-+-+-+


### PR DESCRIPTION
Comments in example code did not include quotes around the `"exceptions"` key, but they should in order to be valid JSON.