### PR TITLE
New: Adding support for custom environments (fixes #1130)

### DIFF
--- a/docs/configuring/README.md
+++ b/docs/configuring/README.md
@@ -150,6 +150,26 @@ And in YAML:
     node: true
 ```
 
+Plugins also can sometimes supply custom environments. In order to enable environment that was included with a plugin, you have to register given plugin in the configuration file (see Configuring Plugins section) and then specify environment that you would like to use:
+
+````json
+{
+    "env": {
+        "plugin-name/plugin-env": true
+    }
+}
+```
+
+And in YAML:
+
+```yaml
+---
+  env:
+    plugin-name/plugin-env: true
+```
+
+**Note:** Plugin name should not include "eslint-plugin-" prefix, when specifying environments.
+
 ## Specifying Globals
 
 By default, ESLint will warn on variables that are accessed but not defined within the same file. If you are using global variables inside of a file then it's worthwhile to define those globals so that ESLint will not warn about their usage. You can define global variables either using comments inside of a file or in the configuration file.

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -66,6 +66,28 @@ module.exports = {
 };
 ```
 
+### Custom Environments in Plugins
+
+Plugins can also provide custom environments. Custom environments can declare `globals`, turn `ecmaFeatures` on and off,
+and configure both core rules as well as rules included in the plugin. To provide custom environment, include `environment`
+property in your exported object.
+
+```js
+module.exports = {
+    environments: {
+        "my-custom-environment": {
+            globals: {
+                "global-variable": true
+            },
+            rules: {
+                "no-alert": 0, //turn off no-alert rule
+                "my-plugin/my-rule": 1 //turn on custom rule from this plugin (given that plugin's name is "my-plugin")
+            }
+        }
+    }
+}
+```
+
 ### Peer Dependency
 
 To make clear that the plugin requires ESLint to work correctly you have to declare ESLint as a `peerDependency` in your `package.json`.

--- a/lib/config.js
+++ b/lib/config.js
@@ -64,30 +64,41 @@ function loadConfig(filePath) {
 }
 
 /**
+ * Loads plugin from node_modules or cache
+ * @param {string} pluginNameWithoutPrefix Name of the plugin without prefix
+ * @returns {Object} Plugin definition
+ */
+function loadPlugin(pluginNameWithoutPrefix) {
+    var plugin;
+    if (!loadedPlugins[pluginNameWithoutPrefix]) {
+        try {
+            plugin = require(util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+            loadedPlugins[pluginNameWithoutPrefix] = plugin;
+        } catch(err) {
+            debug("Failed to load plugin configuration for " + pluginNameWithoutPrefix + ". Proceeding without it.");
+            plugin = { rulesConfig: {}};
+        }
+    } else {
+        plugin = loadedPlugins[pluginNameWithoutPrefix];
+    }
+    return plugin;
+}
+
+/**
  * Load configuration for all plugins provided.
  * @param {string[]} pluginNames An array of plugin names which should be loaded.
- * @returns {Object} all plugin configurations merged together
+ * @returns {Object} All plugin configurations merged together
  */
 function getPluginsConfig(pluginNames) {
     var pluginConfig = {};
 
     if (pluginNames) {
-        pluginNames.forEach(function (pluginName) {
+        pluginNames.forEach(function(pluginName) {
             var pluginNameWithoutPrefix = util.removePluginPrefix(pluginName),
                 plugin = {},
                 rules = {};
 
-            if (!loadedPlugins[pluginNameWithoutPrefix]) {
-                try {
-                    plugin = require(util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
-                    loadedPlugins[pluginNameWithoutPrefix] = plugin;
-                } catch(err) {
-                    debug("Failed to load plugin configuration for " + pluginNameWithoutPrefix + ". Proceeding without it.");
-                    plugin = { rulesConfig: {}};
-                }
-            } else {
-                plugin = loadedPlugins[pluginNameWithoutPrefix];
-            }
+            plugin = loadPlugin(pluginNameWithoutPrefix);
 
             if (!plugin.rulesConfig) {
                 plugin.rulesConfig = {};
@@ -102,6 +113,37 @@ function getPluginsConfig(pluginNames) {
     }
 
     return {rules: pluginConfig};
+}
+
+/**
+ * Load environments for all plugins provided.
+ * @param {string[]} pluginNames An array of plugin names with should be loaded.
+ * @returns {Object} All plugin environments merged together
+ */
+function getPluginsEnvironments(pluginNames) {
+    var pluginEnvironments = {};
+
+    if (pluginNames) {
+        pluginNames.forEach(function(pluginName) {
+            var pluginNameWithoutPrefix = util.removePluginPrefix(pluginName),
+                plugin = {},
+                customEnvironments = {};
+
+            plugin = loadPlugin(pluginNameWithoutPrefix);
+
+            if (!plugin.environments) {
+                plugin.environments = {};
+            }
+
+            Object.keys(plugin.environments).forEach(function(item) {
+                customEnvironments[pluginNameWithoutPrefix + "/" + item] = plugin.environments[item];
+            });
+
+            pluginEnvironments = util.mergeConfigs(pluginEnvironments, customEnvironments);
+        });
+    }
+
+    return pluginEnvironments;
 }
 
 /**
@@ -162,24 +204,30 @@ function getLocalConfig(thisConfig, directory) {
  * @param {Object<string,boolean>} envs The environment settings.
  * @param {boolean} reset The value of the command line reset option. If true,
  *      rules are not automatically merged into the config.
+ * @param {string[]} plugins A list of plugins to load.
  * @returns {Object} A configuration object with the appropriate rules and globals
  *      set.
  * @private
  */
-function createEnvironmentConfig(envs, reset) {
+function createEnvironmentConfig(envs, reset, plugins) {
 
     var envConfig = {
-        globals: {},
-        env: envs || {},
-        rules: {},
-        ecmaFeatures: {}
-    };
+            globals: {},
+            env: envs || {},
+            rules: {},
+            ecmaFeatures: {}
+        },
+        environmentsCopy = util.mergeConfigs({}, environments);
+
+    if (plugins) {
+        environmentsCopy = util.mergeConfigs(environmentsCopy, getPluginsEnvironments(plugins));
+    }
 
     if (envs) {
         Object.keys(envs).filter(function (name) {
             return envs[name];
         }).forEach(function(name) {
-            var environment = environments[name];
+            var environment = environmentsCopy[name];
 
             if (environment) {
 
@@ -281,7 +329,7 @@ Config.prototype.getConfig = function (filePath) {
     config = util.mergeConfigs({}, this.baseConfig);
 
     // Step 3: Merge in environment-specific globals and rules from .eslintrc files
-    config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env, this.options.reset));
+    config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env, this.options.reset, userConfig.plugins));
 
     // Step 4: Merge in the user-specified configuration from .eslintrc and package.json
     config = util.mergeConfigs(config, userConfig);
@@ -291,7 +339,7 @@ Config.prototype.getConfig = function (filePath) {
         debug("Merging command line config file");
 
         if (this.useSpecificConfig.env) {
-            config = util.mergeConfigs(config, createEnvironmentConfig(this.useSpecificConfig.env, this.options.reset));
+            config = util.mergeConfigs(config, createEnvironmentConfig(this.useSpecificConfig.env, this.options.reset, this.useSpecificConfig.plugins));
         }
 
         config = util.mergeConfigs(config, this.useSpecificConfig);
@@ -300,7 +348,7 @@ Config.prototype.getConfig = function (filePath) {
     // Step 6: Merge in command line environments
     if (this.env) {
         debug("Merging command line environment settings");
-        config = util.mergeConfigs(config, createEnvironmentConfig(this.env, this.options.reset));
+        config = util.mergeConfigs(config, createEnvironmentConfig(this.env, this.options.reset, this.plugins));
     }
 
     // Step 7: Merge in command line rules

--- a/tests/fixtures/environments/plugin.yaml
+++ b/tests/fixtures/environments/plugin.yaml
@@ -1,0 +1,6 @@
+{
+    "plugins": ["example"],
+    "env": {
+        "example/example": true
+    }
+}

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -493,6 +493,7 @@ describe("Config", function() {
                 testPluginName = "eslint-plugin-test",
                 requireStubs = {},
                 examplePluginRules = { "example-rule": customRule },
+                examplePluginEnvs = { "example": { globals: { test: false } } },
                 testPluginRules = { "test-rule": customRule },
                 examplePlugin = { rules: examplePluginRules, rulesConfig: { "example-rule": 1 } },
                 testPlugin = { rules: testPluginRules, rulesConfig: { "test-rule": 1, "quotes": 0} },
@@ -593,6 +594,26 @@ describe("Config", function() {
                         plugins: ["example"]
                     },
                     actual = configHelper.getConfig(file);
+
+                assertConfigsEqual(actual, expected);
+            });
+
+            it("should load environments from plugin", function () {
+                requireStubs[examplePluginName] = { environments: examplePluginEnvs };
+
+                StubbedConfig = proxyquire("../../lib/config", requireStubs);
+
+                var configPath = path.resolve(__dirname, "..", "fixtures", "environments", "plugin.yaml"),
+                    configHelper = new StubbedConfig({
+                        reset: true, configFile: configPath, useEslintrc: false
+                    }),
+                    expected = {
+                        env: {
+                            "example/example": true
+                        },
+                        plugins: ["example"]
+                    },
+                    actual = configHelper.getConfig(configPath);
 
                 assertConfigsEqual(actual, expected);
             });


### PR DESCRIPTION
Fixes #1130
This adds support for custom environments provided by plugins. All the same limitations as with custom rules apply here (See #2022). I also think that unit tests are probably lacking a bit right now. It should probably include at least a unit-test for changing rules from custom environment, however, it's pretty hard to test that, since when `reset` is true, rule configuration will be discarded, and when it's false, all of the rules from the default config are being pulled in.