### PR TITLE
Fix: destructured arguments should work in block-scoped-var (fixes #1996...

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -89,9 +89,31 @@ module.exports = function(context) {
 
     function functionHandler(node) {
         pushScope();
-        declare(node.params.map(function(id) {
-            return id.name;
-        }));
+
+        node.params.forEach(function(param) {
+
+            switch (param.type) {
+                case "Identifier":
+                    declare([param.name]);
+                    break;
+
+                case "ObjectPattern":
+                    declare(param.properties.map(function(property) {
+                        return property.key.name;
+                    }));
+                    break;
+
+                case "ArrayPattern":
+                    declare(param.elements.map(function(element) {
+                        return element.name;
+                    }));
+                    break;
+
+                // no default
+            }
+
+        });
+
         declare(node.id ? [node.id.name] : []);
         declare(node.rest ? [node.rest.name] : []);
         declare(["arguments"]);

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -38,6 +38,7 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         { code: "new Date", globals: {Date: false} },
         { code: "new Date", globals: {} },
         { code: "var eslint = require('eslint');", globals: {require: false} },
+        { code: "var fun = function({x}) {return x;};", ecmaFeatures: { destructuring: true } },
         "function f(a) { return a.b; }",
         "var a = { \"foo\": 3 };",
         "var a = { foo: 3 };",


### PR DESCRIPTION
...)