### PR TITLE
Don't warn on super usage

### DIFF
--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -106,6 +106,11 @@ module.exports = function(context) {
                     return;
                 }
 
+                // hack until https://github.com/eslint/eslint/issues/1968 is properly fixed
+                if (name === "super") {
+                    return;
+                }
+
                 if (!variable) {
                     context.report(ref.identifier, NOT_DEFINED_MESSAGE, { name: name });
                 } else if (ref.isWrite() && variable.writeable === false) {

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "doctrine": "^0.6.2",
     "escape-string-regexp": "^1.0.2",
     "escope": "2.0.6",
-    "espree": "^1.11.0",
+    "espree": "^1.12.0",
     "estraverse": "^2.0.0",
     "estraverse-fb": "^1.3.1",
     "globals": "^6.1.0",

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -47,7 +47,8 @@ eslintTester.addRuleTest("lib/rules/no-undef", {
         { code: "var React; React.render(<img />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var React; React.render(<x-gif />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var React, App, a=1; React.render(<App attr={a} />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
-        { code: "var console; [1,2,3].forEach(obj => {\n  console.log(obj);\n});", ecmaFeatures: { arrowFunctions: true } }
+        { code: "var console; [1,2,3].forEach(obj => {\n  console.log(obj);\n});", ecmaFeatures: { arrowFunctions: true } },
+        { code: "var Foo; class Bar extends Foo { constructor() { super();  }}", ecmaFeatures: { classes: true } }
     ],
     invalid: [
         { code: "a = 1;", errors: [{ message: "'a' is not defined.", type: "Identifier"}] },


### PR DESCRIPTION
Includes Espree upgrade because `super` was throwing an error when it shouldn't.