### PR TITLE
New: no-param-reassign rule (fixes #1599)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -69,6 +69,7 @@
         "no-obj-calls": 2,
         "no-octal": 2,
         "no-octal-escape": 2,
+        "no-param-reassign": 0,
         "no-path-concat": 0,
         "no-plusplus": 0,
         "no-process-env": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -72,6 +72,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-new-wrappers](no-new-wrappers.md) - disallows creating new instances of `String`,`Number`, and `Boolean`
 * [no-octal](no-octal.md) - disallow use of octal literals
 * [no-octal-escape](no-octal-escape.md) - disallow use of octal escape sequences in string literals, such as `var foo = "Copyright \251";`
+* [no-param-reassign](no-param-reassign.md) - disallow reassignment of function parameters (off by default)
 * [no-process-env](no-process-env.md) - disallow use of `process.env` (off by default)
 * [no-proto](no-proto.md) - disallow usage of `__proto__` property
 * [no-redeclare](no-redeclare.md) - disallow declaring the same variable more then once

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -1,0 +1,43 @@
+# Disallow Reassignment of Function Parameters (no-param-reassign)
+
+Assignment to variables declared as function parameters can be misleading and lead to confusing behavior, as modifying function parameters will also mutate the `arguments` object. Often, assignment to function parameters is unintended and indicative of a mistake or programmer error.
+
+## Rule Details
+
+This rule aims to prevent unintended behavior caused by overwriting function parameters.
+
+The following patterns are considered warnings:
+
+```js
+function foo(bar) {
+    bar = 13;
+}
+```
+
+```js
+function foo(bar) {
+    bar++;
+}
+```
+
+The following patterns are not warnings:
+
+```js
+function foo(a) {
+    var b = a;
+}
+```
+
+```js
+function foo(a) {
+    a.prop = 'value';
+}
+```
+
+## When Not To Use It
+
+If you want to allow assignment to function parameters, then you can safely disable this rule.
+
+## Further Reading
+
+* [JavaScript: Don’t Reassign Your Function Arguments](http://spin.atomicobject.com/2011/04/10/javascript-don-t-reassign-your-function-arguments/)

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -1,0 +1,85 @@
+/**
+ * @fileoverview Disallow reassignment of function parameters.
+ * @author Nat Burns
+ * @copyright 2014 Nat Burns. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Finds the declaration for a given variable by name, searching up the scope tree.
+     * @param {Scope} scope The scope in which to search.
+     * @param {String} name The name of the variable.
+     * @returns {Variable} The declaration information for the given variable, or null if no declaration was found.
+     */
+    function findDeclaration(scope, name) {
+        var variables = scope.variables;
+
+        for (var i = 0; i < variables.length; i++) {
+            if (variables[i].name === name) {
+                return variables[i];
+            }
+        }
+
+        if (scope.upper) {
+            return findDeclaration(scope.upper, name);
+        } else {
+            return null;
+        }
+    }
+
+    /**
+     * Determines if a given variable is declared as a function parameter.
+     * @param {Variable} variable The variable declaration.
+     * @returns {boolean} True if the variable is a function parameter, false otherwise.
+     */
+    function isParameter(variable) {
+        var defs = variable.defs;
+
+        for (var i = 0; i < defs.length; i++) {
+            if (defs[i].type === "Parameter") {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Checks whether a given node is an assignment to a function parameter.
+     * If so, a linting error will be reported.
+     * @param {ASTNode} node The node to check.
+     * @param {String} name The name of the variable being assigned to.
+     * @returns {void}
+     */
+    function checkParameter(node, name) {
+        var declaration = findDeclaration(context.getScope(), name);
+
+        if (declaration && isParameter(declaration)) {
+            context.report(node, "Assignment to function parameter '{{name}}'.", { name: name });
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        "AssignmentExpression": function(node) {
+            checkParameter(node, node.left.name);
+        },
+
+        "UpdateExpression": function(node) {
+            checkParameter(node, node.argument.name);
+        }
+    };
+};

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Disallow reassignment of function parameters.
+ * @author Nat Burns
+ * @copyright 2014 Nat Burns. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-param-reassign", {
+
+    valid: [
+        "function foo(a) { var b = a; }",
+        "function foo(a) { a.prop = 'value'; }",
+        "function foo(a) { (function() { var a = 12; a++; })(); }",
+        { code: "function foo() { global = 13; }", globals: ["global"] }
+    ],
+
+    invalid: [
+        { code: "function foo(bar) { bar = 13; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { bar += 13; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { (function() { bar = 13; })(); }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { ++bar; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { bar++; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { --bar; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { bar--; }", errors: [{ message: "Assignment to function parameter 'bar'." }] }
+    ]
+});


### PR DESCRIPTION
This only checks for assignments to named parameters, not `arguments`, as the consensus in #1599 says that should be a separate rule.