### PR TITLE
Fix: Exempt \0 from no-octal-escape (fixes #1923)

### DIFF
--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -17,13 +17,18 @@ module.exports = function(context) {
             if (typeof node.value !== "string") {
                 return;
             }
-            var match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-7])/),
+
+            var match = node.raw.match(/^([^\\]|\\[^0-7])*\\([0-3][0-7]{1,2}|[4-7][0-7]|[0-7])/),
                 octalDigit;
 
             if (match) {
                 octalDigit = match[2];
-                context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
-                        { octalDigit: octalDigit });
+
+                // \0 is actually not considered an octal
+                if (match[2] !== "0" || typeof match[3] !== "undefined") {
+                    context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
+                            { octalDigit: octalDigit });
+                }
             }
         }
 

--- a/tests/lib/rules/no-octal-escape.js
+++ b/tests/lib/rules/no-octal-escape.js
@@ -20,14 +20,16 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-octal-escape", {
     valid: [
-        "var foo = \"\\851\";",
+        "var foo = \"\\x51\";",
         "var foo = \"foo \\\\251 bar\";",
-        "var foo = /([abc]) \\1/g;"
+        "var foo = /([abc]) \\1/g;",
+        "var foo = '\\0';"
     ],
     invalid: [
-        { code: "var foo = \"foo \\251 bar\";", errors: [{ message: "Don't use octal: '\\2'. Use '\\u....' instead.", type: "Literal"}] },
-        { code: "var foo = \"\\751\";", errors: [{ message: "Don't use octal: '\\7'. Use '\\u....' instead.", type: "Literal"}] },
+        { code: "var foo = \"foo \\01 bar\";", errors: [{ message: "Don't use octal: '\\01'. Use '\\u....' instead.", type: "Literal"}] },
+        { code: "var foo = \"foo \\251 bar\";", errors: [{ message: "Don't use octal: '\\251'. Use '\\u....' instead.", type: "Literal"}] },
+        { code: "var foo = \"\\751\";", errors: [{ message: "Don't use octal: '\\75'. Use '\\u....' instead.", type: "Literal"}] },
         { code: "var foo = \"\\3s51\";", errors: [{ message: "Don't use octal: '\\3'. Use '\\u....' instead.", type: "Literal"}] },
-        { code: "var foo = \"\\\\\\751\";", errors: [{ message: "Don't use octal: '\\7'. Use '\\u....' instead.", type: "Literal"}] }
+        { code: "var foo = \"\\\\\\751\";", errors: [{ message: "Don't use octal: '\\75'. Use '\\u....' instead.", type: "Literal"}] }
     ]
 });


### PR DESCRIPTION
Fixes #1923. Obsoletes #2027.