### PR TITLE
Fix: getScope when modules or globalReturn are used

### DIFF
--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -908,6 +908,23 @@ describe("eslint", function() {
 
             eslint.verify(code, {}, filename, true);
         });
+        it("should mark variables in module scope as used", function() {
+            var code = "var a = 1, b = 2;";
+
+            eslint.reset();
+            eslint.on("Program:exit", function() {
+                var scope;
+
+                eslint.markVariableAsUsed("a");
+
+                scope = eslint.getScope();
+
+                assert.isTrue(getVariable(scope, "a").eslintUsed);
+                assert.notOk(getVariable(scope, "b").eslintUsed);
+            });
+
+            eslint.verify(code, { ecmaFeatures: { globalReturn: true }}, filename, true);
+        });
     });
 
     describe("when calling report", function() {


### PR DESCRIPTION
When setting the ecmaFeatures `modules` or `globalReturn` to `true` escope is returning 2 scopes: 

* `global` 
* `module` or `function`

```javascript
// Normal case (no ecmaFeatures enabled)
scopeManager = escope.analyze(ast, {
    ignoreEval: true,
    nodejsScope: false,
    ecmaVersion: 5,
    sourceType: "script"
});

scopeManager.scopes.length // 1
scopeManager.scopes[0].type // "global"

// Case for ecmaFeatures.modules to true
scopeManager = escope.analyze(ast, {
    ignoreEval: true,
    nodejsScope: false,
    ecmaVersion: 6,
    sourceType: "module"
});

scopeManager.scopes.length // 2
scopeManager.scopes[0].type // "global"
scopeManager.scopes[1].type // "module"

// Case for ecmaFeatures.globalReturn to true
scopeManager = escope.analyze(ast, {
    ignoreEval: true,
    nodejsScope: true,
    ecmaVersion: 5,
    sourceType: "script"
});

scopeManager.scopes.length // 2
scopeManager.scopes[0].type // "global"
scopeManager.scopes[1].type // "function"
```

Currently `api.getScope` only use the `global` scope, ignoring the `module`/`function` scope. This can cause problems, for example `api.markVariableAsUsed` can not find the variables declared in the upper scope.

~~This fix will make `api.getScope` use the `module`/`function` scope when `modules` or `globalReturn` are set to `true`, and the global scope otherwise.~~

This fix was bad, I need to investigate more on this issue. You can still look at the added test in `tests/eslint.js`