### PR TITLE
New: newline-after-var rule (fixes #2057)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -135,6 +135,7 @@
         "max-statements": [0, 10],
         "new-cap": 2,
         "new-parens": 2,
+	"newline-after-var": 0,
         "one-var": 0,
         "operator-assignment": [0, "always"],
         "padded-blocks": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -141,6 +141,7 @@ These rules are purely matters of style and are quite subjective.
 * [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested (off by default)
 * [new-cap](new-cap.md) - require a capital letter for constructors
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments
+* [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after `var` statement (off by default)
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
 * [no-inline-comments](no-inline-comments.md) - disallow comments inline after code (off by default)
 * [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block (off by default)

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -1,0 +1,39 @@
+# Allow/disallow an empty newline after var statement (newline-after-var)
+
+The `newline-after-var` rule enforces a coding style where empty newlines are allowed or disallowed after `var` statement.
+
+It takes an option as the second parameter which can be `"always"` or `"never"` for wanting or disallowing at least one empty newline after the `var` statement respectively. There is no default.
+
+## Rule Details
+
+The rule aims to achieve a consistent coding style across the project.
+
+The following patterns are considered warnings:
+
+```js
+// When [1, "always"]
+var greet = "hello,",
+    name = "world";
+console.log(greet, name);
+
+// When [1, "never"]
+var greet = "hello,",
+    name = "world";
+
+console.log(greet, name);
+```
+
+The following patterns are not considered warnings:
+
+```js
+// When [1, "always"]
+var greet = "hello,",
+    name = "world";
+
+console.log(greet, name);
+
+// When [1, "never"]
+var greet = "hello,",
+    name = "world";
+console.log(greet, name);
+```

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -1,0 +1,42 @@
+/**
+ * @fileoverview Rule to check empty newline after "var" statement
+ * @author Gopal Venkatesan <http://g13n.me>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var mode = context.options[0],
+        validator;              // regex to validate the rule
+
+    if (mode === "always") {
+        validator = /\S(?:\r?\n){2,}\S?/;
+    } else if (mode === "never") {
+        validator = /\S(?:\r?\n)?\S/;
+    }
+
+    return {
+        "VariableDeclaration:exit": function(node) {
+            var lastToken = context.getLastToken(node),
+                nextToken = context.getTokenAfter(node),
+                // peek few characters beyond the last token (typically the semi-colon)
+                sourceLines = context.getSource(lastToken, 0, 3);
+
+            // Some coding styles like Google uses multiple `var` statements.
+            // So if the next token is a `var` statement don't do anything.
+            if (nextToken && nextToken.type === "Keyword" && nextToken.value === "var") {
+                return;
+            }
+
+            // Next statement is not a `var`
+            if (sourceLines && !sourceLines.match(validator)) {
+                context.report(node, "Newline is " + mode + " expected after a \"var\" statement.",
+                               { identifier: node.name });
+            }
+        }
+    };
+};

--- a/tests/lib/rules/newline-after-var.js
+++ b/tests/lib/rules/newline-after-var.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Tests for newline-after-var rule.
+ * @author Gopal Venkatesan <http://g13n.me>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+
+eslintTester.addRuleTest("lib/rules/newline-after-var", {
+    valid: [
+        { code: "var greet = 'hello'; console.log(greet);", args: [2, "never"] },
+        { code: "var greet = 'hello';\n\nconsole.log(greet);", args: [2, "always"] },
+        { code: "var greet = 'hello';\n\n\nconsole.log(greet);", args: [2, "always"] },
+        { code: "var greet = 'hello'; var name = 'world';\n\n\nconsole.log(greet);", args: [2, "always"] }
+    ],
+
+    invalid: [
+        {
+            code: "var greet = 'hello';\n\nconsole.log(greet);",
+            args: [2, "never"],
+            errors: [{
+                message: "Newline is never expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var greet = 'hello'; console.log(greet);",
+            args: [2, "always"],
+            errors: [{
+                message: "Newline is always expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var greet = 'hello'; var name = 'world'; console.log(greet);",
+            args: [2, "always"],
+            errors: [{
+                message: "Newline is always expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
Allow/disallow empty newline after `var` statement.