### PR TITLE
New: newline-after-var rule (fixes #2057)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -136,6 +136,7 @@
         "max-statements": [0, 10],
         "new-cap": 2,
         "new-parens": 2,
+	"newline-after-var": 0,
         "one-var": 0,
         "operator-assignment": [0, "always"],
         "padded-blocks": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -142,6 +142,7 @@ These rules are purely matters of style and are quite subjective.
 * [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested (off by default)
 * [new-cap](new-cap.md) - require a capital letter for constructors
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments
+* [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after `var` statement (off by default)
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
 * [no-inline-comments](no-inline-comments.md) - disallow comments inline after code (off by default)
 * [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block (off by default)

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -1,0 +1,54 @@
+# Allow/disallow an empty newline after var statement (newline-after-var)
+
+As of today there is no consistency in separating variable declarations from the rest of the code. Some developers leave an empty line between var statements and the rest of the code like:
+
+        var foo;
+
+        // do something with foo
+
+Whereas others don't leave any empty newlines at all.
+
+        var foo;
+        // do something with foo
+
+The problem is when these developers work together in a project. This rule enforces a coding style where empty newlines are allowed or disallowed after `var` statement. It helps the code to look consistent across the entire project.
+
+## Rule Details
+
+This rule enforces a coding style where empty newlines are allowed or disallowed after `var` statement to achieve a consistent coding style across the project.
+Invalid option value (anything other than `always` nor `never`), defaults to `always`.
+
+The following patterns are considered warnings:
+
+```js
+// When [1, "always"]
+var greet = "hello,",
+    name = "world";
+console.log(greet, name);
+
+// When [1, "never"]
+var greet = "hello,",
+    name = "world";
+
+console.log(greet, name);
+
+// When [1, "unknown"] - considered to be "always"
+var greet = "hello,",
+    name = "world";
+console.log(greet, name);
+```
+
+The following patterns are not considered warnings:
+
+```js
+// When [1, "always"]
+var greet = "hello,",
+    name = "world";
+
+console.log(greet, name);
+
+// When [1, "never"]
+var greet = "hello,",
+    name = "world";
+console.log(greet, name);
+```

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -1,0 +1,45 @@
+/**
+ * @fileoverview Rule to check empty newline after "var" statement
+ * @author Gopal Venkatesan
+ * @copyright 2015 Gopal Venkatesan. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var mode = context.options[0],
+        validator;              // regex to validate the rule
+
+    if (mode === "never") {
+        validator = /\S(?:\r?\n)?\S/;
+    } else {                    // assume mode === "always"
+        validator = /\S(?:\r?\n){2,}\S?/;
+        mode = "always";
+    }
+
+    return {
+        "VariableDeclaration:exit": function(node) {
+            var lastToken = context.getLastToken(node),
+                nextToken = context.getTokenAfter(node),
+                // peek few characters beyond the last token (typically the semi-colon)
+                sourceLines = context.getSource(lastToken, 0, 3);
+
+            // Some coding styles like Google uses multiple `var` statements.
+            // So if the next token is a `var` statement don't do anything.
+            if (nextToken && nextToken.type === "Keyword" &&
+                (nextToken.value === "var" || nextToken.value === "let" || nextToken.value === "const")) {
+                return;
+            }
+
+            // Next statement is not a `var`
+            if (sourceLines && !sourceLines.match(validator)) {
+                context.report(node, "Newline is " + mode + " expected after a \"var\" statement.",
+                               { identifier: node.name });
+            }
+        }
+    };
+};

--- a/tests/lib/rules/newline-after-var.js
+++ b/tests/lib/rules/newline-after-var.js
@@ -1,0 +1,132 @@
+/**
+ * @fileoverview Tests for newline-after-var rule.
+ * @author Gopal Venkatesan
+ * @copyright 2015 Gopal Venkatesan. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+
+eslintTester.addRuleTest("lib/rules/newline-after-var", {
+    valid: [
+        { code: "var greet = 'hello'; console.log(greet);", options: ["never"] },
+        { code: "var greet = 'hello';\n\nconsole.log(greet);", options: ["always"] },
+        { code: "var greet = 'hello';\n\n\nconsole.log(greet);", options: ["always"] },
+        {
+            code: "var greet = 'hello'; var name = 'world';\n\n\nconsole.log(greet, name);",
+            options: ["always"]
+        },
+        {
+            code: "var greet = 'hello';\nvar name = 'world';\n\n\nconsole.log(greet, name);",
+            options: ["always"]
+        },
+        // invalid configuration option
+        {
+            code: "var greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
+            options: ["foobar"]
+        },
+        // es6 block bindings
+        {
+            code: "let greet = 'hello';\n\nconsole.log(greet);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            code: "let greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            code: "let greet = 'hello';\nconst name = 'world';\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            code: "const greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            code: "const greet = 'hello';\nlet name = 'world';\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        }
+    ],
+
+    invalid: [
+        {
+            code: "var greet = 'hello';\n\nconsole.log(greet);",
+            options: ["never"],
+            errors: [{
+                message: "Newline is never expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var greet = 'hello'; console.log(greet);",
+            options: ["always"],
+            errors: [{
+                message: "Newline is always expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "var greet = 'hello'; var name = 'world'; console.log(greet);",
+            options: ["always"],
+            errors: [{
+                message: "Newline is always expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        // es6 block bindings
+        {
+            code: "let greet = 'hello'; const name = 'world';\n\nconsole.log(greet);",
+            options: ["never"],
+            ecmaFeatures: { blockBindings: true },
+            errors: [{
+                message: "Newline is never expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "const greet = 'hello';\nlet name = 'world';\n\nconsole.log(greet, name);",
+            options: ["never"],
+            ecmaFeatures: { blockBindings: true },
+            errors: [{
+                message: "Newline is never expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        // invalid configuration option
+        {
+            code: "var greet = 'hello';\nvar name = 'world';\nconsole.log(greet, name);",
+            options: ["foobar"],
+            errors: [{
+                message: "Newline is always expected after a \"var\" statement.",
+                type: "VariableDeclaration"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
Allow/disallow empty newline after `var` statement.