### PR TITLE
Fix: no-unused-vars crash from escope workaround (fixes #2042)

### DIFF
--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -72,6 +72,9 @@ module.exports = function(context) {
     var NOT_DEFINED_MESSAGE = "'{{name}}' is not defined.",
         READ_ONLY_MESSAGE = "'{{name}}' is read only.";
 
+    // TODO: Remove once escope is updated
+    var hackedImports = [];
+
     /**
      * Compare an identifier with the variables declared in the scope
      * @param {ASTNode} node - Identifier or JSXIdentifier node
@@ -110,6 +113,7 @@ module.exports = function(context) {
             variable = new escope.Variable(node.local.name, scope);
         variable.defs.push(node);
         scope.variables.push(variable);
+        hackedImports.push(variable);
     }
 
     return {
@@ -141,6 +145,11 @@ module.exports = function(context) {
                 } else if (ref.isWrite() && variable.writeable === false) {
                     context.report(ref.identifier, READ_ONLY_MESSAGE, { name: name });
                 }
+            });
+
+            // TODO: Remove once escope is updated
+            globalScope.variables = globalScope.variables.filter(function (variable) {
+                return hackedImports.indexOf(variable) < 0;
             });
         },
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -2308,6 +2308,18 @@ describe("eslint", function() {
 
             assert.equal(messages.length, 0);
         });
+
+        // TODO: Remove when escope is updated
+        it("should not crash due to no-undef mutating escope data", function () {
+            var code = "import foo from 'bar';";
+            eslint.verify(code, {
+                ecmaFeatures: { modules: true },
+                rules: {
+                    "no-undef": 2,
+                    "no-unused-vars": 2
+                }
+            }, "filename");
+        });
     });
 
     describe("Edge cases", function() {


### PR DESCRIPTION
Since this fixes an issue that crosses two rules, I'm not really sure how to test it other than manually, which I've done. Suggestions are welcome.