### PR TITLE
Fix: no-undef should check Node.js scope for variables used in JSX (fixes #2093)

### DIFF
--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -90,6 +90,9 @@ module.exports = function(context) {
             scope = scope.upper;
             variables = scope.variables.concat(variables);
         }
+        if (scope.childScopes.length) {
+            variables = scope.childScopes[0].variables.concat(variables);
+        }
 
         for (i = 0, len = variables.length; i < len; i++) {
 

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -43,6 +43,7 @@ eslintTester.addRuleTest("lib/rules/no-undef", {
         "if (typeof a === 'undefined') {}",
         { code: "var toString = 1;", ecmaFeatures: { globalReturn: true }},
         { code: "function myFunc(...foo) {  return foo;}", ecmaFeatures: { restParams: true } },
+        { code: "var App; <App />;", args: [1, {vars: "all"}], ecmaFeatures: { globalReturn: true, jsx: true } },
         { code: "var React, App; React.render(<App />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var React; React.render(<img />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },
         { code: "var React; React.render(<x-gif />);", args: [1, {vars: "all"}], ecmaFeatures: { jsx: true } },


### PR DESCRIPTION
Updated no-undef to add the Node.js scope variables to the variables list in the `checkIdentifierInJSX` function.