### PR TITLE
Fix: func-names with ES6 classes (fixes #2103)

### DIFF
--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -15,15 +15,18 @@ module.exports = function(context) {
 
     /**
      * Determines whether the current FunctionExpression node is a get, set, or
-     * shorthand method in an object literal.
+     * shorthand method in an object literal or a class.
      * @returns {boolean} True if the node is a get, set, or shorthand method.
      */
-    function isObjectMethod() {
+    function isObjectOrClassMethod() {
         var parent = context.getAncestors().pop();
-        return (parent.type === "Property" && (
-            parent.method ||
-            parent.kind === "get" ||
-            parent.kind === "set"
+
+        return (parent.type === "MethodDefinition" || (
+            parent.type === "Property" && (
+                parent.method ||
+                parent.kind === "get" ||
+                parent.kind === "set"
+            )
         ));
     }
 
@@ -32,7 +35,7 @@ module.exports = function(context) {
 
             var name = node.id && node.id.name;
 
-            if (!name && !isObjectMethod()) {
+            if (!name && !isObjectOrClassMethod()) {
                 context.report(node, "Missing function expression name.");
             }
         }

--- a/tests/lib/rules/func-names.js
+++ b/tests/lib/rules/func-names.js
@@ -30,6 +30,10 @@ eslintTester.addRuleTest("lib/rules/func-names", {
         {
             code: "({ foo() { return 1; } });",
             ecmaFeatures: { objectLiteralShorthandMethods: true }
+        },
+        {
+            code: "class A { constructor(){} foo(){} get bar(){} set baz(value){} static qux(){}}",
+            ecmaFeatures: { classes: true }
         }
     ],
     invalid: [


### PR DESCRIPTION
Now works on constructor, getters, setters, static, and normal functions inside a class.