### PR TITLE
New: Add "always" and "never" options to "one-var" rule. (fixes #1619)

### DIFF
--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -13,6 +13,8 @@ function foo() {
 
 This rule is aimed at preventing a possible misunderstanding about scoping of variables and to enforce a single variable declaration convention. As such, it will warn when it encounters more than one variable declaration statement in a function scope.
 
+When configured with `"always"` as the first option (the default), the following patterns are considered warnings:
+
 The following patterns are considered warnings:
 
 ```js
@@ -44,6 +46,41 @@ function foo() {
 
     if (baz) {
         qux = true;
+    }
+}
+```
+
+When configured with `"never"` as the first option, the following patterns are considered warnings:
+
+```js
+function foo() {
+    var bar,
+        baz;
+}
+
+function foo() {
+    var bar,
+        qux;
+
+    if (baz) {
+        qux = true;
+    }
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+function foo() {
+    var bar;
+    var baz;
+}
+
+function foo() {
+    var bar;
+
+    if (baz) {
+        var qux = true;
     }
 }
 ```

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview A rule to ensure the use of a single variable declaration.
  * @author Ian Christian Myers
+ * @copyright 2015 Danny Fritz. All rights reserved.
  * @copyright 2013 Ian Christian Myers. All rights reserved.
  */
 
@@ -12,25 +13,43 @@
 
 module.exports = function(context) {
 
+    var MODE = context.options[0] || "always";
+
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
     var functionStack = [];
 
+    /**
+     * Increments the functionStack counter.
+     * @returns {void}
+     * @private
+     */
     function startFunction() {
         functionStack.push(false);
     }
 
+    /**
+     * Decrements the functionStack counter.
+     * @returns {void}
+     * @private
+     */
     function endFunction() {
         functionStack.pop();
     }
 
-    function checkDeclarations(node) {
+    /**
+     * Determines if there is more than one var statement in the current scope.
+     * @returns {boolean} Returns true if it is the first var declaration, false if not.
+     * @private
+     */
+    function hasOnlyOneVar() {
         if (functionStack[functionStack.length - 1]) {
-            context.report(node, "Combine this with the previous 'var' statement.");
+            return true;
         } else {
             functionStack[functionStack.length - 1] = true;
+            return false;
         }
     }
 
@@ -44,7 +63,18 @@ module.exports = function(context) {
         "FunctionExpression": startFunction,
         "ArrowFunctionExpression": startFunction,
 
-        "VariableDeclaration": checkDeclarations,
+        "VariableDeclaration": function(node) {
+            var declarationCount = node.declarations.length;
+            if (MODE === "never") {
+                if (declarationCount > 1) {
+                    context.report(node, "Split 'var' declaration into multiple statements.");
+                }
+            } else {
+                if (hasOnlyOneVar()) {
+                    context.report(node, "Combine this with the previous 'var' statement.");
+                }
+            }
+        },
 
         "Program:exit": endFunction,
         "FunctionDeclaration:exit": endFunction,

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -19,7 +19,26 @@ eslintTester.addRuleTest("lib/rules/one-var", {
     valid: [
         "function foo() { var bar = true; }",
         "function foo() { var bar = true, baz = 1; if (qux) { bar = false; } }",
-        "var foo = function () { var bar = true; baz(); }"
+        "var foo = function () { var bar = true; baz(); }",
+        {
+            code: "function foo() { var bar = true, baz = false; }",
+            args: [2, "always"]
+        },
+        {
+            code: "function foo() { var bar = true; var baz = false; }",
+            args: [2, "never"]
+        },
+        {
+            code: "function foo() { var bar = true; var baz = false; }",
+            args: [2, "never"]
+        },
+        {
+            code: "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
+            ecmaFeatures: {
+                destructuring: true
+            },
+            args: [2, "never"]
+        }
     ],
     invalid: [
         {
@@ -80,6 +99,33 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                     type: "VariableDeclaration"
                 }
             ]
+        },
+        {
+            code: "function foo() { var bar = true, baz = false; }",
+            args: [2, "never"],
+            errors: [{
+                message: "Split 'var' declaration into multiple statements.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { var bar = true; var baz = false; }",
+            args: [2, "always"],
+            errors: [{
+                message: "Combine this with the previous 'var' statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
+            ecmaFeatures: {
+                destructuring: true
+            },
+            args: [2, "always"],
+            errors: [{
+                message: "Combine this with the previous 'var' statement.",
+                type: "VariableDeclaration"
+            }]
         }
     ]
 });


### PR DESCRIPTION
This adds options to the "one-var" rule:
* `"always"`: Enforce there is one `var` statement in any scope. (default) *(existing behavior)*
* `"never"`: Enforce there is only one declaration per `var` statement. *(new behavior)*

per #1619 and a continuation of https://github.com/eslint/eslint/pull/2109