### PR TITLE
Docs: Adding back deprecated space-unary-word-ops documentation

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -171,6 +171,7 @@ These rules are purely matters of style and are quite subjective.
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators
 * [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`
 * [space-unary-ops](space-unary-ops.md) - Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
+* [space-unary-word-ops](space-unary-word-ops.md) - **(deprecated)** Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
 * [spaced-line-comment](spaced-line-comment.md) - require or disallow a space immediately following the `//` in a line comment (off by default)
 * [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses (off by default)
 

--- a/docs/rules/space-unary-word-ops.md
+++ b/docs/rules/space-unary-word-ops.md
@@ -1,0 +1,39 @@
+# Require spaces following unary word operators (space-unary-word-ops)
+
+**Deprecation notice**: This rule is deprecated and has been superseded by the [space-unary-ops](space-unary-ops.md) rule. It has be removed in ESLint v0.10.0.
+
+Require spaces following unary word operators.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+typeof!a
+```
+
+```js
+void{a:0}
+```
+
+```js
+new[a][0]
+```
+
+```js
+delete(a.b)
+```
+
+The following patterns are not considered warnings:
+
+```js
+delete a.b
+```
+
+```js
+new C
+```
+
+```js
+void 0
+```


### PR DESCRIPTION
Documentation for this rule has been removed completely from the repository. Adding it back and marking it as deprecated. (Google is complaining about it).