### PR TITLE
New: Allow modified base configuration

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -223,6 +223,10 @@ function Config(options) {
     this.baseConfig = options.reset ? { rules: {} } :
             require(path.resolve(__dirname, "..", "conf", "eslint.json"));
 
+    if (options.baseConfig) {
+        this.baseConfig = util.mergeConfigs(this.baseConfig, options.baseConfig);
+    }
+
     this.baseConfig.format = options.format;
     this.useEslintrc = (options.useEslintrc !== false);
 

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -89,6 +89,31 @@ describe("Config", function() {
         rm("-r", fixtureDir);
     });
 
+    describe("when given modified base configuration", function() {
+
+        it("should merge to original one", function() {
+            var configHelper = new Config({
+                    baseConfig: {
+                        parser: "babel-eslint",
+                        env: {
+                            node: true
+                        },
+                        rules: {
+                            strict: [2, "global"]
+                        }
+                    }
+                }),
+                expected = util.mergeConfigs({}, baseConfig),
+                actual = configHelper.baseConfig;
+
+            expected.parser = "babel-eslint";
+            expected.env.node = true;
+            expected.rules.strict = [2, "global"];
+
+            assertConfigsEqual(expected, actual);
+        });
+    });
+
     describe("findLocalConfigFiles()", function() {
 
         it("should return the path when an .eslintrc file is found", function() {


### PR DESCRIPTION
Hi,

A modified base configuration is needed sometimes, for example: changing to another parser with the option to revert back to original `espree` parser in `.eslintrc` files.

I think this is a small feature so I make a pull request without filing an issue first. If it is not according to your roadmap, let me know. Thank you.

P/S: I signed CLA as well.