### PR TITLE
New: no-const-reassign rule (fixes #2097)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -19,6 +19,7 @@
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
+        "no-const-reassign": 0,
         "no-control-regex": 2,
         "no-debugger": 2,
         "no-delete-var": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -10,6 +10,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-comma-dangle](no-comma-dangle.md) - **(deprecated)** disallow trailing commas in object literals (off by default)
 * [no-cond-assign](no-cond-assign.md) - disallow assignment in conditional expressions
 * [no-console](no-console.md) - disallow use of `console` (off by default in the node environment)
+* [no-const-reassign](no-const-reassign.md) - Disallows reassignment of const declarations. (off by default)
 * [no-constant-condition](no-constant-condition.md) - disallow use of constant expressions in conditions
 * [no-control-regex](no-control-regex.md) - disallow control characters in regular expressions
 * [no-debugger](no-debugger.md) - disallow use of `debugger`

--- a/docs/rules/no-const-reassign.md
+++ b/docs/rules/no-const-reassign.md
@@ -1,0 +1,59 @@
+# Disallow Reassignment of const Declarations (no-const-reassign)
+
+Reassigning declarations of const should result in a SyntaxError in both strict and non-strict mode, unfortunately there are still platforms which allow the assigment to fail silently.
+
+```js
+const a = 'a';
+a = 'b'; // Should throw an error
+```
+
+There are still environments where reassignment of const declarations will fail silently.
+
+For full coverage see the following resouces;
+
+* http://kangax.github.io/compat-table/es6/#const_redefining_a_const_is_an_error
+* http://kangax.github.io/compat-table/es6/#const_redefining_a_const_(strict_mode)
+
+## Rule Details
+
+This rule is aimed at eliminating errors and silent defects in code by ensuring that constants are not assigned more then once.
+
+The following patterns are considered warnings:
+
+```js
+const a = 'a';
+a = 'b';
+```
+
+```js
+const b = 0;
+++b;
+```
+
+```js
+const c = {};
+delete c;
+```
+
+The following patterns are not considered warnings:
+
+```js
+const a;
+```
+
+```js
+const b = {};
+b.a = 'a';
+delete b.a;
+b.b = 0;
+++b.b;
+```
+
+### Options
+
+This rule does not require or provide any options
+
+
+## When Not to Use It
+
+If you are not using es6 features, you can safely disable this rule.

--- a/lib/rules/no-const-reassign.js
+++ b/lib/rules/no-const-reassign.js
@@ -1,0 +1,137 @@
+/**
+ * @fileoverview Rule to flag reassignments of constants.
+ * @author Jason Brumwell
+ * @copyright 2015 Jason Brumwell. All rights reserved
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var MESSAGE = "Invalid assignment to const {{name}}.";
+
+    /**
+     * Check if a node is a unary delete expression
+     *
+     * @param {ASTNode} node - The node to compare
+     * @returns {boolean} True if it's a unary delete expression, false if not.
+     * @private
+    */
+    function isDeleted(node) {
+        return (
+            node &&
+            node.type === "UnaryExpression" &&
+            node.operator === "delete" &&
+            node.argument.type === "Identifier"
+        );
+    }
+
+    /**
+     * Determines if the reference should be counted as a re-assignment
+     *
+     * @param {Reference} ref The reference to check.
+     * @returns {boolean} True if it's a valid reassignment, false if not.
+     * @private
+    */
+    function isReassignment(ref) {
+        var isWrite = (ref.isWrite() || !ref.isReadOnly());
+
+        if (!isWrite && isDeleted(ref.identifier.parent)) {
+            isWrite = true;
+        }
+
+        return isWrite;
+    }
+
+    /**
+     * Report a reference as invalid
+     *
+     * @param {string} name - the variables name
+     * @param {Reference} ref - the reference to report
+     * @returns {void}
+     * @private
+    */
+    function report(name, ref) {
+        context.report(ref.identifier, MESSAGE, {name: name});
+    }
+
+    /**
+     * Assigns references to corresponding variable
+     *
+     * @param {Scope} scope - an escope object
+     * @param {Variable} variable - variable to apply references too
+     * @returns {Variable} returns the variable with references
+     * @private
+    */
+    function transformGlobalVariables(scope, variable) {
+        scope.references.forEach(function(ref) {
+            if (ref.identifier.name === variable.name) {
+                variable.references.push(ref);
+            }
+        });
+
+        return variable;
+    }
+
+    /**
+     * Checks for and reports reassigned constants
+     *
+     * @param {Scope} scope - an escope Scope object
+     * @returns {void}
+     * @private
+    */
+    function checkScope(scope) {
+        var variables = scope.variables;
+
+        if (!scope.functionExpressionScope) {
+            for (var i = 0, l = variables.length; i < l; ++i) {
+                // skip implicit "arguments" variable
+                if (scope.type === "function" && variables[i].name === "arguments" && variables[i].identifiers.length === 0) {
+                    continue;
+                }
+
+                var def = variables[i].defs[0];
+
+                // only constants
+                if (!def || def.kind !== "const") {
+                    continue;
+                }
+
+                var variable = variables[i];
+                var references = variable.references;
+                var name = variable.name;
+                var assignments = references.filter(isReassignment);
+
+                if (assignments.length > 1) {
+                    // remove original assigment
+                    assignments.shift();
+
+                    assignments.forEach(report.bind(null, name));
+                }
+            }
+        }
+
+        scope.childScopes.forEach(checkScope);
+    }
+
+    return {
+        "Program:exit": function() {
+            if (context.ecmaFeatures.blockBindings) {
+                var scope = context.getScope();
+
+                if (scope.type === "global") {
+                    scope = {
+                        childScopes: scope.childScopes,
+                        variables: scope.variables.map(transformGlobalVariables.bind(null, scope))
+                    };
+                }
+
+                checkScope(scope);
+            }
+        }
+    };
+
+};

--- a/tests/lib/rules/no-const-reassign.js
+++ b/tests/lib/rules/no-const-reassign.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Tests for no-constant-reassigment rule.
+ * @author Jason Brumwell
+ * @copyright 2015 Jason Brumwell. All rights reserved
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-const-reassign", {
+    valid: [
+        {code: "var a = 'a'; a = 'b';"},
+        {code: "let a = 'a'; a = 'b';", ecmaFeatures: { blockBindings: true }},
+        {code: "const a = 'a';", ecmaFeatures: { blockBindings: true }},
+        {code: "const a = {};", ecmaFeatures: { blockBindings: true }},
+        {code: "const a = 0;", ecmaFeatures: { blockBindings: true }},
+        {code: "const {a, b} = [1, 2];", ecmaFeatures: { blockBindings: true, destructuring: true }},
+        {code: "const a = {}; a.a = 'a'; delete a.a; a.r = 0; ++a.r;", ecmaFeatures: { blockBindings: true }}
+    ],
+    invalid: [
+        {code: "const {a, b} = [1, 2]; a = 3;", errors: [{ message: "Invalid assignment to const a."}], ecmaFeatures: { blockBindings: true, destructuring: true }},
+        {code: "const b = 'b'; b = 'c';", errors: [{ message: "Invalid assignment to const b."}], ecmaFeatures: { blockBindings: true }},
+        {code: "const c = 0; ++c;", errors: [{ message: "Invalid assignment to const c."}], ecmaFeatures: { blockBindings: true }},
+        {code: "function test() { const d = 0; delete d; }", errors: [{ message: "Invalid assignment to const d."}], ecmaFeatures: { blockBindings: true }}
+    ]
+});


### PR DESCRIPTION
The aim of this rule;

Variables that are declared as constants but are later reassigned, are no longer constant, and should be declared with let or var.

fixes: https://github.com/eslint/eslint/issues/2158