### PR TITLE
Fix: Ensure piped in code will trigger correct errors (fixes #2154)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -7,7 +7,13 @@ var exitCode = 0,
 
 if (useStdIn) {
     process.stdin.pipe(concat({ encoding: "string" }, function(text) {
-        exitCode = cli.execute(process.argv, text);
+        try {
+            exitCode = cli.execute(process.argv, text);
+        } catch (ex) {
+            console.error(ex.message);
+            console.error(ex.stack);
+            exitCode = 1;
+        }
     }));
 } else {
     exitCode = cli.execute(process.argv);

--- a/lib/config.js
+++ b/lib/config.js
@@ -55,6 +55,7 @@ function loadConfig(filePath) {
         try {
             config = yaml.safeLoad(stripComments(fs.readFileSync(filePath, "utf8"))) || {};
         } catch (e) {
+            debug("Error reading YAML file: " + filePath);
             e.message = "Cannot read config file: " + filePath + "\nError: " + e.message;
             throw e;
         }
@@ -136,6 +137,7 @@ function getLocalConfig(thisConfig, directory) {
         numFiles = localConfigFiles.length;
 
     for (i = 0; i < numFiles; i++) {
+
         localConfigFile = localConfigFiles[i];
         localConfig = loadConfig(localConfigFile);
 
@@ -259,7 +261,7 @@ Config.prototype.getConfig = function (filePath) {
         directory = filePath ? path.dirname(filePath) : process.cwd(),
         pluginConfig;
 
-    debug("Constructing config for " + filePath);
+    debug("Constructing config for " + (filePath ? filePath : "text"));
 
     config = this.cache[directory];
 


### PR DESCRIPTION
This is a bit gross. `bin/eslint.js` is the one file we don't have unit tests for, but I verified this is working.

The error was being swallowed because the method was being called in a callback.