### PR TITLE
New: no-continue rule (fixes #1945)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -19,6 +19,7 @@
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
+        "no-continue": 0,
         "no-control-regex": 2,
         "no-debugger": 2,
         "no-delete-var": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -144,6 +144,7 @@ These rules are purely matters of style and are quite subjective.
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments
 * [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after `var` statement (off by default)
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
+* [no-continue](no-continue.md) - disallow use of the `continue` statement (off by default)
 * [no-inline-comments](no-inline-comments.md) - disallow comments inline after code (off by default)
 * [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block (off by default)
 * [no-mixed-spaces-and-tabs](no-mixed-spaces-and-tabs.md) - disallow mixed spaces and tabs for indentation

--- a/docs/rules/no-continue.md
+++ b/docs/rules/no-continue.md
@@ -1,0 +1,66 @@
+# Disallow continue (no-continue)
+
+The `continue` statement terminates execution of the statements in the current iteration of the current or labeled loop, and continues execution of the loop with the next iteration. When used incorrectly it makes code less testable, less readable and less maintainable. Structured control flow statements such as `if` should be used instead.
+
+```js
+var sum = 0,
+    i;
+
+for(i = 0; i < 10; i++) {
+    if(i >= 5) {
+        continue;
+    }
+
+    a += i;
+}
+```
+
+## Rule Details
+
+This rule is aimed at preventing the use of `continue` statement.
+As such it warns whenever it sees `continue` statement.
+
+The following patterns are considered warnings:
+
+```js
+var sum = 0,
+    i;
+
+for(i = 0; i < 10; i++) {
+    if(i >= 5) {
+        continue;
+    }
+
+    a += i;
+}
+```
+
+```js
+var sum = 0,
+    i;
+
+labeledLoop: for(i = 0; i < 10; i++) {
+    if(i >= 5) {
+        continue labeledLoop;
+    }
+
+    a += i;
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+var sum = 0,
+    i;
+
+for(i = 0; i < 10; i++) {
+    if(i < 5) {
+       a += i;
+    }
+}
+```
+
+## Compatibility
+
+* **JSLint**: `continue`

--- a/lib/rules/no-continue.js
+++ b/lib/rules/no-continue.js
@@ -1,0 +1,21 @@
+/**
+ * @fileoverview Rule to flag use of continue statement
+ * @author Borislav Zhivkov
+ * @copyright 2015 Borislav Zhivkov. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+        "ContinueStatement": function(node) {
+            context.report(node, "Unexpected use of continue statement");
+        }
+    };
+
+};

--- a/tests/lib/rules/no-continue.js
+++ b/tests/lib/rules/no-continue.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Tests for no-continue rule.
+ * @author Borislav Zhivkov
+ * @copyright 2015 Borislav Zhivkov. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-continue", {
+    valid: [
+        "var sum = 0, i; for(i = 0; i < 10; i++){ if(i > 5) { sum += i; } }",
+        "var sum = 0, i = 0; while(i < 10) { if(i > 5) { sum += i; } i++; }"
+    ],
+
+    invalid: [
+        {
+            code: "var sum = 0, i; for(i = 0; i < 10; i++){ if(i <= 5) { continue; } sum += i; }",
+            errors: [{ message: "Unexpected use of continue statement",
+            type: "ContinueStatement"}]
+        },
+        {
+            code: "var sum = 0, i; myLabel: for(i = 0; i < 10; i++){ if(i <= 5) { continue myLabel; } sum += i; }",
+            errors: [{ message: "Unexpected use of continue statement",
+            type: "ContinueStatement"}]
+        },
+        {
+            code: "var sum = 0, i = 0; while(i < 10) { if(i <= 5) { i++; continue; } sum += i; i++; }",
+            errors: [{ message: "Unexpected use of continue statement",
+            type: "ContinueStatement"}]
+        },
+        {
+            code: "var sum = 0, i = 0; myLabel: while(i < 10) { if(i <= 5) { i++; continue myLabel; } sum += i; i++; }",
+            errors: [{ message: "Unexpected use of continue statement",
+            type: "ContinueStatement"}]
+        }
+    ]
+});


### PR DESCRIPTION
The aim of the rule is to warn the user when `continue` statement is used.

fixes: #1945