### PR TITLE
Build: Fixing site generation

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -331,7 +331,7 @@ target.gensite = function() {
             }
 
             // 6. Remove .md extension for links and change README to empty string
-            text = text.replace(/\.md(.*\))/g, "").replace("README.html", "");
+            text = text.replace(/\.md(.*?\))/g, ")").replace("README.html", "");
 
             // 7. Append first version of ESLint rule was added at.
             if (filename.indexOf("rules/") !== -1 && baseName !== "README.md") {


### PR DESCRIPTION
Fixes #2171 
This was my fault. I didn't verify site generation after removing `.html` from links. I'll regenerate the site and push updated documentation.