### PR TITLE
New: binop-style rule

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -106,6 +106,7 @@
         "no-with": 2,
         "no-wrap-func": 2,
 
+        "binop-style": 0,
         "block-scoped-var": 0,
         "brace-style": [0, "1tbs"],
         "camelcase": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -130,6 +130,7 @@ These rules are specific to JavaScript running on Node.js.
 These rules are purely matters of style and are quite subjective.
 
 * [indent](indent.md) - this option sets a specific tab width for your code (off by default)
+* [binop-style](binop-style.md) - enforce one true binary operator style (off by default)
 * [brace-style](brace-style.md) - enforce one true brace style (off by default)
 * [camelcase](camelcase.md) - require camel case names
 * [comma-spacing](comma-spacing.md) - enforce spacing before and after comma

--- a/docs/rules/binop-style.md
+++ b/docs/rules/binop-style.md
@@ -1,0 +1,136 @@
+# Binary Operator style (binop-style)
+
+Binary operator Style rule enforces binary operators next to a line break to be placed at the end of the previous line of at the beginning of the new line.
+
+
+## Rule Details
+
+This rule is aimed at enforcing a particular binary operator style in JavaScript. As such, it warns whenever it sees a binary expression, logical expression, assignment expression or variable declarator that does not adhere to a particular binary operator style. It doesn't support cases where there are line breaks before and after the operator (lone operator). It also avoids single line expression cases.
+
+### Options
+
+The rule takes an option, a string, which could be either "last" or "first". The default is "last".
+
+You can set the style in configuration like this:
+
+```json
+"binop-style": [2, "first"]
+```
+
+#### "last"
+
+This is the default setting for this rule. This option requires that the operator be placed after and be in the same line as the last expression of the line.
+
+While using this setting, the following patterns are considered warnings:
+
+```js
+
+foo = 1
++ //lone operator
+2;
+
+foo = 1
+    + 2;
+
+
+foo
+    = 5;
+
+if (someCondition
+    || otherCondition) {
+}
+```
+
+The following patterns are not warnings:
+
+```js
+
+foo = 1 + 2;
+
+foo = 1 +
+      2;
+
+
+foo =
+    5;
+
+if (someCondition ||
+    otherCondition) {
+}
+
+```
+
+#### "first"
+
+This option requires that the operator be placed before and be in the same line as the first expression of the line.
+
+While using this setting, the following patterns are considered warnings:
+
+```js
+
+foo = 1 +
+      2;
+
+
+foo =
+    5;
+
+if (someCondition ||
+    otherCondition) {
+}
+
+```
+
+The following patterns are not warnings:
+
+```js
+
+foo = 1 + 2;
+
+foo = 1
+    + 2;
+
+foo
+    = 5;
+
+if (someCondition
+    || otherCondition) {
+}
+
+```
+
+#### Exceptions
+
+Exceptions of the following nodes may be passed in order to tell eslint to ignore nodes of certain types.
+```
+BinaryExpression,
+LogicalExpression,
+AssignmentExpression,
+VariableDeclarator
+```
+
+An example use case is if a user didn't want to enforce operator style in assignments.
+The following code would lint.
+
+```
+/* eslint binop-style: [2, "first", {exceptions: {VariableDeclarator: true} }] */
+var o =
+    something;
+```
+
+Whereas the following would not.
+```
+/* eslint binop-style: [2, "first", {exceptions: {VariableDeclarator: true} }] */
+var o =
+    something +
+    otherthing;
+```
+
+## When Not To Use It
+
+If your project will not be using one true binary operator style, turn this rule off.
+
+## Related Rules
+
+* [comma-style](comma-style.md)
+* [brace-style](brace-style.md)

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -159,3 +159,8 @@ For the first option in comma-style rule:
 * [A better coding convention for lists and object literals in JavaScript by isaacs](https://gist.github.com/isaacs/357981)
 * [npm coding style guideline](https://www.npmjs.org/doc/misc/npm-coding-style.html)
 
+
+## Related Rules
+
+* [binop-style](binop-style.md)
+* [brace-style](brace-style.md)

--- a/lib/rules/binop-style.js
+++ b/lib/rules/binop-style.js
@@ -1,0 +1,104 @@
+/**
+ * @fileoverview Binary binary operator style - enforces binary operator styles of two types: last and first
+ * @author Benoît Zugmeyer
+ * @copyright 2015 Benoît Zugmeyer. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var style = context.options[0] || "last",
+        exceptions = {};
+
+    if (context.options.length === 2 && context.options[1].hasOwnProperty("exceptions")) {
+        exceptions = context.options[1].exceptions;
+    }
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Checks whether two tokens are on the same line.
+     * @param {ASTNode} left The leftmost token.
+     * @param {ASTNode} right The rightmost token.
+     * @returns {boolean} True if the tokens are on the same line, false if not.
+     * @private
+     */
+    function isSameLine(left, right) {
+        return left.loc.end.line === right.loc.start.line;
+    }
+
+    /**
+     * Checks the operator placement
+     * @param {ASTNode} node The binary operator node to check
+     * @private
+     * @returns {void}
+     */
+    function validateBinaryExpression(node) {
+        var leftToken = context.getLastToken(node.left || node.id);
+        var operatorToken = context.getTokenAfter(leftToken);
+        var rightToken = context.getTokenAfter(operatorToken);
+        var operator = operatorToken.value;
+
+        // if single line
+        if (isSameLine(operatorToken, leftToken) &&
+                isSameLine(rightToken, operatorToken)) {
+
+            return;
+
+        } else if (!isSameLine(operatorToken, leftToken) &&
+                !isSameLine(rightToken, operatorToken)) {
+
+            // lone operator
+            context.report(node, {
+                line: operatorToken.loc.end.line,
+                column: operatorToken.loc.start.column
+            }, "Bad line breaking before and after '" + operator + "'.");
+
+        } else if (style === "first" && isSameLine(operatorToken, leftToken)) {
+
+            context.report(node, "'" + operator + "' should be placed first.");
+
+        } else if (style === "last" && isSameLine(operatorToken, rightToken)) {
+
+            context.report(node, {
+                line: operatorToken.loc.end.line,
+                column: operatorToken.loc.end.column
+            }, "'" + operator + "' should be placed last.");
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    var nodes = {};
+
+    if (!exceptions.BinaryExpression) {
+        nodes.BinaryExpression = validateBinaryExpression;
+    }
+
+    if (!exceptions.LogicalExpression) {
+        nodes.LogicalExpression = validateBinaryExpression;
+    }
+
+    if (!exceptions.AssignmentExpression) {
+        nodes.AssignmentExpression = validateBinaryExpression;
+    }
+
+    if (!exceptions.VariableDeclarator) {
+        nodes.VariableDeclarator = function (node) {
+            if (node.init) {
+                validateBinaryExpression(node);
+            }
+        };
+    }
+
+    return nodes;
+};

--- a/tests/lib/rules/binop-style.js
+++ b/tests/lib/rules/binop-style.js
@@ -1,0 +1,152 @@
+/**
+ * @fileoverview Binary operator style
+ * @author Benoît Zugmeyer
+ * @copyright 2015 Benoît Zugmeyer. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var util = require("util");
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+var BAD_LN_BRK_MSG = "Bad line breaking before and after '%s'.",
+    FIRST_MSG = "'%s' should be placed first.",
+    LAST_MSG = "'%s' should be placed last.";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/binop-style", {
+
+    valid: [
+        "1 + 1",
+        "1 + 1 + 1",
+        "1 +\n1",
+        "1 + (1 +\n1)",
+        "f(1 +\n1)",
+        "1 || 1",
+        "1 || \n1",
+        "a += 1",
+        "var a;",
+
+        {code: "1\n+ 1", args: ["2", "first"]},
+        {code: "1 + 1\n+ 1", args: ["2", "first"]},
+        {code: "f(1\n+ 1)", args: ["2", "first"]},
+        {code: "1 \n|| 1", args: ["2", "first"]},
+        {code: "a += 1", args: ["2", "first"]},
+        {
+            code: "var o = \nsomething",
+            args: ["2", "first", {exceptions: {VariableDeclarator: true}}]
+        },
+        {
+            code: "o = \nsomething",
+            args: ["2", "first", {exceptions: {AssignmentExpression: true}}]
+        }
+    ],
+
+    invalid: [
+        {
+            code: "1\n+ 1",
+            errors: [{
+                message: util.format(LAST_MSG, "+"),
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "1 + 2 \n + 3",
+            errors: [{
+                message: util.format(LAST_MSG, "+"),
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "1\n+\n1",
+            errors: [{
+                message: util.format(BAD_LN_BRK_MSG, "+"),
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "1 + (1\n+ 1)",
+            errors: [{
+                message: util.format(LAST_MSG, "+"),
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "f(1\n+ 1);",
+            errors: [{
+                message: util.format(LAST_MSG, "+"),
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "1 \n || 1",
+            errors: [{
+                message: util.format(LAST_MSG, "||"),
+                type: "LogicalExpression"
+            }]
+        },
+        {
+            code: "a\n += 1",
+            errors: [{
+                message: util.format(LAST_MSG, "+="),
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "var a\n = 1",
+            errors: [{
+                message: util.format(LAST_MSG, "="),
+                type: "VariableDeclarator"
+            }]
+        },
+
+        {
+            code: "1 +\n1",
+            args: [2, "first"],
+            errors: [{
+                message: util.format(FIRST_MSG, "+"),
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "f(1 +\n1);",
+            args: [2, "first"],
+            errors: [{
+                message: util.format(FIRST_MSG, "+"),
+                type: "BinaryExpression"
+            }]
+        },
+        {
+            code: "1 || \n 1",
+            args: [2, "first"],
+            errors: [{
+                message: util.format(FIRST_MSG, "||"),
+                type: "LogicalExpression"
+            }]
+        },
+        {
+            code: "a += \n1",
+            args: [2, "first"],
+            errors: [{
+                message: util.format(FIRST_MSG, "+="),
+                type: "AssignmentExpression"
+            }]
+        },
+        {
+            code: "var a = \n1",
+            args: [2, "first"],
+            errors: [{
+                message: util.format(FIRST_MSG, "="),
+                type: "VariableDeclarator"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
The code is heavily inspired from the `comma-style` rule. It applies on any node containing an infix operator: `BinaryExpression`, `LogicalExpression`, `AssignmentExpression` and `VariableDeclarator`. Each node types may be removed with the `exceptions` argument (like the `comma-style` rule).

Obviously I'm open to comments.

This is my first `eslint` contribution, I tried my best to apply all the contribution rule, but tell me if I missed something.