### PR TITLE
Fix: Add linting of Markdown files to "npm test" script (fixes #2182)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 
 Please sign our [Contributor License Agreement](http://eslint.org/cla)
 
-# Full Documentation
+## Full Documentation
 
 Our full contribution guidelines can be found at:
 http://eslint.org/docs/developer-guide/contributing.html

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -370,9 +370,9 @@ Because rules are highly personal (and therefore very contentious), the followin
 * If the same rule exists in JSHint and is turned on by default, it must have the same message and be enabled by default.
 * If the same rule exists in JSLint but not in JSHint, it must have the same message and be disabled by default.
 * If the rule doesn't exist in JSHint or JSLint, then it must:
-  * Not be library-specific.
-  * Demonstrate a possible issue that can be resolved by rewriting the code.
-  * Be general enough so as to apply for a large number of developers.
+    * Not be library-specific.
+    * Demonstrate a possible issue that can be resolved by rewriting the code.
+    * Be general enough so as to apply for a large number of developers.
 
 ## Runtime Rules
 

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -1,6 +1,6 @@
 # Comma style (comma-style)
 
-Comma Style rule enforces comma styles for a list of things separated by commas. There are two comma styles primarily in javascript. The standard one in which commas are placed at the end of the line. And Comma-First, in which, commas are placed at the start of the next line after the list item.
+Comma Style rule enforces comma styles for a list of things separated by commas. There are two comma styles primarily in JavaScript. The standard one in which commas are placed at the end of the line. And Comma-First, in which, commas are placed at the start of the next line after the list item.
 
 One of the justifications for using Comma-First is that it helps tracking missing and trailing commas.
 In case linting is turned off, missing commas in variable declarations lead to leakage of global variables and trailing commas lead to errors in older versions of IE.
@@ -122,7 +122,8 @@ function bar() {
 
 #### Exceptions
 
-Exceptions of the following nodes may be passed in order to tell eslint to ignore nodes of certain types.
+Exceptions of the following nodes may be passed in order to tell ESLint to ignore nodes of certain types.
+
 ```
 ArrayExpression,
 ObjectExpression,
@@ -141,6 +142,7 @@ var o = {fst:1,
 ```
 
 Whereas the following would not.
+
 ```
 /* eslint comma-style: [2, "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }] */
 var o = {},

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -16,8 +16,8 @@ There are many commonly used aliases for `this` such as `self`, `that` or `me`. 
 
 This rule designates a variable as the chosen alias for "this". It then enforces two things:
 
- - if a variable with the designated name is declared or assigned to, it *must* explicitly be assigned the current execution context, i.e. `this`
- - if `this` is explicitly assigned to a variable, the name of that variable must be the designated one
+- if a variable with the designated name is declared or assigned to, it *must* explicitly be assigned the current execution context, i.e. `this`
+- if `this` is explicitly assigned to a variable, the name of that variable must be the designated one
 
 Assuming that alias is `self`, the following patterns are considered warnings:
 

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -5,9 +5,9 @@ It is considered good practice to use the type-safe equality operators `===` and
 The reason for this is that `==` and `!=` do type coercion which follows the rather obscure [Abstract Equality Comparison Algorithm](http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3).
 For instance, the following statements are all considered `true`:
 
- - `[] == false`
- - `[] == ![]`
- - `3 == "03"`
+- `[] == false`
+- `[] == ![]`
+- `3 == "03"`
 
 If one of those occurs in an innocent-looking statement such as `a == b` the actual problem is very difficult to spot.
 
@@ -54,7 +54,6 @@ foo == null
 The following patterns are considered warnings with "smart":
 
 ```js
-
 // comparing two variables requires ===
 a == b
 

--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -46,16 +46,16 @@ If provided, it must be an `Array`.
 Array of uppercase-starting function names that are permitted to be used without the `new` operator.
 If not provided, `capIsNewExceptions` defaults to the following:
 
- - `Array`
- - `Boolean`
- - `Date`
- - `Error`
- - `Function`
- - `Number`
- - `Object`
- - `RegExp`
- - `String`
- - `Symbol`
+- `Array`
+- `Boolean`
+- `Date`
+- `Error`
+- `Function`
+- `Number`
+- `Object`
+- `RegExp`
+- `String`
+- `Symbol`
 
 If provided, it must be an `Array`. The default values will continue to be excluded when `capIsNewExceptions` is provided.
 

--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -6,11 +6,11 @@ Various whitespace characters can be inputted by programmers by mistake for exam
 
 Known issues these spaces cause:
 
--  Zero Width Space
-  -  Is NOT considered a separator for tokens and is often parsed as an `Unexpected token ILLEGAL`
-  -  Is NOT shown in modern browsers making code repository software expected to resolve the visualisation
--  Line Separator
-  -  Is NOT a valid character within JSON which would cause parse errors
+- Zero Width Space
+    - Is NOT considered a separator for tokens and is often parsed as an `Unexpected token ILLEGAL`
+    - Is NOT shown in modern browsers making code repository software expected to resolve the visualisation
+- Line Separator
+    - Is NOT a valid character within JSON which would cause parse errors
 
 ## Rule Details
 

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -6,10 +6,10 @@ In the Node.JS community it is often customary to separate the `require`d module
 
 When this rule is enabled, all `var` statements must satisfy the following conditions:
 
- - either none or all variable declarations must be require declarations
- - all require declarations must be of the same type (optional)
+- either none or all variable declarations must be require declarations
+- all require declarations must be of the same type (optional)
 
-#### Options
+### Options
 
 This rule comes with one boolean option called `grouping` which is turned off by default. You can set it in your `eslint.json`:
 
@@ -21,19 +21,20 @@ This rule comes with one boolean option called `grouping` which is turned off by
 
 If enabled, violations will be reported whenever a single `var` statement contains require declarations of mixed types (see the examples below).
 
-#### Nomenclature
+### Nomenclature
+
 This rule distinguishes between six kinds of variable declaration types:
 
- - `core`: declaration of a required [core module][1]
- - `file`: declaration of a required [file module][2]
- - `module`: declaration of a required module from the [node_modules folder][3]
- - `computed`: declaration of a required module whose type could not be determined (either because it is computed or because require was called without an argument)
- - `uninitialized`: a declaration that is not initialized
- - `other`: any other kind of declaration
+- `core`: declaration of a required [core module][1]
+- `file`: declaration of a required [file module][2]
+- `module`: declaration of a required module from the [node_modules folder][3]
+- `computed`: declaration of a required module whose type could not be determined (either because it is computed or because require was called without an argument)
+- `uninitialized`: a declaration that is not initialized
+- `other`: any other kind of declaration
 
 In this document, the first four types are summed up under the term *require declaration*.
 
-###### Example
+#### Example
 
 ```javascript
 var fs = require('fs'),        // "core"     \
@@ -83,6 +84,7 @@ var foo = require('foo'),
 
 
 ## When Not To Use It
+
 Internally, the list of core modules is retrieved via `require("repl")._builtinLibs`. If you use different versions of Node.JS for ESLint and your application, the list of core modules for each version may be different.
 The above mentioned `_builtinLibs` property became available in 0.8, for earlier versions a hardcoded list of module names is used as a fallback. If your version of Node is older than 0.6 that list may be inaccurate.
 

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -49,7 +49,7 @@ For convenience, JSHint and JSLint provide shortcuts that pre-define global vari
 
 ### browser
 
-Defines common browser globals. Globals that should not be used in production (such as `alert`, `console`, etc) are not included.
+Defines common browser globals. Globals that should not be used in production (such as `alert`, `console`, etc.) are not included.
 
 ```js
 /*jslint browser:true*/
@@ -59,6 +59,7 @@ setTimeout(function() {
 ```
 
 ### node
+
 Defines globals for Node.js development.
 
 ```js

--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -21,7 +21,7 @@ The common case of using `void` operator is to get "pure" `undefined` value as p
     'use strict';
     undefined = 1;
 })();
- ```
+```
 
 Another common case is to minify code as `void 0` is shorter than `undefined`:
 

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -32,4 +32,4 @@ if (isNaN(NaN)) {
 
 ## Further reading
 
- - [Use the isNaN function to compare with NaN](http://jslinterrors.com/use-the-isnan-function-to-compare-with-nan/)
+- [Use the isNaN function to compare with NaN](http://jslinterrors.com/use-the-isnan-function-to-compare-with-nan/)

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -27,6 +27,7 @@ var x = (function () { return { y: 1 };}());
 ```
 
 ### Options
+
 The rule takes one option which can enforce a consistent wrapping style. The default is `outside`.
 
 ```json

--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "istanbul": "^0.3.5",
     "jsdoc": "^3.3.0-beta1",
     "jsonlint": "^1.6.2",
+    "markdownlint": "^0.0.3",
     "mocha": "^2.1.0",
     "mocha-phantomjs": "^3.5.0",
     "npm-license": "^0.2.3",


### PR DESCRIPTION
Lint all Markdown files in the project.
Suppress rules that may be controversial or deliberately violated.