### PR TITLE
Update: added array and object specific options for space-in-brackets (fixes #1576)

### DIFF
--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -160,6 +160,8 @@ In case of `"always"` option, set an exception to `false` to enable it:
 
 ```json
 "space-in-brackets": [2, "always", {
+  "arrays": false,
+  "objects": false,
   "singleValue": false,
   "objectsInArrays": false,
   "arraysInArrays": false,
@@ -173,6 +175,8 @@ In case of `"never"` option, set an exception to `true` to enable it:
 
 ```json
 "space-in-brackets": [2, "never", {
+  "arrays": true,
+  "objects": true,
   "singleValue": true,
   "objectsInArrays": true,
   "arraysInArrays": true,
@@ -184,6 +188,9 @@ In case of `"never"` option, set an exception to `true` to enable it:
 
 The following exceptions are available:
 
+* `arrays` sets the spacing of values inside arrays.
+* `objects` sets the spacing of values inside objects.
+* `singleValue` sets the spacing of a single value inside of square brackets of an array.
 * `singleValue` sets the spacing of a single value inside of square brackets of an array.
 * `objectsInArrays` sets the spacings between the curly braces and square brackets of object literals that are the first or last element in an array.
 * `arraysInArrays` sets the spacing between the square brackets of array literals that are the first or last element in an array.
@@ -192,6 +199,34 @@ The following exceptions are available:
 * `propertyName` sets the spacing in square brackets of computed member expressions.
 
 In each of the following examples, the `"always"` option is assumed.
+
+When `"arrays"` is set to `false`, the following patterns are considered warnings:
+
+```js
+var foo = [ 'foo', 'bar' ];
+var foo = [ 'foo': { 'bar': 1 } ];
+```
+
+The following patterns are not warnings:
+
+```js
+var foo = ['foo', 'bar'];
+var foo = ['foo': { 'bar': 1 }];
+```
+
+When `"objects"` is set to `false`, the following patterns are considered warnings:
+
+```js
+var foo = { foo: [ 1, 2, 3 ] };
+var foo = [ 'foo': { 'bar': 1 } ];
+```
+
+The following patterns are not warnings:
+
+```js
+var foo = {foo: [ 1, 2, 3 ]};
+var foo = [ 'foo': {'bar': 1} ];
+```
 
 When `"singleValue"` is set to `false`, the following patterns are considered warnings:
 

--- a/lib/rules/space-in-brackets.js
+++ b/lib/rules/space-in-brackets.js
@@ -27,6 +27,8 @@ module.exports = function(context) {
 
     var options = {
         spaced: spaced,
+        arraySpacedException: isOptionSet("arrays"),
+        objectSpacedException: isOptionSet("objects"),
         singleElementException: isOptionSet("singleValue"),
         objectsInArraysException: isOptionSet("objectsInArrays"),
         arraysInArraysException: isOptionSet("arraysInArrays"),
@@ -34,6 +36,8 @@ module.exports = function(context) {
         objectsInObjectsException: isOptionSet("objectsInObjects"),
         propertyNameException: isOptionSet("propertyName")
     };
+
+
 
     //--------------------------------------------------------------------------
     // Helpers
@@ -154,6 +158,8 @@ module.exports = function(context) {
                 return;
             }
 
+            var arraysMustBeSpaced = options.arraySpacedException ? !options.spaced : options.spaced;
+
             var first = context.getFirstToken(node),
                 second = context.getFirstToken(node, 1),
                 penultimate = context.getLastToken(node, 1),
@@ -163,13 +169,13 @@ module.exports = function(context) {
                 options.objectsInArraysException && second.value === "{" ||
                 options.arraysInArraysException && second.value === "[" ||
                 options.singleElementException && node.elements.length === 1
-                ? !options.spaced : options.spaced;
+                ? !arraysMustBeSpaced : arraysMustBeSpaced;
 
             var closingBracketMustBeSpaced =
                 options.objectsInArraysException && penultimate.value === "}" ||
                 options.arraysInArraysException && penultimate.value === "]" ||
                 options.singleElementException && node.elements.length === 1
-                ? !options.spaced : options.spaced;
+                ? !arraysMustBeSpaced : arraysMustBeSpaced;
 
             if (isSameLine(first, second)) {
                 if (openingBracketMustBeSpaced && !isSpaced(first, second)) {
@@ -195,6 +201,8 @@ module.exports = function(context) {
                 return;
             }
 
+            var objectsMustBeSpaced = options.objectSpacedException ? !options.spaced : options.spaced;
+
             var first = context.getFirstToken(node),
                 second = context.getFirstToken(node, 1),
                 penultimate = context.getLastToken(node, 1),
@@ -203,13 +211,13 @@ module.exports = function(context) {
             var closingCurlyBraceMustBeSpaced =
                 options.arraysInObjectsException && penultimate.value === "]" ||
                 options.objectsInObjectsException && penultimate.value === "}"
-                ? !options.spaced : options.spaced;
+                ? !objectsMustBeSpaced : objectsMustBeSpaced;
 
             if (isSameLine(first, second)) {
-                if (options.spaced && !isSpaced(first, second)) {
+                if (objectsMustBeSpaced && !isSpaced(first, second)) {
                     reportRequiredBeginningSpace(node, first);
                 }
-                if (!options.spaced && isSpaced(first, second)) {
+                if (!objectsMustBeSpaced && isSpaced(first, second)) {
                     reportNoBeginningSpace(node, first);
                 }
             }

--- a/tests/lib/rules/space-in-brackets.js
+++ b/tests/lib/rules/space-in-brackets.js
@@ -62,6 +62,12 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
         // always - arraysInObjects, objectsInObjects (reverse)
         { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }, 'qux': [ 1, 2 ]};", args: [2, "always", {"arraysInObjects": false, "objectsInObjects": false}] },
 
+        // always - objects
+        { code: "var obj = {'foo': [ 1, 2 ]};", args: [2, "always", {"objects": false}] },
+
+        // always - arrays
+        { code: "var obj = { 'foo': [1, 2] };", args: [2, "always", {"arrays": false}] },
+
         // always
         { code: "obj[ foo ]", args: [2, "always"] },
         { code: "obj[\nfoo\n]", args: [2, "always"] },
@@ -105,6 +111,25 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
         { code: "var arr = [1,\n2,\n3,\n4\n];", args: [2, "never"] },
         { code: "var arr = [\n1,\n2,\n3,\n4];", args: [2, "never"] },
 
+        { code: "var arr = [1, 2, 3, 4];", args: [2, "never"] },
+        { code: "var arr = [[1, 2], 2, 3, 4];", args: [2, "never"] },
+        { code: "var arr = [\n1, 2, 3, 4\n];", args: [2, "never"] },
+
+        { code: "var obj = {foo: bar, baz: qux};", args: [2, "never"] },
+        { code: "var obj = {foo: {bar: quxx}, baz: qux};", args: [2, "never"] },
+        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", args: [2, "never"] },
+
+        { code: "var foo = {};", args: [2, "never"] },
+        { code: "var foo = [];", args: [2, "never"] },
+
+        { code: "var foo = [{'bar':'baz'}, 1, {'bar': 'baz'}];", args: [2, "never"] },
+        { code: "var foo = [{'bar': 'baz'}];", args: [2, "never"] },
+        { code: "var foo = [{\n'bar': 'baz', \n'qux': [{'bar': 'baz'}], \n'quxx': 1 \n}]", args: [2, "never"] },
+        { code: "var foo = [1, {'bar': 'baz'}, 5];", args: [2, "never"] },
+        { code: "var foo = [{'bar': 'baz'}, 1,  5];", args: [2, "never"] },
+        { code: "var foo = [1, 5, {'bar': 'baz'}];", args: [2, "never"] },
+        { code: "var obj = {'foo': [1, 2]}", args: [2, "never"] },
+
         // never - singleValue
         { code: "var foo = [ 'foo' ]", args: [2, "never", {singleValue: true}] },
         { code: "var foo = [ 2 ]", args: [2, "never", {singleValue: true}] },
@@ -130,24 +155,11 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
         // never - arraysInArrays, objectsInArrays
         { code: "var arr = [ [1, 2], 2, 3, {'foo': 'bar'} ];", args: [2, "never", {"arraysInArrays": true, objectsInArrays: true}] },
 
-        { code: "var arr = [1, 2, 3, 4];", args: [2, "never"] },
-        { code: "var arr = [[1, 2], 2, 3, 4];", args: [2, "never"] },
-        { code: "var arr = [\n1, 2, 3, 4\n];", args: [2, "never"] },
+        // never - objects
+        { code: "var obj = { 'foo': [1, 2] };", args: [2, "never", {"objects": true}] },
 
-        { code: "var obj = {foo: bar, baz: qux};", args: [2, "never"] },
-        { code: "var obj = {foo: {bar: quxx}, baz: qux};", args: [2, "never"] },
-        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", args: [2, "never"] },
-
-        { code: "var foo = {};", args: [2, "never"] },
-        { code: "var foo = [];", args: [2, "never"] },
-
-        { code: "var foo = [{'bar':'baz'}, 1, {'bar': 'baz'}];", args: [2, "never"] },
-        { code: "var foo = [{'bar': 'baz'}];", args: [2, "never"] },
-        { code: "var foo = [{\n'bar': 'baz', \n'qux': [{'bar': 'baz'}], \n'quxx': 1 \n}]", args: [2, "never"] },
-        { code: "var foo = [1, {'bar': 'baz'}, 5];", args: [2, "never"] },
-        { code: "var foo = [{'bar': 'baz'}, 1,  5];", args: [2, "never"] },
-        { code: "var foo = [1, 5, {'bar': 'baz'}];", args: [2, "never"] },
-        { code: "var obj = {'foo': [1, 2]}", args: [2, "never"] },
+        // never - arrays
+        { code: "var obj = {'foo': [ 1, 2 ]};", args: [2, "never", {"arrays": true}] },
 
         // propertyName: false
         { code: "var foo = obj[1]", args: [2, "always", {propertyName: false}] },
@@ -378,6 +390,38 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
             ]
         },
 
+        // always-objects
+        {
+            code: "var obj = { 'foo': [ 1, 2 ] };",
+            args: [2, "always", {"arrays": false}],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "ArrayExpression"
+                },
+                {
+                    message: "There should be no space before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+
+        // never-objects
+        {
+            code: "var obj = {'foo': [1, 2]};",
+            args: [2, "never", {"arrays": true}],
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "ArrayExpression"
+                },
+                {
+                    message: "A space is required before ']'",
+                    type: "ArrayExpression"
+                }
+            ]
+        },
+
         // always - arraysInObjects
         {
             code: "var obj = { 'foo': [ 1, 2 ] };",
@@ -459,6 +503,38 @@ eslintTester.addRuleTest("lib/rules/space-in-brackets", {
             code: "var obj = {'foo': [1, 2] , 'bar': {'baz': 1, 'qux': 2}};",
             args: [2, "never", {"objectsInObjects": true}],
             errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+
+        // always-objects
+        {
+            code: "var obj = { 'foo': [ 1, 2 ] };",
+            args: [2, "always", {"objects": false}],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression"
+                },
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+
+        // never-objects
+        {
+            code: "var obj = {'foo': [1, 2]};",
+            args: [2, "never", {"objects": true}],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectExpression"
+                },
                 {
                     message: "A space is required before '}'",
                     type: "ObjectExpression"


### PR DESCRIPTION
Introduces two new options for the `space-in-brackets` rule:

- `arrays`
- `objects`

Both behave the same as the other exceptions, and flip the behaviour for arrays and objects from the default, respectively.

I also added tests, docs, and reorganised the tests slightly to be more consistent.