### PR TITLE
New: operator-linebreak rule (fixes #1405)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -140,6 +140,7 @@
 	"newline-after-var": 0,
         "one-var": 0,
         "operator-assignment": [0, "always"],
+        "operator-linebreak": 0,
         "padded-blocks": 0,
         "quote-props": 0,
         "quotes": [2, "double"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -159,6 +159,7 @@ These rules are purely matters of style and are quite subjective.
 * [no-wrap-func](no-wrap-func.md) - disallow wrapping of non-IIFE statements in parens
 * [one-var](one-var.md) - allow just one var statement per function (off by default)
 * [operator-assignment](operator-assignment.md) - require assignment operator shorthand where possible or prohibit it entirely (off by default)
+* [operator-linebreak](operator-linebreak.md) - enforce operators to be placed before or after line breaks (off by default)
 * [padded-blocks](padded-blocks.md) - enforce padding within blocks (off by default)
 * [quote-props](quote-props.md) - require quotes around object literal property names (off by default)
 * [quotes](quotes.md) - specify whether double or single quotes should be used

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -161,3 +161,7 @@ For the first option in comma-style rule:
 * [A better coding convention for lists and object literals in JavaScript by isaacs](https://gist.github.com/isaacs/357981)
 * [npm coding style guideline](https://www.npmjs.org/doc/misc/npm-coding-style.html)
 
+
+## Related Rules
+
+* [operator-linebreak](operator-linebreak.md)

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -1,0 +1,121 @@
+# Operator Linebreak (operator-linebreak)
+
+When a statement is too long to fit on a single line, line breaks are generally inserted next to the operators separating expressions. The first style coming to mind would be to place the operator at the end of the line, following the english punctuation rules.
+
+```js
+var fullHeight = borderTop +
+                 innerHeight +
+                 borderBottom;
+```
+
+Some developers find that placing operators at the beginning of the line makes the code more readable.
+
+```js
+var fullHeight = borderTop
+               + innerHeight
+               + borderBottom;
+```
+
+## Rule Details
+
+The `operator-linebreak` rule is aimed at enforcing a particular operator line break style. As such, it warns whenever it sees a binary operator or assignment that does not adhere to a particular style: either placing operators after or before the lines.
+
+### Options
+
+The rule takes an option, a string, which could be either "after" or "before". The default is "after".
+
+You can set the style in configuration like this:
+
+```json
+"operator-linebreak": [2, "before"]
+```
+
+#### "after"
+
+This is the default setting for this rule. This option requires that the operator be placed after and be in the same line as the last expression of the line.
+
+While using this setting, the following patterns are considered warnings:
+
+```js
+
+foo = 1
++
+2;
+
+foo = 1
+    + 2;
+
+
+foo
+    = 5;
+
+if (someCondition
+    || otherCondition) {
+}
+```
+
+The following patterns are not warnings:
+
+```js
+
+foo = 1 + 2;
+
+foo = 1 +
+      2;
+
+
+foo =
+    5;
+
+if (someCondition ||
+    otherCondition) {
+}
+
+```
+
+#### "before"
+
+This option requires that the operator be placed before and be in the same line as the first expression of the line.
+
+While using this setting, the following patterns are considered warnings:
+
+```js
+
+foo = 1 +
+      2;
+
+
+foo =
+    5;
+
+if (someCondition ||
+    otherCondition) {
+}
+
+```
+
+The following patterns are not warnings:
+
+```js
+
+foo = 1 + 2;
+
+foo = 1
+    + 2;
+
+foo
+    = 5;
+
+if (someCondition
+    || otherCondition) {
+}
+
+```
+
+## When Not To Use It
+
+If your project will not be using a common operator line break style, turn this rule off.
+
+## Related Rules
+
+* [comma-style](comma-style.md)

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -1,0 +1,89 @@
+/**
+ * @fileoverview Operator linebreak - enforces operator linebreak style of two types: after and before
+ * @author Benoît Zugmeyer
+ * @copyright 2015 Benoît Zugmeyer. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var style = context.options[0] || "after";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Checks whether two tokens are on the same line.
+     * @param {ASTNode} left The leftmost token.
+     * @param {ASTNode} right The rightmost token.
+     * @returns {boolean} True if the tokens are on the same line, false if not.
+     * @private
+     */
+    function isSameLine(left, right) {
+        return left.loc.end.line === right.loc.start.line;
+    }
+
+    /**
+     * Checks the operator placement
+     * @param {ASTNode} node The binary operator node to check
+     * @private
+     * @returns {void}
+     */
+    function validateBinaryExpression(node) {
+        var leftToken = context.getLastToken(node.left || node.id);
+        var operatorToken = context.getTokenAfter(leftToken);
+        var rightToken = context.getTokenAfter(operatorToken);
+        var operator = operatorToken.value;
+
+        // if single line
+        if (isSameLine(operatorToken, leftToken) &&
+                isSameLine(rightToken, operatorToken)) {
+
+            return;
+
+        } else if (!isSameLine(operatorToken, leftToken) &&
+                !isSameLine(rightToken, operatorToken)) {
+
+            // lone operator
+            context.report(node, {
+                line: operatorToken.loc.end.line,
+                column: operatorToken.loc.end.column
+            }, "Bad line breaking before and after '" + operator + "'.");
+
+        } else if (style === "before" && isSameLine(operatorToken, leftToken)) {
+
+            context.report(node, {
+                line: operatorToken.loc.end.line,
+                column: operatorToken.loc.end.column
+            }, "'" + operator + "' should be placed at the beginning of the line.");
+
+        } else if (style === "after" && isSameLine(operatorToken, rightToken)) {
+
+            context.report(node, {
+                line: operatorToken.loc.end.line,
+                column: operatorToken.loc.end.column
+            }, "'" + operator + "' should be placed at the end of the line.");
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        "BinaryExpression": validateBinaryExpression,
+        "LogicalExpression": validateBinaryExpression,
+        "AssignmentExpression": validateBinaryExpression,
+        "VariableDeclarator": function (node) {
+            if (node.init) {
+                validateBinaryExpression(node);
+            }
+        }
+    };
+};

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -1,0 +1,172 @@
+/**
+ * @fileoverview Operator linebreak rule tests
+ * @author Benoît Zugmeyer
+ * @copyright 2015 Benoît Zugmeyer. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var util = require("util");
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+var BAD_LN_BRK_MSG = "Bad line breaking before and after '%s'.",
+    BEFORE_MSG = "'%s' should be placed at the beginning of the line.",
+    AFTER_MSG = "'%s' should be placed at the end of the line.";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/operator-linebreak", {
+
+    valid: [
+        "1 + 1",
+        "1 + 1 + 1",
+        "1 +\n1",
+        "1 + (1 +\n1)",
+        "f(1 +\n1)",
+        "1 || 1",
+        "1 || \n1",
+        "a += 1",
+        "var a;",
+        "var o = \nsomething",
+        "o = \nsomething",
+
+        {code: "1\n+ 1", options: ["before"]},
+        {code: "1 + 1\n+ 1", options: ["before"]},
+        {code: "f(1\n+ 1)", options: ["before"]},
+        {code: "1 \n|| 1", options: ["before"]},
+        {code: "a += 1", options: ["before"]}
+    ],
+
+    invalid: [
+        {
+            code: "1\n+ 1",
+            errors: [{
+                message: util.format(AFTER_MSG, "+"),
+                type: "BinaryExpression",
+                line: 2,
+                column: 1
+            }]
+        },
+        {
+            code: "1 + 2 \n + 3",
+            errors: [{
+                message: util.format(AFTER_MSG, "+"),
+                type: "BinaryExpression",
+                line: 2,
+                column: 2
+            }]
+        },
+        {
+            code: "1\n+\n1",
+            errors: [{
+                message: util.format(BAD_LN_BRK_MSG, "+"),
+                type: "BinaryExpression",
+                line: 2,
+                column: 1
+            }]
+        },
+        {
+            code: "1 + (1\n+ 1)",
+            errors: [{
+                message: util.format(AFTER_MSG, "+"),
+                type: "BinaryExpression",
+                line: 2,
+                column: 1
+            }]
+        },
+        {
+            code: "f(1\n+ 1);",
+            errors: [{
+                message: util.format(AFTER_MSG, "+"),
+                type: "BinaryExpression",
+                line: 2,
+                column: 1
+            }]
+        },
+        {
+            code: "1 \n || 1",
+            errors: [{
+                message: util.format(AFTER_MSG, "||"),
+                type: "LogicalExpression",
+                line: 2,
+                column: 3
+            }]
+        },
+        {
+            code: "a\n += 1",
+            errors: [{
+                message: util.format(AFTER_MSG, "+="),
+                type: "AssignmentExpression",
+                line: 2,
+                column: 3
+            }]
+        },
+        {
+            code: "var a\n = 1",
+            errors: [{
+                message: util.format(AFTER_MSG, "="),
+                type: "VariableDeclarator",
+                line: 2,
+                column: 2
+            }]
+        },
+
+        {
+            code: "1 +\n1",
+            options: ["before"],
+            errors: [{
+                message: util.format(BEFORE_MSG, "+"),
+                type: "BinaryExpression",
+                line: 1,
+                column: 3
+            }]
+        },
+        {
+            code: "f(1 +\n1);",
+            options: ["before"],
+            errors: [{
+                message: util.format(BEFORE_MSG, "+"),
+                type: "BinaryExpression",
+                line: 1,
+                column: 5
+            }]
+        },
+        {
+            code: "1 || \n 1",
+            options: ["before"],
+            errors: [{
+                message: util.format(BEFORE_MSG, "||"),
+                type: "LogicalExpression",
+                line: 1,
+                column: 4
+            }]
+        },
+        {
+            code: "a += \n1",
+            options: ["before"],
+            errors: [{
+                message: util.format(BEFORE_MSG, "+="),
+                type: "AssignmentExpression",
+                line: 1,
+                column: 4
+            }]
+        },
+        {
+            code: "var a = \n1",
+            options: ["before"],
+            errors: [{
+                message: util.format(BEFORE_MSG, "="),
+                type: "VariableDeclarator",
+                line: 1,
+                column: 7
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
This is the follow-up of the pull-request #2175 for the ticket #1405 .

Changes since the previous pull-request:
* Renamed the rule from `binop-style` to `operator-linebreak` (I didn't rename it to `op-linebrak` as the rule `operator-assignment` spells "operator" without abbreviating it)
* Renamed options from `last` and `first` to `after` and `before`
* Rephrased the rule small description in README.md
* Rephrased the rule description in its documentation, to be about the style instead of the rule itself.
* Removed exceptions (could be readded later if needed)
* Added line and column numbers in tests
* Used `options` instead of `args` in tests
* Rebased on current master branch

Ready for a new batch of feedbacks!

EDIT: I didn't add the "lone" or "both" third option to enforce operators to be alone on the new line, because I've never seen this practice and I can't find any argument in favor of using it to put in the rule description.