### PR TITLE
Fix: Allow inline comments in newline-after-var rule (fixes #2229)

### DIFF
--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -2,6 +2,7 @@
  * @fileoverview Rule to check empty newline after "var" statement
  * @author Gopal Venkatesan
  * @copyright 2015 Gopal Venkatesan. All rights reserved.
+ * @copyright 2015 Casey Visco. All rights reserved.
  */
 
 "use strict";
@@ -11,35 +12,70 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var mode = context.options[0],
-        validator;              // regex to validate the rule
 
-    if (mode === "never") {
-        validator = /\S(?:\r?\n)?\S/;
-    } else {                    // assume mode === "always"
-        validator = /\S(?:\r?\n){2,}\S?/;
-        mode = "always";
+    var ALWAYS_MESSAGE = "Expected blank line after variable declarations.",
+        NEVER_MESSAGE = "Unexpected blank line after variable declarations.";
+
+    // Default `mode` to "always". This means that invalid options will also
+    // be treated as "always" and the only special case is "never"
+    var mode = context.options[0] === "never" ? "never" : "always";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Determine if provided keyword is a variable declaration
+     * @private
+     * @param {String} keyword - keyword to test
+     * @returns {Boolean} True if `keyword` is a type of var
+     */
+    function isVar(keyword) {
+        return keyword === "var" || keyword === "let" || keyword === "const";
     }
 
-    return {
-        "VariableDeclaration:exit": function(node) {
-            var lastToken = context.getLastToken(node),
-                nextToken = context.getTokenAfter(node),
-                // peek few characters beyond the last token (typically the semi-colon)
-                sourceLines = context.getSource(lastToken, 0, 3);
+    /**
+     * Checks that a blank line exists after a variable declaration when mode is
+     * set to "always", or checks that there is no blank line when mode is set
+     * to "never"
+     * @private
+     * @param {ASTNode} node - `VariableDeclaration` node to test
+     * @returns {void}
+     */
+    function checkForBlankLine(node) {
+        var lastToken = context.getLastToken(node),
+            nextToken = context.getTokenAfter(node),
+            hasBlankLine;
 
-            // Some coding styles like Google uses multiple `var` statements.
-            // So if the next token is a `var` statement don't do anything.
-            if (nextToken && nextToken.type === "Keyword" &&
-                (nextToken.value === "var" || nextToken.value === "let" || nextToken.value === "const")) {
-                return;
-            }
-
-            // Next statement is not a `var`
-            if (sourceLines && !sourceLines.match(validator)) {
-                context.report(node, "Newline is " + mode + " expected after a \"var\" statement.",
-                               { identifier: node.name });
-            }
+        // Ignore if there is no following statement
+        if (!nextToken) {
+            return;
         }
+
+        // Some coding styles like Google uses multiple `var` statements.
+        // So if the next token is a `var` statement don't do anything.
+        if (nextToken.type === "Keyword" && isVar(nextToken.value)) {
+            return;
+        }
+
+        // Next statement is not a `var`
+        hasBlankLine = nextToken.loc.start.line > lastToken.loc.end.line + 1;
+
+        if (mode === "never" && hasBlankLine) {
+            context.report(node, NEVER_MESSAGE, { identifier: node.name });
+        }
+
+        if (mode === "always" && !hasBlankLine) {
+            context.report(node, ALWAYS_MESSAGE, { identifier: node.name });
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        "VariableDeclaration": checkForBlankLine
     };
+
 };

--- a/tests/lib/rules/newline-after-var.js
+++ b/tests/lib/rules/newline-after-var.js
@@ -2,6 +2,7 @@
  * @fileoverview Tests for newline-after-var rule.
  * @author Gopal Venkatesan
  * @copyright 2015 Gopal Venkatesan. All rights reserved.
+ * @copyright 2015 Casey Visco. All rights reserved.
  */
 
 "use strict";
@@ -17,13 +18,50 @@ var eslint = require("../../../lib/eslint"),
 // Tests
 //------------------------------------------------------------------------------
 
+var ALWAYS_MESSAGE = "Expected blank line after variable declarations.",
+    NEVER_MESSAGE = "Unexpected blank line after variable declarations.";
+
 var eslintTester = new ESLintTester(eslint);
 
 eslintTester.addRuleTest("lib/rules/newline-after-var", {
     valid: [
-        { code: "var greet = 'hello'; console.log(greet);", options: ["never"] },
-        { code: "var greet = 'hello';\n\nconsole.log(greet);", options: ["always"] },
-        { code: "var greet = 'hello';\n\n\nconsole.log(greet);", options: ["always"] },
+        {
+            // ignore `var` with no following token
+            code: "var greet = 'hello';",
+            options: ["always"]
+        },
+        {
+            // ignore `var` with no following token
+            code: "var greet = 'hello';",
+            options: ["never"]
+        },
+        {
+            code: "var greet = 'hello'; console.log(greet);",
+            options: ["never"]
+        },
+        {
+            code: "var greet = 'hello';\n\nconsole.log(greet);",
+            options: ["always"]
+        },
+        {
+            code: "var greet = 'hello';\n\n\nconsole.log(greet);",
+            options: ["always"]
+        },
+        {
+            // single-line `var` with inline comment
+            code: "var greet = 'hello'; // inline comment\n\nconsole.log(greet);",
+            options: ["always"]
+        },
+        {
+            // multi-line `var`
+            code: "var greet = 'hello',\nname = 'world';\n\nconsole.log(greet, name);",
+            options: ["always"]
+        },
+        {
+            // multi-line `var` with inline comments
+            code: "var greet = 'hello', // inline comment\nname = 'world'; // inline comment\n\nconsole.log(greet, name);",
+            options: ["always"]
+        },
         {
             code: "var greet = 'hello'; var name = 'world';\n\n\nconsole.log(greet, name);",
             options: ["always"]
@@ -32,12 +70,30 @@ eslintTester.addRuleTest("lib/rules/newline-after-var", {
             code: "var greet = 'hello';\nvar name = 'world';\n\n\nconsole.log(greet, name);",
             options: ["always"]
         },
-        // invalid configuration option
         {
+            // invalid configuration option
             code: "var greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
             options: ["foobar"]
         },
-        // es6 block bindings
+
+        // ES6 block bindings
+
+        {
+            // ignore `let` with no following token
+            code: "let greet = 'hello';",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            // ignore `let` with no following token
+            code: "let greet = 'hello';",
+            options: ["never"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
         {
             code: "let greet = 'hello';\n\nconsole.log(greet);",
             options: ["always"],
@@ -60,6 +116,46 @@ eslintTester.addRuleTest("lib/rules/newline-after-var", {
             }
         },
         {
+            // single-line `let` with inline comment
+            code: "let greet = 'hello'; // inline comment\n\nconsole.log(greet);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            // multi-line `let`
+            code: "let greet = 'hello',\nname = 'world';\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            // multi-line `let` with inline comments
+            code: "let greet = 'hello', // inline comment\nname = 'world'; // inline comment\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            // ignore `const` with no following token
+            code: "const greet = 'hello';",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            // ignore `const` with no following token
+            code: "const greet = 'hello';",
+            options: ["never"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
             code: "const greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
             options: ["always"],
             ecmaFeatures: {
@@ -72,6 +168,30 @@ eslintTester.addRuleTest("lib/rules/newline-after-var", {
             ecmaFeatures: {
                 blockBindings: true
             }
+        },
+        {
+            // single-line `const` with inline comment
+            code: "const greet = 'hello'; // inline comment\n\nconsole.log(greet);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            // multi-line `const`
+            code: "const greet = 'hello',\nname = 'world';\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
+        },
+        {
+            // multi-line `const` with inline comments
+            code: "const greet = 'hello', // inline comment\nname = 'world'; // inline comment\n\nconsole.log(greet, name);",
+            options: ["always"],
+            ecmaFeatures: {
+                blockBindings: true
+            }
         }
     ],
 
@@ -80,7 +200,7 @@ eslintTester.addRuleTest("lib/rules/newline-after-var", {
             code: "var greet = 'hello';\n\nconsole.log(greet);",
             options: ["never"],
             errors: [{
-                message: "Newline is never expected after a \"var\" statement.",
+                message: NEVER_MESSAGE,
                 type: "VariableDeclaration"
             }]
         },
@@ -88,7 +208,7 @@ eslintTester.addRuleTest("lib/rules/newline-after-var", {
             code: "var greet = 'hello'; console.log(greet);",
             options: ["always"],
             errors: [{
-                message: "Newline is always expected after a \"var\" statement.",
+                message: ALWAYS_MESSAGE,
                 type: "VariableDeclaration"
             }]
         },
@@ -96,35 +216,41 @@ eslintTester.addRuleTest("lib/rules/newline-after-var", {
             code: "var greet = 'hello'; var name = 'world'; console.log(greet);",
             options: ["always"],
             errors: [{
-                message: "Newline is always expected after a \"var\" statement.",
+                message: ALWAYS_MESSAGE,
                 type: "VariableDeclaration"
             }]
         },
-        // es6 block bindings
+
+        // ES6 block bindings
+
         {
             code: "let greet = 'hello'; const name = 'world';\n\nconsole.log(greet);",
             options: ["never"],
-            ecmaFeatures: { blockBindings: true },
+            ecmaFeatures: {
+                blockBindings: true
+            },
             errors: [{
-                message: "Newline is never expected after a \"var\" statement.",
+                message: NEVER_MESSAGE,
                 type: "VariableDeclaration"
             }]
         },
         {
             code: "const greet = 'hello';\nlet name = 'world';\n\nconsole.log(greet, name);",
             options: ["never"],
-            ecmaFeatures: { blockBindings: true },
+            ecmaFeatures: {
+                blockBindings: true
+            },
             errors: [{
-                message: "Newline is never expected after a \"var\" statement.",
+                message: NEVER_MESSAGE,
                 type: "VariableDeclaration"
             }]
         },
-        // invalid configuration option
         {
+            // invalid configuration option
             code: "var greet = 'hello';\nvar name = 'world';\nconsole.log(greet, name);",
             options: ["foobar"],
             errors: [{
-                message: "Newline is always expected after a \"var\" statement.",
+                message: ALWAYS_MESSAGE,
                 type: "VariableDeclaration"
             }]
         }


### PR DESCRIPTION
Previously, the newline-after-var rule relied on a RegEx pattern to
inspect the whitespace following a variable declaration. This resulted
in a warning when an inline comment followed a variable declaration.

* Switch to token-based inspection of line numbers
* Simplify error message for both "always" and "never" cases
* Shortcut rule if no next token exists
* Use `VariableDeclaration` instead of `VariableDeclaration:exit`
* Add additional tests for updated behavior