### PR TITLE
Fix: Ignore single lines for vertical alignment (fixes #2018)

### DIFF
--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -67,7 +67,7 @@ foo = { thisLineWouldBeTooLong:
 
 ### 2. Vertically align values `"align": "value"`
 
-Use the `align` option to enforce vertical alignment of values in an object literal. This mode still respects `beforeColon` and `afterColon` where possible, but it will pad with spaces after the colon where necessary. Groups of properties separated by blank lines are considered distinct and can have different alignment than other groups.
+Use the `align` option to enforce vertical alignment of values in an object literal. This mode still respects `beforeColon` and `afterColon` where possible, but it will pad with spaces after the colon where necessary. Groups of properties separated by blank lines are considered distinct and can have different alignment than other groups. Single line object literals will not be checked for vertical alignment, but each property will still be checked for `beforeColon` and `afterColon`.
 
 The following patterns are considered valid:
 
@@ -91,6 +91,10 @@ call({
     'a' :[],
     b :  []
 });
+
+// "key-spacing": [2, { "align": "colon" }]
+// beforeColon and afterColon default to false and true, respectively
+var obj = { a: "foo", longPropertyName: "bar" };
 ```
 
 The following patterns are considered warnings:

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -63,6 +63,15 @@ function continuesPropertyGroup(lastMember, candidate) {
     return false;
 }
 
+/**
+ * Checks whether a node is contained on a single line.
+ * @param {ASTNode} node AST Node being evaluated.
+ * @returns {boolean} True if the node is a single line.
+ */
+function isSingleLine(node) {
+    return (node.loc.end.line === node.loc.start.line);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -175,11 +184,35 @@ module.exports = function(context) {
     }
 
     /**
+     * Creates groups of properties.
+     * @param  {ASTNode} node ObjectExpression node being evaluated.
+     * @returns {ASTNode[]} Groups of property AST node lists.
+     */
+    function createGroups(node) {
+        if (node.properties.length === 1) {
+            return node.properties;
+        }
+
+        return node.properties.reduce(function(groups, property) {
+            var currentGroup = last(groups),
+                prev = last(currentGroup);
+
+            if (!prev || continuesPropertyGroup(prev, property)) {
+                currentGroup.push(property);
+            } else {
+                groups.push([property]);
+            }
+
+            return groups;
+        }, [[]]);
+    }
+
+    /**
      * Verifies correct vertical alignment of a group of properties.
      * @param {ASTNode[]} properties List of Property AST nodes.
      * @returns {void}
      */
-    function verifyAlignment(properties) {
+    function verifyGroupAlignment(properties) {
         var length = properties.length,
             widths = properties.map(getKeyWidth), // Width of keys, including quotes
             targetWidth = Math.max.apply(null, widths),
@@ -208,24 +241,56 @@ module.exports = function(context) {
         }
     }
 
+    /**
+     * Verifies vertical alignment, taking into account groups of properties.
+     * @param  {ASTNode} node ObjectExpression node being evaluated.
+     * @returns {void}
+     */
+    function verifyAlignment(node) {
+        createGroups(node).forEach(function(group) {
+            verifyGroupAlignment(group);
+        });
+    }
+
+    /**
+     * Verifies spacing of property conforms to specified options.
+     * @param  {ASTNode} node Property node being evaluated.
+     * @returns {void}
+     */
+    function verifySpacing(node) {
+        var whitespace = getPropertyWhitespace(node);
+        if (whitespace) { // Object literal getters/setters lack colons
+            report(node, "key", whitespace.beforeColon, beforeColon);
+            report(node, "value", whitespace.afterColon, afterColon);
+        }
+    }
+
+    /**
+     * Verifies spacing of each property in a list.
+     * @param  {ASTNode[]} properties List of Property AST nodes.
+     * @returns {void}
+     */
+    function verifyListSpacing(properties) {
+        var length = properties.length;
+
+        for (var i = 0; i < length; i++) {
+            verifySpacing(properties[i]);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
     if (align) { // Verify vertical alignment
 
         return {
             "ObjectExpression": function(node) {
-                node.properties.reduce(function(groups, property) {
-                    var currentGroup = last(groups),
-                        prev = last(currentGroup);
-
-                    if (!prev || continuesPropertyGroup(prev, property)) {
-                        currentGroup.push(property);
-                    } else {
-                        groups.push([property]);
-                    }
-
-                    return groups;
-                }, [[]]).forEach(function(group) {
-                    verifyAlignment(group);
-                });
+                if (isSingleLine(node)) {
+                    verifyListSpacing(node.properties);
+                } else {
+                    verifyAlignment(node);
+                }
             }
         };
 
@@ -233,11 +298,7 @@ module.exports = function(context) {
 
         return {
             "Property": function (node) {
-                var whitespace = getPropertyWhitespace(node);
-                if (whitespace) { // Object literal getters/setters lack colons
-                    report(node, "key", whitespace.beforeColon, beforeColon);
-                    report(node, "value", whitespace.afterColon, afterColon);
-                }
+                verifySpacing(node);
             }
         };
 

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -142,6 +142,12 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
     }, {
         code: "({ get fn() {} })",
         options: [{ align: "colon" }]
+    }, {
+        code: "var obj = {foo: 'fee', bar: 'bam'};",
+        options: [{ align: "colon" }]
+    }, {
+        code: "var obj = {a: 'foo', bar: 'bam'};",
+        options: [{ align: "colon" }]
     }],
 
     invalid: [{
@@ -331,6 +337,12 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
         code: "foo = { key:( ( (1+2) ) ) };",
         errors: [
             { message: "Missing space before value for key \"key\".", line: 1, column: 12, type: "BinaryExpression" }
+        ]
+    }, {
+        code: "var obj = {a  : 'foo', bar: 'bam'};",
+        options: [{ align: "colon" }],
+        errors: [
+            { message: "Extra space after key \"a\".", line: 1, column: 11, type: "Identifier" }
         ]
     }]
 


### PR DESCRIPTION
Previously, if an `align` option was passed to key-spacing, the rule
would test alignment on any object with more than one property on a single line.

The changes in this commit first check if an object is a single line,
and if it is, only performs checks against `beforeColon` and `afterColon` of the properties.