### PR TITLE
Docs: Remove hard tabs from *.md, enable corresponding markdownlint rule...

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -214,7 +214,6 @@ function lintMarkdown(files) {
                 indent: 4
             },
             MD009: false, // Trailing spaces
-            MD010: false, // Hard tabs
             MD012: false, // Multiple consecutive blank lines
             MD013: false, // Line length
             MD026: false, // Trailing punctuation in header

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -37,7 +37,7 @@ obj.do_something = function() {
 };
 
 var obj = {
-	my_pref: 1
+    my_pref: 1
 };
 ```
 
@@ -55,7 +55,7 @@ obj.do_something();
 
 /*eslint camelcase: [2, {properties: "never"}]*/
 var obj = {
-	my_pref: 1
+    my_pref: 1
 };
 ```
 

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -5,8 +5,8 @@ It is often necessary to capture the current execution context in order to make 
 ```js
 var self = this;
 jQuery('li').click(function (event) {
-	// here, "this" is the HTMLElement where the click event occurred
-	self.setFoo(42);
+    // here, "this" is the HTMLElement where the click event occurred
+    self.setFoo(42);
 });
 ```
 

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -4,7 +4,7 @@ There are two ways of defining functions in JavaScript: function declarations an
 
 ```js
 function doSomething() {
-	// ...
+    // ...
 }
 ```
 
@@ -12,7 +12,7 @@ Equivalent function expressions begin with the `var` keyword, followed by a name
 
 ```js
 var doSomething = function() {
-	// ...
+    // ...
 };
 ```
 
@@ -22,7 +22,7 @@ The primary difference between function declarations and function expressions is
 doSomething();
 
 function doSomething() {
-	// ...
+    // ...
 }
 ```
 
@@ -31,10 +31,10 @@ Although this code might seem like an error, it actually works fine because Java
 For function expressions, you must define the function before it is used, otherwise it causes an error. Example:
 
 ```js
-doSomething();	// error!
+doSomething();  // error!
 
 var doSomething = function() {
-	// ...
+    // ...
 };
 ```
 
@@ -51,12 +51,12 @@ The following patterns are considered warnings:
 ```js
 // "func-style": [2, "declaration"]
 var foo = function() {
-	// ...
+    // ...
 } ;
 
 // "func-style": [2, "expression"]
 function foo() {
-	// ...
+    // ...
 }
 ```
 
@@ -65,7 +65,7 @@ The following patterns are not considered warnings:
 ```js
 // both styles
 SomeObject.foo = function() {
-	// ...
+    // ...
 };
 ```
 

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -29,7 +29,7 @@ function loadData (err, data) {
 ```js
 function loadData (err, data) {
     if (err) {
-    	console.log(err.stack);
+        console.log(err.stack);
     }
     doSomething();
 }

--- a/docs/rules/no-duplicate-case.md
+++ b/docs/rules/no-duplicate-case.md
@@ -9,14 +9,14 @@ Most likely the case block was copied from above and it was forgotten to change 
 var a = 1;
 
 switch (a) {
-	case 1:
-		break;
-	case 2:
-		break;
-	case 1:			// duplicate literal 1
-		break;
-	default:
-		break;
+    case 1:
+        break;
+    case 2:
+        break;
+    case 1:         // duplicate literal 1
+        break;
+    default:
+        break;
 }
 ```
 
@@ -28,39 +28,39 @@ The following patterns are considered warnings:
 
 ```js
 var a = 1,
-	one = 1;
+    one = 1;
 
 switch (a) {
-	case 1:
-		break;
-	case 1:
-		break;
-	case 2:
-		break;
-	default:
-		break;
+    case 1:
+        break;
+    case 1:
+        break;
+    case 2:
+        break;
+    default:
+        break;
 }
 
 switch (a) {
-	case "1":
-		break;
-	case "1":
-		break;
-	case "2":
-		break;
-	default:
-		break;
+    case "1":
+        break;
+    case "1":
+        break;
+    case "2":
+        break;
+    default:
+        break;
 }
 
 switch (a) {
-	case one:
-		break;
-	case one:
-		break;
-	case 2:
-		break;
-	default:
-		break;
+    case one:
+        break;
+    case one:
+        break;
+    case 2:
+        break;
+    default:
+        break;
 }
 ```
 
@@ -70,11 +70,11 @@ The following patterns are not considered warnings:
 var a = 1;
 
 switch (a) {
-	case 1:
-		break;
-	case 2:
-		break;
-	default:
-		break;
+    case 1:
+        break;
+    case 2:
+        break;
+    default:
+        break;
 }
 ```

--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -4,9 +4,9 @@ Writing functions within loops tends to result in errors due to the way the func
 
 ```js
 for (var i = 0; i < 10; i++) {
-	funcs[i] = function() {
-		return i;
-	};
+    funcs[i] = function() {
+        return i;
+    };
 }
 ```
 

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -31,8 +31,8 @@ var e = new Error("error");
 throw e;
 
 try {
-	throw new Error("error");
+    throw new Error("error");
 } catch (e) {
-	throw e;
+    throw e;
 }
 ```

--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -18,18 +18,18 @@ The following are considered warnings:
 
 ```js
 function foo() {
-	return true;
-	console.log("done");
+    return true;
+    console.log("done");
 }
 
 function bar() {
-	throws new Error("Oops!");
-	console.log("done");
+    throws new Error("Oops!");
+    console.log("done");
 }
 
 while(value) {
-	break;
-	console.log("done");
+    break;
+    console.log("done");
 }
 
 throw new Error("Oops!");
@@ -40,15 +40,15 @@ The following patterns are not considered warnings (due to JavaScript function a
 
 ```js
 function foo() {
-	return bar();
-	function bar() {
-	    return 1;
-	}
+    return bar();
+    function bar() {
+        return 1;
+    }
 }
 
 function bar() {
-	return x;
-	var x;
+    return x;
+    var x;
 }
 
 switch (foo) {

--- a/docs/rules/no-wrap-func.md
+++ b/docs/rules/no-wrap-func.md
@@ -4,11 +4,11 @@ Although it's possible to wrap functions in parentheses, this can be confusing w
 
 ```js
 var foo = (function() {
-	// IIFE
+    // IIFE
 }());
 
 var bar = (function() {
-	// not an IIFE
+    // not an IIFE
 });
 ```
 

--- a/docs/rules/space-after-function-name.md
+++ b/docs/rules/space-after-function-name.md
@@ -6,11 +6,11 @@ Whitespace between a function name and its parameter list is optional.
 
 ```js
 function withoutSpace(x) {
-	// ...
+    // ...
 }
 
 function withSpace (x) {
-	// ...
+    // ...
 }
 ```
 
@@ -25,14 +25,14 @@ The following patterns are considered warnings:
 
 ```js
 function foo (x) {
-	// ...
+    // ...
 }
 
 var x = function named (x) {};
 
 // When [1, "always"]
 function bar(x) {
-	// ...
+    // ...
 }
 ```
 
@@ -40,13 +40,13 @@ The following patterns are not warnings:
 
 ```js
 function foo(x) {
-	// ...
+    // ...
 }
 
 var x = function named(x) {};
 
 // When [1, "always"]
 function bar (x) {
-	// ...
+    // ...
 }
 ```

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -10,11 +10,11 @@ The following patterns are considered warnings:
 
 ```js
 if (foo == NaN) {
-	// ...
+    // ...
 }
 
 if (foo != NaN) {
-	// ...
+    // ...
 }
 ```
 
@@ -22,11 +22,11 @@ The following patterns are not warnings:
 
 ```js
 if (isNaN(foo)) {
-	// ...
+    // ...
 }
 
 if (isNaN(NaN)) {
-	// ...
+    // ...
 }
 ```
 

--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -55,7 +55,7 @@ if (-1 < str.indexOf(substr)) {
 ```js
 // When ["always"]
 if (color == "blue") {
-	// ...
+    // ...
 }
 ```
 


### PR DESCRIPTION
Note:

* GitHub's visual diff of "before" is misleading, suggesting no spacing was present in most cases (ironically, due to improper handling of hard tabs)
* In the two places where a hard tab was present *within* a line, I preserved the column of the following text assuming 4-space tabs