### PR TITLE
Added support for one-based indexes via -i CLI flag

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -180,6 +180,14 @@ var cli = {
                 result.results = getErrorResults(result.results);
             }
 
+            if (currentOptions.oneBasedIndex) {
+                result.results.forEach(function(res) {
+                    res.messages.forEach(function(message) {
+                        message.column = isNaN(message.column) ? 0 : message.column + 1;
+                    });
+                });
+            }
+
             if (printResults(engine, result.results, currentOptions.format, currentOptions.outputFile)) {
                 return result.errorCount ? 1 : 0;
             } else {

--- a/lib/options.js
+++ b/lib/options.js
@@ -112,5 +112,12 @@ module.exports = optionator({
         type: "Boolean",
         default: "false",
         description: "Lint code provided on <STDIN>"
+    },
+    {
+        option: "one-based-index",
+        alias: "i",
+        type: "Boolean",
+        default: "false",
+        description: "Uses 1 as first index, as opposed to 0"
     }]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -413,4 +413,33 @@ describe("cli", function() {
             assert.isTrue(console.error.calledOnce);
         });
     });
+
+    describe("when not using --one-based-index", function() {
+
+        it("should print zero-based indexes", function() {
+            var exit;
+
+            exit = cli.execute("tests/fixtures/single-quoted.js");
+
+            assert.equal(exit, 1);
+            assert.include(console.log.lastCall.args[0], "1:4");
+            assert.include(console.log.lastCall.args[0], "1:10");
+        });
+
+    });
+
+    describe("when using --one-based-index", function() {
+
+        it("should print one-based indexes", function() {
+            var exit;
+
+            exit = cli.execute("-i tests/fixtures/single-quoted.js");
+
+            assert.equal(exit, 1);
+            assert.include(console.log.lastCall.args[0], "1:5");
+            assert.include(console.log.lastCall.args[0], "1:11");
+        });
+
+    });
+
 });


### PR DESCRIPTION
AFAIK currently only zero-based column indexes are used. This pull requests adds a new `-i` or `--one-based-index` flag which enables one-based indexes.

The reason I need this functionality is because Sublime Text's default build system uses one-based indexes and thus all errors selected with `F4` are off by one character. Here is the example of a `.sublime-build` config:

```json
{
    "cmd": ["eslint", "$file"],
    "file_regex": "^(.+\\.js)$",
    "line_regex": " *([0-9]+):([0-9]+) *(.+)$",
    "selector": ["source.js"]
}
```

For example:

```bash
~/src/js/eslint$ bin/eslint.js tests/fixtures/missing-semicolon.js 

tests/fixtures/missing-semicolon.js
  1:4   error  foo is defined but never used  no-unused-vars
  1:15  error  Missing semicolon              semi

✖ 2 problems (2 errors, 0 warnings)
```

And with the `--one-based-index` flag:

```bash
~/src/js/eslint$ bin/eslint.js --one-based-index tests/fixtures/missing-semicolon.js 

tests/fixtures/missing-semicolon.js
  1:5   error  foo is defined but never used  no-unused-vars
  1:16  error  Missing semicolon              semi

✖ 2 problems (2 errors, 0 warnings)
```

I added two new unit tests and `npm test` returns no errors. Let me know if something needs fixing.

Thanks