### PR TITLE
Docs: Fix typo in working-with-rules.md

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -254,7 +254,7 @@ valid: [
 ]
 ```
 
-Your rule will then be passed the arguments just as if it can from a configuration file.
+Your rule will then be passed the arguments as if they came from a configuration file.
 
 ### Invalid Code
 


### PR DESCRIPTION
I noticed this grammar error in the docs and thought I'd submit a PR.