### PR TITLE
Docs: Fix typo in command-line-interface.md

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -190,7 +190,7 @@ Examples:
 
 ### `--rulesdir`
 
-This option allows you to specify a second directory from which to load rules files. This allows you to dynamically loading new rules at run time. This is useful when you have custom rules that aren't suitable for being bundled with ESLint.
+This option allows you to specify a second directory from which to load rules files. This allows you to dynamically load new rules at run time. This is useful when you have custom rules that aren't suitable for being bundled with ESLint.
 
 Example:
 


### PR DESCRIPTION
I saw this typo in the docs and thought I should submit a PR.