### PR TITLE
New: Added an option for one-based column indexes (fixes #2261)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -180,6 +180,14 @@ var cli = {
                 result.results = getErrorResults(result.results);
             }
 
+            if (currentOptions.oneBasedIndex) {
+                result.results.forEach(function(res) {
+                    res.messages.forEach(function(message) {
+                        message.column = isNaN(message.column) ? 0 : message.column + 1;
+                    });
+                });
+            }
+
             if (printResults(engine, result.results, currentOptions.format, currentOptions.outputFile)) {
                 return result.errorCount ? 1 : 0;
             } else {

--- a/lib/options.js
+++ b/lib/options.js
@@ -112,5 +112,12 @@ module.exports = optionator({
         type: "Boolean",
         default: "false",
         description: "Lint code provided on <STDIN>"
+    },
+    {
+        option: "one-based-index",
+        alias: "i",
+        type: "Boolean",
+        default: "false",
+        description: "Uses 1 as first index, as opposed to 0"
     }]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -413,4 +413,33 @@ describe("cli", function() {
             assert.isTrue(console.error.calledOnce);
         });
     });
+
+    describe("when not using --one-based-index", function() {
+
+        it("should print zero-based indexes", function() {
+            var exit;
+
+            exit = cli.execute("tests/fixtures/single-quoted.js");
+
+            assert.equal(exit, 1);
+            assert.include(console.log.lastCall.args[0], "1:4");
+            assert.include(console.log.lastCall.args[0], "1:10");
+        });
+
+    });
+
+    describe("when using --one-based-index", function() {
+
+        it("should print one-based indexes", function() {
+            var exit;
+
+            exit = cli.execute("-i tests/fixtures/single-quoted.js");
+
+            assert.equal(exit, 1);
+            assert.include(console.log.lastCall.args[0], "1:5");
+            assert.include(console.log.lastCall.args[0], "1:11");
+        });
+
+    });
+
 });


### PR DESCRIPTION
This pull requests adds a new `-i` or `--one-based-index` flag which enables one-based column indexes.

If the option is enabled, the lint results are iterated just before sending them to `lib/cli.js#printResults()` function and the field message's `column` is increased by `1`.

There are two new unit tests which cover this case. They can be run with: 
```bash
mocha tests/lib/cli.js --grep 'one-based-index'
```