### PR TITLE
Docs: Standardize on '*' for unordered lists, enable corresponding markd...

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -209,7 +209,9 @@ function lintMarkdown(files) {
             default: true,
             // Exclusions for deliberate/widespread violations
             MD002: false, // First header should be a h1 header
-            MD004: false, // Unordered list style
+            MD004: {      // Unordered list style
+                style: "asterisk"
+            },
             MD007: {      // Unordered list indentation
                 indent: 4
             },

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -16,8 +16,8 @@ There are many commonly used aliases for `this` such as `self`, `that` or `me`. 
 
 This rule designates a variable as the chosen alias for "this". It then enforces two things:
 
-- if a variable with the designated name is declared or assigned to, it *must* explicitly be assigned the current execution context, i.e. `this`
-- if `this` is explicitly assigned to a variable, the name of that variable must be the designated one
+* if a variable with the designated name is declared or assigned to, it *must* explicitly be assigned the current execution context, i.e. `this`
+* if `this` is explicitly assigned to a variable, the name of that variable must be the designated one
 
 Assuming that alias is `self`, the following patterns are considered warnings:
 

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -5,9 +5,9 @@ It is considered good practice to use the type-safe equality operators `===` and
 The reason for this is that `==` and `!=` do type coercion which follows the rather obscure [Abstract Equality Comparison Algorithm](http://www.ecma-international.org/ecma-262/5.1/#sec-11.9.3).
 For instance, the following statements are all considered `true`:
 
-- `[] == false`
-- `[] == ![]`
-- `3 == "03"`
+* `[] == false`
+* `[] == ![]`
+* `3 == "03"`
 
 If one of those occurs in an innocent-looking statement such as `a == b` the actual problem is very difficult to spot.
 
@@ -27,7 +27,7 @@ if (obj.getStuff() != undefined) { ... }
 
 ### Options
 
-- `"smart"`
+* `"smart"`
 
 This option enforces the use of `===` and `!==` except for these cases:
 
@@ -65,7 +65,7 @@ bananas != 1
 value == undefined
 ```
 
-- `"allow-null"`
+* `"allow-null"`
 
 This option will enforce `===` and `!==` in your code with one exception - it permits comparing to `null` to check for `null` or `undefined` in a single expression.
 

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -90,5 +90,5 @@ confident that some other form of monitoring will help you catch the problem.
 
 ## Further Reading
 
-- [The Art Of Node: Callbacks](https://github.com/maxogden/art-of-node#callbacks)
-- [Nodejitsu: What are the error conventions?](http://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions)
+* [The Art Of Node: Callbacks](https://github.com/maxogden/art-of-node#callbacks)
+* [Nodejitsu: What are the error conventions?](http://docs.nodejitsu.com/articles/errors/what-are-the-error-conventions)

--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -46,16 +46,16 @@ If provided, it must be an `Array`.
 Array of uppercase-starting function names that are permitted to be used without the `new` operator.
 If not provided, `capIsNewExceptions` defaults to the following:
 
-- `Array`
-- `Boolean`
-- `Date`
-- `Error`
-- `Function`
-- `Number`
-- `Object`
-- `RegExp`
-- `String`
-- `Symbol`
+* `Array`
+* `Boolean`
+* `Date`
+* `Error`
+* `Function`
+* `Number`
+* `Object`
+* `RegExp`
+* `String`
+* `Symbol`
 
 If provided, it must be an `Array`. The default values will continue to be excluded when `capIsNewExceptions` is provided.
 

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -19,8 +19,8 @@ This rule is aimed at eliminating ambiguous assignments in `for`, `if`, `while`,
 
 The rule takes one option, a string, which must contain one of the following values:
 
-+ `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
-+ `always`: Disallow all assignments.
+* `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
+* `always`: Disallow all assignments.
 
 #### "except-parens"
 

--- a/docs/rules/no-extend-native.md
+++ b/docs/rules/no-extend-native.md
@@ -26,15 +26,15 @@ A common suggestion to avoid this problem would be to wrap the inside of the `fo
 
 Disallows directly modifying the prototype of builtin objects by looking for the following styles:
 
-- `Object.prototype.a = "a";`
-- `Object.defineProperty(Array.prototype, "times", {value: 999});`
+* `Object.prototype.a = "a";`
+* `Object.defineProperty(Array.prototype, "times", {value: 999});`
 
 It *does not* check for any of the following less obvious approaches:
 
-- `var x = Object; x.prototype.thing = a;`
-- `eval("Array.prototype.forEach = 'muhahaha'");`
-- `with(Array) { prototype.thing = 'thing'; };`
-- `window.Function.prototype.bind = 'tight';`
+* `var x = Object; x.prototype.thing = a;`
+* `eval("Array.prototype.forEach = 'muhahaha'");`
+* `with(Array) { prototype.thing = 'thing'; };`
+* `window.Function.prototype.bind = 'tight';`
 
 ## When Not To Use It
 

--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -6,11 +6,11 @@ Various whitespace characters can be inputted by programmers by mistake for exam
 
 Known issues these spaces cause:
 
-- Zero Width Space
-    - Is NOT considered a separator for tokens and is often parsed as an `Unexpected token ILLEGAL`
-    - Is NOT shown in modern browsers making code repository software expected to resolve the visualisation
-- Line Separator
-    - Is NOT a valid character within JSON which would cause parse errors
+* Zero Width Space
+    * Is NOT considered a separator for tokens and is often parsed as an `Unexpected token ILLEGAL`
+    * Is NOT shown in modern browsers making code repository software expected to resolve the visualisation
+* Line Separator
+    * Is NOT a valid character within JSON which would cause parse errors
 
 ## Rule Details
 

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -6,8 +6,8 @@ In the Node.JS community it is often customary to separate the `require`d module
 
 When this rule is enabled, all `var` statements must satisfy the following conditions:
 
-- either none or all variable declarations must be require declarations
-- all require declarations must be of the same type (optional)
+* either none or all variable declarations must be require declarations
+* all require declarations must be of the same type (optional)
 
 ### Options
 
@@ -25,12 +25,12 @@ If enabled, violations will be reported whenever a single `var` statement contai
 
 This rule distinguishes between six kinds of variable declaration types:
 
-- `core`: declaration of a required [core module][1]
-- `file`: declaration of a required [file module][2]
-- `module`: declaration of a required module from the [node_modules folder][3]
-- `computed`: declaration of a required module whose type could not be determined (either because it is computed or because require was called without an argument)
-- `uninitialized`: a declaration that is not initialized
-- `other`: any other kind of declaration
+* `core`: declaration of a required [core module][1]
+* `file`: declaration of a required [file module][2]
+* `module`: declaration of a required module from the [node_modules folder][3]
+* `computed`: declaration of a required module whose type could not be determined (either because it is computed or because require was called without an argument)
+* `uninitialized`: a declaration that is not initialized
+* `other`: any other kind of declaration
 
 In this document, the first four types are summed up under the term *require declaration*.
 

--- a/docs/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/rules/no-mixed-spaces-and-tabs.md
@@ -38,7 +38,7 @@ function main() {
 
 ### Options
 
-- Smart Tabs
+* Smart Tabs
 
 This option suppresses warnings about mixed tabs and spaces when the latter are used for alignment only. This technique is called [SmartTabs](http://www.emacswiki.org/emacs/SmartTabs). The option is turned off by default.
 

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -16,8 +16,8 @@ while (a = next(), a && a.length);
 
 This rule forbids the use of the comma operator, with the following exceptions:
 
-- In the initialization or update portions of a `for` statement.
-- If the expression sequence is explicitly wrapped in parentheses.
+* In the initialization or update portions of a `for` statement.
+* If the expression sequence is explicitly wrapped in parentheses.
 
 The following patterns are considered warnings:
 

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -69,9 +69,9 @@ This option has three settings:
 
 The following code:
 
-- will throw `baz is defined but never used` when `args`: `after-used`
-- will throw `foo is defined but never used` and `baz is defined but never used` when `args`: `all`
-- will throw nothing when `args`: `none`
+* will throw `baz is defined but never used` when `args`: `after-used`
+* will throw `foo is defined but never used` and `baz is defined but never used` when `args`: `all`
+* will throw nothing when `args`: `none`
 
 ```js
 (function(foo, bar, baz) {

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -94,8 +94,8 @@ Unary operator "-" is not followed by whitespace.
 
 This rule have two options: `words` and `nonwords`:
 
-- `words` - applies to unary word operators such as: `new`, `delete`, `typeof`, `void`
-- `nonwords` - applies to unary operators such as: `-`, `+`, `--`, `++`, `!`, `!!`
+* `words` - applies to unary word operators such as: `new`, `delete`, `typeof`, `void`
+* `nonwords` - applies to unary operators such as: `-`, `+`, `--`, `++`, `!`, `!!`
 
 Default values are:
 

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -32,4 +32,4 @@ if (isNaN(NaN)) {
 
 ## Further reading
 
-- [Use the isNaN function to compare with NaN](http://jslinterrors.com/use-the-isnan-function-to-compare-with-nan/)
+* [Use the isNaN function to compare with NaN](http://jslinterrors.com/use-the-isnan-function-to-compare-with-nan/)

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -419,9 +419,9 @@ When ESLint is run, it looks in the current working directory to find an `.eslin
 
 Globs are matched using [minimatch](https://github.com/isaacs/minimatch), so a number of features are available:
 
-- Lines beginning with `#` are treated as comments and do not affect ignore patterns.
-- Lines preceded by `!` are negated patterns that re-include a pattern that was ignored by an earlier pattern.
-- Brace expansion can refer to multiple files in a pattern. For example, `file.{js,ts,coffee}` will ignore `file.js`, `file.ts`, and `file.coffee`.
+* Lines beginning with `#` are treated as comments and do not affect ignore patterns.
+* Lines preceded by `!` are negated patterns that re-include a pattern that was ignored by an earlier pattern.
+* Brace expansion can refer to multiple files in a pattern. For example, `file.{js,ts,coffee}` will ignore `file.js`, `file.ts`, and `file.coffee`.
 
 In addition to any patterns in a `.eslintignore` file, ESLint always ignores files in `node_modules/**`.
 


### PR DESCRIPTION
...ownlint rule.

Note: '*' was overwhelmingly more popular than '-' or '+' (and generally more common), so I picked it. As before, please reject the PR if you see no value in this.