### PR TITLE
Docs: Remove trailing spaces, enable corresponding markdownlint rule.

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -215,7 +215,6 @@ function lintMarkdown(files) {
             MD007: {      // Unordered list indentation
                 indent: 4
             },
-            MD009: false, // Trailing spaces
             MD012: false, // Multiple consecutive blank lines
             MD013: false, // Line length
             MD026: false, // Trailing punctuation in header

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -29,19 +29,19 @@ processors: {
     // assign to the file extension you want (.js, .jsx, .html, etc.)
     ".ext": {
         // takes text of the file and filename
-        preprocess: function(text, filename) { 
+        preprocess: function(text, filename) {
             // here, you can strip out any non-JS content
             // and split into multiple strings to lint
-        
+
             return [string];  // return an array of strings to lint
-        }, 
-        
+        },
+
         // takes an Message[][] and filename
         postprocess: function(messages, filename) {
             // messages is two-dimensional array of Message objects
             // where each array top-level are item are the lint messages related
             // to the text that was returned in an array in preprocess()
-            
+
             // you need to return a one-dimensional array of the messages you want to keep
             return [Message];
         }

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -38,7 +38,7 @@ var doSomething = function() {
 };
 ```
 
-In this case, `doSomething()` is undefined at the time of invocation and so causes a runtime error. 
+In this case, `doSomething()` is undefined at the time of invocation and so causes a runtime error.
 
 Due to these different behaviors, it's common to have guidelines as to which style of function should be used. There is really no correct or incorrect choice here, it's just a preference.
 

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -35,7 +35,7 @@ function loadData (err, data) {
 }
 
 function generateError (err) {
-    if (err) {} 
+    if (err) {}
 }
 ```
 

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -11,7 +11,7 @@ Some consider this to be a bad practice as it was an undocumented feature of Jav
 
 ## Rule Details
 
-This rule is aimed at preventing the use of multiline strings. 
+This rule is aimed at preventing the use of multiline strings.
 
 The following generates a warning:
 

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -11,11 +11,11 @@ The following patterns are considered warnings:
 
 ```js
 // no-multiple-empty-lines: [1, {max: 2}]  // Maximum of 2 empty lines.
-var foo = 5;  
-  
-  
-  
-  
+var foo = 5;
+
+
+
+
 var bar = 3;
 
 ```
@@ -25,16 +25,16 @@ The following patterns are not warnings:
 ```js
 
 // no-multiple-empty-lines: [1, {max: 2}]  // Maximum of 2 empty lines.
-var foo = 5;  
-  
+var foo = 5;
+
 var bar = 3;
 
 // no-multiple-empty-lines: [1, {max: 4}]  // Maximum of 4 empty lines.
-var foo = 5;  
-  
-  
-  
-  
+var foo = 5;
+
+
+
+
 var bar = 3;
 
 ```

--- a/docs/rules/no-new.md
+++ b/docs/rules/no-new.md
@@ -12,7 +12,7 @@ It's less common to use `new` and not store the result, such as:
 new Person();
 ```
 
-In this case, the created object is thrown away because its reference isn't stored anywhere, and in many cases, this means that the constructor should be replaced with a function that doesn't require `new` to be used. 
+In this case, the created object is thrown away because its reference isn't stored anywhere, and in many cases, this means that the constructor should be replaced with a function that doesn't require `new` to be used.
 
 ## Rule Details
 

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -4,7 +4,7 @@ The `with` statement is potentially problematic because it adds members of an ob
 
 ## Rule Details
 
-This rule is aimed at eliminating `with` statements. 
+This rule is aimed at eliminating `with` statements.
 
 The following patterns are considered warnings:
 

--- a/docs/rules/spaced-line-comment.md
+++ b/docs/rules/spaced-line-comment.md
@@ -9,12 +9,12 @@ On the other hand, commenting out code is easier without having to put a whitesp
 
 This rule will enforce consistency of spacing after the start of a line comment `//`.
 
-This rule takes two arguments. If the first is `"always"` then the `//` must be followed by at least once whitespace. 
+This rule takes two arguments. If the first is `"always"` then the `//` must be followed by at least once whitespace.
 If `"never"` then there should be no whitespace following.
 The default is `"always"`.
 
-The second argument is an object with one key, `"exceptions"`. 
-The value is an array of string patterns which are considered exceptions to the rule. 
+The second argument is an object with one key, `"exceptions"`.
+The value is an array of string patterns which are considered exceptions to the rule.
 It is important to note that the exceptions are ignored if the first argument is `"never"`.
 Exceptions cannot be mixed.
 
@@ -28,7 +28,7 @@ The following patterns are considered warnings:
 ```js
 //When ["always"]
 //This is a comment with no whitespace at the beginning
-var foo = 5;  
+var foo = 5;
 ```
 
 ```js
@@ -43,13 +43,13 @@ The following patterns are not warnings:
 ```js
 // When ["always"]
 // This is a comment with a whitespace at the beginning
-var foo = 5;  
+var foo = 5;
 ```
 
 ```js
 //When ["never"]
 //This is a comment with no whitespace at the beginning
-var foo = 5;  
+var foo = 5;
 ```
 
 ```js


### PR DESCRIPTION
Note that there is one scenario where trailing spaces is desirable: [when forcing a `<br>` tag via 2 or more spaces](http://daringfireball.net/projects/markdown/syntax#p). However, none of the instances I saw appeared to be doing that - all were either a single space OR multiple spaces within a fenced code block where consecutive lines are not wrapped anyway.