### PR TITLE
one-var: add “var-only” option

### DIFF
--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -30,7 +30,7 @@ This rule is aimed at enforcing the use of either one variable declaration or mu
 
 ### Options
 
-There is one option for this rule, and that is specified as `"always"` (the default) to enforce one variable declaration per function, or `"never"` to enforce multiple variable declarations per function. You can configure the rule as follows:
+There is one option for this rule, and that is specified as `"always"` (the default) to enforce one variable declaration per function, `"never"` to enforce multiple variable declarations per function, or `"var-only"` to not apply this rule to `let` and `const` declarations. You can configure the rule as follows:
 
 ```json
 {
@@ -110,9 +110,55 @@ function foo() {
 }
 ```
 
+When configured with `"var-only"` as the first option, the following patterns are considered warnings:
+
+The following patterns are considered warnings:
+
+```js
+function foo() {
+    var bar;
+    var baz;
+}
+
+function foo() {
+    var bar;
+
+    if (baz) {
+        var qux = true;
+    }
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+function foo() {
+    var bar,
+        baz;
+}
+
+function foo() {
+    var bar,
+        qux;
+
+    if (baz) {
+        qux = true;
+    }
+}
+
+function foo() {
+    const baz = true;
+    let bar;
+
+    if (baz) {
+        bar = true;
+    }
+}
+```
+
 ## Compatibility
 
-* **JSHint** - This rule maps to the `onevar` JSHint rule.
+* **JSHint** - This rule maps to the `onevar` JSHint rule, but adds support for `let` and `const` with the `var-only` option.
 
 ## Further Reading
 

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -64,7 +64,13 @@ module.exports = function(context) {
         "ArrowFunctionExpression": startFunction,
 
         "VariableDeclaration": function(node) {
+            // do not apply to let and const delclarations
+            if (node.kind !== "var" && MODE === "var-only") {
+                return;
+            }
+
             var declarationCount = node.declarations.length;
+
             if (MODE === "never") {
                 if (declarationCount > 1) {
                     context.report(node, "Split 'var' declaration into multiple statements.");

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -38,6 +38,13 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                 destructuring: true
             },
             args: [2, "never"]
+        },
+        {
+            code: "function foo() { let a = 1; const b = false; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "var-only"]
         }
     ],
     invalid: [
@@ -120,6 +127,17 @@ eslintTester.addRuleTest("lib/rules/one-var", {
             code: "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
             ecmaFeatures: {
                 destructuring: true
+            },
+            args: [2, "always"],
+            errors: [{
+                message: "Combine this with the previous 'var' statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { let a = 1; const b = false; }",
+            ecmaFeatures: {
+                blockBindings: true
             },
             args: [2, "always"],
             errors: [{


### PR DESCRIPTION
Previously, there was no way to configure this rule to enforce itself on
combining var statements but allowing `let` and `const` to be declared 
in the same scope. 

This adds a third value to the first option, “var-only” which only
enforces the var rule for the `var` declaration, but allows `let` and
`const` to both be declared, a valid use-case that was previously 
impossible.