### PR TITLE
Update: Add "none" option to operator-linebreak rule (fixes #2295)

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -22,7 +22,7 @@ The `operator-linebreak` rule is aimed at enforcing a particular operator line b
 
 ### Options
 
-The rule takes an option, a string, which could be either "after" or "before". The default is "after".
+The rule takes an option, a string, which could be "after", "before" or "none". The default is "after".
 
 You can set the style in configuration like this:
 
@@ -108,6 +108,43 @@ foo
 
 if (someCondition
     || otherCondition) {
+}
+
+```
+
+#### "none"
+
+This option disallows line breaks on either side of the operator.
+
+While using this setting, the following patterns are considered warnings:
+
+```js
+
+foo = 1 +
+      2;
+
+foo = 1
+    + 2;
+
+if (someCondition ||
+    otherCondition) {
+}
+
+if (someCondition
+    || otherCondition) {
+}
+
+```
+
+The following patterns are not warnings:
+
+```js
+
+foo = 1 + 2;
+
+foo = 5;
+
+if (someCondition || otherCondition) {
 }
 
 ```

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -80,6 +80,14 @@ module.exports = function(context) {
                 line: operatorToken.loc.end.line,
                 column: operatorToken.loc.end.column
             }, "'" + operator + "' should be placed at the end of the line.");
+
+        } else if (style === "none") {
+
+            context.report(node, {
+                line: operatorToken.loc.end.line,
+                column: operatorToken.loc.end.column
+            }, "There should be no line break before or after '" + operator + "'");
+
         }
     }
 

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -15,7 +15,8 @@ var eslint = require("../../../lib/eslint"),
 
 var BAD_LN_BRK_MSG = "Bad line breaking before and after '%s'.",
     BEFORE_MSG = "'%s' should be placed at the beginning of the line.",
-    AFTER_MSG = "'%s' should be placed at the end of the line.";
+    AFTER_MSG = "'%s' should be placed at the end of the line.",
+    NONE_MSG = "There should be no line break before or after '%s'";
 
 //------------------------------------------------------------------------------
 // Tests
@@ -44,7 +45,15 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
         {code: "1 + 1\n+ 1", options: ["before"]},
         {code: "f(1\n+ 1)", options: ["before"]},
         {code: "1 \n|| 1", options: ["before"]},
-        {code: "a += 1", options: ["before"]}
+        {code: "a += 1", options: ["before"]},
+
+        {code: "1 + 1", options: ["none"]},
+        {code: "1 + 1 + 1", options: ["none"]},
+        {code: "1 || 1", options: ["none"]},
+        {code: "a += 1", options: ["none"]},
+        {code: "var a;", options: ["none"]},
+        {code: "\n1 + 1", options: ["none"]},
+        {code: "1 + 1\n", options: ["none"]}
     ],
 
     invalid: [
@@ -178,6 +187,107 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 type: "VariableDeclarator",
                 line: 1,
                 column: 7
+            }]
+        },
+
+        {
+            code: "1 +\n1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "+"),
+                type: "BinaryExpression",
+                line: 1,
+                column: 3
+            }]
+        },
+        {
+            code: "1\n+1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "+"),
+                type: "BinaryExpression",
+                line: 2,
+                column: 1
+            }]
+        },
+        {
+            code: "f(1 +\n1);",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "+"),
+                type: "BinaryExpression",
+                line: 1,
+                column: 5
+            }]
+        },
+        {
+            code: "f(1\n+ 1);",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "+"),
+                type: "BinaryExpression",
+                line: 2,
+                column: 1
+            }]
+        },
+        {
+            code: "1 || \n 1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "||"),
+                type: "LogicalExpression",
+                line: 1,
+                column: 4
+            }]
+        },
+        {
+            code: "1 \n || 1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "||"),
+                type: "LogicalExpression",
+                line: 2,
+                column: 3
+            }]
+        },
+        {
+            code: "a += \n1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "+="),
+                type: "AssignmentExpression",
+                line: 1,
+                column: 4
+            }]
+        },
+        {
+            code: "a \n+= 1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "+="),
+                type: "AssignmentExpression",
+                line: 2,
+                column: 2
+            }]
+        },
+        {
+            code: "var a = \n1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "="),
+                type: "VariableDeclarator",
+                line: 1,
+                column: 7
+            }]
+        },
+        {
+            code: "var a \n = 1",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "="),
+                type: "VariableDeclarator",
+                line: 2,
+                column: 2
             }]
         }
     ]


### PR DESCRIPTION
This option disallows line breaks on either side of an operator.