### PR TITLE
Docs: `no-invalid-regexp`: add `ecmaFeatures` flags for `u`/`y`

### DIFF
--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -32,6 +32,17 @@ new RegExp
 this.RegExp('[')
 ```
 
+## New ECMAScript 6 Flags
+
+ECMAScript 6 adds the "u" ([unicode](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode)) and "y" ([sticky](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky)) flags. You can enable these to be recognized as valid by adding the following to your `.eslintrc` file:
+
+```js
+"ecmaFeatures": {
+  "regexYFlag": true,
+  "regexUFlag": true
+}
+```
+
 ## Further Reading
 
 * [Annotated ES5 §7.8.5 - Regular Expression Literals](http://es5.github.io/#x7.8.5)


### PR DESCRIPTION
Documenting https://github.com/eslint/eslint/issues/1537#issuecomment-69674739 since I got confused looking for it.