### PR TITLE
Upgrade: beefy to 2.1.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "xml-escape": "~1.0.0"
   },
   "devDependencies": {
-    "beefy": "^1.0.0",
+    "beefy": "^2.0.0",
     "brfs": "0.0.9",
     "browserify": "^8.1.3",
     "chai": "^1.9.1",


### PR DESCRIPTION
This fixes installation issues on OS X and Node.js 0.12. The 1.* branch of beefy tried to install fsevents at a version that was incompatible with the updated v8 C(++) API in Node.js 0.11/0.12.

**Please review carefully** - I have not checked what other changes have been introduced to beefy that could impact other parts of the library.