### PR TITLE
(Proposal) New: no-inline-require rule

### DIFF
--- a/docs/rules/no-inline-require.md
+++ b/docs/rules/no-inline-require.md
@@ -1,0 +1,44 @@
+# Enforces module dependencies to be declared before use (no-inline-require)
+
+Declaring your module's dependencies at the beginning of your module improves readability and provides insight to other developers about what modules are required. Declaring these dependencies inline within other parts of your code may make them harder to spot and could lead to poorly-maintainable code.
+
+## Rule details
+
+This rule enforces that modules are declared in the module's scope and are not used before that.
+
+The following patterns are considered errors:
+
+```js
+// Use of module function before dependency declaration
+var formatted = require("util").format("Ultimate answer: %s", 42);
+
+var util;
+util = require('util');
+
+function myFunc () {
+    // require() statements should be in the module's top-level scope
+    var util = require('util');
+}
+
+// Use of require() in a function call
+myFunc(require('util').inspect);
+
+var result = require('myfunc')();
+```
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+var util = require('util')
+
+var inspect = require('util').inspect
+
+var util = require('util')
+function myFunc () {
+    var inspect = util.inspect
+}
+```
+
+## When Not To Use It
+
+If you want to be able to require other modules from anywhere in your code you can safely keep this rule disabled.

--- a/tests/lib/rules/no-inline-require.js
+++ b/tests/lib/rules/no-inline-require.js
@@ -1,0 +1,40 @@
+/**
+ * @fileoverview Tests for no-inline-require rule.
+ * @author Robert Rossmann
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+var eslintTester = new ESLintTester(eslint),
+    expectedMessage = "Inline require() statements not allowed; declare your dependency first",
+    expectedError = { message: expectedMessage, type: "CallExpression" };
+
+eslintTester.addRuleTest("lib/rules/no-inline-require", {
+    valid: [
+        "var util = require('util');",
+        "var util = require('util');\nutil.inspect({});",
+        "var insp = require('util').inspect;",
+        "var a = 1,\ninsp = require('util').inspect;",
+        "var util = require('util');\nmodule.exports = function f () {}"
+    ],
+    invalid: [
+        { code: "require('util').inspect({})", errors: [expectedError] },
+        { code: "function f () {};\nf(require('util'));", errors: [expectedError] },
+        { code: "function f () {};\nf(require('util').inspect);", errors: [expectedError] },
+        { code: "function f () {};\nf(require('util').inspect({}));", errors: [expectedError] },
+        { code: "function f () {};\nvar util = require('util');", errors: [expectedError] },
+        { code: "function f () {\nvar util = require('util');\n};", errors: [expectedError] },
+        { code: "var result = require('util').inspect({})", errors: [expectedError] },
+        { code: "var result;\nresult = require('util').inspect({})", errors: [expectedError] },
+        { code: "var insp;\ninsp = require('util').inspect;", errors: [expectedError] }
+    ]
+});


### PR DESCRIPTION
> Warning: Missing implementation. Tests will fail.

After seeing code like this...
```js
// code code code, lots of code... Then, suddenly
console.log(require('util').inspect(obj))
```

I decided to propose a rule that would require `require()` statements to be placed in the module's top-level scope before any of the module's functions or other resources are **used**. I believe this provides better insight into what modules/dependencies a particular module uses. See the included documentation for the proposed rule for details/examples.

**This is a proposal and RFC.** Implementation is missing for this rule. Unfortunately, I am not skilled enough in this area to implement it myself so community help is absolutely welcome (and necessary :) )!

*PS. I feel a strong urge to congratulate you on implementing such an easy way to write tests for these rules. With a tool of such a complexity, writing a test case for the proposed rule was quite a breeze.:)*