### PR TITLE
Add --stdin-filename option to allow naming the text being processed on STDIN

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -40,6 +40,7 @@ Options:
   -o, --output-file path::String  Specify file to write report to
   --quiet                     Report errors only - default: false
   --stdin                     Lint code provided on <STDIN> - default: false
+  --stdin-filename            Specify filename to process STDIN as
 ```
 
 ### `-c`, `--config`
@@ -207,6 +208,14 @@ This option tells ESLint to read and lint source code from STDIN instead files. 
 Example
 
     cat myfile.js | eslint --stdin
+
+### `--stdin-filename`
+
+This option allows you to specify a filename to process STDIN as. This is useful when processing files from STDIN and you have rules which depend on the filename.
+
+Example
+
+    cat myfile.js | eslint --stdin --stdin-filename=myfile.js
 
 ### `-v`, `--version`
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -209,10 +209,11 @@ function processFile(filename, configHelper) {
  * Processes an source code using ESLint.
  * @param {string} text The source code to check.
  * @param {Object} configHelper The configuration options for ESLint.
+ * @param {string} filename An optional string representing the texts filename.
  * @returns {Result} The results for linting on this text.
  * @private
  */
-function processText(text, configHelper) {
+function processText(text, configHelper, filename) {
 
     // clear all existing settings for a new file
     eslint.reset();
@@ -221,15 +222,16 @@ function processText(text, configHelper) {
         messages,
         stats;
 
-    debug("Linting <text>");
+    filename = filename || "<text>";
+    debug("Linting " + filename);
     config = configHelper.getConfig();
     loadPlugins(config.plugins);
-    messages = eslint.verify(text, config, "<text>");
+    messages = eslint.verify(text, config, filename);
 
     stats = calculateStatsPerFile(messages);
 
     return {
-        filePath: "<text>",
+        filePath: filename,
         messages: messages,
         errorCount: stats.errorCount,
         warningCount: stats.warningCount
@@ -327,15 +329,16 @@ CLIEngine.prototype = {
     /**
      * Executes the current configuration on text.
      * @param {string} text A string of JavaScript code to lint.
+     * @param {string} filename An optional string representing the texts filename.
      * @returns {Object} The results for the linting.
      */
-    executeOnText: function(text) {
+    executeOnText: function(text, filename) {
 
         var configHelper = new Config(this.options),
             results = [],
             stats;
 
-        results.push(processText(text, configHelper));
+        results.push(processText(text, configHelper, filename));
         stats = calculateStatsPerRun(results);
 
         return {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -175,7 +175,7 @@ var cli = {
             engine = new CLIEngine(translateOptions(currentOptions));
             debug("Running on " + (text ? "text" : "files"));
 
-            result = text ? engine.executeOnText(text) : engine.executeOnFiles(files);
+            result = text ? engine.executeOnText(text, currentOptions.stdinFilename) : engine.executeOnFiles(files);
             if (currentOptions.quiet) {
                 result.results = getErrorResults(result.results);
             }

--- a/lib/options.js
+++ b/lib/options.js
@@ -112,5 +112,10 @@ module.exports = optionator({
         type: "Boolean",
         default: "false",
         description: "Lint code provided on <STDIN>"
+    },
+    {
+        option: "stdin-filename",
+        type: "String",
+        description: "Specify filename to process STDIN as"
     }]
 });

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -77,6 +77,14 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 0);
         });
 
+        it("should report the filename when passed in", function() {
+
+            engine = new CLIEngine();
+
+            var report = engine.executeOnText("var foo = 'bar';", "test.js");
+            assert.equal(report.results[0].filePath, "test.js");
+        });
+
     });
 
     describe("executeOnFiles()", function() {

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -158,6 +158,13 @@ describe("options", function() {
         });
     });
 
+    describe("--stdin-filename", function() {
+        it("should return a string for .stdinFilename when passed", function() {
+            var currentOptions = options.parse("--stdin-filename test.js");
+            assert.equal(currentOptions.stdinFilename, "test.js");
+        });
+    });
+
     describe("--global", function() {
         it("should return an array for a single occurrence", function () {
             var currentOptions = options.parse("--global foo");


### PR DESCRIPTION
This PR should fix #1950
@nzakas please let me know if you have any feedback or would like me to make any changes.