### PR TITLE
Update: one-var: add let and const configuration

### DIFF
--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -5,7 +5,7 @@ Variables can be declared at any point in JavaScript code using `var`, `let`, or
 There are two schools of thought in this regard:
 
 1. There should be just one variable declaration for all variables in the function. That declaration typically appears at the top of the function.
-1. You should use one variable declaration for each variable you want to define.
+2. You should use one variable declaration for each variable you want to define.
 
 For instance:
 
@@ -30,22 +30,46 @@ This rule is aimed at enforcing the use of either one variable declaration or mu
 
 ### Options
 
-There is one option for this rule, and that is specified as `"always"` (the default) to enforce one variable declaration per function, or `"never"` to enforce multiple variable declarations per function. You can configure the rule as follows:
+There are two ways to configure this rule. The first is with one string specified as `"always"` (the default) to enforce one variable declaration per function or `"never"` to enforce multiple variable declarations per function.
 
-```json
+If you declare with `let` and `const`, `"always"` and `"never"` will only apply to the block scope, not the function scope.
+
+An alternative is to configure with an object. The keys are any of `var`, `let`, or `const`, and the values are either `"always"` or `"never"`. This allows you to set behavior differently for each type of declaration.
+
+You can configure the rule as follows:
+
+```javascript
 {
-    "one-var": [2, "always"]
+    // (default) Exactly one variable declaration per type per function (var) or block (let or const)
+    "one-var": [2, "always"],
+
+    // Exactly one declarator per declaration per function (var) or block (let or const)
+    "one-var": [2, "never"],
+
+    // Configure each declaration type individually. Defaults to "always" if key not present.
+    "one-var": [2, {
+        "var": "always", // Exactly one var declaration per function
+        "let": "always", // Exactly one let declaration per block
+        "const", "never" // Exactly one declarator per const declaration per block
+    }]
 }
 ```
 
 When configured with `"always"` as the first option (the default), the following patterns are considered warnings:
 
-The following patterns are considered warnings:
-
 ```js
 function foo() {
     var bar;
     var baz;
+    let qux;
+    let norf;
+}
+
+function foo(){
+    const bar = false;
+    const baz = true;
+    let qux;
+    let norf;
 }
 
 function foo() {
@@ -63,6 +87,15 @@ The following patterns are not considered warnings:
 function foo() {
     var bar,
         baz;
+    let qux,
+        norf;
+}
+
+function foo(){
+    const bar = true,
+        baz = false;
+    let qux,
+        norf;
 }
 
 function foo() {
@@ -71,6 +104,14 @@ function foo() {
 
     if (baz) {
         qux = true;
+    }
+}
+
+function foo(){
+    let bar;
+
+    if (baz) {
+        let qux;
     }
 }
 ```
@@ -81,6 +122,8 @@ When configured with `"never"` as the first option, the following patterns are c
 function foo() {
     var bar,
         baz;
+    const bar = true,
+        baz = false;
 }
 
 function foo() {
@@ -90,6 +133,11 @@ function foo() {
     if (baz) {
         qux = true;
     }
+}
+
+function foo(){
+    let bar = true,
+        baz = false;
 }
 ```
 
@@ -108,11 +156,37 @@ function foo() {
         var qux = true;
     }
 }
+
+function foo() {
+    let bar;
+
+    if (baz) {
+        let qux = true;
+    }
+}
+```
+
+When configured with an object as the first option, you can individually control how `var`, `let`, and `const` are handled. The following patterns are not considered warnings when the first option is `{var: "always", let: "never", const: "never"}`
+
+```js
+function foo() {
+    var bar,
+        baz;
+    let qux;
+    let norf;
+}
+
+function foo() {
+    const bar;
+    const baz;
+    let qux;
+    let norf;
+}
 ```
 
 ## Compatibility
 
-* **JSHint** - This rule maps to the `onevar` JSHint rule.
+* **JSHint** - This rule maps to the `onevar` JSHint rule, but allows `let` and `const` to be configured separately.
 
 ## Further Reading
 

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview A rule to ensure the use of a single variable declaration.
  * @author Ian Christian Myers
+ * @copyright 2015 Joey Baker. All rights reserved.
  * @copyright 2015 Danny Fritz. All rights reserved.
  * @copyright 2013 Ian Christian Myers. All rights reserved.
  */
@@ -14,12 +15,32 @@
 module.exports = function(context) {
 
     var MODE = context.options[0] || "always";
+    var options = {};
+
+    // simple options configuration with just a string or no option
+    if (typeof context.options[0] === "string" || context.options[0] == null) {
+        options.var = MODE;
+        options.let = MODE;
+        options.const = MODE;
+    } else {
+        options = context.options[0];
+    }
 
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
     var functionStack = [];
+    var blockStack = [];
+
+    /**
+     * Increments the blockStack counter.
+     * @returns {void}
+     * @private
+     */
+    function startBlock() {
+        blockStack.push({let: false, const: false});
+    }
 
     /**
      * Increments the functionStack counter.
@@ -28,6 +49,16 @@ module.exports = function(context) {
      */
     function startFunction() {
         functionStack.push(false);
+        startBlock();
+    }
+
+    /**
+     * Decrements the blockStack counter.
+     * @returns {void}
+     * @private
+     */
+    function endBlock() {
+        blockStack.pop();
     }
 
     /**
@@ -37,6 +68,7 @@ module.exports = function(context) {
      */
     function endFunction() {
         functionStack.pop();
+        endBlock();
     }
 
     /**
@@ -53,6 +85,34 @@ module.exports = function(context) {
         }
     }
 
+    /**
+     * Determines if there is more than one let statement in the current scope.
+     * @returns {boolean} Returns true if it is the first let declaration, false if not.
+     * @private
+     */
+    function hasOnlyOneLet() {
+        if (blockStack[blockStack.length - 1].let) {
+            return true;
+        } else {
+            blockStack[blockStack.length - 1].let = true;
+            return false;
+        }
+    }
+
+    /**
+     * Determines if there is more than one const statement in the current scope.
+     * @returns {boolean} Returns true if it is the first const declaration, false if not.
+     * @private
+     */
+    function hasOnlyOneConst() {
+        if (blockStack[blockStack.length - 1].const) {
+            return true;
+        } else {
+            blockStack[blockStack.length - 1].const = true;
+            return false;
+        }
+    }
+
     //--------------------------------------------------------------------------
     // Public API
     //--------------------------------------------------------------------------
@@ -62,20 +122,50 @@ module.exports = function(context) {
         "FunctionDeclaration": startFunction,
         "FunctionExpression": startFunction,
         "ArrowFunctionExpression": startFunction,
+        "BlockStatement": startBlock,
+        "ForStatement": startBlock,
+        "SwitchStatement": startBlock,
 
         "VariableDeclaration": function(node) {
             var declarationCount = node.declarations.length;
-            if (MODE === "never") {
-                if (declarationCount > 1) {
-                    context.report(node, "Split 'var' declaration into multiple statements.");
+
+            if (node.kind === "var") {
+                if (options.var === "never") {
+                    if (declarationCount > 1) {
+                        context.report(node, "Split 'var' declaration into multiple statements.");
+                    }
+                } else {
+                    if (hasOnlyOneVar()) {
+                        context.report(node, "Combine this with the previous 'var' statement.");
+                    }
                 }
-            } else {
-                if (hasOnlyOneVar()) {
-                    context.report(node, "Combine this with the previous 'var' statement.");
+            } else if (node.kind === "let") {
+                if (options.let === "never") {
+                    if (declarationCount > 1) {
+                        context.report(node, "Split 'let' declaration into multiple statements.");
+                    }
+                } else {
+                    if (hasOnlyOneLet()) {
+                        context.report(node, "Combine this with the previous 'let' statement.");
+                    }
                 }
+            } else if (node.kind === "const") {
+                if (options.const === "never") {
+                    if (declarationCount > 1) {
+                        context.report(node, "Split 'const' declaration into multiple statements.");
+                    }
+                } else {
+                    if (hasOnlyOneConst()) {
+                        context.report(node, "Combine this with the previous 'const' statement.");
+                    }
+                }
+
             }
         },
 
+        "ForStatement:exit": endBlock,
+        "SwitchStatement:exit": endBlock,
+        "BlockStatement:exit": endBlock,
         "Program:exit": endFunction,
         "FunctionDeclaration:exit": endFunction,
         "FunctionExpression:exit": endFunction,

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -38,6 +38,69 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                 destructuring: true
             },
             args: [2, "never"]
+        },
+        {
+            code: "function foo() { let a = 1; var c = true; if (a) {let c = true; } }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "always"]
+        },
+        {
+            code: "function foo() { const a = 1; var c = true; if (a) {const c = true; } }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "always"]
+        },
+        {
+            code: "function foo() { if (true) { const a = 1; }; if (true) {const a = true; } }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "always"]
+        },
+        {
+            code: "function foo() { let a = 1; let b = true; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "never"]
+        },
+        {
+            code: "function foo() { const a = 1; const b = true; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "never"]
+        },
+        {
+            code: "function foo() { let a = 1; const b = false; var c = true; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "always"]
+        },
+        {
+            code: "function foo() { let a = 1, b = false; var c = true; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "always"]
+        },
+        {
+            code: "function foo() { let a = 1; let b = 2; const c = false; const d = true; var e = true, f = false; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {var: "always", let: "never", const: "never"}]
+        },
+        {
+            code: "let foo = true; for (let i = 0; i < 1; i++) { let foo = false; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {var: "always", let: "always", const: "never"}]
         }
     ],
     invalid: [
@@ -125,6 +188,85 @@ eslintTester.addRuleTest("lib/rules/one-var", {
             errors: [{
                 message: "Combine this with the previous 'var' statement.",
                 type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { let a = 1; let b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "always"],
+            errors: [{
+                message: "Combine this with the previous 'let' statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { const a = 1; const b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, "always"],
+            errors: [{
+                message: "Combine this with the previous 'const' statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { let a = 1; let b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {let: "always"}],
+            errors: [{
+                message: "Combine this with the previous 'let' statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { const a = 1; const b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {const: "always"}],
+            errors: [{
+                message: "Combine this with the previous 'const' statement.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { let a = 1, b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {let: "never"}],
+            errors: [{
+                message: "Split 'let' declaration into multiple statements.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { const a = 1, b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {const: "never"}],
+            errors: [{
+                message: "Split 'const' declaration into multiple statements.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "let foo = true; switch(foo) { case true: let bar = 2; break; case false: let baz = 3; break; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {var: "always", let: "always", const: "never"}],
+            errors: [{
+                message: "Combine this with the previous 'let' statement.",
+                type: "VariableDeclaration",
+                line: 1,
+                column: 73
             }]
         }
     ]


### PR DESCRIPTION
Fixes #2301

Previously, there was no way to configure this rule to allow `var` `let`
and `const` to be declared in the same function scope. 

This changes the rule to treat `let` and `const` declarations as block
scoped, and allows each of the three variable declaration types to be
configured separately.