### PR TITLE
New: Added `no-redeclare-func` rule (fixes #2340)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -77,6 +77,7 @@
         "no-process-exit": 2,
         "no-proto": 2,
         "no-redeclare": 2,
+        "no-redeclare-func": 0,
         "no-regex-spaces": 2,
         "no-reserved-keys": 0,
         "no-restricted-modules": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -76,6 +76,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-process-env](no-process-env.md) - disallow use of `process.env` (off by default)
 * [no-proto](no-proto.md) - disallow usage of `__proto__` property
 * [no-redeclare](no-redeclare.md) - disallow declaring the same variable more then once
+* [no-redeclare-func](no-redeclare-func.md) - disallow declaring the same function more than once (off by default)
 * [no-return-assign](no-return-assign.md) - disallow use of assignment in `return` statement
 * [no-script-url](no-script-url.md) - disallow use of javascript: urls.
 * [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same (off by default)

--- a/docs/rules/no-redeclare-func.md
+++ b/docs/rules/no-redeclare-func.md
@@ -1,0 +1,126 @@
+# Disallow Duplicate Functions (no-redeclare-func)
+
+It is seldom intentional to overrwrite a function declared earlier in the same file.
+Declaring a function twice is an easy way to unintentionally override the original function's behavior instead of
+extending it. The `no-redeclare-func` rule flags the overriding of a previously defined function.
+
+The existing rule `no-redeclare` will catch instances of declaring the following types of function duplications:
+
+
+```js
+function foo() {
+    // does something
+}
+
+function foo() {
+    // does something else
+}
+```
+
+and
+
+```js
+var foo = function () {
+    // does something
+};
+
+var foo = function () {
+    // does something else
+};
+
+```
+
+However, it does not help in the cases of:
+
+```js
+var proto = {};
+
+proto.foo = function () {
+    // does something
+};
+
+proto.foo = function () {
+    // does something else
+};
+```
+
+or
+
+```js
+function Foo () {
+
+}
+
+Foo.prototype.bar = function () {
+    // does something
+};
+
+Foo.prototype.bar = function () {
+    // does something else
+};
+```
+
+That's where `no-redeclare-func` comes in
+
+## Rule Details
+
+This rule is aimed at preventing possible errors and unexpected behavior that might arise from accidentally overriding
+a function that was defined earlier in the file. As such, it warns whenever a function is overridden in the same file
+it's defined in.
+
+The following patterns are considered warnings:
+
+```js
+var proto = {};
+
+proto.foo = function () {
+    // does something
+};
+
+proto.foo = function () {
+    // does something else
+};
+```
+
+```js
+function Foo () {
+
+}
+
+Foo.prototype.bar = function () {
+    // does something
+};
+
+Foo.prototype.bar = function () {
+    // does something else
+};
+```
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+var proto = {};
+
+proto.sayHi = function () {
+    console.log('hi');
+};
+
+proto.sayHello = function () {
+    console.log('hello');
+};
+
+```
+
+```js
+function Foo () {
+
+}
+
+Foo.prototype.sayHi = function () {
+    console.log('hi');
+};
+
+Foo.prototype.sayHello() {
+    console.log('hello');
+}
+```

--- a/lib/rules/no-redeclare-func.js
+++ b/lib/rules/no-redeclare-func.js
@@ -1,0 +1,30 @@
+/**
+ * @fileoverview Rule to flag overriding a previously defined function
+ * @author Adam Meadows
+ * @copyright 2015 Adam Meadows. All rights reserved.
+ */
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    "use strict";
+
+    var functionAssignments = {};
+
+    return {
+
+        "AssignmentExpression": function(node) {
+            if (node.right.type === "FunctionExpression") {
+                var name = context.getSource(node.left);
+                if (functionAssignments[name]) {
+                    context.report(node, "Duplicate function '{{name}}'.", { name: name });
+                } else {
+                    functionAssignments[name] = true;
+                }
+            }
+        }
+    };
+};

--- a/tests/lib/rules/no-redeclare-func.js
+++ b/tests/lib/rules/no-redeclare-func.js
@@ -1,0 +1,34 @@
+/**
+ * @fileoverview Tests for no-redeclare-func rule.
+ * @author Adam Meadows
+ * @copyright 2015 Adam Meadows. All rights reserved.
+ */
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-redeclare-func", {
+    valid: [
+        "var foo = {}; foo.bar = function () {}; foo.baz = function () {};",
+        "function Foo () {}\nFoo.prototype.bar = function () {}; Foo.prototype.baz = function () {};"
+    ],
+    invalid: [
+        {
+          code: "var proto = {}; proto.foo = function () {}; proto.foo = function () {};",
+          errors: [{ message: "Duplicate function 'proto.foo'.", type: "AssignmentExpression"}]
+        },
+        {
+          code: "function Foo () {}\nFoo.prototype.bar = function () {}; Foo.prototype.bar = function () {};",
+          errors: [{ message: "Duplicate function 'Foo.prototype.bar'.", type: "AssignmentExpression"}]
+        }
+    ]
+});


### PR DESCRIPTION
This rule works similar to `no-redeclare` only handling the case
of assigning prototype functions and then re-declaring those prototype
functions later in the same file.