### PR TITLE
Docs: Use increasing order for list item prefixes, enable corresponding ...

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -217,8 +217,12 @@ function lintMarkdown(files) {
             },
             MD012: false, // Multiple consecutive blank lines
             MD013: false, // Line length
-            MD026: false, // Trailing punctuation in header
-            MD029: false, // Ordered list item prefix
+            MD026: {      // Trailing punctuation in header
+                punctuation: ".,;:\'"
+            },
+            MD029: {      // Ordered list item prefix
+                style: "ordered"
+            },
             MD034: false, // Bare URL used
             MD040: false  // Fenced code blocks should have a language specified
         },

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -174,7 +174,7 @@ Each rule must have a set of unit tests submitted with it to be accepted. The te
 For your rule, be sure to test:
 
 1. All instances that should be flagged as warnings.
-1. At least one pattern that should **not** be flagged as a warning.
+2. At least one pattern that should **not** be flagged as a warning.
 
 The basic pattern for a rule unit test file is:
 

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -5,7 +5,7 @@ Variables can be declared at any point in JavaScript code using `var`, `let`, or
 There are two schools of thought in this regard:
 
 1. There should be just one variable declaration for all variables in the function. That declaration typically appears at the top of the function.
-1. You should use one variable declaration for each variable you want to define.
+2. You should use one variable declaration for each variable you want to define.
 
 For instance:
 

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -32,9 +32,9 @@ Effectively, an object literal is created in an unreachable part of the code. Th
 On the other side of the argument are those who say ASI isn't magic, it follows a set of rules as to when semicolons are inserted and it's fairly easy to remember them. In short, as once described by Isaac Schlueter, a `\n` character always ends a statement (just like a semicolon) unless one of the following is true:
 
 1. The statement has an unclosed paren, array literal, or object literal or ends in some other way that is not a valid way to end a statement. (For instance, ending with `.` or `,`.)
-1. The line is `--` or `++` (in which case it will decrement/increment the next token.)
-1. It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
-1. The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other binary operator that can only be found between two tokens in a single expression.
+2. The line is `--` or `++` (in which case it will decrement/increment the next token.)
+3. It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
+4. The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other binary operator that can only be found between two tokens in a single expression.
 
 ## Rule Details
 

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -21,11 +21,11 @@ The JSDoc comments have a syntax all their own, and it is easy to mistakenly mis
 This rule aims to prevent invalid and incomplete JSDoc comments. In doing so, it will warn when:
 
 1. There is a JSDoc syntax error
-1. A `@param` or `@returns` is used without a type specified
-1. A `@param` or `@returns` is used without a description
-1. A comment for a function is missing `@returns`
-1. A parameter has no associated `@param` in the JSDoc comment
-1. `@param`s are out of order with named arguments
+2. A `@param` or `@returns` is used without a type specified
+3. A `@param` or `@returns` is used without a description
+4. A comment for a function is missing `@returns`
+5. A parameter has no associated `@param` in the JSDoc comment
+6. `@param`s are out of order with named arguments
 
 The following patterns are considered warnings:
 

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -3,7 +3,7 @@
 ESLint is designed to be completely configurable, meaning you can turn off every rule and run only with basic syntax validation, or mix and match the bundled rules and your custom rules to make ESLint perfect for your project. There are two primary ways to configure ESLint:
 
 1. **Configuration Comments** - use JavaScript comments to embed configuration information directly into a file.
-1. **Configuration Files** - use a JSON or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of an `.eslintrc` file or an `eslintConfig` field in a `package.json` file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](command-line-interface).
+2. **Configuration Files** - use a JSON or YAML file to specify configuration information for an entire directory and all of its subdirectories. This can be in the form of an `.eslintrc` file or an `eslintConfig` field in a `package.json` file, both of which ESLint will look for and read automatically, or you can specify a configuration file on the [command line](command-line-interface).
 
 There are several pieces of information that can be configured:
 
@@ -64,8 +64,8 @@ Setting language options helps ESLint determine what is a parsing error. All lan
 By default, ESLint uses [Espree](https://github.com/eslint/espree) as its parser. You can optionally specify that a different parser should be used in your configuration file so long as the parser meets the following requirements:
 
 1. It must be an npm module installed locally.
-1. It must have an Esprima-compatible interface (it must export a `parse()` method).
-1. It must produce Esprima-compatible AST and token objects.
+2. It must have an Esprima-compatible interface (it must export a `parse()` method).
+3. It must produce Esprima-compatible AST and token objects.
 
 Note that even with these compatibilities, there are no guarantees that an external parser will work correctly with ESLint and ESLint will not fix bugs related to incompatibilities with other parsers.
 
@@ -372,23 +372,23 @@ The complete configuration hierarchy, from highest precedence to lowest preceden
 
 1. Inline configuration
     1. `/*eslint-disable*/` and `/*eslint-enable*/`
-    1. `/*global*/`
-    1. `/*eslint*/`
-    1. `/*eslint-env*/`
+    2. `/*global*/`
+    3. `/*eslint*/`
+    4. `/*eslint-env*/`
 2. Command line options:
     1. `--global`
-    1. `--rule`
-    1. `--env`
-    1. `-c`, `--config`
+    2. `--rule`
+    3. `--env`
+    4. `-c`, `--config`
 3. Project-level configuration:
     1. `.eslintrc` file in same directory as linted file
-    1. `package.json` file in same directory as linted file
-    1. Continue searching for `.eslintrc` and `package.json` files in ancestor directories (parent has highest precedence, then grandparent, etc.), up to and including the root directory.
-    1. In the absence of any configuration from (i) and (ii), fall back to `~/.eslintrc` - personal default configuration
+    2. `package.json` file in same directory as linted file
+    3. Continue searching for `.eslintrc` and `package.json` files in ancestor directories (parent has highest precedence, then grandparent, etc.), up to and including the root directory.
+    4. In the absence of any configuration from (i) and (ii), fall back to `~/.eslintrc` - personal default configuration
 4. ESLint default configuration:
     1. `environments.json`
-    1. `eslint.json`
-    1. Blank (no config)
+    2. `eslint.json`
+    3. Blank (no config)
 
 ## Comments in Configuration Files
 


### PR DESCRIPTION
...markdownlint rule.

Notes:
* The repo was split about 60/40 in favor of 1/2/3 style vs. 1/1/1 style. 1/2/3 is easier to read in text form and rule MD029 ensures the numbering stays correct, so I converted to that approach.
* I also enabled MD026 to warn for trailing punctuation in headers. After changing the default to allow for '?' and '!' as used by README.md, there were no other changes needed.