### PR TITLE
Update: Use `Object.assign()` polyfill for all object merging (fixes #2348)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -265,11 +265,11 @@ function modifyConfigsFromComments(ast, config, reportingConfig, messages) {
                 switch (match[1]) {
                     case "globals":
                     case "global":
-                        util.mixin(commentConfig.astGlobals, parseBooleanConfig(value));
+                        assign(commentConfig.astGlobals, parseBooleanConfig(value));
                         break;
 
                     case "eslint-env":
-                        util.mixin(commentConfig.env, parseListConfig(value));
+                        assign(commentConfig.env, parseListConfig(value));
                         break;
 
                     case "eslint-disable":
@@ -306,10 +306,10 @@ function modifyConfigsFromComments(ast, config, reportingConfig, messages) {
     Object.keys(commentConfig.env).forEach(function (name) {
         var environmentRules = environments[name] && environments[name].rules;
         if (commentConfig.env[name] && environmentRules) {
-            util.mixin(commentConfig.rules, environmentRules);
+            assign(commentConfig.rules, environmentRules);
         }
     });
-    util.mixin(commentConfig.rules, commentRules);
+    assign(commentConfig.rules, commentRules);
 
     util.mergeConfigs(config, commentConfig);
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -12,17 +12,6 @@ var PLUGIN_NAME_PREFIX = "eslint-plugin-";
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
-/**
- * Merges two objects together and assigns the result to the initial object. Can be used for shallow cloning.
- * @param {Object} target of the cloning operation
- * @param {Object} source object
- * @returns {void}
- */
-exports.mixin = function(target, source) {
-    Object.keys(source).forEach(function(key) {
-        target[key] = source[key];
-    });
-};
 
 /**
  * Merges two config objects. This will not only add missing keys, but will also modify values to match.

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -17,28 +17,6 @@ var assert = require("chai").assert,
 
 describe("util", function() {
 
-    describe("mixin()", function() {
-        function code() {
-            var a = {}, b = { foo: "f", bar: 1 };
-            util.mixin(a, b);
-            return [a, b];
-        }
-
-        it("should add properties to target object", function() {
-            var a = code()[0];
-            assert.equal(Object.keys(a).length, 2);
-            assert.equal(a.foo, "f");
-            assert.equal(a.bar, 1);
-        });
-
-        it("should not change the source object", function() {
-            var b = code()[1];
-            assert.equal(Object.keys(b).length, 2);
-            assert.equal(b.foo, "f");
-            assert.equal(b.bar, 1);
-        });
-    });
-
     describe("removePluginPrefix()", function() {
         it("should remove common prefix when passed a plugin name  with a prefix", function() {
             var pluginName = util.removePluginPrefix("eslint-plugin-test");


### PR DESCRIPTION
More DRY and faster. Fixes #2348.