### PR TITLE
Add "grouped" formatter

### DIFF
--- a/lib/formatters/grouped.js
+++ b/lib/formatters/grouped.js
@@ -1,0 +1,90 @@
+/**
+ * @fileoverview Reporter grouped by warnings and then errors
+ * @author Jack Franklin
+ */
+"use strict";
+
+var chalk = require("chalk"),
+    table = require("text-table");
+
+function pluralize(word, count) {
+    return (count === 1 ? word : word + "s");
+}
+
+function outputTable(messages) {
+    return table(
+        messages.map(function(message) {
+            return [
+                "",
+                message.line || 0,
+                message.column || 0,
+                message.message.replace(/\.$/, ""),
+                chalk.gray(message.ruleId || "")
+            ];
+        }),
+        {
+            align: ["", "r", "l"],
+            stringLength: function(str) {
+                return chalk.stripColor(str).length;
+            }
+        }
+    ).split("\n").map(function(el) {
+        return el.replace(/(\d+)\s+(\d+)/, function(m, p1, p2) {
+            return chalk.gray(p1 + ":" + p2);
+        });
+    }).join("\n") + "\n\n";
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = function(results) {
+
+    var output = "\n",
+        summaryColor = "yellow",
+        errorsForFiles = {},
+        warningsForFiles = {};
+
+    results.forEach(function(result) {
+        if (result.errorCount > 0) {
+            errorsForFiles[result.filePath] = result.messages.filter(function(message) {
+                return message.severity === 2;
+            });
+        }
+
+        if (result.warningCount > 0) {
+            warningsForFiles[result.filePath] = result.messages.filter(function(message) {
+                return message.severity === 1;
+            });
+        }
+    });
+
+    var filesWithErrors = Object.keys(errorsForFiles),
+        filesWithWarnings = Object.keys(warningsForFiles),
+        totalErrors = filesWithErrors.length,
+        totalWarnings = filesWithWarnings.length,
+        total = totalErrors + totalWarnings;
+
+    if (total === 0) {
+        return;
+    }
+
+    filesWithWarnings.forEach(function(warningFile) {
+        output += chalk.yellow("Warnings for ") + chalk.underline(warningFile) + "\n";
+        output += outputTable(warningsForFiles[warningFile]);
+    });
+
+    filesWithErrors.forEach(function(errorFile) {
+        output += chalk.red("Errors for ") + chalk.underline(errorFile) + "\n";
+        output += outputTable(errorsForFiles[errorFile]);
+    });
+
+    output += chalk.yellow.bold([
+        "\u2716 ", total, pluralize(" problem", total),
+        " (", totalErrors, pluralize(" error", totalErrors), ", ",
+        totalWarnings, pluralize(" warning", totalWarnings), ")\n"
+    ].join(""));
+
+    return output;
+};


### PR DESCRIPTION
This outputs all warnings first, and then all errors. Useful for CLI
tools where you want to see warnings and errors but care more at first
about the errors.

Looks like so:

![screen shot 2015-04-22 at 17 39 18](https://cloud.githubusercontent.com/assets/193238/7279838/b2974ce2-e916-11e4-873e-c3e66af6b88e.png)

Stole a lot from the stylish formatter - largely the same (maybe worth looking at de-duping?) except I just gather up all warnings, output those, and then do the same with errors.

I've also just signed the CLA.

Let me know what you think - and thanks for an awesome tool! :)

Jack