### PR TITLE
Add support for extending configurations

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -391,6 +391,25 @@ The complete configuration hierarchy, from highest precedence to lowest preceden
     1. `eslint.json`
     1. Blank (no config)
 
+## Extending Configuration Files
+
+If you want to extend a specific configuration file, you can use the `extends` property and specify the path to the file. The path can be either relative or absolute.
+
+The extended configuration provides base rules, which can be overriden by the configuration that references it. For example:
+
+```js
+{
+    "extends": "node_modules/coding-standard/.eslintrc",
+
+    "rules": {
+        // Override any settings from the "parent" configuration
+        "eqeqeq": 1
+    }
+}
+```
+
+The extended configurations can also contain their own `extends`, resulting in recursive merging of the referenced configurations.
+
 ## Comments in Configuration Files
 
 Both the JSON and YAML configuration file formats support comments (`package.json` files should not include them). You can use JavaScript-style comments or YAML-style comments in either type of file and ESLint will safely ignore them. This allows your configuration files to be more human-friendly. For example:

--- a/lib/config.js
+++ b/lib/config.js
@@ -20,7 +20,8 @@ var fs = require("fs"),
     assign = require("object-assign"),
     debug = require("debug"),
     yaml = require("js-yaml"),
-    userHome = require("user-home");
+    userHome = require("user-home"),
+    isAbsolutePath = require("path-is-absolute");
 
 //------------------------------------------------------------------------------
 // Constants
@@ -57,6 +58,28 @@ function loadConfig(filePath) {
         } catch (e) {
             debug("Error reading YAML file: " + filePath);
             e.message = "Cannot read config file: " + filePath + "\nError: " + e.message;
+            throw e;
+        }
+    }
+
+    // If an `extends` property is defined, it represents a configuration file to use as
+    // a "parent". Load the referenced file and merge the configuration recursively.
+    if (config.extends) {
+        // If the `extends` path is relative, use the directory of the current configuration
+        // file as the reference point. Otherwise, use as-is.
+        var parentPath = (!isAbsolutePath(config.extends) ?
+            path.join(path.dirname(filePath), config.extends) :
+            config.extends
+        );
+
+        // Merge the configuration, ensuring children get preference over the parent
+        try {
+            config = util.mergeConfigs(loadConfig(parentPath), config);
+        } catch (e) {
+            // If the file referenced by `extends` failed to load, add the path to the
+            // configuration file that referenced it to the error message so the user is
+            // able to see where it was referenced from, then re-throw
+            e.message += "\nReferenced from: " + filePath;
             throw e;
         }
     }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "mkdirp": "^0.5.0",
     "object-assign": "^2.0.0",
     "optionator": "^0.5.0",
+    "path-is-absolute": "^1.0.0",
     "strip-json-comments": "~1.0.1",
     "text-table": "~0.2.0",
     "user-home": "^1.0.0",

--- a/tests/fixtures/config-extends/.eslintrc
+++ b/tests/fixtures/config-extends/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "subdir/.eslintrc",
+
+    "rules": {
+        "quotes": [2, "double"],
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/fixtures/config-extends/deep.json
+++ b/tests/fixtures/config-extends/deep.json
@@ -1,0 +1,11 @@
+{
+    "rules": {
+        "yoda": 2
+    },
+
+    "env": {
+        "browser": true
+    },
+
+    "extends": "subdir/subsubdir/deeper.json"
+}

--- a/tests/fixtures/config-extends/error.json
+++ b/tests/fixtures/config-extends/error.json
@@ -1,0 +1,3 @@
+{
+    "extends": "non-existant.json"
+}

--- a/tests/fixtures/config-extends/subdir/.eslintrc
+++ b/tests/fixtures/config-extends/subdir/.eslintrc
@@ -1,0 +1,10 @@
+{
+    "rules": {
+        "quotes": [1, "single"],
+        "yoda": 2
+    },
+
+    "env": {
+        "browser": true
+    }
+}

--- a/tests/fixtures/config-extends/subdir/subsubdir/deeper.json
+++ b/tests/fixtures/config-extends/subdir/subsubdir/deeper.json
@@ -1,0 +1,11 @@
+{
+    "rules": {
+        "semi": 2
+    },
+
+    "env": {
+        "browser": false
+    },
+
+    "extends": "subsubsubdir/deepest.json"
+}

--- a/tests/fixtures/config-extends/subdir/subsubdir/subsubsubdir/deepest.json
+++ b/tests/fixtures/config-extends/subdir/subsubdir/subsubsubdir/deepest.json
@@ -1,0 +1,10 @@
+{
+    "rules": {
+        "semi": 1,
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": true
+    }
+}

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -524,6 +524,44 @@ describe("Config", function() {
             configHelper.getConfig(path.resolve(__dirname, "..", "fixtures", "configurations", "empty", "empty.json"));
         });
 
+        // Extending configurations --------------------------------------------
+
+        // Non-recursive extends
+        it("should extend defined configuration file", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "config-extends", ".eslintrc"),
+                configHelper = new Config({ reset: true, useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "quotes": [2, "double"], "yoda": 2, "valid-jsdoc": 0 },
+                    env: { "browser": false }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Non-recursive extends
+        it("should extend recursively defined configuration files", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "config-extends", "deep.json"),
+                configHelper = new Config({ reset: true, useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "semi": 2, "yoda": 2, "valid-jsdoc": 0 },
+                    env: { "browser": true }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        // Meaningful stack-traces
+        it("should include references to where an `extends` configuration was loaded from", function() {
+            var configPath = path.resolve(__dirname, "..", "fixtures", "config-extends", "error.json");
+
+            assert.throws(function () {
+                var configHelper = new Config({ useEslintrc: false, configFile: configPath });
+                configHelper.getConfig(configPath);
+            }, /Referenced from:.*?error\.json/);
+        });
+
         describe("with plugin configuration", function() {
             var customRule = require("../fixtures/rules/custom-rule");
 


### PR DESCRIPTION
This PR adds support for the `extends` configuration option, which allows users to extend other configurations.

The primary use case I want to address is where you have a coding standard (for instance as an npm package) and want to make small modifications to it, for instance adding plugins or similar. In this case, cascading configurations doesn't help.

The PR addresses #1637, where @nzakas said:
> If you want to implement extends, I'd say go for it.

This is my first contribution, feedback is appreciated :-)