### PR TITLE
Update: Add uninitialized and initialized options (fixes #2206)

### DIFF
--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -26,15 +26,24 @@ The single-declaration school of thought is based in pre-ECMAScript 6 behaviors,
 
 ## Rule Details
 
-This rule is aimed at enforcing the use of either one variable declaration or multiple declarations per function. As such, it will warn when it encounters an unexpected number of variable declarations.
+This rule is aimed at enforcing the use of either one variable declaration or multiple declarations per function (for `var`) or block (for `let` and `const`) scope. As such, it will warn when it encounters an unexpected number of variable declarations.
 
 ### Options
 
-There are two ways to configure this rule. The first is with one string specified as `"always"` (the default) to enforce one variable declaration per function or `"never"` to enforce multiple variable declarations per function.
+There are two ways to configure this rule. The first is by using one string specified as `"always"` (the default) to enforce one variable declaration per scope or `"never"` to enforce multiple variable declarations per scope.  If you declare variables in your code with `let` and `const`, then `"always"` and `"never"` will apply to the block scope for those declarations, not the function scope.
 
-If you declare with `let` and `const`, `"always"` and `"never"` will only apply to the block scope, not the function scope.
+The second way to configure this rule is with an object. The keys are any of:
 
-An alternative is to configure with an object. The keys are any of `var`, `let`, or `const`, and the values are either `"always"` or `"never"`. This allows you to set behavior differently for each type of declaration.
+* `var`
+* `let`
+* `const`
+
+or:
+
+* `uninitialized`
+* `initialized`
+
+and the values are either `"always"` or `"never"`. This allows you to set behavior differently for each type of declaration, or whether variables are initialized during declaration.
 
 You can configure the rule as follows:
 
@@ -51,6 +60,12 @@ You can configure the rule as follows:
         "var": "always", // Exactly one var declaration per function
         "let": "always", // Exactly one let declaration per block
         "const", "never" // Exactly one declarator per const declaration per block
+    }]
+
+    // Configure uninitialized and initialized seperately. Defaults to "always" if key not present.
+    "one-var": [2, {
+        "uninitialized": "always", // Exactly one declaration for uninitialized variables per function (var) or block (let or const)
+        "initialized": "never" // Exactly one declarator per initialized variable declaration per function (var) or block (let or const)
     }]
 }
 ```
@@ -166,7 +181,9 @@ function foo() {
 }
 ```
 
-When configured with an object as the first option, you can individually control how `var`, `let`, and `const` are handled. The following patterns are not considered warnings when the first option is `{var: "always", let: "never", const: "never"}`
+When configured with an object as the first option, you can individually control how `var`, `let`, and `const` are handled, or alternatively how `uninitialized` and `initialized` variables are handled (which if used will override `var`, `let`, and `const`).
+
+The following patterns are not considered warnings when the first option is `{ var: "always", let: "never", const: "never" }`
 
 ```js
 function foo() {
@@ -184,9 +201,22 @@ function foo() {
 }
 ```
 
+The following patterns are not considered warnings when the first option is `{ uninitialized: "always", initialized: "never" }`
+
+```js
+function foo() {
+    var a, b, c;
+    var foo = true;
+    var bar = false;
+}
+```
+
+
+
 ## Compatibility
 
 * **JSHint** - This rule maps to the `onevar` JSHint rule, but allows `let` and `const` to be configured separately.
+* **JSCS** - This rule roughly maps to `"disallowMultipleVarDecl"`
 
 ## Further Reading
 

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -1,6 +1,7 @@
 /**
- * @fileoverview A rule to ensure the use of a single variable declaration.
+ * @fileoverview A rule to control the use of single variable declarations.
  * @author Ian Christian Myers
+ * @copyright 2015 Ian VanSchooten. All rights reserved.
  * @copyright 2015 Joey Baker. All rights reserved.
  * @copyright 2015 Danny Fritz. All rights reserved.
  * @copyright 2013 Ian Christian Myers. All rights reserved.
@@ -14,16 +15,42 @@
 
 module.exports = function(context) {
 
-    var MODE = context.options[0] || "always";
-    var options = {};
+    var MODE_ALWAYS = "always",
+        MODE_NEVER = "never";
 
-    // simple options configuration with just a string or no option
-    if (typeof context.options[0] === "string" || context.options[0] == null) {
-        options.var = MODE;
-        options.let = MODE;
-        options.const = MODE;
-    } else {
-        options = context.options[0];
+    var mode = context.options[0];
+
+    // default options
+    var options = {
+        var: { uninitialized: MODE_ALWAYS, initialized: MODE_ALWAYS},
+        let: { uninitialized: MODE_ALWAYS, initialized: MODE_ALWAYS},
+        const: { uninitialized: MODE_ALWAYS, initialized: MODE_ALWAYS}
+    };
+
+    if (typeof mode === "string") { // simple options configuration with just a string
+        options.var = { uninitialized: mode, initialized: mode};
+        options.let = { uninitialized: mode, initialized: mode};
+        options.const = { uninitialized: mode, initialized: mode};
+    } else if (typeof mode === "object") { // options configuration is an object
+        if (mode.hasOwnProperty("var") && typeof mode.var === "string") {
+            options.var = { uninitialized: mode.var, initialized: mode.var};
+        }
+        if (mode.hasOwnProperty("let") && typeof mode.let === "string") {
+            options.let = { uninitialized: mode.let, initialized: mode.let};
+        }
+        if (mode.hasOwnProperty("const") && typeof mode.const === "string") {
+            options.const = { uninitialized: mode.const, initialized: mode.const};
+        }
+        if (mode.hasOwnProperty("uninitialized")) {
+            options.var.uninitialized = mode.uninitialized;
+            options.let.uninitialized = mode.uninitialized;
+            options.const.uninitialized = mode.uninitialized;
+        }
+        if (mode.hasOwnProperty("initialized")) {
+            options.var.initialized = mode.initialized;
+            options.let.initialized = mode.initialized;
+            options.const.initialized = mode.initialized;
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -39,7 +66,10 @@ module.exports = function(context) {
      * @private
      */
     function startBlock() {
-        blockStack.push({let: false, const: false});
+        blockStack.push({
+            let: {initialized: false, uninitialized: false},
+            const: {initialized: false, uninitialized: false}
+        });
     }
 
     /**
@@ -48,7 +78,7 @@ module.exports = function(context) {
      * @private
      */
     function startFunction() {
-        functionStack.push(false);
+        functionStack.push({initialized: false, uninitialized: false});
         startBlock();
     }
 
@@ -72,46 +102,77 @@ module.exports = function(context) {
     }
 
     /**
+     * Records whether initialized or uninitialized variables are defined in current scope.
+     * @param {string} statementType node.kind, one of: "var", "let", or "const"
+     * @param {ASTNode[]} declarations List of declarations
+     * @param {Object} currentScope The scope being investigated
+     * @returns {void}
+     * @private
+     */
+    function recordTypes(statementType, declarations, currentScope) {
+        for (var i = 0; i < declarations.length; i++) {
+            if (declarations[i].init === null) {
+                if (options[statementType].uninitialized === MODE_ALWAYS) {
+                    currentScope.uninitialized = true;
+                }
+            } else {
+                if (options[statementType].initialized === MODE_ALWAYS) {
+                    currentScope.initialized = true;
+                }
+            }
+        }
+    }
+
+    /**
+     * Counts the number of initialized and uninitialized declarations in a list of declarations
+     * @param {ASTNode[]} declarations List of declarations
+     * @returns {Object} Counts of 'uninitialized' and 'initialized' declarations
+     * @private
+     */
+    function countDeclarations(declarations) {
+        var counts = { uninitialized: 0, initialized: 0 };
+        for (var i = 0; i < declarations.length; i++) {
+            if (declarations[i].init === null) {
+                counts.uninitialized++;
+            } else {
+                counts.initialized++;
+            }
+        }
+        return counts;
+    }
+
+    /**
      * Determines if there is more than one var statement in the current scope.
+     * @param {string} statementType node.kind, one of: "var", "let", or "const"
+     * @param {ASTNode[]} declarations List of declarations
      * @returns {boolean} Returns true if it is the first var declaration, false if not.
      * @private
      */
-    function hasOnlyOneVar() {
-        if (functionStack[functionStack.length - 1]) {
-            return true;
-        } else {
-            functionStack[functionStack.length - 1] = true;
-            return false;
+    function hasOnlyOneStatement(statementType, declarations) {
+        var currentScope;
+        var declarationCounts = countDeclarations(declarations);
+
+        if (statementType === "var") {
+            currentScope = functionStack[functionStack.length - 1];
+        } else if (statementType === "let") {
+            currentScope = blockStack[blockStack.length - 1].let;
+        } else if (statementType === "const") {
+            currentScope = blockStack[blockStack.length - 1].const;
         }
+        if (declarationCounts.uninitialized > 0) {
+            if (options[statementType].uninitialized === MODE_ALWAYS && currentScope.uninitialized) {
+                return false;
+            }
+        }
+        if (declarationCounts.initialized > 0) {
+            if (options[statementType].initialized === MODE_ALWAYS && currentScope.initialized) {
+                return false;
+            }
+        }
+        recordTypes(statementType, declarations, currentScope);
+        return true;
     }
 
-    /**
-     * Determines if there is more than one let statement in the current scope.
-     * @returns {boolean} Returns true if it is the first let declaration, false if not.
-     * @private
-     */
-    function hasOnlyOneLet() {
-        if (blockStack[blockStack.length - 1].let) {
-            return true;
-        } else {
-            blockStack[blockStack.length - 1].let = true;
-            return false;
-        }
-    }
-
-    /**
-     * Determines if there is more than one const statement in the current scope.
-     * @returns {boolean} Returns true if it is the first const declaration, false if not.
-     * @private
-     */
-    function hasOnlyOneConst() {
-        if (blockStack[blockStack.length - 1].const) {
-            return true;
-        } else {
-            blockStack[blockStack.length - 1].const = true;
-            return false;
-        }
-    }
 
     //--------------------------------------------------------------------------
     // Public API
@@ -127,39 +188,39 @@ module.exports = function(context) {
         "SwitchStatement": startBlock,
 
         "VariableDeclaration": function(node) {
-            var declarationCount = node.declarations.length;
+            var type = node.kind;
+            var declarations = node.declarations;
+            var declarationCounts = countDeclarations(declarations);
 
-            if (node.kind === "var") {
-                if (options.var === "never") {
-                    if (declarationCount > 1) {
-                        context.report(node, "Split 'var' declaration into multiple statements.");
-                    }
+            // always
+            if (!hasOnlyOneStatement(type, declarations)) {
+                if (options[type].initialized === MODE_ALWAYS && options[type].uninitialized === MODE_ALWAYS) {
+                    context.report(node, "Combine this with the previous '" + type + "' statement.");
                 } else {
-                    if (hasOnlyOneVar()) {
-                        context.report(node, "Combine this with the previous 'var' statement.");
+                    if (options[type].initialized === MODE_ALWAYS) {
+                        context.report(node, "Combine this with the previous '" + type + "' statement with initialized variables.");
+                    }
+                    if (options[type].uninitialized === MODE_ALWAYS) {
+                        context.report(node, "Combine this with the previous '" + type + "' statement with uninitialized variables.");
                     }
                 }
-            } else if (node.kind === "let") {
-                if (options.let === "never") {
-                    if (declarationCount > 1) {
-                        context.report(node, "Split 'let' declaration into multiple statements.");
-                    }
-                } else {
-                    if (hasOnlyOneLet()) {
-                        context.report(node, "Combine this with the previous 'let' statement.");
+            }
+            // never
+            if (options[type].initialized === MODE_NEVER && options[type].uninitialized === MODE_NEVER) {
+                if ((declarationCounts.uninitialized + declarationCounts.initialized) > 1) {
+                    context.report(node, "Split '" + type + "' declarations into multiple statements.");
+                }
+            } else {
+                if (options[type].initialized === MODE_NEVER) {
+                    if (declarationCounts.initialized > 1) {
+                        context.report(node, "Split initialized '" + type + "' declarations into multiple statements.");
                     }
                 }
-            } else if (node.kind === "const") {
-                if (options.const === "never") {
-                    if (declarationCount > 1) {
-                        context.report(node, "Split 'const' declaration into multiple statements.");
-                    }
-                } else {
-                    if (hasOnlyOneConst()) {
-                        context.report(node, "Combine this with the previous 'const' statement.");
+                if (options[type].uninitialized === MODE_NEVER) {
+                    if (declarationCounts.uninitialized > 1) {
+                        context.report(node, "Split uninitialized '" + type + "' declarations into multiple statements.");
                     }
                 }
-
             }
         },
 

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -33,6 +33,54 @@ eslintTester.addRuleTest("lib/rules/one-var", {
             args: [2, "never"]
         },
         {
+            code: "var bar = true; var baz = false;",
+            args: [2, {initialized: "never"}]
+        },
+        {
+            code: "var bar = true, baz = false;",
+            args: [2, {initialized: "always"}]
+        },
+        {
+            code: "var bar, baz;",
+            args: [2, {initialized: "never"}]
+        },
+        {
+            code: "var bar; var baz;",
+            args: [2, {uninitialized: "never"}]
+        },
+        {
+            code: "var bar, baz;",
+            args: [2, {uninitialized: "always"}]
+        },
+        {
+            code: "var bar = true, baz = false;",
+            args: [2, {uninitialized: "never"}]
+        },
+        {
+            code: "var bar = true, baz = false, a, b;",
+            args: [2, {uninitialized: "always", initialized: "always"}]
+        },
+        {
+            code: "var bar = true; var baz = false; var a; var b;",
+            args: [2, {uninitialized: "never", initialized: "never"}]
+        },
+        {
+            code: "var bar, baz; var a = true; var b = false;",
+            args: [2, {uninitialized: "always", initialized: "never"}]
+        },
+        {
+            code: "var bar, baz; var a = true; var b = false;",
+            args: [2, {uninitialized: "always", initialized: "never"}]
+        },
+        {
+            code: "var bar = true, baz = false; var a; var b;",
+            args: [2, {uninitialized: "never", initialized: "always"}]
+        },
+        {
+            code: "var bar; var baz; var a = true, b = false;",
+            args: [2, {uninitialized: "never", initialized: "always"}]
+        },
+        {
             code: "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
             ecmaFeatures: {
                 destructuring: true
@@ -101,6 +149,55 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                 blockBindings: true
             },
             args: [2, {var: "always", let: "always", const: "never"}]
+        },
+        {
+            code: "let foo = true; for (let i = 0; i < 1; i++) { let foo = false; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {var: "always"}]
+        },
+        {
+            code: "let foo = true, bar = false;",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {var: "never"}]
+        },
+        {
+            code: "let foo = true, bar = false;",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {const: "never"}]
+        },
+        {
+            code: "let foo = true, bar = false;",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {uninitialized: "never"}]
+        },
+        {
+            code: "let foo, bar",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {initialized: "never"}]
+        },
+        {
+            code: "let foo = true, bar = false; let a; let b;",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {uninitialized: "never"}]
+        },
+        {
+            code: "let foo, bar; let a = true; let b = true;",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {initialized: "never"}]
         }
     ],
     invalid: [
@@ -167,7 +264,7 @@ eslintTester.addRuleTest("lib/rules/one-var", {
             code: "function foo() { var bar = true, baz = false; }",
             args: [2, "never"],
             errors: [{
-                message: "Split 'var' declaration into multiple statements.",
+                message: "Split 'var' declarations into multiple statements.",
                 type: "VariableDeclaration"
             }]
         },
@@ -178,6 +275,74 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                 message: "Combine this with the previous 'var' statement.",
                 type: "VariableDeclaration"
             }]
+        },
+        {
+            code: "function foo() { var foo = true, bar = false; }",
+            args: [2, {initialized: "never"}],
+            errors: [
+                {
+                    message: "Split initialized 'var' declarations into multiple statements.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "function foo() { var foo, bar; }",
+            args: [2, {uninitialized: "never"}],
+            errors: [
+                {
+                    message: "Split uninitialized 'var' declarations into multiple statements.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "function foo() { var bar, baz; var a = true; var b = false; var c, d;}",
+            args: [2, {uninitialized: "always", initialized: "never"}],
+            errors: [
+                {
+                    message: "Combine this with the previous 'var' statement with uninitialized variables.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "function foo() { var bar = true, baz = false; var a; var b; var c = true, d = false; }",
+            args: [2, {uninitialized: "never", initialized: "always"}],
+            errors: [
+                {
+                    message: "Combine this with the previous 'var' statement with initialized variables.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "function foo() { var bar = true, baz = false; var a, b;}",
+            args: [2, {uninitialized: "never", initialized: "never"}],
+            errors: [
+                {
+                    message: "Split 'var' declarations into multiple statements.",
+                    type: "VariableDeclaration"
+                },
+                {
+                    message: "Split 'var' declarations into multiple statements.",
+                    type: "VariableDeclaration"
+                }
+            ]
+        },
+        {
+            code: "function foo() { var bar = true; var baz = false; var a; var b;}",
+            args: [2, {uninitialized: "always", initialized: "always"}],
+            errors: [
+                {
+                    message: "Combine this with the previous 'var' statement.",
+                    type: "VariableDeclaration"
+                },
+                {
+                    message: "Combine this with the previous 'var' statement.",
+                    type: "VariableDeclaration"
+                }
+            ]
         },
         {
             code: "function foo() { var a = [1, 2, 3]; var [b, c, d] = a; }",
@@ -241,7 +406,40 @@ eslintTester.addRuleTest("lib/rules/one-var", {
             },
             args: [2, {let: "never"}],
             errors: [{
-                message: "Split 'let' declaration into multiple statements.",
+                message: "Split 'let' declarations into multiple statements.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { let a = 1, b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {initialized: "never"}],
+            errors: [{
+                message: "Split initialized 'let' declarations into multiple statements.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { let a, b; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {uninitialized: "never"}],
+            errors: [{
+                message: "Split uninitialized 'let' declarations into multiple statements.",
+                type: "VariableDeclaration"
+            }]
+        },
+        {
+            code: "function foo() { const a = 1, b = 2; }",
+            ecmaFeatures: {
+                blockBindings: true
+            },
+            args: [2, {initialized: "never"}],
+            errors: [{
+                message: "Split initialized 'const' declarations into multiple statements.",
                 type: "VariableDeclaration"
             }]
         },
@@ -252,7 +450,7 @@ eslintTester.addRuleTest("lib/rules/one-var", {
             },
             args: [2, {const: "never"}],
             errors: [{
-                message: "Split 'const' declaration into multiple statements.",
+                message: "Split 'const' declarations into multiple statements.",
                 type: "VariableDeclaration"
             }]
         },


### PR DESCRIPTION
I am far from an expert in JavaScript, so please give this a thorough review.  

I realize that `uninitialized` makes no sense for `const`, but in the interest of commonality I didn't see any harm in standardizing across the three types of declarations.  If it is in fact a problem, I can try to rethink it.