### PR TITLE
Fix: no-irregular-whitespace should work with irregular line breaks (fixes #2316)

### DIFF
--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -12,7 +12,8 @@
 
 module.exports = function(context) {
 
-    var irregularWhitespace = /[\u0085\u00A0\ufeff\f\v\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u202f\u205f\u3000]+/mg;
+    var irregularWhitespace = /[\u0085\u00A0\ufeff\f\v\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000]+/mg,
+        irregularLineTerminators = /[\u2028\u2029]/mg;
 
     // Module store of errors that we have found
     var errors = [];
@@ -30,7 +31,7 @@ module.exports = function(context) {
         errors = errors.filter(function (error) {
             var errorLoc = error[1];
             if (errorLoc.line >= locStart.line && errorLoc.line <= locEnd.line) {
-                if (errorLoc.column >= locStart.column && errorLoc.column <= locEnd.column) {
+                if (errorLoc.column >= locStart.column && (errorLoc.column <= locEnd.column || errorLoc.line < locEnd.line)) {
                     return false;
                 }
             }
@@ -39,7 +40,7 @@ module.exports = function(context) {
     }
 
     /**
-     * Checks nodes for errors that we are choosing to ignore and calls the relevent methods to remove the errors
+     * Checks nodes for errors that we are choosing to ignore and calls the relevant methods to remove the errors
      * @param {ASTNode} node to check for matching errors.
      * @returns {void}
      * @private
@@ -47,9 +48,62 @@ module.exports = function(context) {
     function removeInvalidNodeErrors(node) {
         if (typeof node.value === "string") {
             // If we have irregular characters remove them from the errors list
-            if (node.value.match(irregularWhitespace)) {
+            if (node.raw.match(irregularWhitespace) || node.raw.match(irregularLineTerminators)) {
                 removeStringError(node);
             }
+        }
+    }
+
+    /**
+     * Checks the program source for irregular whitespace
+     * @param {ASTNode} node The program node
+     * @returns {void}
+     * @private
+     */
+    function checkForIrregularWhitespace(node) {
+        var sourceLines = context.getSourceLines();
+
+        sourceLines.forEach(function (sourceLine, lineIndex) {
+            var lineNumber = lineIndex + 1,
+                location,
+                match;
+
+            while ((match = irregularWhitespace.exec(sourceLine)) !== null) {
+                location = {
+                    line: lineNumber,
+                    column: match.index
+                };
+
+                errors.push([node, location, "Irregular whitespace not allowed"]);
+            }
+        });
+    }
+
+    /**
+     * Checks the program source for irregular line terminators
+     * @param {ASTNode} node The program node
+     * @returns {void}
+     * @private
+     */
+    function checkForIrregularLineTerminators(node) {
+        var source = context.getSource(),
+            sourceLines = context.getSourceLines(),
+            linebreaks = source.match(/\r\n|\r|\n|\u2028|\u2029/g),
+            lastLineIndex = -1,
+            lineIndex,
+            location,
+            match;
+
+        while ((match = irregularLineTerminators.exec(source)) !== null) {
+            lineIndex = linebreaks.indexOf(match[0], lastLineIndex + 1) || 0;
+
+            location = {
+                line: lineIndex + 1,
+                column: sourceLines[lineIndex].length
+            };
+
+            errors.push([node, location, "Irregular whitespace not allowed"]);
+            lastLineIndex = lineIndex;
         }
     }
 
@@ -61,26 +115,13 @@ module.exports = function(context) {
              * When writing this code also evaluating per node was missing out connecting tokens in some cases
              * We can later filter the errors when they are found to be not an issue in nodes we don't care about
              */
-            var sourceLines = context.getSourceLines();
 
-            sourceLines.forEach(function (sourceLine, lineIndex) {
-                var location,
-                    match = irregularWhitespace.exec(sourceLine);
-
-                if (match !== null) {
-                    location = {
-                        line: lineIndex + 1,
-                        column: match.index
-                    };
-
-                    errors.push([node, location, "Irregular whitespace not allowed"]);
-                }
-            });
+            checkForIrregularWhitespace(node);
+            checkForIrregularLineTerminators(node);
         },
+
         "Identifier": removeInvalidNodeErrors,
         "Literal": removeInvalidNodeErrors,
-        "Statement": removeInvalidNodeErrors,
-        "Expression": removeInvalidNodeErrors,
         "Program:exit": function () {
 
             // If we have any errors remaining report on them

--- a/tests/lib/rules/no-irregular-whitespace.js
+++ b/tests/lib/rules/no-irregular-whitespace.js
@@ -18,54 +18,186 @@ var eslint = require("../../../lib/eslint"),
 //------------------------------------------------------------------------------
 
 var eslintTester = new ESLintTester(eslint);
-/* Ignored chars as cause parse errors: \u0085 \u200B \u2028 \u2029*/
-var invalidChars = "\u000B\u000C\u00A0\u180E\ufeff\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205f\u3000";
-var invalid = [];
-var valid = [
-    "var thing1 = ' 	';",
-    "var thing2 = '\\u000B';",
-    "var thing3 = '\\u000C';",
-    "var thing4 = '\\u0085';",
-    "var thing5 = '\\u00A0'",
-    "var thing6 = '\\u180E';",
-    "var thing7 = '\\ufeff';",
-    "var thing8 = '\\u2000';",
-    "var thing9 = '\\u2001';",
-    "var thing10 = '\\u2002';",
-    "var thing11 = '\\u2003';",
-    "var thing12 = '\\u2004';",
-    "var thing13 = '\\u2005';",
-    "var thing14 = '\\u2006';",
-    "var thing15 = '\\u2007';",
-    "var thing16 = '\\u2008';",
-    "var thing17 = '\\u2009';",
-    "var thing18 = '\\u200A';",
-    "var thing19 = '\\u200B';",
-    "var thing20 = '\\u2028';",
-    "var thing21 = '\\u2029';",
-    "var thing22 = '\\u202F';",
-    "var thing23 = '\\u205f';",
-    "var thing24 = '\\u3000';",
-    "var thing25 = 'test';"
-];
-var errors = [{
+
+var expectedErrors = [{
     message: "Irregular whitespace not allowed",
     type: "Program"
 }];
-var charArray = invalidChars.split("");
-charArray.forEach(function (char, i) {
-    var invalidCode = "var thing" + i + " = 'test'; " + char + " var thingElse = 'test';";
-    invalid.push({
-      code: invalidCode,
-      errors: errors
-    });
-
-    valid.push("var test" + i + " = '" + char + "';");
-});
-
-valid.push("var test = 'Is this ok?';"); // Test regular string
 
 eslintTester.addRuleTest("lib/rules/no-irregular-whitespace", {
-    valid: valid,
-    invalid: invalid
+    valid: [
+        "'\\u000B';",
+        "'\\u000C';",
+        "'\\u0085';",
+        "'\\u00A0'",
+        "'\\u180E';",
+        "'\\ufeff';",
+        "'\\u2000';",
+        "'\\u2001';",
+        "'\\u2002';",
+        "'\\u2003';",
+        "'\\u2004';",
+        "'\\u2005';",
+        "'\\u2006';",
+        "'\\u2007';",
+        "'\\u2008';",
+        "'\\u2009';",
+        "'\\u200A';",
+        "'\\u200B';",
+        "'\\u2028';",
+        "'\\u2029';",
+        "'\\u202F';",
+        "'\\u205f';",
+        "'\\u3000';",
+        "'\u000B';",
+        "'\u000C';",
+        "'\u0085';",
+        "'\u00A0'",
+        "'\u180E';",
+        "'\ufeff';",
+        "'\u2000';",
+        "'\u2001';",
+        "'\u2002';",
+        "'\u2003';",
+        "'\u2004';",
+        "'\u2005';",
+        "'\u2006';",
+        "'\u2007';",
+        "'\u2008';",
+        "'\u2009';",
+        "'\u200A';",
+        "'\u200B';",
+        "'\\\u2028';", // multiline string
+        "'\\\u2029';", // multiline string
+        "'\u202F';",
+        "'\u205f';",
+        "'\u3000';"
+    ],
+
+    invalid: [
+        {
+            code: "var any \u000B = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u000C = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u00A0 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u180E = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \ufeff = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2000 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2001 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2002 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2003 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2004 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2005 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2006 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2007 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2008 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2009 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u200A = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2028 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u2029 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u202F = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u205f = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var any \u3000 = 'thing';",
+            errors: expectedErrors
+        },
+        {
+            code: "var a = 'b',\u2028c = 'd',\ne = 'f'\u2028",
+            errors: [
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 12
+                },
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 3,
+                    column: 7
+                }
+            ]
+        },
+        {
+            code: "var any \u3000 = 'thing', other \u3000 = 'thing';\nvar third \u3000 = 'thing';",
+            errors: [
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 8
+                },
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 27
+                },
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 2,
+                    column: 10
+                }
+            ]
+        }
+    ]
 });


### PR DESCRIPTION
The underlying problem of `\u2028` and `\u2029` not being checked by this rule was that it only operated on the source lines retrieved by `context.getSourceLines()`. `\u2028` and `\u2029` are line terminators and are removed by [splitting the source](https://github.com/eslint/eslint/blob/88b5ffa14fe11b0cc55ca60bf42d508a32d5c231/lib/eslint.js#L692) into lines.