### PR TITLE
WIP: Add reset flag support to .eslintrc

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -161,8 +161,7 @@ function getLocalConfig(thisConfig, directory) {
         localConfigFiles = thisConfig.findLocalConfigFiles(directory),
         numFiles = localConfigFiles.length;
 
-    for (i = 0; i < numFiles; i++) {
-
+    for (i = numFiles - 1; i >= 0; i--) {
         localConfigFile = localConfigFiles[i];
 
         // Don't consider the personal config file in the home directory.
@@ -173,7 +172,6 @@ function getLocalConfig(thisConfig, directory) {
         localConfig = loadConfig(localConfigFile);
 
         if (path.basename(localConfigFile) !== LOCAL_CONFIG_FILENAME) {
-
             // Don't consider a local config file found if the package.json doesn't have the eslintConfig field.
             if (!localConfig.hasOwnProperty(PACKAGE_CONFIG_FIELD_NAME)) {
                 continue;
@@ -183,7 +181,12 @@ function getLocalConfig(thisConfig, directory) {
 
         found = true;
         debug("Using " + localConfigFile);
-        config = util.mergeConfigs(localConfig, config);
+        config = util.mergeConfigs(config, localConfig);
+
+        // Check if the last config specified reset flag. If so, break out of the loop.
+        if (config.reset) {
+            break;
+        }
     }
 
     // Use the personal config file if there are no other local config files found.
@@ -319,8 +322,10 @@ Config.prototype.getConfig = function (filePath) {
         userConfig = {};
     }
 
-    // Step 2: Create a copy of the baseConfig
-    config = util.mergeConfigs({}, this.baseConfig);
+    // Step 2: Create a copy of the baseConfig only if reset flag not specified.
+    if (!userConfig.reset) {
+        config = util.mergeConfigs({}, this.baseConfig);
+    }
 
     // Step 3: Merge in environment-specific globals and rules from .eslintrc files
     config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env, this.options.reset));


### PR DESCRIPTION
This pull request is purely to show an alternative discussed in #2100 
What this does, is changes the way config files get merged. Instead of going bottom up, for local configs, it goes top down and it will break out of the loop as soon as it finds a config with `reset` flag. I'm sure this pull request doesn't catch every edge case, nor is it suppose to. It's just an illustration a point in an argument.