### PR TITLE
New Rule Suggestion: newline-before-return

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -140,6 +140,7 @@
         "new-cap": 2,
         "new-parens": 2,
         "newline-after-var": 0,
+        "newline-before-return": 0,
         "object-shorthand": 0,
         "one-var": 0,
         "operator-assignment": [0, "always"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -144,6 +144,7 @@ These rules are purely matters of style and are quite subjective.
 * [new-cap](new-cap.md) - require a capital letter for constructors
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments
 * [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after `var` statement (off by default)
+* [newline-before-return](newline-before-return.md) - require newline before `return` statement (off by default)
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
 * [no-continue](no-continue.md) - disallow use of the `continue` statement (off by default)
 * [no-inline-comments](no-inline-comments.md) - disallow comments inline after code (off by default)

--- a/docs/rules/newline-before-return.md
+++ b/docs/rules/newline-before-return.md
@@ -1,0 +1,124 @@
+# Require newline before `return` statement (newline-before-return)
+
+Projects usually start with clear, minimal code:
+
+```js
+function greet(greeting) {
+  return greeting || "Hello" + " world!";
+}
+```
+
+As variables & logic increases, it becomes difficult to quickly tell
+how `return` values are created
+and which preceding statements are relevant:
+
+```js
+function greet(greeting, subject) {
+  greeting = greeting || "Hello";
+  if (!subject) {
+    greeting += "!";
+    return greeting
+  }
+  // greet the subject
+  return greeting + " " + subject + "!";
+}
+```
+
+Leveraging whitespace can help visibly
+distinguish variable assignments & logic blocks from `return` statements:
+
+
+```js
+function greet(greeting, subject) {
+  greeting = greeting || "Hello";
+
+  if (!subject) {
+    greeting += "!";
+
+    return greeting
+  }
+
+  // greet the subject
+  return greeting + " " + subject + "!";
+}
+```
+
+As a result, the `return` value is visibly separate from the statements
+that created it, revealing clear exit points within the function.
+
+
+## Rule Details
+
+The following patterns are considered **warnings**:
+
+```js
+var greet = 'hello'; return greet;
+```
+
+```js
+var greet = 'hello';
+return greet;
+```
+
+```js
+var greet = 'hello';
+// Comment
+return greet;
+```
+
+The following patterns are **valid**:
+
+```js
+return 'hello';
+```
+
+```js
+var greet = 'hello';
+
+return greet;
+```
+
+```js
+var greet = 'hello';
+
+
+
+
+return greet;
+```
+
+```js
+var greet = 'hello';
+
+// about to return a variable
+return greet;
+```
+
+```js
+var greet = 'hello';
+// just set a variable
+
+return greet;
+```
+
+As you can see, a blank line has to _precede_ the `return` statement and any
+accompanying comments.
+
+
+## When Not To Use It
+
+If you have simplistic functions with minimal assignments, logic, & `return`
+statements, disable this rule.
+
+
+## Further Reading
+
+When using this rule, consider also enabling [`newline-after-var`][2].
+
+Thanks to [Symfony2's Coding Standards][1] for inspiration!
+
+_This rule works just as well with `globalReturn` set to either `true` or `false`._
+
+
+[1]: http://symfony.com/doc/current/contributing/code/standards.html#structure
+[2]: http://eslint.org/docs/rules/newline-after-var

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Rule to check empty line before "return" statement
+ * @author Eric Clemmons <eric@smarterspam.com>
+ * @copyright 2014 Eric Clemmons. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Determine if provided node has a preceding empty line
+     * @private
+     * @param {ASTNode} node ReturnStatement node
+     * @returns {boolean} True if `node` has a blank line before it
+     */
+    function hasEmptyLineBefore(node) {
+        var previousToken = context.getTokenBefore(node);
+
+        var lineNum = node.loc.start.line,
+            previousLineNum = previousToken.loc.end.line;
+
+        // Measure the # of lines between tokens
+        var gap = lineNum - previousLineNum - 1;
+
+        // Exclude comments from gap measurement
+        context.getComments(node).leading.forEach(function() {
+            gap--;
+        });
+
+        // There should be an empty line _somewhere_ between tokens
+        return gap > 0;
+    }
+
+    /**
+     * Determine if provided node is with an `if` or `{}` block
+     * @private
+     * @param {ASTNode} node - ReturnStatement node
+     * @returns {boolean} True if `node`'s parent is `IfStatement` or `BlockStatement`
+     */
+    function isIfOrBlock(node) {
+        return ["IfStatement", "BlockStatement"].indexOf(node.parent.type) !== -1;
+    }
+
+    /**
+     * Determine if provided node is the first token in an `if` or `{}` block
+     * @private
+     * @param {ASTNode} node ReturnStatement node
+     * @returns {boolean} True if `node` the first token within a block
+     */
+    function isFirstTokenInBlock(node) {
+        var previousToken = context.getTokenBefore(node);
+
+        if (!previousToken) {
+            return true;
+        }
+
+        if (!isIfOrBlock(node)) {
+            return false;
+        }
+
+        if (previousToken.type !== "Punctuator") {
+            return false;
+        }
+
+        return [")", "{"].indexOf(previousToken.value) !== -1;
+    }
+
+    /**
+     * Reports the provided node if missing a preceding blank line
+     * @private
+     * @param {ASTNode} node - ReturnStatement node
+     * @returns {void}
+     */
+    function checkForBlankLine(node) {
+        if (isFirstTokenInBlock(node)) {
+            return;
+        }
+
+        if (hasEmptyLineBefore(node)) {
+            return;
+        }
+
+        context.report(node, "Expected blank line before `return` statement.");
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        "ReturnStatement": checkForBlankLine
+    };
+};

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -1,0 +1,78 @@
+/**
+ * @fileoverview Rule to check empty line before "return" statement
+ * @author Eric Clemmons <eric@smarterspam.com>
+ * @copyright 2014 Eric Clemmons. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Fixtures
+//------------------------------------------------------------------------------
+
+var NO_RETURN = "function test() {\nconsole.log('hello');\n}";
+var IF_RETURN = "function test() {\nif (a)\nreturn;\n}";
+var IF_NO_BLANK_RETURN = "function test() {\nif (a)\nvar greet= 'hello';\nreturn greet;\n}";
+var ONLY_RETURN = "function test() {\nreturn 'hello';\n}";
+var NO_BREAK = "function test() {\nvar greet = 'hello'; return greet;\n}";
+var NO_BLANK = "function test() {\nvar greet = 'hello';\nreturn greet;\n}";
+var ONE_BLANK = "function test() {\nvar greet = 'hello';\n\nreturn greet;\n}";
+var TWO_BLANK = "function test() {\nvar greet = 'hello';\n\n\nreturn greet;\n}";
+var THREE_BLANK = "function test() {\nvar greet = 'hello';\n\n\n\nreturn greet;\n}";
+var COMMENT_AND_NO_BLANK = "function test() {\nvar greet = 'hello';\n// Multi-line\n// comment\nreturn greet;\n}";
+var COMMENT_AND_BLANK = "function test() {\nvar greet = 'hello';\n\n// Multi-line\n// comment\nreturn greet;\n}";
+var BLANK_BEFORE_COMMENT = "function test() {\nvar greet = 'hello';\n\n// Comment\nreturn greet;\n}";
+var BLANK_BEFORE_BLOCK_COMMENT = "function test() {\nvar greet = 'hello';\n\n/*\n Comment\n*/\nreturn greet;\n}";
+var BLANK_AFTER_COMMENT = "function test() {\nvar greet = 'hello';\n\n// Comment\n\nreturn greet;\n}";
+var GLOBAL_ONLY_RETURN = "return 'hello';";
+var GLOBAL_NO_BREAK = "var greet = 'hello'; return greet;";
+var GLOBAL_ONE_BLANK = "function test() {\nvar greet = 'hello';\n\nreturn greet;\n}";
+
+var ERROR = {
+    message: "Expected blank line before `return` statement.",
+    type: "ReturnStatement"
+};
+
+var FEATURES = {
+    globalReturn: true
+};
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/newline-before-return", {
+    valid: [
+        NO_RETURN, // should skip rule entirely
+        IF_RETURN, // should not require preceding blank
+        ONLY_RETURN, // should not require preceding blank
+        ONE_BLANK, // should be satisfied with preceding blank
+        TWO_BLANK, // should be satisfied with preceding blank
+        THREE_BLANK, // should be satisfied with preceding blank
+        COMMENT_AND_BLANK, // should ignore commented lines
+        BLANK_BEFORE_COMMENT, // should ignore commented lines
+        BLANK_BEFORE_BLOCK_COMMENT, // should ignore commented lines
+        BLANK_AFTER_COMMENT, // should ignore commented lines
+
+        // // should skip rule entirely
+        { code: GLOBAL_ONLY_RETURN, ecmaFeatures: FEATURES },
+
+        // // should behave just like non-globalReturn version
+        { code: GLOBAL_ONE_BLANK, ecmaFeatures: FEATURES }
+    ],
+
+    invalid: [
+        { code: NO_BREAK, errors: [ERROR] },
+        { code: NO_BLANK, errors: [ERROR] },
+        { code: COMMENT_AND_NO_BLANK, errors: [ERROR] },
+        { code: GLOBAL_NO_BREAK, ecmaFeatures: FEATURES, errors: [ERROR] },
+        { code: IF_NO_BLANK_RETURN, errors: [ERROR] }
+    ]
+});


### PR DESCRIPTION
Inspired by [Symfony2's Coding Standards][1]:
> Add a blank line before return statements, unless the return is alone inside a statement-group (like an if statement);

### No Errors / Warnings

```js
class Foo {
  getBar(forRealz = false) {
    if (!forRealz) {
      return "Nah, I'm playin'.";
    }

    return "Bar";  
  }
}
```

### Errors / Warnings

```js
if (!forRealz) {

  return "Nah, I'm playin'.";
}
```

```js
getBar(forRealz = false) {
  if (!forRealz) {
    return "Nah, I'm playin'.";
  }
  return "Bar";  
}
```

- - -

Thoughts?

[1]: http://symfony.com/doc/current/contributing/code/standards.html#structure