### PR TITLE
New: Add dot-location rule. (fixes #1884)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -120,6 +120,7 @@
         "consistent-this": [0, "that"],
         "curly": [2, "all"],
         "default-case": 0,
+        "dot-location": 0,
         "dot-notation": [2, { "allowKeywords": true }],
         "eol-last": 2,
         "eqeqeq": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -46,6 +46,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [curly](curly.md) - specify curly brace conventions for all control statements
 * [default-case](default-case.md) - require `default` case in `switch` statements (off by default)
 * [dot-notation](dot-notation.md) - encourages use of dot notation whenever possible
+* [dot-location](dot-location.md) - enforces consistent newlines before or after dots (off by default)
 * [eqeqeq](eqeqeq.md) - require the use of `===` and `!==`
 * [guard-for-in](guard-for-in.md) - make sure `for-in` loops have an `if` statement (off by default)
 * [no-alert](no-alert.md) - disallow the use of `alert`, `confirm`, and `prompt`

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -1,0 +1,76 @@
+# Enforce newline before and after dot (dot-location)
+
+JavaScript allows you to place newlines before or after a dot in a member expression.
+
+Consistency in placing a newline before or after the dot can greatly increase readability.
+
+```js
+var a = universe.
+        galaxy;
+
+var b = universe
+       .galaxy;
+```
+
+## Rule Details
+
+This rule aims to enforce newline consistency in member expressions. This rule prevents the use of mixed newlines around the dot in a member expression.
+
+### Options
+
+The rule takes one option, a string, which can be either `object` or `property`.
+If it is `object`, the dot in a member expression should be on the same line as the object portion.
+If it is `property`, the dot in a member expression should be on the same line as the property portion.
+
+If unset, the default behavior is `"object"`.
+
+```json
+    "dot-location": [2, "object"]
+```
+
+#### "object"
+
+This is the default option. It requires the dot to be on the same line as the object.
+
+The following patterns are considered warnings:
+
+```js
+var foo = object
+.property;
+```
+
+The following patterns are not warnings:
+
+```js
+var foo = object.
+property;
+var bar = object.property;
+```
+
+#### "property"
+
+This option requires the dot to be on the same line as the property.
+
+The following patterns are considered warnings:
+
+```js
+var foo = object.
+property;
+```
+
+The following patterns are not warnings:
+
+```js
+var foo = object
+.property;
+var bar = object.property;
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the consistency of newlines before or after dots in member expressions.
+
+## Related Rules
+
+* [newline-after-var](newline-after-var.md)
+* [dot-notation](dot-notation.md)

--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -1,0 +1,64 @@
+/**
+ * @fileoverview Validates newlines before and after dots
+ * @author Greg Cochard
+ * @copyright 2015 Greg Cochard
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function (context) {
+
+    var config = context.options[0],
+        // default to onObject if no preference is passed
+        onObject = config === "object" || !config;
+
+    /**
+     * Checks whether two tokens are on the same line.
+     * @param {Object} left The leftmost token.
+     * @param {Object} right The rightmost token.
+     * @returns {boolean} True if the tokens are on the same line, false if not.
+     * @private
+     */
+    function isSameLine(left, right) {
+        return left.loc.end.line === right.loc.start.line;
+    }
+
+    /**
+     * Reports if the given token has invalid spacing.
+     * @param {ASTNode} obj The object owning the property.
+     * @param {ASTNode} prop The property of the object.
+     * @param {ASTNode} node The corresponding node of the token.
+     * @returns {void}
+     */
+    function checkDotLocation(obj, prop, node) {
+
+        if (!isSameLine(obj, prop)) {
+            var dot = context.getTokensBetween(obj, prop)[0];
+            if (onObject) {
+                if (obj.loc.start.line !== dot.loc.start.line) {
+                    context.report(node, dot.loc.start, "Expected dot to be on same line as object.");
+                }
+            } else if (prop.loc.start.line !== dot.loc.start.line) {
+            // if (afterNewline && prop.loc.line !== dot.loc.line) {
+                context.report(node, dot.loc.start, "Expected dot to be on same line as property.");
+            }
+        }
+    }
+
+    /**
+     * Checks the spacing of the dot within a member expression.
+     * @param {ASTNode} node The node to check.
+     * @returns {void}
+     */
+    function checkNode(node) {
+        checkDotLocation(node.object, node.property, node);
+    }
+
+    return {
+        "MemberExpression": checkNode
+    };
+};

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -26,7 +26,7 @@ module.exports = function (context) {
     }
 
     /**
-     * Determines whether two adjacent tokens are have whitespace between them.
+     * Determines whether two adjacent tokens have whitespace between them.
      * @param {Object} left - The left token object.
      * @param {Object} right - The right token object.
      * @returns {boolean} Whether or not there is space between the tokens.

--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -1,0 +1,48 @@
+/**
+ * @fileoverview Tests for dot-location.
+ * @author Greg Cochard
+ * @copyright 2015 Greg Cochard
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+
+eslintTester.addRuleTest("lib/rules/dot-location", {
+    valid: [
+        "obj.\nprop",
+        "obj. \nprop",
+        "obj.\n prop",
+        {
+            code: "obj.\nprop",
+            options: [ "object" ]
+        },
+        {
+            code: "obj\n.prop",
+            options: [ "property" ]
+        }
+    ],
+    invalid: [
+        {
+            code: "obj\n.property",
+            options: [ "object" ],
+            errors: [ { message: "Expected dot to be on same line as object.", type: "MemberExpression", line: 2, column: 0 } ]
+        },
+        {
+            code: "obj.\nproperty",
+            options: [ "property" ],
+            errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 3 } ]
+        }
+    ]
+});


### PR DESCRIPTION
This rule requires the dot in a member expression to be on the same line as the object or property.