### PR TITLE
Fix: Improves detection of self-referential functions (fixes #2363)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -27,9 +27,14 @@ module.exports = function(context) {
         }
     }
 
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+
     /**
      * Determines if a given variable is being exported from a module.
-     * @param {Variable} variable EScope variable object.
+     * @param {Variable} variable - EScope variable object.
      * @returns {boolean} True if the variable is exported, false if not.
      * @private
      */
@@ -52,7 +57,7 @@ module.exports = function(context) {
 
     /**
      * Determines if a reference is a read operation.
-     * @param {Reference} ref - an escope Reference
+     * @param {Reference} ref - An escope Reference
      * @returns {Boolean} whether the given reference represents a read operation
      * @private
      */
@@ -61,30 +66,47 @@ module.exports = function(context) {
     }
 
     /**
-     * Determine if an identifier is referencing the enclosing function name.
-     * @param {Reference} ref The reference to check.
+     * Determine if an identifier is referencing an enclosing function name.
+     * @param {Reference} ref - The reference to check.
+     * @param {ASTNode[]} nodes - The candidate function nodes.
      * @returns {boolean} True if it's a self-reference, false if not.
      * @private
      */
-    function isSelfReference(ref) {
+    function isSelfReference(ref, nodes) {
+        var scope = ref.from;
 
-        if (ref.from.type === "function" && ref.from.block.id) {
-            return ref.identifier.name === ref.from.block.id.name;
+        while (scope != null) {
+            if (nodes.indexOf(scope.block) >= 0) {
+                return true;
+            }
+
+            scope = scope.upper;
         }
 
         return false;
     }
 
     /**
-     * Determines if a reference should be counted as a read. A reference should
-     * be counted only if it's a read and it's not a reference to the containing
-     * function declaration name.
-     * @param {Reference} ref The reference to check.
-     * @returns {boolean} True if it's a value read reference, false if not.
-     * @private
+     * Determines if the variable is used.
+     * @param {Variable} variable - The variable to check.
+     * @param {Reference[]} [references=variable.references] - The variable references to check.
+     * @returns {boolean} True if the variable is used
      */
-    function isValidReadRef(ref) {
-        return isReadRef(ref) && !isSelfReference(ref);
+    function isUsedVariable(variable, references) {
+        var functionNodes = variable.defs.filter(function (def) {
+            return def.type === "FunctionName";
+        }).map(function (def) {
+            return def.node;
+        }),
+            isFunctionDefinition = functionNodes.length > 0;
+
+        if (!references) {
+            references = variable.references;
+        }
+
+        return references.some(function (ref) {
+            return isReadRef(ref) && !(isFunctionDefinition && isSelfReference(ref, functionNodes));
+        });
     }
 
     /**
@@ -132,7 +154,7 @@ module.exports = function(context) {
                     continue;
                 }
 
-                if (variables[i].references.filter(isValidReadRef).length === 0 && !isExported(variables[i])) {
+                if (!isUsedVariable(variables[i]) && !isExported(variables[i])) {
                     unused.push(variables[i]);
                 }
             }
@@ -140,6 +162,10 @@ module.exports = function(context) {
 
         return [].concat.apply(unused, scope.childScopes.map(getUnusedLocals));
     }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
 
     return {
         "Program:exit": function(programNode) {
@@ -149,15 +175,34 @@ module.exports = function(context) {
 
             // determine unused globals
             if (config.vars === "all") {
-                var unresolvedRefs = globalScope.through.filter(isValidReadRef).map(function(ref) {
-                    return ref.identifier.name;
-                });
+                var ref, name;
+                // Avoid inherited properties that could induce false positives (e.g. "constructor")
+                var unresolvedRefs = Object.create(null);
+
+                // Search for read references, and store them in a dictionary by name
+                for (i = 0, l = globalScope.through.length; i < l; ++i) {
+                    ref = globalScope.through[i];
+                    name = ref.identifier.name;
+
+                    if (isReadRef(ref)) {
+                        if (!unresolvedRefs[name]) {
+                            unresolvedRefs[name] = [];
+                        }
+                        unresolvedRefs[name].push(ref);
+                    }
+                }
 
                 for (i = 0, l = globalScope.variables.length; i < l; ++i) {
-                    if (unresolvedRefs.indexOf(globalScope.variables[i].name) < 0 &&
-                            !globalScope.variables[i].eslintUsed && !isExported(globalScope.variables[i])) {
+                    name = globalScope.variables[i].name;
+
+                    var isUsed = unresolvedRefs[name] &&
+                        isUsedVariable(globalScope.variables[i], unresolvedRefs[name]);
+
+                    if (!isUsed && !globalScope.variables[i].eslintUsed &&
+                            !isExported(globalScope.variables[i])) {
                         unused.push(globalScope.variables[i]);
                     }
+
                 }
             }
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -51,8 +51,6 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         "myFunc(function foo(){}.toString())",
         "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});}; foo()",
         "(function() { var doSomething = function doSomething() {}; doSomething() }())",
-        "function f() { var a = 1; return function(){ f(a *= 2); }; }",
-        "function f() { var a = 1; return function(){ f(++a); }; }",
         "try {} catch(e) {}",
         "/*global a */ a;",
         { code: "var a=10; (function() { alert(a); })();", options: [{vars: "all"}] },
@@ -72,6 +70,12 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "class Foo{}; var x = new Foo(); x.foo()", ecmaFeatures: { classes: true }},
         { code: "const foo = \"hello!\";function bar(foobar = foo) {  foobar.replace(/!$/, \" world!\");}\nbar();", ecmaFeatures: { blockBindings: true, defaultParams: true }},
         "function Foo(){}; var x = new Foo(); x.foo()",
+        "function foo() {var foo = 1; return foo}; foo();",
+        "function foo(foo) {return foo}; foo(1);",
+        "function foo() {function foo() {return 1;}; return foo()}; foo();",
+        {code: "function foo() {var foo = 1; return foo}; foo();", ecmaFeatures: {globalReturn: true}},
+        {code: "function foo(foo) {return foo}; foo(1);", ecmaFeatures: {globalReturn: true}},
+        {code: "function foo() {function foo() {return 1;}; return foo()}; foo();", ecmaFeatures: {globalReturn: true}},
 
         // Can mark variables as used via context.markVariableAsUsed()
         { code: "/*eslint use-every-a:1*/ var a;"},
@@ -82,6 +86,8 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "function foox() { return foox(); }", errors: [{ message: "foox is defined but never used", type: "Identifier"}] },
         { code: "(function() { function foox() { if (true) { return foox(); } } }())", errors: [{ message: "foox is defined but never used", type: "Identifier"}] },
         { code: "var a=10", errors: [{ message: "a is defined but never used", type: "Identifier"}] },
+        { code: "function f() { var a = 1; return function(){ f(a *= 2); }; }", errors: [{message: "f is defined but never used", type: "Identifier"}]},
+        { code: "function f() { var a = 1; return function(){ f(++a); }; }", errors: [{message: "f is defined but never used", type: "Identifier"}]},
         { code: "/*global a */", errors: [{ message: "a is defined but never used", type: "Program"}] },
         { code: "function foo(first, second) {\ndoStuff(function() {\nconsole.log(second);});};", errors: [{ message: "foo is defined but never used", type: "Identifier"}] },
         { code: "var a=10;", options: ["all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },
@@ -92,6 +98,7 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "var a=10, b=0, c=null; setTimeout(function() { var b=2; var c=2; alert(a+b+c); }, 0);", options: ["all"], errors: [{ message: "b is defined but never used", type: "Identifier"}, { message: "c is defined but never used", type: "Identifier"}] },
         { code: "function f(){var a=[];return a.map(function(){});}", options: ["all"], errors: [{ message: "f is defined but never used", type: "Identifier"}] },
         { code: "function f(){var a=[];return a.map(function g(){});}", options: ["all"], errors: [{ message: "f is defined but never used", type: "Identifier"}] },
+        { code: "function foo() {function foo(x) {\nreturn x; }; return function () {return foo; }; }", errors: [{message: "foo is defined but never used", line: 1, type: "Identifier"}]},
         { code: "function f(){var x;function a(){x=42;}function b(){alert(x);}}", options: ["all"], errors: 3 },
         { code: "function f(a) {}; f();", options: ["all"], errors: [{ message: "a is defined but never used", type: "Identifier"}] },
         { code: "function a(x, y, z){ return y; }; a();", options: ["all"], errors: [{ message: "z is defined but never used", type: "Identifier"}] },
@@ -104,7 +111,7 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "(function(foo, baz, bar) { return baz; })();", options: [{"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]},
         { code: "(function z(foo) { var bar = 33; })();", options: [{"vars": "all", "args": "all"}], errors: [{ message: "foo is defined but never used" }, { message: "bar is defined but never used" }]},
         { code: "(function z(foo) { z(); })();", options: [{}], errors: [{ message: "foo is defined but never used" }]},
-        { code: "function f() { var a = 1; return function(){ f(a = 2); }; }", options: [{}], errors: [{ message: "a is defined but never used" }]},
+        { code: "function f() { var a = 1; return function(){ f(a = 2); }; }", options: [{}], errors: [{ message: "f is defined but never used" }, {message: "a is defined but never used"}]},
         { code: "import x from \"y\";", ecmaFeatures: { modules: true }, errors: [{ message: "x is defined but never used" }]}
     ]
 });


### PR DESCRIPTION
This implementation considers inner self-reference as invalid (i.e. not valid reads):

```javascript
// foo is defined but not used
function foo() {
  return function () {
     return foo;
  }
}
```