### PR TITLE
Fix object-shorthand arrow functions (fixes #2414)

### DIFF
--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -60,6 +60,15 @@ var foo = {
 };
 ```
 
+This rule does not flag arrow functions inside of object literals.
+The following will *not* warn:
+
+```js
+var foo = {
+    x: (y) => y
+};
+```
+
 ### Options
 
 The rule takes an option which specifies when it should be applied. It can be set to

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -44,11 +44,7 @@ module.exports = function(context) {
                 return;
             }
 
-            if (node.value.type === "ArrowFunctionExpression" && APPLY_TO_METHODS) {
-
-                // {x: ()=>{}} should be written as {x() {}}
-                context.report(node, "Expected method shorthand.");
-            } else if (node.value.type === "FunctionExpression" && APPLY_TO_METHODS) {
+            if (node.value.type === "FunctionExpression" && APPLY_TO_METHODS) {
 
                 // {x: function(){}} should be written as {x() {}}
                 context.report(node, "Expected method shorthand.");

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -53,6 +53,12 @@ eslintTester.addRuleTest("lib/rules/object-shorthand", {
         { code: "doSomething({x: y, y() {}})", ecmaFeatures: features},
         { code: "doSomething({y() {}, z: a})", ecmaFeatures: features},
 
+        // arrows functions are still alright
+        { code: "var x = {y: (x)=>x}", ecmaFeatures: features },
+        { code: "doSomething({y: (x)=>x})", ecmaFeatures: features },
+        { code: "var x = {y: (x)=>x, y: a}", ecmaFeatures: features },
+        { code: "doSomething({x, y: (x)=>x})", ecmaFeatures: features },
+
         // options
         { code: "var x = {y() {}}", ecmaFeatures: features, args: [2, "methods"] },
         { code: "var x = {x, y() {}, a:b}", ecmaFeatures: features, args: [2, "methods"] },
@@ -68,7 +74,6 @@ eslintTester.addRuleTest("lib/rules/object-shorthand", {
         { code: "var x = {y: y, x: x}", ecmaFeatures: features, errors: [{ message: "Expected property shorthand.", type: "Property" }, { message: "Expected property shorthand.", type: "Property" }] },
         { code: "var x = {y: z, x: x, a: b}", ecmaFeatures: features, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
         { code: "var x = {y: function() {}}", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "var x = {y: (x)=>x}", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
         { code: "var x = {y: function*() {}}", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
         { code: "var x = {x: y, y: z, a: a}", ecmaFeatures: features, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
         { code: "var x = {x: y, y: z, a: function(){}, b() {}}", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
@@ -78,7 +83,6 @@ eslintTester.addRuleTest("lib/rules/object-shorthand", {
         { code: "doSomething({a: 'a', 'x': x})", ecmaFeatures: features, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
         { code: "doSomething({y: function() {}})", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
         { code: "doSomething({y: function y() {}})", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "doSomething({y: (x)=>x})", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
 
         // options
         { code: "var x = {y: function() {}}", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }], args: [2, "methods"] },


### PR DESCRIPTION
We decided that we should not make the object-shorthand rule enforce in the case of arrow functions. 