### PR TITLE
Fix: crash on 0 max (fixes #2423)

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -36,7 +36,9 @@ module.exports = function(context) {
                 });
 
             // Aggregate and count blank lines
-            do {
+            lastLocation = currentLocation;
+            currentLocation = trimmedLines.indexOf("", currentLocation + 1);
+            while (currentLocation !== -1) {
                 lastLocation = currentLocation;
                 currentLocation = trimmedLines.indexOf("", currentLocation + 1);
                 if (lastLocation === currentLocation - 1) {
@@ -53,7 +55,7 @@ module.exports = function(context) {
                     // Finally, reset the blank counter
                     blankCounter = 0;
                 }
-            } while (currentLocation !== -1);
+            }
         }
     };
 

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -41,12 +41,11 @@ eslintTester.addRuleTest("lib/rules/no-multiple-empty-lines", {
         },
         {
             code: "var a = 5;\n\n\n\n\nvar b = 3;",
-            args: [
-                2,
-                {
-                    max: 4
-                }
-            ]
+            args: [ 2, { max: 4 } ]
+        },
+        {
+            code: "var a = 5;\n/* comment */\nvar b = 5;",
+            args: [ 2, { max: 0 } ]
         }
     ],
 
@@ -80,6 +79,11 @@ eslintTester.addRuleTest("lib/rules/no-multiple-empty-lines", {
             code: "var a=5;\n\n\n\n\n",
             errors: [ expectedError ],
             args: ruleArgs
+        },
+        {
+            code: "var a = 5;\n\nvar b = 3;",
+            errors: [ expectedError ],
+            args: [ 2, { max: 0 } ]
         }
     ]
 });


### PR DESCRIPTION
The loop was a `do-while` because it needed to initialize vars before checking the exit condition. Duplicated two lines of code so that the loop can be a regular `while` to handle max of 0 in the config options.