### PR TITLE
Fix: Allow comment before comma for comma-spacing rule (fixes #2408)

### DIFF
--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -22,6 +22,22 @@ module.exports = function(context) {
 
     // the index of the last comment that was checked
     var lastCommentIndex = 0;
+    var allComments;
+
+    /**
+     * Determines the length of comment between 2 tokens
+     * @param {Object} left - The left token object.
+     * @param {Object} right - The right token object.
+     * @returns {number} Length of comment in between tokens
+     */
+    function getCommentLengthBetweenTokens(left, right) {
+        return allComments.reduce(function(val, comment) {
+            if (left.range[1] <= comment.range[0] && comment.range[1] <= right.range[0]) {
+                val = val + comment.range[1] - comment.range[0];
+            }
+            return val;
+        }, 0);
+    }
 
     /**
      * Determines whether two adjacent tokens have whitespace between them.
@@ -31,7 +47,8 @@ module.exports = function(context) {
      */
     function isSpaced(left, right) {
         var punctuationLength = context.getTokensBetween(left, right).length; // the length of any parenthesis
-        return (left.range[1] + punctuationLength) < right.range[0];
+        var commentLenth = getCommentLengthBetweenTokens(left, right);
+        return (left.range[1] + punctuationLength + commentLenth) < right.range[0];
     }
 
     /**
@@ -130,12 +147,12 @@ module.exports = function(context) {
         "Program": function() {
 
             var source = context.getSource(),
-                allComments = context.getAllComments(),
                 pattern = /,/g,
                 commaToken,
                 previousToken,
                 nextToken;
 
+            allComments = context.getAllComments();
             while (pattern.test(source)) {
 
                 // do not flag anything inside of comments

--- a/tests/lib/rules/comma-spacing.js
+++ b/tests/lib/rules/comma-spacing.js
@@ -21,6 +21,8 @@ var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/comma-spacing", {
 
     valid: [
+        "myfunc(404, true/* bla bla bla */, 'hello');",
+        "myfunc(404, true/* bla bla bla *//* hi */, 'hello');",
         "var a = 1, b = 2;",
         "var arr = [, ];",
         "var arr = [1, ];",
@@ -419,6 +421,24 @@ eslintTester.addRuleTest("lib/rules/comma-spacing", {
                 },
                 {
                     message: "A space is required after ','.",
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "myfunc(404, true/* bla bla bla */ , 'hello');",
+            errors: [
+                {
+                    message: "There should be no space before ','.",
+                    type: "Punctuator"
+                }
+            ]
+        },
+        {
+            code: "myfunc(404, true/* bla bla bla */ /* hi */, 'hello');",
+            errors: [
+                {
+                    message: "There should be no space before ','.",
                     type: "Punctuator"
                 }
             ]


### PR DESCRIPTION
I am thinking what I have done would be expensive, but I wan't able to figure any other way since I was not able to use `getComments(node)` function as tokens at this level did not carry `leadingComments` and `trailingComments`.

After fixing I actually saw this coversation: https://github.com/eslint/eslint/issues/2211#issuecomment-91922185
I guess we can hold on to this PR if we are planning on a better solution in the future.