### PR TITLE
Fix: Enable full support to eslint-env comments (Fixes #2134)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -302,11 +302,10 @@ function modifyConfigsFromComments(ast, config, reportingConfig, messages) {
         }
     });
 
-    // apply environment rules before user rules
+    // apply environment configs
     Object.keys(commentConfig.env).forEach(function (name) {
-        var environmentRules = environments[name] && environments[name].rules;
-        if (commentConfig.env[name] && environmentRules) {
-            assign(commentConfig.rules, environmentRules);
+        if (environments[name]) {
+            util.mergeConfigs(commentConfig, environments[name]);
         }
     });
     assign(commentConfig.rules, commentRules);

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1251,9 +1251,8 @@ describe("eslint", function() {
     });
 
     describe("when evaluating code containing /*eslint-env */ block", function() {
-        var code = "/*eslint-env node*/ function f() {} /*eslint-env browser, foo*/";
-
         it("variables should be available in global scope", function() {
+            var code = "/*eslint-env node*/ function f() {} /*eslint-env browser, foo*/";
             var config = { rules: {} };
 
             eslint.reset();
@@ -1266,6 +1265,15 @@ describe("eslint", function() {
                 assert.equal(window.writeable, false);
             });
             eslint.verify(code, config, filename, true);
+        });
+        it("should error on node specific rule", function() {
+            var code = "/*eslint-env node*/ var appHeader = new require('app-header');";
+            var config = { rules: {} };
+
+            eslint.reset();
+            var messages = eslint.verify(code, config, filename, true);
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, "no-new-require");
         });
     });
 


### PR DESCRIPTION
Refs #2134 There doesn't seems to be a way to unittest this code at all. Any suggestions?
Old code was also broken even for env rules. Somehow env globals work, but I can't figure out how...