### PR TITLE
New: Add addPlugin method to CLI-engine (Fixes #1971)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -204,6 +204,29 @@ var report = cli.executeOnText("var foo = 'bar';");
 
 The `report` returned from `executeOnText()` is in the same format as from `executeOnFiles()`, but there is only ever one result in `report.results`.
 
+### addPlugin()
+
+Loads a plugin from configuration object with specified name. Name can include plugin prefix ("eslint-plugin-")
+
+```js
+var CLIEngine = require("eslint").CLIEngine;
+var cli = new CLIEngine({
+    ignore: true
+});
+cli.addPlugin("eslint-plugin-processor", {
+    processors: {
+        ".txt": {
+            preprocess: function(text) {
+                return [text];
+            },
+            postprocess: function(messages) {
+                return messages[0];
+            }
+        }
+    }
+});
+```
+
 ### isPathIgnored()
 
 Checks if a given path is ignored by ESLint.

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -285,13 +285,25 @@ function CLIEngine(options) {
             rules.load(rulesdir);
         });
     }
-
-    loadPlugins(this.options.plugins);
 }
 
 CLIEngine.prototype = {
 
     constructor: CLIEngine,
+
+    /**
+     * Add a plugin by passing it's configuration
+     * @param {string} name Name of the plugin.
+     * @param {Object} pluginobject Plugin configuration object.
+     * @returns {void}
+     */
+    addPlugin: function(name, pluginobject) {
+        var pluginNameWithoutPrefix = util.removePluginPrefix(util.removeNameSpace(name));
+        if (pluginobject.rules) {
+            rules.import(pluginobject.rules, pluginNameWithoutPrefix);
+        }
+        loadedPlugins[pluginNameWithoutPrefix] = pluginobject;
+    },
 
     /**
      * Executes the current configuration on an array of file and directory names.
@@ -432,8 +444,6 @@ CLIEngine.prototype = {
         } else {
             return null;
         }
-
-
     }
 
 };

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -860,6 +860,23 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages.length, 2);
                 assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
             });
+
+            it("should return two messages when executing with cli option that specifies preloaded plugin", function() {
+                engine = new CLIEngine({
+                    reset: true,
+                    useEslintrc: false,
+                    plugins: ["test"],
+                    rules: { "test/example-rule": 1 }
+                });
+
+                engine.addPlugin("eslint-plugin-test", { rules: { "example-rule": require("../fixtures/rules/custom-rule") } });
+
+                var report = engine.executeOnFiles(["tests/fixtures/rules/test/test-custom-rule.js"]);
+
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 2);
+                assert.equal(report.results[0].messages[0].ruleId, "test/example-rule");
+            });
         });
 
         describe("processors", function() {
@@ -869,6 +886,36 @@ describe("CLIEngine", function() {
                     reset: true,
                     useEslintrc: false,
                     extensions: ["js", "txt"]
+                });
+
+                var report = engine.executeOnFiles(["tests/fixtures/processors/test/test-processor.txt"]);
+
+                assert.equal(report.results.length, 1);
+                assert.equal(report.results[0].messages.length, 2);
+            });
+            it("should return two messages when executing with config file that specifies preloaded processor", function() {
+                engine = new CLIEngine({
+                    reset: true,
+                    useEslintrc: false,
+                    plugins: ["test-processor"],
+                    rules: {
+                        "no-console": 2,
+                        "no-unused-vars": 2
+                    },
+                    extensions: ["js", "txt"]
+                });
+
+                engine.addPlugin("test-processor", {
+                    processors: {
+                        ".txt": {
+                            preprocess: function(text) {
+                                return [text];
+                            },
+                            postprocess: function(messages) {
+                                return messages[0];
+                            }
+                        }
+                    }
                 });
 
                 var report = engine.executeOnFiles(["tests/fixtures/processors/test/test-processor.txt"]);


### PR DESCRIPTION
Fixes #1971 I'm not 100% sure why we needed to loadPlugins in constructor before. Each method already calls it anyways. So I removed it, because otherwise, if your config specified a plugin, you would get an error as soon as constructor is called.