### PR TITLE
New: add asi-safe rule (fixes #746)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -99,6 +99,7 @@
         "no-undef": 2,
         "no-undef-init": 2,
         "no-undefined": 0,
+        "no-unexpected-multiline": 0,
         "no-underscore-dangle": 2,
         "no-unneeded-ternary": 0,
         "no-unreachable": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -36,6 +36,7 @@ The following rules point out areas where you might have made mistakes.
 * [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
 * [valid-jsdoc](valid-jsdoc.md) - Ensure JSDoc comments are valid (off by default)
 * [valid-typeof](valid-typeof.md) - Ensure that the results of typeof are compared against a valid string
+* [no-unexpected-multiline](no-unexpected-multiline.md) - Avoid code that looks like two expressions but is actually one (off by default)
 
 ## Best Practices
 

--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -1,0 +1,54 @@
+# Avoid unexpected multiline expressions (no-unexpected-multiline)
+
+Semicolons are optional in JavaScript, via a process called automatic semicolon insertion (ASI). See the documentation for [semi](./semi.md) for a fuller discussion of that feature.
+
+The rules for ASI are relatively straightforward: In short, as once described by Isaac Schlueter, a `\n` character always ends a statement (just like a semicolon) unless one of the following is true:
+
+1. The statement has an unclosed paren, array literal, or object literal or ends in some other way that is not a valid way to end a statement. (For instance, ending with `.` or `,`.)
+2. The line is `--` or `++` (in which case it will decrement/increment the next token.)
+3. It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
+4. The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other binary operator that can only be found between two tokens in a single expression.
+
+This particular rule aims to spot scenarios where a newline looks like it is ending a statement, but is not.
+
+## Rule Details
+
+This rule is aimed at ensuring that two unrelated consecutive lines are not accidentially interpreted as a single expression.
+
+The following patterns are considered warnings:
+
+```js
+var foo = bar
+(1 || 2).baz();
+
+var hello = 'world'
+[1, 2, 3].forEach(addNumber);
+```
+
+The following patterns are not considered warnings:
+
+```js
+var foo = bar;
+(1 || 2).baz();
+
+var foo = bar
+;(1 || 2).baz()
+
+var hello = 'world';
+[1, 2, 3].forEach(addNumber);
+
+var hello = 'world'
+void [1, 2, 3].forEach(addNumber);
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are confident that you will not accidentally introduce code like this.
+
+Note that the patterns considered warnings are **not** flagged by the [semi](semi.md) rule.
+
+## Related Rules
+
+* [semi](semi.md)
+* [no-spaced-func](no-spaced-func.md)
+* [space-unary-ops](space-unary-ops.md)

--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview Rule to spot scenarios where a newline looks like it is ending a statement, but is not.
+ * @author Glen Mailer
+ * @copyright 2015 Glen Mailer
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+module.exports = function(context) {
+
+    var FUNCTION_MESSAGE = "Unexpected newline between function and ( of function call.";
+    var PROPERTY_MESSAGE = "Unexpected newline between object and [ of property access.";
+
+    /**
+     * Check to see if the bracket prior to the node is continuing the previous
+     * line's expression
+     * @param {ASTNode} node The node to check.
+     * @param {string} msg The error message to use.
+     * @returns {void}
+     * @private
+     */
+    function checkForBreakBefore(node, msg) {
+        var tokens = context.getTokensBefore(node, 2);
+        var paren = tokens[1];
+        var before = tokens[0];
+        if (paren.loc.start.line !== before.loc.end.line) {
+            context.report(node, paren.loc.start, msg, { char: paren.value });
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "MemberExpression": function(node) {
+            if (!node.computed) {
+                return;
+            }
+
+            checkForBreakBefore(node.property, PROPERTY_MESSAGE);
+        },
+
+        "CallExpression": function(node) {
+            if (node.arguments.length === 0) {
+                return;
+            }
+
+            checkForBreakBefore(node.arguments[0], FUNCTION_MESSAGE);
+        }
+    };
+
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-unexpected-multiline.js
+++ b/tests/lib/rules/no-unexpected-multiline.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Tests for no-unexpected-multiline rule.
+ * @author Glen Mailer
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-unexpected-multiline", {
+    valid: [
+        "(x || y).aFunction()",
+        "[a, b, c].forEach(doSomething)",
+        "var a = b;\n(x || y).doSomething()",
+        "var a = b\n;(x || y).doSomething()",
+        "var a = b\nvoid (x || y).doSomething()",
+        "var a = b;\n[1, 2, 3].forEach(console.log)",
+        "var a = b\nvoid [1, 2, 3].forEach(console.log)",
+        "\"abc\\\n(123)\"",
+        "var a = (\n(123)\n)"
+    ],
+    invalid: [
+        {
+            code: "var a = b\n(x || y).doSomething()",
+            line: 2,
+            column: 0,
+            errors: [{ message: "Unexpected newline between function and ( of function call." }]
+        },
+        {
+            code: "var a = (a || b)\n(x || y).doSomething()",
+            line: 2,
+            column: 0,
+            errors: [{ message: "Unexpected newline between function and ( of function call." }]
+        },
+        {
+            code: "var a = (a || b)\n(x).doSomething()",
+            line: 2,
+            column: 0,
+            errors: [{ message: "Unexpected newline between function and ( of function call." }]
+        },
+        {
+			code: "var a = b\n[a, b, c].forEach(doSomething)",
+            line: 2,
+            column: 0,
+            errors: [{ message: "Unexpected newline between object and [ of property access." }]
+		},
+        {
+			code: "var a = b\n    (x || y).doSomething()",
+            line: 2,
+            column: 4,
+            errors: [{ message: "Unexpected newline between function and ( of function call." }]
+		},
+        {
+			code: "var a = b\n  [a, b, c].forEach(doSomething)",
+            line: 2,
+            column: 2,
+            errors: [{ message: "Unexpected newline between object and [ of property access." }]
+		}
+    ]
+});


### PR DESCRIPTION
I took a fairly naïve approach, which I'm now not sure was a great idea.

This will flag as errors lines starting with `"[", "("` even if they are within a structure which is safe from ASI rules like an array or object literal.

On a related note, I wonder if it would be worthwhile to add a "line" visitor that rules can hook into. It would allow rules which check per-line things to all share the same single pass, and possibly make it easier to align with the AST parsing if done in the correct order.