### PR TITLE
Fix: Stop linebreak-style from crashing (fixes #2490)

### DIFF
--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Rule to forbid mixing LF and LFCR line breaks.
  * @author Erik Mueller
+ * @copyright 2015 James Whitney. All rights reserved.
  * @copyright 2015 Erik Mueller. All rights reserved.
  */
 
@@ -19,7 +20,11 @@ module.exports = function (context) {
             var linebreakStyle = context.options[0] || "unix",
                 expectedLF = linebreakStyle === "unix",
                 linebreaks = context.getSource().match(/\r\n|\r|\n|\u2028|\u2029/g),
+                lineOfError = -1;
+
+            if (linebreaks !== null) {
                 lineOfError = linebreaks.indexOf(expectedLF ? "\r\n" : "\n");
+            }
 
             if (lineOfError !== -1) {
                 context.report(node, {

--- a/tests/lib/rules/linebreak-style.js
+++ b/tests/lib/rules/linebreak-style.js
@@ -34,6 +34,14 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
         {
             code: "var a = 'a',\r\n b = 'b';\r\n\r\n function foo(params) {\r\n /* do stuff */ \r\n }\r\n",
             args: [2, "windows"]
+        },
+        {
+            code: "var b = 'b';",
+            args: [2, "unix"]
+        },
+        {
+            code: "var b = 'b';",
+            args: [2, "windows"]
         }
     ],
 


### PR DESCRIPTION
Due to the fact that the `linebreak-style` rule always expected to find linebreaks within a file there was a possibility that the rule would throw an Error if this was not the case.

This can be causes by a file with 1 line or less being generated in a windows environment that does not insert linefeeds on the last line of the file.