### PR TITLE
Rule to disallow unescaped innerHTML assignments and insertAdjacentHTML calls

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -99,6 +99,7 @@
         "no-undefined": 0,
         "no-underscore-dangle": 2,
         "no-unneeded-ternary": 0,
+        "no-unsafe-innerhtml": 0,
         "no-unreachable": 2,
         "no-unused-expressions": 2,
         "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -192,6 +192,12 @@ These rules are only relevant to ES6 environments and are off by default.
 * [no-var](no-var.md) - require `let` or `const` instead of `var` (off by default)
 * [object-shorthand](object-shorthand.md) - require method and property shorthand syntax for object literals (off by default)
 
+## Security
+
+These rules are only relevant for security checks are off by default.
+
+* [no-unsafe-innerhtml](no-unsafe-innerhtml.md) - require `escapeHTML` or similar escaping function for innerHTML and calls to insertAdjacentHTML (off by default)
+
 ## Legacy
 
 The following rules are included for compatibility with [JSHint](http://jshint.com/) and [JSLint](http://jslint.com/). While the names of the rules may not match up with the JSHint/JSLint counterpart, the functionality is the same.

--- a/docs/rules/no-unsafe-innerhtml.md
+++ b/docs/rules/no-unsafe-innerhtml.md
@@ -1,0 +1,26 @@
+# Disallow unsafe HTML templating (no-unsafe-innerhtml)
+
+This function disallows unsafe coding practices that may result into security vulnerabilities. We will disallow assignments to innerHTML as well as calls to insertAdjacentHTML without the use of a pre-defined escaping function. The escaping functions must be called with a template string. The function names are hardcoded as `Tagged.escapeHTML` and `escapeHTML`.
+
+## Rule Details
+
+The rule disallows unsafe coding practices while trying to allow safe coding practices.
+
+Here are a few examples of code that we do not want to allow:
+
+```js
+foo.innerHTML = input.value;
+bar.innerHTML = "<a href='"+url+"'>About</a>";
+```
+
+A few examples of allowed practices:
+
+
+```js
+foo.innerHTML = 5;
+bar.innerHTML = "<a href='/about.html'>About</a>";
+bar.innerHTML = escapeHTML`<a href='${url}'>About</a>`;
+```
+
+
+This rule is being used within Mozilla to maintain and improve the security of the Firefox OS front-end codebase *Gaia*. Further documentation, which includes references to the escaping functions can be found on [MDN](https://developer.mozilla.org/en-US/Firefox_OS/Security/Security_Automation).

--- a/lib/rules/no-unsafe-innerhtml.js
+++ b/lib/rules/no-unsafe-innerhtml.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview Rule to flag unescaped assignments to innerHTML
+ * @author Frederik Braun, April King
+ * @copyright 2015 Mozilla Corporation. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function (context) {
+
+    // valid operators to match against, such as X.innerHTML += foo
+    var OPERATORS = ["=", "+="];
+
+    // names of escaping functions that we acknowledge
+    var VALID_ESCAPERS = ["Tagged.escapeHTML", "escapeHTML"];
+
+    function allowedExpression(expression) {
+        /* check the stringish-part, which is either the right-hand-side of
+         an inner/outerHTML assignment or the 2nd parameter to insertAdjacentTML
+         */
+
+        /*  surely, someone could have an evil literal in there, but that"s malice
+         we can just check for unsafe coding practice, not outright malice
+         example literal "<script>eval(location.hash.slice(1)</script>"
+         (it"s the task of the tagger-function to be the gateway here.)
+         */
+        if (expression.type === "Literal") {
+            // we just assign a literal (e.g. a string, a number, a bool)
+            return true;
+        } else if (expression.type === "TemplateLiteral") {
+            // check for ${..} expressions
+            if (expression.expressions.length === 0) {
+                return true;
+            } else {
+                return false;
+            } // else: contains expressions, but no tagged function? not cool.
+        } else if (expression.type === "TaggedTemplateExpression") {
+            // context.getSource(expression.tag) is the function name
+            if (VALID_ESCAPERS.indexOf(context.getSource(expression.tag)) !== -1) {
+                return true;
+            } else {
+                return false;
+            }
+        } else {
+            return false;
+        } // everything that doesn't match is unsafe
+    }
+
+    return {
+        "AssignmentExpression:exit": function (node) {
+            // called when an identifier is found in the tree.
+            // the "exit" prefix ensures we know all subnodes already.
+            if ("property" in node.left) {
+                if (OPERATORS.indexOf(node.operator) !== -1) {
+                    if (node.left.property.name === ("innerHTML" || "outerHTML")) {
+                        if (!allowedExpression(node.right)) {
+                            context.report(node, "Unsafe assignment to innerHTML"); // report error
+                        }
+                    }
+                }
+            }
+        },
+
+        CallExpression: function (node) {
+            // this is for insertAdjacentHTML(position, markup)
+            if ("property" in node.callee) {
+                if (node.callee.property.name === "insertAdjacentHTML") {
+                    if (!allowedExpression(node.arguments[1])) {
+                        context.report(node, "Unsafe call to insertAdjacentHTML"); // report error
+                    }
+                }
+            }
+        }
+    };
+
+};

--- a/lib/rules/no-unsafe-innerhtml.js
+++ b/lib/rules/no-unsafe-innerhtml.js
@@ -17,7 +17,13 @@ module.exports = function (context) {
     // names of escaping functions that we acknowledge
     var VALID_ESCAPERS = ["Tagged.escapeHTML", "escapeHTML"];
 
-    function allowedExpression(expression) {
+    function allowedExpression(expression, parent) {
+        /*
+         expression = { right-hand side of innerHTML or 2nd param to insertAdjacentHTML
+         parent is the parent node of the call or assignment. used to look into comments.
+
+        */
+        var allowed;
         /* check the stringish-part, which is either the right-hand-side of
          an inner/outerHTML assignment or the 2nd parameter to insertAdjacentTML
          */
@@ -29,24 +35,39 @@ module.exports = function (context) {
          */
         if (expression.type === "Literal") {
             // we just assign a literal (e.g. a string, a number, a bool)
-            return true;
+            allowed = true;
         } else if (expression.type === "TemplateLiteral") {
             // check for ${..} expressions
             if (expression.expressions.length === 0) {
-                return true;
+                allowed = true;
             } else {
-                return false;
+                allowed = false;
             } // else: contains expressions, but no tagged function? not cool.
         } else if (expression.type === "TaggedTemplateExpression") {
             // context.getSource(expression.tag) is the function name
             if (VALID_ESCAPERS.indexOf(context.getSource(expression.tag)) !== -1) {
-                return true;
+                allowed = true;
             } else {
-                return false;
+                allowed = false;
             }
         } else {
-            return false;
-        } // everything that doesn't match is unsafe
+            // everything that doesn't match is unsafe:
+            allowed = false;
+        }
+        if (allowed === false) {
+            // Check for comment that link to approval in bugzilla:
+            var comments = context.getComments(parent).trailing;
+            for (var i = 0; i < comments.length; i++) {
+                var comment = comments[i];
+                /* looking for comment directly after the semicolon
+                   (same or next line), that matches /bug \d{7,}/.
+                 */
+                if (comment.value.match(/a=.*, bug \d{7,}/)) {
+                    allowed = true;
+                }
+            }
+        }
+        return allowed;
     }
 
     return {
@@ -56,7 +77,7 @@ module.exports = function (context) {
             if ("property" in node.left) {
                 if (OPERATORS.indexOf(node.operator) !== -1) {
                     if (node.left.property.name === ("innerHTML" || "outerHTML")) {
-                        if (!allowedExpression(node.right)) {
+                        if (!allowedExpression(node.right, node.parent)) {
                             context.report(node, "Unsafe assignment to innerHTML"); // report error
                         }
                     }
@@ -68,7 +89,7 @@ module.exports = function (context) {
             // this is for insertAdjacentHTML(position, markup)
             if ("property" in node.callee) {
                 if (node.callee.property.name === "insertAdjacentHTML") {
-                    if (!allowedExpression(node.arguments[1])) {
+                    if (!allowedExpression(node.arguments[1], node.parent)) {
                         context.report(node, "Unsafe call to insertAdjacentHTML"); // report error
                     }
                 }

--- a/tests/lib/rules/no-unsafe-innerhtml.js
+++ b/tests/lib/rules/no-unsafe-innerhtml.js
@@ -81,7 +81,13 @@ eslintTester.addRuleTest("lib/rules/no-unsafe-innerhtml", {
         {
             code: "n.insertAdjacentHTML('afterend', Tagged.escapeHTML`${title}`);",
             ecmaFeatures: { templateStrings: true }
-       }],
+        },
+        // override for manual review and legacy code
+        {
+            code: "g.innerHTML = potentiallyUnsafe; // a=legacy, bug 1155131",
+            ecmaFeatures: { templateStrings: true }
+        }
+    ],
 
     // Examples of code that should trigger the rule
     invalid: [

--- a/tests/lib/rules/no-unsafe-innerhtml.js
+++ b/tests/lib/rules/no-unsafe-innerhtml.js
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview Test for no-unsafe-innerhtml rule
+ * @author Frederik Braun
+ * @copyright 2015 Mozilla Corporation. All rights reserved
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-unsafe-innerhtml", {
+
+    // Examples of code that should not trigger the rule
+    // XXX this does not find z['innerHTML'] and the like.
+    // XXX define a valid pattern that is for seemingly evil patterns, e.g. '//approved by fxossec bug <id>'
+
+    valid: [
+        // tests for innerHTML equals
+        { code: "a.innerHTML = '';",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "c.innerHTML = ``;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "g.innerHTML = Tagged.escapeHTML``;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "h.innerHTML = Tagged.escapeHTML`foo`;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "i.innerHTML = Tagged.escapeHTML`foo${bar}baz`;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        // tests for innerHTML update (+= operator)
+        {
+            code: "a.innerHTML += '';",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "b.innerHTML += \"\";",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "c.innerHTML += ``;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "g.innerHTML += Tagged.escapeHTML``;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "h.innerHTML += Tagged.escapeHTML`foo`;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "i.innerHTML += Tagged.escapeHTML`foo${bar}baz`;",
+            ecmaFeatures: { templateStrings: true }
+        },
+        // tests for insertAdjacentHTML calls
+        {
+            code: "n.insertAdjacentHTML('afterend', 'meh');",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "n.insertAdjacentHTML('afterend', `<br>`);",
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "n.insertAdjacentHTML('afterend', Tagged.escapeHTML`${title}`);",
+            ecmaFeatures: { templateStrings: true }
+       }],
+
+    // Examples of code that should trigger the rule
+    invalid: [
+        /* XXX Do NOT change the error strings below without review from freddy:
+         * The strings are optimized for SEO and understandability.
+         * The developer can search for them and will find this MDN article:
+         *  https://developer.mozilla.org/en-US/Firefox_OS/Security/Security_Automation
+         */
+
+        // innerHTML examples
+        {
+            code: "m.innerHTML = htmlString;",
+            errors: [
+                { message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression" }
+            ]
+        },
+        {
+            code: "a.innerHTML += htmlString;",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ]
+        },
+        {
+            code: "a.innerHTML += template.toHtml();",
+            errors: [
+                {
+                    message: "Unsafe assignment to innerHTML",
+                    type: "AssignmentExpression"
+                }
+            ]
+        },
+        // insertAdjacentHTML examples
+        {
+            code: "node.insertAdjacentHTML('beforebegin', htmlString);",
+            errors: [
+                {
+                    message: "Unsafe call to insertAdjacentHTML",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "node.insertAdjacentHTML('beforebegin', template.getHTML());",
+            errors: [
+                {
+                    message: "Unsafe call to insertAdjacentHTML",
+                    type: "CallExpression"
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
I am not entirely sure if test is interesting to the eslint project, but it's disabled by default and some security checks may be worth your time.

Alternatively, I'm happy to maintain this rule on my own, as we are hoping to use this in the [Firefox OS UI "gaia"](https://github.com/mozilla-b2g/gaia)


(Also, mentioning @marumari here, because she helped on a much earlier version of this test)