### PR TITLE
Fix: dot-location should use correct dot token (fixes #2504)

### DIFF
--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -28,22 +28,21 @@ module.exports = function (context) {
     }
 
     /**
-     * Reports if the given token has invalid spacing.
+     * Reports if the dot between object and property is on the correct loccation.
      * @param {ASTNode} obj The object owning the property.
      * @param {ASTNode} prop The property of the object.
      * @param {ASTNode} node The corresponding node of the token.
      * @returns {void}
      */
     function checkDotLocation(obj, prop, node) {
+        var dot = context.getTokenBefore(prop);
 
-        if (!isSameLine(obj, prop)) {
-            var dot = context.getTokensBetween(obj, prop)[0];
+        if (dot.type === "Punctuator" && dot.value === ".") {
             if (onObject) {
-                if (obj.loc.start.line !== dot.loc.start.line) {
+                if (!isSameLine(obj, dot)) {
                     context.report(node, dot.loc.start, "Expected dot to be on same line as object.");
                 }
-            } else if (prop.loc.start.line !== dot.loc.start.line) {
-            // if (afterNewline && prop.loc.line !== dot.loc.line) {
+            } else if (!isSameLine(dot, prop)) {
                 context.report(node, dot.loc.start, "Expected dot to be on same line as property.");
             }
         }

--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -24,12 +24,19 @@ eslintTester.addRuleTest("lib/rules/dot-location", {
         "obj.\nprop",
         "obj. \nprop",
         "obj.\n prop",
+        "(obj).\nprop",
+        "obj\n['prop']",
+        "obj['prop']",
         {
             code: "obj.\nprop",
             options: [ "object" ]
         },
         {
             code: "obj\n.prop",
+            options: [ "property" ]
+        },
+        {
+            code: "(obj)\n.prop",
             options: [ "property" ]
         }
     ],
@@ -43,6 +50,11 @@ eslintTester.addRuleTest("lib/rules/dot-location", {
             code: "obj.\nproperty",
             options: [ "property" ],
             errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 3 } ]
+        },
+        {
+            code: "(obj).\nproperty",
+            options: [ "property" ],
+            errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 5 } ]
         }
     ]
 });


### PR DESCRIPTION
This PR fixes also the problem if you use a multiline `MemberExpression` with the brackets notation

```js
obj
['prop'];
```