### PR TITLE
New: Allow plugins to provide environments (fixes #1130)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -76,6 +76,32 @@ module.exports = {
 };
 ```
 
+### Providing Environments with Plugins
+
+You can provide environments in your plugin by modifying the
+exported object to include an `environments` property. `environments` follows the same pattern as
+you see in the conf/environments.js file. Be sure to reference any plugin specific rules using the plugin name
+prefix as the environments can configure rules defined in the plugin or from other sources.
+
+```js
+module.exports = {
+    environments: {
+        strict: {
+            rules: {
+                "example/example-rule": 2, // must use the namespace prefix because we also want to
+                "strict": [2, "function"]  // be able to define a complete environment, not just for this plugin's rules
+            }
+        }
+    },
+    rules: {
+        "example-rule": require("./lib/rules/example-rule")
+    },
+    rulesConfig: {
+        "example-rule": 1
+    }
+};
+```
+
 ### Peer Dependency
 
 To make clear that the plugin requires ESLint to work correctly you have to declare ESLint as a `peerDependency` in your `package.json`.

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -105,6 +105,9 @@ An environment defines both global variables that are predefined as well as whic
 * `meteor` - meteor global variables.
 * `es6` - enable all ECMAScript 6 features except for modules.
 
+Plugins can also provide environments which are prefixed with the plugin name. So the plugin `example` could provide an environment
+called `strict` which would be referred to in your configuration with the environment named `example/strict`.
+
 These environments are not mutually exclusive, so you can define more than one at a time.
 
 Environments can be specified inside of a file, in configuration files or using the `--env` [command line](command-line-interface) flag.

--- a/lib/config.js
+++ b/lib/config.js
@@ -331,6 +331,7 @@ Config.prototype.getConfig = function (filePath) {
     var config,
         userConfig,
         directory = filePath ? path.dirname(filePath) : process.cwd(),
+        plugins = [],
         pluginConfig;
 
     debug("Constructing config for " + (filePath ? filePath : "text"));
@@ -353,6 +354,30 @@ Config.prototype.getConfig = function (filePath) {
 
     // Step 2: Create a copy of the baseConfig
     config = util.mergeConfigs({}, this.baseConfig);
+
+    // Produce a set of plugins from all sources
+    [config, userConfig, this.useSpecificConfig].forEach(function(item) {
+        if (item && item.plugins) {
+            item.plugins.forEach(function(plugin) {
+                if (plugins.indexOf(plugin) === -1) {
+                    plugins.push(plugin);
+                }
+            });
+        }
+    });
+    if (plugins.length !== 0) {
+        // load them
+        pluginConfig = getPluginsConfig(plugins);
+        // update environments to include environments provided by plugins prefixed by plugin name
+        Object.keys(loadedPlugins).forEach(function(pluginNameWithoutPrefix) {
+            var plugin = loadedPlugins[pluginNameWithoutPrefix];
+            if (plugin.environments) {
+                Object.keys(plugin.environments).forEach(function(environmentName) {
+                    environments[pluginNameWithoutPrefix + "/" + environmentName] = plugin.environments[environmentName];
+                });
+            }
+        });
+    }
 
     // Step 3: Merge in environment-specific globals and rules from .eslintrc files
     config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env, this.options.reset));
@@ -389,7 +414,6 @@ Config.prototype.getConfig = function (filePath) {
 
     // Step 9: Merge in plugin specific rules in reverse
     if (config.plugins) {
-        pluginConfig = getPluginsConfig(config.plugins);
         config = util.mergeConfigs(pluginConfig, config);
     }
 

--- a/tests/fixtures/configurations/plugins-with-environment.json
+++ b/tests/fixtures/configurations/plugins-with-environment.json
@@ -1,0 +1,10 @@
+{
+    "plugins": [
+        "example"
+    ],
+
+    "env": {
+        "example/strict": true
+    }
+
+}

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -728,6 +728,44 @@ describe("Config", function() {
 
                 assertConfigsEqual(actual, expected);
             });
+
+            it("should allow the plugin to contribute an environment", function () {
+                var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "plugins-with-environment.json");
+                requireStubs[examplePluginName] = {
+                    environments: {
+                        strict: {
+                            rules: {
+                                "example/example-rule": 2, // must use the namespace prefix because we also want to
+                                "strict": [2, "function"]  // be able to define a complete environment, not just for this plugin's rules
+                            }
+                        }
+                    },
+                    rules: examplePluginRules
+                };
+
+                StubbedConfig = proxyquire("../../lib/config", requireStubs);
+
+                var configHelper = new StubbedConfig({
+                        baseConfig: false,
+                        useEslintrc: false,
+                        configFile: configPath
+                    }),
+                    file = getFixturePath("broken", "plugins", "console-wrong-quotes.js"),
+                    expected = {
+                        env: {
+                            "example/strict": true
+                        },
+                        rules: {
+                            "example/example-rule": 2,
+                            "strict": [2, "function"]
+                        },
+                        plugins: ["example"]
+                    },
+                    actual = configHelper.getConfig(file);
+
+                assertConfigsEqual(actual, expected);
+            });
+
         });
     });
 });


### PR DESCRIPTION
Adapted lib/config.js to load plugins prior to env block processing and modify the environments object to include environments defined in plugins. Updated doc and tests.