### PR TITLE
New: object-curly-spacing (fixes #2225)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -140,6 +140,7 @@
         "new-cap": 2,
         "new-parens": 2,
         "newline-after-var": 0,
+        "object-curly-spacing": [0, "never"],
         "object-shorthand": 0,
         "one-var": 0,
         "operator-assignment": [0, "always"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -159,6 +159,7 @@ These rules are purely matters of style and are quite subjective.
 * [no-underscore-dangle](no-underscore-dangle.md) - disallow dangling underscores in identifiers
 * [no-unneeded-ternary](no-unneeded-ternary.md) - disallow the use of `Boolean` literals in conditional expressions (off by default)
 * [no-wrap-func](no-wrap-func.md) - disallow wrapping of non-IIFE statements in parens
+* [object-curly-spacing](object-curly-spacing.md) - require or disallow padding inside curly braces (off by default)
 * [one-var](one-var.md) - allow or disallow one variable declaration per function (off by default)
 * [operator-assignment](operator-assignment.md) - require assignment operator shorthand where possible or prohibit it entirely (off by default)
 * [operator-linebreak](operator-linebreak.md) - enforce operators to be placed before or after line breaks (off by default)

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -1,0 +1,149 @@
+# Disallow or enforce spaces inside of curly braces in objects. (object-curly-spacing)
+
+While formatting preferences are very personal, a number of style guides require
+or disallow spaces between curly braces in the following situations:
+
+```js
+// simple object literals
+var obj = { foo: "bar" };
+
+// nested object literals
+var obj = { foo: { zoo: "bar" } };
+
+// destructuring assignment (EcmaScript 6)
+var { x, y } = y;
+
+// import/export declarations (EcmaScript 6)
+import { foo } from "bar";
+export { foo };
+```
+
+## Rule Details
+
+This rule aims to maintain consistency around the spacing inside of object literals. It also
+applies to EcmaScript 6 destructured assignment and import/export specifiers.
+
+It either requires or disallows spaces between those braces and the values inside of them.
+Braces that are separated from the adjacent value by a new line are exempt from this rule.
+
+### Options
+
+There are two main options for the rule:
+
+* `"always"` enforces a space inside of curly braces
+* `"never"` disallows spaces inside of curly braces (default)
+
+Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+
+```json
+"curly-braces-spacing": [2, "always"]
+```
+
+#### never
+
+When `"never"` is set, the following patterns are considered warnings:
+
+```js
+var obj = { 'foo': 'bar' };
+var obj = {'foo': 'bar' };
+var obj = { baz: {'foo': 'qux'}, 'bar'};
+var obj = {baz: { 'foo': 'qux' }, 'bar'};
+var {x } = y;
+import { foo } from 'bar';
+```
+
+The following patterns are not warnings:
+
+```js
+// When options are [2, "never"]
+var obj = {'foo': 'bar'};
+var obj = {'foo': {'bar': 'baz'}, 'qux': 'quxx'};
+var obj = {
+  'foo': 'bar'
+};
+var obj = {'foo': 'bar'
+};
+var obj = {
+  'foo':'bar'};
+var obj = {};
+var {x} = y;
+import {foo} from 'bar';
+```
+
+#### always
+
+When `"always"` is used, the following patterns are considered warnings:
+
+```js
+var obj = {'foo': 'bar'};
+var obj = {'foo': 'bar' };
+var obj = { baz: {'foo': 'qux'}, 'bar'};
+var obj = {baz: { 'foo': 'qux' }, 'bar'};
+var obj = {'foo': 'bar'
+};
+var obj = {
+  'foo':'bar'};
+var {x} = y;
+import {foo } from 'bar';
+```
+
+The following patterns are not warnings:
+
+```js
+var obj = {};
+var obj = { 'foo': 'bar' };
+var obj = { 'foo': { 'bar': 'baz' }, 'qux': 'quxx' };
+var obj = {
+  'foo': 'bar'
+};
+var { x } = y;
+import { foo } from 'bar';
+```
+
+Note that `{}` is always exempt from spacing requirements with this rule.
+
+#### Exceptions
+
+There is one exception you can apply to this rule. It's called `objectsInObjects` and
+can be set either `true` or `false` as part of an object literal set as the 3rd argument
+for the rule.
+
+These exceptions work in the context of the first option.
+That is, if `"always"` is set to enforce spacing and an exception is set to `false`,
+it will disallow spacing for cases matching the exception. Likewise,
+if `"never"` is set to disallow spacing and an exception is set to `true`,
+it will enforce spacing for cases matching the exception.
+
+You can add exceptions like so:
+
+```json
+"space-in-brackets": [2, "always", {
+  "objectsInObjects": false
+}]
+```
+
+In the case of the `"always"` option, set `objectsInObjects` exception to `false` to
+enforce the following syntax (notice the `}}` at the end):
+
+```js
+var obj = { "foo": { "baz": 1, "bar": 2 }};
+```
+
+In the case of the `"never"` option, set `objectsInObjects` exception to `true` to enforce
+the following style (with a space between the `}` at the end:
+
+
+```js
+var obj = {"foo": {"baz": 1, "bar": 2} };
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the consistency of spacing between brackets.
+
+## Related Rules
+
+* [comma-spacing](comma-spacing.md)
+* [space-in-parens](space-in-parens.md)
+* [space-in-brackets](space-in-brackets.md) (deprecated)
+

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -1,0 +1,206 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside of object literals.
+ * @author Jamund Ferguson
+ * @copyright 2014 Brandyn Bennett. All rights reserved.
+ * @copyright 2014 Michael Ficarra. No rights reserved.
+ * @copyright 2014 Vignesh Anand. All rights reserved.
+ * @copyright 2015 Jamund Ferguson. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var spaced = context.options[0] === "always";
+
+    /**
+     * Determines whether an option is set, relative to the spacing option.
+     * If spaced is "always", then check whether option is set to false.
+     * If spaced is "never", then check whether option is set to true.
+     * @param {Object} option - The option to exclude.
+     * @returns {boolean} Whether or not the property is excluded.
+     */
+    function isOptionSet(option) {
+        return context.options[1] != null ? context.options[1][option] === !spaced : false;
+    }
+
+    var options = {
+        spaced: spaced,
+        objectsInObjectsException: isOptionSet("objectsInObjects")
+    };
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Determines whether two adjacent tokens are have whitespace between them.
+     * @param {Object} left - The left token object.
+     * @param {Object} right - The right token object.
+     * @returns {boolean} Whether or not there is space between the tokens.
+     */
+    function isSpaced(left, right) {
+        return left.range[1] < right.range[0];
+    }
+
+    /**
+     * Determines whether two adjacent tokens are on the same line.
+     * @param {Object} left - The left token object.
+     * @param {Object} right - The right token object.
+     * @returns {boolean} Whether or not the tokens are on the same line.
+     */
+    function isSameLine(left, right) {
+        return left.loc.start.line === right.loc.start.line;
+    }
+
+    /**
+    * Reports that there shouldn't be a space after the first token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportNoBeginningSpace(node, token) {
+        context.report(node, token.loc.start,
+            "There should be no space after '" + token.value + "'");
+    }
+
+    /**
+    * Reports that there shouldn't be a space before the last token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportNoEndingSpace(node, token) {
+        context.report(node, token.loc.start,
+            "There should be no space before '" + token.value + "'");
+    }
+
+    /**
+    * Reports that there should be a space after the first token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportRequiredBeginningSpace(node, token) {
+        context.report(node, token.loc.start,
+            "A space is required after '" + token.value + "'");
+    }
+
+    /**
+    * Reports that there should be a space before the last token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportRequiredEndingSpace(node, token) {
+        context.report(node, token.loc.start,
+                    "A space is required before '" + token.value + "'");
+    }
+
+
+    /**
+     * Determines if spacing in curly braces is valid.
+     * @param {ASTNode} node The AST node to check.
+     * @param {Token} first The first token to check (should be the opening brace)
+     * @param {Token} second The second token to check (should be first after the opening brace)
+     * @param {Token} penultimate The penultimate token to check (should be last before closing brace)
+     * @param {Token} last The last token to check (should be closing brace)
+     * @returns {void}
+     */
+    function validateBraceSpacing(node, first, second, penultimate, last) {
+        var closingCurlyBraceMustBeSpaced =
+            options.objectsInObjectsException && penultimate.value === "}"
+            ? !options.spaced : options.spaced;
+
+        if (isSameLine(first, second)) {
+            if (options.spaced && !isSpaced(first, second)) {
+                reportRequiredBeginningSpace(node, first);
+            }
+            if (!options.spaced && isSpaced(first, second)) {
+                reportNoBeginningSpace(node, first);
+            }
+        }
+
+        if (isSameLine(penultimate, last)) {
+            if (closingCurlyBraceMustBeSpaced && !isSpaced(penultimate, last)) {
+                reportRequiredEndingSpace(node, last);
+            }
+            if (!closingCurlyBraceMustBeSpaced && isSpaced(penultimate, last)) {
+                reportNoEndingSpace(node, last);
+            }
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        // var {x} = y;
+        ObjectPattern: function(node) {
+            var firstSpecifier = node.properties[0],
+                lastSpecifier = node.properties[node.properties.length - 1];
+
+            var first = context.getTokenBefore(firstSpecifier),
+                second = context.getFirstToken(firstSpecifier),
+                penultimate = context.getLastToken(lastSpecifier),
+                last = context.getTokenAfter(lastSpecifier);
+
+            validateBraceSpacing(node, first, second, penultimate, last);
+        },
+
+        // import {y} from 'x';
+        ImportDeclaration: function(node) {
+
+            var firstSpecifier = node.specifiers[0],
+                lastSpecifier = node.specifiers[node.specifiers.length - 1];
+
+            // don't do anything for namespace or default imports
+            if (firstSpecifier && lastSpecifier && firstSpecifier.type === "ImportSpecifier" && lastSpecifier.type === "ImportSpecifier") {
+                var first = context.getTokenBefore(firstSpecifier),
+                    second = context.getFirstToken(firstSpecifier),
+                    penultimate = context.getLastToken(lastSpecifier),
+                    last = context.getTokenAfter(lastSpecifier);
+
+                validateBraceSpacing(node, first, second, penultimate, last);
+            }
+
+        },
+
+        // export {name} from 'yo';
+        ExportNamedDeclaration: function(node) {
+            if (!node.specifiers.length) {
+                return;
+            }
+
+            var firstSpecifier = node.specifiers[0],
+                lastSpecifier = node.specifiers[node.specifiers.length - 1],
+                first = context.getTokenBefore(firstSpecifier),
+                second = context.getFirstToken(firstSpecifier),
+                penultimate = context.getLastToken(lastSpecifier),
+                last = context.getTokenAfter(lastSpecifier);
+
+            validateBraceSpacing(node, first, second, penultimate, last);
+
+        },
+
+        // var y = {x: 'y'}
+        ObjectExpression: function(node) {
+            if (node.properties.length === 0) {
+                return;
+            }
+
+            var first = context.getFirstToken(node),
+                second = context.getFirstToken(node, 1),
+                penultimate = context.getLastToken(node, 1),
+                last = context.getLastToken(node);
+
+            validateBraceSpacing(node, first, second, penultimate, last);
+        }
+
+    };
+
+};

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -1,0 +1,417 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside of object literals.
+ * @author Jamund Ferguson
+ * @copyright 2014 Vignesh Anand. All rights reserved.
+ * @copyright 2015 Jamund Ferguson. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
+
+    valid: [
+
+        // always - object literals
+        { code: "var obj = { foo: bar, baz: qux };", options: ["always"] },
+        { code: "var obj = { foo: { bar: quxx }, baz: qux };", options: ["always"] },
+        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", options: ["always"] },
+
+        // always - destructuring
+        { code: "var { x } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var { x, y } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var { x,y } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var {\nx,y } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var {\nx,y\n} = z", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var { x = 10, y } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var { x: { z }, y } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
+
+        // always - import / export
+        { code: "import { door } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "import {\ndoor } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "export { door } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "import { house, mouse } from 'caravan'", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "export { door }", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "import 'room'", options: ["always"], ecmaFeatures: { modules: true } },
+
+        // always - empty object
+        { code: "var foo = {};", options: ["always"] },
+
+        // always - objectsInObjects
+        { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }};", options: ["always", {"objectsInObjects": false}] },
+
+        // never
+        { code: "var obj = {foo: bar,\nbaz: qux\n};", options: ["never"] },
+        { code: "var obj = {\nfoo: bar,\nbaz: qux};", options: ["never"] },
+
+        // never - object literals
+        { code: "var obj = {foo: bar, baz: qux};", options: ["never"] },
+        { code: "var obj = {foo: {bar: quxx}, baz: qux};", options: ["never"] },
+        { code: "var obj = {foo: {\nbar: quxx}, baz: qux\n};", options: ["never"] },
+        { code: "var obj = {foo: {\nbar: quxx\n}, baz: qux};", options: ["never"] },
+        { code: "var obj = {\nfoo: bar,\nbaz: qux\n};", options: ["never"] },
+
+        // never - destructuring
+        { code: "var {x} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {x, y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {x,y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {\nx,y\n} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {x = 10} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {x = 10, y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {x: {z}, y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {\nx: {z\n}, y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+
+        // never - import / export
+        { code: "import {door} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "export {door} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import {\ndoor} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "export {\ndoor\n} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import {house,mouse} from 'caravan'", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import {house, mouse} from 'caravan'", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "export {door}", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import 'room'", options: ["never"], ecmaFeatures: { modules: true } },
+
+        // never - empty object
+        { code: "var foo = {};", options: ["never"] },
+
+        // never - objectsInObjects
+        { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", {"objectsInObjects": true}] }
+
+    ],
+
+    invalid: [
+        {
+            code: "import {bar} from 'foo.js';",
+            options: ["always"],
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 7
+                },
+                {
+                    message: "A space is required before '}'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "export {bar};",
+            options: ["always"],
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ExportNamedDeclaration",
+                    line: 1,
+                    column: 7
+                },
+                {
+                    message: "A space is required before '}'",
+                    type: "ExportNamedDeclaration",
+                    line: 1,
+                    column: 11
+                }
+            ]
+        },
+        // always-objectsInObjects
+        {
+            code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 } };",
+            options: ["always", {"objectsInObjects": false}],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 42
+                }
+            ]
+        },
+        {
+            code: "var obj = { 'foo': [ 1, 2 ] , 'bar': { 'baz': 1, 'qux': 2 } };",
+            options: ["always", {"objectsInObjects": false}],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 60
+                }
+            ]
+        },
+
+        // never-objectsInObjects
+        {
+            code: "var obj = {'foo': {'bar': 1, 'baz': 2}};",
+            options: ["never", {"objectsInObjects": true}],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 38
+                }
+            ]
+        },
+        {
+            code: "var obj = {'foo': [1, 2] , 'bar': {'baz': 1, 'qux': 2}};",
+            options: ["never", {"objectsInObjects": true}],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 54
+                }
+            ]
+        },
+
+        // always & never
+        {
+            code: "var obj = {foo: bar, baz: qux};",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 10
+                },
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 29
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: bar, baz: qux };",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: bar, baz: qux};",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 30
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: bar, baz: qux };",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 10
+                },
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 31
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: bar, baz: qux };",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 30
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: bar, baz: qux};",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "var obj = { foo: { bar: quxx}, baz: qux};",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 10
+                },
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo: {bar: quxx }, baz: qux };",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 27
+                },
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 39
+                }
+            ]
+        },
+        {
+            code: "export const thing = {value: 1 };",
+            ecmaFeatures: {
+                modules: true,
+                blockBindings: true
+            },
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 21
+                }
+            ]
+        },
+
+        // destructuring
+        {
+            code: "var {x, y} = y",
+            ecmaFeatures: {destructuring: true},
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 4
+                },
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 9
+                }
+            ]
+        },
+        {
+            code: "var { x, y} = y",
+            ecmaFeatures: {destructuring: true},
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "var { x, y } = y",
+            ecmaFeatures: {destructuring: true},
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 4
+                },
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "var {x, y } = y",
+            ecmaFeatures: {destructuring: true},
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "var { x=10} = y",
+            ecmaFeatures: {destructuring: true},
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "var {x=10 } = y",
+            ecmaFeatures: {destructuring: true},
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 4
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Mostly copied over from the deprecated `space-in-brackets` rule. Added additional logic to enforce spacing around destructured assignment. Used `object-literal-spacing`, because people will generally get the idea and it leaves the door open to splitting out destructuring into its own rule later if people decide they want that flexibllity.

Preserves the only option (besides `always` and `never`) from the old rule that applied specifically to object-literals and that is `objectsInObjects` which allows you to stack the braces `}}` inside of nested objects.