### PR TITLE
Fix: forced no-shadow to check all scopes (fixes #2294)

### DIFF
--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -39,6 +39,14 @@ function b(a) {
 b(a);
 ```
 
+```js
+var a = 3;
+
+if (true) {
+    let a = 5;
+}
+```
+
 ## Further Reading
 
 * [Variable Shadowing](http://en.wikipedia.org/wiki/Variable_shadowing)

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -49,11 +49,11 @@ module.exports = function(context) {
 
     /**
      * Checks the current context for shadowed variables.
+     * @param {Scope} scope - Fixme
      * @returns {void}
      */
-    function checkForShadows() {
-        var scope = context.getScope(),
-            variables = scope.variables;
+    function checkForShadows(scope) {
+        var variables = scope.variables;
 
         // iterate through the array of variables and find duplicates with the upper scope
         var upper = scope.upper;
@@ -64,9 +64,17 @@ module.exports = function(context) {
     }
 
     return {
-        "FunctionDeclaration": checkForShadows,
-        "FunctionExpression": checkForShadows,
-        "ArrowFunctionExpression": checkForShadows
+        "Program:exit": function () {
+            var globalScope = context.getScope(),
+                stack = globalScope.childScopes.slice(),
+                scope;
+
+            while (stack.length) {
+                scope = stack.pop();
+                stack.push.apply(stack, scope.childScopes);
+                checkForShadows(scope);
+            }
+        }
     };
 
 };

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -76,6 +76,16 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
         {
             code: "var a=3; function b() { var a=10; var b=0; }; setTimeout(function() { b(); }, 0);",
             errors: [{ message: "a is already declared in the upper scope.", type: "Identifier" }, { message: "b is already declared in the upper scope.", type: "Identifier" }]
+        },
+        {
+            code: "var x = 1; { let x = 2; }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "x is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "let x = 1; { const x = 2; }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "x is already declared in the upper scope.", type: "Identifier"}]
         }
     ]
 });


### PR DESCRIPTION
Instead of listing all the nodes that could potentially create a scope in ES6, I just built a stack to traverse the scopes tree top-down.

Performance looks OK in my machine:

* Before:

    ```
    CPU Speed is 800 with multiplier 7500000
    Performance Run #1:  1276.091608ms
    Performance Run #2:  1313.046001ms
    Performance Run #3:  1282.84558ms
    Performance Run #4:  1280.500036ms
    Performance Run #5:  1308.158333ms
    Performance budget ok:  1282.84558ms (limit: 9375ms)
    ```
* After:

    ```
    CPU Speed is 800 with multiplier 7500000
    Performance Run #1:  1264.320176ms
    Performance Run #2:  1256.536445ms
    Performance Run #3:  1258.839234ms
    Performance Run #4:  1276.002489ms
    Performance Run #5:  1273.202285ms
    Performance budget ok:  1264.320176ms (limit: 9375ms)
    ```