### PR TITLE
Fix: location object in report function expects column instead of col…

### DIFF
--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Rule to forbid mixing LF and LFCR line breaks.
  * @author Erik Mueller
+ * @copyright 2015 Varun Verma. All rights reserverd.
  * @copyright 2015 James Whitney. All rights reserved.
  * @copyright 2015 Erik Mueller. All rights reserved.
  */
@@ -29,7 +30,7 @@ module.exports = function (context) {
             if (lineOfError !== -1) {
                 context.report(node, {
                     line: lineOfError + 1,
-                    col: context.getSourceLines()[lineOfError].length
+                    column: context.getSourceLines()[lineOfError].length
                 }, expectedLF ? EXPECTED_LF_MSG : EXPECTED_CRLF_MSG);
             }
         }

--- a/tests/lib/rules/linebreak-style.js
+++ b/tests/lib/rules/linebreak-style.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview No mixed linebreaks
  * @author Erik Mueller
+ * @copyright 2015 Varun Verma. All rights reserverd.
+ * @copyright 2015 James Whitney. All rights reserved.
  * @copyright 2015 Erik Mueller. All rights reserved.
  */
 "use strict";
@@ -51,7 +53,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2],
             errors: [{
                 line: 1,
-                col: 12,
+                column: 12,
                 message: EXPECTED_LF_MSG
             }]
         },
@@ -60,7 +62,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2, "unix"],
             errors: [{
                 line: 1,
-                col: 12,
+                column: 12,
                 message: EXPECTED_LF_MSG
             }]
         },
@@ -69,7 +71,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2, "windows"],
             errors: [{
                 line: 1,
-                col: 12,
+                column: 12,
                 message: EXPECTED_CRLF_MSG
             }]
         },
@@ -78,7 +80,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2],
             errors: [{
                 line: 4,
-                col: 23,
+                column: 23,
                 message: EXPECTED_LF_MSG
             }]
         },
@@ -87,7 +89,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2, "windows"],
             errors: [{
                 line: 3,
-                col: 9,
+                column: 0,
                 message: EXPECTED_CRLF_MSG
             }]
         }


### PR DESCRIPTION
The function 'report' in [eslint.js](https://github.com/eslint/eslint/blob/master/lib/eslint.js#L768)  expects the 'location' object to contain 2 key's 'line' and 'column'. The [linebreak-style.js](https://github.com/eslint/eslint/blob/master/lib/rules/linebreak-style.js#L33) was passing in 'col' key instead of 'column' on the 'location' object.

As these options are not mandatory few of the tests for linebreak-style.js were not able to catch it correctly.