### PR TITLE
Fix: Allow scoped packages in configuration extends (fixes #2544)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ tmp/
 .idea
 jsdoc/
 versions.json
+*.iml

--- a/lib/config.js
+++ b/lib/config.js
@@ -47,13 +47,13 @@ debug = debug("eslint:config");
 /**
  * Determines if a given string represents a filepath or not using the same
  * conventions as require(), meaning that the first character must be nonalphanumeric
- * to be considered a file path.
+ * and not the @ sign which is used for scoped packages to be considered a file path.
  * @param {string} filePath The string to check.
  * @returns {boolean} True if it's a filepath, false if not.
  * @private
  */
 function isFilePath(filePath) {
-    return isAbsolutePath(filePath) || !/\w/.test(filePath[0]);
+    return isAbsolutePath(filePath) || !/\w|@/.test(filePath[0]);
 }
 
 /**
@@ -80,7 +80,12 @@ function loadConfig(filePath) {
 
             // it's a package
             if (filePath.indexOf("eslint-config-") === -1) {
-                filePath = "eslint-config-" + filePath;
+                if (filePath.indexOf("@") === 0) {
+                    // for scoped packages, insert the eslint-config after the last /
+                    filePath = filePath.replace(/(.*\/)([^\/]+)/, "$1eslint-config-$2");
+                } else {
+                    filePath = "eslint-config-" + filePath;
+                }
             }
 
             var packagedConfig = require(filePath);

--- a/tests/fixtures/config-extends/scoped-package/.eslintrc
+++ b/tests/fixtures/config-extends/scoped-package/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "@scope/eslint-config-foo",
+
+    "rules": {
+        "quotes": [2, "double"],
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/fixtures/config-extends/scoped-package2/.eslintrc
+++ b/tests/fixtures/config-extends/scoped-package2/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "@scope/foo",
+
+    "rules": {
+        "quotes": [2, "double"],
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -595,6 +595,48 @@ describe("Config", function() {
             assertConfigsEqual(expected, actual);
         });
 
+        it("should extend scoped package configuration", function() {
+
+            var StubbedConfig = proxyquire("../../lib/config", {
+                "@scope/eslint-config-foo": {
+                    rules: {
+                        foo: "bar"
+                    }
+                }
+            });
+
+            var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package/.eslintrc"),
+                configHelper = new StubbedConfig({ reset: true, useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "quotes": [2, "double"], "foo": "bar", "valid-jsdoc": 0 },
+                    env: { "browser": false }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(expected, actual);
+        });
+
+        it("should extend scoped package configuration without prefix", function() {
+
+            var StubbedConfig = proxyquire("../../lib/config", {
+                "@scope/eslint-config-foo": {
+                    rules: {
+                        foo: "bar"
+                    }
+                }
+            });
+
+            var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package2/.eslintrc"),
+                configHelper = new StubbedConfig({ reset: true, useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "quotes": [2, "double"], "foo": "bar", "valid-jsdoc": 0 },
+                    env: { "browser": false }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(expected, actual);
+        });
+
         it("should extend package configuration with sub directories", function() {
 
             var StubbedConfig = proxyquire("../../lib/config", {


### PR DESCRIPTION
Added test cases for scoped packages then fixed lib/config.js to handle them properly.