### PR TITLE
New: lines-around-comment (fixes #1344)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -133,6 +133,7 @@
         "handle-callback-err": 0,
         "indent": 0,
         "key-spacing": [2, { "beforeColon": false, "afterColon": true }],
+        "lines-around-comment": 0,
         "max-depth": [0, 4],
         "max-len": [0, 80, 4],
         "max-nested-callbacks": [0, 2],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -140,6 +140,7 @@ These rules are purely matters of style and are quite subjective.
 * [func-style](func-style.md) - enforces use of function declarations or expressions (off by default)
 * [indent](indent.md) - this option sets a specific tab width for your code (off by default)
 * [key-spacing](key-spacing.md) - enforces spacing between keys and values in object literal properties
+* [lines-around-comment](lines-around-comment.md) - enforces empty lines around comments (off by default)
 * [linebreak-style](linebreak-style.md) - disallow mixed 'LF' and 'CRLF' as linebreaks (off by default)
 * [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested (off by default)
 * [new-cap](new-cap.md) - require a capital letter for constructors

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -1,0 +1,142 @@
+# Enforce empty lines around comments (lines-around-comment)
+
+Many style guides require empty lines before or after comments. The primary goal
+of these rules is to make the comments easier to read and improve readability of the code.
+
+## Rule Details
+
+This rule allows you to specify whether an empty line should be found
+before or after a comment. It can be enabled separately for both block (`/*`)
+and line (`//`) comments, and does not apply to comments that appear on the same
+line as code.
+
+
+By default an empty line is required above a block comment,
+such as in the following example:
+
+```js
+var x = 0;
+
+/**
+ * The vertical position.
+ */
+var y = 10;
+```
+
+The following would *not* pass the rule:
+
+```js
+var x = 0;
+/* the vertical position */
+var y = 10;
+```
+
+### Options
+
+This rule has 4 options:
+
+1. `beforeBlockComment` (enabled by default)
+2. `afterBlockComment`
+3. `beforeLineComment`
+4. `afterLineComment`
+
+Any combination of these rules may be applied at the same time.
+
+
+```json
+{
+    "lines-around-comment": [2, { beforeBlockComment: true, beforeLineComment: true }]
+}
+```
+
+When set to `false` the option is simply ignored.
+
+
+#### Block Comments
+
+Block comments are any comment that start with `/*` and need not extend to multiple lines.
+
+With both `beforeBlockComment` and `afterBlockComment` set to `true` the following code
+would not warn:
+
+```js
+var night = "long";
+
+/* what a great and wonderful day */
+
+var day = "great"
+```
+
+This however would provide 2 warnings:
+
+```js
+var night = "long";
+/* what a great and wonderful day */
+var day = "great"
+```
+
+With only `beforeBlockComment` set to `true` the following code
+would not warn:
+
+```js
+var night = "long";
+
+/* what a great and wonderful day */
+var day = "great"
+```
+
+But this would cause 1 warning:
+
+```js
+var night = "long";
+/* what a great and wonderful day */
+var day = "great"
+```
+
+#### Line Comments
+
+Line comments are any comments that start with `//`.
+
+With both `beforeLineComment` and `afterLineComment` set to `true` the following code
+would not warn:
+
+```js
+var night = "long";
+
+// what a great and wonderful day
+
+var day = "great"
+```
+
+With only `beforeLineComment` set to `true` the following code
+would not warn:
+
+```js
+var night = "long";
+
+// what a great and wonderful day
+var day = "great"
+```
+
+### Exceptions
+
+Inline comments are always excluded from the rule.
+
+The following would be acceptable:
+
+```js
+var x = 0;
+var y = 10; /* the vertical position */
+```
+
+Empty lines are also not required at the beginning or end of a file.
+
+## When Not To Use It
+
+Many people enjoy a terser code style and don't mind comments bumping up against code. If you
+fall into that category this rule is not for you.
+
+## Related Rules
+
+* [space-before-blocks](space-before-blocks.md)
+* [spaced-line-comment](spaced-line-comment.md)

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -1,0 +1,160 @@
+/**
+ * @fileoverview Enforces empty lines around comments.
+ * @author Jamund Ferguson
+ * @copyright 2015 Jamund Ferguson. All rights reserved.
+ */
+"use strict";
+
+/**
+ * Return an array with with any line numbers that are empty.
+ * @param {Array} lines An array of each line of the file.
+ * @returns {Array} An array of line numbers.
+ */
+function getEmptyLineNums(lines) {
+    var emptyLines = lines.map(function(line, i) {
+        return {
+            code: line.trim(),
+            num: i + 1
+        };
+    }).filter(function(line) {
+        return !line.code;
+    }).map(function(line) {
+        return line.num;
+    });
+    return emptyLines;
+}
+
+/**
+ * Return an array with with any line numbers that contain comments.
+ * @param {Array} comments An array of comment nodes.
+ * @returns {Array} An array of line numbers.
+ */
+function getCommentLineNums(comments) {
+    var lines = [];
+    comments.forEach(function (token) {
+        var start = token.loc.start.line;
+        var end = token.loc.end.line;
+        lines.push(start, end);
+    });
+    return lines;
+}
+
+/**
+ * Determines if a value is an array.
+ * @param {number} val The value we wish to check for in the array..
+ * @param {Array} array An array.
+ * @returns {boolean} True if the value is in the array..
+ */
+function contains(val, array) {
+    return array.indexOf(val) > -1;
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var options = context.options[0] || {};
+    options.beforeLineComment = options.beforeLineComment || false;
+    options.afterLineComment = options.afterLineComment || false;
+    options.beforeBlockComment = options.beforeBlockComment || false;
+    options.afterBlockComment = typeof options.afterBlockComment !== "undefined" ? options.afterBlockComment : true;
+
+    /**
+     * Returns whether or not comments are not on lines starting with or ending with code
+     * @param {ASTNode} node The comment node to check.
+     * @returns {boolean} True if the comment is not alone.
+     */
+    function codeAroundComment(node) {
+
+        var lines = context.getSourceLines();
+
+        // Get the whole line and cut it off at the start of the comment
+        var startLine = lines[node.loc.start.line - 1];
+        var endLine = lines[node.loc.end.line - 1];
+
+        var preamble = startLine.slice(0, node.loc.start.column).trim();
+
+        // Also check after the comment
+        var postamble = endLine.slice(node.loc.end.column).trim();
+
+        // Should be false if there was only whitespace around the comment
+        return !!(preamble || postamble);
+    }
+
+    /**
+     * Checks if a comment node has lines around it (ignores inline comments)
+     * @param {ASTNode} node The Comment node.
+     * @param {Object} opts Options to determine the newline.
+     * @param {Boolean} opts.after Should have a newline after this line.
+     * @param {Boolean} opts.before Should have a newline before this line.
+     * @returns {void}
+     */
+    function checkForEmptyLine(node, opts) {
+
+        var lines = context.getSourceLines(),
+            numLines = lines.length + 1,
+            comments = context.getAllComments(),
+            commentLines = getCommentLineNums(comments),
+            emptyLines = getEmptyLineNums(lines),
+            commentAndEmptyLines = commentLines.concat(emptyLines);
+
+        var after = opts.after,
+            before = opts.before;
+
+        var prevLineNum = node.loc.start.line - 1,
+            nextLineNum = node.loc.end.line + 1,
+            commentIsNotAlone = codeAroundComment(node);
+
+        // ignore top of the file and bottom of the file
+        if (prevLineNum < 1) {
+            before = false;
+        }
+        if (nextLineNum >= numLines) {
+            after = false;
+        }
+
+        // we ignore all inline comments
+        if (commentIsNotAlone) {
+            return;
+        }
+
+        // check for newline before
+        if (before && !contains(prevLineNum, commentAndEmptyLines)) {
+            context.report(node, "Expected line before comment.");
+        }
+
+        // check for newline after
+        if (after && !contains(nextLineNum, commentAndEmptyLines)) {
+            context.report(node, "Expected line after comment.");
+        }
+
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "LineComment": function(node) {
+            if (options.beforeLineComment || options.afterLineComment) {
+                checkForEmptyLine(node, {
+                    after: options.afterLineComment,
+                    before: options.beforeLineComment
+                });
+            }
+        },
+
+        "BlockComment": function(node) {
+            if (options.beforeBlockComment || options.afterBlockComment) {
+                checkForEmptyLine(node, {
+                    after: options.afterBlockComment,
+                    before: options.beforeBlockComment
+                });
+            }
+        }
+
+    };
+};

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Test enforcement of lines around comments.
+ * @author Jamund Ferguson
+ * @copyright 2015 Jamund Ferguson. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+var afterMessage = "Expected line after comment.",
+    beforeMessage = "Expected line before comment.";
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/lines-around-comment", {
+
+    valid: [
+
+        // default rules
+        { code: "bar()\n/** block block block\n * block \n */\n\nvar a = 1;" },
+        { code: "bar()\n\n/** block block block\n * block \n */\n\nvar a = 1;" },
+        { code: "bar()\n// line line line \nvar a = 1;" },
+        { code: "bar()\n\n// line line line\nvar a = 1;" },
+        { code: "bar()\n// line line line\n\nvar a = 1;" },
+
+        // line comments
+        {
+            code: "bar()\n// line line line\n\nvar a = 1;",
+            options: [{ afterLineComment: true }]
+        },
+        {
+            code: "foo()\n\n// line line line\nvar a = 1;",
+            options: [{ beforeLineComment: true }]
+        },
+        {
+            code: "foo()\n\n// line line line\n\nvar a = 1;",
+            options: [{ beforeLineComment: true, afterLineComment: true }]
+        },
+        {
+            code: "foo()\n\n// line line line\n// line line\n\nvar a = 1;",
+            options: [{ beforeLineComment: true, afterLineComment: true }]
+        },
+        {
+            code: "// line line line\n// line line",
+            options: [{ beforeLineComment: true, afterLineComment: true }]
+        },
+
+        // block comments
+        {
+            code: "bar()\n\n/** A Block comment with a an empty line after\n *\n */\nvar a = 1;",
+            options: [{ afterBlockComment: false, beforeBlockComment: true }]
+        },
+        {
+            code: "bar()\n/** block block block\n * block \n */\nvar a = 1;",
+            options: [{ afterBlockComment: false }]
+        },
+        {
+            code: "/** \nblock \nblock block\n */\n/* block \n block \n */",
+            options: [{ afterBlockComment: true, beforeBlockComment: true }]
+        },
+        {
+            code: "bar()\n\n/** block block block\n * block \n */\n\nvar a = 1;",
+            options: [{ afterBlockComment: true, beforeBlockComment: true }]
+        },
+
+        // inline comments (should not ever warn)
+        {
+            code: "foo() // An inline comment with a an empty line after\nvar a = 1;",
+            options: [{ afterLineComment: true, beforeLineComment: true }]
+        },
+        {
+            code: "foo();\nbar() /* An inline block comment with a an empty line after\n *\n */\nvar a = 1;",
+            options: [{ beforeBlockComment: true }]
+        },
+
+        // mixed comment (some block & some line)
+        {
+            code: "bar()\n/** block block block\n * block \n */\n//line line line\nvar a = 1;",
+            options: [{ afterBlockComment: true }]
+        },
+        {
+            code: "bar()\n/** block block block\n * block \n */\n//line line line\nvar a = 1;",
+            options: [{ beforeLineComment: true }]
+        }
+
+    ],
+
+    invalid: [
+
+        // default rules
+        {
+            code: "bar()\n/** block block block\n * block \n */\nvar a = 1;",
+            errors: [{ message: afterMessage, type: "Block" }]
+        },
+
+        // line comments
+        {
+            code: "baz()\n// A line comment with no empty line after\nvar a = 1;",
+            options: [{ afterLineComment: true }],
+            errors: [{ message: afterMessage, type: "Line" }]
+        },
+        {
+            code: "baz()\n// A line comment with no empty line after\nvar a = 1;",
+            options: [{ beforeLineComment: true, afterLineComment: false }],
+            errors: [{ message: beforeMessage, type: "Line" }]
+        },
+        {
+            code: "// A line comment with no empty line after\nvar a = 1;",
+            options: [{ beforeLineComment: true, afterLineComment: true }],
+            errors: [{ message: afterMessage, type: "Line", line: 1, column: 0 }]
+        },
+        {
+            code: "baz()\n// A line comment with no empty line after\nvar a = 1;",
+            options: [{ beforeLineComment: true, afterLineComment: true }],
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }, { message: afterMessage, type: "Line", line: 2 }]
+        },
+
+        // block comments
+        {
+            code: "bar()\n/**\n * block block block\n */\nvar a = 1;",
+            options: [{ afterBlockComment: true, beforeBlockComment: true }],
+            errors: [{ message: beforeMessage, type: "Block", line: 2 }, { message: afterMessage, type: "Block", line: 2 }]
+        },
+        {
+            code: "bar()\n/**\n * block block block\n */\nvar a = 1;",
+            options: [{ afterBlockComment: true, beforeBlockComment: false }],
+            errors: [{ message: afterMessage, type: "Block", line: 2 }]
+        },
+        {
+            code: "bar()\n/**\n * block block block\n */\nvar a = 1;",
+            options: [{ afterBlockComment: false, beforeBlockComment: true }],
+            errors: [{ message: beforeMessage, type: "Block", line: 2 }]
+        }
+    ]
+
+});


### PR DESCRIPTION
Enforces lines around comments. Default to off.