### PR TITLE
[WIP] Rule: no-constant-expressions

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -19,6 +19,7 @@
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
+        "no-constant-expressions": 2,
         "no-continue": 0,
         "no-control-regex": 2,
         "no-debugger": 2,

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -19,7 +19,7 @@
         "no-cond-assign": 2,
         "no-console": 2,
         "no-constant-condition": 2,
-        "no-constant-expressions": 2,
+        "no-constant-expressions": 0,
         "no-continue": 0,
         "no-control-regex": 2,
         "no-debugger": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -11,6 +11,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-cond-assign](no-cond-assign.md) - disallow assignment in conditional expressions
 * [no-console](no-console.md) - disallow use of `console` (off by default in the node environment)
 * [no-constant-condition](no-constant-condition.md) - disallow use of constant expressions in conditions
+* [no-constant-expressions](no-constant-expressions) - disallow use of computed constant expressions
 * [no-control-regex](no-control-regex.md) - disallow control characters in regular expressions
 * [no-debugger](no-debugger.md) - disallow use of `debugger`
 * [no-dupe-args](no-dupe-args.md) - disallow duplicate arguments in functions

--- a/docs/rules/no-constant-expressions.md
+++ b/docs/rules/no-constant-expressions.md
@@ -1,0 +1,29 @@
+# Disallow use of constant boolean expressions (no-constant-boolean-expressions)
+
+Dynamically calculating a boolean constant is likely to be an error.
+
+```js
+var success = a === a;
+```
+
+This pattern is most likely an error.
+
+## Rule Details
+
+The rule is aimed at preventing the use of a constant boolean expression.
+
+## Examples
+
+The following patterns are considered okay and do not cause warnings:
+
+```js
+var r = a === 3;
+var r = a === true && b === a;
+```
+
+The following patterns are considered warnings:
+
+```js
+var r = a && !a;
+var r = a === b && a === c && b !== c;
+```

--- a/lib/rules/no-constant-expressions.js
+++ b/lib/rules/no-constant-expressions.js
@@ -1,0 +1,303 @@
+/**
+ * @fileoverview Rule to prevent boolean expression logic errors
+ * @author Denis Sokolov
+ */
+
+"use strict";
+
+var staticEval = require("static-eval");
+
+var EVAL_FAILED = {};
+
+function evaluate(node, env) {
+    try {
+        return staticEval(node, env);
+    } catch (err) {
+        return EVAL_FAILED;
+    }
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+/* eslint-disable curly, valid-jsdoc */
+
+function unique(list) {
+    return list.filter(function(elem, pos) {
+        return list.indexOf(elem) === pos;
+    });
+}
+
+function delta(num) {
+    num = num || 1;
+    return num * 0.000000000000001;
+}
+
+
+var ARITHMETIC_OPERATORS = "&,|,<,<=,>,>=,===,==,!=,!==".split(",");
+
+function findArithmeticComparison(node) {
+    if (ARITHMETIC_OPERATORS.indexOf(node.operator) === -1)
+        return false;
+
+    function attempt(idnode, numnode, op) {
+        if (idnode.type !== "Identifier") return false;
+        if (numnode.type !== "Literal" || typeof numnode.value !== "number") return false;
+        return [idnode.name, numnode.value, op];
+    }
+
+    function reverse(op) {
+        if (op === "<") return ">";
+        if (op === "<=") return ">=";
+        if (op === ">") return "<";
+        if (op === ">=") return "<=";
+        return op;
+    }
+
+    return attempt(node.left, node.right, node.operator) ||
+        attempt(node.right, node.left, reverse(node.operator));
+}
+
+function isLiteralString(node) {
+    return node.type === "Literal" && typeof node.value === "string";
+}
+
+function isLiteralValue(node, value) {
+    return node.type === "Literal" && node.value === value;
+}
+
+function isSameIdentifier(left, right) {
+    return left.type === "Identifier" && right.type === "Identifier" &&
+        left.name === right.name;
+}
+
+function findBinaryTautologies(node) {
+    if (node.operator === "*") {
+        if (node.left.type === "Identifier" && isLiteralValue(node.right, 0))
+            return node.left.name;
+        if (node.right.type === "Identifier" && isLiteralValue(node.left, 0))
+            return node.right.name;
+    }
+    if (node.operator === "/") {
+        if (isSameIdentifier(node.left, node.right)) {
+            return node.left.name;
+        }
+    }
+    if ("==,===,!=,!==".indexOf(node.operator) > -1) {
+        if (isSameIdentifier(node.left, node.right))
+            return node.left.name;
+    }
+}
+
+/**
+ * Finds all identifiers in the expression with a list of values with should try out:
+ * @returns [
+ *   { name: "isFoo", values: [true, false] },
+ *   { name: "bar", values: [1, 0, -1] }
+ * ]
+ */
+function findIdentifiers(topNode) {
+    var result = {};
+
+    function push(arg, values) {
+        if (typeof arg !== "string") {
+            if (arg.type !== "Identifier") {
+                descend(arg); // eslint-disable-line no-use-before-define
+                return;
+            }
+            arg = arg.name;
+        }
+        var name = arg;
+        if (!result[name]) {
+            result[name] = [];
+        }
+        if (values.length === 0) {
+            result.noconstantexpressionfail = [];
+        }
+        result[name] = result[name].concat(values);
+    }
+
+    function pushBoolean(arg) {
+        push(arg, [true, false]);
+    }
+
+    function descend(node) {
+        if (node.type === "LogicalExpression") {
+            descend(node.left);
+            descend(node.right);
+            return;
+        }
+        if (node.type === "UnaryExpression") {
+            if (node.operator === "!") {
+                pushBoolean(node.argument);
+                return;
+            }
+            descend(node.argument);
+            return;
+        }
+        if (node.type === "BinaryExpression") {
+            var arithmComp = findArithmeticComparison(node);
+            if (arithmComp) {
+                var name = arithmComp[0];
+                var val = arithmComp[1];
+                var op = arithmComp[2];
+                if (op === "<") push(name, [val - delta(val), val]);
+                else if (op === "<=") push(name, [val, val + delta(val)]);
+                else if (op === ">") push(name, [val + delta(val), val]);
+                else if (op === ">=") push(name, [val, val - delta(val)]);
+                else push(name, [val, val + 1]);
+                return;
+            }
+
+            var arithmTaut = findBinaryTautologies(node);
+            if (arithmTaut) {
+                push(arithmTaut, [1]);
+                return;
+            }
+
+            if ((node.operator === "===" || node.operator === "!==") &&
+                node.left.type === "Identifier" && node.right.type === "Identifier"
+            ) {
+                pushBoolean(node.left);
+                pushBoolean(node.right);
+                return;
+            }
+
+            descend(node.left);
+            descend(node.right);
+            return;
+        }
+        if (node.type === "Identifier") {
+            push(node.name, []);
+            return;
+        }
+        if (node.type === "Literal") {
+            return;
+        }
+        if (node.type === "ArrayExpression") {
+            node.elements.forEach(descend);
+            return;
+        }
+        if (node.type === "CallExpression") {
+            push("!dummy-callee-confusing", []);
+            return;
+        }
+        if (node.type === "AssignmentExpression") {
+            push("!dummy-assign-not-supported", []);
+            return;
+        }
+        if (node.type === "ConditionalExpression") {
+            if (node.test.type === "Identifier") {
+                pushBoolean(node.test);
+            } else {
+                descend(node.test);
+            }
+            descend(node.consequent);
+            descend(node.alternate);
+            return;
+        }
+
+        push("!dummy-unknown-expression", []);
+    }
+
+    descend(topNode);
+
+    return Object.keys(result).map(function(name) {
+        return {
+            name: name,
+            values: unique(result[name])
+        };
+    });
+}
+
+function permutations(idents) {
+    var counter = 1;
+    var identsWithCounters = idents.map(function(ident) {
+        var i = {
+            name: ident.name,
+            values: ident.values,
+            permutationsBefore: counter
+        };
+        counter *= ident.values.length;
+        return i;
+    });
+    return (new Array(counter)).join().split(",").map(function(_, iteration) {
+        var env = {};
+        identsWithCounters.forEach(function(ident) {
+            env[ident.name] = ident.values[
+                Math.floor(iteration / ident.permutationsBefore) % (ident.values.length)
+            ];
+        });
+        return env;
+    });
+}
+
+function find(arr, cb) {
+    for (var i = arr.length - 1; i >= 0; i--) {
+        if (cb(arr[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+module.exports = function(context) {
+    var warnedParents = [];
+
+    function warned(node) {
+        if (node.type !== "BinaryExpression" && node.type !== "LogicalExpression") {
+            return false;
+        }
+        var found = find(warnedParents, function(p) {
+            return node === p;
+        });
+        if (found) {
+            return true;
+        }
+        return warned(node.parent);
+    }
+
+    function report(node, result) {
+        if (result === EVAL_FAILED) return;
+        context.report(node, "Expression always " + result);
+        warnedParents.push(node);
+    }
+
+    function check(node) {
+        if (warned(node.parent)) {
+            return;
+        }
+
+        var idents = findIdentifiers(node);
+        if (idents.length === 0) {
+            if (isLiteralString(node.left) && isLiteralString(node.right)) {
+                return;
+            }
+            report(node, evaluate(node, {}));
+            return;
+        }
+
+        var noInformationAboutSomeidents = find(idents, function(ident) {
+            return ident.values.length === 0;
+        });
+        if (noInformationAboutSomeidents) {
+            return;
+        }
+
+        var perms = permutations(idents);
+        var result = evaluate(node, perms[0]);
+        var foundDifferentResult = find(perms.slice(1), function(env) {
+            return evaluate(node, env) !== result;
+        });
+        if (!foundDifferentResult) {
+            report(node, result);
+            return;
+        }
+    }
+
+    return {
+        "BinaryExpression": check,
+        "LogicalExpression": check
+    };
+};

--- a/lib/rules/no-constant-expressions.js
+++ b/lib/rules/no-constant-expressions.js
@@ -67,6 +67,11 @@ function isLiteralValue(node, value) {
     return node.type === "Literal" && node.value === value;
 }
 
+function isOnlyLiteralStrings(node) {
+    return (node.type === "Literal" && typeof node.value === "string") ||
+        (node.type === "BinaryExpression" && isOnlyLiteralStrings(node.left) && isOnlyLiteralStrings(node.right));
+}
+
 function isSameIdentifier(left, right) {
     return left.type === "Identifier" && right.type === "Identifier" &&
         left.name === right.name;
@@ -271,7 +276,7 @@ module.exports = function(context) {
 
         var idents = findIdentifiers(node);
         if (idents.length === 0) {
-            if (isLiteralString(node.left) && isLiteralString(node.right)) {
+            if (isOnlyLiteralStrings(node)) {
                 return;
             }
             report(node, evaluate(node, {}));

--- a/lib/rules/no-constant-expressions.js
+++ b/lib/rules/no-constant-expressions.js
@@ -59,10 +59,6 @@ function findArithmeticComparison(node) {
         attempt(node.right, node.left, reverse(node.operator));
 }
 
-function isLiteralString(node) {
-    return node.type === "Literal" && typeof node.value === "string";
-}
-
 function isLiteralValue(node, value) {
     return node.type === "Literal" && node.value === value;
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "object-assign": "^2.0.0",
     "optionator": "^0.5.0",
     "path-is-absolute": "^1.0.0",
+    "static-eval": "^0.2.4",
     "strip-json-comments": "~1.0.1",
     "text-table": "~0.2.0",
     "user-home": "^1.0.0",

--- a/tests/lib/rules/no-constant-expressions.js
+++ b/tests/lib/rules/no-constant-expressions.js
@@ -42,6 +42,7 @@ eslintTester.addRuleTest("lib/rules/no-constant-expressions", {
         { code: "5 === (a || true)", args: 1 },
         { code: "a === 'true'", args: 1 },
         { code: "'long string' + 'another string'", args: 1 },
+        { code: "\"long string\" + \"another string\" + \"another string\"", args: 1 },
         { code: "3 + (-a)", args: 1 }
     ],
     invalid: [

--- a/tests/lib/rules/no-constant-expressions.js
+++ b/tests/lib/rules/no-constant-expressions.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview Tests for the no-mixed-requires rule.
+ * @author Raphael Pigulla
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-constant-expressions", {
+    valid: [
+        { code: "5", args: 1 },
+        { code: "a", args: 1 },
+        { code: "b && c", args: 1 },
+        { code: "b & 7", args: 1 },
+        { code: "b | c", args: 1 },
+        { code: "b === 3 && c !== 4", args: 1 },
+        { code: "a && b && c && d && e && f && g && h && i && j && k && l && m", args: 1 },
+        { code: "a === foo(a)", args: 1 },
+        { code: "(null)(5) + 9", args: 1},
+        { code: "(null)(5) && a === 3", args: 1},
+        { code: "(foo || bar)(5) + 9", args: 1},
+        { code: "(foo || bar)(5) && a === 3", args: 1},
+        { code: "foo() || bar()", args: 1 },
+        { code: "(a = 5) === 5", args: 1 },
+        { code: "3 === (a ? 2 : 3)", args: 1 },
+        { code: "a - 9 > -25", args: 1 },
+        { code: "2 < a && a < 2.1", args: 1 },
+        { code: "a >= 0", args: 1 },
+        { code: "200000 < a && a < 200000.0000001", args: 1 },
+        { code: "a > 19 || a + 1 > 0", args: 1 },
+        { code: "5 === (a || true)", args: 1 },
+        { code: "a === 'true'", args: 1 },
+        { code: "'long string' + 'another string'", args: 1 },
+        { code: "3 + (-a)", args: 1 }
+    ],
+    invalid: [
+        { code: "5 + 3", args: 1, errors: [{ message: "Expression always 8", type: "BinaryExpression" }] },
+        { code: "true && false", args: 1, errors: [{ message: "Expression always false", type: "LogicalExpression" }] },
+        { code: "a * 0 + 5;", args: 1, errors: [{ message: "Expression always 5", type: "BinaryExpression"}] },
+        { code: "a === a;", args: 1, errors: [{ message: "Expression always true", type: "BinaryExpression"}] },
+        { code: "a !== a;", args: 1, errors: [{ message: "Expression always false", type: "BinaryExpression"}] },
+        { code: "a / a;", args: 1, errors: [{ message: "Expression always 1", type: "BinaryExpression"}] },
+        { code: "a == 1 && a == 2;", args: 1, errors: [{ message: "Expression always false", type: "LogicalExpression"}] },
+        { code: "a > 1 || a <= 1;", args: 1, errors: [{ message: "Expression always true", type: "LogicalExpression"}] },
+        { code: "a > 1 && a < 1;", args: 1, errors: [{ message: "Expression always false", type: "LogicalExpression"}] },
+        { code: "a != 1 || a != 2;", args: 1, errors: [{ message: "Expression always true", type: "LogicalExpression"}] },
+        { code: "a > 1 && a === b && b < 1", args: 1, errors: [{ message: "Expression always false", type: "LogicalExpression"}] },
+        { code: "(a / a - 1) + 13", args: 1, errors: [{ message: "Expression always 13", type: "BinaryExpression"}] },
+        { code: "(a === 3 || b === 4 || c !== c) && (a !== 3 && b !== 4 && d === d)", args: 1, errors: [{ message: "Expression always false", type: "LogicalExpression"}] },
+        { code: "a === 0 && (a ? 4 : false)", args: 1, errors: [{ message: "Expression always false", type: "LogicalExpression"}] }
+    ]
+});


### PR DESCRIPTION
Important disclaimer: I am probably in over my head, please be gentle with your criticism. This rule is work in progress, and code has not been tidied at all. This PR is a request for comment.

I've seen #987 and figured - I can do basic static analysis on the expressions.
Well, I did, but, of course, it's a potentially very deep problem. I have tried to be very conservative and avoid false positives at the cost of missing true positives. 
Please see the test cases to see what the current implementation handles and what it doesn't handle.

The question is - should I pursue this further? Are you even open for something like this?
The next step that can be strived for is handling multiple subexpressions at the same time to be able to handle cases such as `a === a`,  `a === b && b === c && c !== a`, `a === 5 && a + 3 === 8` and others.

Thanks.