### PR TITLE
Fix: Improve around function/class names of `no-shadow` (fixes #2556, #2552)

### DIFF
--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -13,6 +13,48 @@
 module.exports = function(context) {
 
     /**
+     * Checks if a variable of the class name in the class scope of ClassDeclaration.
+     *
+     * ClassDeclaration creates two variables of its name into its outer scope and its class scope.
+     * So we should ignore the variable in the class scope.
+     *
+     * @param {Object} variable The variable to check.
+     * @returns {boolean} Whether or not the variable of the class name in the class scope of ClassDeclaration.
+     */
+    function isDuplicatedClassNameVariable(variable) {
+        var block = variable.scope.block;
+        return block.type === "ClassDeclaration" && block.id === variable.identifiers[0];
+    }
+
+    /**
+     * Checks if a variable is inside the initializer of scopeVar.
+     *
+     * To avoid reporting at declarations such as `var a = function a() {};`.
+     * But it should report `var a = function(a) {};` or `var a = function() { function a() {} };`.
+     *
+     * @param {Object} variable The variable to check.
+     * @param {Object} scopeVar The scope variable to look for.
+     * @returns {boolean} Whether or not the variable is inside initializer of scopeVar.
+     */
+    function isOnInitializer(variable, scopeVar) {
+        var outerScope = scopeVar.scope;
+        var outerDef = scopeVar.defs[0];
+        var outer = outerDef && outerDef.parent && outerDef.parent.range;
+        var innerScope = variable.scope;
+        var innerDef = variable.defs[0];
+        var inner = innerDef && innerDef.name.range;
+
+        return (
+            outer &&
+            inner &&
+            outer[0] < inner[0] &&
+            inner[1] < outer[1] &&
+            ((innerDef.type === "FunctionName" && innerDef.node.type === "FunctionExpression") || innerDef.node.type === "ClassExpression") &&
+            outerScope === innerScope.upper
+        );
+    }
+
+    /**
      * Checks if a variable is contained in the list of given scope variables.
      * @param {Object} variable The variable to check.
      * @param {Array} scopeVars The scope variables to look for.
@@ -20,10 +62,12 @@ module.exports = function(context) {
      */
     function isContainedInScopeVars(variable, scopeVars) {
         return scopeVars.some(function (scopeVar) {
-            if (scopeVar.identifiers.length > 0) {
-                return variable.name === scopeVar.name;
-            }
-            return false;
+            return (
+                scopeVar.identifiers.length > 0 &&
+                variable.name === scopeVar.name &&
+                !isDuplicatedClassNameVariable(scopeVar) &&
+                !isOnInitializer(variable, scopeVar)
+            );
         });
     }
 
@@ -35,14 +79,12 @@ module.exports = function(context) {
      */
     function checkShadowsInScope(variables, scope) {
         variables.forEach(function (variable) {
-            if (isContainedInScopeVars(variable, scope.variables) &&
-                    // "arguments" is a special case that has no identifiers (#1759)
-                    variable.identifiers.length > 0 &&
-
-                    // function and class names are exempt
-                    variable.defs.length && variable.defs[0].type !== "FunctionName" && variable.defs[0].type !== "ClassName"
-            ) {
-                context.report(variable.identifiers[0], "{{a}} is already declared in the upper scope.", {a: variable.name});
+            // "arguments" is a special case that has no identifiers (#1759)
+            if (variable.identifiers.length > 0 && isContainedInScopeVars(variable, scope.variables)) {
+                context.report(
+                    variable.identifiers[0],
+                    "{{name}} is already declared in the upper scope.",
+                    {name: variable.name});
             }
         });
     }
@@ -53,7 +95,19 @@ module.exports = function(context) {
      * @returns {void}
      */
     function checkForShadows(scope) {
-        var variables = scope.variables;
+        var variables = scope.variables.filter(function(variable) {
+            return (
+                // Skip "arguments".
+                variable.identifiers.length > 0 &&
+                // Skip variables of a class name in the class scope of ClassDeclaration.
+                !isDuplicatedClassNameVariable(variable)
+            );
+        });
+
+        // Checking is needless if there aren't variables.
+        if (variables.length === 0) {
+            return;
+        }
 
         // iterate through the array of variables and find duplicates with the upper scope
         var upper = scope.upper;

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -25,7 +25,8 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
         "var arguments;\nfunction bar() { }",
         { code: "var a=3; var b = (x) => { a++; return x + a; }; setTimeout(() => { b(a); }, 0);", ecmaFeatures: { arrowFunctions: true } },
         { code: "class A {}", ecmaFeatures: {classes: true} },
-        { code: "class A { constructor() { var a; } }", ecmaFeatures: {classes: true} }
+        { code: "class A { constructor() { var a; } }", ecmaFeatures: {classes: true} },
+        { code: "(function() { var A = class A {}; })()", ecmaFeatures: {classes: true} }
     ],
     invalid: [
         {
@@ -88,6 +89,56 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
             code: "let x = 1; { const x = 2; }",
             ecmaFeatures: {blockBindings: true},
             errors: [{ message: "x is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function a() { function a(){} })()",
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function a() { class a{} })()",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function a() { (function a(){}); })()",
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function a() { (class a{}); })()",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { var a = function(a) {}; })()",
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { var a = function() { function a() {} }; })()",
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { var a = function() { class a{} }; })()",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { var a = function() { (function a() {}); }; })()",
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { var a = function() { (class a{}); }; })()",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { var a = class { constructor() { class a {} } }; })()",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "class A { constructor() { var A; } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "A is already declared in the upper scope.", type: "Identifier"}]
         }
     ]
 });


### PR DESCRIPTION
I changed the logic to check function names and class names.
Basically it checks shadowing around function/class names. But it handles variable initializers specially in order to be compatible with declarations such as `var a = function a() { };`.

And I added [only one line](https://github.com/eslint/eslint/compare/eslint:master...mysticatea:fix-function-name-and-class-name-of-shadow?expand=1#diff-bb960ca8871dafb0bbd3959858e00231R68) to fix #2552.
If I should separate PR for this, I will do.