### PR TITLE
Fix: `no-shadow` allows shadowing in the TDZ (fixes #2568)

### DIFF
--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -47,6 +47,42 @@ if (true) {
 }
 ```
 
+## Options
+
+This rule has a option for the hoisting behavior.
+
+```json
+{
+    "rules": {
+        "no-shadow": [2, {"hoist": "functions"}]
+    }
+}
+```
+
+### hoist
+
+The option has three settings:
+
+* `all` - reports all shadowing before the outer variables/functions are defined.
+* `functions` (by default) - reports shadowing before the outer functions are defined.
+* `never` - never report shadowing before the outer variables/functions are defined.
+
+Thought with the following codes:
+
+```js
+if (true) {
+    let a = 3;
+    let b = 6;
+}
+
+let a = 5;
+function b() {}
+```
+
+* `all` - Both `let a` and `let b` in the `if` statement are considered warnings.
+* `functions` - `let b` is considered warnings. But `let a` in the `if` statement is not considered warnings. Because there is it before `let a` of the outer scope.
+* `never` - Both `let a` and `let b` in the `if` statement are not considered warnings. Because there are those before each declaration of the outer scope.
+
 ## Further Reading
 
 * [Variable Shadowing](http://en.wikipedia.org/wiki/Variable_shadowing)

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -12,6 +12,10 @@
 
 module.exports = function(context) {
 
+    var options = {
+        hoist: (context.options[0] && context.options[0].hoist) || "functions"
+    };
+
     /**
      * Checks if a variable of the class name in the class scope of ClassDeclaration.
      *
@@ -45,12 +49,41 @@ module.exports = function(context) {
         var inner = innerDef && innerDef.name.range;
 
         return (
-            outer &&
-            inner &&
+            outer != null &&
+            inner != null &&
             outer[0] < inner[0] &&
             inner[1] < outer[1] &&
             ((innerDef.type === "FunctionName" && innerDef.node.type === "FunctionExpression") || innerDef.node.type === "ClassExpression") &&
             outerScope === innerScope.upper
+        );
+    }
+
+    /**
+     * Get a range of a variable's identifier node.
+     * @param {Object} variable The variable to get.
+     * @returns {Array|undefined} The range of the variable's identifier node.
+     */
+    function getNameRange(variable) {
+        var def = variable.defs[0];
+        return def && def.name.range;
+    }
+
+    /**
+     * Checks if a variable is in TDZ of scopeVar.
+     * @param {Object} variable The variable to check.
+     * @param {Object} scopeVar The variable of TDZ.
+     * @returns {boolean} Whether or not the variable is in TDZ of scopeVar.
+     */
+    function isInTdz(variable, scopeVar) {
+        var outerDef = scopeVar.defs[0];
+        var inner = getNameRange(variable);
+        var outer = getNameRange(scopeVar);
+        return (
+            inner != null &&
+            outer != null &&
+            inner[1] < outer[0] &&
+            // Excepts FunctionDeclaration if is {"hoist":"function"}.
+            (options.hoist !== "functions" || outerDef == null || outerDef.node.type !== "FunctionDeclaration")
         );
     }
 
@@ -66,7 +99,8 @@ module.exports = function(context) {
                 scopeVar.identifiers.length > 0 &&
                 variable.name === scopeVar.name &&
                 !isDuplicatedClassNameVariable(scopeVar) &&
-                !isOnInitializer(variable, scopeVar)
+                !isOnInitializer(variable, scopeVar) &&
+                !(options.hoist !== "all" && isInTdz(variable, scopeVar))
             );
         });
     }
@@ -133,4 +167,13 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "hoist": {
+                "enum": ["all", "functions", "never"]
+            }
+        }
+    }
+];

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -26,7 +26,33 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
         { code: "var a=3; var b = (x) => { a++; return x + a; }; setTimeout(() => { b(a); }, 0);", ecmaFeatures: { arrowFunctions: true } },
         { code: "class A {}", ecmaFeatures: {classes: true} },
         { code: "class A { constructor() { var a; } }", ecmaFeatures: {classes: true} },
-        { code: "(function() { var A = class A {}; })()", ecmaFeatures: {classes: true} }
+        { code: "(function() { var A = class A {}; })()", ecmaFeatures: {classes: true} },
+        { code: "{ var a; } let a;", ecmaFeatures: {blockBindings: true} }, // this case reports `no-redeclare`, not shadowing.
+        { code: "{ let a; } let a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "{ let a; } var a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "{ let a; } function a() {}", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "{ const a = 0; } const a = 1;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "{ const a = 0; } var a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "{ const a = 0; } function a() {}", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { let a; } let a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { let a; } var a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { let a; } function a() {}", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { var a; } let a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { var a; } var a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { var a; } function a() {}", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo(a) { } let a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo(a) { } var a;", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "function foo(a) { } function a() {}", options: [{hoist: "never"}], ecmaFeatures: {blockBindings: true} },
+        { code: "{ let a; } let a;", ecmaFeatures: {blockBindings: true} },
+        { code: "{ let a; } var a;", ecmaFeatures: {blockBindings: true} },
+        { code: "{ const a = 0; } const a = 1;", ecmaFeatures: {blockBindings: true} },
+        { code: "{ const a = 0; } var a;", ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { let a; } let a;", ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { let a; } var a;", ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { var a; } let a;", ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { var a; } var a;", ecmaFeatures: {blockBindings: true} },
+        { code: "function foo(a) { } let a;", ecmaFeatures: {blockBindings: true} },
+        { code: "function foo(a) { } var a;", ecmaFeatures: {blockBindings: true} }
     ],
     invalid: [
         {
@@ -89,6 +115,121 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
             code: "let x = 1; { const x = 2; }",
             ecmaFeatures: {blockBindings: true},
             errors: [{ message: "x is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ let a; } function a() {}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ const a = 0; } function a() {}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { let a; } function a() {}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { var a; } function a() {}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo(a) { } function a() {}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ let a; } let a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ let a; } var a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ let a; } function a() {}",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ const a = 0; } const a = 1;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ const a = 0; } var a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "{ const a = 0; } function a() {}",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { let a; } let a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { let a; } var a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { let a; } function a() {}",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { var a; } let a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { var a; } var a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { var a; } function a() {}",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo(a) { } let a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo(a) { } var a;",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo(a) { } function a() {}",
+            options: [{hoist: "all"}],
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "a is already declared in the upper scope.", type: "Identifier"}]
         },
         {
             code: "(function a() { function a(){} })()",


### PR DESCRIPTION
I changed `no-shadow` rule to allowing shadowing in the TDZ.
But, if there are function/class scopes between the two variables, it's excepted.
