### PR TITLE
Fix: no-multiple-empty-lines and template strings (fixes #2605)

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -15,6 +15,9 @@ module.exports = function(context) {
     // Use options.max or 2 as default
     var numLines = 2;
 
+    // store lines that appear empty but really aren't
+    var notEmpty = [];
+
     if (context.options.length) {
         numLines = context.options[0].max;
     }
@@ -25,7 +28,16 @@ module.exports = function(context) {
 
     return {
 
-        "Program": function checkBlankLines(node) {
+        "TemplateLiteral": function(node) {
+            var start = node.loc.start.line;
+            var end = node.loc.end.line;
+            while (start <= end) {
+                notEmpty.push(start);
+                start++;
+            }
+        },
+
+        "Program:exit": function checkBlankLines(node) {
             var lines = context.getSourceLines(),
                 currentLocation = -1,
                 lastLocation,
@@ -34,6 +46,12 @@ module.exports = function(context) {
                 trimmedLines = lines.map(function(str) {
                     return str.trim();
                 });
+
+            // add the notEmpty lines in there with a placeholder
+            notEmpty.forEach(function(x, i) {
+                trimmedLines[i] = x;
+            });
+
             // swallow the final newline, as some editors add it automatically
             // and we don't want it to cause an issue
             if (trimmedLines[trimmedLines.length - 1] === "") {

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -50,7 +50,20 @@ eslintTester.addRuleTest("lib/rules/no-multiple-empty-lines", {
         {
             code: "// valid 5\nvar a = 5;\n",
             args: [2, { max: 0 } ]
+        },
+
+        // template strings
+        {
+            code: "x = `\n\n\n\nhi\n\n\n\n`",
+            args: ruleArgs,
+            ecmaFeatures: { templateStrings: true }
+        },
+        {
+            code: "`\n\n`",
+            options: [{ max: 0 }],
+            ecmaFeatures: { templateStrings: true }
         }
+
     ],
 
     invalid: [


### PR DESCRIPTION
A simple fix for the `no-multiple-empty-lines` bug with template strings.

Happy to receive suggestions on making this better.