### PR TITLE
New: `prefer-const` rule (fixes #2333)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -106,6 +106,7 @@
         "no-use-before-define": 2,
         "no-void": 0,
         "no-var": 0,
+        "prefer-const": 0,
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 2,
         "no-wrap-func": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -196,6 +196,7 @@ These rules are only relevant to ES6 environments and are off by default.
 * [generator-star](generator-star.md) - **(deprecated)** enforce the position of the `*` in generator functions (off by default)
 * [no-var](no-var.md) - require `let` or `const` instead of `var` (off by default)
 * [object-shorthand](object-shorthand.md) - require method and property shorthand syntax for object literals (off by default)
+* [prefer-const](prefer-const.md) - suggest using of `const` declaration for variables that are never modified after declared (off by default)
 
 ## Legacy
 

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -1,0 +1,55 @@
+# Suggest to use `const` (prefer-const)
+
+If a variable is never modified, using the `const` declaration is better.
+
+`const` declaration tells readers "this variable is never modified", reduces what they must think.
+So it will improve maintainability.
+
+## Rule Details
+
+This rule is aimed to flag variables that are declared using `let` keyword, but never modified after initial assignment.
+
+The following patterns are considered warnings:
+
+```js
+let a = 3;
+console.log(a);
+```
+
+```js
+for (let a of [1,2,3]) { // `a` is re-defined (not modified) on each loop step.
+    console.log(a);
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+let a; // there is not the initializer.
+console.log(a);
+```
+
+```js
+for (let i = 0, end = 10; i < end; ++i) { // `end` is never modified, but we cannot separate the declaration without changing the scope.
+    console.log(a);
+}
+```
+
+```js
+for (let a in [1,2,3]) { // `a` is modified on each loop step.
+    console.log(a);
+}
+```
+
+```js
+var a = 3; // suggest to use `no-var` rule.
+console.log(a);
+```
+
+## When Not to Use It
+
+If you don't want to be notified about variables that are never modified after initial assignment, you can safely disable this rule.
+
+## Related
+
+* [no-var](no-var.md)

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -1,0 +1,92 @@
+/**
+ * @fileoverview A rule to suggest using of const declaration for variables that are never modified after declared.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    /**
+     * Checks whether a reference is the initializer.
+     * @param {Reference} reference - A reference to check.
+     * @returns {boolean} Whether or not the reference is the initializer.
+     */
+    function isInitializer(reference) {
+        return reference.init === true;
+    }
+
+    /**
+     * Checks whether a reference is read-only or the initializer.
+     * @param {Reference} reference - A reference to check.
+     * @returns {boolean} Whether or not the reference is read-only or the initializer.
+     */
+    function isReadOnlyOrInitializer(reference) {
+        return reference.isReadOnly() || reference.init === true;
+    }
+
+    /**
+     * Searches and reports variables that are never modified after declared.
+     * @param {Scope} scope - A scope of the search domain.
+     * @returns {void}
+     */
+    function checkForVariables(scope) {
+        // Skip the TDZ type.
+        if (scope.type === "TDZ") {
+            return;
+        }
+
+        var variables = scope.variables;
+        for (var i = 0, end = variables.length; i < end; ++i) {
+            var variable = variables[i];
+            var def = variable.defs[0];
+            var declaration = def && def.parent;
+            var statement = declaration && declaration.parent;
+            var references = variable.references;
+            var identifier = variable.identifiers[0];
+
+            if (statement != null &&
+                identifier != null &&
+                declaration.type === "VariableDeclaration" &&
+                declaration.kind === "let" &&
+                (statement.type !== "ForStatement" || statement.init !== declaration) &&
+                (statement.type !== "ForInStatement" || statement.left !== declaration) &&
+                references.some(isInitializer) &&
+                references.every(isReadOnlyOrInitializer)
+            ) {
+                context.report(
+                    identifier,
+                    "`{{name}}` is never modified, use `const` instead.",
+                    {name: identifier.name});
+            }
+        }
+    }
+
+    /**
+     * Adds multiple items to the tail of an array.
+     * @param {any[]} array - A destination to add.
+     * @param {any[]} values - Items to be added.
+     * @returns {void}
+     */
+    var pushAll = Function.apply.bind(Array.prototype.push);
+
+    return {
+        "Program:exit": function () {
+            var stack = [context.getScope()];
+            while (stack.length) {
+                var scope = stack.pop();
+                pushAll(stack, scope.childScopes);
+
+                checkForVariables(scope);
+            }
+        }
+    };
+
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Tests for prefer-const rule.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/prefer-const", {
+    valid: [
+        { code: "var x = 0;" },
+        { code: "let x;", ecmaFeatures: {blockBindings: true} },
+        { code: "let x; x = 0;", ecmaFeatures: {blockBindings: true} },
+        { code: "let x = 0; x = 1;", ecmaFeatures: {blockBindings: true} },
+        { code: "const x = 0;", ecmaFeatures: {blockBindings: true} },
+        { code: "for (let i = 0, end = 10; i < end; ++i) {}", ecmaFeatures: {blockBindings: true} },
+        { code: "for (let i in [1,2,3]) {}", ecmaFeatures: {blockBindings: true} },
+        { code: "for (let x of [1,2,3]) { x = 0; }", ecmaFeatures: {blockBindings: true, forOf: true} },
+        { code: "(function() { var x = 0; })();" },
+        { code: "(function() { let x; })();", ecmaFeatures: {blockBindings: true} },
+        { code: "(function() { let x; x = 0; })();", ecmaFeatures: {blockBindings: true} },
+        { code: "(function() { let x = 0; x = 1; })();", ecmaFeatures: {blockBindings: true} },
+        { code: "(function() { const x = 0; })();", ecmaFeatures: {blockBindings: true} },
+        { code: "(function() { for (let i = 0, end = 10; i < end; ++i) {} })();", ecmaFeatures: {blockBindings: true} },
+        { code: "(function() { for (let i in [1,2,3]) {} })();", ecmaFeatures: {blockBindings: true} },
+        { code: "(function() { for (let x of [1,2,3]) { x = 0; } })();", ecmaFeatures: {blockBindings: true, forOf: true} },
+        { code: "(function(x = 0) { })();", ecmaFeatures: {defaultParams: true} }
+    ],
+    invalid: [
+        {
+            code: "let x = 1; foo(x);",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "for (let x of [1,2,3]) { foo(x); }",
+            ecmaFeatures: {blockBindings: true, forOf: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "let [x = -1, y] = [1,2]; y = 0;",
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { let x = 1; foo(x); })();",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { for (let x of [1,2,3]) { foo(x); } })();",
+            ecmaFeatures: {blockBindings: true, forOf: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "let x = 0; { let x = 1; foo(x); } x = 0;",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        },
+        {
+            code: "for (let i in [1,2,3]) { let x = 1; foo(x); }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
+        }
+    ]
+});


### PR DESCRIPTION
I tried to implement #2333.

There are some note:

- It skips `var`-declared variables.  
  Because global `var`-declared variables don't have references (by escope's design), I did to avoid complexity.  I expect to use this rule together with `no-var` rule.
- It skips `ForStatement.init`.  
  e.g. `for (let i = 0, end = xs.length; i < end; ++i) { ... }`  
  We cannot separate the declaration to `let` and `const` without changing scope.
- It skips `ForInStatement.left`.  
  The variables are changed by each loop step.
- It *doesn't* skip `ForOfStatement.left`.
  The variables are re-defined by each loop step.
  
  ```js
  for (const a of [1,2,3]) { setTimeout(function() { console.log(a) }, 1000); }
  // Probably it will print 1 2 3
  ```