### PR TITLE
Build: Remove release notes auto-publish (refs #2640)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -18,8 +18,8 @@ var path = require("path"),
     markdownlint = require("markdownlint"),
     nodeCLI = require("shelljs-nodecli"),
     os = require("os"),
-    semver = require("semver"),
-    ghGot = require("gh-got");
+    semver = require("semver");
+    // ghGot = require("gh-got");
 
 //------------------------------------------------------------------------------
 // Settings
@@ -111,14 +111,15 @@ function execSilent(cmd) {
  * @returns {void}
  */
 function release(type) {
-    var newVersion, changes;
+    var newVersion; /*, changes; */
 
     target.test();
     echo("Generating new version");
     newVersion = execSilent("npm version " + type).trim();
 
     echo("Generating changelog");
-    changes = target.changelog();
+    // changes =
+    target.changelog();
 
     // add changelog to commit
     exec("git add CHANGELOG.md");
@@ -132,30 +133,30 @@ function release(type) {
     exec("git push origin master --tags");
 
     // now push the changelog...changes to the tag
-    echo("Publishing changes to github release");
+    // echo("Publishing changes to github release");
     // this requires a github API token in process.env.ESLINT_GITHUB_TOKEN
     // it will continue with an error message logged if not set
-    ghGot("repos/eslint/eslint/releases", {
-        body: {
-            "tag_name": newVersion,
-            name: newVersion,
-            "target_commitish": "master",
-            body: changes
-        },
-        method: "POST",
-        json: true,
-        token: process.env.ESLINT_GITHUB_TOKEN
-    }, function(pubErr) {
-        if (pubErr) {
-            echo("Warning: error when publishing changes to github release: " + pubErr.message);
-        }
-        echo("Publishing to npm");
-        exec("npm publish");
+    // ghGot("repos/eslint/eslint/releases", {
+    //     body: {
+    //         "tag_name": newVersion,
+    //         name: newVersion,
+    //         "target_commitish": "master",
+    //         body: changes
+    //     },
+    //     method: "POST",
+    //     json: true,
+    //     token: process.env.ESLINT_GITHUB_TOKEN
+    // }, function(pubErr) {
+    //     if (pubErr) {
+    //         echo("Warning: error when publishing changes to github release: " + pubErr.message);
+    //     }
+    echo("Publishing to npm");
+    exec("npm publish");
 
-        echo("Generating site");
-        target.gensite();
-        target.publishsite();
-    });
+    echo("Generating site");
+    target.gensite();
+    target.publishsite();
+    // });
 }
 
 /**


### PR DESCRIPTION
I just commented out code related to release notes publishing for now. We still want this in, but given an issue on mac/Linux, I don't want to spend the time figuring it our right now.