### PR TITLE
Update: no-lone-blocks does not report block-level scopes (fixes #2119)

### DIFF
--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -1,12 +1,14 @@
 # Disallow Unnecessary Nested Blocks (no-lone-blocks)
 
-In JavaScript, standalone code blocks delimited by curly braces do not create a new scope and have no use. For example, these curly braces do nothing to `foo`:
+In JavaScript, prior to ES6, standalone code blocks delimited by curly braces do not create a new scope and have no use. For example, these curly braces do nothing to `foo`:
 
 ```js
 {
     var foo = bar();
 }
 ```
+
+In ES6, code blocks may create a new scope if a block-level binding (`let` and `const`), a class declaration or a function declaration (in strict mode) are present. A block is not considered redundant in these cases.
 
 ## Rule details
 
@@ -29,6 +31,10 @@ function bar() {
         baz();
     }
 }
+
+{
+    function foo() {}
+}
 ```
 
 The following patterns are not considered warnings:
@@ -46,5 +52,22 @@ if (foo) {
 
 function bar() {
     baz();
+}
+
+{
+    let x = 1;
+}
+
+{
+    const y = 1;
+}
+
+{
+    class Foo {}
+}
+
+// In strict mode, with blockBindings: true
+{
+    function foo() {}
 }
 ```

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Rule to flag blocks with no reason to exist
  * @author Brandon Mills
+ * @copyright 2015 Roberto Vidal. All rights reserved.
+ * @copyright 2014 Brandon Mills. All rights reserved.
  */
 
 "use strict";
@@ -11,17 +13,94 @@
 
 module.exports = function(context) {
 
-    return {
-        "BlockStatement": function (node) {
-            // Check for any occurrence of BlockStatement > BlockStatement or
-            // Program > BlockStatement
-            var parent = context.getAncestors().pop();
-            if (parent.type === "BlockStatement" || parent.type === "Program") {
-                context.report(node, "Block is nested inside another block.");
+    // A stack of lone blocks to be checked for block-level bindings
+    var loneBlocks = [],
+        ruleDef;
+
+    /**
+     * Reports a node as invalid.
+     * @param {ASTNode} node - The node to be reported.
+     * @returns {void}
+    */
+    function report(node) {
+        var parent = context.getAncestors().pop();
+        context.report(node, parent.type === "Program" ?
+            "Block is redundant." :
+            "Nested block is redundant."
+        );
+    }
+
+    /**
+     * Checks for any ocurrence of BlockStatement > BlockStatement or Program > BlockStatement
+     * @returns {boolean} True if the current node is a lone block.
+    */
+    function isLoneBlock() {
+        var parent = context.getAncestors().pop();
+        return parent.type === "BlockStatement" || parent.type === "Program";
+    }
+
+    /**
+     * Checks the enclosing block of the current node for block-level bindings,
+     * and "marks it" as valid if any.
+     * @returns {void}
+    */
+    function markLoneBlock() {
+        if (loneBlocks.length === 0) {
+            return;
+        }
+
+        var block = context.getAncestors().pop();
+
+        if (loneBlocks[loneBlocks.length - 1] === block) {
+            loneBlocks.pop();
+        }
+    }
+
+    // Default rule definition: report all lone blocks
+    ruleDef = {
+        BlockStatement: function(node) {
+            if (isLoneBlock(node)) {
+                report(node);
             }
         }
     };
 
+    // ES6: report blocks without block-level bindings
+    if (context.ecmaFeatures.blockBindings || context.ecmaFeatures.classes) {
+        ruleDef = {
+            "BlockStatement": function(node) {
+                if (isLoneBlock(node)) {
+                    loneBlocks.push(node);
+                }
+            },
+            "BlockStatement:exit": function(node) {
+                if (loneBlocks.length > 0 && loneBlocks[loneBlocks.length - 1] === node) {
+                    loneBlocks.pop();
+                    report(node);
+                }
+            }
+        };
+    }
+
+    if (context.ecmaFeatures.blockBindings) {
+        ruleDef.VariableDeclaration = function(node) {
+            if (node.kind === "let" || node.kind === "const") {
+                markLoneBlock(node);
+            }
+        };
+
+        ruleDef.FunctionDeclaration = function(node) {
+            if (context.getScope().isStrict) {
+                markLoneBlock(node);
+            }
+        };
+    }
+
+    if (context.ecmaFeatures.classes) {
+        ruleDef.ClassDeclaration = markLoneBlock;
+    }
+
+    return ruleDef;
 };
 
 module.exports.schema = [];

--- a/tests/lib/rules/no-lone-blocks.js
+++ b/tests/lib/rules/no-lone-blocks.js
@@ -21,14 +21,52 @@ eslintTester.addRuleTest("lib/rules/no-lone-blocks", {
     valid: [
         "if (foo) { if (bar) { baz(); } }",
         "do { bar(); } while (foo)",
-        "function foo() { while (bar) { baz() } }"
+        "function foo() { while (bar) { baz() } }",
+
+        // Block-level bindings
+        {code: "{ let x = 1; }", ecmaFeatures: {blockBindings: true}},
+        {code: "{ const x = 1; }", ecmaFeatures: {blockBindings: true}},
+        {code: "'use strict'; { function bar() {} }", ecmaFeatures: {blockBindings: true}},
+        {code: "{ class Bar {} }", ecmaFeatures: {classes: true}},
+
+        {code: "{ {let y = 1;} let x = 1; }", ecmaFeatures: {blockBindings: true}}
     ],
     invalid: [
-        { code: "{}", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
-        { code: "foo(); {} bar();", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
-        { code: "if (foo) { bar(); {} baz(); }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
-        { code: "{ { } }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}, { message: "Block is nested inside another block.", type: "BlockStatement"}] },
-        { code: "function foo() { bar(); {} baz(); }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] },
-        { code: "while (foo) { {} }", errors: [{ message: "Block is nested inside another block.", type: "BlockStatement"}] }
+        { code: "{}", errors: [{ message: "Block is redundant.", type: "BlockStatement"}] },
+        { code: "{var x = 1;}", errors: [{ message: "Block is redundant.", type: "BlockStatement"}] },
+        { code: "foo(); {} bar();", errors: [{ message: "Block is redundant.", type: "BlockStatement"}] },
+        { code: "if (foo) { bar(); {} baz(); }", errors: [{ message: "Nested block is redundant.", type: "BlockStatement"}] },
+        { code: "{ \n{ } }", errors: [
+            { message: "Block is redundant.", type: "BlockStatement", line: 1},
+            { message: "Nested block is redundant.", type: "BlockStatement", line: 2}]
+        },
+        { code: "function foo() { bar(); {} baz(); }", errors: [{ message: "Nested block is redundant.", type: "BlockStatement"}] },
+        { code: "while (foo) { {} }", errors: [{ message: "Nested block is redundant.", type: "BlockStatement"}] },
+
+        // Non-block-level bindings, even in ES6
+        { code: "{ function bar() {} }", errors: [{ message: "Block is redundant.", type: "BlockStatement"}], ecmaFeatures: {blockBindings: true}},
+        { code: "{var x = 1;}", errors: [{ message: "Block is redundant.", type: "BlockStatement"}], ecmaFeatures: {blockBindings: true} },
+        { code: "{ function bar() {} }", errors: [{ message: "Block is redundant.", type: "BlockStatement"}], ecmaFeatures: {classes: true}},
+        { code: "{var x = 1;}", errors: [{ message: "Block is redundant.", type: "BlockStatement"}], ecmaFeatures: {classes: true} },
+
+        {
+            code: "{ \n{var x = 1;}\n let y = 2; } {let z = 1;}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "Nested block is redundant.", type: "BlockStatement", line: 2}]
+        },
+        {
+            code: "{ \n{let x = 1;}\n var y = 2; } {let z = 1;}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "Block is redundant.", type: "BlockStatement", line: 1}]
+        },
+        {
+            code: "{ \n{var x = 1;}\n var y = 2; }\n {var z = 1;}",
+            ecmaFeatures: {blockBindings: true},
+            errors: [
+                {message: "Block is redundant.", type: "BlockStatement", line: 1},
+                {message: "Nested block is redundant.", type: "BlockStatement", line: 2},
+                {message: "Block is redundant.", type: "BlockStatement", line: 4}
+            ]
+        }
     ]
 });


### PR DESCRIPTION
I considered block-level function declarations to be active if the `blockBindings` flag is `true`.