### PR TITLE
Build: Stringify payload of release notes (fixes #2640)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -4,6 +4,7 @@ env:
 rules:
     indent: 2
     brace-style: [2, "1tbs"]
+    camelcase: [2, { properties: "never" }]
     comma-style: [2, "last"]
     default-case: 2
     func-style: [2, "declaration"]

--- a/Makefile.js
+++ b/Makefile.js
@@ -18,8 +18,8 @@ var path = require("path"),
     markdownlint = require("markdownlint"),
     nodeCLI = require("shelljs-nodecli"),
     os = require("os"),
-    semver = require("semver");
-    // ghGot = require("gh-got");
+    semver = require("semver"),
+    ghGot = require("gh-got");
 
 //------------------------------------------------------------------------------
 // Settings
@@ -111,15 +111,14 @@ function execSilent(cmd) {
  * @returns {void}
  */
 function release(type) {
-    var newVersion; /*, changes; */
+    var newVersion, changes;
 
     target.test();
     echo("Generating new version");
     newVersion = execSilent("npm version " + type).trim();
 
     echo("Generating changelog");
-    // changes =
-    target.changelog();
+    changes = target.changelog();
 
     // add changelog to commit
     exec("git add CHANGELOG.md");
@@ -133,30 +132,30 @@ function release(type) {
     exec("git push origin master --tags");
 
     // now push the changelog...changes to the tag
-    // echo("Publishing changes to github release");
+    echo("Publishing changes to github release");
     // this requires a github API token in process.env.ESLINT_GITHUB_TOKEN
     // it will continue with an error message logged if not set
-    // ghGot("repos/eslint/eslint/releases", {
-    //     body: {
-    //         "tag_name": newVersion,
-    //         name: newVersion,
-    //         "target_commitish": "master",
-    //         body: changes
-    //     },
-    //     method: "POST",
-    //     json: true,
-    //     token: process.env.ESLINT_GITHUB_TOKEN
-    // }, function(pubErr) {
-    //     if (pubErr) {
-    //         echo("Warning: error when publishing changes to github release: " + pubErr.message);
-    //     }
-    echo("Publishing to npm");
-    exec("npm publish");
+    ghGot("repos/eslint/eslint/releases", {
+        body: JSON.stringify({
+            tag_name: newVersion,
+            name: newVersion,
+            target_commitish: "master",
+            body: changes
+        }),
+        method: "POST",
+        json: true,
+        token: process.env.ESLINT_GITHUB_TOKEN
+    }, function(pubErr) {
+        if (pubErr) {
+            echo("Warning: error when publishing changes to github release: " + pubErr.message);
+        }
+        echo("Publishing to npm");
+        exec("npm publish");
 
-    echo("Generating site");
-    target.gensite();
-    target.publishsite();
-    // });
+        echo("Generating site");
+        target.gensite();
+        target.publishsite();
+    });
 }
 
 /**


### PR DESCRIPTION
This stringifies the `body` of the github API request, so that `gh-got` will not throw an error. I was so used to other request modules that I had assumed it happened automatically.