### PR TITLE
Add tests to assert that the preprocessor is running (fixes #2651)

### DIFF
--- a/tests/fixtures/processors/custom-processor.js
+++ b/tests/fixtures/processors/custom-processor.js
@@ -2,9 +2,10 @@ module.exports = {
     processors: {
         ".txt": {
             preprocess: function(text) {
-                return [text];
+                return [text.replace("a()", "b()")];
             },
             postprocess: function(messages) {
+                messages[0][0].ruleId = "post-processed";
                 return messages[0];
             }
         }


### PR DESCRIPTION
These tests assert that when a `processor` is included both the `preprocess` and `postprocess` functions run.

The `preprocess` hook is tested by modifying the input source from `a()` to `b()` and then asserting that the message comes out referencing `b` instead of `a`

The `postprocess` hook is tested by modifying the `ruleId` of the first rule and then asserting that the `ruleId` in the report matches what the `postprocess` hook modified it to.