### PR TITLE
Build: Lock io.js to v2.1.0 (fixes #2653)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - iojs
+    - "iojs-v2.1.0"
 sudo: false
 script: "npm test && npm run docs"
 after_success:


### PR DESCRIPTION
This should be removed once io.js fixes the issue.