### PR TITLE
Run processors when calling executeOnText (fixes #2331)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -154,30 +154,33 @@ function calculateStatsPerRun(results) {
 }
 
 /**
- * Processes an individual file using ESLint. Files used here are known to
- * exist, so no need to check that here.
- * @param {string} filename The filename of the file being checked.
+ * Processes an source code using ESLint.
+ * @param {string} text The source code to check.
  * @param {Object} configHelper The configuration options for ESLint.
- * @returns {Result} The results for linting on this file.
+ * @param {string} filename An optional string representing the texts filename.
+ * @returns {Result} The results for linting on this text.
  * @private
  */
-function processFile(filename, configHelper) {
+function processText(text, configHelper, filename) {
 
     // clear all existing settings for a new file
     eslint.reset();
 
-    var filePath = path.resolve(filename),
+    var filePath,
         config,
-        text,
         messages,
         stats,
         fileExtension = path.extname(filename),
         processor;
 
-    debug("Linting " + filePath);
+    if (filename) {
+        filePath = path.resolve(filename);
+    }
+
+    filename = filename || "<text>";
+    debug("Linting " + filename);
     config = configHelper.getConfig(filePath);
     loadPlugins(config.plugins);
-    text = fs.readFileSync(path.resolve(filename), "utf8");
 
     for (var plugin in loadedPlugins) {
         if (loadedPlugins[plugin].processors && Object.keys(loadedPlugins[plugin].processors).indexOf(fileExtension) >= 0) {
@@ -208,36 +211,18 @@ function processFile(filename, configHelper) {
 }
 
 /**
- * Processes an source code using ESLint.
- * @param {string} text The source code to check.
+ * Processes an individual file using ESLint. Files used here are known to
+ * exist, so no need to check that here.
+ * @param {string} filename The filename of the file being checked.
  * @param {Object} configHelper The configuration options for ESLint.
- * @param {string} filename An optional string representing the texts filename.
- * @returns {Result} The results for linting on this text.
+ * @returns {Result} The results for linting on this file.
  * @private
  */
-function processText(text, configHelper, filename) {
+function processFile(filename, configHelper) {
 
-    // clear all existing settings for a new file
-    eslint.reset();
+    var text = fs.readFileSync(path.resolve(filename), "utf8");
 
-    var config,
-        messages,
-        stats;
-
-    filename = filename || "<text>";
-    debug("Linting " + filename);
-    config = configHelper.getConfig();
-    loadPlugins(config.plugins);
-    messages = eslint.verify(text, config, filename);
-
-    stats = calculateStatsPerFile(messages);
-
-    return {
-        filePath: filename,
-        messages: messages,
-        errorCount: stats.errorCount,
-        warningCount: stats.warningCount
-    };
+    return processText(text, configHelper, filename);
 }
 
 /**
@@ -358,10 +343,10 @@ CLIEngine.prototype = {
      */
     executeOnText: function(text, filename) {
 
-        var configHelper = new Config(this.options),
-            results = [],
+        var results = [],
             stats,
             options = this.options,
+            configHelper = new Config(options),
             ignoredPaths = IgnoredPaths.load(options),
             exclude = ignoredPaths.contains.bind(ignoredPaths);
 

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -118,8 +118,8 @@ describe("CLIEngine", function() {
             var report = engine.executeOnText("var bar = foo;", "tests/fixtures/passing.js");
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].filePath, "tests/fixtures/passing.js");
-            assert.equal(report.results[0].messages[1].ruleId, "no-undef");
-            assert.equal(report.results[0].messages[1].severity, 2);
+            assert.equal(report.results[0].messages[0].ruleId, "no-undef");
+            assert.equal(report.results[0].messages[0].severity, 2);
         });
 
     });
@@ -923,7 +923,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
             });
-            it("should run processors when executing with config file that specifies a processor", function() {
+            it("should run processors when calling executeOnFiles with config file that specifies a processor", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/processors.json",
                     reset: true,
@@ -936,7 +936,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].message, "b is defined but never used");
                 assert.equal(report.results[0].messages[0].ruleId, "post-processed");
             });
-            it("should run processors when executing with config file that specifies preloaded processor", function() {
+            it("should run processors when calling executeOnFiles with config file that specifies preloaded processor", function() {
                 engine = new CLIEngine({
                     reset: true,
                     useEslintrc: false,
@@ -963,6 +963,50 @@ describe("CLIEngine", function() {
                 });
 
                 var report = engine.executeOnFiles(["tests/fixtures/processors/test/test-processor.txt"]);
+
+                assert.equal(report.results[0].messages[0].message, "b is defined but never used");
+                assert.equal(report.results[0].messages[0].ruleId, "post-processed");
+            });
+            it("should run processors when calling executeOnText with config file that specifies a processor", function() {
+                engine = new CLIEngine({
+                    configFile: "./tests/fixtures/configurations/processors.json",
+                    reset: true,
+                    useEslintrc: false,
+                    extensions: ["js", "txt"]
+                });
+
+                var report = engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
+
+                assert.equal(report.results[0].messages[0].message, "b is defined but never used");
+                assert.equal(report.results[0].messages[0].ruleId, "post-processed");
+            });
+            it("should run processors when calling executeOnText with config file that specifies preloaded processor", function() {
+                engine = new CLIEngine({
+                    reset: true,
+                    useEslintrc: false,
+                    plugins: ["test-processor"],
+                    rules: {
+                        "no-console": 2,
+                        "no-unused-vars": 2
+                    },
+                    extensions: ["js", "txt"]
+                });
+
+                engine.addPlugin("test-processor", {
+                    processors: {
+                        ".txt": {
+                            preprocess: function(text) {
+                                return [text.replace("a()", "b()")];
+                            },
+                            postprocess: function(messages) {
+                                messages[0][0].ruleId = "post-processed";
+                                return messages[0];
+                            }
+                        }
+                    }
+                });
+
+                var report = engine.executeOnText("function a() {console.log(\"Test\");}", "tests/fixtures/processors/test/test-processor.txt");
 
                 assert.equal(report.results[0].messages[0].message, "b is defined but never used");
                 assert.equal(report.results[0].messages[0].ruleId, "post-processed");


### PR DESCRIPTION
Right now processors are only ran when calling `executeOnFiles` this PR changes it so that processors will be run on both `executeOnText` and `executeOnFiles`.

Since with this update both `executeOnText` and `executeOnFiles` are now pretty much doing the same thing, I changed `executeOnFiles` to just read the file and then call `executeOnText` with the file contents.

One thing to note: There was one existing test that I updated, but it seems like the test was broken before.
The test I am referring to is https://github.com/tikotzky/eslint/blob/e0c95947fc7c18acdebef85d6db508a83e1c57be/tests/lib/cli-engine.js#L107-L123

```
// before
assert.equal(report.results[0].messages[1].ruleId, "no-undef");
// after
assert.equal(report.results[0].messages[0].ruleId, "no-undef");
```
The reason why it was looking at `messages[1]` was because `messages[0]` was [`strict`](http://eslint.org/docs/rules/strict). 
That test sets `reset:true` in its config and then only enables `no-undef` like...
```
reset: true,
rules: {
  "no-undef": 2
}
```
so i'm not sure how `strict` was ever getting in there in the first place.
When I made these changes to support processors when calling `executeOnText` it fixed that issue so I updated that test.
Please let me know if you'd like it done differently.