### PR TITLE
Docs: be consistent about deprecation status

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -178,7 +178,7 @@ These rules are purely matters of style and are quite subjective.
 * [space-before-blocks](space-before-blocks.md) - require or disallow space before blocks (off by default)
 * [space-before-function-paren](space-before-function-paren.md) - require or disallow space before function opening parenthesis (off by default)
 * [space-before-function-parentheses](space-before-function-parentheses.md) - **(deprecated)** require or disallow space before function parentheses (off by default)
-* [space-in-brackets](space-in-brackets.md) - require or disallow spaces inside brackets (off by default)
+* [space-in-brackets](space-in-brackets.md) - **(deprecated)** require or disallow spaces inside brackets (off by default)
 * [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses (off by default)
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators
 * [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -97,7 +97,7 @@ If your project will not be following a consistent comma-spacing pattern, turn t
 ## Related Rules
 
 * [comma-style](comma-style.md)
-* [space-in-brackets](space-in-brackets.md)
+* [space-in-brackets](space-in-brackets.md) (deprecated)
 * [space-in-parens](space-in-parens.md)
 * [space-infix-ops](space-infix-ops.md)
 * [space-after-keywords](space-after-keywords)

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -103,7 +103,7 @@ If you don't want to check and disallow multiple spaces, then you should turn th
 
 * [key-spacing](key-spacing.md)
 * [space-infix-ops](space-infix-ops.md)
-* [space-in-brackets](space-in-brackets.md)
+* [space-in-brackets](space-in-brackets.md) (deprecated)
 * [space-in-parens](space-in-parens.md)
 * [space-after-keywords](space-after-keywords)
 * [space-unary-ops](space-unary-ops)

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -213,4 +213,4 @@ You can turn this rule off if you are not concerned with the consistency of spac
 
 ## Related Rules
 
-* [space-in-brackets](space-in-brackets.md)
+* [space-in-brackets](space-in-brackets.md) (deprecated)


### PR DESCRIPTION
Another small docs update, as a result of the discussion in #2656. This one marks space-in-brackets as deprecated in locations where it wasn't.