### PR TITLE
Fix: no-trailing-spaces does not handle skipBlankLines (fixes #2575)

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -10,10 +10,9 @@
 
 module.exports = function(context) {
 
-    var BLANK_PREFIX = "[^( |\t)]",
-        TRAILER = "[ \t\u00a0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u3000]$";
-
-    var options = context.options[0] || {},
+    // Not sure why we're not just using "\s" for whitespace. - PM
+    var WHITESPACE = "[ \t\u00a0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u3000]",
+    options = context.options[0] || {},
         skipBlankLines = options.skipBlankLines || false;
 
 
@@ -29,8 +28,12 @@ module.exports = function(context) {
             // fetch the source code and do black magic via regexps.
 
             var src = context.getSource(),
-                re = new RegExp((skipBlankLines ? BLANK_PREFIX : "") + TRAILER, "mg"),
+                re = new RegExp(WHITESPACE + "$", "mg"),
                 match, lines, location;
+
+            if (skipBlankLines) {
+                src = src.replace(new RegExp("^" + WHITESPACE + "+$", "mg"), "-");
+            }
 
             while ((match = re.exec(src)) !== null) {
                 lines = src.slice(0, re.lastIndex).split(/\r?\n/g);

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -144,6 +144,18 @@ eslintTester.addRuleTest("lib/rules/no-trailing-spaces", {
                 type: "Program"
             }],
             options: [{}]
+        },
+        {
+            code: "var a = 'bar';  \n \n\t\nvar b;",
+            errors: [{
+                message: "Trailing spaces not allowed.",
+                type: "Program",
+                line: 1,
+                column: 16 // there are invalid spaces in columns 15 and 16
+            }],
+            options: [{
+                skipBlankLines: true
+            }]
         }
     ]
 


### PR DESCRIPTION
Fixes issue in no-trailing-spaces that would cause it to incorrectly report blank lines. 

The solution was to preprocess the copy of the source code, replacing all blank lines with "-" when the `skipBlankLines` option is enabled. 



