### PR TITLE
Update: Add markers to spaced-line-comment (fixes #2588)

### DIFF
--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -13,11 +13,15 @@ This rule takes two arguments. If the first is `"always"` then the `//` or `/*` 
 If `"never"` then there should be no whitespace following.
 The default is `"always"`.
 
-The second argument is an object with one key, `"exceptions"`.
-The value is an array of string patterns which are considered exceptions to the rule.
+The second argument is an object with two keys, `"exceptions"` and `"markers"`.
+The `"exceptions"` value is an array of string patterns which are considered exceptions to the rule.
 It is important to note that the exceptions are ignored if the first argument is `"never"`.
 
 Exceptions cannot be mixed. From the collection of exceptions provided only one of them can be used inside the comment. Mixing of more than one is not valid.
+
+The `"markers"` value is an array of string patterns which are considered markers for docblock-style comments,
+such as an additional `/`, used to denote documentation read by doxygen, vsdoc, etc. which must have additional characters.
+The `"markers"` array will apply regardless of the value of the first argument, e.g. `"always"` or `"never"`.
 
 The following patterns are considered warnings:
 
@@ -53,6 +57,11 @@ var foo = 5;
 //------++++++++
 // Comment block
 //------++++++++
+```
+
+```js
+// When ["always",{"markers":["/"]}]
+///This is a comment with a marker but without whitespace
 ```
 
 ```js
@@ -108,4 +117,14 @@ var foo = 5;
 /*-+-+-+-+-+-+-+*/
 // Comment block
 /*-+-+-+-+-+-+-+*/
+```
+
+```js
+// When ["always",{"markers":["/"]}]
+/// This is a comment with a marker
+```
+
+```js
+// When ["never",{"markers":["!<"]}]
+//!<This is a comment with a marker
 ```

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -17,17 +17,36 @@ module.exports = function(context) {
 
     // Default to match anything, so all will fail if there are no exceptions
     var exceptionMatcher = new RegExp(" ");
+    var markerMatcher = new RegExp(" ");
+
+    // Fetch the options dict
+    var hasOptions = context.options.length === 2;
+    var optionsDict = hasOptions ? context.options[1] : {};
 
     // Grab the exceptions array and build a RegExp matcher for it
-    var hasExceptions = context.options.length === 2;
-    var unescapedExceptions = hasExceptions ? context.options[1].exceptions : [];
+    var hasExceptions = hasOptions && optionsDict.exceptions && optionsDict.exceptions.length;
+    var unescapedExceptions = hasExceptions ? optionsDict.exceptions : [];
     var exceptions;
 
-    if (unescapedExceptions.length) {
-        exceptions = unescapedExceptions.map(function(s) {
-            return s.replace(/([.*+?${}()|\^\[\]\/\\])/g, "\\$1");
-        });
+    // Now do the same for markers
+    var hasMarkers = hasOptions && optionsDict.markers && optionsDict.markers.length;
+    var unescapedMarkers = hasMarkers ? optionsDict.markers : [];
+    var markers;
+
+    function escaper(s) {
+        return s.replace(/([.*+?${}()|\^\[\]\/\\])/g, "\\$1");
+    }
+
+    if (hasExceptions) {
+        exceptions = unescapedExceptions.map(escaper);
         exceptionMatcher = new RegExp("(^(" + exceptions.join(")+$)|(^(") + ")+$)");
+    }
+
+    if (hasMarkers) {
+        markers = unescapedMarkers.map(escaper);
+
+        // the markerMatcher includes any markers in the list, followed by space/tab
+        markerMatcher = new RegExp("((^(" + markers.join("))|(^(") + ")))[ \\t]");
     }
 
 
@@ -38,6 +57,11 @@ module.exports = function(context) {
 
             // If length is zero, ignore it
             if (node.value.length === 0) {
+                return;
+            }
+
+            // Check for markers now, and short-circuit if found
+            if (hasMarkers && markerMatcher.test(node.value)) {
                 return;
             }
 
@@ -60,6 +84,12 @@ module.exports = function(context) {
             if (node.value.indexOf(" ") === 0 || node.value.indexOf("\t") === 0) {
                 context.report(node, "Unexpected space or tab after " + commentIdentifier + " in comment.");
             }
+            // there won't be a space or tab after commentIdentifier here, but check for the markers and whitespace
+            if (hasMarkers && markerMatcher.test(node.value)) {
+                var matches = node.value.match(markerMatcher), match = matches.length ? matches[0] : "";
+
+                context.report(node, "Unexpected space or tab after marker (" + match + ") in comment.");
+            }
         }
     }
 
@@ -79,6 +109,12 @@ module.exports.schema = [
         "type": "object",
         "properties": {
             "exceptions": {
+                "type": "array",
+                "items": {
+                    "type": "string"
+                }
+            },
+            "markers": {
                 "type": "array",
                 "items": {
                     "type": "string"

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -53,6 +53,25 @@ eslintTester.addRuleTest("lib/rules/spaced-comment", {
             }]
         },
         {
+            code: "//!< docblock style comment",
+            options: ["always", {
+                markers: ["/", "!<"]
+            }]
+        },
+        {
+            code: "//----\n// a comment\n//----\n/// xmldoc style comment\n//!< docblock style comment",
+            options: ["always", {
+                exceptions: ["-"],
+                markers: ["/", "!<"]
+            }]
+        },
+        {
+            code: "///xmldoc style comment",
+            options: ["never", {
+                markers: ["/", "!<"]
+            }]
+        },
+        {
             code: validShebangProgram,
             options: ["always"]
         },
@@ -157,6 +176,20 @@ eslintTester.addRuleTest("lib/rules/spaced-comment", {
             ],
             options: ["always", {
                 exceptions: ["-", "=", "*", "#", "!@#"]
+            }]
+        },
+        {
+            code: "//!<docblock style comment",
+            errors: 1,
+            options: ["always", {
+                markers: ["/", "!<"]
+            }]
+        },
+        {
+            code: "//!< docblock style comment",
+            errors: 1,
+            options: ["never", {
+                    markers: ["/", "!<"]
             }]
         },
         {


### PR DESCRIPTION
This adds `markers` as an additional option to the `spaced-line-comment` rule. It supports both `"always"` and `"never"` space in the options. Documentation is updated accordingly.