### PR TITLE
Fix: trailing commas in object-curly-spacing (fixes #2647)

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -149,6 +149,12 @@ module.exports = function(context) {
                 penultimate = context.getLastToken(lastSpecifier),
                 last = context.getTokenAfter(lastSpecifier);
 
+            // support trailing commas
+            if (last.value === ",") {
+                penultimate = last;
+                last = context.getTokenAfter(last);
+            }
+
             validateBraceSpacing(node, first, second, penultimate, last);
         },
 

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -35,6 +35,8 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
         { code: "var {\nx,y\n} = z", options: ["always"], ecmaFeatures: { destructuring: true } },
         { code: "var { x = 10, y } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
         { code: "var { x: { z }, y } = y", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var {\ny,\n} = x", options: ["always"], ecmaFeatures: { destructuring: true } },
+        { code: "var { y, } = x", options: ["always"], ecmaFeatures: { destructuring: true } },
 
         // always - import / export
         { code: "import { door } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
@@ -70,6 +72,8 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
         { code: "var {x = 10, y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
         { code: "var {x: {z}, y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
         { code: "var {\nx: {z\n}, y} = y", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {\ny,\n} = x", options: ["never"], ecmaFeatures: { destructuring: true } },
+        { code: "var {y,} = x", options: ["never"], ecmaFeatures: { destructuring: true } },
 
         // never - import / export
         { code: "import {door} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
@@ -154,6 +158,34 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     type: "ObjectExpression",
                     line: 1,
                     column: 60
+                }
+            ]
+        },
+
+        // always-destructuring trailing comma
+        {
+            code: "var { a,} = x;",
+            options: ["always"],
+            ecmaFeatures: { destructuring: true },
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "var {a, } = x;",
+            options: ["never"],
+            ecmaFeatures: { destructuring: true },
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectPattern",
+                    line: 1,
+                    column: 8
                 }
             ]
         },


### PR DESCRIPTION
Fixes `var {x,} = y;`
Does not fix `import {y,} from 'x';` (blocked by https://github.com/eslint/espree/issues/148)