### PR TITLE
Fixing grammar: then -> than

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -55,7 +55,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-caller](no-caller.md) - disallow use of `arguments.caller` or `arguments.callee`
 * [no-div-regex](no-div-regex.md) - disallow division operators explicitly at beginning of regular expression (off by default)
 * [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if` (off by default)
-* [no-empty-label](no-empty-label.md) - disallow use of labels for anything other then loops and switches
+* [no-empty-label](no-empty-label.md) - disallow use of labels for anything other than loops and switches
 * [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator (off by default)
 * [no-eval](no-eval.md) - disallow use of `eval()`
 * [no-extend-native](no-extend-native.md) - disallow adding to native types


### PR DESCRIPTION
Docs: Fixing grammatical error on http://eslint.org/docs/rules/ in the description for `no-empty-label`