### PR TITLE
Fix: Allowing u flag in regex to properly lint no-empty-character-class rule (Fixes #2679)

### DIFF
--- a/lib/rules/no-empty-character-class.js
+++ b/lib/rules/no-empty-character-class.js
@@ -21,7 +21,7 @@ plain-English description of the following regexp:
 4. `[gimy]*`: optional regexp flags
 5. `$`: fix the match at the end of the string
 */
-var regex = /^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/[gimy]*$/;
+var regex = /^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/[gimuy]*$/;
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/tests/lib/rules/no-empty-character-class.js
+++ b/tests/lib/rules/no-empty-character-class.js
@@ -28,7 +28,8 @@ eslintTester.addRuleTest("lib/rules/no-empty-character-class", {
         "var foo = /[[]/;",
         "var foo = /[\\[a-z[]]/;",
         "var foo = /[\\-\\[\\]\\/\\{\\}\\(\\)\\*\\+\\?\\.\\\\^\\$\\|]/g;",
-        "var foo = /\\s*:\\s*/gim;"
+        "var foo = /\\s*:\\s*/gim;",
+        { code: "var foo = /[\\]]/uy;", ecmaFeatures: { regexUFlag: true, regexYFlag: true } }
     ],
     invalid: [
         { code: "var foo = /^abc[]/;", errors: [{ message: "Empty class.", type: "Literal"}] },


### PR DESCRIPTION
This adds `u` to the list of allowed flags used by the regex that tests the `no-empty-character-class` rule. (since `y` is already in the list, adding `u` was trivial)

A test has been included as well. (which also bumps the "coverage" to include the `y` flag as well)

I've already signed the CLA, so I think I've done everything I need to do. Let me know if there's anything else you need from me!

(fixes #2679)