### PR TITLE
Breaking: Automatically validate rule options (fixes #2595)

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -8,5 +8,6 @@
 module.exports = {
     linter: require("./eslint"),
     cli: require("./cli"),
-    CLIEngine: require("./cli-engine")
+    CLIEngine: require("./cli-engine"),
+    validator: require("./config-validator")
 };

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -27,7 +27,8 @@ var fs = require("fs"),
     traverse = require("./util/traverse"),
     IgnoredPaths = require("./ignored-paths"),
     Config = require("./config"),
-    util = require("./util");
+    util = require("./util"),
+    validator = require("./config-validator");
 
 //------------------------------------------------------------------------------
 // Typedefs
@@ -270,6 +271,10 @@ function CLIEngine(options) {
             rules.load(rulesdir);
         });
     }
+
+    Object.keys(this.options.rules || {}).forEach(function(name) {
+        validator.validateRuleOptions(name, this.options.rules[name], "CLI");
+    }.bind(this));
 }
 
 CLIEngine.prototype = {

--- a/lib/config.js
+++ b/lib/config.js
@@ -21,7 +21,8 @@ var fs = require("fs"),
     debug = require("debug"),
     yaml = require("js-yaml"),
     userHome = require("user-home"),
-    isAbsolutePath = require("path-is-absolute");
+    isAbsolutePath = require("path-is-absolute"),
+    validator = require("./config-validator");
 
 //------------------------------------------------------------------------------
 // Constants
@@ -90,6 +91,8 @@ function loadConfig(filePath) {
 
             config = util.mergeConfigs(config, require(filePath));
         }
+
+        validator.validate(config, filePath);
 
         // If an `extends` property is defined, it represents a configuration file to use as
         // a "parent". Load the referenced file and merge the configuration recursively.

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -18,7 +18,8 @@ var estraverse = require("estraverse-fb"),
     timing = require("./timing"),
     createTokenStore = require("./token-store.js"),
     EventEmitter = require("events").EventEmitter,
-    escapeRegExp = require("escape-string-regexp");
+    escapeRegExp = require("escape-string-regexp"),
+    validator = require("./config-validator");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -238,13 +239,14 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
  * Parses comments in file to extract file-specific config of rules, globals
  * and environments and merges them with global config; also code blocks
  * where reporting is disabled or enabled and merges them with reporting config.
+ * @param {string} filename The file being checked.
  * @param {ASTNode} ast The top node of the AST.
  * @param {Object} config The existing configuration data.
  * @param {Object[]} reportingConfig The existing reporting configuration data.
  * @param {Object[]} messages The messages queue.
  * @returns {void}
  */
-function modifyConfigsFromComments(ast, config, reportingConfig, messages) {
+function modifyConfigsFromComments(filename, ast, config, reportingConfig, messages) {
 
     var commentConfig = {
         astGlobals: {},
@@ -285,6 +287,7 @@ function modifyConfigsFromComments(ast, config, reportingConfig, messages) {
                         Object.keys(items).forEach(function(name) {
                             var ruleValue = items[name];
                             if (typeof ruleValue === "number" || (Array.isArray(ruleValue) && typeof ruleValue[0] === "number")) {
+                                validator.validateRuleOptions(name, ruleValue, filename + " line " + comment.loc.start.line);
                                 commentRules[name] = ruleValue;
                             }
                         });
@@ -612,7 +615,7 @@ module.exports = (function() {
             currentAST = ast;
 
             // parse global comments and modify config
-            modifyConfigsFromComments(ast, config, reportingConfig, messages);
+            modifyConfigsFromComments(filename, ast, config, reportingConfig, messages);
 
             // enable appropriate rules
             Object.keys(config.rules).filter(function(key) {

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -352,4 +352,8 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "enum": ["all", "functions"]
+    }
+];

--- a/tests/fixtures/rules/custom-rule.js
+++ b/tests/fixtures/rules/custom-rule.js
@@ -11,3 +11,5 @@ module.exports = function(context) {
     };
 
 };
+
+module.exports.schema = [];

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -334,7 +334,7 @@ describe("CLIEngine", function() {
         });
 
 
-        it("should thrown an error when loading a custom rule that doesn't exist", function() {
+        it("should throw an error when loading a custom rule that doesn't exist", function() {
 
             engine = new CLIEngine({
                 ignore: false,
@@ -350,7 +350,7 @@ describe("CLIEngine", function() {
 
         });
 
-        it("should thrown an error when loading a custom rule that doesn't exist", function() {
+        it("should throw an error when loading a custom rule that doesn't exist", function() {
 
             engine = new CLIEngine({
                 ignore: false,

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -570,7 +570,7 @@ describe("Config", function() {
             var StubbedConfig = proxyquire("../../lib/config", {
                 "eslint-config-foo": {
                     rules: {
-                        foo: "bar"
+                        eqeqeq: [2, "smart"]
                     }
                 }
             });
@@ -578,7 +578,7 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "../fixtures/config-extends/package/.eslintrc"),
                 configHelper = new StubbedConfig({ reset: true, useEslintrc: false, configFile: configPath }),
                 expected = {
-                    rules: { "quotes": [2, "double"], "foo": "bar", "valid-jsdoc": 0 },
+                    rules: { "quotes": [2, "double"], "eqeqeq": [2, "smart"], "valid-jsdoc": 0 },
                     env: { "browser": false }
                 },
                 actual = configHelper.getConfig(configPath);
@@ -591,7 +591,7 @@ describe("Config", function() {
             var StubbedConfig = proxyquire("../../lib/config", {
                 "eslint-config-foo": {
                     rules: {
-                        foo: "bar"
+                        eqeqeq: [2, "smart"]
                     }
                 }
             });
@@ -599,7 +599,7 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "../fixtures/config-extends/package2/.eslintrc"),
                 configHelper = new StubbedConfig({ reset: true, useEslintrc: false, configFile: configPath }),
                 expected = {
-                    rules: { "quotes": [2, "double"], "foo": "bar", "valid-jsdoc": 0 },
+                    rules: { eqeqeq: [2, "smart"], "quotes": [2, "double"], "valid-jsdoc": 0 },
                     env: { "browser": false }
                 },
                 actual = configHelper.getConfig(configPath);
@@ -612,7 +612,7 @@ describe("Config", function() {
             var StubbedConfig = proxyquire("../../lib/config", {
                 "@scope/eslint-config-foo": {
                     rules: {
-                        foo: "bar"
+                        eqeqeq: 2
                     }
                 }
             });
@@ -620,7 +620,7 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package/.eslintrc"),
                 configHelper = new StubbedConfig({ reset: true, useEslintrc: false, configFile: configPath }),
                 expected = {
-                    rules: { "quotes": [2, "double"], "foo": "bar", "valid-jsdoc": 0 },
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
                     env: { "browser": false }
                 },
                 actual = configHelper.getConfig(configPath);
@@ -633,7 +633,7 @@ describe("Config", function() {
             var StubbedConfig = proxyquire("../../lib/config", {
                 "@scope/eslint-config-foo": {
                     rules: {
-                        foo: "bar"
+                        eqeqeq: 2
                     }
                 }
             });
@@ -641,7 +641,7 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package2/.eslintrc"),
                 configHelper = new StubbedConfig({ reset: true, useEslintrc: false, configFile: configPath }),
                 expected = {
-                    rules: { "quotes": [2, "double"], "foo": "bar", "valid-jsdoc": 0 },
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
                     env: { "browser": false }
                 },
                 actual = configHelper.getConfig(configPath);
@@ -654,7 +654,7 @@ describe("Config", function() {
             var StubbedConfig = proxyquire("../../lib/config", {
                 "eslint-config-foo/bar": {
                     rules: {
-                        bar: "baz"
+                        eqeqeq: 2
                     }
                 }
             });
@@ -662,7 +662,7 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "../fixtures/config-extends/package3/.eslintrc"),
                 configHelper = new StubbedConfig({ reset: true, useEslintrc: true, configFile: configPath }),
                 expected = {
-                    rules: { "quotes": [2, "double"], "bar": "baz", "valid-jsdoc": 0 },
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
                     env: { "browser": false }
                 };
 
@@ -683,7 +683,7 @@ describe("Config", function() {
             var StubbedConfig = proxyquire("../../lib/config", {
                 "@scope/eslint-config-foo/bar": {
                     rules: {
-                        bar: "baz"
+                        eqeqeq: 2
                     }
                 }
             });
@@ -691,7 +691,7 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package3/.eslintrc"),
                 configHelper = new StubbedConfig({ reset: true, useEslintrc: true, configFile: configPath }),
                 expected = {
-                    rules: { "quotes": [2, "double"], "bar": "baz", "valid-jsdoc": 0 },
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
                     env: { "browser": false }
                 };
 
@@ -712,7 +712,7 @@ describe("Config", function() {
             var StubbedConfig = proxyquire("../../lib/config", {
                 "eslint-config-foo": {
                     rules: {
-                        foo: "bar"
+                        "eqeqeq": 2
                     }
                 }
             });
@@ -720,7 +720,7 @@ describe("Config", function() {
             var configPath = path.resolve(__dirname, "../fixtures/config-extends/package2/.eslintrc"),
                 configHelper = new StubbedConfig({ reset: true, useEslintrc: true, configFile: configPath }),
                 expected = {
-                    rules: { "quotes": [2, "double"], "foo": "bar", "valid-jsdoc": 0 },
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
                     env: { "browser": false }
                 };
 
@@ -874,7 +874,7 @@ describe("Config", function() {
             });
 
             it("should not clobber config objects when loading shared configs", function () {
-                requireStubs[exampleConfigName] = { rules: examplePluginRules };
+                requireStubs[exampleConfigName] = { rules: { "example-rule": 2 } };
 
                 StubbedConfig = proxyquire("../../lib/config", requireStubs);
 


### PR DESCRIPTION
Getting this merged is going to be interesting, as it will require a parallel update in eslint-tester to validate test case options. (I already have the code for this in eslint/eslint-tester#21.) Between the time this is merged and eslint-tester is updated, changes to rule options could sneak through without updating the schema, but the tests wouldn't start failing until eslint-tester begins validating the tests.