### PR TITLE
Fix: generalize some brittle checks

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -460,12 +460,18 @@ module.exports = (function() {
             });
         } catch (ex) {
 
+            // If the message includes a leading line number, strip it:
+            var message = ex.message;
+            var lineMarker = message.match(/^line \d+: */i);
+            if (lineMarker) {
+                message = message.slice(lineMarker[0].length);
+            }
+
             messages.push({
                 fatal: true,
                 severity: 2,
 
-                // messages come as "Line X: Unexpected token foo", so strip off leading part
-                message: ex.message.substring(ex.message.indexOf(":") + 1).trim(),
+                message: message,
 
                 line: ex.lineNumber,
                 column: ex.column

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -31,7 +31,7 @@ module.exports = function(context) {
     * @returns {boolean} Whether the word is in the list of known words
     */
     function isWordExpression(type) {
-        return ["delete", "new", "typeof", "void"].indexOf(type) !== -1;
+        return /^[a-z]/.test(type);
     }
 
     /**
@@ -74,7 +74,7 @@ module.exports = function(context) {
             firstToken = tokens[0],
             secondToken = tokens[1];
 
-        if (isWordExpression(firstToken.value)) {
+        if (firstToken.type === "Keyword" && isWordExpression(firstToken.value)) {
             checkUnaryWordOperatorForSpaces(node, firstToken, secondToken);
             return void 0;
         }


### PR DESCRIPTION
While extending eslint to work on AST generated by StratifiedJS, I uncovered a couple of places where the code is unnecessarily strict. I believe my changes shouldn't break anything, but are less strict in the assumptions they make:

 - eslint won't mangle an error message thrown from `parser.parse()` if it doesn't have a "line:" prefix, 
 - the space-unary-ops rule no longer cares about a specific set of words, but distinguishes words from symbols by checking whether they start with a lowercase letter

Both of these are required to allow my StratifiedJS integration to work, but seem reasonable for the default implementation as well.