### PR TITLE
updated object-assign version to 3.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint",
-  "version": "0.22.1",
+  "version": "0.22.2",
   "author": "Nicholas C. Zakas <nicholas+npm@nczconsulting.com>",
   "description": "An AST-based pattern checker for JavaScript.",
   "bin": {

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "js-yaml": "^3.2.5",
     "minimatch": "^2.0.1",
     "mkdirp": "^0.5.0",
-    "object-assign": "^2.0.0",
+    "object-assign": "^3.0.0",
     "optionator": "^0.5.0",
     "path-is-absolute": "^1.0.0",
     "strip-json-comments": "~1.0.1",


### PR DESCRIPTION
The object-assign package made a change and published that as 2.1.0, which broke eslint behaviour. 3.0.0 contains the fix, but wouldn't be picked up by eslint, because of the major version increase. This change fixes that issue.