### PR TITLE
Fix: remove hard-coded list of unary keywords in space-unary-ops rule (fixes #2696)

### DIFF
--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -26,15 +26,6 @@ module.exports = function(context) {
     }
 
     /**
-    * Checks if the type is a unary word expression
-    * @param {string} type value of AST token
-    * @returns {boolean} Whether the word is in the list of known words
-    */
-    function isWordExpression(type) {
-        return ["delete", "new", "typeof", "void"].indexOf(type) !== -1;
-    }
-
-    /**
     * Check if the node's child argument is an "ObjectExpression"
     * @param {ASTnode} node AST node
     * @returns {boolean} Whether or not the argument's type is "ObjectExpression"
@@ -74,7 +65,7 @@ module.exports = function(context) {
             firstToken = tokens[0],
             secondToken = tokens[1];
 
-        if (isWordExpression(firstToken.value)) {
+        if (firstToken.type === "Keyword") {
             checkUnaryWordOperatorForSpaces(node, firstToken, secondToken);
             return void 0;
         }


### PR DESCRIPTION
Unfortunately I couldn't see any way of adding tests to cover this case, short of integrating a custom JS parser into the test suite which allows additional keywords (which doesn't seem worth the effort). But it's a simple change, and it still passes everything in the existing test suite.