### PR TITLE
New: add util method to expand home in paths; use it for cli path options. (fixes #2701)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -22,7 +22,8 @@ var fs = require("fs"),
 
     options = require("./options"),
     CLIEngine = require("./cli-engine"),
-    mkdirp = require("mkdirp");
+    mkdirp = require("mkdirp"),
+    util = require("./util");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -77,7 +78,7 @@ function printResults(engine, results, format, outputFile) {
 
     if (output) {
         if (outputFile) {
-            filePath = path.resolve(process.cwd(), outputFile);
+            filePath = path.resolve(process.cwd(), util.expandHome(outputFile));
 
             if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
                 console.error("Cannot write to output file path, it is a directory: %s", outputFile);

--- a/lib/config.js
+++ b/lib/config.js
@@ -320,7 +320,7 @@ function Config(options) {
 
     if (useConfig) {
         debug("Using command line config " + useConfig);
-        this.useSpecificConfig = loadConfig(path.resolve(process.cwd(), useConfig));
+        this.useSpecificConfig = loadConfig(path.resolve(process.cwd(), util.expandHome(useConfig)));
     }
 }
 

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -11,7 +11,9 @@
 var fs = require("fs"),
     debug = require("debug"),
     minimatch = require("minimatch"),
-    FileFinder = require("./file-finder");
+    FileFinder = require("./file-finder"),
+    path = require("path"),
+    util = require("./util");
 
 debug = debug("eslint:ignored-paths");
 
@@ -91,7 +93,7 @@ IgnoredPaths.load = function (options) {
     options = options || {};
 
     if (options.ignore) {
-        patterns = loadIgnoreFile(options.ignorePath || findIgnoreFile());
+        patterns = loadIgnoreFile(options.ignorePath ? path.resolve(process.cwd(), util.expandHome(options.ignorePath)) : findIgnoreFile());
     } else {
         patterns = [];
     }

--- a/lib/load-rules.js
+++ b/lib/load-rules.js
@@ -10,7 +10,8 @@
 //------------------------------------------------------------------------------
 
 var fs = require("fs"),
-    path = require("path");
+    path = require("path"),
+    util = require("./util");
 
 //------------------------------------------------------------------------------
 // Public Interface
@@ -25,7 +26,7 @@ module.exports = function(rulesDir) {
     if (!rulesDir) {
         rulesDir = path.join(__dirname, "rules");
     } else {
-        rulesDir = path.resolve(process.cwd(), rulesDir);
+        rulesDir = path.resolve(process.cwd(), util.expandHome(rulesDir));
     }
 
     var rules = Object.create(null);

--- a/lib/util.js
+++ b/lib/util.js
@@ -4,6 +4,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var path = require("path");
+
+//------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
 
@@ -80,6 +86,28 @@ exports.getNamespace = function getNamespace(pluginName) {
  */
 exports.removeNameSpace = function removeNameSpace(pluginName) {
     return pluginName.replace(NAMESPACE_REGEX, "");
+};
+
+/**
+ * Expand a given path to the current user's home directory if it starts with ~
+ *
+ * @param {string} expand A path to expand
+ * @returns {string} the expanded path if it started with ~, or the given path otherwise
+ */
+exports.expandHome = function expandHome(expand) {
+    if (!expand) {
+        return expand;
+    }
+
+    var platformHomeEnv = process.platform === "win32" ? "USERPROFILE" : "HOME",
+        home = process.env[platformHomeEnv],
+        parts = expand.split(path.sep);
+
+    if (parts[0] === "~") {
+        return path.join.apply(path, [home].concat(parts.slice(1)));
+    }
+
+    return expand;
 };
 
 exports.PLUGIN_NAME_PREFIX = PLUGIN_NAME_PREFIX;

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -102,7 +102,7 @@ describe("IgnoredPaths", function() {
 
         it("should return true for file matching a child of an ignore pattern with windows line termination", function() {
             var stub = sinon.stub(fs, "readFileSync");
-            stub.withArgs("test", "utf8").returns("undef.js\r\n");
+            stub.withArgs(path.resolve(process.cwd(), "test"), "utf8").returns("undef.js\r\n");
 
             var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: "test" });
             assert.ok(ignoredPaths.contains("undef.js/subdir/grandsubdir"));


### PR DESCRIPTION
For options that you can give on the command line, it's useful to be able to give paths relative to home like `--config="~/.eslintrc"` or `--output="~/out"` or `--rulesdir="~/.config/eslint/rules"`.

Let's expand paths that begin with "~" instead of trying to resolve them in the current working directory.

Note that this change also now treats ignore files like any other file: they are resolved from the current directory unless they are absolute paths.