### PR TITLE
Fix Object Assign 2.1 issue: boolean is not a function

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "js-yaml": "^3.2.5",
     "minimatch": "^2.0.1",
     "mkdirp": "^0.5.0",
-    "object-assign": "^2.0.0",
+    "object-assign": "^3.0.0",
     "optionator": "^0.5.0",
     "path-is-absolute": "^1.0.0",
     "strip-json-comments": "~1.0.1",


### PR DESCRIPTION
My build was broken because my local build was using version 2.1 of "object-assign". Directly after the release of 2.1 they've uploaded a new version 3.0 which fixes this issue.

Fixed error message:
Running "eslint:target" (eslint) task                      
Warning: boolean is not a function Use --force to continue.