### PR TITLE
Fix: no-trailing-spaces now handles skipBlankLines (fixes #2575)

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Disallow trailing spaces at the end of lines.
  * @author Nodeca Team <https://github.com/nodeca>
+ * @copyright 2015 Greg Cochard
  */
 "use strict";
 
@@ -10,8 +11,9 @@
 
 module.exports = function(context) {
 
-    var BLANK_PREFIX = "[^( |\t)]",
-        TRAILER = "[ \t\u00a0\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u2028\u2029\u3000]$";
+    var BLANK_CLASS = "[ \t\u00a0\u2000-\u200b\u2028\u2029\u3000]",
+        SKIP_BLANK = "^" + BLANK_CLASS + "*$",
+        NONBLANK = BLANK_CLASS + "$";
 
     var options = context.options[0] || {},
         skipBlankLines = options.skipBlankLines || false;
@@ -25,25 +27,34 @@ module.exports = function(context) {
 
         "Program": function checkTrailingSpaces(node) {
 
-            // Let's hack. Since Esprima does not return whitespace nodes,
-            // fetch the source code and do black magic via regexps.
+            // Let's hack. Since Espree does not return whitespace nodes,
+            // fetch the source code and do matching via regexps.
 
             var src = context.getSource(),
-                re = new RegExp((skipBlankLines ? BLANK_PREFIX : "") + TRAILER, "mg"),
-                match, lines, location;
+                re = new RegExp(NONBLANK),
+                skipMatch = new RegExp(SKIP_BLANK),
+                matches, lines = src.split(/\r?\n/), location;
 
-            while ((match = re.exec(src)) !== null) {
-                lines = src.slice(0, re.lastIndex).split(/\r?\n/g);
+            for (var i = 0, ii = lines.length; i < ii; i++) {
 
-                location = {
-                    line: lines.length,
-                    column: lines[lines.length - 1].length - match[0].length + 1
-                };
+                matches = re.exec(lines[i]);
+                if (matches) {
 
-                // Passing node is a bit dirty, because message data will contain
-                // big text in `source`. But... who cares :) ?
-                // One more kludge will not make worse the bloody wizardry of this plugin.
-                context.report(node, location, "Trailing spaces not allowed.");
+                    // If the line has only whitespace, and skipBlankLines
+                    // is true, don't report it
+                    if (skipBlankLines && skipMatch.test(lines[i])) {
+                        continue;
+                    }
+                    location = {
+                        line: i + 1,
+                        column: lines[i].length - matches[0].length + 1
+                    };
+
+                    // Passing node is a bit dirty, because message data will contain
+                    // big text in `source`. But... who cares :) ?
+                    // One more kludge will not make worse the bloody wizardry of this plugin.
+                    context.report(node, location, "Trailing spaces not allowed.");
+                }
             }
         }
 

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Disallow trailing spaces at the end of lines.
  * @author Nodeca Team <https://github.com/nodeca>
+ * @copyright 2015 Patrick McElhaney
  */
 "use strict";
 
@@ -144,6 +145,18 @@ eslintTester.addRuleTest("lib/rules/no-trailing-spaces", {
                 type: "Program"
             }],
             options: [{}]
+        },
+        {
+            code: "var a = 'bar';  \n \n\t",
+            errors: [{
+                message: "Trailing spaces not allowed.",
+                type: "Program",
+                line: 1,
+                column: 16 // there are invalid spaces in columns 15 and 16
+            }],
+            options: [{
+                skipBlankLines: true
+            }]
         }
     ]
 


### PR DESCRIPTION
This does potentially two regexp tests per line. With this change, the performance does not seem to be impacted in a statistically significant way.

With: 
```
node Makefile.js perf
CPU Speed is 2200 with multiplier 7500000
Performance Run #1:  2177.437605ms
Performance Run #2:  2095.757845ms
Performance Run #3:  2085.389922ms
Performance Run #4:  2096.332165ms
Performance Run #5:  2082.197974ms
Performance budget ok:  2095.757845ms (limit: 3409.090909090909ms)
```
Without:
```
node Makefile.js perf
CPU Speed is 2200 with multiplier 7500000
Performance Run #1:  2085.415068ms
Performance Run #2:  2181.624126ms
Performance Run #3:  2082.826633ms
Performance Run #4:  2136.809016ms
Performance Run #5:  2126.298463ms
Performance budget ok:  2126.298463ms (limit: 3409.090909090909ms)
```