### PR TITLE
Add jsx to default file extension

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -77,7 +77,7 @@ var defaultOptions = {
         envs: [],
         globals: [],
         rules: {},
-        extensions: [".js"],
+        extensions: [".js", ".jsx"],
         ignore: true,
         ignorePath: null
     },

--- a/lib/options.js
+++ b/lib/options.js
@@ -63,7 +63,7 @@ module.exports = optionator({
     }, {
         option: "ext",
         type: "[String]",
-        default: ".js",
+        default: ".js,.jsx",
         description: "Specify JavaScript file extensions"
     }, {
         option: "plugin",


### PR DESCRIPTION
Our team is using eslint on a react project and are unable to specify `--ext` option due to linting as part of our gulp build process.  Our ideal solution would be to configure this in `.eslintrc` on a project by project basis. There is an issue open right now (https://github.com/eslint/eslint/issues/2419), but there is no consensus on moving forward with that.