### PR TITLE
Update: Add clarification to spaced-comment (refs #2588)

### DIFF
--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -127,4 +127,7 @@ var foo = 5;
 ```js
 // When ["never",{"markers":["!<"]}]
 //!<This is a comment with a marker
+/*!<this is a block comment with a marker
+subsequent lines are ignored
+*/
 ```

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -98,6 +98,12 @@ eslintTester.addRuleTest("lib/rules/spaced-comment", {
             }]
         },
         {
+            code: "var a = 1; /*# This is an example of a marker in a block comment\nsubsequent lines do not count*/",
+            options: ["always", {
+                markers: ["#"]
+            }]
+        },
+        {
             code: "var a = 1; /*A valid comment NOT starting with space */",
             options: ["never"]
         },


### PR DESCRIPTION
This clarifies the behavior of the `spaced-comment` rule on subsequent lines of multi-line block comments. Relevant discussion [here](https://github.com/eslint/eslint/pull/2663#issuecomment-109769244).