### PR TITLE
New: computed-property-spacing (part of #2226)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -119,6 +119,7 @@
         "comma-spacing": 2,
         "comma-style": 0,
         "complexity": [0, 11],
+        "computed-property-spacing": [0, "never"],
         "consistent-return": 2,
         "consistent-this": [0, "that"],
         "curly": [2, "all"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -136,6 +136,7 @@ These rules are purely matters of style and are quite subjective.
 * [camelcase](camelcase.md) - require camel case names
 * [comma-spacing](comma-spacing.md) - enforce spacing before and after comma
 * [comma-style](comma-style.md) - enforce one true comma style (off by default)
+* [computed-property-spacing](computed-property-spacing.md) - require or disallow padding inside computed properties (off by default)
 * [consistent-this](consistent-this.md) - enforces consistent naming when capturing the current execution context (off by default)
 * [eol-last](eol-last.md) - enforce newline at the end of file, with no multiple empty lines
 * [func-names](func-names.md) - require function expressions to have a name (off by default)

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -1,0 +1,91 @@
+# Disallow or enforce spaces inside of computed properties. (computed-property-spacing)
+
+While formatting preferences are very personal, a number of style guides require
+or disallow spaces between computed properties in the following situations:
+
+```js
+// computed properties
+var obj = { prop: "value" };
+var a = "prop";
+var x = obj[a];
+
+// object literal computed properties (EcmaScript 6)
+var a = "prop";
+var obj = { [a]: "value" };
+```
+
+## Rule Details
+
+This rule aims to maintain consistency around the spacing inside of computed properties.
+
+It either requires or disallows spaces between the brackets and the values inside of them.
+Brackets that are separated from the adjacent value by a new line are exempt from this rule.
+
+### Options
+
+There are two main options for the rule:
+
+* `"always"` enforces a space inside of computed properties
+* `"never"` disallows spaces inside of computed properties (default)
+
+Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+
+```json
+"computed-property-spacing": [2, "never"]
+```
+
+#### never
+
+When `"never"` is set, the following patterns are considered correct:
+
+```js
+obj[foo]
+obj['foo']
+var x = {[b]: a}
+obj[foo[bar]]
+```
+
+The following patterns will warn:
+
+```js
+obj[foo ]
+obj[ 'foo']
+var x = {[ b ]: a}
+obj[foo[ bar ]]
+```
+
+#### always
+
+When `"always"` is used, the following patterns are considered correct:
+
+```js
+obj[ foo ]
+obj[ 'foo' ]
+var x = {[ b ]: a}
+obj[ foo[ bar ] ]
+
+```
+
+The following patterns will warn:
+
+```js
+obj[foo]
+var x = {[b]: a}
+obj[ foo]
+obj[ foo ]
+obj['foo' ]
+obj[foo[ bar ]]
+var x = {[ b]: a}
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the consistency of computed properties.
+
+## Related Rules
+
+* [comma-spacing](comma-spacing.md)
+* [space-in-parens](space-in-parens.md)
+* [curly-braces-spacing](curly-braces-spacing.md)
+* [space-in-brackets](space-in-brackets.md) (deprecated)
+

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -1,0 +1,144 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside computed properties.
+ * @author Jamund Ferguson
+ * @copyright 2015 Jamund Ferguson. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var propertyNameMustBeSpaced = context.options[0] === "always"; // default is "never"
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Determines whether two adjacent tokens are have whitespace between them.
+     * @param {Object} left - The left token object.
+     * @param {Object} right - The right token object.
+     * @returns {boolean} Whether or not there is space between the tokens.
+     */
+    function isSpaced(left, right) {
+        return left.range[1] < right.range[0];
+    }
+
+    /**
+     * Determines whether two adjacent tokens are on the same line.
+     * @param {Object} left - The left token object.
+     * @param {Object} right - The right token object.
+     * @returns {boolean} Whether or not the tokens are on the same line.
+     */
+    function isSameLine(left, right) {
+        return left.loc.start.line === right.loc.start.line;
+    }
+
+    /**
+    * Reports that there shouldn't be a space after the first token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportNoBeginningSpace(node, token) {
+        context.report(node, token.loc.start,
+            "There should be no space after '" + token.value + "'");
+    }
+
+    /**
+    * Reports that there shouldn't be a space before the last token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportNoEndingSpace(node, token) {
+        context.report(node, token.loc.start,
+            "There should be no space before '" + token.value + "'");
+    }
+
+    /**
+    * Reports that there should be a space after the first token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportRequiredBeginningSpace(node, token) {
+        context.report(node, token.loc.start,
+            "A space is required after '" + token.value + "'");
+    }
+
+    /**
+    * Reports that there should be a space before the last token
+    * @param {ASTNode} node - The node to report in the event of an error.
+    * @param {Token} token - The token to use for the report.
+    * @returns {void}
+    */
+    function reportRequiredEndingSpace(node, token) {
+        context.report(node, token.loc.start,
+                    "A space is required before '" + token.value + "'");
+    }
+
+    /**
+     * Returns a function that checks the spacing of a node on the property name
+     * that was passed in.
+     * @param {String} propertyName The property on the node to check for spacing
+     * @returns {Function} A function that will check spacing on a node
+     */
+    function checkSpacing(propertyName) {
+        return function(node) {
+            if (!node.computed) {
+                return;
+            }
+
+            var property = node[propertyName];
+
+            var before = context.getTokenBefore(property),
+                first = context.getFirstToken(property),
+                last = context.getLastToken(property),
+                after = context.getTokenAfter(property);
+
+            if (isSameLine(before, first)) {
+                if (propertyNameMustBeSpaced) {
+                    if (!isSpaced(before, first) && isSameLine(before, first)) {
+                        reportRequiredBeginningSpace(node, before);
+                    }
+                } else {
+                    if (isSpaced(before, first)) {
+                        reportNoBeginningSpace(node, before);
+                    }
+                }
+            }
+
+            if (isSameLine(last, after)) {
+                if (propertyNameMustBeSpaced) {
+                    if (!isSpaced(last, after) && isSameLine(last, after)) {
+                        reportRequiredEndingSpace(node, after);
+                    }
+                } else {
+                    if (isSpaced(last, after)) {
+                        reportNoEndingSpace(node, after);
+                    }
+                }
+            }
+        };
+    }
+
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        Property: checkSpacing("key"),
+        MemberExpression: checkSpacing("property")
+    };
+
+};
+
+module.exports.schema = [
+    {
+        "enum": ["always", "never"]
+    }
+];

--- a/tests/lib/rules/computed-property-spacing.js
+++ b/tests/lib/rules/computed-property-spacing.js
@@ -1,0 +1,320 @@
+/**
+ * @fileoverview Disallows or enforces spaces inside computed properties.
+ * @author Jamund Ferguson
+ * @copyright 2015 Jamund Ferguson. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
+
+    valid: [
+
+        // default - never
+        { code: "obj[foo]" },
+        { code: "obj['foo']" },
+        { code: "var x = {[b]: a}", ecmaFeatures: { objectLiteralComputedProperties: true } },
+
+        // always
+        { code: "obj[ foo ]", options: ["always"] },
+        { code: "obj[\nfoo\n]", options: ["always"] },
+        { code: "obj[ 'foo' ]", options: ["always"] },
+        { code: "obj[ 'foo' + 'bar' ]", options: ["always"] },
+        { code: "obj[ obj2[ foo ] ]", options: ["always"] },
+        { code: "obj.map(function (item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["always"] },
+        { code: "obj[ 'map' ](function (item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["always"] },
+        { code: "obj[ 'for' + 'Each' ](function (item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["always"] },
+        { code: "obj[ obj2[ foo ] ]", options: ["always"] },
+        { code: "var foo = obj[ 1 ]", options: ["always"] },
+        { code: "var foo = obj[ 'foo' ];", options: ["always"] },
+        { code: "var foo = obj[ [1, 1] ];", options: ["always"] },
+
+        // always - objectLiteralComputedProperties
+        { code: "var x = {[ \"a\" ]: a}", options: ["always"], ecmaFeatures: { "objectLiteralComputedProperties": true } },
+        { code: "var y = {[ x ]: a}", options: ["always"], ecmaFeatures: { "objectLiteralComputedProperties": true } },
+        { code: "var x = {[ \"a\" ]() {}}", options: ["always"], ecmaFeatures: { objectLiteralComputedProperties: true, objectLiteralShorthandMethods: true } },
+        { code: "var y = {[ x ]() {}}", options: ["always"], ecmaFeatures: { objectLiteralComputedProperties: true, objectLiteralShorthandMethods: true } },
+
+        // always - unrelated cases
+        { code: "var foo = {};", options: ["always"] },
+        { code: "var foo = [];", options: ["always"] },
+
+        // never
+        { code: "obj[foo]", options: ["never"] },
+        { code: "obj['foo']", options: ["never"] },
+        { code: "obj['foo' + 'bar']", options: ["never"] },
+        { code: "obj['foo'+'bar']", options: ["never"] },
+        { code: "obj[obj2[foo]]", options: ["never"] },
+        { code: "obj.map(function (item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["never"] },
+        { code: "obj['map'](function (item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["never"] },
+        { code: "obj['for' + 'Each'](function (item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["never"] },
+        { code: "obj['for' + 'Each'](function (item) { return [\n1,\n2,\n3,\n4\n]; })", options: ["never"] },
+        { code: "obj[\nfoo]", options: ["never"] },
+        { code: "obj[foo\n]", options: ["never"] },
+        { code: "var foo = obj[1]", options: ["never"] },
+        { code: "var foo = obj['foo'];", options: ["never"] },
+        { code: "var foo = obj[[ 1, 1 ]];", options: ["never"] },
+
+        // never - objectLiteralComputedProperties
+        { code: "var x = {[\"a\"]: a}", options: ["never"], ecmaFeatures: { objectLiteralComputedProperties: true } },
+        { code: "var y = {[x]: a}", options: ["never"], ecmaFeatures: { objectLiteralComputedProperties: true } },
+        { code: "var x = {[\"a\"]() {}}", options: ["never"], ecmaFeatures: { objectLiteralComputedProperties: true, objectLiteralShorthandMethods: true } },
+        { code: "var y = {[x]() {}}", options: ["never"], ecmaFeatures: { objectLiteralComputedProperties: true, objectLiteralShorthandMethods: true } },
+
+        // never - unrelated cases
+        { code: "var foo = {};", options: ["never"] },
+        { code: "var foo = [];", options: ["never"] }
+    ],
+
+    invalid: [
+        {
+            code: "var foo = obj[ 1];",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required before ']'",
+                    type: "MemberExpression",
+                    column: 16,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var foo = obj[1 ];",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "MemberExpression",
+                    column: 13,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var foo = obj[ 1];",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "MemberExpression",
+                    column: 13,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var foo = obj[1 ];",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before ']'",
+                    type: "MemberExpression"
+                }
+            ]
+        },
+        {
+            code: "var foo = obj[ 1];",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required before ']'",
+                    type: "MemberExpression",
+                    column: 16,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var foo = obj[1 ];",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "MemberExpression",
+                    column: 13,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "obj[ foo ]",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "MemberExpression",
+                    column: 3,
+                    line: 1
+                },
+                {
+                    message: "There should be no space before ']'",
+                    type: "MemberExpression",
+                    column: 9,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "obj[foo ]",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before ']'",
+                    type: "MemberExpression",
+                    column: 8,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "obj[ foo]",
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "MemberExpression",
+                    column: 3,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var foo = obj[1]",
+            options: ["always"],
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "MemberExpression",
+                    column: 13,
+                    line: 1
+                },
+                {
+                    message: "A space is required before ']'",
+                    type: "MemberExpression",
+                    column: 15,
+                    line: 1
+                }
+            ]
+        },
+
+        // always - objectLiteralComputedProperties
+        {
+            code: "var x = {[a]: b}",
+            options: ["always"],
+            ecmaFeatures: { "objectLiteralComputedProperties": true },
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "Property",
+                    column: 9,
+                    line: 1
+                },
+                {
+                    message: "A space is required before ']'",
+                    type: "Property",
+                    column: 11,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var x = {[a ]: b}",
+            options: ["always"],
+            ecmaFeatures: { "objectLiteralComputedProperties": true },
+            errors: [
+                {
+                    message: "A space is required after '['",
+                    type: "Property",
+                    column: 9,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var x = {[ a]: b}",
+            options: ["always"],
+            ecmaFeatures: { "objectLiteralComputedProperties": true },
+            errors: [
+                {
+                    message: "A space is required before ']'",
+                    type: "Property",
+                    column: 12,
+                    line: 1
+                }
+            ]
+        },
+
+        // never - objectLiteralComputedProperties
+        {
+            code: "var x = {[ a ]: b}",
+            options: ["never"],
+            ecmaFeatures: { "objectLiteralComputedProperties": true },
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "Property",
+                    column: 9,
+                    line: 1
+                },
+                {
+                    message: "There should be no space before ']'",
+                    type: "Property",
+                    column: 13,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var x = {[a ]: b}",
+            options: ["never"],
+            ecmaFeatures: { "objectLiteralComputedProperties": true },
+            errors: [
+                {
+                    message: "There should be no space before ']'",
+                    type: "Property",
+                    column: 12,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var x = {[ a]: b}",
+            options: ["never"],
+            ecmaFeatures: { "objectLiteralComputedProperties": true },
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "Property",
+                    column: 9,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "var x = {[ a\n]: b}",
+            options: ["never"],
+            ecmaFeatures: { "objectLiteralComputedProperties": true },
+            errors: [
+                {
+                    message: "There should be no space after '['",
+                    type: "Property",
+                    column: 9,
+                    line: 1
+                }
+            ]
+        }
+
+    ]
+});


### PR DESCRIPTION
Enforces spacing in the following situations:

```js
// computed properties
var obj = { prop: "value" };
var a = "prop";
var x = obj[a];

// object literal computed properties (EcmaScript 6)
var a = "prop";
var obj = { [a]: "value" };
```