### PR TITLE
Fix: don't try to strip "line:" prefix from parser errors with no such prefix

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -461,12 +461,14 @@ module.exports = (function() {
             });
         } catch (ex) {
 
+            // If the message includes a leading line number, strip it:
+            var message = ex.message.replace(/^line \d+:/i, "").trim();
+
             messages.push({
                 fatal: true,
                 severity: 2,
 
-                // messages come as "Line X: Unexpected token foo", so strip off leading part
-                message: ex.message.substring(ex.message.indexOf(":") + 1).trim(),
+                message: message,
 
                 line: ex.lineNumber,
                 column: ex.column

--- a/tests/fixtures/parsers/line-error.js
+++ b/tests/fixtures/parsers/line-error.js
@@ -1,0 +1,5 @@
+exports.expectedError = "Failed to parse: unexpected token";
+
+exports.parse = function() {
+    throw new Error("Line 123: " + exports.expectedError);
+}

--- a/tests/fixtures/parsers/no-line-error.js
+++ b/tests/fixtures/parsers/no-line-error.js
@@ -1,0 +1,5 @@
+exports.expectedError = "Failed to parse: unexpected token";
+
+exports.parse = function() {
+    throw new Error(exports.expectedError);
+}

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -27,6 +27,7 @@ function compatRequire(name, windowName) {
 
 var assert = compatRequire("chai").assert,
     sinon = compatRequire("sinon"),
+    path = compatRequire("path"),
     eslint = compatRequire("../../lib/eslint", "eslint");
 
 //------------------------------------------------------------------------------
@@ -2437,6 +2438,8 @@ describe("eslint", function() {
 
         describe("Custom parser", function() {
 
+            var parserFixtures = path.join(__dirname, "../fixtures/parsers");
+
             it("should not report an error when JSX code contains a spread operator and JSX is enabled", function() {
                 var code = "var myDivElement = <div {...this.props} />;";
                 var messages = eslint.verify(code, { parser: "esprima-fb" }, "filename");
@@ -2449,6 +2452,22 @@ describe("eslint", function() {
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);
                 assert.equal(messages[0].message, "Cannot find module 'esprima-fbxyz'");
+            });
+
+            it("should strip leading line: prefix from parser error", function() {
+                var parser = path.join(parserFixtures, "line-error.js");
+                var messages = eslint.verify(";", { parser: parser }, "filename");
+                assert.equal(messages.length, 1);
+                assert.equal(messages[0].severity, 2);
+                assert.equal(messages[0].message, require(parser).expectedError);
+            });
+
+            it("should not modify a parser error message without a leading line: prefix", function() {
+                var parser = path.join(parserFixtures, "no-line-error.js");
+                var messages = eslint.verify(";", { parser: parser }, "filename");
+                assert.equal(messages.length, 1);
+                assert.equal(messages[0].severity, 2);
+                assert.equal(messages[0].message, require(parser).expectedError);
             });
 
         });


### PR DESCRIPTION
fixes #2698