### PR TITLE
New: `no-const-assign` rule (Fixes #2719)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -8,6 +8,7 @@
         "no-catch-shadow": 0,
         "no-cond-assign": 2,
         "no-console": 2,
+        "no-const-assign": 0,
         "no-constant-condition": 2,
         "no-continue": 0,
         "no-control-regex": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -191,6 +191,7 @@ These rules are only relevant to ES6 environments.
 * [arrow-spacing](arrow-spacing.md) - Require space before/after arrow functions arrow
 * [constructor-super](constructor-super.md) - verify `super()` callings in constructors
 * [generator-star-spacing](generator-star-spacing.md) - enforce the spacing around the `*` in generator functions
+* [no-const-assign](no-const-assign.md) - disallow modifying variables that are declared using `const`
 * [no-this-before-super](no-this-before-super.md) - disallow to use `this`/`super` before `super()` calling in constructors.
 * [no-var](no-var.md) - require `let` or `const` instead of `var`
 * [object-shorthand](object-shorthand.md) - require method and property shorthand syntax for object literals

--- a/docs/rules/no-const-assign.md
+++ b/docs/rules/no-const-assign.md
@@ -1,0 +1,50 @@
+# Disallow modifying variables that are declared using `const` (no-const-assign)
+
+We cannot modify variables that are declared using `const` keyword.
+It will raise a runtime error.
+
+Under non ES2015 environment, it might be ignored merely.
+
+## Rule Details
+
+This rule is aimed to flag modifying variables that are declared using `const` keyword.
+
+The following patterns are considered warnings:
+
+```js
+const a = 0;
+a = 1;
+```
+
+```js
+const a = 0;
+a += 1;
+```
+
+```js
+const a = 0;
+++a;
+```
+
+The following patterns are not considered warnings:
+
+```js
+const a = 0;
+console.log(a);
+```
+
+```js
+for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.
+    console.log(a);
+}
+```
+
+```js
+for (const a of [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.
+    console.log(a);
+}
+```
+
+## When Not to Use It
+
+If you don't want to be notified about modifying variables that are declared using `const` keyword, you can safely disable this rule.

--- a/lib/rules/no-const-assign.js
+++ b/lib/rules/no-const-assign.js
@@ -1,0 +1,58 @@
+/**
+ * @fileoverview A rule to disallow modifying variables that are declared using `const`
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    /**
+     * Reports a reference if is non initializer and writable.
+     * @param {Reference} reference - A reference to check.
+     * @param {int} index - The index of the reference in the references.
+     * @param {Reference[]} references - The array that the reference belongs to.
+     * @returns {void}
+     */
+    function checkReference(reference, index, references) {
+        var identifier = reference.identifier;
+
+        if (identifier != null &&
+            reference.init === false &&
+            reference.isWrite() &&
+            // Destructuring assignments can have multiple default value,
+            // so possibly there are multiple writeable references for the same identifier.
+            (index === 0 || references[index - 1].identifier !== identifier)
+        ) {
+            context.report(
+                identifier,
+                "`{{name}}` is constant.",
+                {name: identifier.name});
+        }
+    }
+
+    /**
+     * Finds and reports references that are non initializer and writable.
+     * @param {Variable} variable - A variable to check.
+     * @returns {void}
+     */
+    function checkVariable(variable) {
+        variable.references.forEach(checkReference);
+    }
+
+    return {
+        "VariableDeclaration": function(node) {
+            if (node.kind === "const") {
+                context.getDeclaredVariables(node).forEach(checkVariable);
+            }
+        }
+    };
+
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-const-assign.js
+++ b/tests/lib/rules/no-const-assign.js
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Tests for no-const-assign rule.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint");
+var ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-const-assign", {
+    valid: [
+        {code: "const x = 0; { let x; x = 1; }", ecmaFeatures: {blockBindings: true}},
+        {code: "const x = 0; function a(x) { x = 1; }", ecmaFeatures: {blockBindings: true}},
+        {code: "const x = 0; foo(x);", ecmaFeatures: {blockBindings: true}},
+        {code: "for (const x in [1,2,3]) { foo(x); }", ecmaFeatures: {blockBindings: true}},
+        {code: "for (const x of [1,2,3]) { foo(x); }", ecmaFeatures: {blockBindings: true, forOf: true}},
+        {code: "const x = {key: 0}; x.key = 1;", ecmaFeatures: {blockBindings: true}},
+
+        // ignores non constant.
+        {code: "var x = 0; x = 1;"},
+        {code: "let x = 0; x = 1;", ecmaFeatures: {blockBindings: true}},
+        {code: "function x() {} x = 1;"},
+        {code: "function foo(x) { x = 1; }"},
+        {code: "class X {} X = 1;", ecmaFeatures: {classes: true}},
+        {code: "try {} catch (x) { x = 1; }"}
+    ],
+    invalid: [
+        {
+            code: "const x = 0; x = 1;",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const {a: x} = {a: 0}; x = 1;",
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const x = 0; ({x}) = {x: 1};",
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const x = 0; ({a: x = 1}) = {};",
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const x = 0; x += 1;",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const x = 0; ++x;",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "for (const i = 0; i < 10; ++i) { foo(i); }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "`i` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const x = 0; x = 1; x = 2;",
+            ecmaFeatures: {blockBindings: true},
+            errors: [
+                {message: "`x` is constant.", type: "Identifier", line: 1, column: 14},
+                {message: "`x` is constant.", type: "Identifier", line: 1, column: 21}
+            ]
+        },
+        {
+            code: "const x = 0; function foo() { x = x + 1; }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const x = 0; function foo(a) { x = a; }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        },
+        {
+            code: "const x = 0; while (true) { x = x + 1; }",
+            ecmaFeatures: {blockBindings: true},
+            errors: [{message: "`x` is constant.", type: "Identifier"}]
+        }
+    ]
+});


### PR DESCRIPTION
For the destructuring assignments, to check from `AssignmentExpression` or `VariableDeclaration` was very hard. So I traversed scopes.