### PR TITLE
adding nofunc-noclass to no-use-before-define rule. (fixes #2750)

### DIFF
--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -38,3 +38,12 @@ var a = 10; alert(a);
 
 function f() {} f();
 ```
+
+The `"nofunc-noclass"` option does for Classes the same that `"nofunc"` does for functions. Not only
+all of the patterns above are considered OK, but also the following pattern is not considered warning:
+
+```js
+var a = new A();
+
+class A{}
+```

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 var NO_FUNC = "nofunc";
+var NO_FUNC_CLASS = "nofunc-noclass";
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -48,7 +49,11 @@ module.exports = function(context) {
         var typeOption = context.options[0];
 
         function checkLocationAndReport(reference, declaration) {
-            if (typeOption !== NO_FUNC || declaration.defs[0].type !== "FunctionName") {
+            var nofunc = (typeOption === NO_FUNC) || (typeOption === NO_FUNC_CLASS);
+            var supressWarning = false;
+            supressWarning |= (nofunc && declaration.defs[0].type === "FunctionName");
+            supressWarning |= (typeOption === NO_FUNC_CLASS && declaration.defs[0].type === "ClassName");
+            if (!supressWarning) {
                 if (declaration.identifiers[0].range[1] > reference.identifier.range[1]) {
                     context.report(reference.identifier, "{{a}} was used before it was defined", {a: reference.identifier.name});
                 }
@@ -100,6 +105,6 @@ module.exports = function(context) {
 
 module.exports.schema = [
     {
-        "enum": ["nofunc"]
+        "enum": [NO_FUNC, NO_FUNC_CLASS]
     }
 ];

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -25,7 +25,9 @@ eslintTester.addRuleTest("lib/rules/no-use-before-define", {
         "Object.hasOwnProperty.call(a);",
         "function a() { alert(arguments);}",
         { code: "a(); function a() { alert(arguments); }", options: [ "nofunc"] },
-        { code: "(() => { var a = 42; alert(a); })();", ecmaFeatures: { arrowFunctions: true } }
+        { code: "(() => { var a = 42; alert(a); })();", ecmaFeatures: { arrowFunctions: true } },
+        { code: "var a = new A(); class A{};", ecmaFeatures: {classes: true}, options: [ "nofunc-noclass"] },
+        { code: "a(); function a() { alert(arguments); }", options: [ "nofunc-noclass"] }
     ],
     invalid: [
         { code: "a++; var a=19;", ecmaFeatures: { modules: true }, errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
@@ -36,6 +38,8 @@ eslintTester.addRuleTest("lib/rules/no-use-before-define", {
         { code: "a(); function a() { alert(b); var b=10; a(); }", errors: [{ message: "a was used before it was defined", type: "Identifier"}, { message: "b was used before it was defined", type: "Identifier"}] },
         { code: "a(); var a=function() {};", options: [ "nofunc"], errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
         { code: "(() => { alert(a); var a = 42; })();", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
-        { code: "(() => a())(); function a() { }", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] }
+        { code: "(() => a())(); function a() { }", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "var a = new A(); class A{};", ecmaFeatures: {classes: true}, options: [ "nofunc"], errors: [{ message: "A was used before it was defined", type: "Identifier"}] },
+        { code: "var a = new A(); var A = class{};", ecmaFeatures: {classes: true}, options: [ "nofunc-noclass"], errors: [{ message: "A was used before it was defined", type: "Identifier"}] }
     ]
 });


### PR DESCRIPTION
typically, for functions and classes it is OK to be defined "later" (in terms of lines of code) than used; currently no-use-before-define allow to supress such warnings for functions, but not for classes; this feature is added by the current commit.

I don't like nofunc-noclass naming, IMO nofunc, noclass should be two separate independent options; however, nofunc was defined as the enum type and I don't see how I can do this properly without breaking the backwards compatibility.