### PR TITLE
Build: Revert lock io.js to v2.1.0 (refs #2745)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: node_js
 node_js:
     - "0.10"
     - "0.12"
-    - "iojs-v2.1.0"
+    - iojs
 sudo: false
 script: "npm test && npm run docs"
 after_success:


### PR DESCRIPTION
Reverts eslint/eslint#2654 since nodejs/io.js#1850 was fixed in iojs v2.2.1.