### PR TITLE
Fix: arraysInObjects for object-curly-spacing (fixes #275)

### DIFF
--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -118,9 +118,12 @@ You can add exceptions like so:
 
 ```json
 "object-curly-spacing": [2, "always", {
-  "objectsInObjects": false
+  "objectsInObjects": false,
+  "arraysInObjects": false
 }]
 ```
+
+##### objectsInObjects
 
 In the case of the `"always"` option, set `objectsInObjects` exception to `false` to
 enforce the following syntax (notice the `}}` at the end):
@@ -137,9 +140,27 @@ the following style (with a space between the `}` at the end:
 var obj = {"foo": {"baz": 1, "bar": 2} };
 ```
 
+##### arraysInObjects
+
+In the case of the `"always"` option, set `arraysInObjects` exception to `false` to
+enforce the following syntax (notice the `]}` at the end):
+
+```js
+var obj = { "foo": [ 1, 2 ]};
+var obj = { "foo": [ "baz", "bar" ]};
+```
+
+In the case of the `"never"` option, set `arraysInObjects` exception to `true` to enforce
+the following style (with a space between the `]` and  `}` at the end:
+
+```js
+var obj = {"foo": [ 1, 2 ] };
+var obj = {"foo": [ "baz", "bar" ] };
+```
+
 ## When Not To Use It
 
-You can turn this rule off if you are not concerned with the consistency of spacing between brackets.
+You can turn this rule off if you are not concerned with the consistency of spacing between curly braces.
 
 ## Related Rules
 

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -28,6 +28,7 @@ module.exports = function(context) {
 
     var options = {
         spaced: spaced,
+        arraysInObjectsException: isOptionSet("arraysInObjects"),
         objectsInObjectsException: isOptionSet("objectsInObjects")
     };
 
@@ -99,7 +100,6 @@ module.exports = function(context) {
                     "A space is required before '" + token.value + "'");
     }
 
-
     /**
      * Determines if spacing in curly braces is valid.
      * @param {ASTNode} node The AST node to check.
@@ -111,8 +111,9 @@ module.exports = function(context) {
      */
     function validateBraceSpacing(node, first, second, penultimate, last) {
         var closingCurlyBraceMustBeSpaced =
+            options.arraysInObjectsException && penultimate.value === "]" ||
             options.objectsInObjectsException && penultimate.value === "}"
-            ? !options.spaced : options.spaced;
+                ? !options.spaced : options.spaced;
 
         if (isSameLine(first, second)) {
             if (options.spaced && !isSpaced(first, second)) {
@@ -210,3 +211,21 @@ module.exports = function(context) {
     };
 
 };
+
+module.exports.schema = [
+    {
+        "enum": ["always", "never"]
+    },
+    {
+        "type": "object",
+        "properties": {
+            "arraysInObjects": {
+                "type": "boolean"
+            },
+            "objectsInObjects": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -52,6 +52,15 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
         // always - objectsInObjects
         { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }};", options: ["always", {"objectsInObjects": false}] },
 
+        // always - arraysInObjects
+        { code: "var obj = { 'foo': [ 1, 2 ]};", options: ["always", {"arraysInObjects": false}] },
+
+        // always - arraysInObjects, objectsInObjects
+        { code: "var obj = { 'qux': [ 1, 2 ], 'foo': { 'bar': 1, 'baz': 2 }};", options: ["always", {"arraysInObjects": false, "objectsInObjects": false}] },
+
+        // always - arraysInObjects, objectsInObjects (reverse)
+        { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }, 'qux': [ 1, 2 ]};", options: ["always", {"arraysInObjects": false, "objectsInObjects": false}] },
+
         // never
         { code: "var obj = {foo: bar,\nbaz: qux\n};", options: ["never"] },
         { code: "var obj = {\nfoo: bar,\nbaz: qux};", options: ["never"] },
@@ -89,7 +98,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
         { code: "var foo = {};", options: ["never"] },
 
         // never - objectsInObjects
-        { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", {"objectsInObjects": true}] }
+        { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", {"objectsInObjects": true}]}
 
     ],
 
@@ -136,6 +145,29 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                 }
             ]
         },
+
+        // always - arraysInObjects
+        {
+            code: "var obj = { 'foo': [ 1, 2 ] };",
+            options: ["always", {"arraysInObjects": false}],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = { 'foo': [ 1, 2 ] , 'bar': [ 'baz', 'qux' ] };",
+            options: ["always", {"arraysInObjects": false}],
+            errors: [
+                {
+                    message: "There should be no space before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+
         // always-objectsInObjects
         {
             code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 } };",
@@ -442,6 +474,28 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     type: "ObjectPattern",
                     line: 1,
                     column: 4
+                }
+            ]
+        },
+
+        // never - arraysInObjects
+        {
+            code: "var obj = {'foo': [1, 2]};",
+            options: ["never", {"arraysInObjects": true}],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression"
+                }
+            ]
+        },
+        {
+            code: "var obj = {'foo': [1, 2] , 'bar': ['baz', 'qux']};",
+            options: ["never", {"arraysInObjects": true}],
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ObjectExpression"
                 }
             ]
         }


### PR DESCRIPTION
Quick port from the existing space-in-brackets rule of this missing exception