### PR TITLE
New: `constructor-super` (Fixes #2720)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -122,6 +122,7 @@
         "computed-property-spacing": [0, "never"],
         "consistent-return": 2,
         "consistent-this": [0, "that"],
+        "constructor-super": 0,
         "curly": [2, "all"],
         "default-case": 0,
         "dot-location": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -193,6 +193,7 @@ These rules are purely matters of style and are quite subjective.
 
 These rules are only relevant to ES6 environments and are off by default.
 
+* [constructor-super](constructor-super.md) - verify `super()` callings in constructors (off by default)
 * [generator-star-spacing](generator-star-spacing.md) - enforce the spacing around the `*` in generator functions (off by default)
 * [generator-star](generator-star.md) - **(deprecated)** enforce the position of the `*` in generator functions (off by default)
 * [no-var](no-var.md) - require `let` or `const` instead of `var` (off by default)

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -1,0 +1,61 @@
+# Verify `super()` callings in constructors (constructor-super)
+
+Constructors of derived classes must call `super()`.
+Constructors of non derived classes must not call `super()`.
+If not so, it will raise a runtime error.
+
+This rule checks whether or not there is valid `super()` calling.
+
+## Rule Details
+
+This rule is aimed to flag invalid/missing `super()` callings.
+
+The following patterns are considered warnings:
+
+```js
+class A {
+    constructor() {
+        super(); // unexpected `super()`.
+    }
+}
+```
+
+```js
+class A extends null {
+    constructor() {
+        super(); // unexpected `super()`.
+    }
+}
+```
+
+```js
+class A extends B {
+    constructor() { } // requires `super()`.
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+class A {
+    constructor() { }
+}
+```
+
+```js
+class A extends null {
+    constructor() { }
+}
+```
+
+```js
+class A extends B {
+    constructor() {
+        super();
+    }
+}
+```
+
+## When Not to Use It
+
+If you don't want to be notified about invalid/missing `super()` callings in constructors, you can safely disable this rule.

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -25,10 +25,6 @@ var estraverse = require("estraverse-fb"),
 // Helpers
 //------------------------------------------------------------------------------
 
-// TODO: Remove when estraverse is updated
-estraverse.Syntax.Super = "Super";
-estraverse.VisitorKeys.Super = [];
-
 /**
  * Parses a list of "name:boolean_value" or/and "name" options divided by comma or
  * whitespace.

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview A rule to verify `super()` callings in constructor.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    /**
+     * Searches a class node from ancestors of a node.
+     * @param {Node} node - A node to get.
+     * @returns {ClassDeclaration|ClassExpression|null} the found class node or `null`.
+     */
+    function getClassInAncestor(node) {
+        while (node != null) {
+            if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
+                return node;
+            }
+            node = node.parent;
+        }
+        /* istanbul ignore next */
+        return null;
+    }
+
+    /**
+     * Checks whether or not a node is the null literal.
+     * @param {Node} node - A node to check.
+     * @returns {boolean} whether or not a node is the null literal.
+     */
+    function isNullLiteral(node) {
+        return node != null && node.type === "Literal" && node.value === null;
+    }
+
+    /**
+     * Checks whether or not the current traversal context is on constructors.
+     * @param {{scope: Scope}} item - A checking context to check.
+     * @returns {boolean} whether or not the current traversal context is on constructors.
+     */
+    function isOnConstructor(item) {
+        return item != null && item.scope === context.getScope().variableScope.upper.variableScope;
+    }
+
+    // A stack for checking context.
+    var stack = [];
+
+    return {
+        /**
+         * Start checking.
+         * @param {MethodDefinition} node - A target node.
+         * @returns {void}
+         */
+        "MethodDefinition": function(node) {
+            if (node.kind !== "constructor") {
+                return;
+            }
+            stack.push({
+                superCallings: [],
+                scope: context.getScope().variableScope
+            });
+        },
+
+        /**
+         * Checks the result, then reports invalid/missing `super()`.
+         * @param {MethodDefinition} node - A target node.
+         * @returns {void}
+         */
+        "MethodDefinition:exit": function(node) {
+            if (node.kind !== "constructor") {
+                return;
+            }
+            var result = stack.pop();
+
+            var classNode = getClassInAncestor(node);
+            /* istanbul ignore if */
+            if (classNode == null) {
+                return;
+            }
+
+            if (classNode.superClass === null || isNullLiteral(classNode.superClass)) {
+                result.superCallings.forEach(function(superCalling) {
+                    context.report(superCalling, "unexpected `super()`.");
+                });
+            } else if (result.superCallings.length === 0) {
+                context.report(node.key, "this constructor requires `super()`.");
+            }
+        },
+
+        /**
+         * Checks the result of checking, then reports invalid/missing `super()`.
+         * @param {MethodDefinition} node - A target node.
+         * @returns {void}
+         */
+        "CallExpression": function(node) {
+            var item = stack[stack.length - 1];
+            if (isOnConstructor(item) && node.callee.type === "Super") {
+                item.superCallings.push(node);
+            }
+        }
+    };
+};
+
+module.exports.schema = [];

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "escape-string-regexp": "^1.0.2",
     "escope": "^3.1.0",
     "espree": "^2.0.1",
-    "estraverse": "^2.0.0",
+    "estraverse": "^4.1.0",
     "estraverse-fb": "^1.3.1",
     "globals": "^8.0.0",
     "inquirer": "^0.8.2",

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -1,0 +1,100 @@
+/**
+ * @fileoverview Tests for constructor-super rule.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint");
+var ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/constructor-super", {
+    valid: [
+        // non derived classes.
+        { code: "class A { }", ecmaFeatures: {classes: true} },
+        { code: "class A { constructor() { } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends null { }", ecmaFeatures: {classes: true} },
+        { code: "class A extends null { constructor() { } }", ecmaFeatures: {classes: true} },
+
+        // derived classes.
+        { code: "class A extends B { }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { super(); } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { if (true) { super(); } else { super(); } } }", ecmaFeatures: {classes: true} },
+
+        // nested.
+        { code: "class A { constructor() { class B extends C { constructor() { super(); } } } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { super(); class C extends D { constructor() { super(); } } } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { super(); class C { constructor() { } } } }", ecmaFeatures: {classes: true} },
+
+        // ignores out of constructors.
+        { code: "class A { b() { super(); } }", ecmaFeatures: {classes: true} },
+        { code: "function a() { super(); }", ecmaFeatures: {classes: true} }
+    ],
+    invalid: [
+        // non derived classes.
+        {
+            code: "class A { constructor() { super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "unexpected `super()`.", type: "CallExpression"}]
+        },
+        {
+            code: "class A extends null { constructor() { super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "unexpected `super()`.", type: "CallExpression"}]
+        },
+
+        // derived classes.
+        {
+            code: "class A extends B { constructor() { } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+        },
+
+        // nested execution scope.
+        {
+            code: "class A extends B { constructor() { function c() { super(); } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+        },
+        {
+            code: "class A extends B { constructor() { var c = function() { super(); } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+        },
+        {
+            code: "class A extends B { constructor() { var c = () => super(); } }",
+            ecmaFeatures: {classes: true, arrowFunctions: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+        },
+        {
+            code: "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 20}]
+        },
+        {
+            code: "class A extends B { constructor() { var C = class extends D { constructor() { super(); } } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 20}]
+        },
+        {
+            code: "class A extends B { constructor() { super(); class C extends D { constructor() { } } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 65}]
+        },
+        {
+            code: "class A extends B { constructor() { super(); var C = class extends D { constructor() { } } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 71}]
+        }
+    ]
+});


### PR DESCRIPTION
I made analyzing the execution paths of constructors.

This rule verify all execution paths, then report invalid/missing `super()` calling. So even if `super()`/`return a;`/`throw new Error()` were mixed, this rule can verify `super()` callings correctly.

(This rule doesn't evaluate constant expressions, so `if (false) { }` is treated as a valid path.)