### PR TITLE
Fix: space-unary-ops flags expressions starting w/ keyword (fixes #2764)

### DIFF
--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -65,7 +65,7 @@ module.exports = function(context) {
             firstToken = tokens[0],
             secondToken = tokens[1];
 
-        if (firstToken.type === "Keyword") {
+        if ((node.type === "NewExpression" || node.prefix) && firstToken.type === "Keyword") {
             checkUnaryWordOperatorForSpaces(node, firstToken, secondToken);
             return void 0;
         }

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -21,6 +21,22 @@ eslintTester.addRuleTest("lib/rules/space-unary-ops", {
 
     valid: [
         {
+            code: "++this.a",
+            args: [1, { "words": true }]
+        },
+        {
+            code: "--this.a",
+            args: [1, { "words": true }]
+        },
+        {
+            code: "this.a++",
+            args: [1, { "words": true }]
+        },
+        {
+            code: "this.a--",
+            args: [1, { "words": true }]
+        },
+        {
             code: "delete foo.bar",
             args: [1, { "words": true }]
         },


### PR DESCRIPTION
Fixes #2764.