### PR TITLE
Fix: comma-dangle with always-multiline shouldn't allow a trailing comma without a new line afterward

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -97,6 +97,9 @@ var foo = { bar: "baz", qux: "quux", };
 
 var arr = [1,2,];
 
+var arr = [1,
+    2,];
+
 var arr = [
     1,
     2
@@ -118,6 +121,9 @@ var foo = {
 
 var foo = {bar: "baz", qux: "quux"};
 var arr = [1,2];
+
+var arr = [1,
+    2];
 
 var arr = [
     1,

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -25,7 +25,7 @@ module.exports = function (context) {
     function checkForTrailingComma(node) {
         var items = node.properties || node.elements,
             length = items.length,
-            nodeIsMultiLine = node.loc.start.line !== node.loc.end.line,
+            lastTokenOnNewLine,
             lastItem,
             penultimateToken,
             hasDanglingComma;
@@ -39,9 +39,10 @@ module.exports = function (context) {
                 if (forbidDangle && hasDanglingComma) {
                     context.report(lastItem, penultimateToken.loc.start, UNEXPECTED_MESSAGE);
                 } else if (allowDangle === "always-multiline") {
-                    if (hasDanglingComma && !nodeIsMultiLine) {
+                    lastTokenOnNewLine = node.loc.end.line !== penultimateToken.loc.end.line;
+                    if (hasDanglingComma && !lastTokenOnNewLine) {
                         context.report(lastItem, penultimateToken.loc.start, UNEXPECTED_MESSAGE);
-                    } else if (!hasDanglingComma && nodeIsMultiLine) {
+                    } else if (!hasDanglingComma && lastTokenOnNewLine) {
                         context.report(lastItem, penultimateToken.loc.end, MISSING_MESSAGE);
                     }
                 } else if (allowDangle === "always" && !hasDanglingComma) {

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -54,6 +54,11 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
         { code: "var foo = {\nbar: 'baz',\n}", options: [ "always-multiline" ] },
         { code: "var foo = [ 'baz' ]", options: [ "always-multiline" ] },
         { code: "var foo = [\n'baz',\n]", options: [ "always-multiline" ] },
+        { code: "var foo = { bar:\n\n'bar' }", options: [ "always-multiline" ] },
+        { code: "var foo = {a: 1, b: 2, c: 3, d: 4}", options: [ "always-multiline" ]},
+        { code: "var foo = {a: 1, b: 2,\n c: 3, d: 4}", options: [ "always-multiline" ]},
+        { code: "var foo = {x: {\nfoo: 'bar',\n}}", options: [ "always-multiline" ]},
+        { code: "var foo = new Map([\n[key, {\na: 1,\nb: 2,\nc: 3,\n}],\n])", options: [ "always-multiline" ]},
         { code: "[,,]", options: [ "always" ] },
         { code: "[\n,\n,\n]", options: [ "always" ] },
         { code: "[,]", options: [ "always" ] },
@@ -336,14 +341,38 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
             ]
         },
         {
-            code: "var foo = { bar:\n\n'bar' }",
+            code: "var foo = {x: {\nfoo: 'bar',\n},}",
             options: [ "always-multiline" ],
             errors: [
                 {
-                    message: "Missing trailing comma.",
+                    message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 3,
-                    column: 5
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "var foo = {a: 1, b: 2,\nc: 3, d: 4,}",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 2,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "var foo = [{\na: 1,\nb: 2,\nc: 3,\nd: 4,\n},]",
+            options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "ObjectExpression",
+                    line: 6,
+                    column: 1
                 }
             ]
         }


### PR DESCRIPTION
Fixes #2091.

Sorry for the long commit message.