### PR TITLE
Fix: object-shorthand rule should not warn for NFEs (fixes #2748)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -48,7 +48,7 @@ module.exports = function(context) {
                 return;
             }
 
-            if (node.value.type === "FunctionExpression" && APPLY_TO_METHODS) {
+            if (node.value.type === "FunctionExpression" && node.value.id == null && APPLY_TO_METHODS) {
 
                 // {x: function(){}} should be written as {x() {}}
                 context.report(node, "Expected method shorthand.");

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -52,6 +52,7 @@ eslintTester.addRuleTest("lib/rules/object-shorthand", {
         { code: "doSomething({y() {}})", ecmaFeatures: features},
         { code: "doSomething({x: y, y() {}})", ecmaFeatures: features},
         { code: "doSomething({y() {}, z: a})", ecmaFeatures: features},
+        { code: "!{ a: function a(){} };", ecmaFeatures: features },
 
         // arrows functions are still alright
         { code: "var x = {y: (x)=>x}", ecmaFeatures: features },
@@ -90,7 +91,6 @@ eslintTester.addRuleTest("lib/rules/object-shorthand", {
         { code: "doSomething({'x': x})", ecmaFeatures: features, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
         { code: "doSomething({a: 'a', 'x': x})", ecmaFeatures: features, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
         { code: "doSomething({y: function() {}})", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
-        { code: "doSomething({y: function y() {}})", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
 
         // options
         { code: "var x = {y: function() {}}", ecmaFeatures: features, errors: [{ message: "Expected method shorthand.", type: "Property" }], args: [2, "methods"] },


### PR DESCRIPTION
Fixes #2748.