### PR TITLE
Docs: Fix a minor typo in a prefer-const example

### DIFF
--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -17,7 +17,7 @@ console.log(a);
 ```
 
 ```js
-for (let i in [1,2,3]) { // `a` is re-defined (not modified) on each loop step.
+for (let i in [1,2,3]) { // `i` is re-defined (not modified) on each loop step.
     console.log(i);
 }
 ```


### PR DESCRIPTION
This fixes a minor typo in the prefer-const for-in example. The explanatory comment referred to a variable name not used in the code.