### PR TITLE
Fix: one-var 'never' option for mixed initialization (Fixes #2786)

### DIFF
--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -138,6 +138,23 @@ module.exports = function(context) {
     }
 
     /**
+     * Determines the current scope (function or block)
+     * @param  {string} statementType node.kind, one of: "var", "let", or "const"
+     * @returns {Object} The scope associated with statementType
+     */
+    function getCurrentScope(statementType) {
+        var currentScope;
+        if (statementType === "var") {
+            currentScope = functionStack[functionStack.length - 1];
+        } else if (statementType === "let") {
+            currentScope = blockStack[blockStack.length - 1].let;
+        } else if (statementType === "const") {
+            currentScope = blockStack[blockStack.length - 1].const;
+        }
+        return currentScope;
+    }
+
+    /**
      * Counts the number of initialized and uninitialized declarations in a list of declarations
      * @param {ASTNode[]} declarations List of declarations
      * @returns {Object} Counts of 'uninitialized' and 'initialized' declarations
@@ -163,17 +180,10 @@ module.exports = function(context) {
      * @private
      */
     function hasOnlyOneStatement(statementType, declarations) {
-        var currentScope;
+
         var declarationCounts = countDeclarations(declarations);
         var currentOptions = options[statementType] || {};
-
-        if (statementType === "var") {
-            currentScope = functionStack[functionStack.length - 1];
-        } else if (statementType === "let") {
-            currentScope = blockStack[blockStack.length - 1].let;
-        } else if (statementType === "const") {
-            currentScope = blockStack[blockStack.length - 1].const;
-        }
+        var currentScope = getCurrentScope(statementType);
 
         if (currentOptions.uninitialized === MODE_ALWAYS && currentOptions.initialized === MODE_ALWAYS) {
             if (currentScope.uninitialized || currentScope.initialized) {
@@ -236,20 +246,17 @@ module.exports = function(context) {
             }
             // never
             if (parent.type !== "ForStatement" || parent.init !== node) {
-                if (options[type].initialized === MODE_NEVER && options[type].uninitialized === MODE_NEVER) {
-                    if ((declarationCounts.uninitialized + declarationCounts.initialized) > 1) {
+                var totalDeclarations = declarationCounts.uninitialized + declarationCounts.initialized;
+                if (totalDeclarations > 1) {
+                    // both initialized and uninitialized
+                    if (options[type].initialized === MODE_NEVER && options[type].uninitialized === MODE_NEVER) {
                         context.report(node, "Split '" + type + "' declarations into multiple statements.");
-                    }
-                } else {
-                    if (options[type].initialized === MODE_NEVER) {
-                        if (declarationCounts.initialized > 1) {
-                            context.report(node, "Split initialized '" + type + "' declarations into multiple statements.");
-                        }
-                    }
-                    if (options[type].uninitialized === MODE_NEVER) {
-                        if (declarationCounts.uninitialized > 1) {
-                            context.report(node, "Split uninitialized '" + type + "' declarations into multiple statements.");
-                        }
+                    // initialized
+                    } else if (options[type].initialized === MODE_NEVER && declarationCounts.initialized > 0) {
+                        context.report(node, "Split initialized '" + type + "' declarations into multiple statements.");
+                    // uninitialized
+                    } else if (options[type].uninitialized === MODE_NEVER && declarationCounts.uninitialized > 0) {
+                        context.report(node, "Split uninitialized '" + type + "' declarations into multiple statements.");
                     }
                 }
             }

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -465,6 +465,22 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                 line: 2,
                 column: 0
             } ]
+        },
+        {
+            code: "var i = [0], j;",
+            options: [ { "initialized": "never" } ],
+            errors: [ {
+                message: "Split initialized 'var' declarations into multiple statements.",
+                type: "VariableDeclaration"
+            } ]
+        },
+        {
+            code: "var i = [0], j;",
+            options: [ { "uninitialized": "never" } ],
+            errors: [ {
+                message: "Split uninitialized 'var' declarations into multiple statements.",
+                type: "VariableDeclaration"
+            } ]
         }
     ]
 });


### PR DESCRIPTION
These changes will ensure that if `"never"` is specified for `"initialized"` or `"uninitialized"`, that type of var declaration must be on its own, and not grouped with other declarations of the opposite type.