### PR TITLE
Update: Ignore JsDoc comments by default for `spaced-comment` (fixes …

### DIFF
--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -131,3 +131,18 @@ var foo = 5;
 subsequent lines are ignored
 */
 ```
+
+```js
+// When ["always"]
+/**
+* I am jsdoc
+*/
+```
+
+```js
+// When ["never"]
+/**
+* I am jsdoc
+*/
+```
+

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -18,6 +18,7 @@ module.exports = function(context) {
     // Default to match anything, so all will fail if there are no exceptions
     var exceptionMatcher = new RegExp(" ");
     var markerMatcher = new RegExp(" ");
+    var jsDocMatcher = new RegExp("((^(\\*)))[ \\n]");
 
     // Fetch the options dict
     var hasOptions = context.options.length === 2;
@@ -49,6 +50,17 @@ module.exports = function(context) {
         markerMatcher = new RegExp("((^(" + markers.join("))|(^(") + ")))[ \\t\\n]");
     }
 
+    /**
+     * Check to see if the block comment is jsDoc comment
+     * @param {ASTNode} node comment node
+     * @returns {boolean} True if its jsdoc comment
+     * @private
+     */
+    function isJsdoc(node) {
+        // make sure comment type is block and it start with /**\n
+        return node.type === "Block" && jsDocMatcher.test(node.value);
+    }
+
 
     function checkCommentForSpace(node) {
         var commentIdentifier = node.type === "Block" ? "/*" : "//";
@@ -57,6 +69,11 @@ module.exports = function(context) {
 
             // If length is zero, ignore it
             if (node.value.length === 0) {
+                return;
+            }
+
+            // if comment is jsdoc style then ignore it
+            if (isJsdoc(node)) {
                 return;
             }
 

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -134,7 +134,20 @@ eslintTester.addRuleTest("lib/rules/spaced-comment", {
         {
             code: "/*!\n *comment\n */",
             options: ["always", { markers: ["!"] }]
+        },
+        {
+            code: "/**\n *jsdoc\n */",
+            options: ["always"]
+        },
+        {
+            code: "/**\n *jsdoc\n */",
+            options: ["never"]
+        },
+        {
+            code: "/**   \n *jsdoc \n */",
+            options: ["always"]
         }
+
     ],
 
     invalid: [


### PR DESCRIPTION
…#2766)