### PR TITLE
New: Option to specify a specific plugin module name when prefixed with a ~

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -97,21 +97,19 @@ debug = debug("eslint:cli-engine");
 function loadPlugins(pluginNames) {
     if (pluginNames) {
         pluginNames.forEach(function (pluginName) {
-            var pluginNamespace = util.getNamespace(pluginName),
-                pluginNameWithoutNamespace = util.removeNameSpace(pluginName),
-                pluginNameWithoutPrefix = util.removePluginPrefix(pluginNameWithoutNamespace),
+            var parsedName = util.parsePluginName(pluginName),
                 plugin;
 
-            if (!loadedPlugins[pluginNameWithoutPrefix]) {
-                debug("Load plugin " + pluginNameWithoutPrefix);
+            if (!loadedPlugins[parsedName.key]) {
+                debug("Load plugin " + parsedName.key);
 
-                plugin = require(pluginNamespace + util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+                plugin = require(parsedName.entry);
                 // if this plugin has rules, import them
                 if (plugin.rules) {
-                    rules.import(plugin.rules, pluginNameWithoutPrefix);
+                    rules.import(plugin.rules, parsedName.key);
                 }
 
-                loadedPlugins[pluginNameWithoutPrefix] = plugin;
+                loadedPlugins[parsedName.key] = plugin;
             }
         });
     }

--- a/lib/config.js
+++ b/lib/config.js
@@ -149,22 +149,20 @@ function getPluginsConfig(pluginNames) {
     var pluginConfig = {};
 
     pluginNames.forEach(function (pluginName) {
-        var pluginNamespace = util.getNamespace(pluginName),
-            pluginNameWithoutNamespace = util.removeNameSpace(pluginName),
-            pluginNameWithoutPrefix = util.removePluginPrefix(pluginNameWithoutNamespace),
+        var parsedName = util.parsePluginName(pluginName),
             plugin = {},
             rules = {};
 
-        if (!loadedPlugins[pluginNameWithoutPrefix]) {
+        if (!loadedPlugins[parsedName.key]) {
             try {
-                plugin = require(pluginNamespace + util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
-                loadedPlugins[pluginNameWithoutPrefix] = plugin;
+                plugin = require(parsedName.entry);
+                loadedPlugins[parsedName.key] = plugin;
             } catch(err) {
-                debug("Failed to load plugin configuration for " + pluginNameWithoutPrefix + ". Proceeding without it.");
+                debug("Failed to load plugin configuration for " + parsedName.key + ". Proceeding without it.");
                 plugin = { rulesConfig: {}};
             }
         } else {
-            plugin = loadedPlugins[pluginNameWithoutPrefix];
+            plugin = loadedPlugins[parsedName.key];
         }
 
         if (!plugin.rulesConfig) {
@@ -172,7 +170,7 @@ function getPluginsConfig(pluginNames) {
         }
 
         Object.keys(plugin.rulesConfig).forEach(function(item) {
-            rules[pluginNameWithoutPrefix + "/" + item] = plugin.rulesConfig[item];
+            rules[parsedName.key + "/" + item] = plugin.rulesConfig[item];
         });
 
         pluginConfig = util.mergeConfigs(pluginConfig, rules);

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,6 +8,7 @@
 //------------------------------------------------------------------------------
 
 var PLUGIN_NAME_PREFIX = "eslint-plugin-",
+    SPECIFIC_MODULE_REGEX = /^~(.*)/i,
     NAMESPACE_REGEX = /^@.*\//i;
 
 //------------------------------------------------------------------------------
@@ -80,6 +81,32 @@ exports.getNamespace = function getNamespace(pluginName) {
  */
 exports.removeNameSpace = function removeNameSpace(pluginName) {
     return pluginName.replace(NAMESPACE_REGEX, "");
+};
+
+/**
+ * Parses the pluginName string
+ *
+ * @param {string} pluginName The name of the plugin which may have the prefix.
+ * @returns {Object} parsed pluginName object.
+ */
+exports.parsePluginName = function parsePluginName(pluginName) {
+    var namespace = exports.getNamespace(pluginName),
+        withoutNamespace = exports.removeNameSpace(pluginName),
+        key,
+        entry;
+
+    if (pluginName.match(SPECIFIC_MODULE_REGEX)) {
+        entry = pluginName.match(SPECIFIC_MODULE_REGEX)[1];
+        key = entry.split("/")[0];
+    } else {
+        key = exports.removePluginPrefix(withoutNamespace);
+        entry = namespace + PLUGIN_NAME_PREFIX + key;
+    }
+
+    return {
+        key: key,
+        entry: entry
+    };
 };
 
 exports.PLUGIN_NAME_PREFIX = PLUGIN_NAME_PREFIX;

--- a/tests/lib/util.js
+++ b/tests/lib/util.js
@@ -30,16 +30,39 @@ describe("util", function() {
     });
 
     describe("getNamespace()", function() {
-        it("should remove namepace when passed with namepace", function() {
-            var namespace = util.getNamespace("@namepace/eslint-plugin-test");
-            assert.equal(namespace, "@namepace/");
+        it("should remove namespace when passed with namespace", function() {
+            var namespace = util.getNamespace("@namespace/eslint-plugin-test");
+            assert.equal(namespace, "@namespace/");
         });
     });
 
     describe("removeNameSpace()", function() {
-        it("should remove namepace when passed with namepace", function() {
-            var namespace = util.removeNameSpace("@namepace/eslint-plugin-test");
+        it("should remove namespace when passed with namespace", function() {
+            var namespace = util.removeNameSpace("@namespace/eslint-plugin-test");
             assert.equal(namespace, "eslint-plugin-test");
+        });
+    });
+
+    describe("parsePluginName()", function() {
+        it("should parse the plugin name with npm namespace", function() {
+            var parsed = util.parsePluginName("@namespace/eslint-plugin-test");
+
+            assert.equal(parsed.key, "test");
+            assert.equal(parsed.entry, "@namespace/eslint-plugin-test");
+        });
+
+        it("should parse the plugin name with explicit path", function() {
+            var parsed = util.parsePluginName("~module/path");
+
+            assert.equal(parsed.key, "module");
+            assert.equal(parsed.entry, "module/path");
+        });
+
+        it("should parse the short plugin name", function() {
+            var parsed = util.parsePluginName("test");
+
+            assert.equal(parsed.key, "test");
+            assert.equal(parsed.entry, "eslint-plugin-test");
         });
     });
 


### PR DESCRIPTION
Allows you to specify a specific module to import. The primary use case would be for a custom parser that would also like to add additional rules.

Initially proposed in https://github.com/babel/babel-eslint/issues/131#issuecomment-113330418

This would allow custom parsers and custom named modules to be included as plugins. So for example with something like babel-eslint the parser and additional rules could be housed in the same project instead of separate repos therefore keeping babel-eslint related issues consolidated to a single repo. An example configuration would be:

```
{
  "parser": "babel-eslint",
  "plugins": [
    "~babel-eslint/plugin"
  ],
  rules: {
    "babel-eslint/es7.objectRestSpread": 1
  }
}
```