### PR TITLE
Update: Add `except-parens` option to `no-return-assign` rule (fixes #2809)

### DIFF
--- a/docs/rules/no-return-assign.md
+++ b/docs/rules/no-return-assign.md
@@ -16,6 +16,18 @@ Because of this ambiguity, it's considered a best practice to not use assignment
 
 This rule aims to eliminate assignments from `return` statements. As such, it will warn whenever an assignment is found as part of `return`.
 
+### Options
+
+The rule takes one option, a string, which must contain one of the following values:
+
+* `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
+* `always`: Disallow all assignments.
+
+#### "except-parens"
+
+This is the default option.
+It disallows assignments unless they are enclosed in parentheses.
+
 The following patterns are considered warnings:
 
 ```js
@@ -25,6 +37,43 @@ function doSomething() {
 
 function doSomething() {
     return foo += 2;
+}
+```
+
+The following patterns are not warnings:
+
+```js
+function doSomething() {
+    return foo == bar + 2;
+}
+
+function doSomething() {
+    return foo === bar + 2;
+}
+
+function doSomething() {
+    return (foo = bar + 2);
+}
+```
+
+#### "always"
+
+This option disallows all assignments in `return` statements.
+All assignments are treated as warnings.
+
+The following patterns are considered warnings:
+
+```js
+function doSomething() {
+    return foo = bar + 2;
+}
+
+function doSomething() {
+    return foo += 2;
+}
+
+function doSomething() {
+    return (foo = bar + 2);
 }
 ```
 

--- a/lib/rules/no-return-assign.js
+++ b/lib/rules/no-return-assign.js
@@ -5,20 +5,49 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a node is an `AssignmentExpression`.
+ * @param {Node|null} node - A node to check.
+ * @returns {boolean} Whether or not the node is an `AssignmentExpression`.
+ */
+function isAssignment(node) {
+    return node != null && node.type === "AssignmentExpression";
+}
+
+/**
+ * Checks whether or not a node is enclosed in parentheses.
+ * @param {Node|null} node - A node to check.
+ * @param {RuleContext} context - The current context.
+ * @returns {boolean} Whether or not the node is enclosed in parentheses.
+ */
+function isEnclosedInParens(node, context) {
+    var prevToken = context.getTokenBefore(node);
+    var nextToken = context.getTokenAfter(node);
+
+    return prevToken.value === "(" && nextToken.value === ")";
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var always = (context.options[0] || "except-parens") !== "except-parens";
 
     return {
-
         "ReturnStatement": function(node) {
-            if (node.argument && node.argument.type === "AssignmentExpression") {
+            if (isAssignment(node.argument) && (always || !isEnclosedInParens(node.argument, context))) {
                 context.report(node, "Return statement should not contain assignment.");
             }
         }
     };
-
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "enum": ["except-parens", "always"]
+    }
+];

--- a/tests/lib/rules/no-return-assign.js
+++ b/tests/lib/rules/no-return-assign.js
@@ -16,12 +16,57 @@ var eslint = require("../../../lib/eslint"),
 // Tests
 //------------------------------------------------------------------------------
 
+var error = {
+    message: "Return statement should not contain assignment.",
+    type: "ReturnStatement"
+};
+
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-return-assign", {
     valid: [
-        "function x() { var result = a * b; return result; };"
+        "function x() { var result = a * b; return result; }",
+        "function x() { return (result = a * b); }",
+        {
+            code: "function x() { var result = a * b; return result; }",
+            options: ["except-parens"]
+        },
+        {
+            code: "function x() { return (result = a * b); }",
+            options: ["except-parens"]
+        },
+        {
+            code: "function x() { var result = a * b; return result; }",
+            options: ["always"]
+        }
     ],
     invalid: [
-        { code: "function x() { return result = a * b; };", errors: [{ message: "Return statement should not contain assignment.", type: "ReturnStatement"}] }
+        {
+            code: "function x() { return result = a * b; };",
+            errors: [error]
+        },
+        {
+            code: "function x() { return (result) = (a * b); };",
+            errors: [error]
+        },
+        {
+            code: "function x() { return result = a * b; };",
+            options: ["except-parens"],
+            errors: [error]
+        },
+        {
+            code: "function x() { return (result) = (a * b); };",
+            options: ["except-parens"],
+            errors: [error]
+        },
+        {
+            code: "function x() { return result = a * b; };",
+            options: ["always"],
+            errors: [error]
+        },
+        {
+            code: "function x() { return (result = a * b); };",
+            options: ["always"],
+            errors: [error]
+        }
     ]
 });


### PR DESCRIPTION
I added the option and its tests.

I made a default value of the option `"except-parens"` as same as the `no-cond-assign` rule.
Please tell me if this is a problem.