### PR TITLE
Update: refactor handle-callback-err to improve performance (fixes #2841)

### DIFF
--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Ensure handling of errors when we know they exist.
  * @author Jamund Ferguson
+ * @copyright 2015 Mathias Schreck.
  * @copyright 2014 Jamund Ferguson. All rights reserved.
  */
 
@@ -13,8 +14,6 @@
 module.exports = function(context) {
 
     var errorArgument = context.options[0] || "err";
-    var callbacks = [];
-    var scopes = 0;
 
     /**
      * Checks if the given argument should be interpreted as a regexp pattern.
@@ -40,44 +39,14 @@ module.exports = function(context) {
     }
 
     /**
-     * Check the arguments to see if we need to start tracking the error object.
-     * @param {ASTNode} node The AST node to check.
-     * @returns {void}
+     * Get the parameters of a given function scope.
+     * @param {object} scope The function scope.
+     * @returns {array} All parameters of the given scope.
      */
-    function startFunction(node) {
-
-        // keep track of nested scopes
-        scopes++;
-
-        // check if the first argument matches our argument name
-        var firstArg = node.params && node.params[0];
-        if (firstArg && matchesConfiguredErrorName(firstArg.name)) {
-            callbacks.push({handled: false, depth: scopes, errorVariableName: firstArg.name});
-        }
-    }
-
-    /**
-     * At the end of a function check to see if the error was handled.
-     * @param {ASTNode} node The AST node to check.
-     * @returns {void}
-     */
-    function endFunction(node) {
-
-        var callback = callbacks[callbacks.length - 1] || {};
-
-        // check if a callback is ending, if so pop it off the stack
-        if (callback.depth === scopes) {
-            callbacks.pop();
-
-            // check if there were no handled errors since the last callback
-            if (!callback.handled) {
-                context.report(node, "Expected error to be handled.");
-            }
-        }
-
-        // less nested functions
-        scopes--;
-
+    function getParameters(scope) {
+        return scope.variables.filter(function (variable) {
+            return variable.defs[0] && variable.defs[0].type === "Parameter";
+        });
     }
 
     /**
@@ -86,38 +55,21 @@ module.exports = function(context) {
      * @returns {void}
      */
     function checkForError(node) {
-        if (callbacks.length > 0) {
-            var callback = callbacks[callbacks.length - 1] || {};
+        var scope = context.getScope(),
+            parameters = getParameters(scope),
+            firstParameter = parameters[0];
 
-            // make sure the node's name matches our error argument name
-            var isAboutError = node.name === callback.errorVariableName;
-
-            // we don't consider being params in these use cases as "handling" the error
-            var doNotCount = ["FunctionDeclaration", "ArrowFunctionExpression", "FunctionExpression", "CatchClause"];
-
-            // make sure this identifier isn't used as part of one of them
-            var isHandled = doNotCount.indexOf(node.parent.type) === -1;
-
-            // special handling for arrow function expressions where we return the error
-            if (node.parent.type === "ArrowFunctionExpression" && node === node.parent.body) {
-                isHandled = true;
-            }
-
-            if (isAboutError && isHandled) {
-                // record that this callback handled its error
-                callback.handled = true;
+        if (firstParameter && matchesConfiguredErrorName(firstParameter.name)) {
+            if (firstParameter.references.length === 0) {
+                context.report(node, "Expected error to be handled.");
             }
         }
     }
 
     return {
-        "FunctionDeclaration": startFunction,
-        "FunctionExpression": startFunction,
-        "ArrowFunctionExpression": startFunction,
-        "Identifier": checkForError,
-        "FunctionDeclaration:exit": endFunction,
-        "FunctionExpression:exit": endFunction,
-        "ArrowFunctionExpression:exit": endFunction
+        "FunctionDeclaration": checkForError,
+        "FunctionExpression": checkForError,
+        "ArrowFunctionExpression": checkForError
     };
 
 };


### PR DESCRIPTION
**Before**:

```
TIMING=1 ./bin/eslint.js lib
handle-callback-err     |    67.463 |     4.2%
```

```
TIMING=1 ./node_modules/.bin/mocha tests/lib/rules/handle-callback-err.js
handle-callback-err |     5.256 |   100.0%
```

**After**:

```
TIMING=1 ./bin/eslint.js lib
handle-callback-err        |    10.106 |     0.7%
```

```
TIMING=1 ./node_modules/.bin/mocha tests/lib/rules/handle-callback-err.js
handle-callback-err |     3.350 |   100.0%
```