### PR TITLE
Fix no-dupe-args for destructuring sparse arrays

### DIFF
--- a/lib/rules/no-dupe-args.js
+++ b/lib/rules/no-dupe-args.js
@@ -57,7 +57,11 @@ module.exports = function(context) {
 
                 case "ArrayPattern":
                     param.elements.forEach(function(element) {
-                        markParam(element.name);
+
+                        // Arrays can be sparse (unwanted arguments)
+                        if (element !== null) {
+                            markParam(element.name);
+                        }
                     });
                     break;
 

--- a/tests/lib/rules/no-dupe-args.js
+++ b/tests/lib/rules/no-dupe-args.js
@@ -22,12 +22,14 @@ eslintTester.addRuleTest("lib/rules/no-dupe-args", {
     valid: [
         "function a(a, b, c){}",
         "var a = function(a, b, c){}",
-        { code: "function a({a, b}, {c, d}){}", ecmaFeatures: { destructuring: true } }
+        { code: "function a({a, b}, {c, d}){}", ecmaFeatures: { destructuring: true } },
+        { code: "function a([ , a]) {}", ecmaFeatures: { destructuring: true } }
     ],
     invalid: [
         { code: "function a(a, b, b) {}", errors: [{ message: "Duplicate param 'b'." }] },
         { code: "function a({a, b}, b) {}", ecmaFeatures: { destructuring: true }, errors: [{ message: "Duplicate param 'b'." }] },
         { code: "function a([a, b], b) {}", ecmaFeatures: { destructuring: true }, errors: [{ message: "Duplicate param 'b'." }] },
+        { code: "function a([ , a], [b, , a]) {}", ecmaFeatures: { destructuring: true }, errors: [{ message: "Duplicate param 'a'." }] },
         { code: "function a([a, b], {b}) {}", ecmaFeatures: { destructuring: true }, errors: [{ message: "Duplicate param 'b'." }] },
         { code: "function a(a, a, a) {}", errors: [{ message: "Duplicate param 'a'." }] },
         { code: "function a(a, b, a) {}", errors: [{ message: "Duplicate param 'a'." }]},


### PR DESCRIPTION
Previously the parser would crash on encountering an empty
element in a destructured array argument declaration.

fixes eslint/eslint#2848