### PR TITLE
New: `require-yield` rule (fixes #2822)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -158,6 +158,7 @@
         "quote-props": 0,
         "quotes": [2, "double"],
         "radix": 0,
+        "require-yield": 0,
         "semi": 2,
         "semi-spacing": [2, {"before": false, "after": true}],
         "sort-vars": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -201,6 +201,7 @@ These rules are only relevant to ES6 environments and are off by default.
 * [no-var](no-var.md) - require `let` or `const` instead of `var` (off by default)
 * [object-shorthand](object-shorthand.md) - require method and property shorthand syntax for object literals (off by default)
 * [prefer-const](prefer-const.md) - suggest using of `const` declaration for variables that are never modified after declared (off by default)
+* [require-yield](require-yield.md) - disallow generator functions that does not have `yield` (off by default)
 
 ## Legacy
 

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -1,0 +1,33 @@
+# Disallow generator functions that does not have `yield` (require-yield)
+
+This rule catches generator functions that does not have `yield`, then warns those.
+
+## Rule details
+
+The following patterns are considered warnings:
+
+```js
+function* foo() {
+  return 10;
+}
+```
+
+The following patterns are not considered warnings:
+
+```js
+function* foo() {
+  yield 5;
+  return 10;
+}
+```
+
+```js
+function foo() {
+  return 10;
+}
+```
+
+```js
+// This rule does not warn just empty generator functions.
+function* foo() { }
+```

--- a/lib/rules/require-yield.js
+++ b/lib/rules/require-yield.js
@@ -1,0 +1,62 @@
+/**
+ * @fileoverview Rule to flag the generator functions that does not have yield.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var stack = [];
+
+    /**
+     * If the node is a generator function, start counting `yield` keywords.
+     * @param {Node} node - A function node to check.
+     * @returns {void}
+     */
+    function beginChecking(node) {
+        if (node.generator) {
+            stack.push(0);
+        }
+    }
+
+    /**
+     * If the node is a generator function, end counting `yield` keywords, then
+     * reports result.
+     * @param {Node} node - A function node to check.
+     * @returns {void}
+     */
+    function endChecking(node) {
+        if (!node.generator) {
+            return;
+        }
+
+        var countYield = stack.pop();
+        if (countYield === 0 && node.body.body.length > 0) {
+            context.report(
+                node,
+                "This generator function does not have `yield`.");
+        }
+    }
+
+    return {
+        "FunctionDeclaration": beginChecking,
+        "FunctionDeclaration:exit": endChecking,
+        "FunctionExpression": beginChecking,
+        "FunctionExpression:exit": endChecking,
+
+        // Increases the count of `yield` keyword.
+        "YieldExpression": function() {
+            /* istanbul ignore else */
+            if (stack.length > 0) {
+                stack[stack.length - 1] += 1;
+            }
+        }
+    };
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/require-yield.js
+++ b/tests/lib/rules/require-yield.js
@@ -1,0 +1,102 @@
+/**
+ * @fileoverview Tests for require-yield rule
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint");
+var ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var errorMessage = "This generator function does not have `yield`.";
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/require-yield", {
+    valid: [
+        {
+            code: "function foo() { return 0; }",
+            ecmaFeatures: {generators: true}
+        },
+        {
+            code: "function* foo() { yield 0; }",
+            ecmaFeatures: {generators: true}
+        },
+        {
+            code: "function* foo() { }",
+            ecmaFeatures: {generators: true}
+        },
+        {
+            code: "(function* foo() { yield 0; })();",
+            ecmaFeatures: {generators: true}
+        },
+        {
+            code: "(function* foo() { })();",
+            ecmaFeatures: {generators: true}
+        },
+        {
+            code: "var obj = { *foo() { yield 0; } };",
+            ecmaFeatures: {generators: true, objectLiteralShorthandMethods: true}
+        },
+        {
+            code: "var obj = { *foo() { } };",
+            ecmaFeatures: {generators: true, objectLiteralShorthandMethods: true}
+        },
+        {
+            code: "class A { *foo() { yield 0; } };",
+            ecmaFeatures: {classes: true, generators: true}
+        },
+        {
+            code: "class A { *foo() { } };",
+            ecmaFeatures: {classes: true, generators: true}
+        }
+    ],
+    invalid: [
+        {
+            code: "function* foo() { return 0; }",
+            ecmaFeatures: {generators: true},
+            errors: [{message: errorMessage, type: "FunctionDeclaration"}]
+        },
+        {
+            code: "(function* foo() { return 0; })();",
+            ecmaFeatures: {generators: true},
+            errors: [{message: errorMessage, type: "FunctionExpression"}]
+        },
+        {
+            code: "var obj = { *foo() { return 0; } }",
+            ecmaFeatures: {generators: true, objectLiteralShorthandMethods: true},
+            errors: [{message: errorMessage, type: "FunctionExpression"}]
+        },
+        {
+            code: "class A { *foo() { return 0; } }",
+            ecmaFeatures: {classes: true, generators: true},
+            errors: [{message: errorMessage, type: "FunctionExpression"}]
+        },
+        {
+            code: "function* foo() { function* bar() { yield 0; } }",
+            ecmaFeatures: {generators: true},
+            errors: [{
+                message: errorMessage,
+                type: "FunctionDeclaration",
+                column: 0
+            }]
+        },
+        {
+            code: "function* foo() { function* bar() { return 0; } yield 0; }",
+            ecmaFeatures: {generators: true},
+            errors: [{
+                message: errorMessage,
+                type: "FunctionDeclaration",
+                column: 18
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
I added.

I made that this rule does not warn just empty generator functions. 
Because it's useful as a default value, or etc.