### PR TITLE
New: `no-invalid-this` rule (fixes #2815)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -36,6 +36,7 @@ rules:
     no-fallthrough: 2
     no-floating-decimal: 2
     no-implied-eval: 2
+    no-invalid-this: 2
     no-iterator: 2
     no-label-var: 2
     no-labels: 2

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -38,6 +38,7 @@
         "no-inline-comments": 0,
         "no-inner-declarations": [2, "functions"],
         "no-invalid-regexp": 2,
+        "no-invalid-this": 0,
         "no-irregular-whitespace": 2,
         "no-iterator": 0,
         "no-label-var": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -62,6 +62,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-fallthrough](no-fallthrough.md) - disallow fallthrough of `case` statements (recommended)
 * [no-floating-decimal](no-floating-decimal.md) - disallow the use of leading or trailing decimal points in numeric literals
 * [no-implied-eval](no-implied-eval.md) - disallow use of `eval()`-like methods
+* [no-invalid-this](no-invalid-this.md) - disallow `this` keywords outside of classes or class-like objects
 * [no-iterator](no-iterator.md) - disallow usage of `__iterator__` property
 * [no-labels](no-labels.md) - disallow use of labeled statements
 * [no-lone-blocks](no-lone-blocks.md) - disallow unnecessary nested blocks

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -1,0 +1,236 @@
+# Disallow `this` keywords outside of classes or class-like objects. (no-invalid-this)
+
+Under the strict mode, `this` keywords outside of classes or class-like objects might be `undefined` and raise a `TypeError`.
+
+## Rule Details
+
+This rule aims to flag usage of `this` keywords outside of classes or class-like objects.
+
+Basically this rule checks whether or not a function which are containing `this` keywords is a constructor or a method.
+
+This rule judges from following conditions whether or not the function is a constructor:
+
+* The name of the function starts with uppercase.
+* The function is a constructor of ES2015 Classes.
+
+This rule judges from following conditions whether or not the function is a method:
+
+* The function is on an object literal.
+* The function assigns to a property.
+* The function is a method/getter/setter of ES2015 Classes. (excepts static methods)
+
+And this rule allows `this` keywords in functions below:
+
+* The `call/apply/bind` method of the function is called directly.
+* The function is a callback of array methods (such as `.forEach()`) if `thisArg` is given.
+* The function has `@this` tag in its JSDoc comment.
+
+Otherwise are considered warnings.
+
+### The following patterns are considered warnings:
+
+This rule warns below **only** under the strict mode.
+Please note your code in ES2015 Modules/Classes is always the strict mode.
+
+```js
+this.a = 0;
+baz(() => this);
+```
+
+```js
+(function() {
+    this.a = 0;
+    baz(() => this);
+})();
+```
+
+```js
+function foo() {
+    this.a = 0;
+    baz(() => this);
+}
+```
+
+```js
+var foo = function() {
+    this.a = 0;
+    baz(() => this);
+};
+```
+
+```js
+foo(function() {
+    this.a = 0;
+    baz(() => this);
+});
+```
+
+```js
+obj.foo = () => {
+    // `this` of arrow functions is the outer scope's.
+    this.a = 0;
+};
+```
+
+```js
+var obj = {
+    aaa: function() {
+        return function foo() {
+            // There is in a method `aaa`, but `foo` is not a method.
+            this.a = 0;
+            baz(() => this);
+        };
+    }
+};
+```
+
+```js
+class Foo {
+    static foo() {
+        this.a = 0;
+        baz(() => this);
+    }
+}
+```
+
+```js
+foo.forEach(function() {
+    this.a = 0;
+    baz(() => this);
+});
+```
+
+### The following patterns are not considered warnings:
+
+```js
+function Foo() {
+    // OK, this is in a legacy style constructor.
+    this.a = 0;
+    baz(() => this);
+}
+```
+
+```js
+class Foo {
+    constructor() {
+        // OK, this is in a constructor.
+        this.a = 0;
+        baz(() => this);
+    }
+}
+```
+
+```js
+var obj = {
+    foo: function foo() {
+        // OK, this is in a method (this function is on object literal).
+        this.a = 0;
+    }
+};
+```
+
+```js
+var obj = {
+    foo() {
+        // OK, this is in a method (this function is on object literal).
+        this.a = 0;
+    }
+};
+```
+
+```js
+var obj = {
+    get foo() {
+        // OK, this is in a method (this function is on object literal).
+        return this.a;
+    }
+};
+```
+
+```js
+var obj = Object.create(null, {
+    foo: {value: function foo() {
+        // OK, this is in a method (this function is on object literal).
+        this.a = 0;
+    }}
+});
+```
+
+```js
+Object.defineProperty(obj, "foo", {
+    value: function foo() {
+        // OK, this is in a method (this function is on object literal).
+        this.a = 0;
+    }
+};
+```
+
+```js
+Object.defineProperties(obj, {
+    foo: {value: function foo() {
+        // OK, this is in a method (this function is on object literal).
+        this.a = 0;
+    }}
+};
+```
+
+```js
+function Foo() {
+    this.foo = function foo() {
+        // OK, this is in a method (this function assigns to a property).
+        this.a = 0;
+        baz(() => this);
+    };
+}
+```
+
+```js
+obj.foo = function foo() {
+    // OK, this is in a method (this function assigns to a property).
+    this.a = 0;
+};
+```
+
+```js
+Foo.prototype.foo = function foo() {
+    // OK, this is in a method (this function assigns to a property).
+    this.a = 0;
+};
+```
+
+```js
+class Foo {
+    foo() {
+        // OK, this is in a method.
+        this.a = 0;
+        baz(() => this);
+    }
+}
+```
+
+```js
+var foo = (function foo() {
+    // OK, the `bind` method of this function is called directly.
+    this.a = 0;
+}).bind(obj);
+```
+
+```js
+foo.forEach(function() {
+    // OK, `thisArg` of `.forEach()` is given.
+    this.a = 0;
+    baz(() => this);
+}, thisArg);
+```
+
+```js
+/** @this Foo */
+function foo() {
+    // OK, this function has a `@this` tag in its JSDoc comment.
+    this.a = 0;
+}
+```
+
+## When Not To Use It
+
+If you don't want to be notified about usage of `this` keyword outside of classes or class-like objects, you can safely disable this rule.

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -1,0 +1,340 @@
+/**
+ * @fileoverview A rule to disallow `this` keywords outside of classes or class-like objects.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var thisTagPattern = /^[\s\*]*@this/m;
+var anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionExpression)$/;
+var bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/;
+var arrayOrTypedArrayPattern = /Array$/;
+var arrayMethodPattern = /^(?:every|filter|find|findIndex|forEach|map|some)$/;
+
+/**
+ * Checks whether or not a node is a constructor.
+ * @param {ASTNode} node - A function node to check.
+ * @returns {boolean} Wehether or not a node is a constructor.
+ */
+function isES5Constructor(node) {
+    return (
+        node.id != null &&
+        node.id.name[0] === node.id.name[0].toLocaleUpperCase()
+    );
+}
+
+/**
+ * Checks whether or not a node has a `@this` tag in its comments.
+ * @param {ASTNode} node - A node to check.
+ * @param {RuleContext} context - A context to get the comments of the node.
+ * @returns {boolean} Whether or not the node has a `@this` tag in its comments.
+ */
+function hasJSDocThisTag(node, context) {
+    return context.getComments(node).leading.some(function(comment) {
+        return thisTagPattern.test(comment.value);
+    });
+}
+
+/**
+ * Finds a function node from ancestors of a node.
+ * @param {ASTNode} node - A start node to find.
+ * @returns {Node|null} A found function node.
+ */
+function getUpperFunction(node) {
+    while (node != null) {
+        if (anyFunctionPattern.test(node.type)) {
+            return node;
+        }
+        node = node.parent;
+    }
+    return null;
+}
+
+/**
+ * Checks whether or not a node is callee.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is callee.
+ */
+function isCallee(node) {
+    return node.parent.type === "CallExpression" && node.parent.callee === node;
+}
+
+/**
+ * Checks whether or not a node is `null` or `undefined`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a `null` or `undefined`.
+ */
+function isNullOrUndefined(node) {
+    return (
+        (node.type === "Literal" && node.value === null) ||
+        (node.type === "Identifier" && node.name === "undefined") ||
+        (node.type === "UnaryExpression" && node.operator === "void")
+    );
+}
+
+/**
+ * Checks whether or not a node is `Reclect.apply`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a `Reclect.apply`.
+ */
+function isReflectApply(node) {
+    return (
+        node.type === "MemberExpression" &&
+        node.object.type === "Identifier" &&
+        node.object.name === "Reflect" &&
+        node.property.type === "Identifier" &&
+        node.property.name === "apply" &&
+        node.computed === false
+    );
+}
+
+/**
+ * Checks whether or not a node is `Array.from`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a `Array.from`.
+ */
+function isArrayFrom(node) {
+    return (
+        node.type === "MemberExpression" &&
+        node.object.type === "Identifier" &&
+        arrayOrTypedArrayPattern.test(node.object.name) &&
+        node.property.type === "Identifier" &&
+        node.property.name === "from" &&
+        node.computed === false
+    );
+}
+
+/**
+ * Checks whether or not a node is a method which has `thisArg`.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} Whether or not the node is a method which has `thisArg`.
+ */
+function isMethodWhichHasThisArg(node) {
+    while (node != null) {
+        if (node.type === "Identifier") {
+            return arrayMethodPattern.test(node.name);
+        }
+        if (node.type === "MemberExpression" && !node.computed) {
+            node = node.property;
+            continue;
+        }
+
+        break;
+    }
+
+    return false;
+}
+
+/**
+ * Checks whether or not a node has valid `this`.
+ *
+ * First, this checks the node:
+ *
+ * - The function name starts with uppercase (it's a constructor).
+ * - The function has a JSDoc comment that has a @this tag.
+ *
+ * Next, this checks the location of the node.
+ * If the location is below, this judges `this` is valid.
+ *
+ * - The location is on an object literal.
+ * - The location assigns to a property.
+ * - The location is on an ES2015 class.
+ * - The location calls its `bind`/`call`/`apply` method directly.
+ * - The function is a callback of array methods (such as `.forEach()`) if `thisArg` is given.
+ *
+ * @param {ASTNode} node - A node to check.
+ * @param {RuleContext} context - A context to get the JSDoc comment of the node.
+ * @returns {boolean} A found function node.
+ */
+function hasValidThis(node, context) {
+    if (isES5Constructor(node) || hasJSDocThisTag(node, context)) {
+        return true;
+    }
+
+    while (node != null) {
+        var parent = node.parent;
+        switch (parent.type) {
+            // Looks up the destination.
+            // e.g.
+            //   obj.foo = nativeFoo || function foo() { ... };
+            case "LogicalExpression":
+            case "ConditionalExpression":
+                node = parent;
+                break;
+
+            // If the upper function is IIFE, checks the destination of the return value.
+            // e.g.
+            //   obj.foo = (function() {
+            //     // setup...
+            //     return function foo() { ... };
+            //   })();
+            case "ReturnStatement":
+                var func = getUpperFunction(parent);
+                if (func === null || !isCallee(func)) {
+                    return false;
+                }
+                node = func.parent;
+                break;
+
+            // e.g.
+            //   var obj = { foo() { ... } };
+            //   var obj = { foo: function() { ... } };
+            case "Property":
+                return true;
+
+            // e.g.
+            //   obj.foo = foo() { ... };
+            case "AssignmentExpression":
+                return (
+                    parent.right === node &&
+                    parent.left.type === "MemberExpression"
+                );
+
+            // e.g.
+            //   class A { constructor() { ... } }
+            //   class A { foo() { ... } }
+            //   class A { get foo() { ... } }
+            //   class A { set foo() { ... } }
+            //   class A { static foo() { ... } }
+            case "MethodDefinition":
+                return !parent.static;
+
+            // e.g.
+            //   var foo = function foo() { ... }.bind(obj);
+            //   (function foo() { ... }).call(obj);
+            //   (function foo() { ... }).apply(obj, []);
+            case "MemberExpression":
+                return (
+                    parent.object === node &&
+                    parent.property.type === "Identifier" &&
+                    bindOrCallOrApplyPattern.test(parent.property.name) &&
+                    isCallee(parent) &&
+                    parent.parent.arguments.length > 0 &&
+                    !isNullOrUndefined(parent.parent.arguments[0])
+                );
+
+            // e.g.
+            //   Reflect.apply(function() {}, obj, []);
+            //   Array.from([], function() {}, obj);
+            //   list.forEach(function() {}, obj);
+            case "CallExpression":
+                if (isReflectApply(parent.callee)) {
+                    return (
+                        parent.arguments.length === 3 &&
+                        parent.arguments[0] === node &&
+                        !isNullOrUndefined(parent.arguments[1])
+                    );
+                }
+                if (isArrayFrom(parent.callee)) {
+                    return (
+                        parent.arguments.length === 3 &&
+                        parent.arguments[1] === node &&
+                        !isNullOrUndefined(parent.arguments[2])
+                    );
+                }
+                if (isMethodWhichHasThisArg(parent.callee)) {
+                    return (
+                        parent.arguments.length === 2 &&
+                        parent.arguments[0] === node &&
+                        !isNullOrUndefined(parent.arguments[1])
+                    );
+                }
+                return false;
+
+            // Otherwise `this` is invalid.
+            default:
+                return false;
+        }
+    }
+
+    /* istanbul ignore next */
+    throw new Error("unreachable");
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var stack = [];
+
+    /**
+     * Gets the current checking context.
+     *
+     * The return value has a flag that whether or not `this` keyword is valid.
+     * The flag is initialized when got at the first time.
+     *
+     * @returns {{valid: boolean}}
+     *   an object which has a flag that whether or not `this` keyword is valid.
+     */
+    stack.getCurrent = function() {
+        var current = this[this.length - 1];
+        if (!current.init) {
+            current.init = true;
+            current.valid = hasValidThis(current.node, context);
+        }
+        return current;
+    };
+
+    /**
+     * Pushs new checking context into the stack.
+     *
+     * The checking context is not initialized yet.
+     * Because most functions don't have `this` keyword.
+     * When `this` keyword was found, the checking context is initialized.
+     *
+     * @param {ASTNode} node - A function node that was entered.
+     * @returns {void}
+     */
+    function enterFunction(node) {
+        // `this` can be invalid only under strict mode.
+        stack.push({
+            init: !context.getScope().isStrict,
+            node: node,
+            valid: true
+        });
+    }
+
+    /**
+     * Pops the current checking context from the stack.
+     * @returns {void}
+     */
+    function exitFunction() {
+        stack.pop();
+    }
+
+    return {
+        // `this` is invalid only under strict mode.
+        // Modules is always strict mode.
+        "Program": function(node) {
+            stack.push({
+                init: true,
+                node: node,
+                valid: !(context.ecmaFeatures.modules || context.getScope().isStrict)
+            });
+        },
+        "Program:exit": function() {
+            stack.pop();
+        },
+
+        "FunctionDeclaration": enterFunction,
+        "FunctionDeclaration:exit": exitFunction,
+        "FunctionExpression": enterFunction,
+        "FunctionExpression:exit": exitFunction,
+
+        // Reports if `this` of the current context is invalid.
+        "ThisExpression": function(node) {
+            var current = stack.getCurrent();
+            if (current != null && !current.valid) {
+                context.report(node, "Unexpected `this`.");
+            }
+        }
+    };
+};
+
+module.exports.schema = [];

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -126,7 +126,7 @@ module.exports = function(context) {
 
             // If we have any errors remaining report on them
             errors.forEach(function(error) {
-                context.report.apply(this, error);
+                context.report.apply(context, error);
             });
         }
     };

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -796,7 +796,7 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].ruleId, "example/example-rule");
             });
 
-            it("should import the same plugin only once if it is configured multiple times", sinon.test(function() {
+            it("should import the same plugin only once if it is configured multiple times", sinon.test(/* @this sinon.sandbox */function() {
                 var importPlugin = this.spy(rules, "import");
 
                 engine = new CLIEngine({

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -1,0 +1,494 @@
+/**
+ * @fileoverview Tests for no-invalid-this rule.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assign = require("object-assign");
+var eslint = require("../../../lib/eslint");
+var ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * A constant value for non strict mode environment.
+ * @returns {void}
+ */
+function NORMAL() {
+    // do nohting.
+}
+
+/**
+ * A constant value for strict mode environment.
+ * This modifies pattern object to make strict mode.
+ * @param {object} pattern - A pattern object to modify.
+ * @returns {void}
+ */
+function USE_STRICT(pattern) {
+    pattern.code = "\"use strict\"; " + pattern.code;
+}
+
+/**
+ * A constant value for modules environment.
+ * This modifies pattern object to make modules.
+ * @param {object} pattern - A pattern object to modify.
+ * @returns {void}
+ */
+function MODULES(pattern) {
+    pattern.code = "/* modules */ " + pattern.code;
+    pattern.ecmaFeatures = assign({}, pattern.ecmaFeatures, {modules: true});
+}
+
+/**
+ * Extracts patterns each condition for a specified type. The type is `valid` or `invalid`.
+ * @param {object[]} patterns - Original patterns.
+ * @param {string} type - One of `"valid"` or `"invalid"`.
+ * @returns {object[]} Test patterns.
+ */
+function extractPatterns(patterns, type) {
+    // Clone and apply the pattern environment.
+    var patternsList = patterns.map(function(pattern) {
+        return pattern[type].map(function(applyCondition) {
+            var thisPattern = assign({}, pattern);
+            applyCondition(thisPattern);
+
+            if (type === "valid") {
+                thisPattern.errors = [];
+            } else {
+                thisPattern.code += " /* should error */";
+            }
+
+            return thisPattern;
+        });
+    });
+
+    // Flatten.
+    return Array.prototype.concat.apply([], patternsList);
+}
+
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var errors = [
+    {message: "Unexpected `this`.", type: "ThisExpression"},
+    {message: "Unexpected `this`.", type: "ThisExpression"}
+];
+
+var patterns = [
+    // Global.
+    {
+        code: "console.log(this); z(x => console.log(x, this));",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+
+    // IIFE.
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); })();",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+
+    // Just functions.
+    {
+        code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "function foo() { \"use strict\"; console.log(this); z(x => console.log(x, this)); }",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, MODULES]
+    },
+    {
+        code: "return function() { console.log(this); z(x => console.log(x, this)); };",
+        ecmaFeatures: {arrowFunctions: true, globalReturn: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT] // modules cannot return on global.
+    },
+    {
+        code: "var foo = (function() { console.log(this); z(x => console.log(x, this)); }).bar(obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+
+    // Functions in methods.
+    {
+        code: "var obj = {foo: function() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "var obj = {foo() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
+        ecmaFeatures: {arrowFunctions: true, objectLiteralShorthandMethods: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "var obj = {foo: function() { return function() { console.log(this); z(x => console.log(x, this)); }; }};",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "var obj = {foo: function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; }};",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, MODULES]
+    },
+    {
+        code: "obj.foo = function() { return function() { console.log(this); z(x => console.log(x, this)); }; };",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "obj.foo = function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; };",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, MODULES]
+    },
+    {
+        code: "class A { foo() { return function() { console.log(this); z(x => console.log(x, this)); }; } }",
+        ecmaFeatures: {arrowFunctions: true, classes: true},
+        errors: errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, MODULES]
+    },
+
+    // Class Static methods.
+    {
+        code: "class A {static foo() { console.log(this); z(x => console.log(x, this)); }};",
+        ecmaFeatures: {arrowFunctions: true, classes: true},
+        errors: errors,
+        valid: [],
+        invalid: [NORMAL, USE_STRICT, MODULES]
+    },
+
+    // Constructors.
+    {
+        code: "function Foo() { console.log(this); z(x => console.log(x, this)); }",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var Foo = function Foo() { console.log(this); z(x => console.log(x, this)); };",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "class A {constructor() { console.log(this); z(x => console.log(x, this)); }};",
+        ecmaFeatures: {arrowFunctions: true, classes: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+
+    // On a property.
+    {
+        code: "var obj = {foo: function() { console.log(this); z(x => console.log(x, this)); }};",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo() { console.log(this); z(x => console.log(x, this)); }};",
+        ecmaFeatures: {arrowFunctions: true, objectLiteralShorthandMethods: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo: foo || function() { console.log(this); z(x => console.log(x, this)); }};",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo: hasNative ? foo : function() { console.log(this); z(x => console.log(x, this)); }};",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var obj = {foo: (function() { return function() { console.log(this); z(x => console.log(x, this)); }; })()};",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "Object.defineProperty(obj, \"foo\", {value: function() { console.log(this); z(x => console.log(x, this)); }})",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "Object.defineProperties(obj, {foo: {value: function() { console.log(this); z(x => console.log(x, this)); }}})",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Assigns to a property.
+    {
+        code: "obj.foo = function() { console.log(this); z(x => console.log(x, this)); };",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.foo = foo || function() { console.log(this); z(x => console.log(x, this)); };",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.foo = foo ? bar : function() { console.log(this); z(x => console.log(x, this)); };",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "obj.foo = (function() { return function() { console.log(this); z(x => console.log(x, this)); }; })();",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Class Instance Methods.
+    {
+        code: "class A {foo() { console.log(this); z(x => console.log(x, this)); }};",
+        ecmaFeatures: {arrowFunctions: true, classes: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Bind/Call/Apply
+    {
+        code: "var foo = function() { console.log(this); z(x => console.log(x, this)); }.bind(obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "var foo = function() { console.log(this); z(x => console.log(x, this)); }.bind(null);",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).call(obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).call(undefined);",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).apply(obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "(function() { console.log(this); z(x => console.log(x, this)); }).apply(void 0);",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "Reflect.apply(function() { console.log(this); z(x => console.log(x, this)); }, obj, []);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+
+    // Array methods.
+    {
+        code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); }, obj);",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, null);",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+
+    // @this tag.
+    {
+        code: "/** @this Obj */ function foo() { console.log(this); z(x => console.log(x, this)); }",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "/**\n * @returns {void}\n * @this Obj\n */\nfunction foo() { console.log(this); z(x => console.log(x, this)); }",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    },
+    {
+        code: "/** @returns {void} */ function foo() { console.log(this); z(x => console.log(x, this)); }",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "/** @this Obj */ foo(function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
+    {
+        code: "foo(/* @this Obj */ function() { console.log(this); z(x => console.log(x, this)); });",
+        ecmaFeatures: {arrowFunctions: true},
+        errors: errors,
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
+    }
+];
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-invalid-this", {
+    valid: extractPatterns(patterns, "valid"),
+    invalid: extractPatterns(patterns, "invalid")
+});

--- a/tests/lib/traverse.js
+++ b/tests/lib/traverse.js
@@ -123,7 +123,7 @@ describe("traverse", function() {
         assert.notEqual(files.length, 0);
     });
 
-    it("should throw if fs.statSync throws", sinon.test(function() {
+    it("should throw if fs.statSync throws", sinon.test(/* @this sinon.sandbox */function() {
         var error = new Error("anyError"),
             options = {
                 files: [ "/any/file.js" ],


### PR DESCRIPTION
I wrote, but it became larger than the first code...
I think what this rule does might not be simple, but is still not complex: just checking the function node and its parent node, almost.

The main reason that becomes larger than the first is processes for options.

Now, this rule two options.

1. `surelyUndefinedOnly` - If this is `true`, this rule warns only cases that `this` is `undefined` absolutely. In order to do so, I need to check whether or not this is under strict mode.
2. `allowInCallback` - If this is given an array of function names, `this` turns valid in callbacks of the functions.

As a test, I validated the source code of ESLint by this rule, there are some warnings in callbacks of `forEach` and `sinon.test`. This rule warned nothing (excepts in callbacks), so this implementation works as I expected. Actually both `this` in callbacks is valid, but we can turn off the warnings by `allowInCallback` option easily.

  ```
  Validating JavaScript files

  lib/rule-context.js
    83:8  error  Unexpected `this`  no-invalid-this

  lib/rules/no-irregular-whitespace.js
    129:37  error  Unexpected `this`  no-invalid-this

  ✖ 2 problems (2 errors, 0 warnings)

  Validating JavaScript test files

  tests/lib/cli-engine.js
    834:35  error  Unexpected `this`  no-invalid-this

  tests/lib/traverse.js
    133:23  error  Unexpected `this`  no-invalid-this
    135:8   error  Unexpected `this`  no-invalid-this

  ✖ 3 problems (3 errors, 0 warnings)
  ```

  