### PR TITLE
Update: Loosens regex rules around intentional fall through comments (Fixes #2811)

### DIFF
--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -36,6 +36,24 @@ switch(foo) {
     case 2:
         doSomethingElse();
 }
+
+switch(foo) {
+    case 1:
+        doSomething();
+        // fall through
+
+    case 2:
+        doSomethingElse();
+}
+
+switch(foo) {
+    case 1:
+        doSomething();
+        // fallsthrough
+
+    case 2:
+        doSomethingElse();
+}
 ```
 
 In this example, there is no confusion as to the expected behavior. It is clear that the first case is meant to fall through to the second case.

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -5,7 +5,7 @@
 "use strict";
 
 
-var FALLTHROUGH_COMMENT = /falls\sthrough/;
+var FALLTHROUGH_COMMENT = /falls?\s?through/i;
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -23,6 +23,10 @@ eslintTester.addRuleTest("lib/rules/no-fallthrough", {
     valid: [
         "switch(foo) { case 0: a(); /* falls through */ case 1: b(); }",
         "switch(foo) { case 0: a()\n /* falls through */ case 1: b(); }",
+        "switch(foo) { case 0: a(); /* fall through */ case 1: b(); }",
+        "switch(foo) { case 0: a(); /* falls through */ case 1: b(); }",
+        "switch(foo) { case 0: a(); /* fallthrough */ case 1: b(); }",
+        "switch(foo) { case 0: a(); /* FALLS THROUGH */ case 1: b(); }",
         "function foo() { switch(foo) { case 0: a(); return; case 1: b(); }; }",
         "switch(foo) { case 0: a(); throw 'foo'; case 1: b(); }",
         "while (a) { switch(foo) { case 0: a(); continue; case 1: b(); } }",


### PR DESCRIPTION
* Loosens the regex that validates there is an intentional fall through comment in switch statements
  * Updates code
  * Tests added
  * Documentation updated to imply more than just `// falls through` is acceptable
