### PR TITLE
Added missing export syntax support to the block-scoped-var rule. (fixes #2887)

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Rule to check for "block scoped" variables by binding context
  * @author Matt DuVall <http://www.mattduvall.com>
+ * @copyright 2015 Mathieu M-Gosselin. All rights reserved.
  */
 "use strict";
 
@@ -98,6 +99,22 @@ module.exports = function(context) {
 
         if (node.imported && node.imported.name !== node.local.name) {
             declare([node.imported.name]);
+        }
+    }
+
+    /**
+     * Declares all relevant identifiers for module exports.
+     * @param {ASTNode} node The AST node representing an export.
+     * @returns {void}
+     * @private
+     */
+    function declareExports(node) {
+        if (node.exported && node.exported.name) {
+            declare([node.exported.name]);
+
+            if (node.local) {
+                declare([node.local.name]);
+            }
         }
     }
 
@@ -240,6 +257,8 @@ module.exports = function(context) {
         "ImportSpecifier": declareImports,
         "ImportDefaultSpecifier": declareImports,
         "ImportNamespaceSpecifier": declareImports,
+
+        "ExportSpecifier": declareExports,
 
         "BlockStatement": function(node) {
             var statements = node.body;

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Tests for block-scoped-var rule
  * @author Matt DuVall <http://www.mattduvall.com>
+ * @copyright 2015 Mathieu M-Gosselin. All rights reserved.
  */
 
 "use strict";
@@ -64,6 +65,10 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         { code: "import * as y from \"./other.js\"; y();", ecmaFeatures: { modules: true }},
         { code: "import y from \"./other.js\"; y();", ecmaFeatures: { modules: true }},
         { code: "import {x as y} from \"./other.js\"; y();", ecmaFeatures: { modules: true }},
+        { code: "var x; export {x};", ecmaFeatures: { modules: true }},
+        { code: "var x; export {x as v};", ecmaFeatures: { modules: true }},
+        { code: "export {x} from \"./other.js\";", ecmaFeatures: { modules: true }},
+        { code: "export {x as v} from \"./other.js\";", ecmaFeatures: { modules: true }},
         { code: "class Test { myFunction() { return true; }}", ecmaFeatures: { classes: true }},
         { code: "class Test { get flag() { return true; }}", ecmaFeatures: { classes: true }},
         { code: "var Test = class { myFunction() { return true; }}", ecmaFeatures: { classes: true }},


### PR DESCRIPTION
#2807 mentions the 

```js
export x from "package";
```

syntax, but that is part of the experimental https://github.com/leebyron/ecmascript-more-export-from

However, this PR adds support for

```js
export {x} from "package";
```

and

```js
export {x as v} from "package";
```

which should have been working.

Fixes #2887.