### PR TITLE
Build: gensite target supports rule removal (refs #1898)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -185,8 +185,7 @@ These rules are purely matters of style and are quite subjective.
 * [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses (off by default)
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators
 * [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`
-* [space-unary-ops](space-unary-ops.md) - Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
-* [space-unary-word-ops](space-unary-word-ops.md) - **(deprecated)** Require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
+* [space-unary-ops](space-unary-ops.md) - require or disallow spaces before/after unary operators (words on by default, nonwords off by default)
 * [spaced-comment](spaced-comment.md) - require or disallow a space immediately following the `//` or `/*` in a comment (off by default)
 * [spaced-line-comment](spaced-line-comment.md) - **(deprecated)** require or disallow a space immediately following the `//` in a line comment (off by default)
 * [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses (off by default)
@@ -213,3 +212,9 @@ The following rules are included for compatibility with [JSHint](http://jshint.c
 * [max-statements](max-statements.md) - specify the maximum number of statement allowed in a function (off by default)
 * [no-bitwise](no-bitwise.md) - disallow use of bitwise operators (off by default)
 * [no-plusplus](no-plusplus.md) - disallow use of unary operators, `++` and `--` (off by default)
+
+## Removed
+
+These rules existed in a previous version of ESLint but have since been replaced by newer rules.
+
+* [space-unary-word-ops](space-unary-word-ops.md) - require or disallow spaces before/after unary operators (replaced by [space-unary-ops](space-unary-ops.md))

--- a/docs/rules/space-unary-word-ops.md
+++ b/docs/rules/space-unary-word-ops.md
@@ -1,6 +1,6 @@
 # Require spaces following unary word operators (space-unary-word-ops)
 
-**Deprecation notice**: This rule is deprecated and has been superseded by the [space-unary-ops](space-unary-ops.md) rule. It has be removed in ESLint v0.10.0.
+**Removal notice**: This rule was removed and has been superseded by the [space-unary-ops](space-unary-ops.md) rule.
 
 Require spaces following unary word operators.
 


### PR DESCRIPTION
Generated documentation will now include the version in which a rule was removed, if applicable. I included a step to convert the `versions.json` cache in a backwards-compatible way, so the cache won't need to be regenerated for those of you who already have it.

Conveniently, `space-unary-word-ops` was already removed, so I used it as a dry run and brought it in sync with the removal sequence in #1898.