### PR TITLE
Fix: typo in array-bracket-spacing rule doc

### DIFF
--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -28,7 +28,7 @@ There are two options for this rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"arrays-bracket-spacing": [2, "always"]
+"array-bracket-spacing": [2, "always"]
 ```
 
 #### never


### PR DESCRIPTION
Just a doc typo.