### PR TITLE
New: Add arrow-parens and arrow-paces rule (fixes #2628)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -114,6 +114,8 @@
         "no-wrap-func": 2,
 
         "array-bracket-spacing": [0, "never"],
+        "arrow-parens": 0,
+        "arrow-spacing": 0,
         "accessor-pairs": 0,
         "block-scoped-var": 0,
         "brace-style": [0, "1tbs"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -196,6 +196,8 @@ These rules are purely matters of style and are quite subjective.
 
 These rules are only relevant to ES6 environments and are off by default.
 
+* [arrow-parens](arrow-parens.md) - Require parens in arrow function arguments (off by default)
+* [arrow-spacing](arrow-spacing.md) - Require space before/after arrow functions arrow (off by default)
 * [constructor-super](constructor-super.md) - verify `super()` callings in constructors (off by default)
 * [generator-star-spacing](generator-star-spacing.md) - enforce the spacing around the `*` in generator functions (off by default)
 * [generator-star](generator-star.md) - **(deprecated)** enforce the position of the `*` in generator functions (off by default)

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -1,0 +1,94 @@
+# Require parens in arrow function arguments (arrow-parens)
+
+Arrow function can omit parens if there passed only one arguments.
+But you need to add parens if arguments decreased to 0 or increase.
+This rule requires parens in arrow function arguments for normalize coding style.
+
+```js
+// Bad
+a => {}
+
+// Good
+(a) => {}
+```
+
+
+And also it will help to find if arrow function(`=>`) are wrote in condition context instead of comparison (`>=`) by mistake.
+
+
+```js
+// Bad
+if (a => 2) {
+}
+
+// Good
+if (a >= 2) {
+}
+```
+
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+a => {}
+a => a
+a => {\n}
+a.then(foo => {});
+a.then(foo => a);
+a(foo => { if (true) {}; });
+```
+
+The following patterns are not warnings:
+
+```js
+() => {}
+(a) => {}
+(a) => a
+(a) => {\n}
+a.then((foo) => {});
+a.then((foo) => { if (true) {}; });
+```
+
+this saves you from bizarre behavior like below
+
+```js
+var a = 1;
+if (a => 2) {
+ console.log('bigger');
+} else {
+ console.log('smaller')
+};
+```
+
+this is better, because condition of if is arrow function, not comparison.
+this should be like this, and you can notice it's not what you expect.
+
+```js
+var a = 1;
+if ((a) => 2) {
+ console.log('bigger');
+} else {
+ console.log('smaller')
+};
+```
+
+same thing happens here.
+
+```js
+var a = 1, b = 2, c = 3, d = 4;
+var f = a => b ? c: d;
+// f = ?
+```
+
+`f` is arrow function which gets a as arguments and returns the result of `b ? c: d`.
+
+this should be like this again.
+
+```js
+var a = 1, b = 2, c = 3, d = 4;
+var f = (a) => b ? c: d;
+```
+
+you may notice what this is.

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -1,0 +1,69 @@
+# Require space before/after arrow functions arrow (arrow-spacing)
+
+This rule normalize style of spacing before/after of arrow functions arrow(`=>`).
+
+```js
+// { "before": true, "after": true }
+(a) => {}
+
+// { "before": false, "after": false }
+(a)=>{}
+```
+
+## Rule Details
+
+this rules takes one arguments of structure contains `before` and `after` property
+and each property has bool value.
+
+default configuration is `{ "before": true, "after": true }`.
+
+`true` means there should have **one space** and `false` means **no space**.
+
+The following patterns are considered warnings if `{ "before": true, "after": true }`.
+
+```js
+()=> {}
+() =>{}
+(a)=> {}
+(a) =>{}
+a =>a
+a=> a
+()=> {\n}
+() =>{\n}
+```
+
+The following patterns are not warnings if `{ "before": true, "after": true }`.
+
+```js
+() => {}
+(a) => {}
+a => a
+() => {\n}
+```
+
+The following patterns are not warnings if `{ "before": false, "after": false }`.
+
+```js
+()=>{}
+(a)=>{}
+a=>a
+()=>{\n}
+```
+
+The following patterns are not warnings if `{ "before": true, "after": false }`.
+
+```js
+() =>{}
+(a) =>{}
+a =>a
+() =>{\n}
+```
+
+The following patterns are not warnings if `{ "before": false, "after": true }`.
+
+```js
+()=> {}
+(a)=> {}
+a=> a
+()=> {\n}
+```

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -1,0 +1,35 @@
+/**
+ * @fileoverview Rule to require parens in arrow function arguments.
+ * @author Jxck
+ * @copyright 2015 Jxck. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var message = "Expected parentheses around arrow function argument.";
+
+    /**
+     * Determines whether a arrow function argument end with `)`
+     * @param {ASTNode} node The arrow function node.
+     * @returns {void}
+     */
+    function parens(node) {
+        var token = context.getFirstToken(node);
+        if (token.type === "Identifier") {
+            var after = context.getTokenAfter(token);
+            if (after.value !== ")") {
+                context.report(node, message);
+            }
+        }
+    }
+
+    return {
+        "ArrowFunctionExpression": parens
+    };
+};
+
+module.exports.schema = [];

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -1,0 +1,106 @@
+/**
+ * @fileoverview Rule to require parens in arrow function arguments.
+ * @author Jxck
+ * @copyright 2015 Jxck. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    // merge rules with default
+    var rule = { before: true, after: true };
+    var option = context.options[0] || {};
+    rule.before = option.before !== false;
+    rule.after = option.after !== false;
+
+    /**
+     * Get tokens of arrow(`=>`) and before/after arrow.
+     * @param {ASTNode} node The arrow function node.
+     * @returns {Object} Tokens of arrow and before/after arrow.
+     */
+    function getTokens(node) {
+        var t = context.getFirstToken(node);
+        var before;
+        while (t.value !== "=>") {
+            before = t;
+            t = context.getTokenAfter(t);
+        }
+        var after = context.getTokenAfter(t);
+        return { before: before, arrow: t, after: after };
+    }
+
+    /**
+     * Count spaces before/after arrow(`=>`) token.
+     * @param {Object} tokens Tokens before/after arrow.
+     * @returns {Object} count of space before/after arrow.
+     */
+    function countSpaces(tokens) {
+        var before = tokens.arrow.range[0] - tokens.before.range[1];
+        var after = tokens.after.range[0] - tokens.arrow.range[1];
+        return { before: before, after: after };
+    }
+
+    /**
+     * Determines whether spaces before after arrow(`=>`) is satisfy rule.
+     * if before/after value is `true`, there should be one space.
+     * if before/after value is `false`, there should be no space.
+     * @param {ASTNode} node The arrow function node.
+     * @returns {void}
+     */
+    function spaces(node) {
+        var tokens = getTokens(node);
+        var countSpace = countSpaces(tokens);
+
+        if (rule.before === true) {
+            // should one space before arrow
+            if (countSpace.before > 1) {
+                context.report(tokens.before, "Unexpected space before =>");
+            }
+            if (countSpace.before === 0) {
+                context.report(tokens.before, "Missing space before =>");
+            }
+        } else if (rule.before === false) {
+            // should no space before arrow
+            if (countSpace.before > 0) {
+                context.report(tokens.before, "Unexpected space before =>");
+            }
+        }
+
+        if (rule.after === true) {
+            // should one space after arrow
+            if (countSpace.after > 1) {
+                context.report(tokens.after, "Unexpected space after =>");
+            }
+            if (countSpace.after === 0) {
+                context.report(tokens.after, "Missing space after =>");
+            }
+        } else if (rule.after === false) {
+            // should no space after arrow
+            if (countSpace.after > 0) {
+                context.report(tokens.after, "Unexpected space after =>");
+            }
+        }
+    }
+
+    return {
+        "ArrowFunctionExpression": spaces
+    };
+};
+
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "before": {
+                "type": "boolean"
+            },
+            "after": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Tests for arrow-parens
+ * @author Jxck
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+var eslintTester = new ESLintTester(eslint);
+
+var valid = [
+    { code: "() => {}", ecmaFeatures: { arrowFunctions: true } },
+    { code: "(a) => {}", ecmaFeatures: { arrowFunctions: true } },
+    { code: "(a) => a", ecmaFeatures: { arrowFunctions: true } },
+    { code: "(a) => {\n}", ecmaFeatures: { arrowFunctions: true } },
+    { code: "a.then((foo) => {});", ecmaFeatures: { arrowFunctions: true } },
+    { code: "a.then((foo) => { if (true) {}; });", ecmaFeatures: { arrowFunctions: true } }
+];
+
+var message = message;
+var type = type;
+
+var invalid = [
+    {
+        code: "a => {}",
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: message,
+            type: type
+        }]
+    },
+    {
+        code: "a => a",
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: message,
+            type: type
+        }]
+    },
+    {
+        code: "a => {\n}",
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: message,
+            type: type
+        }]
+    },
+    {
+        code: "a.then(foo => {});",
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            line: 1,
+            column: 8,
+            message: message,
+            type: type
+        }]
+    },
+    {
+        code: "a.then(foo => a);",
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            line: 1,
+            column: 8,
+            message: message,
+            type: type
+        }]
+    },
+    {
+        code: "a(foo => { if (true) {}; });",
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [{
+            line: 1,
+            column: 3,
+            message: message,
+            type: type
+        }]
+    }
+];
+
+eslintTester.addRuleTest("lib/rules/arrow-parens", {
+    valid: valid,
+    invalid: invalid
+});

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -1,0 +1,322 @@
+/**
+ * @fileoverview Tests for arrow-spacing
+ * @author Jxck
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+//
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+
+var valid = [
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "a => a",
+        options: [{ after: true, before: true }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "() => {}",
+        options: [{ after: true, before: true }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a) => {}",
+        options: [{ after: true, before: true }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "a=> a",
+        options: [{ after: true, before: false }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "()=> {}",
+        options: [{ after: true, before: false }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a)=> {}",
+        options: [{ after: true, before: false }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "a =>a",
+        options: [{ after: false, before: true }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "() =>{}",
+        options: [{ after: false, before: true }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a) =>{}",
+        options: [{ after: false, before: true }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "a=>a",
+        options: [{ after: false, before: false }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "()=>{}",
+        options: [{ after: false, before: false }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a)=>{}",
+        options: [{ after: false, before: false }]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "a => a",
+        options: [{}]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "() => {}",
+        options: [{}]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a) => {}",
+        options: [{}]
+    }
+];
+
+
+var invalid = [
+    {
+        code: "a=>a",
+        options: [{ after: true, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 4, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "()=>{}",
+        options: [{ after: true, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 5, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a)=>{}",
+        options: [{ after: true, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 6, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "a  =>  a",
+        options: [{ after: true, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 8, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "()  =>  {}",
+        options: [{ after: true, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 9, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a)  =>  {}",
+        options: [{ after: true, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 10, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "a=> a",
+        options: [{ after: false, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 5, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "()=> {}",
+        options: [{ after: false, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 6, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a)=> {}",
+        options: [{ after: false, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 7, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "a=>  a",
+        options: [{ after: false, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 6, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "()=>  {}",
+        options: [{ after: false, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 7, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a)=>  {}",
+        options: [{ after: false, before: true }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 8, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "a =>a",
+        options: [{ after: true, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 5, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "() =>{}",
+        options: [{ after: true, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 6, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a) =>{}",
+        options: [{ after: true, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 7, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "a  =>a",
+        options: [{ after: true, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 6, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "()  =>{}",
+        options: [{ after: true, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 7, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a)  =>{}",
+        options: [{ after: true, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 8, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "a => a",
+        options: [{ after: false, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 6, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "() => {}",
+        options: [{ after: false, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 7, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a) => {}",
+        options: [{ after: false, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 8, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "a  =>  a",
+        options: [{ after: false, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 1, type: "Identifier" },
+            { column: 8, line: 1, type: "Identifier" }
+        ]
+    },
+    {
+        code: "()  =>  {}",
+        options: [{ after: false, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 2, line: 1, type: "Punctuator" },
+            { column: 9, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a)  =>  {}",
+        options: [{ after: false, before: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 3, line: 1, type: "Punctuator" },
+            { column: 10, line: 1, type: "Punctuator" }
+        ]
+    }
+];
+
+eslintTester.addRuleTest("lib/rules/arrow-spacing", {
+    valid: valid,
+    invalid: invalid
+});


### PR DESCRIPTION
This PR is related to #2628 and adding two rules

- arrow-parens
- arrow-spaces

both are categories to ECMAScript 6 and off by default.
options are discussed in #2628 

rule, test, docs are originally from [eslint-plugin-arrow-function](https://github.com/Jxck/eslint-plugin-arrow-function) and fixed style for matching eslint project.
if this PR will accepted, I will remove these rules from my plugin project.
