### PR TITLE
Breaking: Switch to 1-based columns (fixes #2284)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -73,7 +73,7 @@ function parseJsonConfig(string, location, messages) {
             severity: 2,
             message: "Failed to parse JSON from '" + string + "': " + ex.message,
             line: location.start.line,
-            column: location.start.column
+            column: location.start.column + 1
         });
 
     }
@@ -467,7 +467,7 @@ module.exports = (function() {
                 message: message,
 
                 line: ex.lineNumber,
-                column: ex.column
+                column: ex.column + 1
             });
 
             return null;
@@ -785,7 +785,7 @@ module.exports = (function() {
             severity: severity,
             message: message,
             line: location.line,
-            column: location.column,
+            column: location.column + 1,   // switch to 1-base instead of 0-base
             nodeType: node.type,
             source: currentTextLines[location.line - 1] || ""
         });

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1043,7 +1043,7 @@ describe("eslint", function() {
             var messages = eslint.verify("0", config);
             assert.equal(messages[0].message, "hello world");
             assert.equal(messages[0].line, 42);
-            assert.equal(messages[0].column, 13);
+            assert.equal(messages[0].column, 14);
         });
 
         it("should correctly parse a message with object keys as numbers", function() {
@@ -1758,8 +1758,8 @@ describe("eslint", function() {
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 2);
-            assert.equal(messages[0].column, 20);
-            assert.equal(messages[1].column, 18);
+            assert.equal(messages[0].column, 21);
+            assert.equal(messages[1].column, 19);
         });
 
         it("should not report a violation", function() {
@@ -2068,7 +2068,7 @@ describe("eslint", function() {
             // parseJsonConfig function in lib/eslint.js
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":'1'':/);
             assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 0);
+            assert.equal(messages[0].column, 1);
 
             assert.equal(messages[1].ruleId, "no-alert");
             assert.equal(messages[1].message, "Unexpected alert.");
@@ -2090,7 +2090,7 @@ describe("eslint", function() {
             // parseJsonConfig function in lib/eslint.js
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":abc':/);
             assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 0);
+            assert.equal(messages[0].column, 1);
 
             assert.equal(messages[1].ruleId, "no-alert");
             assert.equal(messages[1].message, "Unexpected alert.");
@@ -2112,7 +2112,7 @@ describe("eslint", function() {
             // parseJsonConfig function in lib/eslint.js
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":0 2':/);
             assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 0);
+            assert.equal(messages[0].column, 1);
 
             assert.equal(messages[1].ruleId, "no-alert");
             assert.equal(messages[1].message, "Unexpected alert.");
@@ -2348,11 +2348,11 @@ describe("eslint", function() {
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 3);
             assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 5);
+            assert.equal(messages[0].column, 6);
             assert.equal(messages[1].line, 2);
-            assert.equal(messages[1].column, 1);
+            assert.equal(messages[1].column, 2);
             assert.equal(messages[2].line, 2);
-            assert.equal(messages[2].column, 17);
+            assert.equal(messages[2].column, 18);
         });
 
         it("should properly parse let declaration when passed ecmaFeatures", function() {
@@ -2432,7 +2432,7 @@ describe("eslint", function() {
 
             assert.equal(messages.length, 1);
             assert.equal(messages[0].line, 1);
-            assert.equal(messages[0].column, 20);
+            assert.equal(messages[0].column, 21);
             assert.equal(messages[0].message, "Unexpected token <");
         });
 

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -159,13 +159,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "A space is required before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 35
+                    column: 36
                 }
             ]
         },
@@ -177,13 +177,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "A space is required after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 34
+                    column: 35
                 }
             ]
         },
@@ -195,13 +195,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 49
+                    column: 50
                 }
             ]
         },
@@ -215,13 +215,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 18
+                    column: 19
                 }
             ]
         },
@@ -233,7 +233,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 17
+                    column: 18
                 }
             ]
         },
@@ -245,13 +245,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "A space is required after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "A space is required before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 16
+                    column: 17
                 }
             ]
         },
@@ -265,7 +265,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -277,7 +277,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 30
+                    column: 31
                 }
             ]
         },
@@ -289,7 +289,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 33
+                    column: 34
                 }
             ]
         },
@@ -301,7 +301,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -313,13 +313,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 34
+                    column: 35
                 }
             ]
         },
@@ -333,13 +333,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                 message: "A space is required after '['",
                 type: "ArrayPattern",
                 line: 1,
-                column: 4
+                column: 5
             },
             {
                 message: "A space is required before ']'",
                 type: "ArrayPattern",
                 line: 1,
-                column: 8
+                column: 9
             }]
         },
         {
@@ -350,7 +350,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                 message: "A space is required after '['",
                 type: "ArrayPattern",
                 line: 1,
-                column: 4
+                column: 5
             }]
         },
         {
@@ -361,13 +361,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                 message: "A space is required after '['",
                 type: "ArrayPattern",
                 line: 1,
-                column: 4
+                column: 5
             },
             {
                 message: "A space is required before ']'",
                 type: "ArrayPattern",
                 line: 1,
-                column: 11
+                column: 12
             }]
         },
         {
@@ -378,7 +378,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                 message: "A space is required before ']'",
                 type: "ArrayPattern",
                 line: 1,
-                column: 12
+                column: 13
             }]
         },
         {
@@ -389,13 +389,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                 message: "A space is required after '['",
                 type: "ArrayPattern",
                 line: 1,
-                column: 4
+                column: 5
             },
             {
                 message: "A space is required before ']'",
                 type: "ArrayPattern",
                 line: 1,
-                column: 13
+                column: 14
             }]
         },
         {
@@ -406,7 +406,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                 message: "A space is required after '['",
                 type: "ArrayPattern",
                 line: 1,
-                column: 4
+                column: 5
             }]
         },
 
@@ -419,13 +419,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "A space is required after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "A space is required before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 28
+                    column: 29
                 }
             ]
         },
@@ -439,13 +439,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "A space is required after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "A space is required before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 21
+                    column: 22
                 }
             ]
         },
@@ -457,7 +457,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "A space is required after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -469,7 +469,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "A space is required before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -481,13 +481,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 23
+                    column: 24
                 }
             ]
         },
@@ -499,7 +499,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -511,7 +511,7 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -523,13 +523,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space after '['",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 12
+                    column: 13
                 }
             ]
         },
@@ -541,13 +541,13 @@ eslintTester.addRuleTest("lib/rules/array-bracket-spacing", {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 14
+                    column: 15
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "ArrayExpression",
                     line: 1,
-                    column: 25
+                    column: 26
                 }
             ]
         }

--- a/tests/lib/rules/callback-return.js
+++ b/tests/lib/rules/callback-return.js
@@ -75,15 +75,15 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
         // options (only warns with the correct callback name)
         {
             code: "if (err) { callback(err) }",
-            options: ["cb"]
+            options: [["cb"]]
         },
         {
             code: "function a(err) { if (err) { callback(err) } next(); }",
-            options: ["cb", "next"]
+            options: [["cb", "next"]]
         },
         {
             code: "function a(err) { if (err) { return next(err) } else { callback(); } }",
-            options: ["cb", "next"]
+            options: [["cb", "next"]]
         },
 
         //  known bad examples that we know we are ignoring
@@ -97,7 +97,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 29,
+                column: 30,
                 nodeType: "CallExpression"
             }]
         },
@@ -106,7 +106,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 62,
+                column: 63,
                 nodeType: "CallExpression"
             }]
         },
@@ -115,7 +115,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 60,
+                column: 61,
                 nodeType: "CallExpression"
             }]
         },
@@ -124,7 +124,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 34,
+                column: 35,
                 nodeType: "CallExpression"
             }]
         },
@@ -134,7 +134,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 30,
+                column: 31,
                 nodeType: "CallExpression"
             }]
         },
@@ -144,7 +144,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 30,
+                column: 31,
                 nodeType: "CallExpression"
             }]
         },
@@ -153,7 +153,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 3,
-                column: 1,
+                column: 2,
                 nodeType: "CallExpression"
             }]
         },
@@ -163,7 +163,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 42,
+                column: 43,
                 nodeType: "CallExpression"
             }]
         },
@@ -172,7 +172,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 18,
+                column: 19,
                 nodeType: "CallExpression"
             }]
         },
@@ -181,7 +181,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 18,
+                column: 19,
                 nodeType: "CallExpression"
             }]
         },
@@ -190,7 +190,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 29,
+                column: 30,
                 nodeType: "CallExpression"
             }]
         },
@@ -200,7 +200,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 19,
+                column: 20,
                 nodeType: "CallExpression"
             }]
         },
@@ -209,7 +209,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 29,
+                column: 30,
                 nodeType: "CallExpression"
             }]
         },
@@ -218,7 +218,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 3,
-                column: 0,
+                column: 1,
                 nodeType: "CallExpression"
 
             }]
@@ -229,7 +229,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 31,
+                column: 32,
                 nodeType: "CallExpression"
             }]
         },
@@ -241,12 +241,12 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
             errors: [{
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 29,
+                column: 30,
                 nodeType: "CallExpression"
             }, {
                 message: "Expected return with your callback function.",
                 line: 1,
-                column: 49,
+                column: 50,
                 nodeType: "CallExpression"
             }]
         },
@@ -256,7 +256,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
                 {
                     message: "Expected return with your callback function.",
                     line: 1,
-                    column: 51,
+                    column: 52,
                     nodeType: "CallExpression"
                 }
             ]
@@ -268,7 +268,7 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
                 {
                     message: "Expected return with your callback function.",
                     line: 1,
-                    column: 17,
+                    column: 18,
                     nodeType: "CallExpression"
                 }
             ]
@@ -279,19 +279,19 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
                 {
                     message: "Expected return with your callback function.",
                     line: 1,
-                    column: 41,
+                    column: 42,
                     nodeType: "CallExpression"
                 }
             ]
         },
         {
             code: "function a() { switch(x) { case 'horse': move(); } }",
-            options: ["move"],
+            options: [["move"]],
             errors: [
                 {
                     message: "Expected return with your callback function.",
                     line: 1,
-                    column: 41,
+                    column: 42,
                     nodeType: "CallExpression"
                 }
             ]
@@ -300,36 +300,36 @@ eslintTester.addRuleTest("lib/rules/callback-return", {
         // loops
         {
             code: "var x = function() { while(x) { move(); } }",
-            options: ["move"],
+            options: [["move"]],
             errors: [
                 {
                     message: "Expected return with your callback function.",
                     line: 1,
-                    column: 32,
+                    column: 33,
                     nodeType: "CallExpression"
                 }
             ]
         },
         {
             code: "function x() { for (var i = 0; i < 10; i++) { move(); } }",
-            options: ["move"],
+            options: [["move"]],
             errors: [
                 {
                     message: "Expected return with your callback function.",
                     line: 1,
-                    column: 46,
+                    column: 47,
                     nodeType: "CallExpression"
                 }
             ]
         },
         {
             code: "var x = function() { for (var i = 0; i < 10; i++) move(); }",
-            options: ["move"],
+            options: [["move"]],
             errors: [
                 {
                     message: "Expected return with your callback function.",
                     line: 1,
-                    column: 50,
+                    column: 51,
                     nodeType: "CallExpression"
                 }
             ]

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -74,7 +74,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -85,7 +85,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 2,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -96,7 +96,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 29
+                    column: 30
                 }
             ]
         },
@@ -107,7 +107,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 3,
-                    column: 11
+                    column: 12
                 }
             ]
         },
@@ -118,7 +118,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Literal",
                     line: 1,
-                    column: 17
+                    column: 18
                 }
             ]
         },
@@ -129,7 +129,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Literal",
                     line: 1,
-                    column: 17
+                    column: 18
                 }
             ]
         },
@@ -140,7 +140,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 3,
-                    column: 0
+                    column: 1
                 }
             ]
         },
@@ -154,7 +154,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -166,7 +166,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 2,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -178,7 +178,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 29
+                    column: 30
                 }
             ]
         },
@@ -191,7 +191,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -203,7 +203,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Property",
                     line: 2,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -215,7 +215,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 29
+                    column: 30
                 }
             ]
         },
@@ -227,7 +227,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Property",
                     line: 3,
-                    column: 11
+                    column: 12
                 }
             ]
         },
@@ -239,7 +239,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Literal",
                     line: 1,
-                    column: 17
+                    column: 18
                 }
             ]
         },
@@ -251,7 +251,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Literal",
                     line: 1,
-                    column: 17
+                    column: 18
                 }
             ]
         },
@@ -263,7 +263,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Property",
                     line: 3,
-                    column: 5
+                    column: 6
                 }
             ]
         },
@@ -276,7 +276,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Property",
                     line: 2,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -288,7 +288,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -300,7 +300,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Property",
                     line: 3,
-                    column: 11
+                    column: 12
                 }
             ]
         },
@@ -312,7 +312,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 1,
-                    column: 29
+                    column: 30
                 }
             ]
         },
@@ -324,7 +324,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Missing trailing comma.",
                     type: "Literal",
                     line: 2,
-                    column: 5
+                    column: 6
                 }
             ]
         },
@@ -336,7 +336,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Literal",
                     line: 1,
-                    column: 16
+                    column: 17
                 }
             ]
         },
@@ -348,7 +348,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 3,
-                    column: 1
+                    column: 2
                 }
             ]
         },
@@ -360,7 +360,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "Property",
                     line: 2,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -372,7 +372,7 @@ eslintTester.addRuleTest("lib/rules/comma-dangle", {
                     message: "Unexpected trailing comma.",
                     type: "ObjectExpression",
                     line: 6,
-                    column: 1
+                    column: 2
                 }
             ]
         }

--- a/tests/lib/rules/computed-property-spacing.js
+++ b/tests/lib/rules/computed-property-spacing.js
@@ -85,7 +85,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required before ']'",
                     type: "MemberExpression",
-                    column: 16,
+                    column: 17,
                     line: 1
                 }
             ]
@@ -97,7 +97,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required after '['",
                     type: "MemberExpression",
-                    column: 13,
+                    column: 14,
                     line: 1
                 }
             ]
@@ -109,7 +109,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space after '['",
                     type: "MemberExpression",
-                    column: 13,
+                    column: 14,
                     line: 1
                 }
             ]
@@ -131,7 +131,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required before ']'",
                     type: "MemberExpression",
-                    column: 16,
+                    column: 17,
                     line: 1
                 }
             ]
@@ -143,7 +143,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required after '['",
                     type: "MemberExpression",
-                    column: 13,
+                    column: 14,
                     line: 1
                 }
             ]
@@ -155,13 +155,13 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space after '['",
                     type: "MemberExpression",
-                    column: 3,
+                    column: 4,
                     line: 1
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "MemberExpression",
-                    column: 9,
+                    column: 10,
                     line: 1
                 }
             ]
@@ -173,7 +173,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space before ']'",
                     type: "MemberExpression",
-                    column: 8,
+                    column: 9,
                     line: 1
                 }
             ]
@@ -185,7 +185,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space after '['",
                     type: "MemberExpression",
-                    column: 3,
+                    column: 4,
                     line: 1
                 }
             ]
@@ -197,13 +197,13 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required after '['",
                     type: "MemberExpression",
-                    column: 13,
+                    column: 14,
                     line: 1
                 },
                 {
                     message: "A space is required before ']'",
                     type: "MemberExpression",
-                    column: 15,
+                    column: 16,
                     line: 1
                 }
             ]
@@ -218,13 +218,13 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required after '['",
                     type: "Property",
-                    column: 9,
+                    column: 10,
                     line: 1
                 },
                 {
                     message: "A space is required before ']'",
                     type: "Property",
-                    column: 11,
+                    column: 12,
                     line: 1
                 }
             ]
@@ -237,7 +237,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required after '['",
                     type: "Property",
-                    column: 9,
+                    column: 10,
                     line: 1
                 }
             ]
@@ -250,7 +250,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "A space is required before ']'",
                     type: "Property",
-                    column: 12,
+                    column: 13,
                     line: 1
                 }
             ]
@@ -265,13 +265,13 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space after '['",
                     type: "Property",
-                    column: 9,
+                    column: 10,
                     line: 1
                 },
                 {
                     message: "There should be no space before ']'",
                     type: "Property",
-                    column: 13,
+                    column: 14,
                     line: 1
                 }
             ]
@@ -284,7 +284,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space before ']'",
                     type: "Property",
-                    column: 12,
+                    column: 13,
                     line: 1
                 }
             ]
@@ -297,7 +297,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space after '['",
                     type: "Property",
-                    column: 9,
+                    column: 10,
                     line: 1
                 }
             ]
@@ -310,7 +310,7 @@ eslintTester.addRuleTest("lib/rules/computed-property-spacing", {
                 {
                     message: "There should be no space after '['",
                     type: "Property",
-                    column: 9,
+                    column: 10,
                     line: 1
                 }
             ]

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -79,22 +79,22 @@ eslintTester.addRuleTest("lib/rules/constructor-super", {
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 20}]
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 21}]
         },
         {
             code: "class A extends B { constructor() { var C = class extends D { constructor() { super(); } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 20}]
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 21}]
         },
         {
             code: "class A extends B { constructor() { super(); class C extends D { constructor() { } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 65}]
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 66}]
         },
         {
             code: "class A extends B { constructor() { super(); var C = class extends D { constructor() { } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 71}]
+            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 72}]
         }
     ]
 });

--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -44,17 +44,17 @@ eslintTester.addRuleTest("lib/rules/dot-location", {
         {
             code: "obj\n.property",
             options: [ "object" ],
-            errors: [ { message: "Expected dot to be on same line as object.", type: "MemberExpression", line: 2, column: 0 } ]
+            errors: [ { message: "Expected dot to be on same line as object.", type: "MemberExpression", line: 2, column: 1 } ]
         },
         {
             code: "obj.\nproperty",
             options: [ "property" ],
-            errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 3 } ]
+            errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 4 } ]
         },
         {
             code: "(obj).\nproperty",
             options: [ "property" ],
-            errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 5 } ]
+            errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 6 } ]
         }
     ]
 });

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -169,33 +169,33 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             beforeColon: false,
             afterColon: false
         }],
-        errors: [{ message: "Extra space before value for key \"key\".", type: "Identifier", line: 1, column: 48 }]
+        errors: [{ message: "Extra space before value for key \"key\".", type: "Identifier", line: 1, column: 49 }]
     }, {
         code: "var obj = { [ (a + b) ]:value };",
         options: [{}],
         ecmaFeatures: { objectLiteralComputedProperties: true },
-        errors: [{ message: "Missing space before value for computed key \"(a + b)\".", type: "Identifier", line: 1, column: 23 }]
+        errors: [{ message: "Missing space before value for computed key \"(a + b)\".", type: "Identifier", line: 1, column: 24 }]
     }, {
         code: "fn({ foo:bar, 'key' :value });",
         options: [{
             beforeColon: false,
             afterColon: false
         }],
-        errors: [{ message: "Extra space after key \"key\".", type: "Literal", line: 1, column: 14 }]
+        errors: [{ message: "Extra space after key \"key\".", type: "Literal", line: 1, column: 15 }]
     }, {
         code: "var obj = {prop :(42)};",
         options: [{
             beforeColon: true,
             afterColon: true
         }],
-        errors: [{ message: "Missing space before value for key \"prop\".", type: "Literal", line: 1, column: 17 }]
+        errors: [{ message: "Missing space before value for key \"prop\".", type: "Literal", line: 1, column: 18 }]
     }, {
         code: "({'a' : foo, b: bar() }).b();",
         options: [{
             beforeColon: true,
             afterColon: true
         }],
-        errors: [{ message: "Missing space after key \"b\".", type: "Identifier", line: 1, column: 13 }]
+        errors: [{ message: "Missing space after key \"b\".", type: "Identifier", line: 1, column: 14 }]
     }, {
         code: "({'a'  :foo(), b:  bar() }).b();",
         options: [{
@@ -203,10 +203,10 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             afterColon: true
         }],
         errors: [
-            { message: "Extra space after key \"a\".", type: "Literal", line: 1, column: 2 },
-            { message: "Missing space before value for key \"a\".", type: "CallExpression", line: 1, column: 8 },
-            { message: "Missing space after key \"b\".", type: "Identifier", line: 1, column: 15 },
-            { message: "Extra space before value for key \"b\".", type: "CallExpression", line: 1, column: 19 }
+            { message: "Extra space after key \"a\".", type: "Literal", line: 1, column: 3 },
+            { message: "Missing space before value for key \"a\".", type: "CallExpression", line: 1, column: 9 },
+            { message: "Missing space after key \"b\".", type: "Identifier", line: 1, column: 16 },
+            { message: "Extra space before value for key \"b\".", type: "CallExpression", line: 1, column: 20 }
         ]
     }, {
         code: "bar = { key:value };",
@@ -214,7 +214,7 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             beforeColon: false,
             afterColon: true
         }],
-        errors: [{ message: "Missing space before value for key \"key\".", type: "Identifier", line: 1, column: 12 }]
+        errors: [{ message: "Missing space before value for key \"key\".", type: "Identifier", line: 1, column: 13 }]
     }, {
         code: [
             "obj = {",
@@ -227,9 +227,9 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             align: "colon"
         }],
         errors: [
-            { message: "Missing space after key \"key\".", type: "Identifier", line: 2, column: 4 },
-            { message: "Extra space before value for key \"key\".", type: "Identifier", line: 2, column: 11 },
-            { message: "Missing space before value for key \"foobar\".", type: "CallExpression", line: 3, column: 11}
+            { message: "Missing space after key \"key\".", type: "Identifier", line: 2, column: 5 },
+            { message: "Extra space before value for key \"key\".", type: "Identifier", line: 2, column: 12 },
+            { message: "Missing space before value for key \"foobar\".", type: "CallExpression", line: 3, column: 12}
         ]
     }, {
         code: [
@@ -246,9 +246,9 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             afterColon: false
         }],
         errors: [
-            { message: "Extra space before value for key \"a\".", type: "Identifier", line: 2, column: 10 },
-            { message: "Missing space after key \"foo\".", type: "Identifier", line: 3, column: 4 },
-            { message: "Extra space after key \"b\".", type: "Identifier", line: 4, column: 4 }
+            { message: "Extra space before value for key \"a\".", type: "Identifier", line: 2, column: 11 },
+            { message: "Missing space after key \"foo\".", type: "Identifier", line: 3, column: 5 },
+            { message: "Extra space after key \"b\".", type: "Identifier", line: 4, column: 5 }
         ]
     }, {
         code: [
@@ -265,10 +265,10 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
         }],
         ecmaFeatures: { objectLiteralComputedProperties: true },
         errors: [
-            { message: "Extra space before value for key \"a\".", type: "CallExpression", line: 2, column: 10 },
-            { message: "Extra space after key \"b\".", type: "Literal", line: 3, column: 4 },
-            { message: "Missing space before value for key \"foo\".", type: "Identifier", line: 4, column: 8 },
-            { message: "Extra space after computed key \"a\".", type: "Identifier", line: 6, column: 5 }
+            { message: "Extra space before value for key \"a\".", type: "CallExpression", line: 2, column: 11 },
+            { message: "Extra space after key \"b\".", type: "Literal", line: 3, column: 5 },
+            { message: "Missing space before value for key \"foo\".", type: "Identifier", line: 4, column: 9 },
+            { message: "Extra space after computed key \"a\".", type: "Identifier", line: 6, column: 6 }
         ]
     }, {
         code: [
@@ -285,8 +285,8 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             afterColon: false
         }],
         errors: [
-            { message: "Missing space after key \"a\".", type: "Identifier", line: 2, column: 4 },
-            { message: "Extra space before value for key \"bar\".", type: "CallExpression", line: 5, column: 10 }
+            { message: "Missing space after key \"a\".", type: "Identifier", line: 2, column: 5 },
+            { message: "Extra space before value for key \"bar\".", type: "CallExpression", line: 5, column: 11 }
         ]
     }, {
         code: [
@@ -302,9 +302,9 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             align: "colon"
         }],
         errors: [
-            { message: "Missing space after key \"a\".", type: "Identifier", line: 2, column: 4 },
-            { message: "Missing space after key \"e\".", type: "Identifier", line: 5, column: 4 },
-            { message: "Missing space before value for key \"fg\".", type: "Literal", line: 6, column: 7 }
+            { message: "Missing space after key \"a\".", type: "Identifier", line: 2, column: 5 },
+            { message: "Missing space after key \"e\".", type: "Identifier", line: 5, column: 5 },
+            { message: "Missing space before value for key \"fg\".", type: "Literal", line: 6, column: 8 }
         ]
     }, {
         code: [
@@ -320,8 +320,8 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
             afterColon: false
         }],
         errors: [
-            { message: "Extra space before value for key \"key\".", type: "Identifier", line: 3, column: 8 },
-            { message: "Extra space after key \"key2\".", type: "Identifier", line: 4, column: 4 }
+            { message: "Extra space before value for key \"key\".", type: "Identifier", line: 3, column: 9 },
+            { message: "Extra space after key \"key2\".", type: "Identifier", line: 4, column: 5 }
         ]
     }, {
         code: [
@@ -344,18 +344,18 @@ eslintTester.addRuleTest("lib/rules/key-spacing", {
     }, {
         code: "foo = { key:(1+2) };",
         errors: [
-            { message: "Missing space before value for key \"key\".", line: 1, column: 12, type: "BinaryExpression" }
+            { message: "Missing space before value for key \"key\".", line: 1, column: 13, type: "BinaryExpression" }
         ]
     }, {
         code: "foo = { key:( ( (1+2) ) ) };",
         errors: [
-            { message: "Missing space before value for key \"key\".", line: 1, column: 12, type: "BinaryExpression" }
+            { message: "Missing space before value for key \"key\".", line: 1, column: 13, type: "BinaryExpression" }
         ]
     }, {
         code: "var obj = {a  : 'foo', bar: 'bam'};",
         options: [{ align: "colon" }],
         errors: [
-            { message: "Extra space after key \"a\".", line: 1, column: 11, type: "Identifier" }
+            { message: "Extra space after key \"a\".", line: 1, column: 12, type: "Identifier" }
         ]
     }]
 

--- a/tests/lib/rules/linebreak-style.js
+++ b/tests/lib/rules/linebreak-style.js
@@ -53,7 +53,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2],
             errors: [{
                 line: 1,
-                column: 12,
+                column: 13,
                 message: EXPECTED_LF_MSG
             }]
         },
@@ -62,7 +62,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2, "unix"],
             errors: [{
                 line: 1,
-                column: 12,
+                column: 13,
                 message: EXPECTED_LF_MSG
             }]
         },
@@ -71,7 +71,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2, "windows"],
             errors: [{
                 line: 1,
-                column: 12,
+                column: 13,
                 message: EXPECTED_CRLF_MSG
             }]
         },
@@ -80,7 +80,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2],
             errors: [{
                 line: 4,
-                column: 23,
+                column: 24,
                 message: EXPECTED_LF_MSG
             }]
         },
@@ -89,7 +89,7 @@ eslintTester.addRuleTest("lib/rules/linebreak-style", {
             args: [2, "windows"],
             errors: [{
                 line: 3,
-                column: 0,
+                column: 1,
                 message: EXPECTED_CRLF_MSG
             }]
         }

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -343,7 +343,7 @@ eslintTester.addRuleTest("lib/rules/lines-around-comment", {
         {
             code: "// A line comment with no empty line after\nvar a = 1;",
             options: [{ beforeLineComment: true, afterLineComment: true }],
-            errors: [{ message: afterMessage, type: "Line", line: 1, column: 0 }]
+            errors: [{ message: afterMessage, type: "Line", line: 1, column: 1 }]
         },
         {
             code: "baz()\n// A line comment with no empty line after\nvar a = 1;",

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -73,7 +73,7 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
                     message: "A function with a name starting with an uppercase letter should only be used as a constructor.",
                     type: "CallExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -84,7 +84,7 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
                     message: "A function with a name starting with an uppercase letter should only be used as a constructor.",
                     type: "CallExpression",
                     line: 2,
-                    column: 1
+                    column: 2
                 }
             ]
         },
@@ -95,7 +95,7 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
                     message: "A constructor name should not start with a lowercase letter.",
                     type: "NewExpression",
                     line: 1,
-                    column: 14
+                    column: 15
                 }
             ]
         },
@@ -106,7 +106,7 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
                     message: "A constructor name should not start with a lowercase letter.",
                     type: "NewExpression",
                     line: 2,
-                    column: 0
+                    column: 1
                 }
             ]
         },
@@ -117,7 +117,7 @@ eslintTester.addRuleTest("lib/rules/new-cap", {
                     message: "A constructor name should not start with a lowercase letter.",
                     type: "NewExpression",
                     line: 1,
-                    column: 12
+                    column: 13
                 }
             ]
         }

--- a/tests/lib/rules/no-alert.js
+++ b/tests/lib/rules/no-alert.js
@@ -40,71 +40,71 @@ eslintTester.addRuleTest("lib/rules/no-alert", {
     invalid: [
         {
             code: "alert(foo)",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "window.alert(foo)",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "window['alert'](foo)",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "confirm(foo)",
-            errors: [{ message: "Unexpected confirm.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected confirm.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "window.confirm(foo)",
-            errors: [{ message: "Unexpected confirm.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected confirm.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "window['confirm'](foo)",
-            errors: [{ message: "Unexpected confirm.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected confirm.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "prompt(foo)",
-            errors: [{ message: "Unexpected prompt.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected prompt.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "window.prompt(foo)",
-            errors: [{ message: "Unexpected prompt.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected prompt.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "window['prompt'](foo)",
-            errors: [{ message: "Unexpected prompt.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected prompt.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "function alert() {} window.alert(foo)",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 21 }]
         },
         {
             code: "var alert = function () {};\nwindow.alert(foo)",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 2, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 2, column: 1 }]
         },
         {
             code: "function foo(alert) { window.alert(); }",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 22 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 23 }]
         },
         {
             code: "function foo() { alert(); }",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 17 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 18 }]
         },
         {
             code: "function foo() { var alert = function() {}; }\nalert();",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 2, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 2, column: 1 }]
         },
         {
             code: "this.alert(foo)",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "this['alert'](foo)",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 1, column: 1 }]
         },
         {
             code: "function foo() { var window = bar; window.alert(); }\nwindow.alert();",
-            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 2, column: 0 }]
+            errors: [{ message: "Unexpected alert.", type: "CallExpression", line: 2, column: 1 }]
         }
     ]
 });

--- a/tests/lib/rules/no-extra-semi.js
+++ b/tests/lib/rules/no-extra-semi.js
@@ -37,41 +37,41 @@ eslintTester.addRuleTest("lib/rules/no-extra-semi", {
         {
             code: "class A { ; }",
             ecmaFeatures: {classes: true},
-            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 10}]
+            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 11}]
         },
         {
             code: "class A { /*a*/; }",
             ecmaFeatures: {classes: true},
-            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 15}]
+            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 16}]
         },
         {
             code: "class A { ; a() {} }",
             ecmaFeatures: {classes: true},
-            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 10}]
+            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 11}]
         },
         {
             code: "class A { a() {}; }",
             ecmaFeatures: {classes: true},
-            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 16}]
+            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 17}]
         },
         {
             code: "class A { a() {}; b() {} }",
             ecmaFeatures: {classes: true},
-            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 16}]
+            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 17}]
         },
         {
             code: "class A {; a() {}; b() {}; }",
             ecmaFeatures: {classes: true},
             errors: [
-                {message: "Unnecessary semicolon.", type: "Punctuator", column: 9},
-                {message: "Unnecessary semicolon.", type: "Punctuator", column: 17},
-                {message: "Unnecessary semicolon.", type: "Punctuator", column: 25}
+                {message: "Unnecessary semicolon.", type: "Punctuator", column: 10},
+                {message: "Unnecessary semicolon.", type: "Punctuator", column: 18},
+                {message: "Unnecessary semicolon.", type: "Punctuator", column: 26}
             ]
         },
         {
             code: "class A { a() {}; get b() {} }",
             ecmaFeatures: {classes: true},
-            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 16}]
+            errors: [{message: "Unnecessary semicolon.", type: "Punctuator", column: 17}]
         }
     ]
 });

--- a/tests/lib/rules/no-irregular-whitespace.js
+++ b/tests/lib/rules/no-irregular-whitespace.js
@@ -166,13 +166,13 @@ eslintTester.addRuleTest("lib/rules/no-irregular-whitespace", {
                     message: "Irregular whitespace not allowed",
                     type: "Program",
                     line: 1,
-                    column: 12
+                    column: 13
                 },
                 {
                     message: "Irregular whitespace not allowed",
                     type: "Program",
                     line: 3,
-                    column: 7
+                    column: 8
                 }
             ]
         },
@@ -183,19 +183,19 @@ eslintTester.addRuleTest("lib/rules/no-irregular-whitespace", {
                     message: "Irregular whitespace not allowed",
                     type: "Program",
                     line: 1,
-                    column: 8
+                    column: 9
                 },
                 {
                     message: "Irregular whitespace not allowed",
                     type: "Program",
                     line: 1,
-                    column: 27
+                    column: 28
                 },
                 {
                     message: "Irregular whitespace not allowed",
                     type: "Program",
                     line: 2,
-                    column: 10
+                    column: 11
                 }
             ]
         }

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -61,7 +61,7 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
                 message: "x is already declared in the upper scope.",
                 type: "Identifier",
                 line: 1,
-                column: 43
+                column: 44
             }]
         },
         {
@@ -73,7 +73,7 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
                 message: "x is already declared in the upper scope.",
                 type: "Identifier",
                 line: 1,
-                column: 37
+                column: 38
             }]
         },
         {
@@ -82,7 +82,7 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
                 message: "x is already declared in the upper scope.",
                 type: "Identifier",
                 line: 1,
-                column: 42
+                column: 43
             }]
         },
         {
@@ -91,7 +91,7 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
                 message: "x is already declared in the upper scope.",
                 type: "Identifier",
                 line: 1,
-                column: 22
+                column: 23
             }]
         },
         {
@@ -284,8 +284,8 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
         {
             code: "(function a() { function a(){ function a(){} } })()",
             errors: [
-                { message: "a is already declared in the upper scope.", type: "Identifier", line: 1, column: 25},
-                { message: "a is already declared in the upper scope.", type: "Identifier", line: 1, column: 39}
+                { message: "a is already declared in the upper scope.", type: "Identifier", line: 1, column: 26},
+                { message: "a is already declared in the upper scope.", type: "Identifier", line: 1, column: 40}
             ]
         }
     ]

--- a/tests/lib/rules/no-space-before-semi.js
+++ b/tests/lib/rules/no-space-before-semi.js
@@ -40,57 +40,57 @@ eslintTester.addRuleTest("lib/rules/no-space-before-semi", {
     invalid: [
         {
             code: "var foo = \"bar\" ;",
-            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 16 } ]
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 17 } ]
         },
         {
             code: "var foo = function() {} ;",
-            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 24 } ]
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 25 } ]
         },
         {
             code: "var foo = function() {\n} ;",
-            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 2, column: 2 } ]
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 2, column: 3 } ]
         },
         {
             code: "var thing = 'test' ;",
-            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 19 } ]
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 20 } ]
         },
         {
             code: "var foo = 1 + 2 ;",
-            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 16 } ]
+            errors: [ { message: expectedErrorMessage, type: "VariableDeclaration", line: 1, column: 17 } ]
         },
         {
             code: "/^thing$/.test('thing') ;",
-            errors: [{ message: expectedErrorMessage, type: "ExpressionStatement", line: 1, column: 24 } ]
+            errors: [{ message: expectedErrorMessage, type: "ExpressionStatement", line: 1, column: 25 } ]
         },
         {
             code: ";(function(){}()) ;",
-            errors: [ { message: expectedErrorMessage, type: "ExpressionStatement", line: 1, column: 18 } ]
+            errors: [ { message: expectedErrorMessage, type: "ExpressionStatement", line: 1, column: 19 } ]
         },
         {
             code: "while (true) { break ; }",
-            errors: [ { message: expectedErrorMessage, type: "BreakStatement", line: 1, column: 21 } ]
+            errors: [ { message: expectedErrorMessage, type: "BreakStatement", line: 1, column: 22 } ]
         },
         {
             code: "while (true) { continue ; }",
-            errors: [ { message: expectedErrorMessage, type: "ContinueStatement", line: 1, column: 24 } ]
+            errors: [ { message: expectedErrorMessage, type: "ContinueStatement", line: 1, column: 25 } ]
         },
         {
             code: "debugger ;",
-            errors: [ { message: expectedErrorMessage, type: "DebuggerStatement", line: 1, column: 9 } ]
+            errors: [ { message: expectedErrorMessage, type: "DebuggerStatement", line: 1, column: 10 } ]
         },
         {
             code: "function foo() { return ; }",
-            errors: [ { message: expectedErrorMessage, type: "ReturnStatement", line: 1, column: 24 } ]
+            errors: [ { message: expectedErrorMessage, type: "ReturnStatement", line: 1, column: 25 } ]
         },
         {
             code: "throw new Error('foo') ;",
-            errors: [ { message: expectedErrorMessage, type: "ThrowStatement", line: 1, column: 23 } ]
+            errors: [ { message: expectedErrorMessage, type: "ThrowStatement", line: 1, column: 24 } ]
         },
         {
             code: "for (var i = 0 ; i < 10 ; i++) {}",
             errors: [
-                { message: expectedErrorMessage, type: "ForStatement", line: 1, column: 15 },
-                { message: expectedErrorMessage, type: "ForStatement", line: 1, column: 24 }
+                { message: expectedErrorMessage, type: "ForStatement", line: 1, column: 16 },
+                { message: expectedErrorMessage, type: "ForStatement", line: 1, column: 25 }
             ]
         }
     ]

--- a/tests/lib/rules/no-this-before-super.js
+++ b/tests/lib/rules/no-this-before-super.js
@@ -105,12 +105,12 @@ eslintTester.addRuleTest("lib/rules/no-this-before-super", {
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { super(); this.e(); } } this.f(); super(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression", column: 95}]
+            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression", column: 96}]
         },
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { this.e(); super(); } } super(); this.f(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression", column: 72}]
+            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression", column: 73}]
         }
     ]
 });

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -152,7 +152,7 @@ eslintTester.addRuleTest("lib/rules/no-trailing-spaces", {
                 message: "Trailing spaces not allowed.",
                 type: "Program",
                 line: 1,
-                column: 16 // there are invalid spaces in columns 15 and 16
+                column: 17 // there are invalid spaces in columns 15 and 16
             }],
             options: [{
                 skipBlankLines: true

--- a/tests/lib/rules/no-unexpected-multiline.js
+++ b/tests/lib/rules/no-unexpected-multiline.js
@@ -29,37 +29,37 @@ eslintTester.addRuleTest("lib/rules/no-unexpected-multiline", {
         {
             code: "var a = b\n(x || y).doSomething()",
             line: 2,
-            column: 0,
+            column: 1,
             errors: [{ message: "Unexpected newline between function and ( of function call." }]
         },
         {
             code: "var a = (a || b)\n(x || y).doSomething()",
             line: 2,
-            column: 0,
+            column: 1,
             errors: [{ message: "Unexpected newline between function and ( of function call." }]
         },
         {
             code: "var a = (a || b)\n(x).doSomething()",
             line: 2,
-            column: 0,
+            column: 1,
             errors: [{ message: "Unexpected newline between function and ( of function call." }]
         },
         {
 			code: "var a = b\n[a, b, c].forEach(doSomething)",
             line: 2,
-            column: 0,
+            column: 1,
             errors: [{ message: "Unexpected newline between object and [ of property access." }]
 		},
         {
 			code: "var a = b\n    (x || y).doSomething()",
             line: 2,
-            column: 4,
+            column: 5,
             errors: [{ message: "Unexpected newline between function and ( of function call." }]
 		},
         {
 			code: "var a = b\n  [a, b, c].forEach(doSomething)",
             line: 2,
-            column: 2,
+            column: 3,
             errors: [{ message: "Unexpected newline between object and [ of property access." }]
 		}
     ]

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -32,7 +32,7 @@ eslintTester.addRuleTest("lib/rules/no-unneeded-ternary", {
                 message: "Unnecessary use of boolean literals in conditional expression",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 18
+                column: 19
             }]
         }
     ]

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -114,13 +114,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required after '{'",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 7
+                    column: 8
                 },
                 {
                     message: "A space is required before '}'",
                     type: "ImportDeclaration",
                     line: 1,
-                    column: 11
+                    column: 12
                 }
             ]
         },
@@ -135,13 +135,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required after '{'",
                     type: "ExportNamedDeclaration",
                     line: 1,
-                    column: 7
+                    column: 8
                 },
                 {
                     message: "A space is required before '}'",
                     type: "ExportNamedDeclaration",
                     line: 1,
-                    column: 11
+                    column: 12
                 }
             ]
         },
@@ -177,7 +177,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 42
+                    column: 43
                 }
             ]
         },
@@ -189,7 +189,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 60
+                    column: 61
                 }
             ]
         },
@@ -204,7 +204,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required before '}'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 8
+                    column: 9
                 }
             ]
         },
@@ -217,7 +217,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space before '}'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 8
+                    column: 9
                 }
             ]
         },
@@ -231,7 +231,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 38
+                    column: 39
                 }
             ]
         },
@@ -243,7 +243,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 54
+                    column: 55
                 }
             ]
         },
@@ -257,13 +257,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required after '{'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "A space is required before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 29
+                    column: 30
                 }
             ]
         },
@@ -275,7 +275,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required after '{'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -287,7 +287,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 30
+                    column: 31
                 }
             ]
         },
@@ -299,13 +299,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space after '{'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 31
+                    column: 32
                 }
             ]
         },
@@ -317,7 +317,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 30
+                    column: 31
                 }
             ]
         },
@@ -329,7 +329,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space after '{'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -341,13 +341,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space after '{'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 10
+                    column: 11
                 },
                 {
                     message: "There should be no space after '{'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 17
+                    column: 18
                 }
             ]
         },
@@ -359,13 +359,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 27
+                    column: 28
                 },
                 {
                     message: "There should be no space before '}'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 39
+                    column: 40
                 }
             ]
         },
@@ -381,7 +381,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required after '{'",
                     type: "ObjectExpression",
                     line: 1,
-                    column: 21
+                    column: 22
                 }
             ]
         },
@@ -396,13 +396,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required after '{'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 4
+                    column: 5
                 },
                 {
                     message: "A space is required before '}'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 9
+                    column: 10
                 }
             ]
         },
@@ -415,7 +415,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required before '}'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -428,13 +428,13 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space after '{'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 4
+                    column: 5
                 },
                 {
                     message: "There should be no space before '}'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 11
+                    column: 12
                 }
             ]
         },
@@ -447,7 +447,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "There should be no space before '}'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -460,7 +460,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required before '}'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 10
+                    column: 11
                 }
             ]
         },
@@ -473,7 +473,7 @@ eslintTester.addRuleTest("lib/rules/object-curly-spacing", {
                     message: "A space is required after '{'",
                     type: "ObjectPattern",
                     line: 1,
-                    column: 4
+                    column: 5
                 }
             ]
         },

--- a/tests/lib/rules/one-var.js
+++ b/tests/lib/rules/one-var.js
@@ -453,7 +453,7 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                 message: "Combine this with the previous 'let' statement.",
                 type: "VariableDeclaration",
                 line: 1,
-                column: 73
+                column: 74
             }]
         },
         {
@@ -463,7 +463,7 @@ eslintTester.addRuleTest("lib/rules/one-var", {
                 message: "Combine this with the previous 'var' statement.",
                 type: "VariableDeclaration",
                 line: 2,
-                column: 0
+                column: 1
             } ]
         },
         {

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -63,7 +63,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -72,7 +72,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 2
+                column: 3
             }]
         },
         {
@@ -81,7 +81,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(BAD_LN_BRK_MSG, "+"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -90,7 +90,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -99,7 +99,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(AFTER_MSG, "+"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -108,7 +108,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(AFTER_MSG, "||"),
                 type: "LogicalExpression",
                 line: 2,
-                column: 3
+                column: 4
             }]
         },
         {
@@ -117,7 +117,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(AFTER_MSG, "+="),
                 type: "AssignmentExpression",
                 line: 2,
-                column: 3
+                column: 4
             }]
         },
         {
@@ -126,7 +126,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(AFTER_MSG, "="),
                 type: "VariableDeclarator",
                 line: 2,
-                column: 2
+                column: 3
             }]
         },
         {
@@ -135,7 +135,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(BAD_LN_BRK_MSG, "*"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 1
+                column: 2
             }]
         },
 
@@ -146,7 +146,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(BEFORE_MSG, "+"),
                 type: "BinaryExpression",
                 line: 1,
-                column: 3
+                column: 4
             }]
         },
         {
@@ -156,7 +156,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(BEFORE_MSG, "+"),
                 type: "BinaryExpression",
                 line: 1,
-                column: 5
+                column: 6
             }]
         },
         {
@@ -166,7 +166,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(BEFORE_MSG, "||"),
                 type: "LogicalExpression",
                 line: 1,
-                column: 4
+                column: 5
             }]
         },
         {
@@ -176,7 +176,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(BEFORE_MSG, "+="),
                 type: "AssignmentExpression",
                 line: 1,
-                column: 4
+                column: 5
             }]
         },
         {
@@ -186,7 +186,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(BEFORE_MSG, "="),
                 type: "VariableDeclarator",
                 line: 1,
-                column: 7
+                column: 8
             }]
         },
 
@@ -197,7 +197,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "+"),
                 type: "BinaryExpression",
                 line: 1,
-                column: 3
+                column: 4
             }]
         },
         {
@@ -207,7 +207,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "+"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -217,7 +217,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "+"),
                 type: "BinaryExpression",
                 line: 1,
-                column: 5
+                column: 6
             }]
         },
         {
@@ -227,7 +227,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "+"),
                 type: "BinaryExpression",
                 line: 2,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -237,7 +237,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "||"),
                 type: "LogicalExpression",
                 line: 1,
-                column: 4
+                column: 5
             }]
         },
         {
@@ -247,7 +247,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "||"),
                 type: "LogicalExpression",
                 line: 2,
-                column: 3
+                column: 4
             }]
         },
         {
@@ -257,7 +257,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "+="),
                 type: "AssignmentExpression",
                 line: 1,
-                column: 4
+                column: 5
             }]
         },
         {
@@ -267,7 +267,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "+="),
                 type: "AssignmentExpression",
                 line: 2,
-                column: 2
+                column: 3
             }]
         },
         {
@@ -277,7 +277,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "="),
                 type: "VariableDeclarator",
                 line: 1,
-                column: 7
+                column: 8
             }]
         },
         {
@@ -287,7 +287,7 @@ eslintTester.addRuleTest("lib/rules/operator-linebreak", {
                 message: util.format(NONE_MSG, "="),
                 type: "VariableDeclarator",
                 line: 2,
-                column: 2
+                column: 3
             }]
         }
     ]

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -45,7 +45,7 @@ eslintTester.addRuleTest("lib/rules/padded-blocks", {
                 {
                     message: ALWAYS_MESSAGE,
                     line: 1,
-                    column: 0
+                    column: 1
                 }
             ]
         },
@@ -55,7 +55,7 @@ eslintTester.addRuleTest("lib/rules/padded-blocks", {
                 {
                     message: ALWAYS_MESSAGE,
                     line: 5,
-                    column: 0
+                    column: 2
                 }
             ]
         },

--- a/tests/lib/rules/require-yield.js
+++ b/tests/lib/rules/require-yield.js
@@ -86,7 +86,7 @@ eslintTester.addRuleTest("lib/rules/require-yield", {
             errors: [{
                 message: errorMessage,
                 type: "FunctionDeclaration",
-                column: 0
+                column: 1
             }]
         },
         {
@@ -95,7 +95,7 @@ eslintTester.addRuleTest("lib/rules/require-yield", {
             errors: [{
                 message: errorMessage,
                 type: "FunctionDeclaration",
-                column: 18
+                column: 19
             }]
         }
     ]

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -53,90 +53,90 @@ eslintTester.addRuleTest("lib/rules/semi-spacing", {
     invalid: [
         {
             code: "var a = 'b' ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 1, column: 12 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 1, column: 13 } ]
         },
         {
             code: "var a = 'b',\nc = 'd' ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 2, column: 8 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 2, column: 9 } ]
         },
         {
             code: "var a = function() {} ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 1, column: 22 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 1, column: 23 } ]
         },
         {
             code: "var a = function() {\n} ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 2, column: 2 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "VariableDeclaration", line: 2, column: 3 } ]
         },
         {
             code: "/^a$/.test('b') ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ExpressionStatement", line: 1, column: 16 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ExpressionStatement", line: 1, column: 17 } ]
         },
         {
             code: ";(function(){}()) ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ExpressionStatement", line: 1, column: 18 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ExpressionStatement", line: 1, column: 19 } ]
         },
         {
             code: "while (true) { break ; }",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "BreakStatement", line: 1, column: 21 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "BreakStatement", line: 1, column: 22 } ]
         },
         {
             code: "while (true) { continue ; }",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ContinueStatement", line: 1, column: 24 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ContinueStatement", line: 1, column: 25 } ]
         },
         {
             code: "debugger ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "DebuggerStatement", line: 1, column: 9 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "DebuggerStatement", line: 1, column: 10 } ]
         },
         {
             code: "function foo() { return ; }",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ReturnStatement", line: 1, column: 24 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ReturnStatement", line: 1, column: 25 } ]
         },
         {
             code: "throw new Error('foo') ;",
-            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ThrowStatement", line: 1, column: 23 } ]
+            errors: [ { message: "Unexpected whitespace before semicolon.", type: "ThrowStatement", line: 1, column: 24 } ]
         },
         {
             code: "for (var i = 0 ; i < 10 ; i++) {}",
             errors: [
-                { message: "Unexpected whitespace before semicolon.", type: "ForStatement", line: 1, column: 15 },
-                { message: "Unexpected whitespace before semicolon.", type: "ForStatement", line: 1, column: 24 }
+                { message: "Unexpected whitespace before semicolon.", type: "ForStatement", line: 1, column: 16 },
+                { message: "Unexpected whitespace before semicolon.", type: "ForStatement", line: 1, column: 25 }
             ]
         },
         {
             code: "var a = 'b';c = 'd';",
-            errors: [ { message: "Missing whitespace after semicolon.", type: "VariableDeclaration", line: 1, column: 11 } ]
+            errors: [ { message: "Missing whitespace after semicolon.", type: "VariableDeclaration", line: 1, column: 12 } ]
         },
         {
             code: "var a = 'b';",
             options: [ { before: true, after: true } ],
-            errors: [ { message: "Missing whitespace before semicolon.", type: "VariableDeclaration", line: 1, column: 11 } ]
+            errors: [ { message: "Missing whitespace before semicolon.", type: "VariableDeclaration", line: 1, column: 12 } ]
         },
         {
             code: "var a = 'b'; c = 'd';",
             options: [ { before: false, after: false } ],
-            errors: [ { message: "Unexpected whitespace after semicolon.", type: "VariableDeclaration", line: 1, column: 11 } ]
+            errors: [ { message: "Unexpected whitespace after semicolon.", type: "VariableDeclaration", line: 1, column: 12 } ]
         },
         {
             code: "for (var i = 0;i < 10;i++) {}",
             errors: [
-                { message: "Missing whitespace after semicolon.", type: "ForStatement", line: 1, column: 14 },
-                { message: "Missing whitespace after semicolon.", type: "ForStatement", line: 1, column: 21 }
+                { message: "Missing whitespace after semicolon.", type: "ForStatement", line: 1, column: 15 },
+                { message: "Missing whitespace after semicolon.", type: "ForStatement", line: 1, column: 22 }
             ]
         },
         {
             code: "for (var i = 0; i < 10; i++) {}",
             options: [ { before: true, after: true } ],
             errors: [
-                { message: "Missing whitespace before semicolon.", type: "ForStatement", line: 1, column: 14 },
-                { message: "Missing whitespace before semicolon.", type: "ForStatement", line: 1, column: 22 }
+                { message: "Missing whitespace before semicolon.", type: "ForStatement", line: 1, column: 15 },
+                { message: "Missing whitespace before semicolon.", type: "ForStatement", line: 1, column: 23 }
             ]
         },
         {
             code: "for (var i = 0; i < 10; i++) {}",
             options: [ { before: false, after: false } ],
             errors: [
-                { message: "Unexpected whitespace after semicolon.", type: "ForStatement", line: 1, column: 14 },
-                { message: "Unexpected whitespace after semicolon.", type: "ForStatement", line: 1, column: 22 }
+                { message: "Unexpected whitespace after semicolon.", type: "ForStatement", line: 1, column: 15 },
+                { message: "Unexpected whitespace after semicolon.", type: "ForStatement", line: 1, column: 23 }
             ]
         }
 

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -49,7 +49,7 @@ eslintTester.addRuleTest("lib/rules/space-before-blocks", {
     invalid: [
         {
             code: "if(a){}",
-            errors: [ { message: expectedSpacingErrorMessage, line: 1, column: 5 } ]
+            errors: [ { message: expectedSpacingErrorMessage, line: 1, column: 6 } ]
         },
         {
             code: "if(a) {}",

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -105,7 +105,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionDeclaration",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 }
             ]
         },
@@ -116,7 +116,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 18
+                    column: 19
                 }
             ]
         },
@@ -127,7 +127,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -138,13 +138,13 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 19
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 33
+                    column: 34
                 }
             ]
         },
@@ -156,7 +156,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 15
+                    column: 16
                 }
             ]
         },
@@ -168,7 +168,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionDeclaration",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 13
+                    column: 14
                 }
             ]
         },
@@ -181,7 +181,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionDeclaration",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 }
             ]
         },
@@ -193,7 +193,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 18
+                    column: 19
                 }
             ]
         },
@@ -205,7 +205,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -217,13 +217,13 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 19
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 34
+                    column: 35
                 }
             ]
         },
@@ -236,7 +236,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 15
+                    column: 16
                 }
             ]
         },
@@ -249,7 +249,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionDeclaration",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 13
+                    column: 14
                 }
             ]
         },
@@ -267,31 +267,31 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionDeclaration",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 2,
-                    column: 18
-                },
-                {
-                    type: "FunctionExpression",
-                    message: "Unexpected space before function parentheses.",
-                    line: 3,
                     column: 19
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 3,
-                    column: 34
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 3,
-                    column: 48
+                    column: 35
+                },
+                {
+                    type: "FunctionExpression",
+                    message: "Unexpected space before function parentheses.",
+                    line: 3,
+                    column: 49
                 }
             ]
         },
@@ -304,13 +304,13 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 23
+                    column: 24
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 37
+                    column: 38
                 }
             ]
         },
@@ -323,7 +323,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 15
+                    column: 16
                 }
             ]
         },
@@ -340,31 +340,31 @@ eslintTester.addRuleTest("lib/rules/space-before-function-paren", {
                     type: "FunctionDeclaration",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 2,
-                    column: 18
-                },
-                {
-                    type: "FunctionExpression",
-                    message: "Missing space before function parentheses.",
-                    line: 3,
                     column: 19
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 3,
-                    column: 33
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 3,
-                    column: 46
+                    column: 34
+                },
+                {
+                    type: "FunctionExpression",
+                    message: "Missing space before function parentheses.",
+                    line: 3,
+                    column: 47
                 }
             ]
         }

--- a/tests/lib/rules/space-before-function-parentheses.js
+++ b/tests/lib/rules/space-before-function-parentheses.js
@@ -105,7 +105,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionDeclaration",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 }
             ]
         },
@@ -116,7 +116,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 18
+                    column: 19
                 }
             ]
         },
@@ -127,7 +127,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -138,13 +138,13 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 19
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 33
+                    column: 34
                 }
             ]
         },
@@ -156,7 +156,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 15
+                    column: 16
                 }
             ]
         },
@@ -168,7 +168,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionDeclaration",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 13
+                    column: 14
                 }
             ]
         },
@@ -181,7 +181,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionDeclaration",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 }
             ]
         },
@@ -193,7 +193,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 18
+                    column: 19
                 }
             ]
         },
@@ -205,7 +205,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 22
+                    column: 23
                 }
             ]
         },
@@ -217,13 +217,13 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 19
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 34
+                    column: 35
                 }
             ]
         },
@@ -236,7 +236,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 15
+                    column: 16
                 }
             ]
         },
@@ -249,7 +249,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionDeclaration",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 13
+                    column: 14
                 }
             ]
         },
@@ -267,31 +267,31 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionDeclaration",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 2,
-                    column: 18
-                },
-                {
-                    type: "FunctionExpression",
-                    message: "Unexpected space before function parentheses.",
-                    line: 3,
                     column: 19
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 3,
-                    column: 34
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 3,
-                    column: 48
+                    column: 35
+                },
+                {
+                    type: "FunctionExpression",
+                    message: "Unexpected space before function parentheses.",
+                    line: 3,
+                    column: 49
                 }
             ]
         },
@@ -304,13 +304,13 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 23
+                    column: 24
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 37
+                    column: 38
                 }
             ]
         },
@@ -323,7 +323,7 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 1,
-                    column: 15
+                    column: 16
                 }
             ]
         },
@@ -340,31 +340,31 @@ eslintTester.addRuleTest("lib/rules/space-before-function-parentheses", {
                     type: "FunctionDeclaration",
                     message: "Missing space before function parentheses.",
                     line: 1,
-                    column: 12
+                    column: 13
                 },
                 {
                     type: "FunctionExpression",
                     message: "Unexpected space before function parentheses.",
                     line: 2,
-                    column: 18
-                },
-                {
-                    type: "FunctionExpression",
-                    message: "Missing space before function parentheses.",
-                    line: 3,
                     column: 19
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 3,
-                    column: 33
+                    column: 20
                 },
                 {
                     type: "FunctionExpression",
                     message: "Missing space before function parentheses.",
                     line: 3,
-                    column: 46
+                    column: 34
+                },
+                {
+                    type: "FunctionExpression",
+                    message: "Missing space before function parentheses.",
+                    line: 3,
+                    column: 47
                 }
             ]
         }

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -35,7 +35,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "BinaryExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -44,7 +44,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "BinaryExpression",
                 line: 1,
-                column: 2
+                column: 3
             }]
         },
         {
@@ -53,7 +53,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "BinaryExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -62,7 +62,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "LogicalExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -71,7 +71,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "LogicalExpression",
                 line: 1,
-                column: 2
+                column: 3
             }]
         },
         {
@@ -80,7 +80,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "LogicalExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -89,7 +89,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "AssignmentExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -98,7 +98,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "AssignmentExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -107,7 +107,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "AssignmentExpression",
                 line: 1,
-                column: 2
+                column: 3
             }]
         },
         {
@@ -116,7 +116,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -125,7 +125,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -134,7 +134,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 5
+                column: 6
             }]
         },
         {
@@ -143,7 +143,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -152,7 +152,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 2
+                column: 3
             }]
         },
         {
@@ -161,7 +161,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 5
+                column: 6
             }]
         },
         {
@@ -170,7 +170,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "ConditionalExpression",
                 line: 1,
-                column: 6
+                column: 7
             }]
         },
         {
@@ -179,7 +179,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "VariableDeclarator",
                 line: 1,
-                column: 5
+                column: 6
             }]
         },
         {
@@ -188,7 +188,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "VariableDeclarator",
                 line: 1,
-                column: 5
+                column: 6
             }]
         },
         {
@@ -197,7 +197,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "VariableDeclarator",
                 line: 1,
-                column: 6
+                column: 7
             }]
         },
         {
@@ -206,7 +206,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "VariableDeclarator",
                 line: 1,
-                column: 12
+                column: 13
             }]
         },
         {
@@ -218,7 +218,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "BinaryExpression",
                 line: 1,
-                column: 1
+                column: 2
             }]
         },
         {
@@ -227,7 +227,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "LogicalExpression",
                 line: 1,
-                column: 42
+                column: 43
             }]
         },
         {
@@ -236,7 +236,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "LogicalExpression",
                 line: 1,
-                column: 15
+                column: 16
             }]
         },
         {
@@ -245,7 +245,7 @@ eslintTester.addRuleTest("lib/rules/space-infix-ops", {
                 message: "Infix operators must be spaced.",
                 type: "LogicalExpression",
                 line: 1,
-                column: 14
+                column: 15
             }]
         }
     ]


### PR DESCRIPTION
This switches all reported messages to be 1-based instead of 0-based. Easy enough change, but had to go through and update all tests that used columns.

Also, the `callback-return` test was failing due to invalid configuration, I fixed those so I could get all tests passing.