### PR TITLE
Docs: missing quotes in JSON

### DIFF
--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -29,7 +29,7 @@ You can enable this option in your config like this:
 
 ```json
 {
-    "no-trailing-spaces": [2, { skipBlankLines: true }]
+    "no-trailing-spaces": [2, { "skipBlankLines": true }]
 }
 ```
 


### PR DESCRIPTION
This was not valid JSON.
It's even marked red by Githubs syntax highlighting.