### PR TITLE
Fix: Make no-implied-eval match more types of strings (fixes #2898)

### DIFF
--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -12,51 +12,86 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var IMPLIED_EVAL = /set(?:Timeout|Interval)|execScript/;
+    var CALLEE_RE = /set(?:Timeout|Interval)|execScript/;
+
+    // Figures out if we should inspect a given binary expression. Is a stack of
+    // stacks, where the first element in each substack is a CallExpression.
+    var impliedEvalAncestorsStack = [];
 
     //--------------------------------------------------------------------------
     // Helpers
     //--------------------------------------------------------------------------
 
     /**
-     * Checks if the first argument of a given CallExpression node is a string literal.
-     * @param {ASTNode} node The CallExpression node the check.
-     * @returns {boolean} True if the first argument is a string literal, false if not.
+     * Get the last element of an array, without modifying arr, like pop(), but non-destructive.
+     * @param {array} arr What to inspect
+     * @returns {*} The last element of arr
+     * @private
      */
-    function hasStringLiteralArgument(node) {
-        var firstArgument = node.arguments[0];
-
-        return firstArgument && firstArgument.type === "Literal" && typeof firstArgument.value === "string";
+    function last(arr) {
+        return arr ? arr[arr.length - 1] : null;
     }
 
     /**
-     * Checks if the given MemberExpression node is window.setTimeout or window.setInterval.
+     * Checks if the given MemberExpression node is a potentially implied eval identifier on window.
      * @param {ASTNode} node The MemberExpression node to check.
-     * @returns {boolean} Whether or not the given node is window.set*.
+     * @returns {boolean} Whether or not the given node is potentially an implied eval.
+     * @private
      */
-    function isSetMemberExpression(node) {
+    function isImpliedEvalMemberExpression(node) {
         var object = node.object,
             property = node.property,
-            hasSetPropertyName = IMPLIED_EVAL.test(property.name) || IMPLIED_EVAL.test(property.value);
+            hasImpliedEvalName = CALLEE_RE.test(property.name) || CALLEE_RE.test(property.value);
 
-        return object.name === "window" && hasSetPropertyName;
-
+        return object.name === "window" && hasImpliedEvalName;
     }
 
     /**
-     * Determines if a node represents a call to setTimeout/setInterval with
-     * a string argument.
-     * @param {ASTNode} node The node to check.
+     * Determines if a node represents a call to a potentially implied eval.
+     *
+     * This checks the callee name and that there's an argument, but not the type of the argument.
+     *
+     * @param {ASTNode} node The CallExpression to check.
      * @returns {boolean} True if the node matches, false if not.
      * @private
      */
-    function isImpliedEval(node) {
+    function isImpliedEvalCallExpression(node) {
         var isMemberExpression = (node.callee.type === "MemberExpression"),
             isIdentifier = (node.callee.type === "Identifier"),
-            isSetMethod = (isIdentifier && IMPLIED_EVAL.test(node.callee.name)) ||
-                (isMemberExpression && isSetMemberExpression(node.callee));
+            isImpliedEvalCallee =
+                (isIdentifier && CALLEE_RE.test(node.callee.name)) ||
+                (isMemberExpression && isImpliedEvalMemberExpression(node.callee));
 
-        return isSetMethod && hasStringLiteralArgument(node);
+        return isImpliedEvalCallee && node.arguments.length;
+    }
+
+    /**
+     * Checks that the parent is a direct descendent of an potential implied eval CallExpression, and if the parent is a CallExpression, that we're the first argument.
+     * @param {ASTNode} node The node to inspect the parent of.
+     * @returns {boolean} Was the parent a direct descendent, and is the child therefore potentially part of a dangerous argument?
+     * @private
+     */
+    function hasImpliedEvalParent(node) {
+        // make sure our parent is marked
+        return node.parent === last(last(impliedEvalAncestorsStack)) &&
+            // if our parent is a CallExpression, make sure we're the first argument
+            (node.parent.type !== "CallExpression" || node === node.parent.arguments[0]);
+    }
+
+    /**
+     * Checks if our parent is marked as part of an implied eval argument. If
+     * so, collapses the top of impliedEvalAncestorsStack and reports on the
+     * original CallExpression.
+     * @param {ASTNode} node The CallExpression to check.
+     * @returns {boolean} True if the node matches, false if not.
+     * @private
+     */
+    function checkString(node) {
+        if (hasImpliedEvalParent(node)) {
+            // remove the entire substack, to avoid duplicate reports
+            var substack = impliedEvalAncestorsStack.pop();
+            context.report(substack[0], "Implied eval. Consider passing a function instead of a string.");
+        }
     }
 
     //--------------------------------------------------------------------------
@@ -65,9 +100,41 @@ module.exports = function(context) {
 
     return {
         "CallExpression": function(node) {
-            if (isImpliedEval(node)) {
-                context.report(node, "Implied eval. Consider passing a function instead of a string.");
+            if (isImpliedEvalCallExpression(node)) {
+                // call expressions create a new substack
+                impliedEvalAncestorsStack.push([node]);
             }
+        },
+
+        "CallExpression:exit": function(node) {
+            if (node === last(last(impliedEvalAncestorsStack))) {
+                // destroys the entire sub-stack, rather than just using
+                // last(impliedEvalAncestorsStack).pop(), as a CallExpression is
+                // always the bottom of a impliedEvalAncestorsStack substack.
+                impliedEvalAncestorsStack.pop();
+            }
+        },
+
+        "BinaryExpression": function(node) {
+            if (node.operator === "+" && hasImpliedEvalParent(node)) {
+                last(impliedEvalAncestorsStack).push(node);
+            }
+        },
+
+        "BinaryExpression:exit": function(node) {
+            if (node === last(last(impliedEvalAncestorsStack))) {
+                last(impliedEvalAncestorsStack).pop();
+            }
+        },
+
+        "Literal": function(node) {
+            if (typeof node.value === "string") {
+                checkString(node);
+            }
+        },
+
+        "TemplateLiteral": function(node) {
+            checkString(node);
         }
     };
 

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -22,13 +22,29 @@ var eslintTester = new ESLintTester(eslint),
 
 eslintTester.addRuleTest("lib/rules/no-implied-eval", {
     valid: [
+        // normal usage
         "setInterval(function() { x = 1; }, 100);",
+        // only checks on top-level statements or window.*
         "foo.setTimeout('hi')",
+        // identifiers are fine
         "setTimeout(foo, 10)",
+        // as are function expressions
         "setTimeout(function() {}, 10)",
+        // setInterval
         "foo.setInterval('hi')",
         "setInterval(foo, 10)",
-        "setInterval(function() {}, 10)"
+        "setInterval(function() {}, 10)",
+        // execScript
+        "foo.execScript('hi')",
+        "execScript(foo)",
+        "execScript(function() {})",
+        // a binary plus on non-strings doesn't guarantee a string
+        "setTimeout(foo + bar, 10)",
+        // doesn't check anything but the first argument
+        "setTimeout(foobar, 'buzz')",
+        "setTimeout(foobar, foo + 'bar')",
+        // only checks immediate subtrees of the argument
+        "setTimeout(function() { return 'foobar'; }, 10)"
     ],
 
     invalid: [
@@ -36,9 +52,39 @@ eslintTester.addRuleTest("lib/rules/no-implied-eval", {
         { code: "setTimeout(\"x = 1;\", 100);", errors: [expectedError] },
         { code: "setInterval(\"x = 1;\");", errors: [expectedError] },
         { code: "execScript(\"x = 1;\");", errors: [expectedError] },
+        // member expressions
         { code: "window.setTimeout('foo')", errors: [expectedError] },
         { code: "window.setInterval('foo')", errors: [expectedError] },
         { code: "window['setTimeout']('foo')", errors: [expectedError] },
-        { code: "window['setInterval']('foo')", errors: [expectedError] }
+        { code: "window['setInterval']('foo')", errors: [expectedError] },
+        // template literals
+        { code: "setTimeout(`foo${bar}`)", errors: [expectedError], ecmaFeatures: {templateStrings: true} },
+        // string concatination
+        { code: "setTimeout('foo' + bar)", errors: [expectedError] },
+        { code: "setTimeout(foo + 'bar')", errors: [expectedError] },
+        { code: "setTimeout(`foo` + bar)", errors: [expectedError], ecmaFeatures: {templateStrings: true} },
+        { code: "setTimeout(1 + ';' + 1)", errors: [expectedError] },
+        // gives the correct node when dealing with nesting
+        {
+            code:
+                "setTimeout('foo' + (function() {\n" +
+                "   setTimeout(helper);\n" +
+                "   execScript('str');\n" +
+                "   return 'bar';\n" +
+                "})())",
+            errors: [
+                {
+                    message: expectedErrorMessage,
+                    type: "CallExpression",
+                    line: "1"
+                },
+                // no error on line 2
+                {
+                    message: expectedErrorMessage,
+                    type: "CallExpression",
+                    line: "3"
+                }
+            ]
+        }
     ]
 });


### PR DESCRIPTION
- TemplateLiterals are strings
- Concatinating with a literal string implies a string. Eg.

  ```js
  setInterval("helper(" + foo + ", " + bar + ")", 50);
  ```