### PR TITLE
Breaking: Default to --reset behavior (fixes #2100)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,5 +1,10 @@
+root: true
+
 env:
     node: true
+
+extends:
+    "./conf/eslint.json"
 
 rules:
     indent: 2
@@ -21,3 +26,13 @@ rules:
     strict: [2, "global"]
     valid-jsdoc: [2, { prefer: { "return": "returns"}}]
     wrap-iife: 2
+
+    # Previously on by default in node environment
+    no-catch-shadow: 0
+    no-console: 0
+    no-mixed-requires: 2
+    no-new-require: 2
+    no-path-concat: 2
+    no-process-exit: 2
+    global-strict: [0, "always"]
+    handle-callback-err: [2, "err"]

--- a/conf/environments.js
+++ b/conf/environments.js
@@ -16,16 +16,6 @@ module.exports = {
         globals: globals.node,
         ecmaFeatures: {
             globalReturn: true
-        },
-        rules: {
-            "no-catch-shadow": 0,
-            "no-console": 0,
-            "no-mixed-requires": 2,
-            "no-new-require": 2,
-            "no-path-concat": 2,
-            "no-process-exit": 2,
-            "global-strict": [0, "always"],
-            "handle-callback-err": [2, "err"]
         }
     },
     worker: {

--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -1,14 +1,5 @@
 {
     "ecmaFeatures": {},
-    "parser": "espree",
-    "env": {
-        "browser": false,
-        "node": false,
-        "amd": false,
-        "mocha": false,
-        "jasmine": false
-    },
-
     "rules": {
         "no-alert": 2,
         "no-array-constructor": 2,

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -74,7 +74,6 @@ The `CLIEngine` is a constructor, and you can create a new instance by passing i
 * `globals` - An array of global variables to declare (default: empty array). Corresponds to `--global`.
 * `ignore` - False disables use of `.eslintignore` (default: true). Corresponds to `--no-ignore`.
 * `ignorePath` - The ignore file to use instead of `.eslintignore` (default: null). Corresponds to `--ignore-path`.
-* `reset` - True disables all default rules and environments (default: false). Corresponds to `--reset`.
 * `baseConfig` - Set to false to disable use of base config. Could be set to an object to override default base config as well.
 * `rulePaths` - An array of directories to load custom rules from (default: empty array). Corresponds to `--rulesdir`.
 * `rules` - An object of rules to use (default: null). Corresponds to `--rule`.

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -377,10 +377,10 @@ no-empty-class          |    21.976 |     2.6%
 semi                    |    19.359 |     2.3%
 ```
 
-To test one rule explicitly, combine the `--reset`, `--no-eslintrc`, and `--rule` options:
+To test one rule explicitly, combine the `--no-eslintrc`, and `--rule` options:
 
 ```bash
-$ TIMING=1 eslint --reset --no-eslintrc --rule "quotes: [2, 'double']" lib
+$ TIMING=1 eslint --no-eslintrc --rule "quotes: [2, 'double']" lib
 Rule   | Time (ms) | Relative
 :------|----------:|--------:
 quotes |    18.066 |   100.0%
@@ -397,14 +397,11 @@ The rule naming conventions for ESLint are fairly simple:
 
 ## Rule Acceptance Criteria
 
-Because rules are highly personal (and therefore very contentious), the following guidelines determine whether or not a rule is accepted and whether or not it is on by default:
+Because rules are highly personal (and therefore very contentious), accepted rules should:
 
-* If the same rule exists in JSHint and is turned on by default, it must have the same message and be enabled by default.
-* If the same rule exists in JSLint but not in JSHint, it must have the same message and be disabled by default.
-* If the rule doesn't exist in JSHint or JSLint, then it must:
-    * Not be library-specific.
-    * Demonstrate a possible issue that can be resolved by rewriting the code.
-    * Be general enough so as to apply for a large number of developers.
+* Not be library-specific.
+* Demonstrate a possible issue that can be resolved by rewriting the code.
+* Be general enough so as to apply for a large number of developers.
 
 ## Runtime Rules
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,221 +1,221 @@
 # Rules
 
-Rules in ESLint are divided into several categories to help you better understand their value. Additionally, not all rules are enabled by default. Those that are not enabled by default are marked as being off.
+Rules in ESLint are divided into several categories to help you better understand their value. Though none are enabled by default, some are specifically recommended by ESLint and may be turned on using [configuration](../user-guide/configuring.md).
 
 ## Possible Errors
 
 The following rules point out areas where you might have made mistakes.
 
-* [comma-dangle](comma-dangle.md) - disallow or enforce trailing commas
-* [no-cond-assign](no-cond-assign.md) - disallow assignment in conditional expressions
-* [no-console](no-console.md) - disallow use of `console` (off by default in the node environment)
-* [no-constant-condition](no-constant-condition.md) - disallow use of constant expressions in conditions
-* [no-control-regex](no-control-regex.md) - disallow control characters in regular expressions
-* [no-debugger](no-debugger.md) - disallow use of `debugger`
-* [no-dupe-args](no-dupe-args.md) - disallow duplicate arguments in functions
-* [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals
-* [no-duplicate-case](no-duplicate-case.md) - disallow a duplicate case label.
-* [no-empty-character-class](no-empty-character-class.md) - disallow the use of empty character classes in regular expressions
-* [no-empty-class](no-empty-class.md) - **(deprecated)** disallow the use of empty character classes in regular expressions (off by default)
-* [no-empty](no-empty.md) - disallow empty statements
-* [no-ex-assign](no-ex-assign.md) - disallow assigning to the exception in a `catch` block
-* [no-extra-boolean-cast](no-extra-boolean-cast.md) - disallow double-negation boolean casts in a boolean context
-* [no-extra-parens](no-extra-parens.md) - disallow unnecessary parentheses (off by default)
-* [no-extra-semi](no-extra-semi.md) - disallow unnecessary semicolons
-* [no-func-assign](no-func-assign.md) - disallow overwriting functions written as function declarations
-* [no-inner-declarations](no-inner-declarations.md) - disallow function or variable declarations in nested blocks
-* [no-invalid-regexp](no-invalid-regexp.md) - disallow invalid regular expression strings in the `RegExp` constructor
-* [no-irregular-whitespace](no-irregular-whitespace.md) - disallow irregular whitespace outside of strings and comments
-* [no-negated-in-lhs](no-negated-in-lhs.md) - disallow negation of the left operand of an `in` expression
-* [no-obj-calls](no-obj-calls.md) - disallow the use of object properties of the global object (`Math` and `JSON`) as functions
-* [no-regex-spaces](no-regex-spaces.md) - disallow multiple spaces in a regular expression literal
-* [no-reserved-keys](no-reserved-keys.md) - disallow reserved words being used as object literal keys (off by default)
-* [no-sparse-arrays](no-sparse-arrays.md) - disallow sparse arrays
-* [no-unreachable](no-unreachable.md) - disallow unreachable statements after a return, throw, continue, or break statement
-* [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN`
-* [valid-jsdoc](valid-jsdoc.md) - Ensure JSDoc comments are valid (off by default)
-* [valid-typeof](valid-typeof.md) - Ensure that the results of typeof are compared against a valid string
-* [no-unexpected-multiline](no-unexpected-multiline.md) - Avoid code that looks like two expressions but is actually one (off by default)
+* [comma-dangle](comma-dangle.md) - disallow or enforce trailing commas (recommended)
+* [no-cond-assign](no-cond-assign.md) - disallow assignment in conditional expressions (recommended)
+* [no-console](no-console.md) - disallow use of `console`the node environment) (recommended)
+* [no-constant-condition](no-constant-condition.md) - disallow use of constant expressions in conditions (recommended)
+* [no-control-regex](no-control-regex.md) - disallow control characters in regular expressions (recommended)
+* [no-debugger](no-debugger.md) - disallow use of `debugger` (recommended)
+* [no-dupe-args](no-dupe-args.md) - disallow duplicate arguments in functions (recommended)
+* [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals (recommended)
+* [no-duplicate-case](no-duplicate-case.md) - disallow a duplicate case label. (recommended)
+* [no-empty-character-class](no-empty-character-class.md) - disallow the use of empty character classes in regular expressions (recommended)
+* [no-empty-class](no-empty-class.md) - **(deprecated)** disallow the use of empty character classes in regular expressions
+* [no-empty](no-empty.md) - disallow empty statements (recommended)
+* [no-ex-assign](no-ex-assign.md) - disallow assigning to the exception in a `catch` block (recommended)
+* [no-extra-boolean-cast](no-extra-boolean-cast.md) - disallow double-negation boolean casts in a boolean context (recommended)
+* [no-extra-parens](no-extra-parens.md) - disallow unnecessary parentheses
+* [no-extra-semi](no-extra-semi.md) - disallow unnecessary semicolons (recommended)
+* [no-func-assign](no-func-assign.md) - disallow overwriting functions written as function declarations (recommended)
+* [no-inner-declarations](no-inner-declarations.md) - disallow function or variable declarations in nested blocks (recommended)
+* [no-invalid-regexp](no-invalid-regexp.md) - disallow invalid regular expression strings in the `RegExp` constructor (recommended)
+* [no-irregular-whitespace](no-irregular-whitespace.md) - disallow irregular whitespace outside of strings and comments (recommended)
+* [no-negated-in-lhs](no-negated-in-lhs.md) - disallow negation of the left operand of an `in` expression (recommended)
+* [no-obj-calls](no-obj-calls.md) - disallow the use of object properties of the global object (`Math` and `JSON`) as functions (recommended)
+* [no-regex-spaces](no-regex-spaces.md) - disallow multiple spaces in a regular expression literal (recommended)
+* [no-reserved-keys](no-reserved-keys.md) - disallow reserved words being used as object literal keys
+* [no-sparse-arrays](no-sparse-arrays.md) - disallow sparse arrays (recommended)
+* [no-unreachable](no-unreachable.md) - disallow unreachable statements after a return, throw, continue, or break statement (recommended)
+* [use-isnan](use-isnan.md) - disallow comparisons with the value `NaN` (recommended)
+* [valid-jsdoc](valid-jsdoc.md) - Ensure JSDoc comments are valid
+* [valid-typeof](valid-typeof.md) - Ensure that the results of typeof are compared against a valid string (recommended)
+* [no-unexpected-multiline](no-unexpected-multiline.md) - Avoid code that looks like two expressions but is actually one
 
 ## Best Practices
 
 These are rules designed to prevent you from making mistakes. They either prescribe a better way of doing something or help you avoid footguns.
 
-* [accessor-pairs](accessor-pairs.md) - Enforces getter/setter pairs in objects (off by default)
-* [block-scoped-var](block-scoped-var.md) - treat `var` statements as if they were block scoped (off by default)
-* [complexity](complexity.md) - specify the maximum cyclomatic complexity allowed in a program (off by default)
-* [consistent-return](consistent-return.md) - require `return` statements to either always or never specify values
-* [curly](curly.md) - specify curly brace conventions for all control statements
-* [default-case](default-case.md) - require `default` case in `switch` statements (off by default)
-* [dot-notation](dot-notation.md) - encourages use of dot notation whenever possible
-* [dot-location](dot-location.md) - enforces consistent newlines before or after dots (off by default)
-* [eqeqeq](eqeqeq.md) - require the use of `===` and `!==`
-* [guard-for-in](guard-for-in.md) - make sure `for-in` loops have an `if` statement (off by default)
-* [no-alert](no-alert.md) - disallow the use of `alert`, `confirm`, and `prompt`
-* [no-caller](no-caller.md) - disallow use of `arguments.caller` or `arguments.callee`
-* [no-div-regex](no-div-regex.md) - disallow division operators explicitly at beginning of regular expression (off by default)
-* [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if` (off by default)
-* [no-empty-label](no-empty-label.md) - disallow use of labels for anything other than loops and switches
-* [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator (off by default)
-* [no-eval](no-eval.md) - disallow use of `eval()`
-* [no-extend-native](no-extend-native.md) - disallow adding to native types
-* [no-extra-bind](no-extra-bind.md) - disallow unnecessary function binding
-* [no-fallthrough](no-fallthrough.md) - disallow fallthrough of `case` statements
-* [no-floating-decimal](no-floating-decimal.md) - disallow the use of leading or trailing decimal points in numeric literals (off by default)
-* [no-implied-eval](no-implied-eval.md) - disallow use of `eval()`-like methods
-* [no-iterator](no-iterator.md) - disallow usage of `__iterator__` property
-* [no-labels](no-labels.md) - disallow use of labeled statements
-* [no-lone-blocks](no-lone-blocks.md) - disallow unnecessary nested blocks
-* [no-loop-func](no-loop-func.md) - disallow creation of functions within loops
-* [no-multi-spaces](no-multi-spaces.md) - disallow use of multiple spaces
-* [no-multi-str](no-multi-str.md) - disallow use of multiline strings
-* [no-native-reassign](no-native-reassign.md) - disallow reassignments of native objects
-* [no-new-func](no-new-func.md) - disallow use of new operator for `Function` object
-* [no-new-wrappers](no-new-wrappers.md) - disallows creating new instances of `String`,`Number`, and `Boolean`
-* [no-new](no-new.md) - disallow use of new operator when not part of the assignment or comparison
-* [no-octal-escape](no-octal-escape.md) - disallow use of octal escape sequences in string literals, such as `var foo = "Copyright \251";`
-* [no-octal](no-octal.md) - disallow use of octal literals
-* [no-param-reassign](no-param-reassign.md) - disallow reassignment of function parameters (off by default)
-* [no-process-env](no-process-env.md) - disallow use of `process.env` (off by default)
-* [no-proto](no-proto.md) - disallow usage of `__proto__` property
-* [no-redeclare](no-redeclare.md) - disallow declaring the same variable more than once
-* [no-return-assign](no-return-assign.md) - disallow use of assignment in `return` statement
-* [no-script-url](no-script-url.md) - disallow use of javascript: urls.
-* [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same (off by default)
-* [no-sequences](no-sequences.md) - disallow use of comma operator
-* [no-throw-literal](no-throw-literal.md) - restrict what can be thrown as an exception (off by default)
-* [no-unused-expressions](no-unused-expressions.md) - disallow usage of expressions in statement position
-* [no-void](no-void.md) - disallow use of `void` operator (off by default)
-* [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME` (off by default)
-* [no-with](no-with.md) - disallow use of the `with` statement
-* [radix](radix.md) - require use of the second argument for `parseInt()` (off by default)
-* [vars-on-top](vars-on-top.md) - requires to declare all vars on top of their containing scope (off by default)
-* [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses (off by default)
-* [yoda](yoda.md) - require or disallow Yoda conditions
+* [accessor-pairs](accessor-pairs.md) - Enforces getter/setter pairs in objects
+* [block-scoped-var](block-scoped-var.md) - treat `var` statements as if they were block scoped
+* [complexity](complexity.md) - specify the maximum cyclomatic complexity allowed in a program
+* [consistent-return](consistent-return.md) - require `return` statements to either always or never specify values (recommended)
+* [curly](curly.md) - specify curly brace conventions for all control statements (recommended)
+* [default-case](default-case.md) - require `default` case in `switch` statements
+* [dot-notation](dot-notation.md) - encourages use of dot notation whenever possible (recommended)
+* [dot-location](dot-location.md) - enforces consistent newlines before or after dots
+* [eqeqeq](eqeqeq.md) - require the use of `===` and `!==` (recommended)
+* [guard-for-in](guard-for-in.md) - make sure `for-in` loops have an `if` statement
+* [no-alert](no-alert.md) - disallow the use of `alert`, `confirm`, and `prompt` (recommended)
+* [no-caller](no-caller.md) - disallow use of `arguments.caller` or `arguments.callee` (recommended)
+* [no-div-regex](no-div-regex.md) - disallow division operators explicitly at beginning of regular expression
+* [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if`
+* [no-empty-label](no-empty-label.md) - disallow use of labels for anything other than loops and switches (recommended)
+* [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator
+* [no-eval](no-eval.md) - disallow use of `eval()` (recommended)
+* [no-extend-native](no-extend-native.md) - disallow adding to native types (recommended)
+* [no-extra-bind](no-extra-bind.md) - disallow unnecessary function binding (recommended)
+* [no-fallthrough](no-fallthrough.md) - disallow fallthrough of `case` statements (recommended)
+* [no-floating-decimal](no-floating-decimal.md) - disallow the use of leading or trailing decimal points in numeric literals
+* [no-implied-eval](no-implied-eval.md) - disallow use of `eval()`-like methods (recommended)
+* [no-iterator](no-iterator.md) - disallow usage of `__iterator__` property (recommended)
+* [no-labels](no-labels.md) - disallow use of labeled statements (recommended)
+* [no-lone-blocks](no-lone-blocks.md) - disallow unnecessary nested blocks (recommended)
+* [no-loop-func](no-loop-func.md) - disallow creation of functions within loops (recommended)
+* [no-multi-spaces](no-multi-spaces.md) - disallow use of multiple spaces (recommended)
+* [no-multi-str](no-multi-str.md) - disallow use of multiline strings (recommended)
+* [no-native-reassign](no-native-reassign.md) - disallow reassignments of native objects (recommended)
+* [no-new-func](no-new-func.md) - disallow use of new operator for `Function` object (recommended)
+* [no-new-wrappers](no-new-wrappers.md) - disallows creating new instances of `String`,`Number`, and `Boolean` (recommended)
+* [no-new](no-new.md) - disallow use of new operator when not part of the assignment or comparison (recommended)
+* [no-octal-escape](no-octal-escape.md) - disallow use of octal escape sequences in string literals, such as `var foo = "Copyright \251";` (recommended)
+* [no-octal](no-octal.md) - disallow use of octal literals (recommended)
+* [no-param-reassign](no-param-reassign.md) - disallow reassignment of function parameters
+* [no-process-env](no-process-env.md) - disallow use of `process.env`
+* [no-proto](no-proto.md) - disallow usage of `__proto__` property (recommended)
+* [no-redeclare](no-redeclare.md) - disallow declaring the same variable more than once (recommended)
+* [no-return-assign](no-return-assign.md) - disallow use of assignment in `return` statement (recommended)
+* [no-script-url](no-script-url.md) - disallow use of javascript: urls. (recommended)
+* [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same
+* [no-sequences](no-sequences.md) - disallow use of comma operator (recommended)
+* [no-throw-literal](no-throw-literal.md) - restrict what can be thrown as an exception
+* [no-unused-expressions](no-unused-expressions.md) - disallow usage of expressions in statement position (recommended)
+* [no-void](no-void.md) - disallow use of `void` operator
+* [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME`
+* [no-with](no-with.md) - disallow use of the `with` statement (recommended)
+* [radix](radix.md) - require use of the second argument for `parseInt()`
+* [vars-on-top](vars-on-top.md) - requires to declare all vars on top of their containing scope
+* [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses
+* [yoda](yoda.md) - require or disallow Yoda conditions (recommended)
 
 ## Strict Mode
 
 These rules relate to using strict mode.
 
-* [global-strict](global-strict.md) - **(deprecated)** require or disallow the `"use strict"` pragma in the global scope (on by default)(off by default in the node environment)
-* [no-extra-strict](no-extra-strict.md) - **(deprecated)** disallow unnecessary use of `"use strict";` when already in strict mode
-* [strict](strict.md) - controls location of Use Strict Directives
+* [global-strict](global-strict.md) - **(deprecated)** require or disallow the `"use strict"` pragma in the global scope (recommended)
+* [no-extra-strict](no-extra-strict.md) - **(deprecated)** disallow unnecessary use of `"use strict";` when already in strict mode (recommended)
+* [strict](strict.md) - controls location of Use Strict Directives (recommended)
 
 ## Variables
 
 These rules have to do with variable declarations.
 
-* [init-declarations](init-declarations.md) - enforce or disallow variable initializations at definition (off by default)
-* [no-catch-shadow](no-catch-shadow.md) - disallow the catch clause parameter name being the same as a variable in the outer scope (off by default in the node environment)
-* [no-delete-var](no-delete-var.md) - disallow deletion of variables
-* [no-label-var](no-label-var.md) - disallow labels that share a name with a variable
-* [no-shadow-restricted-names](no-shadow-restricted-names.md) - disallow shadowing of names such as `arguments`
-* [no-shadow](no-shadow.md) - disallow declaration of variables already declared in the outer scope
-* [no-undef-init](no-undef-init.md) - disallow use of undefined when initializing variables
-* [no-undef](no-undef.md) - disallow use of undeclared variables unless mentioned in a `/*global */` block
-* [no-undefined](no-undefined.md) - disallow use of `undefined` variable (off by default)
-* [no-unused-vars](no-unused-vars.md) - disallow declaration of variables that are not used in the code
-* [no-use-before-define](no-use-before-define.md) - disallow use of variables before they are defined
+* [init-declarations](init-declarations.md) - enforce or disallow variable initializations at definition
+* [no-catch-shadow](no-catch-shadow.md) - disallow the catch clause parameter name being the same as a variable in the outer scope (ofnode environment) (recommended)
+* [no-delete-var](no-delete-var.md) - disallow deletion of variables (recommended)
+* [no-label-var](no-label-var.md) - disallow labels that share a name with a variable (recommended)
+* [no-shadow-restricted-names](no-shadow-restricted-names.md) - disallow shadowing of names such as `arguments` (recommended)
+* [no-shadow](no-shadow.md) - disallow declaration of variables already declared in the outer scope (recommended)
+* [no-undef-init](no-undef-init.md) - disallow use of undefined when initializing variables (recommended)
+* [no-undef](no-undef.md) - disallow use of undeclared variables unless mentioned in a `/*global */` block (recommended)
+* [no-undefined](no-undefined.md) - disallow use of `undefined` variable
+* [no-unused-vars](no-unused-vars.md) - disallow declaration of variables that are not used in the code (recommended)
+* [no-use-before-define](no-use-before-define.md) - disallow use of variables before they are defined (recommended)
 
 ## Node.js
 
 These rules are specific to JavaScript running on Node.js.
 
-* [callback-return](callback-return.md) - enforce return after a callback (off by default) (off by default in the node environment)
-* [handle-callback-err](handle-callback-err.md) - enforces error handling in callbacks (off by default) (on by default in the node environment)
-* [no-mixed-requires](no-mixed-requires.md) - disallow mixing regular variable and require declarations (off by default) (on by default in the node environment)
-* [no-new-require](no-new-require.md) - disallow use of new operator with the `require` function (off by default) (on by default in the node environment)
-* [no-path-concat](no-path-concat.md) - disallow string concatenation with `__dirname` and `__filename` (off by default) (on by default in the node environment)
-* [no-process-exit](no-process-exit.md) - disallow `process.exit()` (on by default in the node environment)
-* [no-restricted-modules](no-restricted-modules.md) - restrict usage of specified node modules (off by default)
-* [no-sync](no-sync.md) - disallow use of synchronous methods (off by default)
+* [callback-return](callback-return.md) - enforce return after a callback
+* [handle-callback-err](handle-callback-err.md) - enforces error handling in callbacks
+* [no-mixed-requires](no-mixed-requires.md) - disallow mixing regular variable and require declarations
+* [no-new-require](no-new-require.md) - disallow use of new operator with the `require` function
+* [no-path-concat](no-path-concat.md) - disallow string concatenation with `__dirname` and `__filename`
+* [no-process-exit](no-process-exit.md) - disallow `process.exit()` (recommended)
+* [no-restricted-modules](no-restricted-modules.md) - restrict usage of specified node modules
+* [no-sync](no-sync.md) - disallow use of synchronous methods
 
 ## Stylistic Issues
 
 These rules are purely matters of style and are quite subjective.
 
-* [array-bracket-spacing](array-bracket-spacing.md) - enforce spacing inside array brackets (off by default)
-* [brace-style](brace-style.md) - enforce one true brace style (off by default)
-* [camelcase](camelcase.md) - require camel case names
-* [comma-spacing](comma-spacing.md) - enforce spacing before and after comma
-* [comma-style](comma-style.md) - enforce one true comma style (off by default)
-* [computed-property-spacing](computed-property-spacing.md) - require or disallow padding inside computed properties (off by default)
-* [consistent-this](consistent-this.md) - enforces consistent naming when capturing the current execution context (off by default)
-* [eol-last](eol-last.md) - enforce newline at the end of file, with no multiple empty lines
-* [func-names](func-names.md) - require function expressions to have a name (off by default)
-* [func-style](func-style.md) - enforces use of function declarations or expressions (off by default)
-* [indent](indent.md) - this option sets a specific tab width for your code (off by default)
-* [key-spacing](key-spacing.md) - enforces spacing between keys and values in object literal properties
-* [lines-around-comment](lines-around-comment.md) - enforces empty lines around comments (off by default)
-* [linebreak-style](linebreak-style.md) - disallow mixed 'LF' and 'CRLF' as linebreaks (off by default)
-* [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested (off by default)
-* [new-cap](new-cap.md) - require a capital letter for constructors
-* [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments
-* [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after `var` statement (off by default)
-* [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
-* [no-continue](no-continue.md) - disallow use of the `continue` statement (off by default)
-* [no-inline-comments](no-inline-comments.md) - disallow comments inline after code (off by default)
-* [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block (off by default)
-* [no-mixed-spaces-and-tabs](no-mixed-spaces-and-tabs.md) - disallow mixed spaces and tabs for indentation
-* [no-multiple-empty-lines](no-multiple-empty-lines.md) - disallow multiple empty lines (off by default)
-* [no-nested-ternary](no-nested-ternary.md) - disallow nested ternary expressions (off by default)
-* [no-new-object](no-new-object.md) - disallow use of the `Object` constructor
-* [no-space-before-semi](no-space-before-semi.md) - **(deprecated)** disallow space before semicolon (off by default)
-* [no-spaced-func](no-spaced-func.md) - disallow space between function identifier and application
-* [no-ternary](no-ternary.md) - disallow the use of ternary operators (off by default)
-* [no-trailing-spaces](no-trailing-spaces.md) - disallow trailing whitespace at the end of lines
-* [no-underscore-dangle](no-underscore-dangle.md) - disallow dangling underscores in identifiers
-* [no-unneeded-ternary](no-unneeded-ternary.md) - disallow the use of `Boolean` literals in conditional expressions (off by default)
-* [no-wrap-func](no-wrap-func.md) - **(deprecated)** disallow wrapping of non-IIFE statements in parens
-* [object-curly-spacing](object-curly-spacing.md) - require or disallow padding inside curly braces (off by default)
-* [one-var](one-var.md) - allow or disallow one variable declaration per function (off by default)
-* [operator-assignment](operator-assignment.md) - require assignment operator shorthand where possible or prohibit it entirely (off by default)
-* [operator-linebreak](operator-linebreak.md) - enforce operators to be placed before or after line breaks (off by default)
-* [padded-blocks](padded-blocks.md) - enforce padding within blocks (off by default)
-* [quote-props](quote-props.md) - require quotes around object literal property names (off by default)
-* [quotes](quotes.md) - specify whether backticks, double or single quotes should be used
-* [semi-spacing](semi-spacing.md) - enforce spacing before and after semicolons
-* [semi](semi.md) - require or disallow use of semicolons instead of ASI
-* [sort-vars](sort-vars.md) - sort variables within the same declaration block (off by default)
-* [space-after-function-name](space-after-function-name.md) - **(deprecated)** require a space after function names (off by default)
-* [space-after-keywords](space-after-keywords.md) - require a space after certain keywords (off by default)
-* [space-before-blocks](space-before-blocks.md) - require or disallow space before blocks (off by default)
-* [space-before-function-paren](space-before-function-paren.md) - require or disallow space before function opening parenthesis (off by default)
-* [space-before-function-parentheses](space-before-function-parentheses.md) - **(deprecated)** require or disallow space before function parentheses (off by default)
-* [space-in-brackets](space-in-brackets.md) - **(deprecated)** require or disallow spaces inside brackets (off by default)
-* [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses (off by default)
-* [space-infix-ops](space-infix-ops.md) - require spaces around operators
-* [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case`
-* [space-unary-ops](space-unary-ops.md) - require or disallow spaces before/after unary operators
-* [spaced-comment](spaced-comment.md) - require or disallow a space immediately following the `//` or `/*` in a comment (off by default)
-* [spaced-line-comment](spaced-line-comment.md) - **(deprecated)** require or disallow a space immediately following the `//` in a line comment (off by default)
-* [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses (off by default)
+* [array-bracket-spacing](array-bracket-spacing.md) - enforce spacing inside array brackets
+* [brace-style](brace-style.md) - enforce one true brace style
+* [camelcase](camelcase.md) - require camel case names (recommended)
+* [comma-spacing](comma-spacing.md) - enforce spacing before and after comma (recommended)
+* [comma-style](comma-style.md) - enforce one true comma style
+* [computed-property-spacing](computed-property-spacing.md) - require or disallow padding inside computed properties
+* [consistent-this](consistent-this.md) - enforces consistent naming when capturing the current execution context
+* [eol-last](eol-last.md) - enforce newline at the end of file, with no multiple empty lines (recommended)
+* [func-names](func-names.md) - require function expressions to have a name
+* [func-style](func-style.md) - enforces use of function declarations or expressions
+* [indent](indent.md) - this option sets a specific tab width for your code
+* [key-spacing](key-spacing.md) - enforces spacing between keys and values in object literal properties (recommended)
+* [lines-around-comment](lines-around-comment.md) - enforces empty lines around comments
+* [linebreak-style](linebreak-style.md) - disallow mixed 'LF' and 'CRLF' as linebreaks
+* [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested
+* [new-cap](new-cap.md) - require a capital letter for constructors (recommended)
+* [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments (recommended)
+* [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after `var` statement
+* [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor (recommended)
+* [no-continue](no-continue.md) - disallow use of the `continue` statement
+* [no-inline-comments](no-inline-comments.md) - disallow comments inline after code
+* [no-lonely-if](no-lonely-if.md) - disallow if as the only statement in an else block
+* [no-mixed-spaces-and-tabs](no-mixed-spaces-and-tabs.md) - disallow mixed spaces and tabs for indentation (recommended)
+* [no-multiple-empty-lines](no-multiple-empty-lines.md) - disallow multiple empty lines
+* [no-nested-ternary](no-nested-ternary.md) - disallow nested ternary expressions
+* [no-new-object](no-new-object.md) - disallow use of the `Object` constructor (recommended)
+* [no-space-before-semi](no-space-before-semi.md) - **(deprecated)** disallow space before semicolon
+* [no-spaced-func](no-spaced-func.md) - disallow space between function identifier and application (recommended)
+* [no-ternary](no-ternary.md) - disallow the use of ternary operators
+* [no-trailing-spaces](no-trailing-spaces.md) - disallow trailing whitespace at the end of lines (recommended)
+* [no-underscore-dangle](no-underscore-dangle.md) - disallow dangling underscores in identifiers (recommended)
+* [no-unneeded-ternary](no-unneeded-ternary.md) - disallow the use of `Boolean` literals in conditional expressions
+* [no-wrap-func](no-wrap-func.md) - **(deprecated)** disallow wrapping of non-IIFE statements in parens (recommended)
+* [object-curly-spacing](object-curly-spacing.md) - require or disallow padding inside curly braces
+* [one-var](one-var.md) - allow or disallow one variable declaration per function
+* [operator-assignment](operator-assignment.md) - require assignment operator shorthand where possible or prohibit it entirely
+* [operator-linebreak](operator-linebreak.md) - enforce operators to be placed before or after line breaks
+* [padded-blocks](padded-blocks.md) - enforce padding within blocks
+* [quote-props](quote-props.md) - require quotes around object literal property names
+* [quotes](quotes.md) - specify whether backticks, double or single quotes should be used (recommended)
+* [semi-spacing](semi-spacing.md) - enforce spacing before and after semicolons (recommended)
+* [semi](semi.md) - require or disallow use of semicolons instead of ASI (recommended)
+* [sort-vars](sort-vars.md) - sort variables within the same declaration block
+* [space-after-function-name](space-after-function-name.md) - **(deprecated)** require a space after function names
+* [space-after-keywords](space-after-keywords.md) - require a space after certain keywords
+* [space-before-blocks](space-before-blocks.md) - require or disallow space before blocks
+* [space-before-function-paren](space-before-function-paren.md) - require or disallow space before function opening parenthesis
+* [space-before-function-parentheses](space-before-function-parentheses.md) - **(deprecated)** require or disallow space before function parentheses
+* [space-in-brackets](space-in-brackets.md) - **(deprecated)** require or disallow spaces inside brackets
+* [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses
+* [space-infix-ops](space-infix-ops.md) - require spaces around operators (recommended)
+* [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case` (recommended)
+* [space-unary-ops](space-unary-ops.md) - require or disallow spaces before/after unary operators (recommended)
+* [spaced-comment](spaced-comment.md) - require or disallow a space immediately following the `//` or `/*` in a comment
+* [spaced-line-comment](spaced-line-comment.md) - **(deprecated)** require or disallow a space immediately following the `//` in a line comment
+* [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses
 
 ## ECMAScript 6
 
-These rules are only relevant to ES6 environments and are off by default.
+These rules are only relevant to ES6 environments.
 
-* [arrow-parens](arrow-parens.md) - Require parens in arrow function arguments (off by default)
-* [arrow-spacing](arrow-spacing.md) - Require space before/after arrow functions arrow (off by default)
-* [constructor-super](constructor-super.md) - verify `super()` callings in constructors (off by default)
-* [generator-star-spacing](generator-star-spacing.md) - enforce the spacing around the `*` in generator functions (off by default)
-* [generator-star](generator-star.md) - **(deprecated)** enforce the position of the `*` in generator functions (off by default)
-* [no-this-before-super](no-this-before-super.md) - disallow to use `this`/`super` before `super()` calling in constructors. (off by default)
-* [no-var](no-var.md) - require `let` or `const` instead of `var` (off by default)
-* [object-shorthand](object-shorthand.md) - require method and property shorthand syntax for object literals (off by default)
-* [prefer-const](prefer-const.md) - suggest using of `const` declaration for variables that are never modified after declared (off by default)
-* [require-yield](require-yield.md) - disallow generator functions that does not have `yield` (off by default)
+* [arrow-parens](arrow-parens.md) - Require parens in arrow function arguments
+* [arrow-spacing](arrow-spacing.md) - Require space before/after arrow functions arrow
+* [constructor-super](constructor-super.md) - verify `super()` callings in constructors
+* [generator-star-spacing](generator-star-spacing.md) - enforce the spacing around the `*` in generator functions
+* [generator-star](generator-star.md) - **(deprecated)** enforce the position of the `*` in generator functions
+* [no-this-before-super](no-this-before-super.md) - disallow to use `this`/`super` before `super()` calling in constructors.
+* [no-var](no-var.md) - require `let` or `const` instead of `var`
+* [object-shorthand](object-shorthand.md) - require method and property shorthand syntax for object literals
+* [prefer-const](prefer-const.md) - suggest using of `const` declaration for variables that are never modified after declared
+* [require-yield](require-yield.md) - disallow generator functions that does not have `yield`
 
 ## Legacy
 
 The following rules are included for compatibility with [JSHint](http://jshint.com/) and [JSLint](http://jslint.com/). While the names of the rules may not match up with the JSHint/JSLint counterpart, the functionality is the same.
 
-* [max-depth](max-depth.md) - specify the maximum depth that blocks can be nested (off by default)
-* [max-len](max-len.md) - specify the maximum length of a line in your program (off by default)
-* [max-params](max-params.md) - limits the number of parameters that can be used in the function declaration. (off by default)
-* [max-statements](max-statements.md) - specify the maximum number of statement allowed in a function (off by default)
-* [no-bitwise](no-bitwise.md) - disallow use of bitwise operators (off by default)
-* [no-plusplus](no-plusplus.md) - disallow use of unary operators, `++` and `--` (off by default)
+* [max-depth](max-depth.md) - specify the maximum depth that blocks can be nested
+* [max-len](max-len.md) - specify the maximum length of a line in your program
+* [max-params](max-params.md) - limits the number of parameters that can be used in the function declaration.
+* [max-statements](max-statements.md) - specify the maximum number of statement allowed in a function
+* [no-bitwise](no-bitwise.md) - disallow use of bitwise operators
+* [no-plusplus](no-plusplus.md) - disallow use of unary operators, `++` and `--`
 
 ## Removed
 

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -67,7 +67,7 @@ function f() {
 
 ### Options
 
-This rule is disabled by default. You can configure the designated `this` variable:
+You can configure the designated `this` variable:
 
 ```js
 "consistent-this": [0, "self"]

--- a/docs/rules/no-implied-eval.md
+++ b/docs/rules/no-implied-eval.md
@@ -1,6 +1,6 @@
 # Disallow Implied eval() (no-implied-eval)
 
-It's considered a good practice to avoid using `eval()` in JavaScript. There are security and performance implications involved with doing so, which is why many linters (including ESLint) disallow `eval()` by default. However, there are some other ways to pass a string and have it interpreted as JavaScript code that have similar concerns.
+It's considered a good practice to avoid using `eval()` in JavaScript. There are security and performance implications involved with doing so, which is why many linters (including ESLint) recommend disallowing `eval()`. However, there are some other ways to pass a string and have it interpreted as JavaScript code that have similar concerns.
 
 The first is using `setTimeout()`, `setInterval()` or `execScript()` (Internet Explorer only), both of which can accept a string of JavaScript code as their first argument. For example:
 

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -4,7 +4,7 @@ When declaring multiple variables within the same block, some developers prefer 
 
 ## Rule Details
 
-This rule checks all variable declaration blocks and verifies that all variables are sorted alphabetically. This rule is off by default.
+This rule checks all variable declaration blocks and verifies that all variables are sorted alphabetically.
 The default configuration of the rule is case-sensitive.
 
 The following patterns are considered warnings:

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -27,7 +27,6 @@ Options:
   --rulesdir [path::String]   Use additional rules from this directory
   -f, --format String         Use a specific output format - default: stylish
   -v, --version               Outputs the version number
-  --reset                     Set all default rules to off - default: false
   --no-eslintrc               Disable use of configuration from .eslintrc
   --env [String]              Specify environments
   --ext [String]              Specify JavaScript file extensions - default: .js
@@ -47,13 +46,13 @@ Options:
 
 ### `-c`, `--config`
 
-This option allows you to specify an alternate configuration file for ESLint (see [Configuring ESLint](configuring) for more). By default, ESLint uses its own configuration file located at `conf/eslint.json`.
+This option allows you to specify an additional configuration file for ESLint (see [Configuring ESLint](configuring) for more).
 
 Example:
 
     eslint -c ~/my-eslint.json file.js
 
-This example uses the configuration file at `~/my-eslint.json` instead of the default.
+This example uses the configuration file at `~/my-eslint.json`.
 
 ### `--env`
 
@@ -172,17 +171,9 @@ Example:
 
     eslint --quiet file.js
 
-### `--reset`
-
-This option turns off all rules enabled in ESLint's default configuration file located at `conf/eslint.json`. ESLint will still report syntax errors.
-
-Example:
-
-    eslint --reset file.js
-
 ### `--rule`
 
-This option specifies rules to be used. These rules will be merged with the default rules and any rules specified with configuration files. (You can use `--reset` and `--no-eslintrc`, respectively, to change those behaviors.) To define multiple rules, separate them using commas, or use the flag multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
+This option specifies rules to be used. These rules will be merged with any rules specified with configuration files. (You can use `--no-eslintrc` to change that behavior.) To define multiple rules, separate them using commas, or use the flag multiple times. The [levn](https://github.com/gkz/levn#levn--) format is used for specifying the rules.
 
 If the rule is defined within a plugin you have to prefix the rule ID with the plugin name and a `/`.
 

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -7,7 +7,7 @@ ESLint is designed to be completely configurable, meaning you can turn off every
 
 There are several pieces of information that can be configured:
 
-* **Environments** - which environments your script is designed to run in. Each environment brings with it a certain set of global variables and rules that are enabled by default.
+* **Environments** - which environments your script is designed to run in. Each environment brings with it a certain set of predefined global variables.
 * **Globals** - the additional global variables your script accesses during execution.
 * **Rules** - which rules are enabled and at what error level.
 
@@ -91,7 +91,7 @@ Note when using a custom parser, the `ecmaFeatures` configuration property is st
 
 ## Specifying Environments
 
-An environment defines both global variables that are predefined as well as which rules should be on or off by default. The available environments are:
+An environment defines global variables that are predefined. The available environments are:
 
 * `browser` - browser global variables.
 * `node` - Node.js global variables and Node.js-specific rules.
@@ -158,7 +158,7 @@ And in YAML:
 
 ## Specifying Globals
 
-By default, ESLint will warn on variables that are accessed but not defined within the same file. If you are using global variables inside of a file then it's worthwhile to define those globals so that ESLint will not warn about their usage. You can define global variables either using comments inside of a file or in the configuration file.
+The [no-undef](../rules/no-undef.md) rule will warn on variables that are accessed but not defined within the same file. If you are using global variables inside of a file then it's worthwhile to define those globals so that ESLint will not warn about their usage. You can define global variables either using comments inside of a file or in the configuration file.
 
 To specify globals using a comment inside of your JavaScript file, use the following format:
 
@@ -222,7 +222,7 @@ And in YAML:
 
 ## Configuring Rules
 
-ESLint comes with a large number of rules, some of which are on by default and some of which are off by default. You can modify which rules your project uses either using configuration comments or configuration files. To change a rule setting, you must set the rule ID equal to one of these values:
+ESLint comes with a large number of rules. You can modify which rules your project uses either using configuration comments or configuration files. To change a rule setting, you must set the rule ID equal to one of these values:
 
 * 0 - turn the rule off
 * 1 - turn the rule on as a warning (doesn't affect exit code)
@@ -417,12 +417,8 @@ The complete configuration hierarchy, from highest precedence to lowest preceden
 3. Project-level configuration:
     1. `.eslintrc` file in same directory as linted file
     1. `package.json` file in same directory as linted file
-    1. Continue searching for `.eslintrc` and `package.json` files in ancestor directories (parent has highest precedence, then grandparent, etc.), up to and including the root directory.
-    1. In the absence of any configuration from (i) and (ii), fall back to `~/.eslintrc` - personal default configuration
-4. ESLint default configuration:
-    1. `environments.json`
-    1. `eslint.json`
-    1. Blank (no config)
+    1. Continue searching for `.eslintrc` and `package.json` files in ancestor directories (parent has highest precedence, then grandparent, etc.), up to and including the root directory or until a config with `"root": true` is found.
+    1. In the absence of any configuration from (1) thru (3), fall back to a personal default configuration in  `~/.eslintrc`.
 
 ## Extending Configuration Files
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -38,8 +38,7 @@ var fs = require("fs"),
  * The options to configure a CLI engine with.
  * @typedef {Object} CLIEngineOptions
  * @property {string} configFile The configuration file to use.
- * @property {boolean} reset True disables all default rules and environments.
- * @property {boolean|object} baseConfig Base config object. False disables all default rules and environments.
+ * @property {boolean|object} baseConfig Base config object. True enables recommend rules and environments.
  * @property {boolean} ignore False disables use of .eslintignore.
  * @property {string[]} rulePaths An array of directories to load custom rules from.
  * @property {boolean} useEslintrc False disables looking for .eslintrc
@@ -70,8 +69,7 @@ var fs = require("fs"),
 
 var defaultOptions = {
         configFile: null,
-        reset: false,
-        baseConfig: require(path.resolve(__dirname, "..", "conf", "eslint.json")),
+        baseConfig: false,
         rulePaths: [],
         useEslintrc: true,
         envs: [],

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -48,7 +48,6 @@ function translateOptions(cliOptions) {
         ignorePattern: cliOptions.ignorePattern,
         configFile: cliOptions.config,
         rulePaths: cliOptions.rulesdir,
-        reset: cliOptions.reset,
         useEslintrc: cliOptions.eslintrc
     };
 }

--- a/lib/config.js
+++ b/lib/config.js
@@ -253,13 +253,11 @@ function getLocalConfig(thisConfig, directory) {
 /**
  * Creates an environment config based on the specified environments.
  * @param {Object<string,boolean>} envs The environment settings.
- * @param {boolean} reset The value of the command line reset option. If true,
- *      rules are not automatically merged into the config.
  * @returns {Object} A configuration object with the appropriate rules and globals
  *      set.
  * @private
  */
-function createEnvironmentConfig(envs, reset) {
+function createEnvironmentConfig(envs) {
 
     var envConfig = {
         globals: {},
@@ -275,10 +273,6 @@ function createEnvironmentConfig(envs, reset) {
             var environment = environments[name];
 
             if (environment) {
-
-                if (!reset && environment.rules) {
-                    assign(envConfig.rules, environment.rules);
-                }
 
                 if (environment.globals) {
                     assign(envConfig.globals, environment.globals);
@@ -314,16 +308,7 @@ function Config(options) {
     this.ignorePath = options.ignorePath;
     this.cache = {};
 
-    if (options.reset || options.baseConfig === false) {
-        // If `options.reset` is truthy or `options.baseConfig` is set to `false`,
-        // disable all default rules and environments
-        this.baseConfig = { rules: {} };
-    } else {
-        // If `options.baseConfig` is an object, just use it,
-        // otherwise use default base config from `conf/eslint.json`
-        this.baseConfig = options.baseConfig ||
-                require(path.resolve(__dirname, "..", "conf", "eslint.json"));
-    }
+    this.baseConfig = options.baseConfig || { rules: {} };
 
     this.useEslintrc = (options.useEslintrc !== false);
 
@@ -382,7 +367,7 @@ Config.prototype.getConfig = function (filePath) {
     config = util.mergeConfigs({}, this.baseConfig);
 
     // Step 3: Merge in environment-specific globals and rules from .eslintrc files
-    config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env, this.options.reset));
+    config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env));
 
     // Step 4: Merge in the user-specified configuration from .eslintrc and package.json
     config = util.mergeConfigs(config, userConfig);
@@ -392,7 +377,7 @@ Config.prototype.getConfig = function (filePath) {
         debug("Merging command line config file");
 
         if (this.useSpecificConfig.env) {
-            config = util.mergeConfigs(config, createEnvironmentConfig(this.useSpecificConfig.env, this.options.reset));
+            config = util.mergeConfigs(config, createEnvironmentConfig(this.useSpecificConfig.env));
         }
 
         config = util.mergeConfigs(config, this.useSpecificConfig);
@@ -400,7 +385,7 @@ Config.prototype.getConfig = function (filePath) {
 
     // Step 6: Merge in command line environments
     debug("Merging command line environment settings");
-    config = util.mergeConfigs(config, createEnvironmentConfig(this.env, this.options.reset));
+    config = util.mergeConfigs(config, createEnvironmentConfig(this.env));
 
     // Step 7: Merge in command line rules
     if (this.options.rules) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -47,11 +47,6 @@ module.exports = optionator({
         type: "Boolean",
         description: "Outputs the version number"
     }, {
-        option: "reset",
-        type: "Boolean",
-        default: "false",
-        description: "Set all default rules to off"
-    }, {
         option: "eslintrc",
         type: "Boolean",
         default: "true",

--- a/tests/fixtures/files/foo.js
+++ b/tests/fixtures/files/foo.js
@@ -1,1 +1,2 @@
 var foo = "<div>Hello world!</div>";
+foo(foo);

--- a/tests/fixtures/files/foo.js2
+++ b/tests/fixtures/files/foo.js2
@@ -1,1 +1,2 @@
 var foo = "<div>Hello world!</div>";
+foo(foo);

--- a/tests/fixtures/missing-semicolon.js
+++ b/tests/fixtures/missing-semicolon.js
@@ -1,1 +1,1 @@
-var foo = "bar"
+console.log("bar")

--- a/tests/fixtures/single-quoted.js
+++ b/tests/fixtures/single-quoted.js
@@ -1,1 +1,1 @@
-var foo = 'bar';
+console.log('bar');

--- a/tests/fixtures/undef.js
+++ b/tests/fixtures/undef.js
@@ -1,2 +1,2 @@
 var bar = baz;
-bat = 42;
+bat = bar;

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -65,7 +65,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 configFile: "tests/fixtures/configurations/quotes-error.json",
-                reset: true,
                 useEslintrc: false
             });
 
@@ -109,7 +108,7 @@ describe("CLIEngine", function() {
             engine = new CLIEngine({
                 ignorePath: "tests/fixtures/.eslintignore",
                 ignore: false,
-                reset: true,
+                useEslintrc: false,
                 rules: {
                     "no-undef": 2
                 }
@@ -142,8 +141,7 @@ describe("CLIEngine", function() {
         it("should report zero messages when given a directory with a .js2 file", function() {
 
             engine = new CLIEngine({
-                extensions: [".js2"],
-                reset: true
+                extensions: [".js2"]
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/files/"]);
@@ -154,8 +152,7 @@ describe("CLIEngine", function() {
         it("should report zero messages when given a directory with a .js and a .js2 file", function() {
 
             engine = new CLIEngine({
-                extensions: [".js", ".js2"],
-                reset: true
+                extensions: [".js", ".js2"]
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/files/"]);
@@ -167,8 +164,7 @@ describe("CLIEngine", function() {
         it("should return one error message when given a config with rules with options and severity level set to error", function() {
 
             engine = new CLIEngine({
-                configFile: "tests/fixtures/configurations/quotes-error.json",
-                reset: true
+                configFile: "tests/fixtures/configurations/quotes-error.json"
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/single-quoted.js"]);
@@ -185,8 +181,7 @@ describe("CLIEngine", function() {
         it("should return two messages when given a config file and a directory of files", function() {
 
             engine = new CLIEngine({
-                configFile: "tests/fixtures/configurations/semi-error.json",
-                reset: true
+                configFile: "tests/fixtures/configurations/semi-error.json"
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/formatters"]);
@@ -204,8 +199,7 @@ describe("CLIEngine", function() {
         it("should return zero messages when given a config with environment set to browser", function() {
 
             engine = new CLIEngine({
-                configFile: "tests/fixtures/configurations/env-browser.json",
-                reset: true
+                configFile: "tests/fixtures/configurations/env-browser.json"
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/globals-browser.js"]);
@@ -218,9 +212,9 @@ describe("CLIEngine", function() {
             engine = new CLIEngine({
                 envs: ["browser"],
                 rules: {
+                    "no-alert": 0,
                     "no-undef": 2
-                },
-                reset: true
+                }
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/globals-browser.js"]);
@@ -231,8 +225,7 @@ describe("CLIEngine", function() {
         it("should return zero messages when given a config with environment set to Node.js", function() {
 
             engine = new CLIEngine({
-                configFile: "tests/fixtures/configurations/env-node.json",
-                reset: true
+                configFile: "tests/fixtures/configurations/env-node.json"
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/globals-node.js"]);
@@ -244,7 +237,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 rules: {
                     semi: 2
                 }
@@ -306,7 +298,6 @@ describe("CLIEngine", function() {
             engine = new CLIEngine({
                 ignorePath: "tests/fixtures/.eslintignore",
                 ignore: false,
-                reset: true,
                 rules: {
                     "no-undef": 2
                 }
@@ -324,8 +315,7 @@ describe("CLIEngine", function() {
         it("should return zero messages when executing a file with a shebang", function() {
 
             engine = new CLIEngine({
-                ignore: false,
-                reset: true
+                ignore: false
             });
 
             var report = engine.executeOnFiles(["tests/fixtures/shebang.js"]);
@@ -338,7 +328,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 rulesPaths: ["./tests/fixtures/rules/dir1"],
                 configFile: "./tests/fixtures/rules/missing-rule.json"
             });
@@ -357,7 +346,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 rulePaths: ["./tests/fixtures/rules/wrong"],
                 configFile: "./tests/fixtures/rules/eslint.json"
             });
@@ -372,7 +360,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 useEslintrc: false,
                 rulePaths: ["./tests/fixtures/rules/"],
                 configFile: "./tests/fixtures/rules/eslint.json"
@@ -390,7 +377,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 rulePaths: [
                     "./tests/fixtures/rules/dir1",
                     "./tests/fixtures/rules/dir2"
@@ -408,11 +394,10 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[1].severity, 2);
         });
 
-        it("should return zero messages when executing with reset flag", function() {
+        it("should return zero messages when executing without useEslintrc flag", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 useEslintrc: false
             });
 
@@ -422,11 +407,10 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
-        it("should return zero messages when executing with reset flag in Node.js environment", function() {
+        it("should return zero messages when executing without useEslintrc flag in Node.js environment", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 useEslintrc: false,
                 envs: ["node"]
             });
@@ -455,7 +439,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 useEslintrc: false,
                 envs: ["node"]
             });
@@ -470,7 +453,6 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                reset: true,
                 useEslintrc: false,
                 envs: ["node"]
             });
@@ -499,10 +481,9 @@ describe("CLIEngine", function() {
             });
 
             // Default configuration - blank
-            it("should return zero messages when executing with reset and no .eslintrc", function() {
+            it("should return zero messages when executing with no .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     useEslintrc: false
                 });
 
@@ -511,26 +492,8 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages.length, 0);
             });
 
-            // Default configuration - conf/eslint.json
-            it("should return three messages when executing with no .eslintrc", function() {
-
-                engine = new CLIEngine({
-                    useEslintrc: false
-                });
-
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
-                assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 3);
-                assert.equal(report.results[0].messages[0].ruleId, "no-console");
-                assert.equal(report.results[0].messages[0].severity, 2);
-                assert.equal(report.results[0].messages[1].ruleId, "no-undef");
-                assert.equal(report.results[0].messages[1].severity, 2);
-                assert.equal(report.results[0].messages[2].ruleId, "quotes");
-                assert.equal(report.results[0].messages[2].severity, 2);
-            });
-
-            // Default configuration - conf/environments.js (/*eslint-env node*/)
-            it("should return one message when executing with no .eslintrc in the Node.js environment", function() {
+            // No default configuration rules - conf/environments.js (/*eslint-env node*/)
+            it("should return zero messages when executing with no .eslintrc in the Node.js environment", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false
@@ -538,29 +501,23 @@ describe("CLIEngine", function() {
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes-node.js"]);
                 assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "quotes");
-                assert.equal(report.results[0].messages[0].severity, 2);
+                assert.equal(report.results[0].messages.length, 0);
             });
 
             // Project configuration - first level .eslintrc
-            it("should return one message when executing with .eslintrc in the Node.js environment", function() {
+            it("should return zero messages when executing with .eslintrc in the Node.js environment", function() {
 
                 engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/process-exit.js"]);
                 assert.equal(report.results.length, 1);
-                assert.equal(report.results[0].messages.length, 1);
-                assert.equal(report.results[0].messages[0].ruleId, "no-process-exit");
-                assert.equal(report.results[0].messages[0].severity, 2);
+                assert.equal(report.results[0].messages.length, 0);
             });
 
             // Project configuration - first level .eslintrc
-            it("should return zero messages when executing with .eslintrc in the Node.js environment and reset", function() {
+            it("should return zero messages when executing with .eslintrc in the Node.js environment", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/process-exit.js"]);
                 assert.equal(report.results.length, 1);
@@ -570,9 +527,7 @@ describe("CLIEngine", function() {
             // Project configuration - first level .eslintrc
             it("should return one message when executing with .eslintrc", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
                 assert.equal(report.results.length, 1);
@@ -584,9 +539,7 @@ describe("CLIEngine", function() {
             // Project configuration - second level .eslintrc
             it("should return one message when executing with local .eslintrc that overrides parent .eslintrc", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js"]);
                 assert.equal(report.results.length, 1);
@@ -598,9 +551,7 @@ describe("CLIEngine", function() {
             // Project configuration - third level .eslintrc
             it("should return one message when executing with local .eslintrc that overrides parent and grandparent .eslintrc", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js"]);
                 assert.equal(report.results.length, 1);
@@ -612,9 +563,7 @@ describe("CLIEngine", function() {
             // Project configuration - first level package.json
             it("should return one message when executing with package.json", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/wrong-quotes.js"]);
                 assert.equal(report.results.length, 1);
@@ -626,9 +575,7 @@ describe("CLIEngine", function() {
              // Project configuration - second level package.json
             it("should return zero messages when executing with local package.json that overrides parent package.json", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js"]);
                 assert.equal(report.results.length, 1);
@@ -638,9 +585,7 @@ describe("CLIEngine", function() {
             // Project configuration - third level package.json
             it("should return one message when executing with local package.json that overrides parent and grandparent package.json", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js"]);
                 assert.equal(report.results.length, 1);
@@ -652,9 +597,7 @@ describe("CLIEngine", function() {
             // Project configuration - .eslintrc overrides package.json in same directory
             it("should return one message when executing with .eslintrc that overrides a package.json in the same directory", function() {
 
-                engine = new CLIEngine({
-                    reset: true
-                });
+                engine = new CLIEngine();
 
                 var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/wrong-quotes.js"]);
                 assert.equal(report.results.length, 1);
@@ -667,7 +610,6 @@ describe("CLIEngine", function() {
             it("should return two messages when executing with config file that adds to local .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
                 });
 
@@ -684,7 +626,6 @@ describe("CLIEngine", function() {
             it("should return no messages when executing with config file that overrides local .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
                 });
 
@@ -697,7 +638,6 @@ describe("CLIEngine", function() {
             it("should return two messages when executing with config file that adds to local and parent .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
                 });
 
@@ -714,7 +654,6 @@ describe("CLIEngine", function() {
             it("should return one message when executing with config file that overrides local and parent .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
                 });
 
@@ -729,7 +668,6 @@ describe("CLIEngine", function() {
             it("should return no messages when executing with config file that overrides local .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
                 });
 
@@ -742,7 +680,6 @@ describe("CLIEngine", function() {
             it("should return one message when executing with command line rule and config file that overrides local .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml",
                     rules: {
                         quotes: [1, "double"]
@@ -760,7 +697,6 @@ describe("CLIEngine", function() {
             it("should return one message when executing with command line rule and config file that overrides local .eslintrc", function() {
 
                 engine = new CLIEngine({
-                    reset: true,
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml",
                     rules: {
                         quotes: [1, "double"]
@@ -780,7 +716,6 @@ describe("CLIEngine", function() {
             it("should return two messages when executing with config file that specifies a plugin", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/plugins-with-prefix.json",
-                    reset: true,
                     useEslintrc: false
                 });
 
@@ -794,7 +729,6 @@ describe("CLIEngine", function() {
             it("should return two messages when executing with config file that specifies a plugin with namespace", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/plugins-with-prefix-and-namespace.json",
-                    reset: true,
                     useEslintrc: false
                 });
 
@@ -808,7 +742,6 @@ describe("CLIEngine", function() {
             it("should return two messages when executing with config file that specifies a plugin without prefix", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/plugins-without-prefix.json",
-                    reset: true,
                     useEslintrc: false
                 });
 
@@ -822,7 +755,6 @@ describe("CLIEngine", function() {
             it("should return two messages when executing with config file that specifies a plugin without prefix and with namespace", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/plugins-without-prefix-with-namespace.json",
-                    reset: true,
                     useEslintrc: false
                 });
 
@@ -838,7 +770,6 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/plugins-with-prefix.json",
-                    reset: true,
                     useEslintrc: false
                 });
 
@@ -851,7 +782,6 @@ describe("CLIEngine", function() {
 
             it("should return two messages when executing with cli option that specifies a plugin", function() {
                 engine = new CLIEngine({
-                    reset: true,
                     useEslintrc: false,
                     plugins: ["example"],
                     rules: { "example/example-rule": 1 }
@@ -866,7 +796,6 @@ describe("CLIEngine", function() {
 
             it("should return two messages when executing with cli option that specifies preloaded plugin", function() {
                 engine = new CLIEngine({
-                    reset: true,
                     useEslintrc: false,
                     plugins: ["test"],
                     rules: { "test/example-rule": 1 }
@@ -886,7 +815,6 @@ describe("CLIEngine", function() {
             it("should return two messages when executing with config file that specifies a processor", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/processors.json",
-                    reset: true,
                     useEslintrc: false,
                     extensions: ["js", "txt"]
                 });
@@ -898,7 +826,6 @@ describe("CLIEngine", function() {
             });
             it("should return two messages when executing with config file that specifies preloaded processor", function() {
                 engine = new CLIEngine({
-                    reset: true,
                     useEslintrc: false,
                     plugins: ["test-processor"],
                     rules: {
@@ -929,7 +856,6 @@ describe("CLIEngine", function() {
             it("should run processors when calling executeOnFiles with config file that specifies a processor", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/processors.json",
-                    reset: true,
                     useEslintrc: false,
                     extensions: ["js", "txt"]
                 });
@@ -941,7 +867,6 @@ describe("CLIEngine", function() {
             });
             it("should run processors when calling executeOnFiles with config file that specifies preloaded processor", function() {
                 engine = new CLIEngine({
-                    reset: true,
                     useEslintrc: false,
                     plugins: ["test-processor"],
                     rules: {
@@ -973,7 +898,6 @@ describe("CLIEngine", function() {
             it("should run processors when calling executeOnText with config file that specifies a processor", function() {
                 engine = new CLIEngine({
                     configFile: "./tests/fixtures/configurations/processors.json",
-                    reset: true,
                     useEslintrc: false,
                     extensions: ["js", "txt"]
                 });
@@ -985,7 +909,6 @@ describe("CLIEngine", function() {
             });
             it("should run processors when calling executeOnText with config file that specifies preloaded processor", function() {
                 engine = new CLIEngine({
-                    reset: true,
                     useEslintrc: false,
                     plugins: ["test-processor"],
                     rules: {
@@ -1022,8 +945,7 @@ describe("CLIEngine", function() {
         it("should return the info from Config#getConfig when called", function() {
 
             var engine = new CLIEngine({
-                configFile: "tests/fixtures/configurations/quotes-error.json",
-                reset: true
+                configFile: "tests/fixtures/configurations/quotes-error.json"
             });
 
             var configHelper = new Config(engine.options);

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -39,7 +39,7 @@ describe("cli", function() {
         });
 
         it("should return no error when --ext .js2 is specified", function() {
-            var result = cli.execute("--ext .js2 --reset ./tests/fixtures/files/");
+            var result = cli.execute("--ext .js2 ./tests/fixtures/files/");
             assert.equal(result, 0);
         });
 
@@ -267,7 +267,7 @@ describe("cli", function() {
         });
 
         it("should return warnings from multiple rules in different directories", function() {
-            var code = "--rulesdir ./tests/fixtures/rules/dir1 --rulesdir ./tests/fixtures/rules/dir2 --reset --config ./tests/fixtures/rules/multi-rulesdirs.json --no-ignore tests/fixtures/rules/test-multi-rulesdirs.js";
+            var code = "--rulesdir ./tests/fixtures/rules/dir1 --rulesdir ./tests/fixtures/rules/dir2 --config ./tests/fixtures/rules/multi-rulesdirs.json --no-ignore tests/fixtures/rules/test-multi-rulesdirs.js";
             var exit = cli.execute(code);
 
             var call = console.log.getCall(0);
@@ -282,26 +282,9 @@ describe("cli", function() {
 
     });
 
-    describe("when executing with reset flag", function() {
-        it("should execute without any errors", function () {
-            var exit = cli.execute("--reset --no-eslintrc --no-ignore ./tests/fixtures/missing-semicolon.js");
-
-            assert.isTrue(console.log.notCalled);
-            assert.equal(exit, 0);
-        });
-
-        it("should execute without any errors in Node.js environment", function () {
-            var exit = cli.execute("--reset --no-eslintrc --env node --no-ignore ./tests/fixtures/process-exit.js");
-
-            assert.isTrue(console.log.notCalled);
-            assert.equal(exit, 0);
-        });
-
-    });
-
     describe("when executing with no-eslintrc flag", function () {
         it("should ignore a local config file", function () {
-            var exit = cli.execute("--reset --no-eslintrc --no-ignore ./tests/fixtures/eslintrc/quotes.js");
+            var exit = cli.execute("--no-eslintrc --no-ignore ./tests/fixtures/eslintrc/quotes.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
@@ -324,7 +307,7 @@ describe("cli", function() {
         ];
 
         it("should not define environment-specific globals", function () {
-            cli.execute("--reset --no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
+            cli.execute("--no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
             assert.equal(console.log.args[0][0].split("\n").length, 12);
         });
     });
@@ -338,14 +321,14 @@ describe("cli", function() {
         });
 
         it("should allow defining writable global variables", function () {
-            var exit = cli.execute("--reset --global baz:false,bat:true --no-ignore ./tests/fixtures/undef.js");
+            var exit = cli.execute("--global baz:false,bat:true --no-ignore ./tests/fixtures/undef.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);
         });
 
         it("should allow defining variables with multiple flags", function () {
-            var exit = cli.execute("--reset --global baz --global bat:true --no-ignore ./tests/fixtures/undef.js");
+            var exit = cli.execute("--global baz --global bat:true --no-ignore ./tests/fixtures/undef.js");
 
             assert.isTrue(console.log.notCalled);
             assert.equal(exit, 0);

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1365,15 +1365,6 @@ describe("eslint", function() {
             });
             eslint.verify(code, config, filename, true);
         });
-        it("should error on node specific rule", function() {
-            var code = "/*eslint-env node*/ var appHeader = new require('app-header');";
-            var config = { rules: {} };
-
-            eslint.reset();
-            var messages = eslint.verify(code, config, filename, true);
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-new-require");
-        });
     });
 
     describe("when evaluating code containing /*eslint-env */ block with sloppy whitespace", function() {
@@ -2306,16 +2297,13 @@ describe("eslint", function() {
             assert.equal(messages.length, 0);
         });
 
-        it("should report a violation", function() {
+        it("should not report a violation", function() {
             var code = "/*eslint-env node */ process.exit();";
 
             var config = { rules: {} };
 
             var messages = eslint.verify(code, config, filename);
-            assert.equal(messages.length, 1);
-            assert.equal(messages[0].ruleId, "no-process-exit");
-            assert.equal(messages[0].nodeType, "CallExpression");
-            assert.equal(messages[0].line, 1);
+            assert.equal(messages.length, 0);
         });
 
         it("should not report a violation", function() {


### PR DESCRIPTION
This is a pass at the code and (some of the) documentation updates that will fix #2100. Right now some cli-engine, cli, and config tests that use the test fixtures are failing, but it'll be cleaner to fix those once a fix for #2736 lands and we can isolate the test fixtures from the project-level .eslintrc. #2713 will be nice as well, though if it's not ready by the time this is, `"extends": "./conf/eslint.json"` will work in the interim.