### PR TITLE
Docs: clarification in no-unused-vars

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -66,7 +66,7 @@ This option has two settings:
 This option has three settings:
 
 * `all` - all named arguments must be used.
-* `after-used` - only arguments after the first used argument must be used. This allows you, for instance, to have two named parameters to a function and as long as you use the second argument, ESLint will not warn you about the first. This is the default setting.
+* `after-used` - only the last argument must be used. This allows you, for instance, to have two named parameters to a function and as long as you use the second argument, ESLint will not warn you about the first. This is the default setting.
 * `none` - do not check arguments.
 
 The following code:


### PR DESCRIPTION
Actually, you may have unused arguments after the first used one (as long as the last is used); so this statement was wrong.
This example is valid:
```js
function calc(a, b, c, d) {
  return b + d;
}
```
Note that both `a` and `c` are unused.

It might even make sense to rename the option to `last`, but that's probably not possible or practical.