### PR TITLE
Update: `no-loop-func` allows block-scoped variables (fixes #2517)

### DIFF
--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -12,6 +12,19 @@ for (var i = 0; i < 10; i++) {
 
 In this case, you would expect each function created within the loop to return a different number. In reality, each function returns 10, because that was the last value of `i` in the scope.
 
+`let` or `const` mitigate this problem.
+
+```js
+for (let i = 0; i < 10; i++) {
+    funcs[i] = function() {
+        return i;
+    };
+}
+```
+
+In this case, each function created within the loop returns a different number as expected.
+
+
 ## Rule Details
 
 This error is raised to highlight a piece of code that may not work as you expect it to and could also indicate a misunderstanding of how the language works. Your code may run without any problems if you do not fix this error, but in some situations it could behave unexpectedly.
@@ -20,18 +33,30 @@ The following patterns are considered warnings:
 
 ```js
 for (var i=10; i; i--) {
-    (function() { ... })();
+    (function() { return i; })();
 }
+```
 
+```js
 while(i) {
-    var a = function() {};
+    var a = function() { return i; };
     a();
 }
+```
 
+```js
 do {
-    function a() {};
+    function a() { return i; };
     a();
 } while (i);
+```
+
+```js
+let foo = 0;
+for (let i=10; i; i--) {
+    var a = function() { return foo; }; // Bad, function is referencing block scoped variable in the outer scope.
+    a();
+}
 ```
 
 The following patterns are considered okay and do not cause warnings:
@@ -40,6 +65,20 @@ The following patterns are considered okay and do not cause warnings:
 var a = function() {};
 
 for (var i=10; i; i--) {
+    a();
+}
+```
+
+```js
+for (var i=10; i; i--) {
+    var a = function() {}; // OK, no references to variables in the outer scopes.
+    a();
+}
+```
+
+```js
+for (let i=10; i; i--) {
+    var a = function() { return i; }; // OK, all references are referring to block scoped variable in the loop.
     a();
 }
 ```

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -7,43 +7,103 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the containing loop node of a specified node.
+ *
+ * We don't need to check nested functions, so this ignores those.
+ * `Scope.through` contains references of nested functions.
+ *
+ * @param {ASTNode} node - An AST node to get.
+ * @returns {ASTNode|null} The containing loop node of the specified node, or `null`.
+ */
+function getContainingLoopNode(node) {
+    var parent = node.parent;
+    while (parent != null) {
+        switch (parent.type) {
+            case "WhileStatement":
+            case "DoWhileStatement":
+                return parent;
+
+            case "ForStatement":
+                // `init` is outside of the loop.
+                if (parent.init !== node) {
+                    return parent;
+                }
+                break;
+
+            case "ForInStatement":
+            case "ForOfStatement":
+                // `right` is outside of the loop.
+                if (parent.right !== node) {
+                    return parent;
+                }
+                break;
+
+            case "ArrowFunctionExpression":
+            case "FunctionExpression":
+            case "FunctionDeclaration":
+                // We don't need to check nested functions.
+                return null;
+
+            default:
+                break;
+        }
+
+        node = parent;
+        parent = node.parent;
+    }
+
+    return null;
+}
+
+/**
+ * Checks whether or not a reference refers to a variable that is block-binding in the loop.
+ * @param {ASTNode} loopNode - A containing loop node.
+ * @param {escope.Reference} reference - A reference to check.
+ * @returns {boolean} Whether or not a reference refers to a variable that is block-binding in the loop.
+ */
+function isBlockBindingsInLoop(loopNode, reference) {
+    // A reference to a `let`/`const` variable always has a resolved variable.
+    var variable = reference.resolved;
+    var definition = variable && variable.defs[0];
+    var declaration = definition && definition.parent;
+
+    return (
+        // Checks whether this is `let`/`const`.
+        declaration != null &&
+        declaration.type === "VariableDeclaration" &&
+        (declaration.kind === "let" || declaration.kind === "const") &&
+        // Checks whether this is in the loop.
+        declaration.range[0] > loopNode.range[0] &&
+        declaration.range[1] < loopNode.range[1]
+    );
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
     /**
-     * Reports if the given node has an ancestor node which is a loop.
+     * Reports such functions:
+     *
+     * - has an ancestor node which is a loop.
+     * - has a reference that refers to a variable that is block-binding in the loop.
+     *
      * @param {ASTNode} node The AST node to check.
      * @returns {boolean} Whether or not the node is within a loop.
      */
     function checkForLoops(node) {
-        var ancestors = context.getAncestors();
-
-        /**
-         * Checks if the given node is a loop and current context is in the loop.
-         * @param {ASTNode} ancestor The AST node to check.
-         * @param {number} index The index of ancestor in ancestors.
-         * @returns {boolean} Whether or not the node is a loop and current context is in the loop.
-         */
-        function isInLoop(ancestor, index) {
-            switch (ancestor.type) {
-                case "ForStatement":
-                    return ancestor.init !== ancestors[index + 1];
-
-                case "ForInStatement":
-                case "ForOfStatement":
-                    return ancestor.right !== ancestors[index + 1];
-
-                case "WhileStatement":
-                case "DoWhileStatement":
-                    return true;
-
-                default:
-                    return false;
-            }
+        var loopNode = getContainingLoopNode(node);
+        if (loopNode == null) {
+            return;
         }
 
-        if (ancestors.some(isInLoop)) {
+        var references = context.getScope().through;
+        if (references.length > 0 && !references.every(isBlockBindingsInLoop.bind(null, loopNode))) {
             context.report(node, "Don't make functions within a loop");
         }
     }

--- a/tests/lib/rules/no-loop-func.js
+++ b/tests/lib/rules/no-loop-func.js
@@ -23,56 +23,125 @@ var eslintTester = new ESLintTester(eslint),
 eslintTester.addRuleTest("lib/rules/no-loop-func", {
     valid: [
         "string = 'function a() {}';",
-        "for (var i=0; i<l; i++) { } var a = function() { };",
-        "for (var i=0, a=function() { }; i<l; i++) { }",
-        "for (var x in xs.filter(function(x) { return x != null; })) { }",
+        "for (var i=0; i<l; i++) { } var a = function() { i; };",
+        "for (var i=0, a=function() { i; }; i<l; i++) { }",
+        "for (var x in xs.filter(function(x) { return x != upper; })) { }",
         {
-            code: "for (var x of xs.filter(function(x) { return x != null; })) { }",
+            code: "for (var x of xs.filter(function(x) { return x != upper; })) { }",
             ecmaFeatures: { forOf: true }
+        },
+
+        // no refers to variables that declared on upper scope.
+        {
+            code: "for (var i=0; i<l; i++) { (function() {}) }"
+        },
+        {
+            code: "for (var i in {}) { (function() {}) }"
+        },
+        {
+            code: "for (var i of {}) { (function() {}) }",
+            ecmaFeatures: { forOf: true }
+        },
+
+        // refers to only variables that declared with `let`/`const` keyword in the loop.
+        // these are rebound on each loop step.
+        {
+            code: "for (let i=0; i<l; i++) { (function() { i; }) }",
+            ecmaFeatures: { blockBindings: true }
+        },
+        {
+            code: "for (let i in {}) { (function() { i; }) }",
+            ecmaFeatures: { blockBindings: true }
+        },
+        {
+            code: "for (const i of {}) { (function() { i; }) }",
+            ecmaFeatures: { blockBindings: true, forOf: true }
+        },
+        {
+            code: "for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
+            ecmaFeatures: { arrowFunctions: true, blockBindings: true }
         }
     ],
     invalid: [
         {
-            code: "for (var i=0; i<l; i++) { (function() {}) }",
+            code: "for (var i=0; i<l; i++) { (function() { i; }) }",
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "for (var i in {}) { (function() {}) }",
+            code: "for (var i in {}) { (function() { i; }) }",
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "for (var i of {}) { (function() {}) }",
+            code: "for (var i of {}) { (function() { i; }) }",
             ecmaFeatures: { forOf: true },
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "for (var i=0; i < l; i++) { (() => {}) }",
+            code: "for (var i=0; i < l; i++) { (() => { i; }) }",
             ecmaFeatures: { arrowFunctions: true },
             errors: [ { message: expectedErrorMessage, type: "ArrowFunctionExpression" } ]
         },
         {
-            code: "for (var i=0; i < l; i++) { var a = function() {} }",
+            code: "for (var i=0; i < l; i++) { var a = function() { i; } }",
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "for (var i=0; i < l; i++) { function a() {}; a(); }",
+            code: "for (var i=0; i < l; i++) { function a() { i; }; a(); }",
             errors: [ { message: expectedErrorMessage, type: "FunctionDeclaration" } ]
         },
         {
-            code: "for (var i=0; (function() {})(), i<l; i++) { }",
+            code: "for (var i=0; (function() { i; })(), i<l; i++) { }",
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "for (var i=0; i<l; (function() {})(), i++) { }",
+            code: "for (var i=0; i<l; (function() { i; })(), i++) { }",
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "while(i) { (function() {}) }",
+            code: "while(i) { (function() { i; }) }",
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "do { (function() {}) } while (i)",
+            code: "do { (function() { i; }) } while (i)",
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+
+        // refers to variables that declared with `let`/`const` keyword on outside of the loop.
+        // these are not rebound on each loop step.
+        {
+            code: "let a; for (let i=0; i<l; i++) { (function() { a; }); }",
+            ecmaFeatures: { blockBindings: true },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "let a; for (let i in {}) { (function() { a; }); }",
+            ecmaFeatures: { blockBindings: true },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "let a; for (let i of {}) { (function() { a; }); }",
+            ecmaFeatures: { blockBindings: true, forOf: true },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "let a; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); }",
+            ecmaFeatures: { blockBindings: true },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "let a; for (let i in {}) { function foo() { (function() { a; }); } }",
+            ecmaFeatures: { blockBindings: true },
+            errors: [ { message: expectedErrorMessage, type: "FunctionDeclaration" } ]
+        },
+        {
+            code: "let a; for (let i of {}) { (() => { (function() { a; }); }); }",
+            ecmaFeatures: { arrowFunctions: true, blockBindings: true, forOf: true },
+            errors: [ { message: expectedErrorMessage, type: "ArrowFunctionExpression" } ]
+        },
+        {
+            code: "for (var i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
+            ecmaFeatures: { arrowFunctions: true, blockBindings: true },
+            errors: [ { message: expectedErrorMessage, type: "ArrowFunctionExpression" } ]
         }
     ]
 });


### PR DESCRIPTION
I enhanced the `no-loop-func` rule.
Now, this rule checks whether or not each function has references to upper scopes.
And when the function has reference to variables (excludes block-scoped variables in the loop) that are on upper scopes, this rule reports the function.

I'm sorry, I rewrote most test cases.
To check references, so I did not have reasons to keep warning functions that does not have references to upper scopes.
So I fixed existing test cases: those functions have a reference to upper scopes.