### PR TITLE
Docs: Clarify when not to use space-before-blocks

### DIFF
--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -84,7 +84,7 @@ try{} catch(a){}
 
 ## When Not To Use It
 
-You can turn this rule off if you are not concerned with the consistency of spacing before blocks.
+You can turn this rule off if you are not concerned with the consistency of spacing before blocks or if you are using the `space-after-keywords` rule set to `"never"`.
 
 ## Related Rules
 


### PR DESCRIPTION
This rule in `"always"` mode is incompatibale with the rule `space-after-keywords` set to `"never"` in the case of `else` statements.

`space-after-keywords` `"never"` requires `} else{` which is an error for `space-before-blocks` `"always"`.

Users should at least be aware of this interplay between the rules.