### PR TITLE
New: Add exported comment option (fixes #1200)

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -42,6 +42,11 @@ myFunc(function foo() {
 })();
 ```
 
+### Exporting Variables
+
+In some environments you may use `var` to create a global variable that may be used by other scripts. You can
+ use the `/* exported variableName */` comment block to indicate that this variable may be used elsewhere.
+
 ### Options
 
 By default this rule is enabled with `all` option for variables and `after-used` for arguments.

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -130,6 +130,7 @@ function getVariable(scope, name) {
  */
 function addDeclaredGlobals(program, globalScope, config) {
     var declaredGlobals = {},
+        exportedGlobals = {},
         explicitGlobals = {},
         builtin = environments.builtin;
 
@@ -144,6 +145,7 @@ function addDeclaredGlobals(program, globalScope, config) {
         }
     });
 
+    assign(exportedGlobals, config.exported);
     assign(declaredGlobals, config.globals);
     assign(explicitGlobals, config.astGlobals);
 
@@ -165,6 +167,14 @@ function addDeclaredGlobals(program, globalScope, config) {
             globalScope.variables.push(variable);
         }
         variable.writeable = explicitGlobals[name];
+    });
+
+    // mark all exported variables as such
+    Object.keys(exportedGlobals).forEach(function(name) {
+        var variable = getVariable(globalScope, name);
+        if (variable) {
+            variable.eslintUsed = true;
+        }
     });
 }
 
@@ -245,6 +255,7 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
 function modifyConfigsFromComments(filename, ast, config, reportingConfig, messages) {
 
     var commentConfig = {
+        exported: {},
         astGlobals: {},
         rules: {},
         env: {}
@@ -254,13 +265,17 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
     ast.comments.forEach(function(comment) {
 
         var value = comment.value.trim();
-        var match = /^(eslint-\w+|eslint-\w+-\w+|eslint|globals?)(\s|$)/.exec(value);
+        var match = /^(eslint-\w+|eslint-\w+-\w+|eslint|exported|globals?)(\s|$)/.exec(value);
 
         if (match) {
             value = value.substring(match.index + match[1].length);
 
             if (comment.type === "Block") {
                 switch (match[1]) {
+                    case "exported":
+                        assign(commentConfig.exported, parseBooleanConfig(value));
+                        break;
+
                     case "globals":
                     case "global":
                         assign(commentConfig.astGlobals, parseBooleanConfig(value));

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -156,7 +156,7 @@ module.exports = function(context) {
                 if (scope.type === "class" && scope.block.id === variable.identifiers[0]) {
                     continue;
                 }
-                // skip function expression names
+                // skip function expression names and variables marked with markVariableAsUsed()
                 if (scope.functionExpressionScope || variable.eslintUsed) {
                     continue;
                 }
@@ -219,7 +219,9 @@ module.exports = function(context) {
             for (var i = 0, l = unusedVars.length; i < l; ++i) {
                 var unusedVar = unusedVars[i];
 
-                if (unusedVar.eslintExplicitGlobal) {
+                if (unusedVar.eslintUsed) {
+                    continue; // explicitly exported variables
+                } else if (unusedVar.eslintExplicitGlobal) {
                     context.report(programNode, MESSAGE, unusedVar);
                 } else if (unusedVar.defs.length > 0) {
                     context.report(unusedVar.identifiers[0], MESSAGE, unusedVar);

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -101,6 +101,12 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         {code: "var x = 1; function foo(y = function(z = x) { bar(z); }) { y(); } foo();", ecmaFeatures: {defaultParams: true}},
         {code: "var x = 1; function foo(y = function() { bar(x); }) { y(); } foo();", ecmaFeatures: {defaultParams: true}},
 
+        // exported variables should work
+        { code: "/*exported toaster*/ var toaster = 'great'" },
+        { code: "/*exported toaster, poster*/ var toaster = 1; poster = 0;" },
+        { code: "/*exported x*/ var { x } = y", ecmaFeatures: {destructuring: true} },
+        { code: "/*exported x, y*/  var { x, y } = z", ecmaFeatures: {destructuring: true} },
+
         // Can mark variables as used via context.markVariableAsUsed()
         { code: "/*eslint use-every-a:1*/ var a;"},
         { code: "/*eslint use-every-a:1*/ !function(a) { return 1; }"},
@@ -138,6 +144,10 @@ eslintTester.addRuleTest("lib/rules/no-unused-vars", {
         { code: "function f() { var a = 1; return function(){ f(a = 2); }; }", options: [{}], errors: [{ message: "f is defined but never used" }, {message: "a is defined but never used"}]},
         { code: "import x from \"y\";", ecmaFeatures: { modules: true }, errors: [{ message: "x is defined but never used" }]},
         { code: "export function fn2({ x, y }) {\n console.log(x); \n};", ecmaFeatures: { modules: true, destructuring: true }, errors: [{ message: "y is defined but never used" }]},
-        { code: "export function fn2( x, y ) {\n console.log(x); \n};", ecmaFeatures: { modules: true }, errors: [{ message: "y is defined but never used" }]}
+        { code: "export function fn2( x, y ) {\n console.log(x); \n};", ecmaFeatures: { modules: true }, errors: [{ message: "y is defined but never used" }]},
+
+        // exported
+        { code: "/*exported max*/ var max = 1, min = {min: 1}", errors: [{ message: "min is defined but never used" }] },
+        { code: "/*exported x*/ var { x, y } = z", ecmaFeatures: { destructuring: true }, errors: [{ message: "y is defined but never used" }] }
     ]
 });


### PR DESCRIPTION
The basic functionality works. I'll need to make sure the edge cases work though.

Here is an example of what this will allow:
```js
/* exported blob */
var blob = 44;
```

Currently allows for both `exported` and `exports` commands for compatibility with jshint. I'm thinking we should only support 1 though.

- [x] Needs Tests (es6 module, node env, strict mode, etc)
- [x] Needs Docs