### PR TITLE
Add rule preventing undocumented functions with names

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -89,6 +89,7 @@
         "no-undef": 2,
         "no-undef-init": 2,
         "no-undefined": 0,
+	"no-undocumented-named-function": 0,
         "no-unexpected-multiline": 0,
         "no-underscore-dangle": 2,
         "no-unneeded-ternary": 0,
@@ -101,7 +102,6 @@
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 2,
         "no-wrap-func": 2,
-
         "array-bracket-spacing": [0, "never"],
         "arrow-parens": 0,
         "arrow-spacing": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -190,6 +190,7 @@ These rules are purely matters of style and are quite subjective.
 * [spaced-comment](spaced-comment.md) - require or disallow a space immediately following the `//` or `/*` in a comment
 * [spaced-line-comment](spaced-line-comment.md) - **(deprecated)** require or disallow a space immediately following the `//` in a line comment
 * [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses
+* [no-undocumented-named-function](no-undocumented-named-function.md) - require functions that are called by a name to have documentation
 
 ## ECMAScript 6
 

--- a/docs/rules/no-undocumented-named-function.md
+++ b/docs/rules/no-undocumented-named-function.md
@@ -1,0 +1,63 @@
+# Do no leave named functions undocumented (no-undocumented-named-function)
+
+[JSDoc](http://usejsdoc.org) is a JavaScript API documentation generator. It uses specially-formatted comments inside of code to generate API documentation automatically. For example, this is what a JSDoc comment looks like for a function:
+
+```js
+/**
+ * Adds two numbers together.
+ * @param {int} num1 The first number.
+ * @param {int} num2 The second number.
+ * @returns {int} The sum of the two numbers.
+ */
+function sum(num1, num2) {
+    return num1 + num2;
+}
+```
+
+The JSDoc comments have a syntax all their own, and it is easy to mistakenly mistype a comment because comments aren't often checked for correctness in editors. Further, it's very easy for the function definition to get out of sync with the comments, making the comments a source of confusion and error.
+
+## Rule Details
+
+This rule aims to enforce documentation for all exported or internally named functions created by the developer.
+It will warn if there is no documentation for a named function in your file.
+
+The following patterns are considered warnings:
+
+```js
+// exported function as property of Object without documentation
+define(function () {
+
+/**
+* A module that says hello!
+* @exports hello/world
+*/
+var ns = {};
+
+ns.sayHello = function() {
+return 'Hello world';
+};
+
+return ns;
+});
+```
+
+The following patterns are not warnings:
+
+```js
+/**
+ * Adds two numbers together.
+ * @param {int} num1 The first number.
+ * @param {int} num2 The second number.
+ * @returns {int} The sum of the two numbers.
+ */
+function add(num1, num2) {
+  return num1 + num2;
+}
+
+/**
+@class MyClass
+*/
+function MyClass() {
+
+}
+```

--- a/lib/rules/no-undocumented-named-function.js
+++ b/lib/rules/no-undocumented-named-function.js
@@ -1,0 +1,114 @@
+/**
+ * @fileoverview No undocumented unnamed functions
+ * @author Andreas Marschke
+ * @copyright 2015 Andreas Marschke All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+/**
+   Rule Definition
+   @param {ASTContext} context for the code
+   @returns {Object} schema with identifiers
+*/
+module.exports = function(context) {
+    // Record found errors
+    var found = {};
+
+    /**
+     * Check if we have seen this error before
+     * @param {Integer} line The line it is reported on
+     * @param {Integer} column The character it is reported on
+     * @returns {boolean} true if found already false if not
+     */
+    function checkIfFound(line, column) {
+        return found[line] && found[line][column] === true;
+    }
+
+    /**
+     * Record found errors in the found variable
+     * @param {Integer} line The line it is reported on
+     * @param {Integer} column The character it is reported on
+     * @returns {void}
+     */
+    function recordFound(line, column) {
+        if (!found[line]) {
+            found[line] = {};
+        }
+        found[line][column] = true;
+    }
+
+    /**
+     * Report Errors on nodes name
+     * @param {String} name The name of the function to be reported
+     * @param {ASTNode} node The node to report on
+     * @returns {void}
+     */
+    function reportMissingFunction(name, node) {
+        if (!checkIfFound(node.loc.start.line, node.loc.start.column)) {
+            context.report(node, "Function " + name + " was not documented");
+            recordFound(node.loc.start.line, node.loc.start.column);
+        }
+    }
+
+    /**
+     * Validate the JSDoc node and output warnings if anything is wrong.
+     * @param {ASTNode} node The AST node to check.
+     * @returns {void}
+     * @private
+     */
+    function checkJSDoc(node) {
+        var jsdocNode = context.getJSDocComment(node);
+
+        if (!jsdocNode) {
+            switch (node.type) {
+            case "FunctionExpression": {
+                if (node.parent && node.parent.id && node.parent.id.name && node.parent.type === "VariableDeclarator") {
+                    reportMissingFunction(node.parent.id.name, node);
+                    return;
+                } else if (node.parent && node.parent.key && node.parent.key.name && node.parent.type === "Property") {
+                    reportMissingFunction(node.parent.key.name, node);
+                    return;
+                } else if (node.parent && node.parent.operator === "=" && node.parent.type === "AssignmentExpression" ) {
+                    reportMissingFunction(node.parent.left.property.name, node);
+                    return;
+                }
+                break;
+            }
+            case "FunctionDeclaration": {
+                if (node.id && node.id.name) {
+                    reportMissingFunction(node.id.name, node);
+                    return;
+                }
+                break;
+            }
+            default:
+                break;
+            }
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+        "ArrowFunctionExpression": checkJSDoc,
+        "FunctionExpression": checkJSDoc,
+        "FunctionDeclaration": checkJSDoc,
+        "ArrowFunctionExpression:exit": checkJSDoc,
+        "FunctionExpression:exit": checkJSDoc,
+        "FunctionDeclaration:exit": checkJSDoc
+    };
+};
+
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {},
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/no-undocumented-named-function.js
+++ b/tests/lib/rules/no-undocumented-named-function.js
@@ -1,0 +1,79 @@
+/**
+ * @fileoverview No undocumented unnamed functions
+ * @author Andreas Marschke
+ * @copyright 2015 Andreas Marschke All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-undocumented-named-function", {
+    valid: [
+        "/**\n @class MyClass \n*/\nfunction MyClass() {}",
+        "/**\n Function doing something\n*/\nfunction myFunction() {}",
+        "/**\n Function doing something\n*/\nvar myFunction = function() {};",
+        "/**\n Function doing something\n*/\nObject.myFunction = function () {};",
+        "var obj = { \n /**\n Function doing something\n*/\n myFunction: function () {} };",
+
+        "/**\n @func myFunction \n*/\nfunction myFunction() {}",
+        "/**\n @method myFunction\n*/\nfunction myFunction() {}",
+        "/**\n @function myFunction\n*/\nfunction myFunction() {}",
+
+        "/**\n @func myFunction \n*/\nvar myFunction = function () {}",
+        "/**\n @method myFunction\n*/\nvar myFunction = function () {}",
+        "/**\n @function myFunction\n*/\nvar myFunction = function () {}",
+
+        "/**\n @func myFunction \n*/\nObject.myFunction = function() {}",
+        "/**\n @method myFunction\n*/\nObject.myFunction = function() {}",
+        "/**\n @function myFunction\n*/\nObject.myFunction = function() {}",
+
+        "var object = {\n/**\n @func myFunction - Some function \n*/\nmyFunction: function() {} }",
+        "var object = {\n/**\n @method myFunction - Some function \n*/\nmyFunction: function() {} }",
+        "var object = {\n/**\n @function myFunction - Some function \n*/\nmyFunction: function() {} }",
+
+        "var array = [1,2,3];\narray.forEach(function() {});",
+        "var array = [1,2,3];\narray.filter(function() {});",
+        "var object = { name: 'key'};\nObject.keys(object).forEach(function() {})"
+    ],
+
+    invalid: [
+        {
+            code: "var testFunction = function() {}",
+            errors: [{
+                message: "Function testFunction was not documented",
+                type: "FunctionExpression"
+            }]
+        },
+        {
+            code: "function myFunction() {}",
+            errors: [{
+                message: "Function myFunction was not documented",
+                type: "FunctionDeclaration"
+            }]
+        },
+        {
+            code: "var object = { myFunction: function() {} };",
+            errors: [{
+                message: "Function myFunction was not documented",
+                type: "FunctionExpression"
+            }]
+        },
+        {
+            code: "var object = {};\nobject.testFunction = function() {}",
+            errors: [{
+                message: "Function testFunction was not documented",
+                type: "FunctionExpression"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
Adds a rule against leaving functions that are declared with names or named in any way to be undocumented.