### PR TITLE
Fix: the `no-wrap-func` rule crashes (#2974)

### DIFF
--- a/lib/rules/no-wrap-func.js
+++ b/lib/rules/no-wrap-func.js
@@ -41,6 +41,12 @@ module.exports = function(context) {
         previousToken = context.getTokenBefore(node);
         nextToken = context.getTokenAfter(node);
 
+        // clearly no wrapped.
+        // https://github.com/eslint/eslint/issues/2974
+        if (previousToken == null || nextToken == null) {
+            return;
+        }
+
         // f(function(){}) and new f(function(){})
         if (isCall) {
 

--- a/tests/lib/rules/no-wrap-func.js
+++ b/tests/lib/rules/no-wrap-func.js
@@ -28,6 +28,10 @@ eslintTester.addRuleTest("lib/rules/no-wrap-func", {
         {
             code: "opts.ease = opts.ease || (a => a * a * a)",
             ecmaFeatures: { arrowFunctions: true }
+        },
+        {
+            code: "(arg) => arg",
+            ecmaFeatures: { arrowFunctions: true }
         }
     ],
     invalid: [


### PR DESCRIPTION
This rule is deprecated, so I sent this PR to the `0.x` branch.