### PR TITLE
Only add tag to the params object if tag.name is defined

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -107,7 +107,7 @@ module.exports = function(context) {
 
                         if (params[tag.name]) {
                             context.report(jsdocNode, "Duplicate JSDoc parameter '{{name}}'.", { name: tag.name });
-                        } else if (tag.name.indexOf(".") === -1) {
+                        } else if (tag.name && tag.name.indexOf(".") === -1) {
                             params[tag.name] = 1;
                         }
                         break;

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -287,6 +287,22 @@ eslintTester.addRuleTest("lib/rules/valid-jsdoc", {
                 message: "Unexpected @returns tag; function has no return statement.",
                 type: "Block"
             }]
+        },
+        {
+            code: "/**\n * Some text\n *\n * @param arg [optional] text description\n */\nfunction testFunction(arg) {}",
+            options: [{"requireReturn": false,
+                       "requireParamDescription": false,
+                       "requireReturnDescription": false}],
+            errors: [
+                {
+                    message: "Missing JSDoc parameter type for \'undefined\'.",
+                    type: "Block"
+                },
+                {
+                    message: "Missing JSDoc for parameter \'arg\'.",
+                    type: "Block"
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
This PR fixes issue #2270 . When the parsed jsDoc code is checked for param tags the code expects `tag.name` to be present which isn't always the case when dealing with non-standard jsDoc code. 

This PR will add a test against this plus a check for `tag.name` in the rule. 