### PR TITLE
New: added unix-style formatter (fixes #2991)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -80,7 +80,7 @@ Examples:
 
 ### `-f`, `--format`
 
-This option specifies the output format for the console. Possible formats are "stylish" (the default), "compact", "checkstyle", "jslint-xml", "junit", "json" and "tap".
+This option specifies the output format for the console. Possible formats are "stylish" (the default), "compact", "checkstyle", "jslint-xml", "junit", "json", "tap" and "unix".
 
 Example:
 

--- a/lib/formatters/unix.js
+++ b/lib/formatters/unix.js
@@ -1,0 +1,59 @@
+/**
+ * @fileoverview unix-style formatter.
+ * @author oshi-shinobu
+ * @copyright 2015 oshi-shinobu. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helper Functions
+//------------------------------------------------------------------------------
+
+/**
+ * Returns a canonical error level string based upon the error message passed in.
+ * @param {object} message Individual error message provided by eslint
+ * @returns {String} Error level string
+ */
+function getMessageType(message) {
+    if (message.fatal || message.severity === 2) {
+        return "Error";
+    } else {
+        return "Warning";
+    }
+}
+
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = function(results) {
+
+    var output = "",
+        total = 0;
+
+    results.forEach(function(result) {
+
+        var messages = result.messages;
+        total += messages.length;
+
+        messages.forEach(function(message) {
+
+            output += result.filePath + ":";
+            output += (message.line || 0) + ":";
+            output += (message.column || 0) + ":";
+            output += " " + message.message + " ";
+            output += "[" + getMessageType(message) +
+                      (message.ruleId ? "/" + message.ruleId : "") + "]";
+            output += "\n";
+
+        });
+
+    });
+
+    if (total > 0) {
+        output += "\n" + total + " problem" + (total !== 1 ? "s" : "");
+    }
+
+    return output;
+};

--- a/tests/lib/formatters/unix.js
+++ b/tests/lib/formatters/unix.js
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview Tests for unix-style formatter.
+ * @author oshi-shinobu
+ * @copyright 2015 oshi-shinobu. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    formatter = require("../../../lib/formatters/unix");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("formatter:compact", function() {
+    describe("when passed no messages", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: []
+        }];
+
+        it("should return nothing", function() {
+            var result = formatter(code);
+            assert.equal(result, "");
+        });
+    });
+
+    describe("when passed a single message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                severity: 2,
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a string in the format filename:line:column: error [Error/rule_id]", function() {
+            var result = formatter(code);
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
+        });
+
+        it("should return a string in the format filename:line:column: warning [Warning/rule_id]", function() {
+            code[0].messages[0].severity = 1;
+            var result = formatter(code);
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Warning/foo]\n\n1 problem");
+        });
+    });
+
+    describe("when passed a fatal error message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Unexpected foo.",
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a string in the format filename:line:column: error [Error/rule_id]", function() {
+            var result = formatter(code);
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\n\n1 problem");
+        });
+    });
+
+    describe("when passed multiple messages", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                severity: 2,
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }, {
+                message: "Unexpected bar.",
+                severity: 1,
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return a string with multiple entries", function() {
+            var result = formatter(code);
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nfoo.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
+        });
+    });
+
+    describe("when passed multiple files with 1 message each", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                message: "Unexpected foo.",
+                severity: 2,
+                line: 5,
+                column: 10,
+                ruleId: "foo"
+            }]
+        }, {
+            filePath: "bar.js",
+            messages: [{
+                message: "Unexpected bar.",
+                severity: 1,
+                line: 6,
+                column: 11,
+                ruleId: "bar"
+            }]
+        }];
+
+        it("should return a string with multiple entries", function() {
+            var result = formatter(code);
+            assert.equal(result, "foo.js:5:10: Unexpected foo. [Error/foo]\nbar.js:6:11: Unexpected bar. [Warning/bar]\n\n2 problems");
+        });
+    });
+
+    describe("when passed one file not found message", function() {
+        var code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Couldn't find foo.js."
+            }]
+        }];
+
+        it("should return a string without line and column", function() {
+            var result = formatter(code);
+            assert.equal(result, "foo.js:0:0: Couldn't find foo.js. [Error]\n\n1 problem");
+        });
+    });
+});


### PR DESCRIPTION
I wrote the formatter described in #2991 and the tests for it, and released it under the same free license as eslint. I hope you will consider distributing it with eslint, as it follows a standardized format adopted by most linters and editors.