### PR TITLE
New: the `prefer-reflect` rule (fixes #2939)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -148,6 +148,7 @@
         "padded-blocks": 0,
         "prefer-const": 0,
         "prefer-spread": 0,
+        "prefer-reflect": 0,
         "quote-props": 0,
         "quotes": [0, "double"],
         "radix": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -198,6 +198,7 @@ These rules are only relevant to ES6 environments.
 * [object-shorthand](object-shorthand.md) - require method and property shorthand syntax for object literals
 * [prefer-const](prefer-const.md) - suggest using `const` declaration for variables that are never modified after declared
 * [prefer-spread](prefer-spread.md) - suggest using the spread operator instead of `.apply()`.
+* [prefer-reflect](prefer-reflect.md) - suggest using Reflect methods where applicable
 * [require-yield](require-yield.md) - disallow generator functions that do not have `yield`
 
 ## Legacy

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -1,0 +1,305 @@
+# Suggest using Reflect methods where applicable (prefer-reflect)
+
+The ES6 Reflect API comes with a handful of methods which somewhat deprecate methods on old constructors:
+
+* [`Reflect.apply`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.apply) effectively deprecates [`Function.prototype.apply`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-function.prototype.apply) and [`Function.prototype.call`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-function.prototype.call)
+* [`Reflect.deleteProperty`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.deleteproperty) effectively deprecates the [`delete` keyword](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-delete-operator-runtime-semantics-evaluation)
+* [`Reflect.getOwnPropertyDescriptor`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.getownpropertydescriptor) effectively deprecates [`Object.getOwnPropertyDescriptor`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.getownpropertydescriptor)
+* [`Reflect.getPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.getprototypeof) effectively deprecates [`Object.getPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.getprototypeof)
+* [`Reflect.setPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.setprototypeof) effectively deprecates [`Object.setPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.setprototypeof)
+* [`Reflect.preventExtensions`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.preventextensions)  effectively deprecates [`Object.preventExtensions`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.preventextensions)
+
+The prefer-reflect rule will flag usage of any older method, suggesting to instead use the newer Reflect version.
+
+## Rule Details
+
+### Reflect.apply (Function.prototype.apply/Function.prototype.call)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+foo.apply(undefined, args);
+foo.apply(null, args);
+obj.foo.apply(obj, args);
+obj.foo.apply(other, args);
+
+foo.call(undefined, arg);
+foo.call(null, arg);
+obj.foo.call(obj, arg);
+obj.foo.call(other, arg);
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.apply(undefined, args);
+Reflect.apply(null, args);
+Reflect.apply(obj.foo, obj, args);
+Reflect.apply(obj.foo, other, args);
+Reflect.apply(undefined, [arg]);
+Reflect.apply(null, [arg]);
+Reflect.apply(obj.foo, obj, [arg]);
+Reflect.apply(obj.foo, other, [arg]);
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["apply"] }]`
+
+```js
+foo.apply(undefined, args);
+foo.apply(null, args);
+obj.foo.apply(obj, args);
+obj.foo.apply(other, args);
+Reflect.apply(undefined, args);
+Reflect.apply(null, args);
+Reflect.apply(obj.foo, obj, args);
+Reflect.apply(obj.foo, other, args);
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["call"] }]`
+
+```js
+foo.call(undefined, arg);
+foo.call(null, arg);
+obj.foo.call(obj, arg);
+obj.foo.call(other, arg);
+Reflect.apply(undefined, [arg]);
+Reflect.apply(null, [arg]);
+Reflect.apply(obj.foo, obj, [arg]);
+Reflect.apply(obj.foo, other, [arg]);
+```
+
+### Reflect.defineProperty (Object.defineProperty)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Object.defineProperty({}, 'foo', {value: 1})
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.defineProperty({}, 'foo', {value: 1})
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["defineProperty"] }]`
+
+```js
+Object.defineProperty({}, 'foo', {value: 1})
+Reflect.defineProperty({}, 'foo', {value: 1})
+```
+
+### Reflect.getOwnPropertyDescriptor (Object.getOwnPropertyDescriptor)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Object.getOwnPropertyDescriptor({}, 'foo')
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.getOwnPropertyDescriptor({}, 'foo')
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["getOwnPropertyDescriptor"] }]`
+
+```js
+Object.getOwnPropertyDescriptor({}, 'foo')
+Reflect.getOwnPropertyDescriptor({}, 'foo')
+```
+
+### Reflect.getPrototypeOf (Object.getPrototypeOf)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Object.getPrototypeOf({}, 'foo')
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.getPrototypeOf({}, 'foo')
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["getPrototypeOf"] }]`
+
+```js
+Object.getPrototypeOf({}, 'foo')
+Reflect.getPrototypeOf({}, 'foo')
+```
+
+### Reflect.setPrototypeOf (Object.setPrototypeOf)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Object.setPrototypeOf({}, Object.prototype)
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.setPrototypeOf({}, Object.prototype)
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["setPrototypeOf"] }]`
+
+```js
+Object.setPrototypeOf({}, Object.prototype)
+Reflect.setPrototypeOf({}, Object.prototype)
+```
+
+### Reflect.isExtensible (Object.isExtensible)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Object.isExtensible({})
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.isExtensible({})
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["isExtensible"] }]`
+
+```js
+Object.isExtensible({})
+Reflect.isExtensible({})
+```
+
+### Reflect.getOwnPropertyNames (Object.getOwnPropertyNames)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Object.getOwnPropertyNames({})
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.getOwnPropertyNames({})
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["getOwnPropertyNames"] }]`
+
+```js
+Object.getOwnPropertyNames({})
+Reflect.getOwnPropertyNames({})
+```
+
+### Reflect.preventExtensions (Object.preventExtensions)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Object.preventExtensions({})
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+Reflect.preventExtensions({})
+```
+
+__config:__ `prefer-reflect: [2, { exceptions: ["preventExtensions"] }]`
+
+```js
+Object.preventExtensions({})
+Reflect.preventExtensions({})
+```
+
+### Reflect.deleteProperty (The `delete` keyword)
+
+The following patterns are considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+delete foo.bar;
+```
+
+The following patterns are not considered warnings:
+
+__config:__ `prefer-reflect: [2]`
+
+```js
+delete bar; // Does not reference an object, just a var
+Reflect.deleteProperty(foo, 'bar');
+```
+
+(Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md))
+
+__config:__ `prefer-reflect: [2, { exceptions: ["delete"] }]`
+
+```js
+delete bar
+delete foo.bar
+Reflect.deleteProperty(foo, 'bar');
+```
+
+## Options
+
+### Exceptions
+
+```js
+"prefer-reflect": [<enabled>, { exceptions: [<...exceptions>] }]
+```
+
+The `exceptions` option allows you to pass an array of methods names you'd like to continue to use in the old style.
+
+For example if you wish to use all Reflect methods, except for `Function.prototype.apply` then your config would look like `prefer-reflect: [2, { exceptions: ["apply"] }]`.
+
+If you want to use Reflect methods, but keep using the `delete` keyword, then your config would look like `prefer-reflect: [2, { exceptions: ["delete"] }]`.
+
+These can be combined as much as you like. To make all methods exceptions (thereby rendering this rule useless), use `prefer-reflect: [2, { exceptions: ["apply", "call", "defineProperty", "getOwnPropertyDescriptor", "getPrototypeOf", "setPrototypeOf", "isExtensible", "getOwnPropertyNames", "preventExtensions", "delete"] }]`
+
+## When Not to Use It
+
+This rule should not be used in ES3/5 environments.
+
+In ES2015 (ES6) or later, if you don't want to be notified about places where Reflect could be used, you can safely disable this rule.
+
+## Related rules
+
+* [no-useless-call](no-useless-call.md)
+* [prefer-spread](prefer-spread.md)
+* [no-delete-var](no-delete-var.md)

--- a/lib/rules/prefer-reflect.js
+++ b/lib/rules/prefer-reflect.js
@@ -1,0 +1,99 @@
+/**
+ * @fileoverview Rule to suggest using "Reflect" api over Function/Object methods
+ * @author Keith Cirkel <http://keithcirkel.co.uk>
+ * @copyright 2015 Keith Cirkel. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var existingNames = {
+        "apply": "Function.prototype.apply",
+        "call": "Function.prototype.call",
+        "defineProperty": "Object.defineProperty",
+        "getOwnPropertyDescriptor": "Object.getOwnPropertyDescriptor",
+        "getPrototypeOf": "Object.getPrototypeOf",
+        "setPrototypeOf": "Object.setPrototypeOf",
+        "isExtensible": "Object.isExtensible",
+        "getOwnPropertyNames": "Object.getOwnPropertyNames",
+        "preventExtensions": "Object.preventExtensions"
+    };
+
+    var reflectSubsitutes = {
+        "apply": "Reflect.apply",
+        "call": "Reflect.apply",
+        "defineProperty": "Reflect.defineProperty",
+        "getOwnPropertyDescriptor": "Reflect.getOwnPropertyDescriptor",
+        "getPrototypeOf": "Reflect.getPrototypeOf",
+        "setPrototypeOf": "Reflect.setPrototypeOf",
+        "isExtensible": "Reflect.isExtensible",
+        "getOwnPropertyNames": "Reflect.getOwnPropertyNames",
+        "preventExtensions": "Reflect.preventExtensions"
+    };
+
+    var exceptions = (context.options[0] || {}).exceptions || [];
+
+    /**
+     * Reports the Reflect violation based on the `existing` and `substitute`
+     * @param {Object} node The node that violates the rule.
+     * @param {string} existing The existing method name that has been used.
+     * @param {string} substitute The Reflect substitute that should be used.
+     * @returns {void}
+     */
+    function report(node, existing, substitute) {
+        context.report(node, "Avoid using {{existing}}, instead use {{substitute}}", {
+            existing: existing,
+            substitute: substitute
+        });
+    }
+
+    return {
+        "CallExpression": function(node) {
+            var methodName = (node.callee.property || {}).name;
+            var isReflectCall = (node.callee.object || {}).name === "Reflect";
+            var hasReflectSubsitute = reflectSubsitutes.hasOwnProperty(methodName);
+            var userConfiguredException = exceptions.indexOf(methodName) !== -1;
+            if (hasReflectSubsitute && !isReflectCall && !userConfiguredException) {
+                report(node, existingNames[methodName], reflectSubsitutes[methodName]);
+            }
+        },
+        "UnaryExpression": function(node) {
+            var isDeleteOperator = node.operator === "delete";
+            var targetsIdentifier = node.argument.type === "Identifier";
+            var userConfiguredException = exceptions.indexOf("delete") !== -1;
+            if (isDeleteOperator && !targetsIdentifier && !userConfiguredException) {
+                report(node, "the delete keyword", "Reflect.deleteProperty");
+            }
+        }
+    };
+
+};
+
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "exceptions": {
+                "type": "array",
+                "items": {
+                    "enum": [
+                        "apply",
+                        "call",
+                        "defineProperty",
+                        "getOwnPropertyDescriptor",
+                        "getPrototypeOf",
+                        "setPrototypeOf",
+                        "isExtensible",
+                        "getOwnPropertyNames",
+                        "preventExtensions"
+                    ]
+                },
+                "uniqueItems": true
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/prefer-reflect.js
+++ b/tests/lib/rules/prefer-reflect.js
@@ -1,0 +1,262 @@
+/**
+ * @fileoverview Tests for prefer-reflect rule.
+ * @author Keith Cirkel
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/prefer-reflect", {
+    valid: [
+        // Reflect.apply
+        { code: "Reflect.apply(function(){}, null, 1, 2);" },
+        { code: "Reflect.apply(function(){}, null, 1, 2);", options: [{ exceptions: "apply" }] },
+        { code: "(function(){}).apply(null, [1, 2]);", options: [{ exceptions: "apply" }] },
+        { code: "(function(){}).call(null, 1, 2);", options: [{ exceptions: "call" }] },
+
+        // Reflect.defineProperty
+        { code: "Reflect.defineProperty({}, 'foo', {value: 1})" },
+        { code: "Reflect.defineProperty({}, 'foo', {value: 1})", options: [{ exceptions: "defineProperty" }] },
+        { code: "Object.defineProperty({}, 'foo', {value: 1})", options: [{ exceptions: "defineProperty" }] },
+
+        // Reflect.getOwnPropertyDescriptor
+        { code: "Reflect.getOwnPropertyDescriptor({}, 'foo');" },
+        { code: "Reflect.getOwnPropertyDescriptor({}, 'foo');", options: [{ exceptions: "getOwnPropertyDescriptor" }] },
+        { code: "Object.getOwnPropertyDescriptor({}, 'foo');", options: [{ exceptions: "getOwnPropertyDescriptor" }] },
+
+        // Reflect.getPrototypeOf
+        { code: "Reflect.getPrototypeOf({});" },
+        { code: "Reflect.getPrototypeOf({});", options: [{ exceptions: "getPrototypeOf" }] },
+        { code: "Object.getPrototypeOf({});", options: [{ exceptions: "getPrototypeOf" }] },
+
+        // Reflect.setPrototypeOf
+        { code: "Reflect.setPrototypeOf({}, Object.prototype);" },
+        { code: "Reflect.setPrototypeOf({}, Object.prototype);", options: [{ exceptions: "setPrototypeOf" }] },
+        { code: "Object.setPrototypeOf({}, Object.prototype);", options: [{ exceptions: "setPrototypeOf" }] },
+
+        // Reflect.isExtensible
+        { code: "Reflect.isExtensible({});" },
+        { code: "Reflect.isExtensible({});", options: [{ exceptions: "isExtensible" }] },
+        { code: "Object.isExtensible({});", options: [{ exceptions: "isExtensible" }] },
+
+        // Reflect.getOwnPropertyNames
+        { code: "Reflect.getOwnPropertyNames({});" },
+        { code: "Reflect.getOwnPropertyNames({});", options: [{ exceptions: "getOwnPropertyNames" }] },
+        { code: "Object.getOwnPropertyNames({});", options: [{ exceptions: "getOwnPropertyNames" }] },
+
+        // Reflect.getOwnPropertyNames
+        { code: "Reflect.preventExtensions({});" },
+        { code: "Reflect.preventExtensions({});", options: [{ exceptions: "preventExtensions" }] },
+        { code: "Object.preventExtensions({});", options: [{ exceptions: "preventExtensions" }] },
+
+        // Reflect.getOwnPropertyNames
+        { code: "Reflect.deleteProperty({}, 'foo');" },
+        { code: "Reflect.deleteProperty({}, 'foo');", options: [{ exceptions: "delete" }] },
+        { code: "delete foo;" },
+        { code: "delete ({}).foo", options: [{ exceptions: "delete" }] }
+    ],
+    invalid: [
+
+        {
+            code: "(function(){}).apply(null, [1, 2])",
+            errors: [
+                {
+                    message: "Avoid using Function.prototype.apply, instead use Reflect.apply",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "(function(){}).apply(null, [1, 2])",
+            options: [{ exceptions: "defineProperty" }],
+            errors: [
+                {
+                    message: "Avoid using Function.prototype.apply, instead use Reflect.apply",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "(function(){}).call(null, 1, 2)",
+            errors: [
+                {
+                    message: "Avoid using Function.prototype.call, instead use Reflect.apply",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "(function(){}).call(null, 1, 2)",
+            options: [{ exceptions: "defineProperty" }],
+            errors: [
+                {
+                    message: "Avoid using Function.prototype.call, instead use Reflect.apply",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.defineProperty({}, 'foo', { value: 1 })",
+            errors: [
+                {
+                    message: "Avoid using Object.defineProperty, instead use Reflect.defineProperty",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.defineProperty({}, 'foo', { value: 1 })",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using Object.defineProperty, instead use Reflect.defineProperty",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getOwnPropertyDescriptor({}, 'foo')",
+            errors: [
+                {
+                    message: "Avoid using Object.getOwnPropertyDescriptor, instead use Reflect.getOwnPropertyDescriptor",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getOwnPropertyDescriptor({}, 'foo')",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using Object.getOwnPropertyDescriptor, instead use Reflect.getOwnPropertyDescriptor",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getPrototypeOf({})",
+            errors: [
+                {
+                    message: "Avoid using Object.getPrototypeOf, instead use Reflect.getPrototypeOf",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getPrototypeOf({})",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using Object.getPrototypeOf, instead use Reflect.getPrototypeOf",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.setPrototypeOf({}, Object.prototype)",
+            errors: [
+                {
+                    message: "Avoid using Object.setPrototypeOf, instead use Reflect.setPrototypeOf",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.setPrototypeOf({}, Object.prototype)",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using Object.setPrototypeOf, instead use Reflect.setPrototypeOf",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.isExtensible({})",
+            errors: [
+                {
+                    message: "Avoid using Object.isExtensible, instead use Reflect.isExtensible",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.isExtensible({})",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using Object.isExtensible, instead use Reflect.isExtensible",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getOwnPropertyNames({})",
+            errors: [
+                {
+                    message: "Avoid using Object.getOwnPropertyNames, instead use Reflect.getOwnPropertyNames",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getOwnPropertyNames({})",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using Object.getOwnPropertyNames, instead use Reflect.getOwnPropertyNames",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.preventExtensions({})",
+            errors: [
+                {
+                    message: "Avoid using Object.preventExtensions, instead use Reflect.preventExtensions",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.preventExtensions({})",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using Object.preventExtensions, instead use Reflect.preventExtensions",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "delete ({}).foo",
+            errors: [
+                {
+                    message: "Avoid using the delete keyword, instead use Reflect.deleteProperty",
+                    type: "UnaryExpression"
+                }
+            ]
+        },
+        {
+            code: "delete ({}).foo",
+            options: [{ exceptions: "apply" }],
+            errors: [
+                {
+                    message: "Avoid using the delete keyword, instead use Reflect.deleteProperty",
+                    type: "UnaryExpression"
+                }
+            ]
+        }
+
+    ]
+});


### PR DESCRIPTION
This PR adds a rule to warn when the user is using "effectively deprecated" methods - which Reflect.* replaces, as discussed in #2939. Fixes #2939.

As the docs/tests suggest, each section can be disabled - meaning the user can configure this how they need to, for example if they want to use reflect for all but the `delete` operator, then they can configure it as `[2, "delete"]`.

Let me know if you need anything else from me to merge this. 

Oh, also, so close!
<img width="326" alt="screen shot 2015-07-15 at 00 22 52" src="https://cloud.githubusercontent.com/assets/118266/8687392/b8d547dc-2a87-11e5-8da5-2ea4cd85e677.PNG">


