### PR TITLE
Docs: Add let and const examples for newline-after-var (fixes #3020)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -149,7 +149,7 @@ These rules are purely matters of style and are quite subjective.
 * [max-nested-callbacks](max-nested-callbacks.md) - specify the maximum depth callbacks can be nested
 * [new-cap](new-cap.md) - require a capital letter for constructors
 * [new-parens](new-parens.md) - disallow the omission of parentheses when invoking a constructor with no arguments
-* [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after `var` statement
+* [newline-after-var](newline-after-var.md) - allow/disallow an empty newline after variable declarations
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
 * [no-continue](no-continue.md) - disallow use of the `continue` statement
 * [no-inline-comments](no-inline-comments.md) - disallow comments inline after code

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -1,21 +1,25 @@
-# Allow/disallow an empty newline after var statement (newline-after-var)
+# Allow/disallow an empty newline after variable declarations (newline-after-var)
 
 As of today there is no consistency in separating variable declarations from the rest of the code. Some developers leave an empty line between var statements and the rest of the code like:
 
-        var foo;
+```js
+var foo;
 
-        // do something with foo
+// do something with foo
+```
 
 Whereas others don't leave any empty newlines at all.
 
-        var foo;
-        // do something with foo
+```js
+var foo;
+// do something with foo
+```
 
-The problem is when these developers work together in a project. This rule enforces a coding style where empty newlines are allowed or disallowed after `var` statement. It helps the code to look consistent across the entire project.
+The problem is when these developers work together in a project. This rule enforces a coding style where empty newlines are allowed or disallowed after `var`, `let`, or `const` statements. It helps the code to look consistent across the entire project.
 
 ## Rule Details
 
-This rule enforces a coding style where empty newlines are allowed or disallowed after `var` statement to achieve a consistent coding style across the project.
+This rule enforces a coding style where empty newlines are allowed or disallowed after `var`, `let`, or `const` statements to achieve a consistent coding style across the project.
 Invalid option value (anything other than `always` nor `never`), defaults to `always`.
 
 The following patterns are considered warnings:
@@ -27,15 +31,15 @@ var greet = "hello,",
 console.log(greet, name);
 
 // When [1, "never"]
-var greet = "hello,",
+let greet = "hello,",
     name = "world";
 
 console.log(greet, name);
 
 // When [1, "unknown"] - considered to be "always"
-var greet = "hello,",
-    name = "world";
-console.log(greet, name);
+var greet = "hello,";
+const NAME = "world";
+console.log(greet, NAME);
 ```
 
 The following patterns are not considered warnings:
@@ -48,7 +52,13 @@ var greet = "hello,",
 console.log(greet, name);
 
 // When [1, "never"]
-var greet = "hello,",
+let greet = "hello,",
     name = "world";
 console.log(greet, name);
+
+// When [1, "unknown"] - considered to be "always"
+var greet = "hello,";
+const NAME = "world";
+
+console.log(greet, NAME);
 ```


### PR DESCRIPTION
Although this rule has always been compatible with `let` and `const`,
until now no documentation existed of that behaviour.

This PR provides that documentation as well as providing a few examples.