### PR TITLE
Fix: strict rule supports classes (fixes #2977)

### DIFF
--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -17,7 +17,9 @@ var messages = {
     global: "Use the global form of \"use strict\".",
     multiple: "Multiple \"use strict\" directives.",
     never: "Strict mode is not permitted.",
-    unnecessary: "Unnecessary \"use strict\" directive."
+    unnecessary: "Unnecessary \"use strict\" directive.",
+    unnecessaryInModules: "\"use strict\" is unnecessary inside of modules.",
+    unnecessaryInClasses: "\"use strict\" is unnecessary inside of classes."
 };
 
 /**
@@ -53,10 +55,7 @@ function getUseStrictDirectives(statements) {
 
 module.exports = function(context) {
 
-    var mode = context.options[0],
-        isModule = context.ecmaFeatures.modules,
-        modes = {},
-        scopes = [];
+    var mode = context.options[0];
 
     /**
      * Report a node or array of nodes with a given message.
@@ -80,45 +79,83 @@ module.exports = function(context) {
     // "never" mode
     //--------------------------------------------------------------------------
 
-    modes.never = {
-        "Program": function(node) {
-            report(getUseStrictDirectives(node.body), messages.never);
-        },
-        "FunctionDeclaration": function(node) {
-            report(getUseStrictDirectives(node.body.body), messages.never);
-        },
-        "FunctionExpression": function(node) {
-            report(getUseStrictDirectives(node.body.body), messages.never);
-        }
-    };
+    if (mode === "never") {
+        return {
+            "Program": function(node) {
+                report(getUseStrictDirectives(node.body), messages.never);
+            },
+            "FunctionDeclaration": function(node) {
+                report(getUseStrictDirectives(node.body.body), messages.never);
+            },
+            "FunctionExpression": function(node) {
+                report(getUseStrictDirectives(node.body.body), messages.never);
+            },
+            "ArrowFunctionExpression": function(node) {
+                if (node.body.type === "BlockStatement") {
+                    report(getUseStrictDirectives(node.body.body), messages.never);
+                }
+            }
+        };
+    }
+
+    //--------------------------------------------------------------------------
+    // If this is modules, all "use strict" directives are unnecessary.
+    //--------------------------------------------------------------------------
+
+    if (context.ecmaFeatures.modules) {
+        return {
+            "Program": function(node) {
+                report(getUseStrictDirectives(node.body), messages.unnecessaryInModules);
+            },
+            "FunctionDeclaration": function(node) {
+                report(getUseStrictDirectives(node.body.body), messages.unnecessaryInModules);
+            },
+            "FunctionExpression": function(node) {
+                report(getUseStrictDirectives(node.body.body), messages.unnecessaryInModules);
+            },
+            "ArrowFunctionExpression": function(node) {
+                if (node.body.type === "BlockStatement") {
+                    report(getUseStrictDirectives(node.body.body), messages.unnecessaryInModules);
+                }
+            }
+        };
+    }
 
     //--------------------------------------------------------------------------
     // "global" mode
     //--------------------------------------------------------------------------
 
-    modes.global = {
-        "Program": function(node) {
-            var useStrictDirectives = getUseStrictDirectives(node.body);
+    if (mode === "global") {
+        return {
+            "Program": function(node) {
+                var useStrictDirectives = getUseStrictDirectives(node.body);
 
-            if (!isModule && node.body.length && useStrictDirectives.length < 1) {
-                report(node, messages.global);
-            } else if (isModule) {
-                report(useStrictDirectives, messages.unnecessary);
-            } else {
-                report(useStrictDirectives.slice(1), messages.multiple);
+                if (node.body.length > 0 && useStrictDirectives.length === 0) {
+                    report(node, messages.global);
+                } else {
+                    report(useStrictDirectives.slice(1), messages.multiple);
+                }
+            },
+            "FunctionDeclaration": function(node) {
+                report(getUseStrictDirectives(node.body.body), messages.global);
+            },
+            "FunctionExpression": function(node) {
+                report(getUseStrictDirectives(node.body.body), messages.global);
+            },
+            "ArrowFunctionExpression": function(node) {
+                if (node.body.type === "BlockStatement") {
+                    report(getUseStrictDirectives(node.body.body), messages.global);
+                }
             }
-        },
-        "FunctionDeclaration": function(node) {
-            report(getUseStrictDirectives(node.body.body), messages.global);
-        },
-        "FunctionExpression": function(node) {
-            report(getUseStrictDirectives(node.body.body), messages.global);
-        }
-    };
+        };
+    }
 
     //--------------------------------------------------------------------------
     // "function" mode (Default)
     //--------------------------------------------------------------------------
+
+    var scopes = [],
+        classScopes = [];
 
     /**
      * Entering a function pushes a new nested scope onto the stack. The new
@@ -127,18 +164,22 @@ module.exports = function(context) {
      * @returns {void}
      */
     function enterFunction(node) {
-        var useStrictDirectives = getUseStrictDirectives(node.body.body),
-            isParentGlobal = scopes.length === 0,
-            isParentStrict = isModule || (scopes.length && scopes[scopes.length - 1]),
-            isStrict = useStrictDirectives.length > 0 || isModule;
+        var isInClass = classScopes.length > 0,
+            isParentGlobal = scopes.length === 0 && classScopes.length === 0,
+            isParentStrict = scopes.length > 0 && scopes[scopes.length - 1],
+            isNotBlock = node.body.type !== "BlockStatement",
+            useStrictDirectives = isNotBlock ? [] : getUseStrictDirectives(node.body.body),
+            isStrict = useStrictDirectives.length > 0;
 
         if (isStrict) {
-            if (isParentStrict && useStrictDirectives.length) {
+            if (isParentStrict) {
                 report(useStrictDirectives[0], messages.unnecessary);
+            } else if (isInClass) {
+                report(useStrictDirectives[0], messages.unnecessaryInClasses);
             }
 
             report(useStrictDirectives.slice(1), messages.multiple);
-        } else if (isParentGlobal && !isModule) {
+        } else if (isParentGlobal) {
             report(node, messages.function);
         }
 
@@ -153,10 +194,19 @@ module.exports = function(context) {
         scopes.pop();
     }
 
-    modes.function = {
+    return {
         "Program": function(node) {
             report(getUseStrictDirectives(node.body), messages.function);
         },
+
+        // Inside of class bodies are always strict mode.
+        "ClassBody": function() {
+            classScopes.push(true);
+        },
+        "ClassBody:exit": function() {
+            classScopes.pop();
+        },
+
         "FunctionDeclaration": enterFunction,
         "FunctionExpression": enterFunction,
         "ArrowFunctionExpression": enterFunction,
@@ -164,11 +214,7 @@ module.exports = function(context) {
         "FunctionDeclaration:exit": exitFunction,
         "FunctionExpression:exit": exitFunction,
         "ArrowFunctionExpression:exit": exitFunction
-
     };
-
-    return modes[mode || "function"];
-
 };
 
 module.exports.schema = [

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -26,6 +26,7 @@ eslintTester.addRuleTest("lib/rules/strict", {
         { code: "var foo = function() { { 'use strict'; } return; };", options: ["never"] },
         { code: "(function() { bar('use strict'); return; }());", options: ["never"] },
         { code: "var fn = x => 1;", ecmaFeatures: { arrowFunctions: true }, options: ["never"] },
+        { code: "var fn = x => { return; };", ecmaFeatures: { arrowFunctions: true }, options: ["never"] },
         { code: "foo();", ecmaFeatures: { modules: true }, options: ["never"] },
 
         // "global" mode
@@ -37,13 +38,32 @@ eslintTester.addRuleTest("lib/rules/strict", {
         { code: "'use strict'; function foo() { bar(); 'use strict'; return; }", options: ["global"] },
         { code: "'use strict'; var foo = function() { bar(); 'use strict'; return; };", options: ["global"] },
         { code: "'use strict'; function foo() { return function() { bar(); 'use strict'; return; }; }", options: ["global"] },
+        { code: "'use strict'; var foo = () => { return () => { bar(); 'use strict'; return; }; }", ecmaFeatures: { arrowFunctions: true }, options: ["global"] },
 
         // "function" mode
         { code: "function foo() { 'use strict'; return; }", options: ["function"] },
         { code: "function foo() { return; }", ecmaFeatures: { modules: true }, options: ["function"] },
+        { code: "var foo = function() { return; }", ecmaFeatures: { modules: true }, options: ["function"] },
         { code: "var foo = function() { 'use strict'; return; }", options: ["function"] },
         { code: "function foo() { 'use strict'; return; } var bar = function() { 'use strict'; bar(); };", options: ["function"] },
         { code: "var foo = function() { 'use strict'; function bar() { return; } bar(); };", options: ["function"] },
+        { code: "var foo = () => { 'use strict'; var bar = () => 1; bar(); };", ecmaFeatures: { arrowFunctions: true }, options: ["function"] },
+        { code: "var foo = () => { var bar = () => 1; bar(); };", ecmaFeatures: { arrowFunctions: true, modules: true }, options: ["function"] },
+        {
+            code: "class A { constructor() { } }",
+            ecmaFeatures: { classes: true },
+            options: ["function"]
+        },
+        {
+            code: "class A { foo() { } }",
+            ecmaFeatures: { classes: true },
+            options: ["function"]
+        },
+        {
+            code: "class A { foo() { function bar() { } } }",
+            ecmaFeatures: { classes: true },
+            options: ["function"]
+        },
 
         // defaults to "function" mode
         { code: "function foo() { 'use strict'; return; }" }
@@ -107,6 +127,14 @@ eslintTester.addRuleTest("lib/rules/strict", {
                 { message: "Use the global form of \"use strict\".", type: "ExpressionStatement" }
             ]
         }, {
+            code: "var foo = () => { 'use strict'; return () => 1; }",
+            options: ["global"],
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [
+                { message: "Use the global form of \"use strict\".", type: "Program" },
+                { message: "Use the global form of \"use strict\".", type: "ExpressionStatement" }
+            ]
+        }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
             options: ["global"],
             errors: [
@@ -129,7 +157,7 @@ eslintTester.addRuleTest("lib/rules/strict", {
             options: ["global"],
             ecmaFeatures: { modules: true },
             errors: [
-                { message: "Unnecessary \"use strict\" directive.", type: "ExpressionStatement" }
+                { message: "\"use strict\" is unnecessary inside of modules.", type: "ExpressionStatement" }
             ]
         },
 
@@ -159,6 +187,20 @@ eslintTester.addRuleTest("lib/rules/strict", {
                 { message: "Use the function form of \"use strict\".", type: "FunctionExpression" }
             ]
         }, {
+            code: "(() => { return true; })();",
+            options: ["function"],
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "ArrowFunctionExpression" }
+            ]
+        }, {
+            code: "(() => true)();",
+            options: ["function"],
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [
+                { message: "Use the function form of \"use strict\".", type: "ArrowFunctionExpression" }
+            ]
+        }, {
             code: "var foo = function() { foo(); 'use strict'; return; }; function bar() { foo(); 'use strict'; }",
             options: ["function"],
             errors: [
@@ -182,7 +224,7 @@ eslintTester.addRuleTest("lib/rules/strict", {
             options: ["function"],
             ecmaFeatures: { modules: true },
             errors: [
-                { message: "Unnecessary \"use strict\" directive.", type: "ExpressionStatement" }
+                { message: "\"use strict\" is unnecessary inside of modules.", type: "ExpressionStatement" }
             ]
         }, {
             code: "function foo() { return function() { 'use strict'; return; }; }",
@@ -229,6 +271,26 @@ eslintTester.addRuleTest("lib/rules/strict", {
             options: ["function"],
             errors: [{ message: "Use the function form of \"use strict\".", type: "ArrowFunctionExpression"}]
         },
+        // Classes
+        {
+            code: "class A { constructor() { \"use strict\"; } }",
+            ecmaFeatures: { classes: true },
+            options: ["function"],
+            errors: [{ message: "\"use strict\" is unnecessary inside of classes.", type: "ExpressionStatement"}]
+        },
+        {
+            code: "class A { foo() { \"use strict\"; } }",
+            ecmaFeatures: { classes: true },
+            options: ["function"],
+            errors: [{ message: "\"use strict\" is unnecessary inside of classes.", type: "ExpressionStatement"}]
+        },
+        {
+            code: "class A { foo() { function bar() { \"use strict\"; } } }",
+            ecmaFeatures: { classes: true },
+            options: ["function"],
+            errors: [{ message: "\"use strict\" is unnecessary inside of classes.", type: "ExpressionStatement"}]
+        },
+
 
         // Default to "function" mode
         {


### PR DESCRIPTION
- I followed [this comment](https://github.com/eslint/eslint/issues/2977#issuecomment-121651016), I set `fixes` label.
- I found lacking a check of `ArrowFunctionExpression` on `never` mode and `global` mode, so added those.
- I separated a logic for inside of modules. In this case, all `use strict` directive are unnecessary.
- I added a class support.
- I improved messages of unnecessary.