### PR TITLE
Fix: `no-*-assgin` rules support destructuring (fixes #3029)

### DIFF
--- a/lib/rules/no-ex-assign.js
+++ b/lib/rules/no-ex-assign.js
@@ -11,30 +11,42 @@
 
 module.exports = function(context) {
 
-    var catchStack = [];
+    /**
+     * Reports a reference if is non initializer and writable.
+     * @param {Reference} reference - A reference to check.
+     * @param {int} index - The index of the reference in the references.
+     * @param {Reference[]} references - The array that the reference belongs to.
+     * @returns {void}
+     */
+    function checkReference(reference, index, references) {
+        var identifier = reference.identifier;
+
+        if (identifier != null &&
+            reference.init === false &&
+            reference.isWrite() &&
+            // Destructuring assignments can have multiple default value,
+            // so possibly there are multiple writeable references for the same identifier.
+            (index === 0 || references[index - 1].identifier !== identifier)
+        ) {
+            context.report(
+                identifier,
+                "Do not assign to the exception parameter.");
+        }
+    }
+
+    /**
+     * Finds and reports references that are non initializer and writable.
+     * @param {Variable} variable - A variable to check.
+     * @returns {void}
+     */
+    function checkVariable(variable) {
+        variable.references.forEach(checkReference);
+    }
 
     return {
-
         "CatchClause": function(node) {
-            catchStack.push(node.param.name);
-        },
-
-        "CatchClause:exit": function() {
-            catchStack.pop();
-        },
-
-        "AssignmentExpression": function(node) {
-
-            if (catchStack.length > 0) {
-
-                var exceptionName = catchStack[catchStack.length - 1];
-
-                if (node.left.name && node.left.name === exceptionName) {
-                    context.report(node, "Do not assign to the exception parameter.");
-                }
-            }
+            context.getDeclaredVariables(node).forEach(checkVariable);
         }
-
     };
 
 };

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -12,70 +12,82 @@
 
 module.exports = function(context) {
 
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
+    var unresolved = Object.create(null);
 
-    /*
-     * Walk the scope chain looking for either a FunctionDeclaration or a
-     * VariableDeclaration with the same name as left-hand side of the
-     * AssignmentExpression. If we find the FunctionDeclaration first, then we
-     * warn, because a FunctionDeclaration is trying to become a Variable or a
-     * FunctionExpression. If we find a VariableDeclaration first, then we have
-     * a legitimate shadow variable.
+    /**
+     * Collects unresolved references from the global scope, then creates a map to references from its name.
+     * Usage of the map is explained at `checkVariable(variable)`.
+     * @returns {void}
      */
-    function checkIfIdentifierIsFunction(scope, name) {
-        var variable,
-            def,
-            i,
-            j;
+    function collectUnresolvedReferences() {
+        unresolved = Object.create(null);
 
-        // Loop over all of the identifiers available in scope.
-        for (i = 0; i < scope.variables.length; i++) {
-            variable = scope.variables[i];
+        var references = context.getScope().through;
+        for (var i = 0; i < references.length; ++i) {
+            var reference = references[i];
+            var name = reference.identifier.name;
 
-            // For each identifier, see if it was defined in _this_ scope.
-            for (j = 0; j < variable.defs.length; j++) {
-                def = variable.defs[j];
-
-                // Identifier is a function and was declared in this scope
-                if (def.type === "FunctionName" && def.name.name === name) {
-                    return true;
-                }
-
-                // Identifier is a variable and was declared in this scope. This
-                // is a legitimate shadow variable.
-                if (def.name && def.name.name === name) {
-                    return false;
-                }
+            if (name in unresolved === false) {
+                unresolved[name] = [];
             }
+            unresolved[name].push(reference);
         }
-
-        // Check the upper scope.
-        if (scope.upper) {
-            return checkIfIdentifierIsFunction(scope.upper, name);
-        }
-
-        // We've reached the global scope and haven't found anything.
-        return false;
     }
 
-    //--------------------------------------------------------------------------
-    // Public API
-    //--------------------------------------------------------------------------
+    /**
+     * Reports a reference if is non initializer and writable.
+     * @param {Reference} reference - A reference to check.
+     * @param {int} index - The index of the reference in the references.
+     * @param {Reference[]} references - The array that the reference belongs to.
+     * @returns {void}
+     */
+    function checkReference(reference, index, references) {
+        var identifier = reference.identifier;
+
+        if (identifier != null &&
+            reference.init === false &&
+            reference.isWrite() &&
+            // Destructuring assignments can have multiple default value,
+            // so possibly there are multiple writeable references for the same identifier.
+            (index === 0 || references[index - 1].identifier !== identifier)
+        ) {
+            context.report(
+                identifier,
+                "'{{name}}' is a function.",
+                {name: identifier.name});
+        }
+    }
+
+    /**
+     * Finds and reports references that are non initializer and writable.
+     * @param {Variable} variable - A variable to check.
+     * @returns {void}
+     */
+    function checkVariable(variable) {
+        if (variable.defs[0].type === "FunctionName") {
+            // If the function is in global scope, its references are not resolved (by escope's design).
+            // So when references of the function are nothing, this checks in unresolved.
+            if (variable.references.length > 0) {
+                variable.references.forEach(checkReference);
+            } else if (unresolved[variable.name] != null) {
+                unresolved[variable.name].forEach(checkReference);
+            }
+        }
+    }
+
+    /**
+     * Checks parameters of a given function node.
+     * @param {ASTNode} node - A function node to check.
+     * @returns {void}
+     */
+    function checkForFunction(node) {
+        context.getDeclaredVariables(node).forEach(checkVariable);
+    }
 
     return {
-
-        "AssignmentExpression": function(node) {
-            var scope = context.getScope(),
-                name = node.left.name;
-
-            if (checkIfIdentifierIsFunction(scope, name)) {
-                context.report(node, "'{{name}}' is a function.", { name: name });
-            }
-
-        }
-
+        "Program": collectUnresolvedReferences,
+        "FunctionDeclaration": checkForFunction,
+        "FunctionExpression": checkForFunction
     };
 
 };

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -5,37 +5,74 @@
 
 "use strict";
 
+var globals = require("globals");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-var globals = require("globals");
+var NATIVE_OBJECTS = Object.keys(globals.builtin);
 
 module.exports = function(context) {
 
-    var NATIVE_OBJECTS = Object.keys(globals.builtin);
-    var config = context.options[0] || {};
-    var exceptions = config.exceptions || [];
-    var modifiedNativeObjects = NATIVE_OBJECTS;
+    var config = context.options[0];
+    var exceptions = config && config.exceptions;
+    var forbiddenNames = NATIVE_OBJECTS.reduce(function(retv, builtIn) {
+        if (exceptions == null || exceptions.indexOf(builtIn) === -1) {
+            retv[builtIn] = true;
+        }
+        return retv;
+    }, Object.create(null));
 
-    if (exceptions.length) {
-        modifiedNativeObjects = NATIVE_OBJECTS.filter(function(builtIn) {
-            return exceptions.indexOf(builtIn) === -1;
-        });
+    /**
+     * Reports if a given reference's name is same as native object's.
+     * @param {Reference} reference - A reference to check.
+     * @param {int} index - The index of the reference in the references.
+     * @param {Reference[]} references - The array that the reference belongs to.
+     * @returns {void}
+     */
+    function checkThroughReference(reference, index, references) {
+        var identifier = reference.identifier;
+
+        if (identifier != null &&
+            forbiddenNames[identifier.name] &&
+            reference.init === false &&
+            reference.isWrite() &&
+            // Destructuring assignments can have multiple default value,
+            // so possibly there are multiple writeable references for the same identifier.
+            (index === 0 || references[index - 1].identifier !== identifier)
+        ) {
+            context.report(
+                identifier,
+                "{{name}} is a read-only native object.",
+                {name: identifier.name});
+        }
+    }
+
+    /**
+     * Finds and reports variables that its name is same as native object's.
+     * @param {Variable} variable - A variable to check.
+     * @returns {void}
+     */
+    function checkVariable(variable) {
+        if (forbiddenNames[variable.name]) {
+            context.report(
+                variable.identifiers[0],
+                "Redefinition of '{{name}}'.",
+                {name: variable.name});
+        }
     }
 
     return {
-
-        "AssignmentExpression": function(node) {
-            if (modifiedNativeObjects.indexOf(node.left.name) >= 0) {
-                context.report(node, node.left.name + " is a read-only native object.");
-            }
+        // Checks assignments of global variables.
+        // References to implicit global variables are not resolved,
+        // so those are in the `through` of the global scope.
+        "Program": function() {
+            context.getScope().through.forEach(checkThroughReference);
         },
 
-        "VariableDeclarator": function(node) {
-            if (modifiedNativeObjects.indexOf(node.id.name) >= 0) {
-                context.report(node, "Redefinition of '{{nativeObject}}'.", { nativeObject: node.id.name });
-            }
+        "VariableDeclaration": function(node) {
+            context.getDeclaredVariables(node).forEach(checkVariable);
         }
     };
 
@@ -47,9 +84,7 @@ module.exports.schema = [
         "properties": {
             "exceptions": {
                 "type": "array",
-                "items": {
-                    "type": "string"
-                },
+                "items": {"enum": NATIVE_OBJECTS},
                 "uniqueItems": true
             }
         },

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -11,77 +11,56 @@
 
 module.exports = function(context) {
 
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
-
     /**
-     * Finds the declaration for a given variable by name, searching up the scope tree.
-     * @param {Scope} scope The scope in which to search.
-     * @param {String} name The name of the variable.
-     * @returns {Variable} The declaration information for the given variable, or null if no declaration was found.
-     */
-    function findDeclaration(scope, name) {
-        var variables = scope.variables;
-
-        for (var i = 0; i < variables.length; i++) {
-            if (variables[i].name === name) {
-                return variables[i];
-            }
-        }
-
-        if (scope.upper) {
-            return findDeclaration(scope.upper, name);
-        } else {
-            return null;
-        }
-    }
-
-    /**
-     * Determines if a given variable is declared as a function parameter.
-     * @param {Variable} variable The variable declaration.
-     * @returns {boolean} True if the variable is a function parameter, false otherwise.
-     */
-    function isParameter(variable) {
-        var defs = variable.defs;
-
-        for (var i = 0; i < defs.length; i++) {
-            if (defs[i].type === "Parameter") {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * Checks whether a given node is an assignment to a function parameter.
-     * If so, a linting error will be reported.
-     * @param {ASTNode} node The node to check.
-     * @param {String} name The name of the variable being assigned to.
+     * Reports a reference if is non initializer and writable.
+     * @param {Reference} reference - A reference to check.
+     * @param {int} index - The index of the reference in the references.
+     * @param {Reference[]} references - The array that the reference belongs to.
      * @returns {void}
      */
-    function checkParameter(node, name) {
-        var declaration = findDeclaration(context.getScope(), name);
+    function checkReference(reference, index, references) {
+        var identifier = reference.identifier;
 
-        if (declaration && isParameter(declaration)) {
-            context.report(node, "Assignment to function parameter '{{name}}'.", { name: name });
+        if (identifier != null &&
+            reference.init === false &&
+            reference.isWrite() &&
+            // Destructuring assignments can have multiple default value,
+            // so possibly there are multiple writeable references for the same identifier.
+            (index === 0 || references[index - 1].identifier !== identifier)
+        ) {
+            context.report(
+                identifier,
+                "Assignment to function parameter '{{name}}'.",
+                {name: identifier.name});
         }
     }
 
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
+    /**
+     * Finds and reports references that are non initializer and writable.
+     * @param {Variable} variable - A variable to check.
+     * @returns {void}
+     */
+    function checkVariable(variable) {
+        if (variable.defs[0].type === "Parameter") {
+            variable.references.forEach(checkReference);
+        }
+    }
+
+    /**
+     * Checks parameters of a given function node.
+     * @param {ASTNode} node - A function node to check.
+     * @returns {void}
+     */
+    function checkForFunction(node) {
+        context.getDeclaredVariables(node).forEach(checkVariable);
+    }
 
     return {
-        "AssignmentExpression": function(node) {
-            checkParameter(node, node.left.name);
-        },
-
-        "UpdateExpression": function(node) {
-            checkParameter(node, node.argument.name);
-        }
+        "FunctionDeclaration": checkForFunction,
+        "FunctionExpression": checkForFunction,
+        "ArrowFunctionExpression": checkForFunction
     };
+
 };
 
 module.exports.schema = [];

--- a/tests/lib/rules/no-ex-assign.js
+++ b/tests/lib/rules/no-ex-assign.js
@@ -24,7 +24,10 @@ eslintTester.addRuleTest("lib/rules/no-ex-assign", {
         "function foo() { try { } catch (e) { return false; } }"
     ],
     invalid: [
-        { code: "try { } catch (e) { e = 10; }", errors: [{ message: "Do not assign to the exception parameter.", type: "AssignmentExpression"}] },
-        { code: "try { } catch (ex) { ex = 10; }", errors: [{ message: "Do not assign to the exception parameter.", type: "AssignmentExpression"}] }
+        { code: "try { } catch (e) { e = 10; }", errors: [{ message: "Do not assign to the exception parameter.", type: "Identifier"}] },
+        { code: "try { } catch (ex) { ex = 10; }", errors: [{ message: "Do not assign to the exception parameter.", type: "Identifier"}] },
+        { code: "try { } catch (ex) { [ex] = []; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "Do not assign to the exception parameter.", type: "Identifier"}] },
+        { code: "try { } catch (ex) { ({x: ex = 0}) = {}; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "Do not assign to the exception parameter.", type: "Identifier"}] },
+        { code: "try { } catch ({message}) { message = 10; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "Do not assign to the exception parameter.", type: "Identifier"}] }
     ]
 });

--- a/tests/lib/rules/no-func-assign.js
+++ b/tests/lib/rules/no-func-assign.js
@@ -29,8 +29,12 @@ eslintTester.addRuleTest("lib/rules/no-func-assign", {
         { code: "import bar from 'bar'; function foo() { var foo = bar; }", ecmaFeatures: { modules: true } }
     ],
     invalid: [
-        { code: "function foo() {}; foo = bar;", errors: [{ message: "'foo' is a function.", type: "AssignmentExpression"}] },
-        { code: "function foo() { foo = bar; }", errors: [{ message: "'foo' is a function.", type: "AssignmentExpression"}] },
-        { code: "foo = bar; function foo() { };", errors: [{ message: "'foo' is a function.", type: "AssignmentExpression"}] }
+        { code: "function foo() {}; foo = bar;", errors: [{ message: "'foo' is a function.", type: "Identifier"}] },
+        { code: "function foo() { foo = bar; }", errors: [{ message: "'foo' is a function.", type: "Identifier"}] },
+        { code: "foo = bar; function foo() { };", errors: [{ message: "'foo' is a function.", type: "Identifier"}] },
+        { code: "[foo] = bar; function foo() { };", ecmaFeatures: {destructuring: true}, errors: [{ message: "'foo' is a function.", type: "Identifier"}] },
+        { code: "({x: foo = 0}) = bar; function foo() { };", ecmaFeatures: {destructuring: true}, errors: [{ message: "'foo' is a function.", type: "Identifier"}] },
+        { code: "function foo() { [foo] = bar; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "'foo' is a function.", type: "Identifier"}] },
+        { code: "(function() { ({x: foo = 0}) = bar; function foo() { }; })();", ecmaFeatures: {destructuring: true}, errors: [{ message: "'foo' is a function.", type: "Identifier"}] }
     ]
 });

--- a/tests/lib/rules/no-native-reassign.js
+++ b/tests/lib/rules/no-native-reassign.js
@@ -27,12 +27,28 @@ eslintTester.addRuleTest("lib/rules/no-native-reassign", {
         }
     ],
     invalid: [
-        { code: "String = 'hello world';", errors: [{ message: "String is a read-only native object.", type: "AssignmentExpression"}] },
-        { code: "var String;", errors: [{ message: "Redefinition of 'String'.", type: "VariableDeclarator"}] },
+        { code: "String = 'hello world';", errors: [{ message: "String is a read-only native object.", type: "Identifier"}] },
+        { code: "var String;", errors: [{ message: "Redefinition of 'String'.", type: "Identifier"}] },
         {
             code: "var Object = 0",
             options: [{exceptions: ["Number"]}],
-            errors: [{ message: "Redefinition of 'Object'.", type: "VariableDeclarator"}]
+            errors: [{ message: "Redefinition of 'Object'.", type: "Identifier"}]
+        },
+        {
+            code: "({Object = 0, String = 0}) = {};",
+            ecmaFeatures: {destructuring: true},
+            errors: [
+                {message: "Object is a read-only native object.", type: "Identifier"},
+                {message: "String is a read-only native object.", type: "Identifier"}
+            ]
+        },
+        {
+            code: "var {Array, Number = 0} = {};",
+            ecmaFeatures: {destructuring: true},
+            errors: [
+                {message: "Redefinition of 'Array'.", type: "Identifier"},
+                {message: "Redefinition of 'Number'.", type: "Identifier"}
+            ]
         }
     ]
 });

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -33,6 +33,10 @@ eslintTester.addRuleTest("lib/rules/no-param-reassign", {
         { code: "function foo(bar) { ++bar; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
         { code: "function foo(bar) { bar++; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
         { code: "function foo(bar) { --bar; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
-        { code: "function foo(bar) { bar--; }", errors: [{ message: "Assignment to function parameter 'bar'." }] }
+        { code: "function foo(bar) { bar--; }", errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo({bar}) { bar = 13; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo([, {bar}]) { bar = 13; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { ({bar}) = {}; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "Assignment to function parameter 'bar'." }] },
+        { code: "function foo(bar) { ({x: [, bar = 0]}) = {}; }", ecmaFeatures: {destructuring: true}, errors: [{ message: "Assignment to function parameter 'bar'." }] }
     ]
 });


### PR DESCRIPTION
I rewrote `no-*-assign` rules to support destructuring. Target rules are `no-ex-assign`, `no-param-reassign`, `no-native-reassign`, and `no-func-assign` (sorry, I had forgotten in #3029).

Basically those logic are same as `no-const-assign` and `no-class-assign`. In short, it takes variables from every declarations, then checks writing references in `variable.references`.

Note:

- `no-native-reassign` - those don't have its declaration in AST tree, so this rule checks `through` references of the global scope.  All references to implicit global variables are always unresolved.
- `no-func-assign` - if a function declaration is in the global scope, its references are unresolved (by escope's spec). In this case, this rule checks `through` references of the global scope.

Question:

- `no-native-reassign` - this rule checks the redeclaration and the shadowing. Why are not those reported by `no-redeclare` and `no-shadow`?  Variables of built-in objects exist in the global scope.