### PR TITLE
Disallow the use of the for-in statement

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -98,6 +98,7 @@
         "no-useless-call": 0,
         "no-void": 0,
         "no-var": 0,
+        "no-for-in": 0,
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 0,
 

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -152,6 +152,7 @@ These rules are purely matters of style and are quite subjective.
 * [newline-after-var](newline-after-var.md) - require or disallow an empty newline after variable declarations
 * [no-array-constructor](no-array-constructor.md) - disallow use of the `Array` constructor
 * [no-continue](no-continue.md) - disallow use of the `continue` statement
+* [no-for-in](no-for-in.md) - disallow use of the `for-in` statement
 * [no-inline-comments](no-inline-comments.md) - disallow comments inline after code
 * [no-lonely-if](no-lonely-if.md) - disallow `if` as the only statement in an `else` block
 * [no-mixed-spaces-and-tabs](no-mixed-spaces-and-tabs.md) - disallow mixed spaces and tabs for indentation (recommended)

--- a/docs/rules/no-for-in.md
+++ b/docs/rules/no-for-in.md
@@ -1,0 +1,45 @@
+# disallow the use of `for (x in y) {}` statements (no-for-in)
+
+The for-in statement is usually not the right tool.  In environments which are
+using ES6 for-of might find that switching between other scripting languages
+and javascript might cause them to accidentally use for-in instead of for-of.
+
+```js
+var numbers = [5, 6, 7];
+
+for (var x in numbers) {
+  console.log(x);
+}
+// This prints:
+// 0
+// 1
+// 2
+
+for (var x of numbers) {
+  console.log(x);
+}
+
+// This prints:
+// 4
+// 5
+// 6
+
+```
+
+## Rule Details
+
+This rule is designed to catch inadvertent uses of the for-in statement.  Its
+uses in modern javascript are limited.  With most other scripting language
+using for-in to do what the ES6 for-of does, it's highly likely that usages of
+for-in are accidental
+
+The following patterns are considered warnings:
+
+```js
+for (x in y) { }
+```
+
+## When Not To Use It
+
+If you understand and truely do want to use for-in
+

--- a/lib/rules/no-for-in.js
+++ b/lib/rules/no-for-in.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview Rule to block usage of for-in statements
+ * @author John Ford
+ * @copyright 2015 John Ford
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "ForInStatement": function(node) {
+            context.report(node, "The for-in statement should not be used");
+        }
+
+    };
+
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-for-in.js
+++ b/tests/lib/rules/no-for-in.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Tests for no-for-in rule.
+ * @author John Ford
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var eslint = require("../../../lib/eslint"),
+    ESLintTester = require("eslint-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var eslintTester = new ESLintTester(eslint);
+eslintTester.addRuleTest("lib/rules/no-for-in", {
+    valid: [
+        "for (var i ; i++ ; i <= 10) {}",
+        " /* for (var x in []) {} */"
+    ],
+    invalid: [
+        { code: "for (var x in o) { foo() }", errors: [{ message: "The for-in statement should not be used", type: "ForInStatement"}] },
+        { code: "for (var x in o) foo();", errors: [{ message: "The for-in statement should not be used", type: "ForInStatement"}] }
+    ]
+});


### PR DESCRIPTION
I'm not the most experienced javascript developer, but my understanding is that for-in is somewhat broken in a number of subtle ways.  Given that it behaves completely differently to the for-in construct in most languages I've used and that for-of in es6 is gaining popularity, it makes sense in my opinion to offer a rule to block the use of this easily confusable and limited utility construct.  This is somewhat similar in purpose and intent to the no-var rule.

Hope that I did all the docs correctly!