### PR TITLE
Fix: handles blocks in no-use-before-define (fixes #2960)

### DIFF
--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -1,18 +1,12 @@
 # Disallow Early Use (no-use-before-define)
 
-Since variable and function declarations are hoisted to the top of a scope, it's possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
+In JavaScript, prior to ES6, variable and function declarations are hoisted to the top of a scope, so it's possible to use identifiers before their formal declarations in code. This can be confusing and some believe it is best to always declare variables and functions before using them.
 
-It takes an optional option as the second parameter which can be `"nofunc"` to allow named function definitions to be used before the location where they are defined.
-
-```js
-alert(a);
-
-var a = 10;
-```
+In ES6, block-level bindings (`let` and `const`) introduce a "temporal dead zone" where a `ReferenceError` will be thrown with any attempt to access the variable before its declaration.
 
 ## Rule Details
 
-This rule will warn when it encounters a reference to an identifier that has not been declared as part of a `var` or function statement.
+This rule will warn when it encounters a reference to an identifier that has not been yet declared.
 
 The following patterns are considered warnings:
 
@@ -22,19 +16,48 @@ var a = 10;
 
 f();
 function f() {}
-```
 
-The following patterns are not considered warnings when `"nofunc"` is specified:
+function g() {
+    return b;
+}
+var b = 1;
 
-```js
-f();
-function f() {}
+// With blockBindings: true
+{
+    alert(c);
+    let c = 1;
+}
 ```
 
 The following patterns are not considered warnings:
 
 ```js
-var a = 10; alert(a);
+var a;
+a = 10;
+alert(a);
 
-function f() {} f();
+function f() {}
+f(1);
+
+var b = 1;
+function g() {
+    return b;
+}
+
+// With blockBindings: true
+{
+    let C;
+    c++;
+}
+```
+
+
+The rule accepts an additional option that can take the value `"nofunc"`. If this option is active, function declarations are exempted from the rule, so it is allowed to use a function name *before* its declaration.
+
+The following patterns are not considered warnings when `"nofunc"` is specified:
+
+```js
+f();
+
+function f() {}
 ```

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -1034,11 +1034,16 @@ module.exports = (function() {
         // Don't do this for Program nodes - they have no parents
         if (parents.length) {
 
-            // if current node is function declaration, add it to the list
+            // if current node introduces a scope, add it to the list
             var current = controller.current();
-            if (["FunctionDeclaration", "FunctionExpression",
-                    "ArrowFunctionExpression", "SwitchStatement"].indexOf(current.type) >= 0) {
-                parents.push(current);
+            if (currentConfig.ecmaFeatures.blockBindings) {
+                if (["BlockStatement", "SwitchStatement", "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
+                    parents.push(current);
+                }
+            } else {
+                if (["FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
+                    parents.push(current);
+                }
             }
 
             // Ascend the current node's parents

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -82,7 +82,7 @@ module.exports = function(context) {
         findVariablesInScope(scope);
     }
 
-    return {
+    var ruleDefinition = {
         "Program": function() {
             var scope = context.getScope();
             findVariablesInScope(scope);
@@ -91,11 +91,22 @@ module.exports = function(context) {
             if (context.ecmaFeatures.globalReturn || context.ecmaFeatures.modules) {
                 findVariablesInScope(scope.childScopes[0]);
             }
-        },
-        "FunctionExpression": findVariables,
-        "FunctionDeclaration": findVariables,
-        "ArrowFunctionExpression": findVariables
+        }
     };
+
+    if (context.ecmaFeatures.blockBindings) {
+        ruleDefinition.BlockStatement = ruleDefinition.SwitchStatement = findVariables;
+
+        ruleDefinition.ArrowFunctionExpression = function(node) {
+            if (node.body.type !== "BlockStatement") {
+                findVariables(node);
+            }
+        };
+    } else {
+        ruleDefinition.FunctionExpression = ruleDefinition.FunctionDeclaration = ruleDefinition.ArrowFunctionExpression = findVariables;
+    }
+
+    return ruleDefinition;
 };
 
 module.exports.schema = [

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -920,6 +920,32 @@ describe("eslint", function() {
 
             eslint.verify("switch(foo){ case 'a': var b = 'foo'; }", config, filename, true);
         });
+
+        it("should retrieve the function scope correctly from within a BlockStatement", function() {
+            var config = { rules: {}, ecmaFeatures: { blockBindings: true } };
+
+            eslint.reset();
+            eslint.on("BlockStatement", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "block");
+                assert.equal(scope.block.type, "BlockStatement");
+            });
+
+            eslint.verify("var x; {let y = 1}", config, filename, true);
+        });
+
+        it("should retrieve the function scope correctly from within a nested block statement", function() {
+            var config = { rules: {}, ecmaFeatures: { blockBindings: true } };
+
+            eslint.reset();
+            eslint.on("BlockStatement", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "block");
+                assert.equal(scope.block.type, "BlockStatement");
+            });
+
+            eslint.verify("if (true) { let x = 1 }", config, filename, true);
+        });
     });
 
     describe("marking variables as used", function() {

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -25,7 +25,14 @@ eslintTester.addRuleTest("lib/rules/no-use-before-define", {
         "Object.hasOwnProperty.call(a);",
         "function a() { alert(arguments);}",
         { code: "a(); function a() { alert(arguments); }", options: [ "nofunc"] },
-        { code: "(() => { var a = 42; alert(a); })();", ecmaFeatures: { arrowFunctions: true } }
+        { code: "(() => { var a = 42; alert(a); })();", ecmaFeatures: { arrowFunctions: true } },
+        { code: "a(); try { throw new Error() } catch (a) {}" },
+
+        // Block-level bindings
+        { code: "\"use strict\"; a(); { function a() {} }", ecmaFeatures: { blockBindings: true } },
+        { code: "\"use strict\"; { a(); function a() {} }", options: ["nofunc"], ecmaFeatures: { blockBindings: true } },
+        { code: "switch (foo) { case 1:  { a(); } default: { let a; }}", ecmaFeatures: { blockBindings: true }},
+        { code: "a(); { let a = function () {}; }", ecmaFeatures: { blockBindings: true } }
     ],
     invalid: [
         { code: "a++; var a=19;", ecmaFeatures: { modules: true }, errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
@@ -36,6 +43,17 @@ eslintTester.addRuleTest("lib/rules/no-use-before-define", {
         { code: "a(); function a() { alert(b); var b=10; a(); }", errors: [{ message: "a was used before it was defined", type: "Identifier"}, { message: "b was used before it was defined", type: "Identifier"}] },
         { code: "a(); var a=function() {};", options: [ "nofunc"], errors: [{ message: "a was used before it was defined", type: "Identifier"}] },
         { code: "(() => { alert(a); var a = 42; })();", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
-        { code: "(() => a())(); function a() { }", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] }
+        { code: "(() => a())(); function a() { }", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "\"use strict\"; a(); { function a() {} }", errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "a(); try { throw new Error() } catch (foo) {var a;}", errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "var f = () => a; var a;", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+
+        // Block-level bindings
+        { code: "a++; { var a; }", ecmaFeatures: { blockBindings: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "\"use strict\"; { a(); function a() {} }", ecmaFeatures: { blockBindings: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "{a; let a = 1}", ecmaFeatures: { blockBindings: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }]},
+        { code: "switch (foo) { case 1: a();\n default: \n let a;}", ecmaFeatures: { blockBindings: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }]},
+        { code: "var f = () => a; var a;", ecmaFeatures: { arrowFunctions: true, blockBindings: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }] },
+        { code: "if (true) { function foo() { a; } let a;}", ecmaFeatures: { blockBindings: true }, errors: [{ message: "a was used before it was defined", type: "Identifier" }]}
     ]
 });


### PR DESCRIPTION
Changes no-use-before-define to look in every block scope when block bindings are being used. The `getScope` method is also updated to retrieve the correct scope in that situation.