### PR TITLE
Build: Check commit message format at end of tests (fixes #3058)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,6 @@ node_js:
     - "0.12"
     - iojs
 sudo: false
-script: "npm test && npm run docs"
+script: "npm test && npm run check-commit && npm run docs"
 after_success:
     - npm run coveralls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,6 +22,7 @@ build: off
 
 test_script:
   - npm test
+  - npm run check-commit
 
 matrix:
   fast_finish: true    # set this flag to immediately finish build once one of the jobs fails.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "browserify": "node Makefile.js browserify",
     "perf": "node Makefile.js perf",
     "profile": "beefy tests/bench/bench.js --open -- -t brfs -t ./tests/bench/xform-rules.js -r espree",
-    "coveralls": "cat ./coverage/lcov.info | coveralls"
+    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "check-commit": "node Makefile.js checkGitCommit"
   },
   "files": [
     "LICENSE",


### PR DESCRIPTION
This adds a test to the end of the existing tests to check commit message formatting.  It only looks at the summary of the last non-merge commit.  It is assumed, but not verified, that only one commit will be created per PR.

This checks for one of the following tags at the beginning of a commit message:

- Fix:
- Update:
- Breaking:
- Docs:
- Build:
- New:
- Upgrade:

And if the tag is not `Docs:`, it checks that the message ends with one of:

- (fixes #XXXX)
- (refs #XXXX)

It also checks that there is only one commit in the PR (compares commits between branch and master).
