### PR TITLE
environments: include phantomjs globals

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -31,7 +31,7 @@ module.exports = {
         globals: globals.jasmine
     },
     phantomjs: {
-        globals: globals.phantom
+        globals: globals.phantomjs
     },
     jquery: {
         globals: globals.jquery


### PR DESCRIPTION
This spelling mistake broke `eslint-env phantomjs` since no global was included at all.

Fixes feross/standard#194