### PR TITLE
New: enable `-c` flag to accept a shareable config (fixes: #2543)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ node_js:
     - "0.12"
     - iojs
 sudo: false
+before_install: "if [[ `node --version` == *v0.10* ]]; then npm install -g npm; fi;"
 script: "npm test && npm run check-commit && npm run docs"
 after_success:
     - npm run coveralls

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -54,6 +54,15 @@ Example:
 
 This example uses the configuration file at `~/my-eslint.json`.
 
+It also accepts a module ID of [sharable config](../developer-guide/shareable-configs).
+
+Example:
+
+    eslint -c myconfig file.js
+
+This example directly uses the sharable config `eslint-config-myconfig`.
+
+
 ### `--env`
 
 This option enables specific environments. Details about the global variables defined by each environment are available on the [configuration](configuring) documentation. This flag only enables environments; it does not disable environments set in other configuration files. To specify multiple environments, separate them using commas, or use the flag multiple times.

--- a/lib/config.js
+++ b/lib/config.js
@@ -22,6 +22,7 @@ var fs = require("fs"),
     yaml = require("js-yaml"),
     userHome = require("user-home"),
     isAbsolutePath = require("path-is-absolute"),
+    isResolvable = require("is-resolvable"),
     validator = require("./config-validator"),
     pathIsInside = require("path-is-inside");
 
@@ -55,7 +56,7 @@ debug = debug("eslint:config");
  * @private
  */
 function isFilePath(filePath) {
-    return isAbsolutePath(filePath) || !/\w|@/.test(filePath[0]);
+    return isAbsolutePath(filePath) || !/\w|@/.test(filePath.charAt(0));
 }
 
 /**
@@ -369,7 +370,11 @@ function Config(options) {
 
     if (useConfig) {
         debug("Using command line config " + useConfig);
-        this.useSpecificConfig = loadConfig(path.resolve(process.cwd(), useConfig));
+        if (isResolvable(useConfig) || isResolvable("eslint-config-" + useConfig) || useConfig.charAt(0) === "@") {
+            this.useSpecificConfig = loadConfig(useConfig);
+        } else {
+            this.useSpecificConfig = loadConfig(path.resolve(process.cwd(), useConfig));
+        }
     }
 }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -30,7 +30,7 @@ module.exports = optionator({
         option: "config",
         alias: "c",
         type: "path::String",
-        description: "Use configuration from this file"
+        description: "Use configuration from this file or sharable config"
     }, {
         option: "rulesdir",
         type: "[path::String]",

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "globals": "^8.3.0",
     "inquirer": "^0.9.0",
     "is-my-json-valid": "^2.10.0",
+    "is-resolvable": "^1.0.0",
     "js-yaml": "^3.2.5",
     "lodash.clonedeep": "^3.0.1",
     "lodash.merge": "^3.3.2",
@@ -63,12 +64,14 @@
     "xml-escape": "~1.0.0"
   },
   "devDependencies": {
+    "@ljharb/eslint-config": "^1.0.4",
     "beefy": "^1.0.0",
     "brfs": "0.0.9",
     "browserify": "^8.1.3",
     "chai": "^1.9.1",
     "coveralls": "2.11.2",
     "dateformat": "^1.0.8",
+    "eslint-config-xo": "^0.3.1",
     "esprima": "^2.4.1",
     "esprima-fb": "^10001.1.0-dev-harmony-fb",
     "gh-got": "^1.0.3",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -161,6 +161,19 @@ describe("cli", function() {
         });
     });
 
+    describe("when given a config that is a sharable config", function() {
+        it("should execute without any errors", function() {
+            var configPath = "xo";
+            var filePath = getFixturePath("passing.js");
+            var code = "--config " + configPath + " " + filePath;
+
+            var exit = cli.execute(code);
+
+            assert.equal(exit, 1);
+            assert.isTrue(console.log.called);
+        });
+    });
+
     describe("when given a valid built-in formatter name", function() {
         it("should execute without any errors", function() {
             var filePath = getFixturePath("passing.js");

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -11,9 +11,9 @@
 
 var assert = require("chai").assert,
     path = require("path"),
-
     fs = require("fs"),
     Config = require("../../lib/config"),
+    fixtureSharableConfig = require("@ljharb/eslint-config"),
     sinon = require("sinon"),
     proxyquire = require("proxyquire");
 
@@ -168,8 +168,20 @@ describe("Config", function() {
             assert.isObject(configHelper.getConfig(configPath));
         });
 
-        it("should throw error when an invalid configuration file is read", function() {
+        it("should throw error when a configuration file doesn't exist", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", ".eslintrc");
+            var configHelper = new Config();
+
+            sandbox.stub(fs, "readFileSync").throws(new Error());
+
+            assert.throws(function() {
+                configHelper.getConfig(configPath);
+            }, "Cannot read config file");
+
+        });
+
+        it("should throw error when a configuration file is not require-able", function() {
+            var configPath = ".eslintrc";
             var configHelper = new Config();
 
             sandbox.stub(fs, "readFileSync").throws(new Error());
@@ -553,6 +565,17 @@ describe("Config", function() {
             config = configHelper.getConfig(configPath);
 
             assert.isUndefined(config.globals.window);
+        });
+
+        it("should load a sharable config as a command line config", function() {
+            var configHelper = new Config({
+                    useEslintrc: false,
+                    configFile: "@ljharb"
+                }),
+                expected = fixtureSharableConfig,
+                actual = configHelper.getConfig(path.resolve(__dirname, "..", "fixtures", "configurations", "empty", "empty.json"));
+
+            assertConfigsEqual(actual, expected);
         });
 
         it("should not error on fake environments", function() {


### PR DESCRIPTION
This PR implements a new CLI feature discussed in https://github.com/eslint/eslint/issues/2543#issuecomment-102441119:

> It might make sense to let `-c` accept a shareable config

For example, if a sharable config `eslint-config-foo` is installed in the project's `node_modules` directory, `eslint` CLI can directly load it with the `--config` flag like below:

```
eslint --config foo .
```

or,

```
eslint --config eslint-config-foo .
```
