### PR TITLE
Fix false warnings when using break/continue

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -320,7 +320,7 @@ module.exports = function(context) {
 
         "Identifier": function(node) {
             var ancestor = context.getAncestors().pop();
-            if (isDeclaration(node, ancestor) || isProperty(node, ancestor) || ancestor.type === "LabeledStatement") {
+            if (isDeclaration(node, ancestor) || isProperty(node, ancestor) || ancestor.type === "LabeledStatement" || ancestor.type === "BreakStatement" || ancestor.type === "ContinueStatement") {
                 return;
             }
 

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -59,6 +59,7 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         "function f(){ for(var a=0, b=1; a; b) a, b; }",
         "function f(){ for(var a in {}) a; }",
         "function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} b; }",
+        "foo: while (true) {bar: for (var i = 0; i < 13; ++i) {if (i === 7) continue foo; if (i === 2) break bar; } }",
         "a:;",
         { code: "const React = require(\"react/addons\");const cx = React.addons.classSet;", globals: { require: false }, ecmaFeatures: { globalReturn: true, modules: true, blockBindings: true }},
         { code: "var v = 1;  function x() { return v; };", ecmaFeatures: { globalReturn: true }},


### PR DESCRIPTION
Currently, the following valid code generates false `"<name>" used outside of binding context` warnings for break and continue statements:

```js
foo:
for (var i = 0; i < 10; ++i)
{
    bar:
    for (var j = 0; j < 13; ++j)
    {
        if (j === 7)
            continue foo;

        if (j === 2)
            break bar;
    }
}
```

This commit fixes the rule to allow identifiers in break and continue statements.