### PR TITLE
Fix: `arrow-spacing` allow multi-spaces and line-endings (fixes #3079)

### DIFF
--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -12,12 +12,11 @@ This rule normalize style of spacing before/after of arrow functions arrow(`=>`)
 
 ## Rule Details
 
-this rules takes one arguments of structure contains `before` and `after` property
-and each property has bool value.
+This rule takes an object argument with `before` and `after` properties, each with a Boolean value.
 
 default configuration is `{ "before": true, "after": true }`.
 
-`true` means there should have **one space** and `false` means **no space**.
+`true` means there should be **one or more spaces** and `false` means **no spaces**.
 
 The following patterns are considered warnings if `{ "before": true, "after": true }`.
 

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -24,7 +24,7 @@ module.exports = function(context) {
     function getTokens(node) {
         var t = context.getFirstToken(node);
         var before;
-        while (t.value !== "=>") {
+        while (t.type !== "Punctuator" || t.value !== "=>") {
             before = t;
             t = context.getTokenAfter(t);
         }
@@ -44,8 +44,8 @@ module.exports = function(context) {
     }
 
     /**
-     * Determines whether spaces before after arrow(`=>`) is satisfy rule.
-     * if before/after value is `true`, there should be one space.
+     * Determines whether space(s) before after arrow(`=>`) is satisfy rule.
+     * if before/after value is `true`, there should be space(s).
      * if before/after value is `false`, there should be no space.
      * @param {ASTNode} node The arrow function node.
      * @returns {void}
@@ -54,31 +54,25 @@ module.exports = function(context) {
         var tokens = getTokens(node);
         var countSpace = countSpaces(tokens);
 
-        if (rule.before === true) {
-            // should one space before arrow
-            if (countSpace.before > 1) {
-                context.report(tokens.before, "Unexpected space before =>");
-            }
+        if (rule.before) {
+            // should be space(s) before arrow
             if (countSpace.before === 0) {
                 context.report(tokens.before, "Missing space before =>");
             }
-        } else if (rule.before === false) {
-            // should no space before arrow
+        } else {
+            // should be no space before arrow
             if (countSpace.before > 0) {
                 context.report(tokens.before, "Unexpected space before =>");
             }
         }
 
-        if (rule.after === true) {
-            // should one space after arrow
-            if (countSpace.after > 1) {
-                context.report(tokens.after, "Unexpected space after =>");
-            }
+        if (rule.after) {
+            // should be space(s) after arrow
             if (countSpace.after === 0) {
                 context.report(tokens.after, "Missing space after =>");
             }
-        } else if (rule.after === false) {
-            // should no space after arrow
+        } else {
+            // should be no space after arrow
             if (countSpace.after > 0) {
                 context.report(tokens.after, "Unexpected space after =>");
             }

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -93,6 +93,18 @@ var valid = [
         ecmaFeatures: { arrowFunctions: true },
         code: "(a) => {}",
         options: [{}]
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a) =>\n{}"
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a) =>\r\n{}"
+    },
+    {
+        ecmaFeatures: { arrowFunctions: true },
+        code: "(a) =>\n    0"
     }
 ];
 
@@ -123,33 +135,6 @@ var invalid = [
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 6, line: 1, type: "Punctuator" }
-        ]
-    },
-    {
-        code: "a  =>  a",
-        options: [{ after: true, before: true }],
-        ecmaFeatures: { arrowFunctions: true },
-        errors: [
-            { column: 1, line: 1, type: "Identifier" },
-            { column: 8, line: 1, type: "Identifier" }
-        ]
-    },
-    {
-        code: "()  =>  {}",
-        options: [{ after: true, before: true }],
-        ecmaFeatures: { arrowFunctions: true },
-        errors: [
-            { column: 2, line: 1, type: "Punctuator" },
-            { column: 9, line: 1, type: "Punctuator" }
-        ]
-    },
-    {
-        code: "(a)  =>  {}",
-        options: [{ after: true, before: true }],
-        ecmaFeatures: { arrowFunctions: true },
-        errors: [
-            { column: 3, line: 1, type: "Punctuator" },
-            { column: 10, line: 1, type: "Punctuator" }
         ]
     },
     {
@@ -312,6 +297,14 @@ var invalid = [
         errors: [
             { column: 3, line: 1, type: "Punctuator" },
             { column: 10, line: 1, type: "Punctuator" }
+        ]
+    },
+    {
+        code: "(a)  =>\n{}",
+        options: [{ after: false }],
+        ecmaFeatures: { arrowFunctions: true },
+        errors: [
+            { column: 1, line: 2, type: "Punctuator" }
         ]
     }
 ];


### PR DESCRIPTION
- The `no-multi-spaces` rule would handle multi-spaces.
- The `brace-style` rule would handle line endings around the open bracket.
