### PR TITLE
Fix: spaces trigger wrong in `no-useless-call` and `prefer-spread` (fixes #3054)

### DIFF
--- a/docs/rules/no-useless-call.md
+++ b/docs/rules/no-useless-call.md
@@ -42,6 +42,19 @@ foo.apply(null, args);
 obj.foo.apply(obj, args);
 ```
 
+Known limitations:
+
+This rule compares code statically to check whether or not `thisArg` is changed.
+So if the code about `thisArg` is a dynamic expression, this rule cannot judge correctly.
+
+```js
+// This is warned.
+a[i++].foo.call(a[i++], 1, 2, 3);
+
+// This is not warned.
+a[++i].foo.call(a[i], 1, 2, 3);
+```
+
 ## When Not to Use It
 
 If you don't want to be notified about unnecessary `.call()` and `.apply()`, you can safely disable this rule.

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -49,6 +49,19 @@ foo.apply(null, [1, 2, 3]);
 obj.foo.apply(obj, [1, 2, 3]);
 ```
 
+Known limitations:
+
+This rule compares code statically to check whether or not `thisArg` is changed.
+So if the code about `thisArg` is a dynamic expression, this rule cannot judge correctly.
+
+```js
+// This is warned.
+a[i++].foo.apply(a[i++], args);
+
+// This is not warned.
+a[++i].foo.apply(a[i], args);
+```
+
 ## When Not to Use It
 
 This rule should not be used in ES3/5 environments.

--- a/lib/rules/no-useless-call.js
+++ b/lib/rules/no-useless-call.js
@@ -41,6 +41,31 @@ function isNullOrUndefined(node) {
 }
 
 /**
+ * Checks whether or not the tokens of two given nodes are same.
+ * @param {ASTNode} left - A node 1 to compare.
+ * @param {ASTNode} right - A node 2 to compare.
+ * @param {RuleContext} context - The ESLint rule context object.
+ * @returns {boolean} the source code for the given node.
+ */
+function equalTokens(left, right, context) {
+    var tokensL = context.getTokens(left);
+    var tokensR = context.getTokens(right);
+
+    if (tokensL.length !== tokensR.length) {
+        return false;
+    }
+    for (var i = 0; i < tokensL.length; ++i) {
+        if (tokensL[i].type !== tokensR[i].type ||
+            tokensL[i].value !== tokensR[i].value
+        ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
  * Checks whether or not `thisArg` is not changed by `.call()`/`.apply()`.
  * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
  * @param {ASTNode} thisArg - The node that is given to the first argument of the `.call()`/`.apply()`.
@@ -51,7 +76,7 @@ function isValidThisArg(expectedThis, thisArg, context) {
     if (expectedThis == null) {
         return isNullOrUndefined(thisArg);
     }
-    return context.getSource(expectedThis) === context.getSource(thisArg);
+    return equalTokens(expectedThis, thisArg, context);
 }
 
 //------------------------------------------------------------------------------

--- a/lib/rules/prefer-spread.js
+++ b/lib/rules/prefer-spread.js
@@ -40,6 +40,31 @@ function isNullOrUndefined(node) {
 }
 
 /**
+ * Checks whether or not the tokens of two given nodes are same.
+ * @param {ASTNode} left - A node 1 to compare.
+ * @param {ASTNode} right - A node 2 to compare.
+ * @param {RuleContext} context - The ESLint rule context object.
+ * @returns {boolean} the source code for the given node.
+ */
+function equalTokens(left, right, context) {
+    var tokensL = context.getTokens(left);
+    var tokensR = context.getTokens(right);
+
+    if (tokensL.length !== tokensR.length) {
+        return false;
+    }
+    for (var i = 0; i < tokensL.length; ++i) {
+        if (tokensL[i].type !== tokensR[i].type ||
+            tokensL[i].value !== tokensR[i].value
+        ) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
  * Checks whether or not `thisArg` is not changed by `.apply()`.
  * @param {ASTNode|null} expectedThis - The node that is the owner of the applied function.
  * @param {ASTNode} thisArg - The node that is given to the first argument of the `.apply()`.
@@ -50,7 +75,7 @@ function isValidThisArg(expectedThis, thisArg, context) {
     if (expectedThis == null) {
         return isNullOrUndefined(thisArg);
     }
-    return context.getSource(expectedThis) === context.getSource(thisArg);
+    return equalTokens(expectedThis, thisArg, context);
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/no-useless-call.js
+++ b/tests/lib/rules/no-useless-call.js
@@ -29,6 +29,7 @@ eslintTester.addRuleTest("lib/rules/no-useless-call", {
         {code: "obj.foo.apply(null, [1, 2]);"},
         {code: "obj.foo.apply(otherObj, [1, 2]);"},
         {code: "a.b(x, y).c.foo.apply(a.b(x, z).c, [1, 2]);"},
+        {code: "a.b.foo.apply(a.b.c, [1, 2]);"},
 
         // ignores variadic.
         {code: "foo.apply(null, args);"},
@@ -59,6 +60,9 @@ eslintTester.addRuleTest("lib/rules/no-useless-call", {
         {code: "foo.apply(null, [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]},
         {code: "obj.foo.apply(obj, [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]},
         {code: "a.b.c.foo.apply(a.b.c, [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]}
+        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]},
+        {code: "[].concat.apply([ ], [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]},
+        {code: "[].concat.apply([\n/*empty*/\n], [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]},
+        {code: "abc.get(\"foo\", 0).concat.apply(abc . get(\"foo\",  0 ), [1, 2]);", errors: [{message: "unnecessary \".apply()\".", type: "CallExpression"}]}
     ]
 });

--- a/tests/lib/rules/prefer-spread.js
+++ b/tests/lib/rules/prefer-spread.js
@@ -26,6 +26,7 @@ eslintTester.addRuleTest("lib/rules/prefer-spread", {
         {code: "obj.foo.apply(null, args);"},
         {code: "obj.foo.apply(otherObj, args);"},
         {code: "a.b(x, y).c.foo.apply(a.b(x, z).c, args);"},
+        {code: "a.b.foo.apply(a.b.c, args);"},
 
         // ignores non variadic.
         {code: "foo.apply(undefined, [1, 2]);"},
@@ -45,6 +46,8 @@ eslintTester.addRuleTest("lib/rules/prefer-spread", {
         {code: "foo.apply(null, args);", errors: errors},
         {code: "obj.foo.apply(obj, args);", errors: errors},
         {code: "a.b.c.foo.apply(a.b.c, args);", errors: errors},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors: errors}
+        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors: errors},
+        {code: "[].concat.apply([ ], args);", errors: errors},
+        {code: "[].concat.apply([\n/*empty*/\n], args);", errors: errors}
     ]
 });


### PR DESCRIPTION
Previously, the rules had checked whether or not `thisArg` is not changed, with using its source code text.
Now, those do with using its token list.

And I added a section for known limitations into those docs.