### PR TITLE
Fix: block-scoped-var rule incorrectly flagging break/continue with label (fixes #3082)

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -320,7 +320,7 @@ module.exports = function(context) {
 
         "Identifier": function(node) {
             var ancestor = context.getAncestors().pop();
-            if (isDeclaration(node, ancestor) || isProperty(node, ancestor) || ancestor.type === "LabeledStatement") {
+            if (isDeclaration(node, ancestor) || isProperty(node, ancestor) || ancestor.type === "LabeledStatement" || ancestor.type === "BreakStatement" || ancestor.type === "ContinueStatement") {
                 return;
             }
 

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -60,6 +60,8 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         "function f(){ for(var a in {}) a; }",
         "function f(){ switch(2) { case 1: var b = 2; b; break; default: b; break;} b; }",
         "a:;",
+        "foo: while (true) { bar: for (var i = 0; i < 13; ++i) {if (i === 7) break foo; } }",
+        "foo: while (true) { bar: for (var i = 0; i < 13; ++i) {if (i === 7) continue foo; } }",
         { code: "const React = require(\"react/addons\");const cx = React.addons.classSet;", globals: { require: false }, ecmaFeatures: { globalReturn: true, modules: true, blockBindings: true }},
         { code: "var v = 1;  function x() { return v; };", ecmaFeatures: { globalReturn: true }},
         { code: "import * as y from \"./other.js\"; y();", ecmaFeatures: { modules: true }},


### PR DESCRIPTION
Previously, the `block-scoped-var` rule, when encountering an "Identifier" node, did not check if the ancestor node was a "BreakStatement" or "ContinueStatement", which triggered the rule if the Identifier was the label of a `break` or `continue` statement.

See #3082 for sample code that triggered the warnings.

This PR adds a check for "BreakStatement" and "ContinueStatement", which eliminates the spurious warnings.