### PR TITLE
Update: move redeclaration checking for builtins (#3070)

### DIFF
--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -4,7 +4,6 @@ Reports an error when they encounter an attempt to assign a value to built-in na
 
 ```js
 String = "hello world";
-var String;
 ```
 
 ## Rule Details
@@ -15,10 +14,6 @@ The following patterns are considered warnings:
 
 ```js
 String = new Object();
-```
-
-```js
-var String;
 ```
 
 ## Options
@@ -40,3 +35,5 @@ If you are trying to override one of the native objects.
 ## Related Rules
 
 * [no-extend-native](no-extend-native.md)
+* [no-redeclare](no-redeclare.md)
+* [no-shadow](no-shadow.md)

--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -10,7 +10,7 @@ The following patterns are considered warnings:
 
 ```js
 var a = 3;
-var a = 10;
+var a = 10; // redeclared
 ```
 
 The following patterns are considered okay and do not cause warnings:
@@ -20,3 +20,40 @@ var a = 3;
 ...
 a = 10;
 ```
+
+### Options
+
+This rule takes one option, an object, with a property `"builtinGlobals"`.
+
+```json
+{
+    "no-redeclare": [2, {"builtinGlobals": true}]
+}
+```
+
+#### builtinGlobals
+
+`false` by default.
+If this is `true`, this rule checks with built-in global variables such as `Object`, `Array`, `Number`, ...
+
+When `{"builtinGlobals": true}`, the following patterns are considered warnings:
+
+```js
+var Object = 0; // redeclared of the built-in globals.
+```
+
+When `{"builtinGlobals": true}` and under `browser` environment, the following patterns are considered warnings:
+
+```js
+var top = 0; // redeclared of the built-in globals.
+```
+
+* Note: The `browser` environment has many built-in global variables, `top` is one of them.
+  Some of built-in global variables cannot be redeclared. It's a trap.
+
+  ```js
+  var top = 0;
+  var left = 0;
+  console.log(top + " " + left); // prints "[object Window] 0"
+  console.log(top * left); // prints "NaN"
+  ```

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -47,19 +47,30 @@ if (true) {
 }
 ```
 
-## Options
+### Options
 
-This rule has a option for the hoisting behavior.
+This rule takes one option, an object, with properties `"builtinGlobals"`, `"hoist"`.
 
 ```json
 {
-    "rules": {
-        "no-shadow": [2, {"hoist": "functions"}]
-    }
+    "no-shadow": [2, {"builtinGlobals": false, "hoist": "functions"}]
 }
 ```
 
-### hoist
+#### builtinGlobals
+
+`false` by default.
+If this is `true`, this rule checks with built-in global variables such as `Object`, `Array`, `Number`, ...
+
+When `{"builtinGlobals": true}`, the following patterns are considered warnings:
+
+```js
+function foo() {
+    var Object = 0; // shadowed the built-in globals.
+}
+```
+
+#### hoist
 
 The option has three settings:
 

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -5,37 +5,43 @@
 
 "use strict";
 
-var globals = require("globals");
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-var NATIVE_OBJECTS = Object.keys(globals.builtin);
-
 module.exports = function(context) {
 
     var config = context.options[0];
-    var exceptions = config && config.exceptions;
-    var forbiddenNames = NATIVE_OBJECTS.reduce(function(retv, builtIn) {
-        if (exceptions == null || exceptions.indexOf(builtIn) === -1) {
-            retv[builtIn] = true;
-        }
-        return retv;
-    }, Object.create(null));
+    var exceptions = (config && config.exceptions) || [];
+
+    /**
+     * Gets the names of writeable built-in variables.
+     * @param {escope.Scope} scope - A scope to get.
+     * @returns {object} A map that its key is variable names.
+     */
+    function getBuiltinGlobals(scope) {
+        return scope.variables.reduce(function(retv, variable) {
+            if (variable.writeable === false && variable.name !== "__proto__") {
+                retv[variable.name] = true;
+            }
+            return retv;
+        }, Object.create(null));
+    }
 
     /**
      * Reports if a given reference's name is same as native object's.
+     * @param {object} builtins - A map that its key is a variable name.
      * @param {Reference} reference - A reference to check.
      * @param {int} index - The index of the reference in the references.
      * @param {Reference[]} references - The array that the reference belongs to.
      * @returns {void}
      */
-    function checkThroughReference(reference, index, references) {
+    function checkThroughReference(builtins, reference, index, references) {
         var identifier = reference.identifier;
 
         if (identifier != null &&
-            forbiddenNames[identifier.name] &&
+            builtins[identifier.name] &&
+            exceptions.indexOf(identifier.name) === -1 &&
             reference.init === false &&
             reference.isWrite() &&
             // Destructuring assignments can have multiple default value,
@@ -49,30 +55,14 @@ module.exports = function(context) {
         }
     }
 
-    /**
-     * Finds and reports variables that its name is same as native object's.
-     * @param {Variable} variable - A variable to check.
-     * @returns {void}
-     */
-    function checkVariable(variable) {
-        if (forbiddenNames[variable.name]) {
-            context.report(
-                variable.identifiers[0],
-                "Redefinition of '{{name}}'.",
-                {name: variable.name});
-        }
-    }
-
     return {
         // Checks assignments of global variables.
         // References to implicit global variables are not resolved,
         // so those are in the `through` of the global scope.
         "Program": function() {
-            context.getScope().through.forEach(checkThroughReference);
-        },
-
-        "VariableDeclaration": function(node) {
-            context.getDeclaredVariables(node).forEach(checkVariable);
+            var globalScope = context.getScope();
+            var builtins = getBuiltinGlobals(globalScope);
+            globalScope.through.forEach(checkThroughReference.bind(null, builtins));
         }
     };
 
@@ -84,7 +74,7 @@ module.exports.schema = [
         "properties": {
             "exceptions": {
                 "type": "array",
-                "items": {"enum": NATIVE_OBJECTS},
+                "items": {"type": "string"},
                 "uniqueItems": true
             }
         },

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -10,22 +10,49 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var options = {
+        builtinGlobals: Boolean(context.options[0] && context.options[0].builtinGlobals)
+    };
+
+    /**
+     * Gets the names of writeable built-in variables.
+     * @param {escope.Scope} scope - A scope to get.
+     * @returns {object} A map that its key is a variable name.
+     */
+    function getBuiltinGlobals(scope) {
+        return scope.variables.reduce(function(retv, variable) {
+            if ("writeable" in variable && variable.name !== "__proto__") {
+                retv[variable.name] = true;
+            }
+            return retv;
+        }, Object.create(null));
+    }
 
     /**
      * Find variables in a given scope and flag redeclared ones.
-     * @param {Scope} scope An escope scope object.
+     * @param {Scope} scope - An escope scope object.
+     * @param {object} builtins - A map that its key is a variable name.
      * @returns {void}
      * @private
      */
-    function findVariablesInScope(scope) {
+    function findVariablesInScope(scope, builtins) {
         scope.variables.forEach(function(variable) {
-            if (variable.identifiers && variable.identifiers.length > 1) {
+            var hasBuiltin = (
+                options.builtinGlobals &&
+                ("writeable" in variable || Boolean(builtins && builtins[variable.name]))
+            );
+            var count = (hasBuiltin ? 1 : 0) + variable.identifiers.length;
+
+            if (count >= 2) {
                 variable.identifiers.sort(function(a, b) {
                     return a.range[1] - b.range[1];
                 });
 
-                for (var i = 1, l = variable.identifiers.length; i < l; i++) {
-                    context.report(variable.identifiers[i], "{{a}} is already defined", {a: variable.name});
+                for (var i = (hasBuiltin ? 0 : 1), l = variable.identifiers.length; i < l; i++) {
+                    context.report(
+                        variable.identifiers[i],
+                        "{{a}} is already defined",
+                        {a: variable.name});
                 }
             }
         });
@@ -33,36 +60,54 @@ module.exports = function(context) {
     }
 
     /**
-     * Find variables in a given node's associated scope.
-     * @param {ASTNode} node The node to check.
+     * Find variables in the current scope.
      * @returns {void}
      * @private
      */
-    function findVariables(node) {
+    function checkForGlobal() {
         var scope = context.getScope();
 
-        findVariablesInScope(scope);
-
-        // globalReturn means one extra scope to check
-        if (node.type === "Program" && (context.ecmaFeatures.globalReturn || context.ecmaFeatures.modules)) {
-            findVariablesInScope(scope.childScopes[0]);
+        // Nodejs env or modules has a special scope.
+        // But built-in global variables are not there.
+        if (context.ecmaFeatures.globalReturn || context.ecmaFeatures.modules) {
+            var builtins = (options.builtinGlobals ? getBuiltinGlobals(scope) : null);
+            findVariablesInScope(scope.childScopes[0], builtins);
+        } else {
+            findVariablesInScope(scope);
         }
+    }
+
+    /**
+     * Find variables in the current scope.
+     * @returns {void}
+     * @private
+     */
+    function checkForBlock() {
+        findVariablesInScope(context.getScope());
     }
 
     if (context.ecmaFeatures.blockBindings) {
         return {
-            "Program": findVariables,
-            "BlockStatement": findVariables,
-            "SwitchStatement": findVariables
+            "Program": checkForGlobal,
+            "BlockStatement": checkForBlock,
+            "SwitchStatement": checkForBlock
         };
     } else {
         return {
-            "Program": findVariables,
-            "FunctionDeclaration": findVariables,
-            "FunctionExpression": findVariables,
-            "ArrowFunctionExpression": findVariables
+            "Program": checkForGlobal,
+            "FunctionDeclaration": checkForBlock,
+            "FunctionExpression": checkForBlock,
+            "ArrowFunctionExpression": checkForBlock
         };
     }
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "builtinGlobals": {"type": "boolean"}
+        },
+        "additionalProperties": false
+    }
+];

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -13,6 +13,7 @@
 module.exports = function(context) {
 
     var options = {
+        builtinGlobals: Boolean(context.options[0] && context.options[0].builtinGlobals),
         hoist: (context.options[0] && context.options[0].hoist) || "functions"
     };
 
@@ -96,7 +97,7 @@ module.exports = function(context) {
     function isContainedInScopeVars(variable, scopeVars) {
         return scopeVars.some(function(scopeVar) {
             return (
-                scopeVar.identifiers.length > 0 &&
+                (scopeVar.identifiers.length > 0 || (options.builtinGlobals && "writeable" in scopeVar)) &&
                 variable.name === scopeVar.name &&
                 !isDuplicatedClassNameVariable(scopeVar) &&
                 !isOnInitializer(variable, scopeVar) &&
@@ -155,9 +156,14 @@ module.exports = function(context) {
 
     return {
         "Program:exit": function() {
-            var globalScope = context.getScope(),
-                stack = globalScope.childScopes.slice(),
-                scope;
+            // Nodejs env or modules has a special scope for globals.
+            var globalScope = context.getScope();
+            if (context.ecmaFeatures.globalReturn || context.ecmaFeatures.modules) {
+                globalScope = globalScope.childScopes[0];
+            }
+
+            var stack = globalScope.childScopes.slice();
+            var scope;
 
             while (stack.length) {
                 scope = stack.pop();
@@ -173,9 +179,9 @@ module.exports.schema = [
     {
         "type": "object",
         "properties": {
-            "hoist": {
-                "enum": ["all", "functions", "never"]
-            }
-        }
+            "builtinGlobals": {"type": "boolean"},
+            "hoist": {"enum": ["all", "functions", "never"]}
+        },
+        "additionalProperties": false
     }
 ];

--- a/tests/lib/rules/no-native-reassign.js
+++ b/tests/lib/rules/no-native-reassign.js
@@ -21,19 +21,13 @@ eslintTester.addRuleTest("lib/rules/no-native-reassign", {
     valid: [
         "string = 'hello world';",
         "var string;",
-        {
-            code: "var Object = 0",
-            options: [{exceptions: ["Object"]}]
-        }
+        { code: "Object = 0;", options: [{exceptions: ["Object"]}] },
+        { code: "top = 0;" },
+        { code: "onload = 0;", env: {browser: true} },
+        { code: "require = 0;" }
     ],
     invalid: [
         { code: "String = 'hello world';", errors: [{ message: "String is a read-only native object.", type: "Identifier"}] },
-        { code: "var String;", errors: [{ message: "Redefinition of 'String'.", type: "Identifier"}] },
-        {
-            code: "var Object = 0",
-            options: [{exceptions: ["Number"]}],
-            errors: [{ message: "Redefinition of 'Object'.", type: "Identifier"}]
-        },
         {
             code: "({Object = 0, String = 0}) = {};",
             ecmaFeatures: {destructuring: true},
@@ -43,12 +37,14 @@ eslintTester.addRuleTest("lib/rules/no-native-reassign", {
             ]
         },
         {
-            code: "var {Array, Number = 0} = {};",
-            ecmaFeatures: {destructuring: true},
-            errors: [
-                {message: "Redefinition of 'Array'.", type: "Identifier"},
-                {message: "Redefinition of 'Number'.", type: "Identifier"}
-            ]
+            code: "top = 0;",
+            env: {browser: true},
+            errors: [{ message: "top is a read-only native object.", type: "Identifier"}]
+        },
+        {
+            code: "require = 0;",
+            env: {node: true},
+            errors: [{ message: "require is a read-only native object.", type: "Identifier"}]
         }
     ]
 });

--- a/tests/lib/rules/no-redeclare.js
+++ b/tests/lib/rules/no-redeclare.js
@@ -26,7 +26,11 @@ eslintTester.addRuleTest("lib/rules/no-redeclare", {
             ecmaFeatures: {
                 blockBindings: true
             }
-        }
+        },
+        { code: "var Object = 0;" },
+        { code: "var Object = 0;", options: [{builtinGlobals: false}] },
+        { code: "var top = 0;", env: {browser: true} },
+        { code: "var top = 0;", options: [{builtinGlobals: true}] }
     ],
     invalid: [
         { code: "var a = 3; var a = 10;", ecmaFeatures: { globalReturn: true }, errors: [{ message: "a is already defined", type: "Identifier"}] },
@@ -41,6 +45,41 @@ eslintTester.addRuleTest("lib/rules/no-redeclare", {
         { code: "var a; var a;", ecmaFeatures: { modules: true }, errors: [{ message: "a is already defined", type: "Identifier"}] },
         { code: "export var a; export var a;", ecmaFeatures: { modules: true }, errors: [{ message: "a is already defined", type: "Identifier"}] },
         { code: "export class A {} export class A {}", ecmaFeatures: { classes: true, modules: true }, errors: [{ message: "A is already defined", type: "Identifier"}] },
-        { code: "export var a; var a;", ecmaFeatures: { modules: true, globalReturn: true }, errors: [{ message: "a is already defined", type: "Identifier"}] }
+        { code: "export var a; var a;", ecmaFeatures: { modules: true, globalReturn: true }, errors: [{ message: "a is already defined", type: "Identifier"}] },
+        {
+            code: "var Object = 0;",
+            options: [{builtinGlobals: true}],
+            errors: [{ message: "Object is already defined", type: "Identifier"}]
+        },
+        {
+            code: "var top = 0;",
+            options: [{builtinGlobals: true}],
+            env: {browser: true},
+            errors: [{ message: "top is already defined", type: "Identifier"}]
+        },
+        {
+            code: "var a; var {a = 0, b: Object = 0} = {};",
+            options: [{builtinGlobals: true}],
+            ecmaFeatures: {destructuring: true},
+            errors: [
+                { message: "a is already defined", type: "Identifier"},
+                { message: "Object is already defined", type: "Identifier"}
+            ]
+        },
+        {
+            code: "var a; var {a = 0, b: Object = 0} = {};",
+            options: [{builtinGlobals: true}],
+            ecmaFeatures: {modules: true, destructuring: true},
+            errors: [
+                { message: "a is already defined", type: "Identifier"},
+                { message: "Object is already defined", type: "Identifier"}
+            ]
+        },
+        {
+            code: "var a; var {a = 0, b: Object = 0} = {};",
+            options: [{builtinGlobals: false}],
+            ecmaFeatures: {modules: true, destructuring: true},
+            errors: [{ message: "a is already defined", type: "Identifier"}]
+        }
     ]
 });

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -52,7 +52,10 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
         { code: "function foo() { var a; } let a;", ecmaFeatures: {blockBindings: true} },
         { code: "function foo() { var a; } var a;", ecmaFeatures: {blockBindings: true} },
         { code: "function foo(a) { } let a;", ecmaFeatures: {blockBindings: true} },
-        { code: "function foo(a) { } var a;", ecmaFeatures: {blockBindings: true} }
+        { code: "function foo(a) { } var a;", ecmaFeatures: {blockBindings: true} },
+        { code: "function foo() { var Object = 0; }" },
+        { code: "function foo() { var top = 0; }" },
+        { code: "function foo() { var top = 0; }", options: [{builtinGlobals: true}] }
     ],
     invalid: [
         {
@@ -287,6 +290,17 @@ eslintTester.addRuleTest("lib/rules/no-shadow", {
                 { message: "a is already declared in the upper scope.", type: "Identifier", line: 1, column: 26},
                 { message: "a is already declared in the upper scope.", type: "Identifier", line: 1, column: 40}
             ]
+        },
+        {
+            code: "function foo() { var Object = 0; }",
+            options: [{builtinGlobals: true}],
+            errors: [{ message: "Object is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "function foo() { var top = 0; }",
+            options: [{builtinGlobals: true}],
+            env: {browser: true},
+            errors: [{ message: "top is already declared in the upper scope.", type: "Identifier"}]
         }
     ]
 });


### PR DESCRIPTION
- Added `builtinGlobals` option into `no-redeclare` and `no-shadow`. Those option is a boolean value, if it's `true`, do checking redeclaration/shadowing for built-in globals.
  - `builtinGlobals` of `no-redeclare` is `true` by default. Redeclarations of built-in globals possibly be traps in browser particularly. And side-effects probably be not many.
  - `builtinGlobals` of `no-shadow` is `false` by default. Side-effects are too many.
  - To be both `false` might be better.
- Removed checking for redeclarations from `no-native-reassign`.
- Changed the checking way to using variables of built-in globals instead of a constant name list. Variables are created by core with configurations.
