### PR TITLE
Docs: Grammar fixes in rule descriptions (refs #3038)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -190,7 +190,7 @@ These rules are purely matters of style and are quite subjective.
 These rules are only relevant to ES6 environments.
 
 * [arrow-parens](arrow-parens.md) - require parens in arrow function arguments
-* [arrow-spacing](arrow-spacing.md) - require space before/after arrow functions arrow
+* [arrow-spacing](arrow-spacing.md) - require space before/after arrow function's arrow
 * [constructor-super](constructor-super.md) - verify calls of `super()` in constructors
 * [generator-star-spacing](generator-star-spacing.md) - enforce spacing around the `*` in generator functions
 * [no-class-assign](no-class-assign.md) - disallow modifying variables of class declarations

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -1,8 +1,8 @@
 # Require parens in arrow function arguments (arrow-parens)
 
-Arrow function can omit parens if there passed only one arguments.
-But you need to add parens if arguments decreased to 0 or increase.
-This rule requires parens in arrow function arguments for normalize coding style.
+Arrow function can omit parens if they are passed only one arguments,
+but you need to add parens if the argument count is different.
+This rule requires parens in arrow function arguments regardless of arity, for consistency.
 
 ```js
 // Bad
@@ -13,7 +13,7 @@ a => {}
 ```
 
 
-And also it will help to find if arrow function(`=>`) are wrote in condition context instead of comparison (`>=`) by mistake.
+It will also help to find arrow functions (`=>`) which may be mistakenly included in a condition when a comparison such as `>=` was the intent.
 
 
 ```js
@@ -51,30 +51,36 @@ a.then((foo) => {});
 a.then((foo) => { if (true) {}; });
 ```
 
-this saves you from bizarre behavior like below
+this saves you from behavior like the following:
 
 ```js
 var a = 1;
-if (a => 2) {
+var b = 2;
+// ...
+if (a => b) {
  console.log('bigger');
 } else {
- console.log('smaller')
+ console.log('smaller');
 };
+// outputs 'bigger', not smaller as expected
 ```
 
-this is better, because condition of if is arrow function, not comparison.
-this should be like this, and you can notice it's not what you expect.
+The contents of the `if` statement is an arrow function, not a comparison.
+If the arrow function is intentional, it should be wrapped in parens to remove ambiguity.
 
 ```js
 var a = 1;
-if ((a) => 2) {
- console.log('bigger');
+var b = 0;
+// ...
+if ((a) => b) {
+ console.log('truthy value returned');
 } else {
- console.log('smaller')
+ console.log('falsey value returned');
 };
+// outputs 'falsey value returned'
 ```
 
-same thing happens here.
+The following is another example of this behavior:
 
 ```js
 var a = 1, b = 2, c = 3, d = 4;
@@ -82,13 +88,11 @@ var f = a => b ? c: d;
 // f = ?
 ```
 
-`f` is arrow function which gets a as arguments and returns the result of `b ? c: d`.
+`f` is an arrow function which takes `a` as an argument and returns the result of `b ? c: d`.
 
-this should be like this again.
+This should be rewritten like so:
 
 ```js
 var a = 1, b = 2, c = 3, d = 4;
 var f = (a) => b ? c: d;
 ```
-
-you may notice what this is.

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -1,6 +1,6 @@
-# Require space before/after arrow functions arrow (arrow-spacing)
+# Require space before/after arrow function's arrow (arrow-spacing)
 
-This rule normalize style of spacing before/after of arrow functions arrow(`=>`).
+This rule normalize style of spacing before/after an arrow function's arrow(`=>`).
 
 ```js
 // { "before": true, "after": true }

--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -1,6 +1,6 @@
 # Enforce Return After Callback (callback-return)
 
-The callback pattern is at the heart most I/O and event programming
+The callback pattern is at the heart most I/O and event-driven programming
  in JavaScript.
 
 ```js
@@ -12,7 +12,7 @@ function doSomething(err, callback) {
 }
 ```
 
-To prevent calling the callback multiple times it's important to `return` anytime the callback is triggered outside
+To prevent calling the callback multiple times it is important to `return` anytime the callback is triggered outside
  of the main function body. Neglecting this technique often leads to issues where you do something more than once.
  For example in the case of an HTTP request, you may try to send HTTP headers more than once leading node.js to `throw`
  a `Can't render headers after they are sent to the client.` error.

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -14,7 +14,7 @@ There are many commonly used aliases for `this` such as `self`, `that` or `me`. 
 
 ## Rule Details
 
-This rule designates a variable as the chosen alias for "this". It then enforces two things:
+This rule designates a variable as the chosen alias for `this`. It then enforces two things:
 
 * if a variable with the designated name is declared or assigned to, it *must* explicitly be assigned the current execution context, i.e. `this`
 * if `this` is explicitly assigned to a variable, the name of that variable must be the designated one

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -1,14 +1,14 @@
-# Verify `super()` callings in constructors (constructor-super)
+# Verify calls of `super()` in constructors (constructor-super)
 
 Constructors of derived classes must call `super()`.
 Constructors of non derived classes must not call `super()`.
-If not so, it will raise a runtime error.
+If this is not observed, the javascript engine will raise a runtime error.
 
-This rule checks whether or not there is valid `super()` calling.
+This rule checks whether or not there is a valid `super()` call.
 
 ## Rule Details
 
-This rule is aimed to flag invalid/missing `super()` callings.
+This rule is aimed to flag invalid/missing `super()` calls.
 
 The following patterns are considered warnings:
 

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -40,7 +40,7 @@ var doSomething = function() {
 
 In this case, `doSomething()` is undefined at the time of invocation and so causes a runtime error.
 
-Due to these different behaviors, it's common to have guidelines as to which style of function should be used. There is really no correct or incorrect choice here, it's just a preference.
+Due to these different behaviors, it is common to have guidelines as to which style of function should be used. There is really no correct or incorrect choice here, it is just a preference.
 
 ## Rule Details
 
@@ -75,7 +75,7 @@ SomeObject.foo = function() {
 "func-style": [2, "declaration"]
 ```
 
-This reports an error (code is 2) if any function expressions are used where function declarations are expected. You can specify to use expressions instead:
+This reports an error if any function expressions are used where function declarations are expected. You can specify to use expressions instead:
 
 ```json
 "func-style": [2, "expression"]

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -1,4 +1,4 @@
-# Enforce the spacing around the * in generators (generator-star-spacing)
+# Enforce spacing around the * in generator functions (generator-star-spacing)
 
 Generators are a new type of function in ECMAScript 6 that can return multiple values over time.
 These special functions are indicated by placing an `*` after the `function` keyword.
@@ -34,17 +34,17 @@ To keep a sense of consistency when using generators this rule enforces a single
 
 ## Rule Details
 
-This rule aims to enforce spacing around `*` of the generator function.
+This rule aims to enforce spacing around the `*` of generator functions.
 
 The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`.
 
-* `before` aims to spacing between the `*` and the `function` keyword.
-  If it's `true`, space is enforced, otherwise space is disallowed.
+* `before` enforces spacing between the `*` and the `function` keyword.
+  If it is `true`, a space is required, otherwise spaces are disallowed.
 
   In object literal shorthand methods, spacing before the `*` is not checked, as they lack a `function` keyword.
 
-* `after` aims to spacing between the `*` and the function name.
-  If it's `true`, space is enforced, otherwise space is disallowed.
+* `after` enforces spacing between the `*` and the function name.
+  If it is `true`, a space is required, otherwise spaces are disallowed.
 
   In anonymous function expressions, spacing between the `*` and the opening parenthesis is not checked. This is checked by the [space-before-function-paren](space-before-function-paren.md) rule.
 
@@ -109,7 +109,7 @@ To use this rule you must set the `generators` flag to `true` in the `ecmaFeatur
 
 ## When Not To Use It
 
-If your project will not be using generators you do not need this rule.
+If your project will not be using generators or you are not concerned with spacing consistency, you do not need this rule.
 
 ## Further Reading
 

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -1,7 +1,7 @@
-# Ensures Callback Error Handling (handle-callback-err)
+# Enforce Callback Error Handling (handle-callback-err)
 
 In node, a common pattern for dealing with asynchronous behavior is called the callback pattern.
-This pattern expects as the first argument of the callback an `Error` object, which may be `null`.
+This pattern expects an `Error` object or `null` as the first argument of the callback.
 Forgetting to handle these errors can lead to some really strange behavior in your application.
 
 ```js

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -2,7 +2,7 @@
 
 This option validates a specific tab width for your code in block statements.
 
-There are several common guidelines, which indentation your code should have in nested blocks and statements, like:
+There are several common guidelines which require specific indentation of nested blocks and statements, like:
 
 ```js
 function hello(indentSize, type) {
@@ -22,19 +22,19 @@ This is the most common scenarios recommended in different style guides:
 
 This rule is aimed to enforce consistent indentation style. The default style is `4 spaces`.
 
-It takes an option as the second parameter which can be `"tab"` for tabs indentation or a positive number for space indentations.
+It takes an option as the second parameter which can be `"tab"` for tab-based indentation or a positive number for space indentations.
 
 ```js
-// 4 spaces indention
+// 4 space indention
 "indent": 2
 
-// 2 spaces indentation
+// 2 space indentation
 "indent": [2, 2]
 
-// tabs indentation
+// tabbed indentation
 "indent": [2, "tab"]
 
-// 4 spaces indentation with enabled switch cases validation
+// 4 space indentation with enabled switch cases validation
  "indent": [2, 4, {"indentSwitchCase": true}]
 ```
 
@@ -62,7 +62,7 @@ function(d) {
 The following patterns are not warnings:
 
 ```js
-// 2 spaces indentation
+// 2 space indentation
 if (a) {
   b=c;
   function(d) {
@@ -70,7 +70,7 @@ if (a) {
   }
 }
 
-// tab indentation
+// tabbed indentation
 if (a) {
     b=c;
     function(d) {
@@ -83,12 +83,12 @@ if (a) {
 
 The `indent` rule has two options:
 
-* Indentation style, positive number or `tab` (see rule detail for samples)
+* Indentation style, positive number or `tab` (see rule details for examples)
 * Configuring optional validations, `Object`.
     * `indentSwitchCase` - indent switch cases, `false` by default.
 
 ```js
-// 2 spaces indentation with enabled switch cases validation
+// 2 space indentation with enabled switch cases validation
  "indent": [2, 2, {"indentSwitchCase": true}]
 ```
 

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -1,6 +1,6 @@
 # Enforce Property Spacing (key-spacing)
 
-Enforces spacing around the colon in object literal properties. It can verify each property individually, or it can ensure vertical alignment of groups of properties in an object literal.
+This rule enforces spacing around the colon in object literal properties. It can verify each property individually, or it can ensure vertical alignment of groups of properties in an object literal.
 
 ## Rule Details
 

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -1,4 +1,4 @@
-# Allow/disallow an empty newline after variable declarations (newline-after-var)
+# Require or disallow an empty newline after variable declarations (newline-after-var)
 
 As of today there is no consistency in separating variable declarations from the rest of the code. Some developers leave an empty line between var statements and the rest of the code like:
 
@@ -19,7 +19,7 @@ The problem is when these developers work together in a project. This rule enfor
 
 ## Rule Details
 
-This rule enforces a coding style where empty newlines are allowed or disallowed after `var`, `let`, or `const` statements to achieve a consistent coding style across the project.
+This rule enforces a coding style where empty newlines are required or disallowed after `var`, `let`, or `const` statements to achieve a consistent coding style across the project.
 Invalid option value (anything other than `always` nor `never`), defaults to `always`.
 
 The following patterns are considered warnings:

--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -1,4 +1,4 @@
-# Disallow if as the Only Statement in an else Block (no-lonely-if)
+# Disallow `if` as the Only Statement in an `else` Block (no-lonely-if)
 
 If an `if` statement is the only statement in the `else` block of a parent `if` statement, it is often clearer to combine the two to using `else if` form.
 

--- a/docs/rules/no-new-object.md
+++ b/docs/rules/no-new-object.md
@@ -1,4 +1,4 @@
-# Disallow new Object (no-new-object)
+# Disallow the use of the Object constructor (no-new-object)
 
 The `Object` constructor is used to create new generic objects in JavaScript, such as:
 

--- a/docs/rules/no-script-url.md
+++ b/docs/rules/no-script-url.md
@@ -1,6 +1,6 @@
 # Disallow Script URLs (no-script-url)
 
-Using `javascript:` urls is considered by some as a form of eval. Script passed after javascript: has to be parsed and evaluated by the browser the same way that it does eval.
+Using `javascript:` URLs is considered by some as a form of `eval`. Code passed in `javascript:` URLs has to be parsed and evaluated by the browser in the same way that `eval` is processed.
 
 ## Rule Details
 

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -1,4 +1,4 @@
-# Disallow Use of Comma Operator (no-sequences)
+# Disallow Use of the Comma Operator (no-sequences)
 
 The comma operator includes multiple expressions where only one is expected. It evaluates each operand from left to right and returns the value of the last operand. However, this frequently obscures side effects, and its use is often an accident. Here are some examples of its use:
 

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -1,6 +1,6 @@
-# Disallow to use `this`/`super` before `super()` calling in constructors. (no-this-before-super)
+# Disallow use of `this`/`super` before calling `super()` in constructors. (no-this-before-super)
 
-On the constructor of derived classes, if `this`/`super` are used before `super()`, it raises a reference error.
+In the constructor of derived classes, if `this`/`super` are used before `super()` calls, it raises a reference error.
 
 This rule checks `this`/`super` keywords in constructors, then reports those that are before `super()`.
 

--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -1,8 +1,8 @@
-# Disallow use of void operator. (no-void)
+# Disallow use of the void operator. (no-void)
 
-The `void` operator takes operand and returns `undefined`: `void expression` will evaluate `expression` and return `undefined`. It can be used to suppress any side effects `expression` may produce:
+The `void` operator takes an operand and returns `undefined`: `void expression` will evaluate `expression` and return `undefined`. It can be used to ignore any side effects `expression` may produce:
 
-The common case of using `void` operator is to get "pure" `undefined` value as prior to ES5 `undefined` variable was mutable:
+The common case of using `void` operator is to get a "pure" `undefined` value as prior to ES5 the `undefined` variable was mutable:
 
 ```js
 // will always return undefined
@@ -57,7 +57,7 @@ var foo = void bar();
 
 ## When Not To Use It
 
-If you intentionally use `void` operator then you can disable this rule.
+If you intentionally use the `void` operator then you can disable this rule.
 
 ## Further Reading
 

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -1,13 +1,12 @@
-# Suggest to use `const` (prefer-const)
+# Suggest using `const` (prefer-const)
 
 If a variable is never modified, using the `const` declaration is better.
 
-`const` declaration tells readers "this variable is never modified", reduces what they must think.
-So it will improve maintainability.
+`const` declaration tells readers, "this variable is never modified," reducing cognitive load and improving maintainability.
 
 ## Rule Details
 
-This rule is aimed to flag variables that are declared using `let` keyword, but never modified after initial assignment.
+This rule is aimed at flagging variables that are declared using `let` keyword, but never modified after the initial assignment.
 
 The following patterns are considered warnings:
 
@@ -31,12 +30,12 @@ for (let a of [1,2,3]) { // `a` is re-defined (not modified) on each loop step.
 The following patterns are not considered warnings:
 
 ```js
-let a; // there is not the initializer.
+let a; // there is no initialization.
 console.log(a);
 ```
 
 ```js
-for (let i = 0, end = 10; i < end; ++i) { // `end` is never modified, but we cannot separate the declaration without changing the scope.
+for (let i = 0, end = 10; i < end; ++i) { // `end` is never modified, but we cannot separate the declarations without modifying the scope.
     console.log(a);
 }
 ```

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -1,13 +1,13 @@
-# Suggest using of the spread operator instead of `.apply()`. (prefer-spread)
+# Suggest using the spread operator instead of `.apply()`. (prefer-spread)
 
-Up to now, we had been using `Function.prototype.apply()` callings for the variadic function.
+Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
 
 ```js
 var args = [1, 2, 3, 4];
 Math.max.apply(Math, args);
 ```
 
-Since ES2015, we can use the spread operator for the variadic function.
+In ES2015, one can use the spread operator to call variadic functions.
 
 ```js
 var args = [1, 2, 3, 4];
@@ -51,14 +51,14 @@ obj.foo.apply(obj, [1, 2, 3]);
 
 Known limitations:
 
-This rule compares code statically to check whether or not `thisArg` is changed.
-So if the code about `thisArg` is a dynamic expression, this rule cannot judge correctly.
+This rule analyzes code statically to check whether or not the `this` argument is changed.
+So if the `this` argument is computed in a dynamic expression, this rule cannot detect a violation.
 
 ```js
-// This is warned.
+// This warns.
 a[i++].foo.apply(a[i++], args);
 
-// This is not warned.
+// This does not warn.
 a[++i].foo.apply(a[i], args);
 ```
 

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -1,6 +1,6 @@
-# Disallow generator functions that does not have `yield` (require-yield)
+# Disallow generator functions that do not have `yield` (require-yield)
 
-This rule catches generator functions that does not have `yield`, then warns those.
+This rule generates warnings for generator functions that do not have the `yield` keyword.
 
 ## Rule details
 
@@ -28,6 +28,6 @@ function foo() {
 ```
 
 ```js
-// This rule does not warn just empty generator functions.
+// This rule does not warn on empty generator functions.
 function* foo() { }
 ```

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -1,4 +1,4 @@
-# Require or disallow spaces before function parenthesis (space-before-function-paren)
+# Require or disallow a space before function parenthesis (space-before-function-paren)
 
 When formatting a function, whitespace is allowed between the function name or `function` keyword and the opening paren. Named functions also require a space between the `function` keyword and the function name, but anonymous functions require no whitespace. For example:
 
@@ -22,7 +22,7 @@ Style guides may require a space after the `function` keyword for anonymous func
 
 This rule aims to enforce consistent spacing before function parentheses and as such, will warn whenever whitespace doesn't match the preferences specified.
 
-This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass an configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`).
+This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`).
 
 The default configuration is `"always"`.
 

--- a/docs/rules/vars-on-top.md
+++ b/docs/rules/vars-on-top.md
@@ -1,4 +1,4 @@
-# Require Variable Declarations to be at the Top (vars-on-top)
+# Require Variable Declarations to be at the top of their scope (vars-on-top)
 
 The `vars-on-top` rule generates warnings when variable declarations are not used serially at the top of a function scope or the top of a program.
 By default variable declarations are always moved (“hoisted”) invisibly to the top of their containing scope by the JavaScript interpreter.
@@ -7,7 +7,9 @@ This rule forces the programmer to represent that behaviour by manually moving t
 ## Rule Details
 
 This rule aims to keep all variable declarations in the leading series of statements.
-Allowing multiple helps promote maintainability and reduces syntax.
+Allowing multiple declarations helps promote maintainability and is thus allowed.
+
+### Examples
 
 No variable declarations in a block.
 


### PR DESCRIPTION
This is a continuation of #3038, with rule descriptions modified to improve grammar and readability.