### PR TITLE
Fix: Check for concatenation in no-throw-literal (fixes #3099)

### DIFF
--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -18,6 +18,8 @@ throw 0;
 throw undefined;
 
 throw null;
+
+throw 'an ' + 'error';
 ```
 
 The following patterns are not considered warnings:

--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -1,10 +1,34 @@
 /**
  * @fileoverview Rule to restrict what can be thrown as an exception.
  * @author Dieter Oberkofler
+ * @copyright 2015 Ian VanSchooten. All rights reserved.
  * @copyright 2015 Dieter Oberkofler. All rights reserved.
  */
 
 "use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determine if a node contains only literals (including concatenation)
+ * @param  {ASTNode}  node  ASTNode to check for only literals
+ * @returns {Boolean}       True if completely literal, false otherwise
+ */
+function isLiteral(node) {
+    if (node.type === "Literal") {
+        return true;
+    }
+
+    if (node.type === "BinaryExpression") {
+        if (isLiteral(node.left) && isLiteral(node.right)) {
+            return true;
+        } else {
+            return false;
+        }
+    }
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -15,8 +39,7 @@ module.exports = function(context) {
     return {
 
         "ThrowStatement": function(node) {
-
-            if (node.argument.type === "Literal") {
+            if (isLiteral(node.argument)) {
                 context.report(node, "Do not throw a literal.");
             } else if (node.argument.type === "Identifier") {
                 if (node.argument.name === "undefined") {

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -26,7 +26,8 @@ eslintTester.addRuleTest("lib/rules/no-throw-literal", {
         "throw {};",
         "throw [];",
         "var e = new Error(); throw e;",
-        "try {throw new Error();} catch (e) {throw e;};"
+        "try {throw new Error();} catch (e) {throw e;};",
+        "var a = 2; throw 'a' + a;"
     ],
     invalid: [
         {
@@ -61,6 +62,28 @@ eslintTester.addRuleTest("lib/rules/no-throw-literal", {
             code: "throw undefined;",
             errors: [{
                 message: "Do not throw undefined.",
+                type: "ThrowStatement"
+            }]
+        },
+        // String concatenation
+        {
+            code: "throw 'a' + 'b';",
+            errors: [{
+                message: "Do not throw a literal.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw 'a' + 'b' + 'c';",
+            errors: [{
+                message: "Do not throw a literal.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "throw 'a' + 2;",
+            errors: [{
+                message: "Do not throw a literal.",
                 type: "ThrowStatement"
             }]
         }


### PR DESCRIPTION
Previously the rule only checked for a single literal.

This change will check string concatenation (or other BinaryExpression) and only report if all items being concatenated are literals.