### PR TITLE
Fix: Check for concatenation in no-throw-literal (fixes #3099)

### DIFF
--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -1,12 +1,13 @@
 # Restrict what can be thrown as an exception (no-throw-literal)
 
-It is considered good practice to only `throw` the `Error`object itself or an object using the `Error` object as base objects for user-defined exceptions.
+It is considered good practice to only `throw` the `Error` object itself or an object using the `Error` object as base objects for user-defined exceptions.
 The fundamental benefit of `Error` objects is that they automatically keep track of where they were built and originated.
-This rule restrict what can be thrown as an exception by preventing to throw literals.
+
+This rule restricts what can be thrown as an exception.  When it was first created, it only prevented literals from being thrown (hence the name), but it has now been expanded to only allow expressions which have a possibility of being an `Error` object.
 
 ## Rule Details
 
-This rule is aimed at maintaining consistency when throwing exception by disallowing to throw literals.
+This rule is aimed at maintaining consistency when throwing exception by disallowing to throw literals and other expressions which cannot possibly be an `Error` object.
 
 The following patterns are considered warnings:
 
@@ -18,6 +19,14 @@ throw 0;
 throw undefined;
 
 throw null;
+
+var err = new Error();
+throw "an " + err;
+// err is recast to a string literal
+
+var err = new Error();
+throw `${err}`
+
 ```
 
 The following patterns are not considered warnings:
@@ -35,4 +44,25 @@ try {
 } catch (e) {
     throw e;
 }
+```
+
+### Known Limitations
+
+Due to the limits of static analysis, this rule cannot guarantee that you will only throw `Error` objects.  For instance, the following cases do not throw an `Error` object, but they will not be considered warnings:
+
+```js
+var err = "error";
+throw err;
+
+function foo(bar) {
+    console.log(bar);
+}
+throw foo("error");
+
+throw new String("error");
+
+var foo = {
+    bar: "error"
+};
+throw foo.bar;
 ```

--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -1,10 +1,48 @@
 /**
  * @fileoverview Rule to restrict what can be thrown as an exception.
  * @author Dieter Oberkofler
+ * @copyright 2015 Ian VanSchooten. All rights reserved.
  * @copyright 2015 Dieter Oberkofler. All rights reserved.
  */
 
 "use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determine if a node has a possiblity to be an Error object
+ * @param  {ASTNode}  node  ASTNode to check
+ * @returns {boolean}       True if there is a chance it contains an Error obj
+ */
+function couldBeError(node) {
+    switch (node.type) {
+        case "Identifier":
+        case "CallExpression":
+        case "NewExpression":
+        case "MemberExpression":
+        case "TaggedTemplateExpression":
+        case "YieldExpression":
+            return true; // possibly an error object.
+
+        case "AssignmentExpression":
+            return couldBeError(node.right);
+
+        case "SequenceExpression":
+            var exprs = node.expressions;
+            return exprs.length !== 0 && couldBeError(exprs[exprs.length - 1]);
+
+        case "LogicalExpression":
+            return couldBeError(node.left) || couldBeError(node.right);
+
+        case "ConditionalExpression":
+            return couldBeError(node.consequent) || couldBeError(node.alternate);
+
+        default:
+            return false;
+    }
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -15,9 +53,8 @@ module.exports = function(context) {
     return {
 
         "ThrowStatement": function(node) {
-
-            if (node.argument.type === "Literal") {
-                context.report(node, "Do not throw a literal.");
+            if (!couldBeError(node.argument)) {
+                context.report(node, "Expected an object to be thrown.");
             } else if (node.argument.type === "Identifier") {
                 if (node.argument.name === "undefined") {
                     context.report(node, "Do not throw undefined.");

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -23,37 +23,48 @@ eslintTester.addRuleTest("lib/rules/no-throw-literal", {
         "throw new Error();",
         "throw new Error('error');",
         "throw Error('error');",
-        "throw {};",
-        "throw [];",
         "var e = new Error(); throw e;",
-        "try {throw new Error();} catch (e) {throw e;};"
+        "try {throw new Error();} catch (e) {throw e;};",
+        "throw a;", // Identifier
+        "throw foo();", // CallExpression
+        "throw new foo();", // NewExpression
+        "throw foo.bar;", // MemberExpression
+        "throw foo[bar];", // MemberExpression
+        "throw foo = new Error();", // AssignmentExpression
+        "throw 1, 2, new Error();", // SequenceExpression
+        "throw 'literal' && new Error();", // LogicalExpression (right)
+        "throw new Error() || 'literal';", // LogicalExpression (left)
+        "throw foo ? new Error() : 'literal';", // ConditionalExpression (consequent)
+        "throw foo ? 'literal' : new Error();", // ConditionalExpression (alternate)
+        { code: "throw tag `${foo}`;", ecmaFeatures: {templateStrings: true} }, // TaggedTemplateExpression
+        { code: "function* foo() { var index = 0; throw yield index++; }", ecmaFeatures: {generators: true} } // YieldExpression
     ],
     invalid: [
         {
             code: "throw 'error';",
             errors: [{
-                message: "Do not throw a literal.",
+                message: "Expected an object to be thrown.",
                 type: "ThrowStatement"
             }]
         },
         {
             code: "throw 0;",
             errors: [{
-                message: "Do not throw a literal.",
+                message: "Expected an object to be thrown.",
                 type: "ThrowStatement"
             }]
         },
         {
             code: "throw false;",
             errors: [{
-                message: "Do not throw a literal.",
+                message: "Expected an object to be thrown.",
                 type: "ThrowStatement"
             }]
         },
         {
             code: "throw null;",
             errors: [{
-                message: "Do not throw a literal.",
+                message: "Expected an object to be thrown.",
                 type: "ThrowStatement"
             }]
         },
@@ -62,6 +73,63 @@ eslintTester.addRuleTest("lib/rules/no-throw-literal", {
             errors: [{
                 message: "Do not throw undefined.",
                 type: "ThrowStatement"
+            }]
+        },
+        // String concatenation
+        {
+            code: "throw 'a' + 'b';",
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+            }]
+        },
+        {
+            code: "var b = new Error(); throw 'a' + b;",
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+            }]
+        },
+        // AssignmentExpression
+        {
+            code: "throw foo = 'error';",
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+            }]
+        },
+        // SequenceExpression
+        {
+            code: "throw new Error(), 1, 2, 3;",
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+            }]
+        },
+        // LogicalExpression
+        {
+            code: "throw 'literal' && 'not an Error';",
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+            }]
+        },
+        // ConditionalExpression
+        {
+            code: "throw foo ? 'not an Error' : 'literal';",
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+            }]
+        },
+        // TemplateLiteral
+        {
+            code: "throw `${err}`;",
+            ecmaFeatures: {templateStrings: true},
+            errors: [{
+                message: "Expected an object to be thrown.",
+                type: "ThrowStatement"
+
             }]
         }
     ]


### PR DESCRIPTION
Previously the rule only checked for a single literal.

This change will now check for string concatenation (or other BinaryExpression)

A current limitation of this rule is that it cannot handle literal template strings.