### PR TITLE
Support shared configs named `@scope/eslint-config`, with shortcuts `@scope` and `@scope/`

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -85,13 +85,20 @@ function loadConfig(filePath) {
         } else {
 
             // it's a package
-            if (filePath.indexOf("eslint-config-") === -1) {
-                if (filePath.indexOf("@") === 0) {
+
+            if (filePath.charAt(0) === "@") {
+                // it's a scoped package
+
+                // package name is "eslint-config", or just a username
+                var scopedPackageShortcutRegex = /^(@[^\/]+)(?:\/(?:eslint-config)?)?$/;
+                if (scopedPackageShortcutRegex.test(filePath)) {
+                    filePath = filePath.replace(scopedPackageShortcutRegex, "$1/eslint-config");
+                } else if (filePath.indexOf("eslint-config-") === -1) {
                     // for scoped packages, insert the eslint-config after the first /
-                    filePath = filePath.replace(/^([^\/]+\/)(.*)$/, "$1eslint-config-$2");
-                } else {
-                    filePath = "eslint-config-" + filePath;
+                    filePath = filePath.replace(/^@([^\/]+)\/(.*)$/, "@$1/eslint-config-$2");
                 }
+            } else if (filePath.indexOf("eslint-config-") === -1) {
+                filePath = "eslint-config-" + filePath;
             }
 
             config = util.mergeConfigs(config, require(filePath));

--- a/tests/fixtures/config-extends/scoped-package4/.eslintrc
+++ b/tests/fixtures/config-extends/scoped-package4/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "@scope/eslint-config",
+
+    "rules": {
+        "quotes": [2, "double"],
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/fixtures/config-extends/scoped-package5/.eslintrc
+++ b/tests/fixtures/config-extends/scoped-package5/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "@scope/",
+
+    "rules": {
+        "quotes": [2, "double"],
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/fixtures/config-extends/scoped-package6/.eslintrc
+++ b/tests/fixtures/config-extends/scoped-package6/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "@scope",
+
+    "rules": {
+        "quotes": [2, "double"],
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/fixtures/config-extends/scoped-package7/.eslintrc
+++ b/tests/fixtures/config-extends/scoped-package7/.eslintrc
@@ -1,0 +1,12 @@
+{
+    "extends": "@scope/eslint-configfoo",
+
+    "rules": {
+        "quotes": [2, "double"],
+        "valid-jsdoc": 0
+    },
+
+    "env": {
+        "browser": false
+    }
+}

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -602,6 +602,90 @@ describe("Config", function() {
             assertConfigsEqual(actual, expected);
         });
 
+        it("should not modify a scoped package named 'eslint-config'", function() {
+
+            var StubbedConfig = proxyquire("../../lib/config", {
+                "@scope/eslint-config": {
+                    rules: {
+                        eqeqeq: 2
+                    }
+                }
+            });
+
+            var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package4/.eslintrc"),
+                configHelper = new StubbedConfig({ useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
+                    env: { "browser": false }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(actual, expected);
+        });
+
+        it("should extend a scope with a slash to '@scope/eslint-config'", function() {
+
+            var StubbedConfig = proxyquire("../../lib/config", {
+                "@scope/eslint-config": {
+                    rules: {
+                        eqeqeq: 2
+                    }
+                }
+            });
+
+            var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package5/.eslintrc"),
+                configHelper = new StubbedConfig({ useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
+                    env: { "browser": false }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(actual, expected);
+        });
+
+        it("should extend a lone scope to '@scope/eslint-config'", function() {
+
+            var StubbedConfig = proxyquire("../../lib/config", {
+                "@scope/eslint-config": {
+                    rules: {
+                        eqeqeq: 2
+                    }
+                }
+            });
+
+            var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package6/.eslintrc"),
+                configHelper = new StubbedConfig({ useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
+                    env: { "browser": false }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(actual, expected);
+        });
+
+        it("should still prefix a name prefix of 'eslint-config' without a dash, with a dash", function() {
+
+            var StubbedConfig = proxyquire("../../lib/config", {
+                "@scope/eslint-config-eslint-configfoo": {
+                    rules: {
+                        eqeqeq: 2
+                    }
+                }
+            });
+
+            var configPath = path.resolve(__dirname, "../fixtures/config-extends/scoped-package7/.eslintrc"),
+                configHelper = new StubbedConfig({ useEslintrc: false, configFile: configPath }),
+                expected = {
+                    rules: { "quotes": [2, "double"], "eqeqeq": 2, "valid-jsdoc": 0 },
+                    env: { "browser": false }
+                },
+                actual = configHelper.getConfig(configPath);
+
+            assertConfigsEqual(actual, expected);
+        });
+
         it("should extend package sub-configuration without prefix", function() {
 
             var StubbedConfig = proxyquire("../../lib/config", {


### PR DESCRIPTION
Fixes #3123