### PR TITLE
Docs: Mention variables defined in a global comment (fixes #3137)

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -9,6 +9,10 @@ This rule is aimed at eliminating unused variables, functions and variables in p
 The following patterns are considered warnings:
 
 ```js
+
+//It checks variables you have defined as global
+/*global some_used_var */
+
 var x = 10;
 
 var y = 10;


### PR DESCRIPTION
Fixes #3137 