### PR TITLE
Fix: traverse `ExperimentalSpread/RestProperty.argument`

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -33,6 +33,10 @@ estraverse.Syntax.ExperimentalRestProperty = "ExperimentalRestProperty";
 estraverse.VisitorKeys.ExperimentalSpreadProperty = ["argument"];
 estraverse.VisitorKeys.ExperimentalRestProperty = ["argument"];
 
+// All nodes in ObjectExpression.properties and ObjectPattern.properties are visited as `Property`.
+// See Also: https://github.com/estools/estraverse/blob/master/estraverse.js#L687-L688
+estraverse.VisitorKeys.Property.push("argument");
+
 /**
  * Parses a list of "name:boolean_value" or/and "name" options divided by comma or
  * whitespace.

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -71,6 +71,13 @@ eslintTester.addRuleTest("lib/rules/no-undef", {
         { code: "[a] = [0];", ecmaFeatures: {destructuring: true}, errors: [{ message: "\"a\" is not defined." }] },
         { code: "({a}) = {};", ecmaFeatures: {destructuring: true}, errors: [{ message: "\"a\" is not defined." }] },
         { code: "({b: a}) = {};", ecmaFeatures: {destructuring: true}, errors: [{ message: "\"a\" is not defined." }] },
-        { code: "[obj.a, obj.b] = [0, 1];", ecmaFeatures: {destructuring: true}, errors: [{ message: "\"obj\" is not defined." }, { message: "\"obj\" is not defined." }] }
+        { code: "[obj.a, obj.b] = [0, 1];", ecmaFeatures: {destructuring: true}, errors: [{ message: "\"obj\" is not defined." }, { message: "\"obj\" is not defined." }] },
+
+        // Experimental
+        {
+            code: "const c = 0; const a = {...b, c};",
+            ecmaFeatures: {blockBindings: true, objectLiteralShorthandProperties: true, experimentalObjectRestSpread: true},
+            errors: [{ message: "\"b\" is not defined." }]
+        }
     ]
 });


### PR DESCRIPTION
Fixes #3157.

I added a workaround to avoid a crash.

The issue seems a bug of estraverse.
estraverse seems to visit all nodes as `Property`, in `ObjectExpression.properties` and `ObjectPattern.properties`.

`VisiterKeys` of `Property` is `["key", "value"]`, so `Spread/RestProperty.argument`s have not been visited. So I added `"argument"` into `VisiterKeys` of `Property`.

See Also:

- https://github.com/estools/estraverse/blob/master/estraverse.js#L449-L451
- https://github.com/estools/estraverse/blob/master/estraverse.js#L533-L534