### PR TITLE
Fix: Check no-new-func on CallExpressions (fixes #3145)

### DIFF
--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -14,6 +14,7 @@ This error is raised to highlight the use of a bad practice. By passing a string
 
 ```js
 var x = new Function("a", "b", "return a + b");
+var x = Function("a", "b", "return a + b");
 ```
 
 The following patterns are considered okay and do not cause warnings:

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -11,13 +11,25 @@
 
 module.exports = function(context) {
 
-    return {
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
 
-        "NewExpression": function(node) {
-            if (node.callee.name === "Function") {
-                context.report(node, "The Function constructor is eval.");
-            }
+    /**
+     * Checks if the callee if the Function constructor, and if so, reports an issue.
+     * @param {ASTNode} node The node to check and report on
+     * @returns {void}
+     * @private
+     */
+    function validateCallee(node) {
+        if (node.callee.name === "Function") {
+            context.report(node, "The Function constructor is eval.");
         }
+    }
+
+    return {
+        "NewExpression": validateCallee,
+        "CallExpression": validateCallee
     };
 
 };

--- a/tests/lib/rules/no-new-func.js
+++ b/tests/lib/rules/no-new-func.js
@@ -19,9 +19,11 @@ var eslint = require("../../../lib/eslint"),
 var eslintTester = new ESLintTester(eslint);
 eslintTester.addRuleTest("lib/rules/no-new-func", {
     valid: [
-        "var a = new _function(\"b\", \"c\", \"return b+c\");"
+        "var a = new _function(\"b\", \"c\", \"return b+c\");",
+        "var a = _function(\"b\", \"c\", \"return b+c\");"
     ],
     invalid: [
-        { code: "var a = new Function(\"b\", \"c\", \"return b+c\");", errors: [{ message: "The Function constructor is eval.", type: "NewExpression"}] }
+        { code: "var a = new Function(\"b\", \"c\", \"return b+c\");", errors: [{ message: "The Function constructor is eval.", type: "NewExpression"}] },
+        { code: "var a = Function(\"b\", \"c\", \"return b+c\");", errors: [{ message: "The Function constructor is eval.", type: "CallExpression"}] }
     ]
 });


### PR DESCRIPTION
Used to only check NewExpressions for Function, but according to MDN:

> Invoking the Function constructor as a function (without using the new
> operator) has the same effect as invoking it as a constructor.