### PR TITLE
Fix: `quotes` with `"backtick"` ignores ModuleSpecifier and LiteralPropertyName

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -81,10 +81,6 @@ module.exports = function(context) {
      * @private
      */
     function isPartOfDirectivePrologue(node) {
-        if (!isDirective(node.parent)) {
-            return false;
-        }
-
         var block = node.parent.parent;
         if (block.type !== "Program" && (block.type !== "BlockStatement" || !FUNCTION_TYPE.test(block.parent.type))) {
             return false;
@@ -105,6 +101,36 @@ module.exports = function(context) {
         return false;
     }
 
+    /**
+     * Checks whether or not a given node is allowed as non backtick.
+     * @param {ASTNode} node - A node to check.
+     * @returns {boolean} Whether or not the node is allowed as non backtick.
+     * @private
+     */
+    function isAllowedAsNonBacktick(node) {
+        var parent = node.parent;
+
+        switch (parent.type) {
+            // Directive Prologues.
+            case "ExpressionStatement":
+                return isPartOfDirectivePrologue(node);
+
+            // LiteralPropertyName.
+            case "Property":
+                return parent.key === node && !parent.computed;
+
+            // ModuleSpecifier.
+            case "ImportDeclaration":
+            case "ExportNamedDeclaration":
+            case "ExportAllDeclaration":
+                return parent.source === node;
+
+            // Others don't allow.
+            default:
+                return false;
+        }
+    }
+
     return {
 
         "Literal": function(node) {
@@ -116,7 +142,7 @@ module.exports = function(context) {
                 isValid;
 
             if (settings && typeof val === "string") {
-                isValid = (quoteOption === "backtick" && isPartOfDirectivePrologue(node)) || isJSXElement(node.parent) || isSurroundedBy(rawVal, settings.quote);
+                isValid = (quoteOption === "backtick" && isAllowedAsNonBacktick(node)) || isJSXElement(node.parent) || isSurroundedBy(rawVal, settings.quote);
 
                 if (!isValid && avoidEscape) {
                     isValid = isSurroundedBy(rawVal, settings.alternateQuote) && rawVal.indexOf(settings.quote) >= 0;

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -41,7 +41,15 @@ eslintTester.addRuleTest("lib/rules/quotes", {
         { code: "\"use strict\"; 'use strong'; \"use asm\"; var foo = `backtick`;", options: ["backtick"], ecmaFeatures: { templateStrings: true }},
         { code: "function foo() { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; }", options: ["backtick"], ecmaFeatures: { templateStrings: true }},
         { code: "(function() { 'use strict'; 'use strong'; 'use asm'; var foo = `backtick`; })();", options: ["backtick"], ecmaFeatures: { templateStrings: true }},
-        { code: "(() => { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; })();", options: ["backtick"], ecmaFeatures: { arrowFunctions: true, templateStrings: true }}
+        { code: "(() => { \"use strict\"; \"use strong\"; \"use asm\"; var foo = `backtick`; })();", options: ["backtick"], ecmaFeatures: { arrowFunctions: true, templateStrings: true }},
+
+        // `backtick` should not warn import/export sources.
+        { code: "import \"a\"; import 'b';", options: ["backtick"], ecmaFeatures: { modules: true, templateStrings: true }},
+        { code: "import a from \"a\"; import b from 'b';", options: ["backtick"], ecmaFeatures: { modules: true, templateStrings: true }},
+        { code: "export * from \"a\"; export * from 'b';", options: ["backtick"], ecmaFeatures: { modules: true, templateStrings: true }},
+
+        // `backtick` should not warn property names (not computed).
+        { code: "var obj = {\"key0\": 0, 'key1': 1};", options: ["backtick"], ecmaFeatures: { templateStrings: true }}
     ],
     invalid: [
         { code: "var foo = 'bar';",
@@ -83,6 +91,15 @@ eslintTester.addRuleTest("lib/rules/quotes", {
         { code: "if (1) { \"use strict\"; var foo = `backtick`; }",
           options: ["backtick"],
           ecmaFeatures: { templateStrings: true },
-          errors: [{ message: "Strings must use backtick.", type: "Literal" }]}
+          errors: [{ message: "Strings must use backtick.", type: "Literal" }]},
+
+        // `backtick` should not warn computed property names.
+        { code: "var obj = {[\"key0\"]: 0, ['key1']: 1};",
+          options: ["backtick"],
+          ecmaFeatures: { objectLiteralComputedProperties: true, templateStrings: true },
+          errors: [
+              { message: "Strings must use backtick.", type: "Literal" },
+              { message: "Strings must use backtick.", type: "Literal" }
+          ]}
     ]
 });


### PR DESCRIPTION
Fixes #3181.