### PR TITLE
Breaking: remove duplicate warnings of `no-undef` from `block-scoped-var`

### DIFF
--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -32,18 +32,6 @@ function collectUnresolvedReferences(context) {
     return unresolved;
 }
 
-/**
- * Checks whether or not there is a variable of a given name.
- * @param {escope.Variable[]} variables - An array of variables to be found.
- * @param {string} name - A name to find.
- * @returns {boolean} Whether or not there is a variable of the given name.
- */
-function exists(variables, name) {
-    return variables.some(function(variable) {
-        return variable.name === name;
-    });
-}
-
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -111,30 +99,10 @@ module.exports = function(context) {
             // In this case, use unresolved references.
             if (isGlobal && variable.name in unresolvedReferences) {
                 references = unresolvedReferences[variable.name];
-
-                // Remove processed references.
-                // In order to report references of undefined variables later.
-                delete unresolvedReferences[variable.name];
             }
 
             // Reports.
             references.filter(isOutsideOfScope).forEach(report);
-        }
-    }
-
-    /**
-     * Finds and reports references which are not resolved (same as no-undef).
-     * @returns {void}
-     */
-    function checkForUnresolvedReferences() {
-        var globals = context.getScope().variables;
-
-        for (var name in unresolvedReferences) {
-            // Skip built-in global variables.
-            // Those references are valid anywhere.
-            if (!exists(globals, name)) {
-                unresolvedReferences[name].forEach(report);
-            }
         }
     }
 
@@ -159,8 +127,7 @@ module.exports = function(context) {
         "CatchClause:exit": exitScope,
 
         // Finds and reports references which are outside of valid scope.
-        "VariableDeclaration": checkForVariables,
-        "Program:exit": checkForUnresolvedReferences
+        "VariableDeclaration": checkForVariables
     };
 
 };

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -77,6 +77,24 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         { code: "var doStuff; let {x: y} = {x: 1}; doStuff(y);", ecmaFeatures: { blockBindings: true, destructuring: true }},
         { code: "function foo({x: y}) { return y; }", ecmaFeatures: { blockBindings: true, destructuring: true }},
 
+        // those are the same as `no-undef`.
+        { code: "!function f(){}; f" },
+        { code: "var f = function foo() { }; foo(); var exports = { f: foo };" },
+        { code: "var f = () => { x; }", ecmaFeatures: { arrowFunctions: true } },
+        { code: "function f(){ x; }" },
+        { code: "var eslint = require('eslint');" },
+        { code: "function f(a) { return a[b]; }" },
+        { code: "function f() { return b.a; }" },
+        { code: "var a = { foo: bar };" },
+        { code: "var a = { foo: foo };" },
+        { code: "var a = { bar: 7, foo: bar };" },
+        { code: "var a = arguments;" },
+        { code: "function x(){}; var a = arguments;" },
+        { code: "function z(b){}; var a = b;" },
+        { code: "function z(){var b;}; var a = b;" },
+        { code: "function f(){ try{}catch(e){} e }" },
+        { code: "a:b;" },
+
         // https://github.com/eslint/eslint/issues/2253
         { code: "/*global React*/ let {PropTypes, addons: {PureRenderMixin}} = React; let Test = React.createClass({mixins: [PureRenderMixin]});", ecmaFeatures: { blockBindings: true, destructuring: true }},
         { code: "/*global prevState*/ const { virtualSize: prevVirtualSize = 0 } = prevState;", ecmaFeatures: { blockBindings: true, destructuring: true }},
@@ -90,26 +108,10 @@ eslintTester.addRuleTest("lib/rules/block-scoped-var", {
         { code: "(function () { foo(); })(); function foo() {}", ecmaFeatures: { modules: true }}
     ],
     invalid: [
-        { code: "!function f(){}; f", errors: [{ message: "\"f\" used outside of binding context." }] },
-        { code: "var f = function foo() { }; foo(); var exports = { f: foo };", errors: [{ message: "\"foo\" used outside of binding context." }, { message: "\"foo\" used outside of binding context."}] },
-        { code: "var f = () => { x; }", ecmaFeatures: { arrowFunctions: true }, errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function f(){ x; }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
         { code: "function f(){ x; { var x; } }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
         { code: "function f(){ { var x; } x; }", errors: [{ message: "\"x\" used outside of binding context.", type: "Identifier" }] },
         { code: "function f() { var a; { var b = 0; } a = b; }", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
         { code: "function f() { try { var a = 0; } catch (e) { var b = a; } }", errors: [{ message: "\"a\" used outside of binding context.", type: "Identifier" }] },
-        { code: "var eslint = require('eslint');", globals: {}, errors: [{ message: "\"require\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function f(a) { return a[b]; }", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function f() { return b.a; }", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
-        { code: "var a = { foo: bar };", errors: [{ message: "\"bar\" used outside of binding context.", type: "Identifier" }] },
-        { code: "var a = { foo: foo };", errors: [{ message: "\"foo\" used outside of binding context.", type: "Identifier" }] },
-        { code: "var a = { bar: 7, foo: bar };", errors: [{ message: "\"bar\" used outside of binding context.", type: "Identifier" }] },
-        { code: "var a = arguments;", errors: [{ message: "\"arguments\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function x(){}; var a = arguments;", errors: [{ message: "\"arguments\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function z(b){}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function z(){var b;}; var a = b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
-        { code: "function f(){ try{}catch(e){} e }", errors: [{ message: "\"e\" used outside of binding context.", type: "Identifier" }] },
-        { code: "a:b;", errors: [{ message: "\"b\" used outside of binding context.", type: "Identifier" }] },
         {
             code: "function a() { for(var b in {}) { var c = b; } c; }",
             errors: [{ message: "\"c\" used outside of binding context.", type: "Identifier" }]


### PR DESCRIPTION
Fixes #3201.