### PR TITLE
Docs: minor cleanup in spaced-comment rule

### DIFF
--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -4,143 +4,158 @@ Some style guides require or disallow a whitespace immediately after the initial
 Whitespace after the `//` or `/*` makes it easier to read text in comments.
 On the other hand, commenting out code is easier without having to put a whitespace right after the `//` or `/*`.
 
-
 ## Rule Details
 
 This rule will enforce consistency of spacing after the start of a comment `//` or `/*`.
 
-This rule takes two arguments. If the first is `"always"` then the `//` or `/*` must be followed by at least once whitespace.
-If `"never"` then there should be no whitespace following.
-The default is `"always"`.
+### Options
 
-The second argument is an object with two keys, `"exceptions"` and `"markers"`.
+The rule takes one option, a string, which could be either "always" or "never". If you pass `"always"` then the `//` or `/*` must be followed by at least once whitespace. If `"never"` then there should be no whitespace following. The default is `"always"`.
+
+Here is an example of how to configure the rule:
+
+```js
+"spaced-comment": [2, "always"]
+```
+
+#### Exceptions
+
+This rule can also take a 2nd option, an object with either of the following keys: `"exceptions"` and `"markers"`.
+
 The `"exceptions"` value is an array of string patterns which are considered exceptions to the rule.
 It is important to note that the exceptions are ignored if the first argument is `"never"`.
 
-Exceptions cannot be mixed. From the collection of exceptions provided only one of them can be used inside the comment. Mixing of more than one is not valid.
+```js
+"spaced-comment": [2, "always", "exceptions": ["-", "+"]]
+```
 
 The `"markers"` value is an array of string patterns which are considered markers for docblock-style comments,
 such as an additional `/`, used to denote documentation read by doxygen, vsdoc, etc. which must have additional characters.
 The `"markers"` array will apply regardless of the value of the first argument, e.g. `"always"` or `"never"`.
 
-The following patterns are considered warnings:
-
 ```js
-// When ["never"]
+"spaced-comment": [2, "always", "markers": ["/"]]
+```
+
+#### Examples
+
+The following patterns **are** considered warnings:
+
+Configuration: `[2, "never"]`
+```js
 // This is a comment with a whitespace at the beginning
 ```
 
+Configuration: `[2, "never"]`
 ```js
-// When ["never"]
 /* This is a comment with a whitespace at the beginning */
 ```
 
+Configuration: `[2, "never"]`
 ```js
-// When ["never"]
 /* \nThis is a comment with a whitespace at the beginning */
 ```
 
+Configuration: `[2, "always"]`
 ```js
-//When ["always"]
 //This is a comment with no whitespace at the beginning
 var foo = 5;
 ```
-
+ 
+Configuration: `[2, "always"]`
 ```js
-//When ["always"]
 /*This is a comment with no whitespace at the beginning */
 var foo = 5;
 ```
 
+Configuration: `[2, "always", { "exceptions": ["-", "+"] }]`
 ```js
-// When ["always",{"exceptions":["-","+"]}]
 //------++++++++
 // Comment block
 //------++++++++
 ```
 
+Configuration: `[2, "always", { "markers": ["/"] }]`
 ```js
-// When ["always",{"markers":["/"]}]
 ///This is a comment with a marker but without whitespace
 ```
 
+Configuration: `[2, "always", { "exceptions": ["-", "+"] }]`
 ```js
-// When ["always",{"exceptions":["-","+"]}]
 /*------++++++++*/
 /* Comment block */
 /*------++++++++*/
 ```
 
-The following patterns are not warnings:
+The following patterns **are not** warnings:
 
+Configuration: `[2, "always"]`
 ```js
-// When ["always"]
 // This is a comment with a whitespace at the beginning
 var foo = 5;
 ```
 
+Configuration: `[2, "always"]`
 ```js
-// When ["always"]
 /* This is a comment with a whitespace at the beginning */
 var foo = 5;
 ```
 
+Configuration: `[2, "always"]`
 ```js
-// When ["always"]
 /*\n * This is a comment with a whitespace at the beginning */
 var foo = 5;
 ```
 
-
+Configuration: `[2, "never"]`
 ```js
-//When ["never"]
 /*This is a comment with no whitespace at the beginning */
 var foo = 5;
 ```
 
+Configuration: `[2, "always", { "exceptions": ["-"] }]`
 ```js
-// When ["always",{"exceptions":["-"]}]
 //--------------
 // Comment block
 //--------------
 ```
 
+Options: `[2, "always", { "exceptions": ["-+"] }]`
 ```js
-// When ["always",{"exceptions":["-+"]}]
 //-+-+-+-+-+-+-+
 // Comment block
 //-+-+-+-+-+-+-+
 ```
 
+Configuration: `[2, "always", {"exceptions": ["-+"]} ]`
 ```js
-// When ["always",{"exceptions":["-+"]}]
 /*-+-+-+-+-+-+-+*/
 // Comment block
 /*-+-+-+-+-+-+-+*/
 ```
 
+Configuration: `[2, "always", { "markers": ["/"] }]`
 ```js
-// When ["always",{"markers":["/"]}]
 /// This is a comment with a marker
 ```
 
+Configuration: `[2, "never", { "markers": ["!<"] }]`
 ```js
-// When ["never",{"markers":["!<"]}]
 //!<This is a comment with a marker
 /*!<this is a block comment with a marker
 subsequent lines are ignored
 */
 ```
 
+Configuration: `[2, "always"]`
 ```js
-// When ["always"]
 /**
 * I am jsdoc
 */
 ```
 
+Configuration: `[2, "never"]`
 ```js
-// When ["never"]
 /**
 * I am jsdoc
 */


### PR DESCRIPTION
After #3017 I thought I'd take a stab at improving the `spaced-comment` docs to improve readability. Wasn't sure if I needed to file an issue, but happy to do so for a discussion first.

Most of things changed were:
- Moved configuration for each example out of the code block for clarity
- Removed a line about exceptions not being able to be combinable that seems contradicted by the examples
- Broke some things out into sections and sub-sections

I just did this in the github editor, so there may be some mistakes :)