### PR TITLE
Docs: Update no-proto.md

### DIFF
--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -1,4 +1,4 @@
-# Disallow Use of __proto__ (no-proto)
+# Disallow Use of `__proto__` (no-proto)
 
 `__proto__` property has been deprecated as of ECMAScript 3.1 and shouldn't be used in the code. Use `getPrototypeOf` method instead.
 


### PR DESCRIPTION
Markdown interpreter was converting the double underscore into bold. I escaped the first underscore to prevent the misinterpretation.