### PR TITLE
Docs: Fix wrong options in examples of key-spacing

### DIFF
--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -95,7 +95,7 @@ call({
     b :  []
 });
 
-// "key-spacing": [2, { "align": "colon" }]
+// "key-spacing": [2, { "align": "value" }]
 // beforeColon and afterColon default to false and true, respectively
 var obj = { a: "foo", longPropertyName: "bar" };
 ```
@@ -131,7 +131,7 @@ var obj = {
 };
 
 // "key-spacing": [2, {
-//     "align": "value",
+//     "align": "colon",
 //     "beforeColon": true,
 //     "afterColon": false
 // }]
@@ -145,7 +145,7 @@ obj = {
 The following patterns are considered warnings:
 
 ```js
-// "key-spacing": [2, { "align": "value" }]
+// "key-spacing": [2, { "align": "colon" }]
 // beforeColon and afterColon default to false and true, respectively
 var obj = {
     one:   1, // Missing space before colon


### PR DESCRIPTION
Probably wrong