### PR TITLE
Fix: `indent` rule for objects and nested one line blocks (fixes #323…

### DIFF
--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -9,30 +9,30 @@
 //------------------------------------------------------------------------------
 
 var PASSTHROUGHS = [
-        "getAllComments",
-        "getAncestors",
-        "getComments",
-        "getDeclaredVariables",
-        "getFilename",
-        "getFirstToken",
-        "getFirstTokens",
-        "getJSDocComment",
-        "getLastToken",
-        "getLastTokens",
-        "getNodeByRangeIndex",
-        "getScope",
-        "getSource",
-        "getSourceLines",
-        "getTokenAfter",
-        "getTokenBefore",
-        "getTokenByRangeStart",
-        "getTokens",
-        "getTokensAfter",
-        "getTokensBefore",
-        "getTokensBetween",
-        "markVariableAsUsed",
-        "isMarkedAsUsed"
-    ];
+    "getAllComments",
+    "getAncestors",
+    "getComments",
+    "getDeclaredVariables",
+    "getFilename",
+    "getFirstToken",
+    "getFirstTokens",
+    "getJSDocComment",
+    "getLastToken",
+    "getLastTokens",
+    "getNodeByRangeIndex",
+    "getScope",
+    "getSource",
+    "getSourceLines",
+    "getTokenAfter",
+    "getTokenBefore",
+    "getTokenByRangeStart",
+    "getTokens",
+    "getTokensAfter",
+    "getTokensBefore",
+    "getTokensBetween",
+    "markVariableAsUsed",
+    "isMarkedAsUsed"
+];
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -208,6 +208,20 @@ module.exports = function(context) {
     }
 
     /**
+     * Check to see if the node is part of the multi-line variable declaration.
+     * Also if its on the same line as the parent
+     * @param {ASTNode} node node to check
+     * @returns {boolean} True if all the above condition staisfy
+     */
+    function isNodeInVarOnTop(node) {
+        var parent = node.parent.type === "VariableDeclarator" ? node.parent : node.parent.parent;
+
+        return parent.type === "VariableDeclarator" &&
+            parent.parent.loc.start.line === node.loc.start.line &&
+            parent.parent.declarations.length > 1;
+    }
+
+    /**
      * Check indent for array block content or object block content
      * @param {ASTNode} node node to examine
      * @returns {void}
@@ -228,10 +242,11 @@ module.exports = function(context) {
         var nodeIndent = getNodeIndent(node);
 
         var elementsIndent = nodeIndent + indentSize;
-        // Elements can have double indent (detected by first item)
-        if (elements.length > 0 &&
-            getNodeIndent(elements[0]) === elementsIndent + indentSize) {
-            elementsIndent = elementsIndent + indentSize;
+
+        // check if the node is a multiple variable declartion, if yes then make sure indetation takes into account
+        // variable indentation concept
+        if (isNodeInVarOnTop(node)) {
+            elementsIndent += indentSize * options.VariableDeclarator;
         }
 
         // Comma can be placed before property name
@@ -245,6 +260,16 @@ module.exports = function(context) {
         }
 
         checkLastNodeLineIndent(node, elementsIndent - indentSize);
+    }
+
+    /**
+     * Check if the node or node body is a BlockStatement or not
+     * @param {ASTNode} node node to test
+     * @returns {boolean} True if it or its body is a block statement
+     */
+    function isNodeBodyBlock(node) {
+        return node.type === "BlockStatement" || (node.body && node.body.type === "BlockStatement") ||
+            (node.consequent && node.consequent.type === "BlockStatement");
     }
 
     /**
@@ -272,7 +297,7 @@ module.exports = function(context) {
             "IfStatement", "WhileStatement", "ForStatement", "ForInStatement", "ForOfStatement", "DoWhileStatement"
         ];
 
-        if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1) {
+        if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1 && isNodeBodyBlock(node)) {
             indent = getNodeIndent(node.parent);
         } else {
             indent = getNodeIndent(node);

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -592,10 +592,10 @@ describe("eslint", function() {
 
     describe("when retrieving comments", function() {
         var code = [
-                "// my line comment",
-                "var a = 42;",
-                "/* my block comment */"
-            ].join("\n");
+            "// my line comment",
+            "var a = 42;",
+            "/* my block comment */"
+        ].join("\n");
 
         it("should attach them to all nodes", function() {
             function assertCommentCount(leading, trailing) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -40,6 +40,77 @@ ruleTester.run("indent", rule, {
     valid: [
         {
             code:
+            "var a = new abc({\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    }),\n" +
+            "    b = 2;",
+            options: [4, {"VariableDeclarator": 1, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "var a = 2,\n" +
+            "  c = {\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "  },\n" +
+            "  b = 2;",
+            options: [2, {"VariableDeclarator": 1, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "var x = 2,\n" +
+            "    y = {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    },\n" +
+            "    b = 2;",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "var e = {\n" +
+            "      a: 1,\n" +
+            "      b: 2\n" +
+            "    },\n" +
+            "    b = 2;",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "var a = {\n" +
+            "  a: 1,\n" +
+            "  b: 2\n" +
+            "};",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "function test() {\n" +
+            "  if (true ||\n " +
+            "            false){\n" +
+            "    console.log(val);\n" +
+            "  }\n" +
+            "}",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "for (var val in obj)\n" +
+            "  if (true)\n" +
+            "    console.log(val);",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "if(true)\n" +
+            "  if (true)\n" +
+            "    if (true)\n" +
+            "      console.log(val);",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}]
+        },
+        {
+            code:
             "function hi(){     var a = 1;\n" +
             "  y++;                   x++;\n" +
             "}",
@@ -172,14 +243,6 @@ ruleTester.run("indent", rule, {
             "});\n",
             options: [4],
             ecmaFeatures: { arrowFunctions: true }
-        },
-        {
-            code:
-            "var a = new Test({\n" +
-            "        a: 1\n" +
-            "    }),\n" +
-            "    b = 4;\n",
-            options: [4]
         },
         {
             code:
@@ -434,15 +497,15 @@ ruleTester.run("indent", rule, {
                 [305, 6, 4, "ExpressionStatement"],
                 [306, 6, 8, "ExpressionStatement"],
                 [308, 2, 4, "VariableDeclarator"],
-                [311, 2, 6, "Identifier"],
-                [312, 2, 6, "Identifier"],
-                [313, 2, 6, "Identifier"],
-                [314, 0, 4, "ArrayExpression"],
+                [311, 4, 6, "Identifier"],
+                [312, 4, 6, "Identifier"],
+                [313, 4, 6, "Identifier"],
+                [314, 2, 4, "ArrayExpression"],
                 [315, 2, 4, "VariableDeclarator"],
-                [318, 2, 6, "Property"],
-                [319, 2, 6, "Property"],
-                [320, 2, 6, "Property"],
-                [321, 0, 4, "ObjectExpression"],
+                [318, 4, 6, "Property"],
+                [319, 4, 6, "Property"],
+                [320, 4, 6, "Property"],
+                [321, 2, 4, "ObjectExpression"],
                 [322, 2, 4, "VariableDeclarator"],
                 [326, 2, 1, "Literal"],
                 [327, 2, 1, "Literal"],
@@ -810,6 +873,53 @@ ruleTester.run("indent", rule, {
             },
             errors: expectedErrors([
                 [2, 4, 2, "VariableDeclarator"]
+            ])
+        },
+        {
+            code:
+            "if(true)\n" +
+            "  if (true)\n" +
+            "    if (true)\n" +
+            "    console.log(val);",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}],
+            errors: expectedErrors([
+                [4, 6, 4, "ExpressionStatement"]
+            ])
+        },
+        {
+            code:
+            "var a = {\n" +
+            "    a: 1,\n" +
+            "    b: 2\n" +
+            "}",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}],
+            errors: expectedErrors([
+                [2, 2, 4, "Property"],
+                [3, 2, 4, "Property"]
+            ])
+        },
+        {
+            code:
+            "var a = [\n" +
+            "    a,\n" +
+            "    b\n" +
+            "]",
+            options: [2, {"VariableDeclarator": 2, "SwitchCase": 1}],
+            errors: expectedErrors([
+                [2, 2, 4, "Identifier"],
+                [3, 2, 4, "Identifier"]
+            ])
+        },
+        {
+            code:
+            "var a = new Test({\n" +
+            "      a: 1\n" +
+            "  }),\n" +
+            "    b = 4;\n",
+            options: [4],
+            errors: expectedErrors([
+                [2, 8, 6, "Property"],
+                [3, 4, 2, "ObjectExpression"]
             ])
         }
     ]

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -17,16 +17,16 @@ function invalid(code, type, line, config) {
     config = config || {};
 
     var result = {
-            code: code,
-            ecmaFeatures: config.ecmaFeatures || {},
-            errors: [
-                {
-                    message: "Gratuitous parentheses around expression.",
-                    type: type
-                }
-            ],
-            options: config.options || []
-        };
+        code: code,
+        ecmaFeatures: config.ecmaFeatures || {},
+        errors: [
+            {
+                message: "Gratuitous parentheses around expression.",
+                type: type
+            }
+        ],
+        options: config.options || []
+    };
 
     if (line) {
         result.errors[0].line = line;


### PR DESCRIPTION
…8, fixes #3237)