### PR TITLE
Fix: use correct encoding for id-match.md (fixes #3246)

### DIFF
--- a/docs/rules/id-match.md
+++ b/docs/rules/id-match.md
@@ -1,6 +1,6 @@
 # Require IDs to match a pattern (id-match)
 
-> "There are only two hard things in Computer Science: cache invalidation and naming things." — Phil Karlton
+> "There are only two hard things in Computer Science: cache invalidation and naming things." â€” Phil Karlton
 
 Naming things consistently in a project is an often underestimated aspect of code creation.
 When done right, it can save your team hours of unnecessary head scratching and misdirections.


### PR DESCRIPTION
The documentation is making use of a non ascii character to delimit the citation from its author. As the file is not utf-8 encoded, it ends up with the missing character glyph when displayed. This PR sets the correct encoding (UTF-8) on the file.