### PR TITLE
Update: Check for default assignment in no-unneeded-ternary (fixes #3232)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -169,7 +169,7 @@ These rules are purely matters of style and are quite subjective.
 * [no-ternary](no-ternary.md) - disallow the use of ternary operators
 * [no-trailing-spaces](no-trailing-spaces.md) - disallow trailing whitespace at the end of lines
 * [no-underscore-dangle](no-underscore-dangle.md) - disallow dangling underscores in identifiers
-* [no-unneeded-ternary](no-unneeded-ternary.md) - disallow the use of `Boolean` literals in conditional expressions
+* [no-unneeded-ternary](no-unneeded-ternary.md) - disallow the use of ternary operators when a simpler alternative exists
 * [object-curly-spacing](object-curly-spacing.md) - require or disallow padding inside curly braces
 * [one-var](one-var.md) - require or disallow one variable declaration per function
 * [operator-assignment](operator-assignment.md) - require assignment operator shorthand where possible or prohibit it entirely

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -1,4 +1,4 @@
-# Disallow boolean literals in conditional expressions (no-unneeded-ternary)
+# Disallow conditional expressions that can be expressed with simpler constructs (no-unneeded-ternary)
 
 It's a common mistake in JavaScript to use a conditional expression to select between two Boolean values instead of using ! to convert the test to a Boolean.
 Here are some examples:
@@ -20,9 +20,22 @@ var isYes = answer !== 1;
 
 This rule disallows the use of 'Boolean' literals inside conditional expressions.
 
+Another common mistake is using a single variable as both the conditional test and the consequent. In such cases, the logical `OR` can be used to provide the same functionality.
+Here is an example:
+
+```js
+// Bad
+var foo = bar ? bar : 1;
+
+// Good
+var foo = bar || 1;
+```
+
+This rule disallows the conditional expression as a default assignment pattern when the `defaultAssignment` option is set to `false`.
+
 ## Rule Details
 
-This rule enforces a coding style where it disallows the use of Boolean literals inside conditional expressions.
+This rule enforces a coding style where it disallows conditional expressions that can be implemented using simpler language constructs. Specifically, this rule disallows the use of Boolean literals inside conditional expressions, and conditional expressions where a single variable is used as both the test and consequent. This rule's default options are `{"defaultAssignment": true }`.
 
 The following patterns are considered warnings:
 
@@ -32,14 +45,30 @@ var a = x === 2 ? true : false;
 var a = x ? true : false;
 ```
 
+The following pattern is considered a warning when `defaultAssignment` is `false`:
+
+```js
+var a = x ? x : 1;
+```
+
 The following patterns are not considered warnings:
 
 ```js
 var a = x === 2 ? "Yes" : "No";
 
 var a = x !== false;
+
+var a = x ? "Yes" : "No";
+
+var a = x ? y : x;
+```
+
+The following pattern is not considered a warning when `defaultAssignment` is `true`:
+
+```js
+var a = x ? x : 1;
 ```
 
 ## When Not To Use It
 
-You can turn this rule off if you are not concerned with booleans in conditional expressions.
+You can turn this rule off if you are not concerned with unnecessary complexity in conditional expressions.

--- a/tests/lib/rules/no-unneeded-ternary.js
+++ b/tests/lib/rules/no-unneeded-ternary.js
@@ -23,7 +23,16 @@ ruleTester.run("no-unneeded-ternary", rule, {
         "var a = x === 2 ? 'Yes' : 'No';",
         "var a = x === 2 ? true : 'No';",
         "var a = x === 2 ? 'Yes' : false;",
-        "var a = x === 2 ? 'true' : 'false';"
+        "var a = x === 2 ? 'true' : 'false';",
+        "var a = foo ? foo : bar;",
+        {
+            code: "var a = foo ? 'Yes' : foo;",
+            options: [{defaultAssignment: false}]
+        },
+        {
+            code: "var a = foo ? bar : foo;",
+            options: [{defaultAssignment: false}]
+        }
     ],
     invalid: [
         {
@@ -33,6 +42,16 @@ ruleTester.run("no-unneeded-ternary", rule, {
                 type: "ConditionalExpression",
                 line: 1,
                 column: 19
+            }]
+        },
+        {
+            code: "var a = foo ? foo : 'No';",
+            options: [{defaultAssignment: false}],
+            errors: [{
+                message: "Unnecessary use of conditional expression for default assignment",
+                type: "ConditionalExpression",
+                line: 1,
+                column: 15
             }]
         }
     ]


### PR DESCRIPTION
Add ability to check for `x ? x : y` pattern, which can be rewritten as `x || y`. Adds `noDefaultAssignment` option to `no-unneeded-ternary` rule. Defaults to off for backwards compatibility. Closes #3232.