### PR TITLE
Fix: `context.getScope()` in blockBindings

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -1041,7 +1041,7 @@ module.exports = (function() {
             // if current node introduces a scope, add it to the list
             var current = controller.current();
             if (currentConfig.ecmaFeatures.blockBindings) {
-                if (["BlockStatement", "SwitchStatement", "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
+                if (["BlockStatement", "SwitchStatement", "CatchClause", "FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression"].indexOf(current.type) >= 0) {
                     parents.push(current);
                 }
             } else {

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -946,6 +946,45 @@ describe("eslint", function() {
 
             eslint.verify("if (true) { let x = 1 }", config, filename, true);
         });
+
+        it("should retrieve the function scope correctly from within a FunctionDeclaration", function() {
+            var config = { rules: {}, ecmaFeatures: { blockBindings: true } };
+
+            eslint.reset();
+            eslint.on("FunctionDeclaration", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "function");
+                assert.equal(scope.block.type, "FunctionDeclaration");
+            });
+
+            eslint.verify("function foo() {}", config, filename, true);
+        });
+
+        it("should retrieve the function scope correctly from within a FunctionExpression", function() {
+            var config = { rules: {}, ecmaFeatures: { blockBindings: true } };
+
+            eslint.reset();
+            eslint.on("FunctionExpression", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "function");
+                assert.equal(scope.block.type, "FunctionExpression");
+            });
+
+            eslint.verify("(function foo() {})();", config, filename, true);
+        });
+
+        it("should retrieve the catch scope correctly from within a CatchClause", function() {
+            var config = { rules: {}, ecmaFeatures: { blockBindings: true } };
+
+            eslint.reset();
+            eslint.on("CatchClause", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "catch");
+                assert.equal(scope.block.type, "CatchClause");
+            });
+
+            eslint.verify("try {} catch (err) {}", config, filename, true);
+        });
     });
 
     describe("marking variables as used", function() {

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -484,6 +484,15 @@ var patterns = [
         errors: errors,
         valid: [NORMAL, USE_STRICT, MODULES],
         invalid: []
+    },
+
+    // https://github.com/eslint/eslint/issues/3254
+    {
+        code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
+        ecmaFeatures: {arrowFunctions: true, blockBindings: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
     }
 ];
 


### PR DESCRIPTION
Fixes #3254.

I found there is the same problem at `CatchClause`, I fixed it.