### PR TITLE
Fix: `accessor-pairs` false positive

### DIFF
--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -7,6 +7,62 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a given node is an `Identifier` node which was named a given name.
+ * @param {ASTNode} node - A node to check.
+ * @param {string} name - An expected name of the node.
+ * @returns {boolean} `true` if the node is an `Identifier` node which was named as expected.
+ */
+function isIdentifier(node, name) {
+    return node.type === "Identifier" && node.name === name;
+}
+
+/**
+ * Checks whether or not a given node is an argument of a specified method call.
+ * @param {ASTNode} node - A node to check.
+ * @param {number} index - An expected index of the node in arguments.
+ * @param {string} object - An expected name of the object of the method.
+ * @param {string} property - An expected name of the method.
+ * @returns {boolean} `true` if the node is an argument of the specified method call.
+ */
+function isArgumentOfMethodCall(node, index, object, property) {
+    var parent = node.parent;
+    return (
+        parent.type === "CallExpression" &&
+        parent.callee.type === "MemberExpression" &&
+        parent.callee.computed === false &&
+        isIdentifier(parent.callee.object, object) &&
+        isIdentifier(parent.callee.property, property) &&
+        parent.arguments[index] === node
+    );
+}
+
+/**
+ * Checks whether or not a given node is a property descriptor.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node is a property descriptor.
+ */
+function isPropertyDescriptor(node) {
+    // Object.defineProperty(obj, "foo", {set: ...})
+    if (isArgumentOfMethodCall(node, 2, "Object", "defineProperty") ||
+        isArgumentOfMethodCall(node, 2, "Reflect", "defineProperty")
+    ) {
+        return true;
+    }
+
+    // Object.defineProperties(obj, {foo: {set: ...}})
+    // Object.create(proto, {foo: {set: ...}})
+    node = node.parent.parent;
+    return node.type === "ObjectExpression" && (
+        isArgumentOfMethodCall(node, 1, "Object", "create") ||
+        isArgumentOfMethodCall(node, 1, "Object", "defineProperties")
+    );
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -24,10 +80,19 @@ module.exports = function(context) {
     function checkLonelySetGet(node) {
         var isSetPresent = false;
         var isGetPresent = false;
-        var propLength = node.properties.length;
+        var isDescriptor = isPropertyDescriptor(node);
 
-        for (var i = 0; i < propLength; i++) {
-            var propToCheck = node.properties[i].kind === "init" ? node.properties[i].key.name : node.properties[i].kind;
+        for (var i = 0, end = node.properties.length; i < end; i++) {
+            var property = node.properties[i];
+
+            var propToCheck = "";
+            if (property.kind === "init") {
+                if (isDescriptor && !property.computed) {
+                    propToCheck = property.key.name;
+                }
+            } else {
+                propToCheck = property.kind;
+            }
 
             switch (propToCheck) {
                 case "set":

--- a/tests/lib/rules/accessor-pairs.js
+++ b/tests/lib/rules/accessor-pairs.js
@@ -34,7 +34,15 @@ ruleTester.run("accessor-pairs", rule, {
             options: [{
                 setWithoutGet: false
             }]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/3262
+        {code: "var o = {set: function() {}}"},
+        {code: "Object.defineProperties(obj, {set: {value: function() {}}});"},
+        {code: "Object.create(null, {set: {value: function() {}}});"},
+        {code: "var o = {get: function() {}}", options: [{getWithoutSet: true}]},
+        {code: "var o = {[set]: function() {}}", ecmaFeatures: {objectLiteralComputedProperties: true}},
+        {code: "var set = 'value'; Object.defineProperty(obj, 'foo', {[set]: function(value) {}});", ecmaFeatures: {objectLiteralComputedProperties: true}}
     ],
     invalid: [
         {
@@ -54,6 +62,24 @@ ruleTester.run("accessor-pairs", rule, {
         },
         {
             code: "var o = {d: 1};\n Object.defineProperty(o, 'c', \n{set: function(value) {\n val = value; \n} \n});",
+            errors: [{
+                message: "Getter is not present"
+            }]
+        },
+        {
+            code: "Reflect.defineProperty(obj, 'foo', {set: function(value) {}});",
+            errors: [{
+                message: "Getter is not present"
+            }]
+        },
+        {
+            code: "Object.defineProperties(obj, {foo: {set: function(value) {}}});",
+            errors: [{
+                message: "Getter is not present"
+            }]
+        },
+        {
+            code: "Object.create(null, {foo: {set: function(value) {}}});",
             errors: [{
                 message: "Getter is not present"
             }]


### PR DESCRIPTION
Fixes #3262.

Checks whether or not each object literal is a property descriptor.