### PR TITLE
Fix: `no-invalid-this` had been missing jsdoc comment.

### DIFF
--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -35,6 +35,15 @@ function isES5Constructor(node) {
  * @returns {boolean} Whether or not the node has a `@this` tag in its comments.
  */
 function hasJSDocThisTag(node) {
+    var jsdocComment = astUtils.getJSDocComment(node);
+    if (jsdocComment != null && thisTagPattern.test(jsdocComment.value)) {
+        return true;
+    }
+
+    // Checks `@this` in its leading comments for callbacks,
+    // because callbacks don't have its JSDoc comment.
+    // e.g.
+    //     sinon.test(/* @this sinon.Sandbox */function() { this.spy(); });
     return astUtils.getComments(node).leading.some(function(comment) {
         return thisTagPattern.test(comment.value);
     });

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -493,6 +493,14 @@ var patterns = [
         errors: errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, MODULES]
+    },
+
+    // https://github.com/eslint/eslint/issues/3287
+    {
+        code: "function foo() { /** @this Obj*/ return function bar() { console.log(this); z(x => console.log(x, this)); }; }",
+        ecmaFeatures: {arrowFunctions: true},
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
     }
 ];
 


### PR DESCRIPTION
Fixes #3287.