### PR TITLE
Fix: `eslint-env` in comments had not been setting `ecmaFeatures`

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -391,7 +391,7 @@ function prepareConfig(config) {
     // merge in environment ecmaFeatures
     if (typeof config.env === "object") {
         Object.keys(config.env).forEach(function(env) {
-            if (config.env[env] && environments[env].ecmaFeatures) {
+            if (config.env[env] && environments[env] && environments[env].ecmaFeatures) {
                 assign(ecmaFeatures, environments[env].ecmaFeatures);
             }
         });
@@ -446,6 +446,24 @@ function getRuleReplacementMessage(ruleId) {
         var newRules = replacements.rules[ruleId];
         return "Rule \'" + ruleId + "\' was removed and replaced by: " + newRules.join(", ");
     }
+}
+
+var eslintEnvPattern = /\/\*\s*eslint-env\s(.+?)\*\//g;
+
+/**
+ * Checks whether or not there is a comment which has "eslint-env *" in a given text.
+ * @param {string} text - A source code text to check.
+ * @returns {object|null} A result of parseListConfig() with "eslint-env *" comment.
+ */
+function findEslintEnv(text) {
+    var match, retv;
+
+    eslintEnvPattern.lastIndex = 0;
+    while ((match = eslintEnvPattern.exec(text)) != null) {
+        retv = assign(retv || {}, parseListConfig(match[1]));
+    }
+
+    return retv;
 }
 
 //------------------------------------------------------------------------------
@@ -657,6 +675,17 @@ module.exports = (function() {
         if (text.trim().length === 0) {
             currentText = text;
             return messages;
+        }
+
+        // search and apply "eslint-env *".
+        var envInFile = findEslintEnv(text);
+        if (envInFile != null) {
+            if (config == null || config.env == null) {
+                config = assign({}, config || {}, {env: envInFile});
+            } else {
+                config = assign({}, config);
+                config.env = assign({}, config.env, envInFile);
+            }
         }
 
         // process initial config to make it safe to extend

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -2167,6 +2167,39 @@ describe("eslint", function() {
                 }
             }, "filename");
         });
+
+        it("should be able to use es6 features if there is a comment which has \"eslint-env es6\"", function() {
+            var code = [
+                "/* eslint-env es6 */",
+                "var arrow = () => 0;",
+                "var binary = 0b1010;",
+                "{ let a = 0; const b = 1; }",
+                "class A {}",
+                "function defaultParams(a = 0) {}",
+                "var {a = 1, b = 2} = {};",
+                "for (var a of []) {}",
+                "function* generator() { yield 0; }",
+                "var computed = {[a]: 0};",
+                "var duplicate = {dup: 0, dup: 1};",
+                "var method = {foo() {}};",
+                "var property = {a, b};",
+                "var octal = 0o755;",
+                "var u = /^.$/u.test('𠮷');",
+                "var y = /hello/y.test('hello');",
+                "function restParam(a, ...rest) {}",
+                "function superInFunc() { super.foo(); }",
+                "var template = `hello, ${a}`;",
+                "var unicode = '\\u{20BB7}';"
+            ].join("\n");
+
+            var messages = eslint.verify(code, null, "eslint-env es6");
+            assert.equal(messages.length, 0);
+        });
+
+        it("should be able to return in global if there is a comment which has \"eslint-env node\"", function() {
+            var messages = eslint.verify("/* eslint-env node */ return;", null, "eslint-env node");
+            assert.equal(messages.length, 0);
+        });
     });
 
     describe("getDeclaredVariables(node)", function() {


### PR DESCRIPTION
Fixes #2134.

- `es6` enables es6 features.
- `node` enables `globalReturn`.

This logic is simple searching with regular expressions.