### PR TITLE
Fix: Indent rule errors if an array literal starts a new statement (fixes #3328)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -240,7 +240,7 @@ module.exports = function(context) {
     }
 
     /**
-     * Check to see if the first element inside an array ia an object and on the same line as the node
+     * Check to see if the first element inside an array is an object and on the same line as the node
      * If the node is not an array then it will return false.
      * @param {ASTNode} node node to check
      * @returns {boolean} success/failure
@@ -299,17 +299,16 @@ module.exports = function(context) {
         if (isNodeFirstInLine(node)) {
             var parentVarNode = getVariableDeclaratorNode(node);
             var parent = node.parent;
-            if (parent.type === "MemberExpression") {
-                parent = node.parent.parent;
+            var effectiveParent = parent;
 
+            if (parent.type === "MemberExpression") {
                 if (isNodeFirstInLine(parent)) {
-                    nodeIndent = getNodeIndent(parent.parent);
+                    effectiveParent = parent.parent.parent;
                 } else {
-                    nodeIndent = getNodeIndent(parent);
+                    effectiveParent = parent.parent;
                 }
-            } else {
-                nodeIndent = getNodeIndent(parent);
             }
+            nodeIndent = getNodeIndent(effectiveParent);
 
             if (parentVarNode && parentVarNode.loc.start.line !== node.loc.start.line) {
                 if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
@@ -317,7 +316,7 @@ module.exports = function(context) {
                 } else if (parent.loc.start.line !== node.loc.start.line && parentVarNode === parentVarNode.parent.declarations[0]) {
                     nodeIndent = nodeIndent + indentSize;
                 }
-            } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent)) {
+            } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && effectiveParent.type !== "ExpressionStatement") {
                 nodeIndent = nodeIndent + indentSize;
             }
 
@@ -328,7 +327,7 @@ module.exports = function(context) {
             elementsIndent = nodeIndent + indentSize;
         }
 
-        // check if the node is a multiple variable declartion, if yes then make sure indetation takes into account
+        // check if the node is a multiple variable declaration, if yes then make sure indentation takes into account
         // variable indentation concept
         if (isNodeInVarOnTop(node)) {
             elementsIndent += indentSize * options.VariableDeclarator;

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -47,6 +47,18 @@ ruleTester.run("indent", rule, {
         },
         {
             code:
+            "[\n" +
+            "  ['gzip', 'gunzip'],\n" +
+            "  ['gzip', 'unzip'],\n" +
+            "  ['deflate', 'inflate'],\n" +
+            "  ['deflateRaw', 'inflateRaw'],\n" +
+            "].forEach(function(method) {\n" +
+            "  console.log(method);\n" +
+            "});\n",
+            options: [2, {"SwitchCase": 1, "VariableDeclarator": 2}]
+        },
+        {
+            code:
             "test(123, {\n" +
             "    bye: {\n" +
             "        hi: [1,\n" +


### PR DESCRIPTION
This might be a bit of a blatant fix but didn't break any existing tests so I guess it is okay.