### PR TITLE
Docs: remove note outdated in 1.0.0

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -143,7 +143,7 @@ These rules are purely matters of style and are quite subjective.
 * [eol-last](eol-last.md) - enforce newline at the end of file, with no multiple empty lines
 * [func-names](func-names.md) - require function expressions to have a name
 * [func-style](func-style.md) - enforce use of function declarations or expressions
-* [id-length](id-length.md) - this option enforces minimum and maximum identifier lengths (variable names, property names etc.) (off by default)
+* [id-length](id-length.md) - this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
 * [id-match](id-match.md) - require identifiers to match the provided regular expression
 * [indent](indent.md) - specify tab or space width for your code
 * [key-spacing](key-spacing.md) - enforce spacing between keys and values in object literal properties


### PR DESCRIPTION
Remove "off by default" that has no meaning since all rules are off by default since 1.0.0.