### PR TITLE
Fix: trailing commas in object-curly-spacing for import/export (fixes #3324)

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -160,6 +160,13 @@ module.exports = function(context) {
                 second = context.getFirstToken(firstSpecifier);
                 penultimate = context.getLastToken(lastSpecifier);
                 last = context.getTokenAfter(lastSpecifier);
+
+                // support trailing commas
+                if (last.value === ",") {
+                    penultimate = last;
+                    last = context.getTokenAfter(last);
+                }
+
                 validateBraceSpacing(node, first, second, penultimate, last);
                 return;
             }
@@ -170,6 +177,12 @@ module.exports = function(context) {
                 second = context.getFirstToken(importSpecifiers[0]);
                 penultimate = context.getLastToken(importSpecifiers[importSpecifiers.length - 1]);
                 last = context.getTokenAfter(importSpecifiers[importSpecifiers.length - 1]);
+
+                // support trailing commas
+                if (last.value === ",") {
+                    penultimate = last;
+                    last = context.getTokenAfter(last);
+                }
 
                 validateBraceSpacing(node, first, second, penultimate, last);
             }

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -49,7 +49,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "export { door }", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import 'room'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import { bar as x } from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
-
+        { code: "import { x, } from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "import {\nx,\n} from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
 
         // always - empty object
         { code: "var foo = {};", options: ["always"] },
@@ -258,7 +259,49 @@ ruleTester.run("object-curly-spacing", rule, {
                     line: 1,
                     column: 20
                 }
+            ]
+        },
+        {
+            code: "import {bar,} from 'foo';",
+            options: ["always"],
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 8
+                },
+                {
+                    message: "A space is required before '}'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 13
+                }
 
+            ]
+        },
+        {
+            code: "import { bar, } from 'foo';",
+            options: ["never"],
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [
+                {
+                    message: "There should be no space after '{'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 8
+                },
+                {
+                    message: "There should be no space before '}'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 15
+                }
             ]
         },
         {


### PR DESCRIPTION
For #3324 

Depends on https://github.com/eslint/espree/pull/186 being merged first + new version