### PR TITLE
Fix: Indent rule errors with array of objects (fixes #3329)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -142,7 +142,10 @@ module.exports = function(context) {
     function checkNodesIndent(nodes, indent, excludeCommas) {
         nodes.forEach(function(node) {
             var nodeIndent = getNodeIndent(node, false, excludeCommas);
-            if (nodeIndent !== indent && isNodeFirstInLine(node)) {
+            if (
+                node.type !== "ArrayExpression" && node.type !== "ObjectExpression" &&
+                nodeIndent !== indent && isNodeFirstInLine(node)
+            ) {
                 report(node, indent, nodeIndent);
             }
         });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -615,6 +615,15 @@ ruleTester.run("indent", rule, {
                 "  }\n" +
                 "}\n",
             options: [2, { SwitchCase: 1 }]
+        },
+        {
+            code:
+                "var items = [\n" +
+                "    {\n" +
+                "      foo: 'bar'\n" +
+                "    }\n" +
+                "];\n",
+            options: [2, {"VariableDeclarator": 2}]
         }
     ],
     invalid: [


### PR DESCRIPTION
May not be the greatest fix for #3329 but it at least avoids double checking Array and Object expressions with conflicting rules so fixing the "infinite" or "unfixable" state that is caused by setting the `VariableDeclarator` option.

Now I'd argue that this is also the expected behavior but I leave that decision to the reviewers and the author of the issue.