### PR TITLE
Fix: object curly spacing incorrectly warning for import with default and multiple named specifiers

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -149,6 +149,9 @@ module.exports = function(context) {
 
             var firstSpecifier = node.specifiers[0],
                 lastSpecifier = node.specifiers[node.specifiers.length - 1],
+                importSpecifiers = node.specifiers.filter(function(specifier) {
+                    return specifier.type === "ImportSpecifier";
+                }),
                 first, second, penultimate, last;
 
             // import { x, y } from 'foo'
@@ -163,10 +166,11 @@ module.exports = function(context) {
 
             // import a, { b, c } from 'foo'
             if (lastSpecifier && lastSpecifier.type === "ImportSpecifier") {
-                first = context.getTokenBefore(lastSpecifier);
-                second = context.getFirstToken(lastSpecifier);
-                penultimate = context.getLastToken(lastSpecifier);
-                last = context.getTokenAfter(lastSpecifier);
+                first = context.getTokenBefore(importSpecifiers[0]);
+                second = context.getFirstToken(importSpecifiers[0]);
+                penultimate = context.getLastToken(importSpecifiers[importSpecifiers.length - 1]);
+                last = context.getTokenAfter(importSpecifiers[importSpecifiers.length - 1]);
+
                 validateBraceSpacing(node, first, second, penultimate, last);
             }
 

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -45,6 +45,7 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "export { door } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import { house, mouse } from 'caravan'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import house, { mouse } from 'caravan'", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "import door, { house, mouse } from 'caravan'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "export { door }", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import 'room'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import { bar as x } from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
@@ -99,6 +100,7 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "export {door}", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "import 'room'", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "import x, {bar} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import x, {bar, baz} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "import {bar as y} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
 
 
@@ -200,6 +202,22 @@ ruleTester.run("object-curly-spacing", rule, {
             ]
         },
         {
+            code: "import x, { bar, baz} from 'foo';",
+            options: ["always"],
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [
+                {
+                    message: "A space is required before '}'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 21
+                }
+
+            ]
+        },
+        {
             code: "import x, {bar} from 'foo';",
             options: ["always"],
             ecmaFeatures: {
@@ -217,6 +235,28 @@ ruleTester.run("object-curly-spacing", rule, {
                     type: "ImportDeclaration",
                     line: 1,
                     column: 15
+                }
+
+            ]
+        },
+        {
+            code: "import x, {bar, baz} from 'foo';",
+            options: ["always"],
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [
+                {
+                    message: "A space is required after '{'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 11
+                },
+                {
+                    message: "A space is required before '}'",
+                    type: "ImportDeclaration",
+                    line: 1,
+                    column: 20
                 }
 
             ]


### PR DESCRIPTION
fixes #3370 

For the case of imports with a default import and multiple named imports, the rule was only checking the last specifier. This change makes it check the first named import and last named import specifiers' tokens instead.

For any existing tests with the format `import defaultImport, {onlyOneNamedImport} from x` I added an additional test with the format `import defaultImport, {oneNamedImport, anotherNamedImport} from x`.