### PR TITLE
Docs: Add "Compatibility" section to linebreak-style

### DIFF
--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -52,3 +52,7 @@ This rule may take one option which is either `unix` (LF) or `windows` (CRLF). W
 ## When Not To Use It
 
 If you aren't concerned about having different line endings within you code, then you can safely turn this rule off.
+
+## Compatibility
+
+* **JSCS**: `validateLineBreaks`


### PR DESCRIPTION
Add a "Compatibility" section to the linebreak-style rule documentation. In JSCS the rule is called 'validateLineBreaks' and it would be helpful for people migrating to ESLint to know this.