### PR TITLE
Upgrade: bump `espree` dependency to `2.2.4` (fixes #3403)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "doctrine": "^0.6.2",
     "escape-string-regexp": "^1.0.2",
     "escope": "^3.2.0",
-    "espree": "^2.2.0",
+    "espree": "^2.2.4",
     "estraverse": "^4.1.0",
     "estraverse-fb": "^1.3.1",
     "globals": "^8.3.0",


### PR DESCRIPTION
I'm torn between a `Fix:` tag and an `Upgrade:` tag. I preferred `Fix:` since it resolves an issue but okay with `Upgrade:` as well.