### PR TITLE
Fixes `no duplicate case` for Array#toString (and possibly all un handled ES 2015 syntax)

### DIFF
--- a/lib/rules/no-duplicate-case.js
+++ b/lib/rules/no-duplicate-case.js
@@ -13,25 +13,31 @@
 module.exports = function(context) {
 
     /**
+     * Strips source code position informations from the node
+     * @param {ASTNode} node The node.
+     * @returns {ASTNode} a copy of the node with the position stripped away
+     * @private
+     */
+    function stripsPosition(node) {
+        var result = {};
+        for (var prop in node) {
+            if (!~["loc", "start", "end", "range"].indexOf(prop)) {
+                result[prop] = node[prop];
+                if (typeof result[prop] === "object") {
+                    result[prop] = stripsPosition(result[prop]);
+                }
+            }
+        }
+        return result;
+    }
+    /**
      * Get a hash value for the node
      * @param {ASTNode} node The node.
      * @returns {string} A hash value for the node.
      * @private
      */
     function getHash(node) {
-        if (node.type === "Literal") {
-            return node.type + typeof node.value + node.value;
-        } else if (node.type === "Identifier") {
-            return node.type + typeof node.name + node.name;
-        } else if (node.type === "MemberExpression") {
-            return node.type + getHash(node.object) + getHash(node.property);
-        } else if (node.type === "CallExpression") {
-            return node.type + getHash(node.callee) + node.arguments.map(getHash).join("");
-        } else if (node.type === "BinaryExpression") {
-            return node.type + getHash(node.left) + node.operator + getHash(node.right);
-        } else if (node.type === "ConditionalExpression") {
-            return node.type + getHash(node.test) + getHash(node.consequent) + getHash(node.alternate);
-        }
+        return JSON.stringify(stripsPosition(node));
     }
 
     var switchStatement = [];

--- a/tests/lib/rules/no-duplicate-case.js
+++ b/tests/lib/rules/no-duplicate-case.js
@@ -55,6 +55,10 @@ ruleTester.run("no-duplicate-case", rule, {
         {
             code: "var a = 1, f1 = function() { return { p1: 1 } }, f2 = function() { return { p1: 2 } }; switch (a) {case f1().p1: break; case f2().p1: break; default: break;}",
             args: 2
+        },
+        {
+            code: "var a = [1,2]; switch(a.toString()){case ([1,2]).toString():break; case ([1]).toString():break; default:break;}",
+            args: 2
         }
     ],
     invalid: [
@@ -116,6 +120,14 @@ ruleTester.run("no-duplicate-case", rule, {
         },
         {
             code: "var a = 1, f1 = function() { return { p1: 1 } }; switch (a) {case f1().p1: break; case f1().p1: break; default: break;}",
+            args: 2,
+            errors: [{
+                message: "Duplicate case label.",
+                type: "SwitchCase"
+            }]
+        },
+        {
+            code: "var a = [1, 2]; switch(a.toString()){case ([1, 2]).toString():break; case ([1, 2]).toString():break; default:break;}",
             args: 2,
             errors: [{
                 message: "Duplicate case label.",


### PR DESCRIPTION
In EcmaScript after the `case` token there can be any valid expression,
in particular this switch was raising a false `no duplicate case` positive:
```
switch(['a','b'].toString()){
  case (['a','b']).toString():
    console.log('right');
    break
  case (['a']).toString():
    console.log('not right');
    break
}    
```

in this case is because the [getHash function](https://github.com/eslint/eslint/blob/master/lib/rules/no-duplicate-case.js#L21-L35) does not handle ArrayExpression nodes;
the [if else cascade](https://github.com/eslint/eslint/blob/master/lib/rules/no-duplicate-case.js#L22-L34) exit without matching, so the function returns `undefined`.
This happens for every node types that isn't checked.

In order to fix this I wrote a more strong getHash function, which just serialize the AST expression node after recursively stripping the source code position information.

Testing:

running `npm run test` passes all the tests.