### PR TITLE
Docs: Fix typo: exception label

### DIFF
--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -98,7 +98,7 @@ var obj = {
 You may wish to align variable declarations or import declarations with spaces. You can add exceptions for these cases:
 
 ```js
-/* eslint no-multi-spaces: [2, { exceptions: { "VariableDeclaration": true } }] */
+/* eslint no-multi-spaces: [2, { exceptions: { "VariableDeclarator": true } }] */
 var someVar      = 'foo';
 var someOtherVar = 'barBaz';
 


### PR DESCRIPTION
Fix typo in the documentation of no-multi-spaces
Works with eslint v1.0.0 and rule in .eslintrc

Refs #3298 