### PR TITLE
Fix: exclude `AssignmentExpression` and `Property` nodes from extra indentation on first line

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -350,18 +350,18 @@ module.exports = function(context) {
                 }
             }
             nodeIndent = getNodeIndent(effectiveParent);
-
             if (parentVarNode && parentVarNode.loc.start.line !== node.loc.start.line) {
                 if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
                     nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]);
                 } else if (parent.loc.start.line !== node.loc.start.line && parentVarNode === parentVarNode.parent.declarations[0]) {
                     nodeIndent = nodeIndent + indentSize;
                 }
-            } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && effectiveParent.type !== "ExpressionStatement") {
+            } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && effectiveParent.type !== "ExpressionStatement" && effectiveParent.type !== "AssignmentExpression" && effectiveParent.type !== "Property") {
                 nodeIndent = nodeIndent + indentSize;
             }
 
             elementsIndent = nodeIndent + indentSize;
+
             checkFirstNodeLineIndent(node, nodeIndent);
         } else {
             nodeIndent = getNodeIndent(node);

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -661,6 +661,27 @@ ruleTester.run("indent", rule, {
             "    };\n",
             options: [2, { VariableDeclarator: { var: 2, const: 3 }, "SwitchCase": 1}],
             ecmaFeatures: { blockBindings: true }
+        },
+        {
+            code:
+                "module.exports =\n" +
+                "{\n" +
+                "  'Unit tests':\n" +
+                "  {\n" +
+                "    rootPath: './',\n" +
+                "    environment: 'node',\n" +
+                "    tests:\n" +
+                "    [\n" +
+                "      'test/test-*.js'\n" +
+                "    ],\n" +
+                "    sources:\n" +
+                "    [\n" +
+                "      '*.js',\n" +
+                "      'test/**.js'\n" +
+                "    ]\n" +
+                "  }\n" +
+                "};",
+            options: [2]
         }
     ],
     invalid: [


### PR DESCRIPTION
Fixes #3391