### PR TITLE
Update: separate options for block and line comments in `spaced-comment` rule

### DIFF
--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -41,6 +41,21 @@ The `"markers"` array will apply regardless of the value of the first argument, 
 The difference between a marker and an exception is that a marker only appears at the beginning of the comment whereas
 exceptions can occur anywhere in the comment string.
 
+You can also define separate exceptions and markers for block and line comments:
+
+```js
+"spaced-comment": [2, "always", {
+    "line": {
+        "markers": ["/"],
+        "exceptions": ["-", "+"]
+    },
+    "block": {
+        "markers": ["!"],
+        "exceptions": ["*"]
+    }
+}]
+```
+
 #### Examples
 
 The following patterns **are** considered warnings:
@@ -74,6 +89,13 @@ var foo = 5;
 ```
 
 ```js
+// When [2, "always", { "block": { "exceptions": ["-"] } }]
+//--------------
+// Comment block
+//--------------
+```
+
+```js
 // When [2, "always", { "exceptions": ["-", "+"] }]
 //------++++++++
 // Comment block
@@ -90,6 +112,13 @@ var foo = 5;
 /*------++++++++*/
 /* Comment block */
 /*------++++++++*/
+```
+
+```js
+// When [2, "always", { "line": { "exceptions": ["-+"] } }]
+/*-+-+-+-+-+-+-+*/
+// Comment block
+/*-+-+-+-+-+-+-+*/
 ```
 
 The following patterns **are not** warnings:
@@ -126,6 +155,13 @@ var foo = 5;
 ```
 
 ```js
+// When [2, "always", { "line": "exceptions": ["-"] } }]
+//--------------
+// Comment block
+//--------------
+```
+
+```js
 // When [2, "always", { "exceptions": ["-+"] }]
 //-+-+-+-+-+-+-+
 // Comment block
@@ -134,6 +170,13 @@ var foo = 5;
 
 ```js
 // When [2, "always", { "exceptions": ["-+"] }]
+/*-+-+-+-+-+-+-+*/
+// Comment block
+/*-+-+-+-+-+-+-+*/
+```
+
+```js
+// When [2, "always", { "block": { "exceptions": ["-+"] } }]
 /*-+-+-+-+-+-+-+*/
 // Comment block
 /*-+-+-+-+-+-+-+*/

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -37,11 +37,11 @@ function escapeAndRepeat(s) {
 /**
  * Parses `markers` option.
  * If markers don't include `"*"`, this adds `"*"` to allow JSDoc comments.
- * @param {string[]|null} markers - A marker list.
+ * @param {string[]} [markers] - A marker list.
  * @returns {string[]} A marker list.
  */
 function parseMarkersOption(markers) {
-    if (markers == null) {
+    if (!markers) {
         markers = [];
     }
 
@@ -51,15 +51,6 @@ function parseMarkersOption(markers) {
     }
 
     return markers;
-}
-
-/**
- * Parses `exceptions` option.
- * @param {string[]|null} exceptions - An exception list.
- * @returns {string[]} An exception list.
- */
-function parseExceptionsOption(exceptions) {
-    return exceptions || [];
 }
 
 /**
@@ -141,16 +132,19 @@ module.exports = function(context) {
 
     // Parse the second options.
     // If markers don't include `"*"`, it's added automatically for JSDoc comments.
-    var markers = parseMarkersOption(context.options[1] && context.options[1].markers);
-    var exceptions = parseExceptionsOption(context.options[1] && context.options[1].exceptions);
+    var config = context.options[1] || {};
+    var styleRules = ["block", "line"].reduce(function(rule, type) {
+        var markers = parseMarkersOption(config[type] && config[type].markers || config.markers);
+        var exceptions = config[type] && config[type].exceptions || config.exceptions || [];
 
-    // Create RegExp object for valid patterns.
-    var stylePattern = null;
-    if (requireSpace) {
-        stylePattern = createAlwaysStylePattern(markers, exceptions);
-    } else {
-        stylePattern = createNeverStylePattern(markers);
-    }
+        // Create RegExp object for valid patterns.
+        rule[type] = {
+            regex: requireSpace ? createAlwaysStylePattern(markers, exceptions) : createNeverStylePattern(markers),
+            hasExceptions: exceptions.length > 0
+        };
+
+        return rule;
+    }, {});
 
     /**
      * Reports a given comment if it's invalid.
@@ -158,7 +152,9 @@ module.exports = function(context) {
      * @returns {void}
      */
     function checkCommentForSpace(node) {
-        var commentIdentifier = node.type === "Block" ? "/*" : "//";
+        var type = node.type.toLowerCase(),
+            rule = styleRules[type],
+            commentIdentifier = type === "block" ? "/*" : "//";
 
         // Ignores empty comments.
         if (node.value.length === 0) {
@@ -167,15 +163,15 @@ module.exports = function(context) {
 
         // Checks.
         if (requireSpace) {
-            if (!stylePattern.test(node.value)) {
-                if (exceptions.length > 0) {
+            if (!rule.regex.test(node.value)) {
+                if (rule.hasExceptions) {
                     context.report(node, "Expected exception block, space or tab after " + commentIdentifier + " in comment.");
                 } else {
                     context.report(node, "Expected space or tab after " + commentIdentifier + " in comment.");
                 }
             }
         } else {
-            var matched = stylePattern.exec(node.value);
+            var matched = rule.regex.exec(node.value);
             if (matched) {
                 if (matched[1] == null) {
                     context.report(node, "Unexpected space or tab after " + commentIdentifier + " in comment.");
@@ -212,6 +208,42 @@ module.exports.schema = [
                 "items": {
                     "type": "string"
                 }
+            },
+            "line": {
+                "type": "object",
+                "properties": {
+                    "exceptions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "markers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false
+            },
+            "block": {
+                "type": "object",
+                "properties": {
+                    "exceptions": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    },
+                    "markers": {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                },
+                "additionalProperties": false
             }
         },
         "additionalProperties": false

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -37,6 +37,12 @@ ruleTester.run("spaced-comment", rule, {
             }]
         },
         {
+            code: "//-----------------------\n// A comment\n//-----------------------",
+            options: ["always", {
+                line: { exceptions: ["-", "=", "*", "#", "!@#"] }
+            }]
+        },
+        {
             code: "//===========\n// A comment\n//*************",
             options: ["always", {
                 exceptions: ["-", "=", "*", "#", "!@#"]
@@ -60,6 +66,12 @@ ruleTester.run("spaced-comment", rule, {
             code: "var a = 1; /*######*/",
             options: ["always", {
                 exceptions: ["-", "=", "*", "#", "!@#"]
+            }]
+        },
+        {
+            code: "var a = 1; /*######*/",
+            options: ["always", {
+                block: { exceptions: ["-", "=", "*", "#", "!@#"] }
             }]
         },
         {
@@ -89,6 +101,12 @@ ruleTester.run("spaced-comment", rule, {
             }]
         },
         {
+            code: "//!< docblock style comment",
+            options: ["always", {
+                line: { markers: ["/", "!<"] }
+            }]
+        },
+        {
             code: "//----\n// a comment\n//----\n/// xmldoc style comment\n//!< docblock style comment",
             options: ["always", {
                 exceptions: ["-"],
@@ -112,6 +130,10 @@ ruleTester.run("spaced-comment", rule, {
         {
             code: "/*!\n *comment\n */",
             options: ["always", { markers: ["!"] }]
+        },
+        {
+            code: "/*!\n *comment\n */",
+            options: ["always", { block: { markers: ["!"] } }]
         },
         {
             code: "/**\n *jsdoc\n */",
@@ -213,7 +235,11 @@ ruleTester.run("spaced-comment", rule, {
         // markers & exceptions
         {
             code: "///--------\r\n/// test\r\n///--------",
-            options: ["always", {markers: ["/"], exceptions: ["-"]}]
+            options: ["always", { markers: ["/"], exceptions: ["-"] }]
+        },
+        {
+            code: "///--------\r\n/// test\r\n///--------\r\n/* blah */",
+            options: ["always", { markers: ["/"], exceptions: ["-"], block: { markers: [] } }]
         }
     ],
 
@@ -348,6 +374,67 @@ ruleTester.run("spaced-comment", rule, {
             errors: [{
                 message: "Unexpected space or tab after /* in comment.",
                 type: "Block"
+            }]
+        },
+        {
+            code: "//-----------------------\n// A comment\n//-----------------------",
+            options: ["always", {
+                block: { exceptions: ["-", "=", "*", "#", "!@#"] }
+            }],
+            errors: [
+                { message: "Expected space or tab after // in comment.", type: "Line"},
+                { message: "Expected space or tab after // in comment.", type: "Line"}
+            ]
+        },
+        {
+            code: "var a = 1; /*######*/",
+            options: ["always", {
+                line: { exceptions: ["-", "=", "*", "#", "!@#"] }
+            }],
+            errors: [{
+                message: "Expected space or tab after /* in comment.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "//!< docblock style comment",
+            options: ["always", {
+                block: { markers: ["/", "!<"] }
+            }],
+            errors: [{
+                message: "Expected space or tab after // in comment.",
+                type: "Line"
+            }]
+        },
+        {
+            code: "/*!\n *comment\n */",
+            options: ["always", { line: { markers: ["!"] } }],
+            errors: [{
+                message: "Expected space or tab after /* in comment.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "///--------\r\n/// test\r\n///--------\r\n/*/ blah *//*-----*/",
+            options: ["always", { markers: ["/"], exceptions: ["-"], block: { markers: [] } }],
+            errors: [{
+                message: "Expected exception block, space or tab after /* in comment.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "///--------\r\n/// test\r\n///--------\r\n/*/ blah */ /*-----*/",
+            options: ["always", { line: { markers: ["/"], exceptions: ["-"] } }],
+            errors: [{
+                message: "Expected space or tab after /* in comment.",
+                type: "Block",
+                line: 4,
+                column: 1
+            }, {
+                message: "Expected space or tab after /* in comment.",
+                type: "Block",
+                line: 4,
+                column: 13
             }]
         }
     ]


### PR DESCRIPTION
Fixes #2897