### PR TITLE
Added "properties" option to `id-length` rule to ignore property names

### DIFF
--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -82,6 +82,8 @@ try {
 
 var myObj = { apple: 1 };
 
+var myObj = { a: 1 };  // With {"properties": "never"}
+
 (num) => { num * num };
 
 function foo(num = 0) { }
@@ -106,6 +108,10 @@ export var num = 0;
 
 ({ prop: obj.longName }) = {};
 
+({ a: obj.x.y.z }) = {};  // With {"properties": "never"}
+
+({ prop: obj.x }) = {};  // With {"properties": "never"}
+
 var data = { "x": 1 };  // excused because of quotes
 
 data["y"] = 3;  // excused because of calculated property access
@@ -113,16 +119,18 @@ data["y"] = 3;  // excused because of calculated property access
 
 ### Options
 
-The `id-length` rule has no required options and has 3 optional ones that needs to be passed in a single options object:
+The `id-length` rule has no required options and has 4 optional ones that needs to be passed in a single options object:
 
 * **min** *(default: 2)*: The minimum number of characters an identifier name should be, after it is stripped from it is prefixes and suffixes
 * **max** *(default: Infinity)*: The maximum number of characters an identifier name should be, after it is stripped from it is prefixes and suffixes
+* **properties** *(default: "always")*: If set to `"never"` does not check property names at all
 * **exceptions**: An array of identifier names that the rule should not apply to
 
-For example, to specify a minimum identifier length of 3 and maximum of 10 and add `x` to exception list, use the following configuration:
+
+For example, to specify a minimum identifier length of 3, a maximum of 10, ignore property names and add `x` to exception list, use the following configuration:
 
 ```json
-"id-length": [2, {"min": 3, "max": 10, "exceptions": ["x"]}]
+"id-length": [2, {"min": 3, "max": 10, "properties": "never", "exceptions": ["x"]}]
 ```
 
 

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -3,6 +3,7 @@
  *               than the values provided in configuration.
  * @author Burak Yigit Kaya aka BYK
  * @copyright 2015 Burak Yigit Kaya. All rights reserved.
+ * @copyright 2015 Mathieu M-Gosselin. All rights reserved.
  */
 
 "use strict";
@@ -15,6 +16,7 @@ module.exports = function(context) {
     var options = context.options[0] || {};
     var minLength = typeof options.min !== "undefined" ? options.min : 2;
     var maxLength = typeof options.max !== "undefined" ? options.max : Infinity;
+    var properties = options.properties !== "never";
     var exceptions = (options.exceptions ? options.exceptions : [])
         .reduce(function(obj, item) {
         obj[item] = true;
@@ -28,7 +30,7 @@ module.exports = function(context) {
                 // regular property assignment
                 parent.parent.left === parent || (
                     // or the last identifier in an ObjectPattern destructuring
-                    parent.parent.type === "Property" && parent.parent.value === parent &&
+                    parent.parent.type === "Property" && properties && parent.parent.value === parent &&
                     parent.parent.parent.type === "ObjectPattern" && parent.parent.parent.parent.left === parent.parent.parent
                 )
             );
@@ -39,7 +41,7 @@ module.exports = function(context) {
         "VariableDeclarator": function(parent, node) {
             return parent.id === node;
         },
-        "Property": function(parent, node) {
+        "Property": properties && function(parent, node) {
             return parent.key === node;
         },
         "ImportDefaultSpecifier": true,
@@ -94,6 +96,9 @@ module.exports.schema = [
                 "items": {
                     "type": "string"
                 }
+            },
+            "properties": {
+                "enum": ["always", "never"]
             }
         },
         "additionalProperties": false

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Tests for id-length rule.
  * @author Burak Yigit Kaya
+ * @copyright 2015 Mathieu M-Gosselin. All rights reserved.
  */
 
 "use strict";
@@ -50,7 +51,10 @@ ruleTester.run("id-length", rule, {
         { code: "import something from 'y';", ecmaFeatures: { modules: true } },
         { code: "export var num = 0;", ecmaFeatures: { modules: true } },
         { code: "({ prop: obj.x.y.something }) = {};", ecmaFeatures: { destructuring: true } },
-        { code: "({ prop: obj.longName }) = {};", ecmaFeatures: { destructuring: true } }
+        { code: "({ prop: obj.longName }) = {};", ecmaFeatures: { destructuring: true } },
+        { code: "var obj = { a: 1, bc: 2 };", options: [{ "properties": "never" }] },
+        { code: "({ a: obj.x.y.z }) = {};", options: [{ "properties": "never" }], ecmaFeatures: { destructuring: true } },
+        { code: "({ prop: obj.x }) = {};", options: [{ "properties": "never" }], ecmaFeatures: { destructuring: true } }
     ],
     invalid: [
         { code: "var x = 1;", errors: [{ message: "Identifier name 'x' is too short. (< 2)", type: "Identifier" }] },
@@ -105,6 +109,7 @@ ruleTester.run("id-length", rule, {
         ]},
         { code: "({ prop: obj.x }) = {};", ecmaFeatures: { destructuring: true }, errors: [
             { message: "Identifier name 'x' is too short. (< 2)", type: "Identifier" }
-        ]}
+        ]},
+        { code: "var x = 1;", options: [{ "properties": "never" }], errors: [{ message: "Identifier name 'x' is too short. (< 2)", type: "Identifier" }] }
     ]
 });


### PR DESCRIPTION
As discussed in #3450, thanks!