### PR TITLE
Fix: "key-spacing" crashes eslint on object literal shorthand properties

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -124,7 +124,7 @@ module.exports = function(context) {
     function getFirstNodeBeforeColon(node) {
         var prevNode;
 
-        while (node.type !== "Punctuator" || node.value !== ":") {
+        while (node && (node.type !== "Punctuator" || node.value !== ":")) {
             prevNode = node;
             node = context.getTokenAfter(node);
         }

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -185,6 +185,18 @@ ruleTester.run("key-spacing", rule, {
             "};"
         ].join("\n"),
         options: [{ align: "colon" }]
+    }, {
+        code: [
+            "var a = 'a';",
+            "var b = 'b';",
+            "",
+            "export default {",
+            "    a,",
+            "    b",
+            "};"
+        ].join("\n"),
+        ecmaFeatures: { modules: true, objectLiteralShorthandProperties: true },
+        options: [{ "align": "value" }]
     }],
 
     invalid: [{


### PR DESCRIPTION
Fixes #3463