### PR TITLE
Allowing inline comments to disable eslint rules.

### DIFF
--- a/lib/rules/no-inline-comments.js
+++ b/lib/rules/no-inline-comments.js
@@ -28,8 +28,11 @@ module.exports = function(context) {
         // Also check after the comment
         var postamble = endLine.slice(node.loc.end.column).trim();
 
+        // Check that this comment isn't an ESLint directive
+        var isDirective = node.value.trim().indexOf("eslint-") === 0;
+
         // Should be empty if there was only whitespace around the comment
-        if (preamble || postamble) {
+        if (!isDirective && (preamble || postamble)) {
             context.report(node, "Unexpected comment inline with code.");
         }
     }

--- a/tests/lib/rules/no-inline-comments.js
+++ b/tests/lib/rules/no-inline-comments.js
@@ -37,6 +37,12 @@ ruleTester.run("no-inline-comments", rule, {
         },
         {
             code: "// A solitary comment"
+        },
+        {
+            code: "var a = 1; // eslint-disable-line some-rule"
+        },
+        {
+            code: "var a = 1; /* eslint-disable-line some-rule */"
         }
     ],
 
@@ -51,6 +57,10 @@ ruleTester.run("no-inline-comments", rule, {
         },
         {
             code: "var a = 3; //A comment inline with code",
+            errors: [ lineError ]
+        },
+        {
+            code: "var a = 3; // someday use eslint-disable-line here",
             errors: [ lineError ]
         },
         {


### PR DESCRIPTION
I'd like to be able to use inline comments to disable eslint rules, but to disallow any other type of inline comment.

This change allows that configuration.