### PR TITLE
New: no-double-assignments (fixes #3481)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -16,6 +16,7 @@
         "no-debugger": 2,
         "no-delete-var": 2,
         "no-div-regex": 0,
+        "no-double-assignments": 2,
         "no-dupe-class-members": 0,
         "no-dupe-keys": 2,
         "no-dupe-args": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -12,6 +12,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-constant-condition](no-constant-condition.md) - disallow use of constant expressions in conditions (recommended)
 * [no-control-regex](no-control-regex.md) - disallow control characters in regular expressions (recommended)
 * [no-debugger](no-debugger.md) - disallow use of `debugger` (recommended)
+* [no-double-assignments](no-double-assignments.md) - disallow overwriting a variable twice in a row (recommended)
 * [no-dupe-args](no-dupe-args.md) - disallow duplicate arguments in functions (recommended)
 * [no-dupe-keys](no-dupe-keys.md) - disallow duplicate keys when creating object literals (recommended)
 * [no-duplicate-case](no-duplicate-case.md) - disallow a duplicate case label. (recommended)

--- a/docs/rules/no-double-assignments.md
+++ b/docs/rules/no-double-assignments.md
@@ -1,0 +1,47 @@
+# Disallow Double Assignments (no-double-assignments)
+
+Overwriting a variable twice in a row is most likely an error:
+
+```js
+cursor_x = 53;
+cursor_x = 62;
+```
+
+The code above most likely is a result of a copy and paste error and the correct code should be
+
+```js
+cursor_x = 53;
+cursor_y = 62;
+```
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+foo = 5;
+foo = 6;
+
+foo += 5;
+foo = 6;
+
+foo = bar();
+foo = quux();
+```
+
+The following patterns are not considered warnings:
+
+```js
+foo = 5;
+bar = 5;
+
+foo = 5;
+foo += 5;
+
+foo = 5;
+foo *= 5;
+
+foo = 5;
+bar(foo);
+foo = 6;
+```

--- a/lib/rules/no-double-assignments.js
+++ b/lib/rules/no-double-assignments.js
@@ -1,0 +1,81 @@
+"use strict";
+
+function getPrevNode(context, node) {
+    var prevToken = context.getTokenBefore(node);
+    if (prevToken) {
+        return context.getNodeByRangeIndex(prevToken.range[0]);
+    }
+}
+
+function expressionname(expression) {
+    if (expression.type === "Identifier") {
+        return expression.name;
+    }
+
+    if (expression.type === "MemberExpression") {
+        return expressionname(expression.object) + "-" + expression.property.name;
+    }
+}
+
+function varname(node) {
+    if (!node || node.type !== "ExpressionStatement") {
+        return null;
+    }
+
+    if (node.expression.type !== "AssignmentExpression") {
+        return null;
+    }
+
+    return expressionname(node.expression.left);
+}
+
+function any(list, testCb) {
+    for (var i = list.length - 1; i >= 0; i--) {
+        if (testCb(list[i])) {
+            return true;
+        }
+    }
+    return false;
+}
+
+function includesname(name, expression) {
+    if (expression.callee && includesname(name, expression.callee)) {
+        return true;
+    }
+
+    if (expression.arguments && any(expression.arguments, includesname.bind(null, name))) {
+        return true;
+    }
+
+    if (expression.left && includesname(name, expression.left)) {
+        return true;
+    }
+
+    if (expression.right && includesname(name, expression.right)) {
+        return true;
+    }
+
+    return (expressionname(expression) || "").substring(0, name.length) === name;
+}
+
+module.exports = function(context) {
+    return {
+        "ExpressionStatement": function(node) {
+            if (node.expression.operator !== "=") {
+                return;
+            }
+
+            var prev = getPrevNode(context, node);
+
+            var name = varname(node);
+            if (name && name === varname(prev) && !includesname(name, node.expression.right)) {
+                context.report(
+                    node.expression.left,
+                    "Double assignment to the same variable, probably a mistake."
+                );
+            }
+        }
+    };
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-double-assignments.js
+++ b/tests/lib/rules/no-double-assignments.js
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Tests for no-double-assignments rule.
+ */
+
+"use strict";
+
+var rule = require("../../../lib/rules/no-double-assignments"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+var defaultErrors = [{ message: "Double assignment to the same variable, probably a mistake.", type: "Identifier"}];
+var defaultPropertyErrors = [{ message: "Double assignment to the same variable, probably a mistake.", type: "MemberExpression"}];
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-double-assignments", rule, {
+    valid: [
+        "foo = 5;",
+        "foo = 5; bar = 5;",
+        "foo = 5; foo += 5;",
+        "foo = 5; foo *= 5;",
+
+        "foo = 5; bar(foo); foo = 6;",
+
+        "foo.x = 1; foo.y = 2",
+        "foo.bar.x = 1; foo.bar.y = 2",
+        "foo.bar.x = 1; foo.quux.x = 2",
+
+        "foo = []; foo = add(foo);",
+        "foo = []; foo = add(foo.concat(bar));",
+        "foo = ''; foo = bar + foo",
+
+        // Whitespace tests
+        "foo = 5;bar = 5;",
+        "foo=5;bar=5;",
+        "   foo = 5   ; "
+    ],
+    invalid: [
+        { code: "foo = 5; foo = 6;", errors: defaultErrors },
+        { code: "foo += 5; foo = 6;", errors: defaultErrors },
+        { code: "foo = bar(); foo = quux();", errors: defaultErrors },
+        { code: "foo1=true;foo1=false;", errors: defaultErrors },
+        { code: "foo.x = 12; foo.x = 15;", errors: defaultPropertyErrors },
+        { code: "foo.bar.x = 12; foo.bar.x = 15;", errors: defaultPropertyErrors }
+    ]
+});


### PR DESCRIPTION
Performance before:

```
CPU Speed is 1800 with multiplier 7500000
Performance Run #1:  3165.737594ms
Performance Run #2:  3165.387589ms
Performance Run #3:  3156.572153ms
Performance Run #4:  3146.225769ms
Performance Run #5:  3129.534463ms
Performance budget ok:  3156.572153ms (limit: 4166.666666666667ms)
```

Performance after:

```
CPU Speed is 1800 with multiplier 7500000
Performance Run #1:  3396.5271119999998ms
Performance Run #2:  3350.931596ms
Performance Run #3:  3398.065597ms
Performance Run #4:  3307.97695ms
Performance Run #5:  3289.81201ms
Performance budget ok:  3350.931596ms (limit: 4166.666666666667ms)
```

Perhaps the code could be improved further, as the hit is noticable. 

It seems a lot of code in this PR (`getPrevNode`, `expressionname`) could be usefully moved into a utility belt on the context or ast-utils. For an example of such a proposal, see #3460.