### PR TITLE
Update: `newline-after-var` Allow comment + blank after var (fixes #2…

### DIFF
--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -3,6 +3,7 @@
  * @author Gopal Venkatesan
  * @copyright 2015 Gopal Venkatesan. All rights reserved.
  * @copyright 2015 Casey Visco. All rights reserved.
+ * @copyright 2015 Ian VanSchooten. All rights reserved.
  */
 
 "use strict";
@@ -20,10 +21,11 @@ module.exports = function(context) {
     // be treated as "always" and the only special case is "never"
     var mode = context.options[0] === "never" ? "never" : "always";
 
-    // Cache line numbers of comments for faster lookup
-    var comments = context.getAllComments().map(function(token) {
-        return token.loc.start.line;
-    });
+    // Cache starting and ending line numbers of comments for faster lookup
+    var commentEndLine = context.getAllComments().reduce(function(result, token) {
+        result[token.loc.start.line] = token.loc.end.line;
+        return result;
+    }, {});
 
 
     //--------------------------------------------------------------------------
@@ -59,6 +61,21 @@ module.exports = function(context) {
     function isExportSpecifier(nodeType) {
         return nodeType === "ExportNamedDeclaration" || nodeType === "ExportSpecifier" ||
             nodeType === "ExportDefaultDeclaration" || nodeType === "ExportAllDeclaration";
+    }
+
+    /**
+     * Determine if a token starts more than one line after a comment ends
+     * @param  {token}   token            The token being checked
+     * @param {integer}  commentStartLine The line number on which the comment starts
+     * @returns {boolean}                 True if `token` does not start immediately after a comment
+     */
+    function hasBlankLineAfterComment(token, commentStartLine) {
+        var commentEnd = commentEndLine[commentStartLine];
+        // If there's another comment, repeat check for blank line
+        if (commentEndLine[commentEnd + 1]) {
+            return hasBlankLineAfterComment(token, commentEnd + 1);
+        }
+        return (token.loc.start.line > commentEndLine[commentStartLine] + 1);
     }
 
     /**
@@ -99,13 +116,19 @@ module.exports = function(context) {
 
         // Next statement is not a `var`...
         noNextLineToken = nextToken.loc.start.line > nextLineNum;
-        hasNextLineComment = comments.indexOf(nextLineNum) >= 0;
+        hasNextLineComment = (typeof commentEndLine[nextLineNum] !== "undefined");
 
         if (mode === "never" && noNextLineToken && !hasNextLineComment) {
             context.report(node, NEVER_MESSAGE, { identifier: node.name });
         }
 
-        if (mode === "always" && (!noNextLineToken || hasNextLineComment)) {
+        // Token on the next line, or comment without blank line
+        if (
+            mode === "always" && (
+                !noNextLineToken ||
+                hasNextLineComment && !hasBlankLineAfterComment(nextToken, nextLineNum)
+            )
+        ) {
             context.report(node, ALWAYS_MESSAGE, { identifier: node.name });
         }
     }

--- a/tests/lib/rules/newline-after-var.js
+++ b/tests/lib/rules/newline-after-var.js
@@ -18,38 +18,9 @@ var rule = require("../../../lib/rules/newline-after-var"),
 // Fixtures
 //------------------------------------------------------------------------------
 
+// Valid for both "Always" and "Never"
 var NO_VAR = "console.log(greet);",
     ONLY_VAR = "var greet = 'hello';",
-    NO_BREAK = "var greet = 'hello'; console.log(greet);",
-    NO_BLANK = "var greet = 'hello';\nconsole.log(greet);",
-    ONE_BLANK = "var greet = 'hello';\n\nconsole.log(greet);",
-    TWO_BLANKS = "var greet = 'hello';\n\n\nconsole.log(greet);",
-    THREE_BLANKS = "var greet = 'hello';\n\n\n\nconsole.log(greet);",
-    NO_BLANK_WITH_TRAILING_WS = "var greet = 'hello';    \nconsole.log(greet);",
-    ONE_BLANK_WITH_TRAILING_WS = "var greet = 'hello';    \n\nconsole.log(greet);",
-    NO_BLANK_WITH_INLINE_COMMENT = "var greet = 'hello'; // inline comment\nconsole.log(greet);",
-    ONE_BLANK_WITH_INLINE_COMMENT = "var greet = 'hello'; // inline comment\n\nconsole.log(greet);",
-    NEXT_LINE_COMMENT = "var greet = 'hello';\n// next-line comment\nconsole.log(greet);",
-    NEXT_LINE_BLOCK_COMMENT = "var greet = 'hello';\n/* block comment\nblock comment */\nconsole.log(greet);",
-    MULTI_VAR_NO_BREAK = "var greet = 'hello'; var name = 'world'; console.log(greet, name);",
-    MULTI_VAR_NO_BLANK = "var greet = 'hello';\nvar name = 'world';\nconsole.log(greet, name);",
-    MULTI_VAR_ONE_BLANK = "var greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
-    MULTI_DEC_NO_BREAK = "var greet = 'hello', name = 'world'; console.log(greet, name);",
-    MULTI_DEC_NO_BLANK = "var greet = 'hello', name = 'world';\nconsole.log(greet, name);",
-    MULTI_DEC_ONE_BLANK = "var greet = 'hello', name = 'world';\n\nconsole.log(greet, name);",
-    MULTI_LINE_NO_BLANK = "var greet = 'hello',\nname = 'world';\nconsole.log(greet, name);",
-    MULTI_LINE_ONE_BLANK = "var greet = 'hello',\nname = 'world';\n\nconsole.log(greet, name);",
-    MULTI_LINE_NO_BLANK_WITH_COMMENTS = "var greet = 'hello', // inline comment\nname = 'world'; // inline comment\nconsole.log(greet, name);",
-    MULTI_LINE_ONE_BLANK_WITH_COMMENTS = "var greet = 'hello', // inline comment\nname = 'world'; // inline comment\n\nconsole.log(greet, name);",
-    MULTI_LINE_NEXT_LINE_COMMENT = "var greet = 'hello',\nname = 'world';\n// next-line comment\nconsole.log(greet);",
-    MULTI_LINE_NEXT_LINE_BLOCK_COMMENT = "var greet = 'hello',\nname = 'world';\n/* block comment\nblock comment */\nconsole.log(greet);",
-    LET_NO_BLANK = "let greet = 'hello';\nconsole.log(greet);",
-    LET_ONE_BLANK = "let greet = 'hello';\n\nconsole.log(greet);",
-    CONST_NO_BLANK = "const greet = 'hello';\nconsole.log(greet);",
-    CONST_ONE_BLANK = "const greet = 'hello';\n\nconsole.log(greet);",
-    MIXED_LET_VAR = "let greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
-    MIXED_CONST_VAR = "const greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
-    MIXED_LET_CONST = "let greet = 'hello';\nconst name = 'world';\n\nconsole.log(greet, name);",
     FOR_LOOP_WITH_LET = "for(let a = 1; a < 1; a++){\n break;\n}",
     FOR_LOOP_WITH_VAR = "for(var a = 1; a < 1; a++){\n break;\n}",
     FOR_IN_LOOP_WITH_LET = "for(let a in obj){\n break;\n}",
@@ -59,6 +30,51 @@ var NO_VAR = "console.log(greet);",
     EXPORT_WITH_LET = "export let a = 1;\nexport let b = 2;",
     EXPORT_WITH_VAR = "export var a = 1;\nexport var b = 2;",
     EXPORT_WITH_CONST = "export const a = 1;\nexport const b = 2;";
+
+// Valid for "Always"
+var ONE_BLANK = "var greet = 'hello';\n\nconsole.log(greet);",
+    TWO_BLANKS = "var greet = 'hello';\n\n\nconsole.log(greet);",
+    THREE_BLANKS = "var greet = 'hello';\n\n\n\nconsole.log(greet);",
+    ONE_BLANK_WITH_TRAILING_WS = "var greet = 'hello';    \n\nconsole.log(greet);",
+    ONE_BLANK_WITH_INLINE_COMMENT = "var greet = 'hello'; // inline comment\n\nconsole.log(greet);",
+    NEXT_LINE_COMMENT_ONE_BLANK = "var greet = 'hello';\n// next-line comment\n\nconsole.log(greet);",
+    NEXT_LINE_BLOCK_COMMENT_ONE_BLANK = "var greet = 'hello';\n/* block comment\nblock comment */\n\nconsole.log(greet);",
+    NEXT_LINE_TWO_COMMENTS_ONE_BLANK = "var greet = 'hello';\n// next-line comment\n// second-line comment\n\nconsole.log(greet);",
+    MIXED_COMMENT_ONE_BLANK = "var greet = 'hello';\n// inline comment\nvar name = 'world';\n\nconsole.log(greet, name);",
+    MIXED_BLOCK_COMMENT_ONE_BLANK = "var greet = 'hello';\n/* block comment\nblock comment */\nvar name = 'world';\n\nconsole.log(greet, name);",
+    MULTI_VAR_ONE_BLANK = "var greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
+    MULTI_DEC_ONE_BLANK = "var greet = 'hello', name = 'world';\n\nconsole.log(greet, name);",
+    MULTI_LINE_ONE_BLANK = "var greet = 'hello',\nname = 'world';\n\nconsole.log(greet, name);",
+    MULTI_LINE_ONE_BLANK_WITH_COMMENTS = "var greet = 'hello', // inline comment\nname = 'world'; // inline comment\n\nconsole.log(greet, name);",
+    LET_ONE_BLANK = "let greet = 'hello';\n\nconsole.log(greet);",
+    CONST_ONE_BLANK = "const greet = 'hello';\n\nconsole.log(greet);",
+    MIXED_LET_VAR = "let greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
+    MIXED_CONST_VAR = "const greet = 'hello';\nvar name = 'world';\n\nconsole.log(greet, name);",
+    MIXED_LET_CONST = "let greet = 'hello';\nconst name = 'world';\n\nconsole.log(greet, name);";
+
+
+// Valid for "Never"
+var NO_BREAK = "var greet = 'hello'; console.log(greet);",
+    NO_BLANK = "var greet = 'hello';\nconsole.log(greet);",
+    NO_BLANK_WITH_TRAILING_WS = "var greet = 'hello';    \nconsole.log(greet);",
+    NO_BLANK_WITH_INLINE_COMMENT = "var greet = 'hello'; // inline comment\nconsole.log(greet);",
+    NEXT_LINE_COMMENT = "var greet = 'hello';\n// next-line comment\nconsole.log(greet);",
+    NEXT_LINE_BLOCK_COMMENT = "var greet = 'hello';\n/* block comment\nblock comment */\nconsole.log(greet);",
+    NEXT_LINE_TWO_COMMENTS_NO_BLANK = "var greet = 'hello';\n// next-line comment\n// second-line comment\nconsole.log(greet);",
+    NEXT_LINE_COMMENT_BLOCK_COMMENT_NO_BLANK = "var greet = 'hello';\n// next-line comment\n/* block comment\nblock comment */\nconsole.log(greet);",
+    MIXED_COMMENT_NO_BLANK = "var greet = 'hello';\n// inline comment\nvar name = 'world';\nconsole.log(greet, name);",
+    MIXED_BLOCK_COMMENT_NO_BLANK = "var greet = 'hello';\n/* block comment\nblock comment */\nvar name = 'world';\nconsole.log(greet, name);",
+    MULTI_VAR_NO_BREAK = "var greet = 'hello'; var name = 'world'; console.log(greet, name);",
+    MULTI_VAR_NO_BLANK = "var greet = 'hello';\nvar name = 'world';\nconsole.log(greet, name);",
+    MULTI_DEC_NO_BREAK = "var greet = 'hello', name = 'world'; console.log(greet, name);",
+    MULTI_DEC_NO_BLANK = "var greet = 'hello', name = 'world';\nconsole.log(greet, name);",
+    MULTI_LINE_NO_BLANK = "var greet = 'hello',\nname = 'world';\nconsole.log(greet, name);",
+    MULTI_LINE_NO_BLANK_WITH_COMMENTS = "var greet = 'hello', // inline comment\nname = 'world'; // inline comment\nconsole.log(greet, name);",
+    MULTI_LINE_NEXT_LINE_COMMENT = "var greet = 'hello',\nname = 'world';\n// next-line comment\nconsole.log(greet);",
+    MULTI_LINE_NEXT_LINE_BLOCK_COMMENT = "var greet = 'hello',\nname = 'world';\n/* block comment\nblock comment */\nconsole.log(greet);",
+    LET_NO_BLANK = "let greet = 'hello';\nconsole.log(greet);",
+    CONST_NO_BLANK = "const greet = 'hello';\nconsole.log(greet);";
+
 
 var ALWAYS_ERROR = {
     message: "Expected blank line after variable declarations.",
@@ -113,10 +129,25 @@ ruleTester.run("newline-after-var", rule, {
         { code: NEXT_LINE_COMMENT, options: ["never"] },
         { code: NEXT_LINE_BLOCK_COMMENT, options: ["never"] },
 
+        // should allow comments on the next line followed by a blank in "always" mode
+        { code: NEXT_LINE_COMMENT_ONE_BLANK, options: ["always"] },
+        { code: NEXT_LINE_BLOCK_COMMENT_ONE_BLANK, options: ["always"] },
+        { code: NEXT_LINE_TWO_COMMENTS_ONE_BLANK, options: ["always"] },
+
+        // should allow comments on the next line followed by no blank in "never" mode
+        { code: NEXT_LINE_TWO_COMMENTS_NO_BLANK, options: ["never"] },
+        { code: NEXT_LINE_COMMENT_BLOCK_COMMENT_NO_BLANK, options: ["never"] },
+
         // should allow another `var` statement to follow without blank line
         { code: MULTI_VAR_NO_BREAK, options: ["never"] },
         { code: MULTI_VAR_NO_BLANK, options: ["never"] },
         { code: MULTI_VAR_ONE_BLANK, options: ["always"] },
+
+        // should allow a comment directly between `var` statements
+        { code: MIXED_COMMENT_ONE_BLANK, options: ["always"] },
+        { code: MIXED_BLOCK_COMMENT_ONE_BLANK, options: ["always"] },
+        { code: MIXED_COMMENT_NO_BLANK, options: ["never"] },
+        { code: MIXED_BLOCK_COMMENT_NO_BLANK, options: ["never"] },
 
         // should handle single `var` statement with multiple declarations
         { code: MULTI_DEC_NO_BREAK, options: ["never"] },
@@ -196,11 +227,13 @@ ruleTester.run("newline-after-var", rule, {
         { code: LET_ONE_BLANK, options: ["never"], ecmaFeatures: BLOCK_BINDINGS, errors: [NEVER_ERROR] },
         { code: CONST_ONE_BLANK, options: ["never"], ecmaFeatures: BLOCK_BINDINGS, errors: [NEVER_ERROR] },
 
-        // should disallow a comment on the next line in "always" mode
+        // should disallow a comment on the next line that's not in turn followed by a blank in "always" mode
         { code: NEXT_LINE_COMMENT, options: ["always"], errors: [ALWAYS_ERROR] },
         { code: NEXT_LINE_BLOCK_COMMENT, options: ["always"], errors: [ALWAYS_ERROR] },
         { code: MULTI_LINE_NEXT_LINE_COMMENT, options: ["always"], errors: [ALWAYS_ERROR] },
-        { code: MULTI_LINE_NEXT_LINE_BLOCK_COMMENT, options: ["always"], errors: [ALWAYS_ERROR] }
+        { code: MULTI_LINE_NEXT_LINE_BLOCK_COMMENT, options: ["always"], errors: [ALWAYS_ERROR] },
+        { code: NEXT_LINE_TWO_COMMENTS_NO_BLANK, options: ["always"], errors: [ALWAYS_ERROR] },
+        { code: NEXT_LINE_COMMENT_BLOCK_COMMENT_NO_BLANK, options: ["always"], errors: [ALWAYS_ERROR] }
 
     ]
 });


### PR DESCRIPTION
…852)

Comments (one or more) are now allowed after a var statement in "always" mode,
as long as the comments have a blank line between them and whatever comes after.