### PR TITLE
Fix: false alarm of semi-spacing with semi set to never

### DIFF
--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -58,6 +58,16 @@ module.exports = function(context) {
     }
 
     /**
+     * Checks if the given token is the first token in its line
+     * @param {Token} token The token to check.
+     * @returns {boolean} Whether or not the token is the first in its line.
+     */
+    function isFirstTokenInCurrentLine(token) {
+        var tokenBefore = context.getTokenBefore(token);
+        return !(tokenBefore && astUtils.isTokenOnSameLine(token, tokenBefore));
+    }
+
+    /**
      * Checks if the next token of a given token is a closing parenthesis.
      * @param {Token} token The token to check.
      * @returns {boolean} Whether or not the next token of a given token is a closing parenthesis.
@@ -102,7 +112,7 @@ module.exports = function(context) {
                 }
             }
 
-            if (!isLastTokenInCurrentLine(token) && !isBeforeClosingParen(token)) {
+            if (!isFirstTokenInCurrentLine(token) && !isLastTokenInCurrentLine(token) && !isBeforeClosingParen(token)) {
                 if (hasTrailingSpace(token)) {
                     if (!requireSpaceAfter) {
                         context.report(node, location, "Unexpected whitespace after semicolon.");

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -26,6 +26,8 @@ ruleTester.run("semi-spacing", rule, {
         "var a = 'b',\nc = 'd';",
         "var a = function() {};",
         ";(function(){}());",
+        "var a = 'b'\n;(function(){}())",
+        "debugger\n;(function(){}())",
         "while (true) { break; }",
         "while (true) { continue; }",
         "debugger;",


### PR DESCRIPTION
Currently this fix just ignore whether the semicolon is spaced after or not if it's at the line beginning. Should we force a code style here too?

See #1983 for detailed discussion.