### PR TITLE
Fix: sort-vars rule fails when memo is undefined

### DIFF
--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -17,21 +17,23 @@ module.exports = function(context) {
     return {
         "VariableDeclaration": function(node) {
             node.declarations.reduce(function(memo, decl) {
-                if (decl.id.type !== "ObjectPattern" && decl.id.type !== "ArrayPattern") {
-                    var lastVariableName = memo.id.name,
-                        currenVariableName = decl.id.name;
+                if (decl.id.type === "ObjectPattern" || decl.id.type === "ArrayPattern") {
+                    return memo;
+                }
 
-                    if (ignoreCase) {
-                        lastVariableName = lastVariableName.toLowerCase();
-                        currenVariableName = currenVariableName.toLowerCase();
-                    }
+                var lastVariableName = memo.id.name,
+                    currenVariableName = decl.id.name;
 
-                    if (currenVariableName < lastVariableName) {
-                        context.report(decl, "Variables within the same declaration block should be sorted alphabetically");
-                        return memo;
-                    } else {
-                        return decl;
-                    }
+                if (ignoreCase) {
+                    lastVariableName = lastVariableName.toLowerCase();
+                    currenVariableName = currenVariableName.toLowerCase();
+                }
+
+                if (currenVariableName < lastVariableName) {
+                    context.report(decl, "Variables within the same declaration block should be sorted alphabetically");
+                    return memo;
+                } else {
+                    return decl;
                 }
             }, node.declarations[0]);
         }

--- a/tests/lib/rules/sort-vars.js
+++ b/tests/lib/rules/sort-vars.js
@@ -67,7 +67,18 @@ ruleTester.run("sort-vars", rule, {
         { code: "var e, [a, c, d] = {};", ecmaFeatures: { destructuring: true }},
         { code: "var a, [E, c, D] = [];", options: ignoreCaseArgs,
             ecmaFeatures: { destructuring: true }},
-        { code: "var a, f, [e, c, d] = [1,2,3];", ecmaFeatures: { destructuring: true }}
+        { code: "var a, f, [e, c, d] = [1,2,3];", ecmaFeatures: { destructuring: true }},
+        { code: [
+            "export default class {",
+            "    render () {",
+            "        let {",
+            "            b",
+            "        } = this,",
+            "            a,",
+            "            c;",
+            "    }",
+            "}"
+        ].join("\n"), env: { es6: true }, ecmaFeatures: { modules: true }}
     ],
     invalid: [
         { code: "var b, a", errors: [ expectedError ] },


### PR DESCRIPTION
Fixes #3474

Also, a good follow-up would be to add checking inside destructuring patterns.