### PR TITLE
Fix: `indent` shouldn't check the last line unless it is a punctuator

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -492,11 +492,9 @@ module.exports = function(context) {
         // Comma can be placed before declaration
         checkNodesIndent(elements, elementsIndent, true);
 
-        if (elements.length > 0) {
-            // Skip last block line check if last item in same line
-            if (lastElement.loc.end.line === node.loc.end.line) {
-                return;
-            }
+        // Only check the last line if it is a `Punctuator` token such as `;` or `}`
+        if (context.getLastToken(node).type !== "Punctuator") {
+            return;
         }
 
         var tokenBeforeLastElement = context.getTokenBefore(lastElement);

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -740,6 +740,30 @@ ruleTester.run("indent", rule, {
                 "    var a;\n" +
                 "  }).d.e;\n",
             options: [2]
+        },
+        {
+            code:
+                "const YO = 'bah',\n" +
+                "      TE = 'mah'\n" +
+                "\n" +
+                "var res,\n" +
+                "    a = 5,\n" +
+                "    b = 4\n",
+            ecmaFeatures: { blockBindings: true },
+            options: [2, {"VariableDeclarator": { "var": 2, "let": 2, "const": 3}}]
+        },
+        {
+            code:
+                "const YO = 'bah',\n" +
+                "      TE = 'mah'\n" +
+                "\n" +
+                "var res,\n" +
+                "    a = 5,\n" +
+                "    b = 4\n" +
+                "\n" +
+                "if (YO) console.log(TE)",
+            ecmaFeatures: { blockBindings: true },
+            options: [2, {"VariableDeclarator": { "var": 2, "let": 2, "const": 3}}]
         }
     ],
     invalid: [


### PR DESCRIPTION
Fixes #3498