### PR TITLE
Fix: `indent` rule does not indent when doing multi-line chain calls

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -238,6 +238,19 @@ module.exports = function(context) {
             indent = getNodeIndent(calleeNode);
         }
 
+        // If part of a multi-line chain call, indent one more to differentiate:
+        // var a = new P()
+        //     .done(function (result) {
+        //         doUsefulStuff(result);
+        //     });
+        var calleeLoc = calleeNode.type === "CallExpression" && calleeNode.callee.loc;
+        if (calleeLoc &&
+            calleeNode.loc.start.line < calleeLoc.end.line &&
+            calleeLoc.end.line < node.loc.start.line
+        ) {
+            indent += indentSize;
+        }
+
         indent += indentSize;
         // If function content is not empty
         if (node.body.length > 0) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -718,6 +718,28 @@ ruleTester.run("indent", rule, {
                 "}\n",
             ecmaFeatures: { modules: true, defaultParams: true },
             options: [2]
+        },
+        {
+            code:
+                "var obj = {\n" +
+                "  foo: function () {\n" +
+                "    return new p()\n" +
+                "      .then(function (ok) {\n" +
+                "        return ok;\n" +
+                "      }, function () {\n" +
+                "        // ignore things\n" +
+                "      });\n" +
+                "  }\n" +
+                "};\n",
+            options: [2]
+        },
+        {
+            code:
+                "a.b()\n" +
+                "  .c(function(){\n" +
+                "    var a;\n" +
+                "  }).d.e;\n",
+            options: [2]
         }
     ],
     invalid: [


### PR DESCRIPTION
Fixes #3279