### PR TITLE
Fix: Detect ternary operator in operator-linebreak rule

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -22,15 +22,17 @@ The `operator-linebreak` rule is aimed at enforcing a particular operator line b
 
 ### Options
 
-The rule takes an option, a string, which could be "after", "before" or "none". The default is "after".
+The rule takes two options, a string, which could be "after", "before" or "none where the default is "after" and an object for more fine-grained configuration.
 
 You can set the style in configuration like this:
 
 ```json
-"operator-linebreak": [2, "before"]
+"operator-linebreak": [2, "before", { "overrides": { "?": "after" } }]
 ```
 
-#### "after"
+The default configuration is to enforce line breaks _after_ the operator except for the ternary operator `?` and `:` following that.
+
+#### `"after"`
 
 This is the default setting for this rule. This option requires the line break to be placed after the operator.
 
@@ -52,6 +54,11 @@ foo
 if (someCondition
     || otherCondition) {
 }
+
+answer = everything
+  ? 42
+  : foo;
+
 ```
 
 The following patterns are not warnings:
@@ -71,9 +78,13 @@ if (someCondition ||
     otherCondition) {
 }
 
+answer = everything ?
+  42 :
+  foo;
+
 ```
 
-#### "before"
+#### `"before"`
 
 This option requires the line break to be placed before the operator.
 
@@ -91,6 +102,10 @@ foo =
 if (someCondition ||
     otherCondition) {
 }
+
+answer = everything ?
+  42 :
+  foo;
 
 ```
 
@@ -110,9 +125,13 @@ if (someCondition
     || otherCondition) {
 }
 
+answer = everything
+  ? 42
+  : foo;
+
 ```
 
-#### "none"
+#### `"none"`
 
 This option disallows line breaks on either side of the operator.
 
@@ -134,6 +153,14 @@ if (someCondition
     || otherCondition) {
 }
 
+answer = everything
+  ? 42
+  : foo;
+
+answer = everything ?
+  42 :
+  foo;
+
 ```
 
 The following patterns are not warnings:
@@ -147,7 +174,19 @@ foo = 5;
 if (someCondition || otherCondition) {
 }
 
+answer = everything ? 42 : foo;
+
 ```
+
+#### Fine-grained control
+
+The rule allows you to have even finer-grained control over individual operators by specifying an `overrides` dictionary:
+
+```json
+"operator-linebreak": [2, "before", { "overrides": { "?": "after", "+=": "none" } }]
+```
+
+This would override the global setting for that specific operator.
 
 ## When Not To Use It
 

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -14,7 +14,18 @@ var astUtils = require("../ast-utils");
 
 module.exports = function(context) {
 
-    var style = context.options[0] || "after";
+    var usedDefaultGlobal = !context.options[0];
+    var globalStyle = context.options[0] || "after";
+    var options = context.options[1] || {};
+    var styleOverrides = options.overrides || {};
+
+    if (usedDefaultGlobal && !styleOverrides["?"]) {
+        styleOverrides["?"] = "before";
+    }
+
+    if (usedDefaultGlobal && !styleOverrides[":"]) {
+        styleOverrides[":"] = "before";
+    }
 
     //--------------------------------------------------------------------------
     // Helpers
@@ -22,12 +33,13 @@ module.exports = function(context) {
 
     /**
      * Checks the operator placement
-     * @param {ASTNode} node The binary operator node to check
+     * @param {ASTNode} node The node to check
+     * @param {ASTNode} leftSide The node that comes before the operator in `node`
      * @private
      * @returns {void}
      */
-    function validateBinaryExpression(node) {
-        var leftToken = context.getLastToken(node.left || node.id);
+    function validateNode(node, leftSide) {
+        var leftToken = context.getLastToken(leftSide);
         var operatorToken = context.getTokenAfter(leftToken);
 
         // When the left part of a binary expression is a single expression wrapped in
@@ -42,6 +54,7 @@ module.exports = function(context) {
 
         var rightToken = context.getTokenAfter(operatorToken);
         var operator = operatorToken.value;
+        var style = styleOverrides[operator] || globalStyle;
 
         // if single line
         if (astUtils.isTokenOnSameLine(leftToken, operatorToken) &&
@@ -82,6 +95,15 @@ module.exports = function(context) {
         }
     }
 
+    /**
+     * Validates a binary expression using `validateNode`
+     * @param {BinaryExpression|LogicalExpression|AssignmentExpression} node node to be validated
+     * @returns {void}
+     */
+    function validateBinaryExpression(node) {
+        validateNode(node, node.left);
+    }
+
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
@@ -92,14 +114,33 @@ module.exports = function(context) {
         "AssignmentExpression": validateBinaryExpression,
         "VariableDeclarator": function(node) {
             if (node.init) {
-                validateBinaryExpression(node);
+                validateNode(node, node.id);
             }
+        },
+        "ConditionalExpression": function(node) {
+            validateNode(node, node.test);
+            validateNode(node, node.consequent);
         }
     };
 };
 
 module.exports.schema = [
     {
-        "enum": ["after", "before", "none"]
+        "enum": ["after", "before", "none", null]
+    },
+    {
+        "type": "object",
+        "properties": {
+            "overrides": {
+                "type": "object",
+                "properties": {
+                    "anyOf": {
+                        "type": "string",
+                        "enum": ["after", "before", "none"]
+                    }
+                }
+            }
+        },
+        "additionalProperties": false
     }
 ];

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -40,12 +40,19 @@ ruleTester.run("operator-linebreak", rule, {
         "'a\\\n' +\n 'c'",
         "'a' +\n 'b\\\n'",
         "(a\n) + b",
+        "answer = everything \n?  42 \n:  foo;",
+        {code: "answer = everything ?\n  42 :\n  foo;", options: ["after"]},
+
+        {code: "a ? 1 + 1\n:2", options: [null, { overrides: {"?": "after"}}]},
+        {code: "a ?\n1 +\n 1\n:2", options: [null, { overrides: {"?": "after"}}]},
+        {code: "o = 1 \n+ 1 - foo", options: [null, { overrides: {"+": "before"}}]},
 
         {code: "1\n+ 1", options: ["before"]},
         {code: "1 + 1\n+ 1", options: ["before"]},
         {code: "f(1\n+ 1)", options: ["before"]},
         {code: "1 \n|| 1", options: ["before"]},
         {code: "a += 1", options: ["before"]},
+        {code: "answer = everything \n?  42 \n:  foo;", options: ["before"]},
 
         {code: "1 + 1", options: ["none"]},
         {code: "1 + 1 + 1", options: ["none"]},
@@ -53,7 +60,8 @@ ruleTester.run("operator-linebreak", rule, {
         {code: "a += 1", options: ["none"]},
         {code: "var a;", options: ["none"]},
         {code: "\n1 + 1", options: ["none"]},
-        {code: "1 + 1\n", options: ["none"]}
+        {code: "1 + 1\n", options: ["none"]},
+        {code: "answer = everything ? 42 : foo;", options: ["none"]}
     ],
 
     invalid: [
@@ -138,6 +146,38 @@ ruleTester.run("operator-linebreak", rule, {
                 column: 2
             }]
         },
+        {
+            code: "answer = everything ?\n  42 :\n  foo;",
+            errors: [{
+                message: util.format(BEFORE_MSG, "?"),
+                type: "ConditionalExpression",
+                line: 1,
+                column: 22
+            },
+            {
+                message: util.format(BEFORE_MSG, ":"),
+                type: "ConditionalExpression",
+                line: 2,
+                column: 7
+            }]
+        },
+
+        {
+            code: "answer = everything \n?  42 \n:  foo;",
+            options: ["after"],
+            errors: [{
+                message: util.format(AFTER_MSG, "?"),
+                type: "ConditionalExpression",
+                line: 2,
+                column: 2
+            },
+            {
+                message: util.format(AFTER_MSG, ":"),
+                type: "ConditionalExpression",
+                line: 3,
+                column: 2
+            }]
+        },
 
         {
             code: "1 +\n1",
@@ -187,6 +227,22 @@ ruleTester.run("operator-linebreak", rule, {
                 type: "VariableDeclarator",
                 line: 1,
                 column: 8
+            }]
+        },
+        {
+            code: "answer = everything ?\n  42 :\n  foo;",
+            options: ["before"],
+            errors: [{
+                message: util.format(BEFORE_MSG, "?"),
+                type: "ConditionalExpression",
+                line: 1,
+                column: 22
+            },
+            {
+                message: util.format(BEFORE_MSG, ":"),
+                type: "ConditionalExpression",
+                line: 2,
+                column: 7
             }]
         },
 
@@ -288,6 +344,33 @@ ruleTester.run("operator-linebreak", rule, {
                 type: "VariableDeclarator",
                 line: 2,
                 column: 3
+            }]
+        },
+        {
+            code: "answer = everything ?\n  42 \n:  foo;",
+            options: ["none"],
+            errors: [{
+                message: util.format(NONE_MSG, "?"),
+                type: "ConditionalExpression",
+                line: 1,
+                column: 22
+            },
+            {
+                message: util.format(NONE_MSG, ":"),
+                type: "ConditionalExpression",
+                line: 3,
+                column: 2
+            }]
+        },
+
+        {
+            code: "foo +=\n42;\nbar -=\n12\n+ 5;",
+            options: ["after", { overrides: {"+=": "none", "+": "before" }}],
+            errors: [{
+                message: util.format(NONE_MSG, "+="),
+                type: "AssignmentExpression",
+                line: 1,
+                column: 7
             }]
         }
     ]


### PR DESCRIPTION
Fixes #3274