### PR TITLE
Fix: `prefer-template` had not been handling TemplateLiteral as literal node

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -31,7 +31,10 @@ function hasNonLiteral(node) {
     if (node.type === "BinaryExpression") {
         return hasNonLiteral(node.left) || hasNonLiteral(node.right);
     }
-    return node.type !== "Literal";
+    if (node.type === "UnaryExpression") {
+        return hasNonLiteral(node.argument);
+    }
+    return node.type !== "Literal" && node.type !== "TemplateLiteral";
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -28,9 +28,14 @@ ruleTester.run("prefer-template", rule, {
         {code: "'use strict';"},
         {code: "var foo = 'bar';"},
         {code: "var foo = 'bar' + 'baz';"},
+        {code: "var foo = +100 + 'yen';"},
         {code: "var foo = foo + +'100';"},
         {code: "var foo = `bar`;", ecmaFeatures: {templateStrings: true}},
-        {code: "var foo = `hello, ${name}!`;", ecmaFeatures: {templateStrings: true}}
+        {code: "var foo = `hello, ${name}!`;", ecmaFeatures: {templateStrings: true}},
+
+        // https://github.com/eslint/eslint/issues/3507
+        {code: "var foo = `foo` + `bar` + \"hoge\";", ecmaFeatures: {templateStrings: true}},
+        {code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";", ecmaFeatures: {templateStrings: true}}
     ],
     invalid: [
         {code: "var foo = 'hello, ' + name + '!';", errors: errors},


### PR DESCRIPTION
Fixes #3507.

Now, `TemplateLiteral` nodes are handled as literal.
So concatenations of template strings and strings are not warned by this rule.