### PR TITLE
Update: Add quotes around the label in  `no-empty-label` error reports

### DIFF
--- a/lib/rules/no-empty-label.js
+++ b/lib/rules/no-empty-label.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
             var type = node.body.type;
 
             if (type !== "ForStatement" && type !== "WhileStatement" && type !== "DoWhileStatement" && type !== "SwitchStatement" && type !== "ForInStatement" && type !== "ForOfStatement") {
-                context.report(node, "Unexpected label {{l}}", {l: node.label.name});
+                context.report(node, "Unexpected label \"{{l}}\"", {l: node.label.name});
             }
         }
     };

--- a/tests/lib/rules/no-empty-label.js
+++ b/tests/lib/rules/no-empty-label.js
@@ -27,6 +27,6 @@ ruleTester.run("no-empty-label", rule, {
         "labeled: switch(i) { case 1: break; default: break; }"
     ],
     invalid: [
-        { code: "labeled: var a = 10;", errors: [{ message: "Unexpected label labeled", type: "LabeledStatement"}] }
+        { code: "labeled: var a = 10;", errors: [{ message: "Unexpected label \"labeled\"", type: "LabeledStatement"}] }
     ]
 });


### PR DESCRIPTION
Fixes #3526