### PR TITLE
docs(curly): Fix broken code in example

### DIFF
--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -84,7 +84,7 @@ It will not warn for these patterns:
 
 ```js
 if (foo) return;
-else foo();
+else baz();
 
 while (true) {
     doSomething();


### PR DESCRIPTION
This has nothing to do with the rule itself, it just bugged me that the code would actually result in a runtime error.