### PR TITLE
Update: `key-spacing` should allow 1+ spaces before/after colon

### DIFF
--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -8,7 +8,9 @@ This rule will warn when spacing in properties does not match the specified opti
 
 ### 1. Individual
 
-Use just the `beforeColon` and `afterColon` options to enforce having one space or zero spaces on each side, using `true` or `false`, respectively. The default is no whitespace between the key and the colon and one space between the colon and the value.
+Use the `beforeColon`, `afterColon` and `mode` options to enforce having one space or zero spaces on each side, using `true` or `false`, respectively. The default is no whitespace between the key and the colon and one space between the colon and the value.
+
+`mode` option can be either `"strict"` or `"minimum"` and defaults to `"strict"`. In `strict` mode, it enforces exactly 1 space before or after the colon where as in `minimum` mode, it enforces at least 1 space but more are okay.
 
 The following patterns are considered valid:
 
@@ -27,6 +29,15 @@ foo = { thisLineWouldBeTooLong:
 
 call({
     foobar :42,
+    bat :(2 * 2)
+});
+```
+
+```js
+/*eslint key-spacing: [2, {"beforeColon": true, "afterColon": false, "mode": "minimum"}]*/
+
+call({
+    foobar   :42,
     bat :(2 * 2)
 });
 ```
@@ -50,6 +61,17 @@ function foo() {
     return {
         foobar: 42,             /*error Missing space after key "foobar".*/
         bat :"value"            /*error Missing space before value for key "bat".*/
+    };
+}
+```
+
+```js
+/*eslint key-spacing: [2, {"beforeColon": true, "afterColon": true}]*/
+
+function foo() {
+    return {
+        foobar  : 42,             /*error Extra space after key "foobar".*/
+        bat :  "value"            /*error Extra space before value for key "bat".*/
     };
 }
 ```

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -94,6 +94,7 @@ module.exports = function(context) {
 
     var options = context.options[0] || {},
         align = options.align,
+        mode = options.mode || "strict",
         beforeColon = +!!options.beforeColon, // Defaults to false
         afterColon = +!(options.afterColon === false); // Defaults to true
 
@@ -162,7 +163,9 @@ module.exports = function(context) {
             firstTokenAfterColon = context.getTokenAfter(key, 1),
             location = side === "key" ? key.loc.start : firstTokenAfterColon.loc.start;
 
-        if (diff && !(expected && containsLineTerminator(whitespace))) {
+        if ((diff && mode === "strict" || diff < 0 && mode === "minimum") &&
+            !(expected && containsLineTerminator(whitespace))
+        ) {
             context.report(property[side], location, messages[side], {
                 error: diff > 0 ? "Extra" : "Missing",
                 computed: property.computed ? "computed " : "",
@@ -332,6 +335,9 @@ module.exports.schema = [
         "properties": {
             "align": {
                 "enum": ["colon", "value"]
+            },
+            "mode": {
+                "enum": ["strict", "minimum"]
             },
             "beforeColon": {
                 "type": "boolean"

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -150,6 +150,24 @@ ruleTester.run("key-spacing", rule, {
             afterColon: true
         }]
     }, {
+        code: [
+            "obj = { key ",
+            "    :     ",
+            " longName };"
+        ].join("\n"),
+        options: [{
+            beforeColon: true,
+            afterColon: false,
+            mode: "minimum"
+        }]
+    }, {
+        code: "obj = { key     :      longName };",
+        options: [{
+            beforeColon: true,
+            afterColon: false,
+            mode: "minimum"
+        }]
+    }, {
         code: "var obj = { get fn() { return 42; } };",
         options: [{}]
     }, {
@@ -415,6 +433,17 @@ ruleTester.run("key-spacing", rule, {
         errors: [
             { message: "Missing space after key \"b\".", line: 3, column: 11, type: "Identifier" }
         ]
+    }, {
+        code: [
+            "obj = { key ",
+            " :     longName };"
+        ].join("\n"),
+        options: [{
+            beforeColon: true,
+            afterColon: true
+        }],
+        errors: [
+            { message: "Extra space before value for key \"key\".", line: 2, column: 8, type: "Identifier" }
+        ]
     }]
-
 });


### PR DESCRIPTION
Fixes #3363.