### PR TITLE
Fix: `quote-props` rule should ignore computed and shorthand properties

### DIFF
--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -59,6 +59,10 @@ module.exports = function(context) {
             isKeywordToken,
             tokens;
 
+        if (node.method || node.computed || node.shorthand) {
+            return;
+        }
+
         if (key.type === "Literal" && typeof key.value === "string") {
             try {
                 tokens = espree.tokenize(key.value);
@@ -92,7 +96,7 @@ module.exports = function(context) {
     function checkOmittedQuotes(node) {
         var key = node.key;
 
-        if (!node.method && !(key.type === "Literal" && typeof key.value === "string")) {
+        if (!node.method && !node.computed && !node.shorthand && !(key.type === "Literal" && typeof key.value === "string")) {
             context.report(node, MESSAGE_UNQUOTED, {
                 property: key.name || key.value
             });
@@ -113,6 +117,10 @@ module.exports = function(context) {
         node.properties.forEach(function(property) {
             var key = property.key,
                 tokens;
+
+            if (property.method || property.computed || property.shorthand) {
+                return;
+            }
 
             if (key.type === "Literal" && typeof key.value === "string") {
 

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -26,7 +26,13 @@ ruleTester.run("quote-props", rule, {
         "({ '@': 0 })",
 
         { code: "({ 'a': 0, b(){} })", ecmaFeatures: { objectLiteralShorthandMethods: true }},
+        { code: "({ [x]: 0 });", env: {es6: true}},
+        { code: "({ x });", env: {es6: true}},
         { code: "({ a: 0, b(){} })", options: ["as-needed"], ecmaFeatures: { objectLiteralShorthandMethods: true } },
+        { code: "({ a: 0, [x]: 1 })", options: ["as-needed"], env: {es6: true} },
+        { code: "({ a: 0, x })", options: ["as-needed"], env: {es6: true} },
+        { code: "({ '@': 0, [x]: 1 })", options: ["as-needed"], env: {es6: true} },
+        { code: "({ '@': 0, x })", options: ["as-needed"], env: {es6: true} },
         { code: "({ a: 0, b: 0 })", options: ["as-needed"] },
         { code: "({ a: 0, 0: 0 })", options: ["as-needed"] },
         { code: "({ a: 0, true: 0 })", options: ["as-needed"] },
@@ -42,10 +48,16 @@ ruleTester.run("quote-props", rule, {
         { code: "({ 'true': 0, 'b': 0 })", options: ["consistent"] },
         { code: "({ null: 0, a: 0 })", options: ["consistent"] },
         { code: "({ a: 0, b: 0 })", options: ["consistent"] },
+        { code: "({ 'a': 1, [x]: 0 });", options: ["consistent"], env: {es6: true}},
+        { code: "({ 'a': 1, x });", options: ["consistent"], env: {es6: true}},
         { code: "({ a: 0, b: 0 })", options: ["consistent-as-needed"] },
         { code: "({ a: 0, null: 0 })", options: ["consistent-as-needed"] },
         { code: "({ 'a': 0, '-b': 0 })", options: ["consistent-as-needed"] },
         { code: "({ '@': 0, 'B': 0 })", options: ["consistent-as-needed"] },
+        { code: "({ '@': 1, [x]: 0 });", env: {"es6": true}, options: ["consistent-as-needed"]},
+        { code: "({ '@': 1, x });", env: {"es6": true}, options: ["consistent-as-needed"]},
+        { code: "({ a: 1, [x]: 0 });", env: {"es6": true}, options: ["consistent-as-needed"]},
+        { code: "({ a: 1, x });", env: {"es6": true}, options: ["consistent-as-needed"]},
         { code: "({ a: 0, 'if': 0 })", options: ["as-needed", {keywords: true}] },
         { code: "({ a: 0, 'while': 0 })", options: ["as-needed", {keywords: true}] },
         { code: "({ a: 0, 'volatile': 0 })", options: ["as-needed", {keywords: true}] },
@@ -105,6 +117,20 @@ ruleTester.run("quote-props", rule, {
         }]
     }, {
         code: "({ 'a': 0, 'b': 0 })",
+        options: ["consistent-as-needed"],
+        errors: [{
+            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
+        }]
+    }, {
+        code: "({ 'a': 0, [x]: 0 })",
+        env: {"es6": true},
+        options: ["consistent-as-needed"],
+        errors: [{
+            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
+        }]
+    }, {
+        code: "({ 'a': 0, x })",
+        env: {"es6": true},
         options: ["consistent-as-needed"],
         errors: [{
             message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"


### PR DESCRIPTION
Fixes #3557 and fixes #3544