### PR TITLE
New: code path analysis.

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -541,6 +541,7 @@ target.gensite = function() {
         "/rules/",
         "/user-guide/command-line-interface.md",
         "/user-guide/configuring.md",
+        "/developer-guide/code-path-analysis.md",
         "/developer-guide/nodejs-api.md",
         "/developer-guide/working-with-plugins.md",
         "/developer-guide/working-with-rules.md"
@@ -579,7 +580,7 @@ target.gensite = function() {
 
     // 4. Loop through all files in temporary directory
     find(TEMP_DIR).forEach(function(filename) {
-        if (test("-f", filename) && path.extname(filename) !== "") {
+        if (test("-f", filename) && path.extname(filename) === ".md") {
 
             var rulesUrl = "https://github.com/eslint/eslint/tree/master/lib/rules/";
             var docsUrl = "https://github.com/eslint/eslint/tree/master/docs/rules/";

--- a/docs/developer-guide/code-path-analysis.md
+++ b/docs/developer-guide/code-path-analysis.md
@@ -1,0 +1,554 @@
+# Code Path Analysis Details
+
+| [Objects](#objects) | [Events](#events) | [Usage Examples](#usage-examples) | [Code Path Examples](#code-path-examples) |
+|:-------------------:|:-----------------:|:---------------------------------:|:-----------------------------------------:|
+
+ESLint's rules can use code paths.
+The code path is execution routes of programs.
+It forks/joins at such as `if` statements.
+
+```js
+if (a && b) {
+    foo();
+}
+bar();
+```
+
+![Code Path Example](./code-path-analysis/helo.svg)
+
+## Objects
+
+Program is expressed with several code paths.
+A code path is expressed with objects of two kinds: `CodePath` and `CodePathSegment`.
+
+### `CodePath`
+
+`CodePath` expresses whole of one code path.
+This object exists for each function and the global.
+This has references of both the initial segment and the final segments of a code path.
+
+`CodePath` has the following properties:
+
+* `id` (`string`) - An unique string. Respective rules can use `id` to save additional information for each code path.
+* `initialSegment` (`CodePathSegment`) - The initial segment of this code path.
+* `finalSegments` (`CodePathSegment[]`) - The final segments which includes both returned and thrown.
+* `returnedSegments` (`CodePathSegment[]`) - The final segments which includes only returned.
+* `thrownSegments` (`CodePathSegment[]`) - The final segments which includes only thrown.
+* `currentSegments` (`CodePathSegment[]`) - Segments of the current position.
+* `upper` (`CodePath|null`) - The code path of the upper function/global scope.
+* `childCodePaths` (`CodePath[]`) - Code paths of functions this code path contains.
+
+### `CodePathSegment`
+
+`CodePathSegment` is a part of a code path.
+A code path is expressed with plural `CodePathSegment` objects, it's similar to doubly linked list.
+Difference from doubly linked list is what there are forking and merging (the next/prev are plural).
+
+`CodePathSegment` has the following properties:
+
+* `id` (`string`) - An unique string. Respective rules can use `id` to save additional information for each segment.
+* `nextSegments` (`CodePathSegment[]`) - The next segments. If forking, there are two or more. If final, there is nothing.
+* `prevSegments` (`CodePathSegment[]`) - The previous segments. If merging, there are two or more. If initial, there is nothing.
+* `reachable` (`boolean`) - A flag which shows whether or not it's reachable. This becomes `false` when preceded by `return`, `throw`, `break`, or `continue`.
+
+## Events
+
+There are five events related to code paths, and you can define event handlers in rules.
+
+```js
+module.exports = function(context) {
+    return {
+        /**
+         * This is called at the start of analyzing a code path.
+         * In this time, the code path object has only the initial segment.
+         *
+         * @param {CodePath} codePath - The new code path.
+         * @param {ASTNode} node - The current node.
+         * @returns {void}
+         */
+        "onCodePathStart": function(codePath, node) {
+            // do something with codePath
+        },
+
+        /**
+         * This is called at the end of analyzing a code path.
+         * In this time, the code path object is complete.
+         *
+         * @param {CodePath} codePath - The completed code path.
+         * @param {ASTNode} node - The current node.
+         * @returns {void}
+         */
+        "onCodePathEnd": function(codePath, node) {
+            // do something with codePath
+        },
+
+        /**
+         * This is called when a code path segment was created.
+         * It meant the code path is forked or merged.
+         * In this time, the segment has the previous segments and has been
+         * judged reachable or not.
+         *
+         * @param {CodePathSegment} segment - The new code path segment.
+         * @param {ASTNode} node - The current node.
+         * @returns {void}
+         */
+        "onCodePathSegmentStart": function(segment, node) {
+            // do something with segment
+        },
+
+        /**
+         * This is called when a code path segment was leaved.
+         * In this time, the segment does not have the next segments yet.
+         *
+         * @param {CodePathSegment} segment - The leaved code path segment.
+         * @param {ASTNode} node - The current node.
+         * @returns {void}
+         */
+        "onCodePathSegmentEnd": function(segment, node) {
+            // do something with segment
+        },
+
+        /**
+         * This is called when a code path segment was looped.
+         * Usually segments have each previous segments when created,
+         * but when looped, a segment is added as a new previous segment into a
+         * existing segment.
+         *
+         * @param {CodePathSegment} fromSegment - A code path segment of source.
+         * @param {CodePathSegment} toSegment - A code path segment of destination.
+         * @param {ASTNode} node - The current node.
+         * @returns {void}
+         */
+        "onCodePathSegmentLoop": function(fromSegment, toSegment, node) {
+            // do something with segment
+        }
+    };
+};
+```
+
+### About `onCodePathSegmentLoop`
+
+This event is always fired when the next segment has existed already.
+That timing is the end of loops mainly.
+
+For Example 1:
+
+```js
+while (a) {
+    a = foo();
+}
+bar();
+```
+
+1. First, the analysis advances to the end of loop.
+
+   ![Loop Event's Example 1](./code-path-analysis/loop-event-example-while-1.svg)
+
+2. Second, it creates the looping path.
+   At this time, the next segment has existed already, so the `onCodePathSegmentStart` event is not fired.
+   It fires `onCodePathSegmentLoop` instead.
+
+   ![Loop Event's Example 2](./code-path-analysis/loop-event-example-while-2.svg)
+
+3. Last, it advances to the end.
+
+   ![Loop Event's Example 3](./code-path-analysis/loop-event-example-while-3.svg)
+
+For example 2:
+
+```js
+for (let i = 0; i < 10; ++i) {
+    foo(i);
+}
+bar();
+```
+
+1. `for` statements are more complex.
+   First, the analysis advances to `ForStatement.update`.
+   The `update` segment is hovered at first.
+
+   ![Loop Event's Example 1](./code-path-analysis/loop-event-example-for-1.svg)
+
+2. Second, it advances to `ForStatement.body`.
+   Of course the `body` segment is preceded by the `test` segment.
+   It keeps the `update` segment hovering.
+
+   ![Loop Event's Example 2](./code-path-analysis/loop-event-example-for-2.svg)
+
+3. Third, it creates the looping path from `body` segment to `update` segment.
+   At this time, the next segment has existed already, so the `onCodePathSegmentStart` event is not fired.
+   It fires `onCodePathSegmentLoop` instead.
+
+   ![Loop Event's Example 3](./code-path-analysis/loop-event-example-for-3.svg)
+
+4. Fourth, also it creates the looping path from `update` segment to `test` segment.
+   At this time, the next segment has existed already, so the `onCodePathSegmentStart` event is not fired.
+   It fires `onCodePathSegmentLoop` instead.
+
+   ![Loop Event's Example 4](./code-path-analysis/loop-event-example-for-4.svg)
+
+5. Last, it advances to the end.
+
+   ![Loop Event's Example 5](./code-path-analysis/loop-event-example-for-5.svg)
+
+
+
+## Usage Examples
+
+### To check whether or not this is reachable
+
+```js
+var getLast = require("../ast-utils").getLast;
+
+function isReachable(segment) {
+    return segment.reachable;
+}
+
+module.exports = function(context) {
+    var codePathStack = [];
+
+    return {
+        // Stores CodePath objects.
+        "onCodePathStart": function(codePath) {
+            codePathStack.push(codePath);
+        },
+        "onCodePathEnd": function(codePath) {
+            codePathStack.pop();
+        },
+
+        // Checks reachable or not.
+        "ExpressionStatement": function(node) {
+            var codePath = getLast(codePathStack);
+
+            // Checks the current code path segments.
+            if (!codePath.currentSegments.some(isReachable)) {
+                context.report({message: "Unreachable!", node: node});
+            }
+        }
+    };
+};
+```
+
+See Also:
+[no-unreachable](https://github.com/eslint/eslint/blob/master/lib/rules/no-unreachable.js),
+[no-fallthrough](https://github.com/eslint/eslint/blob/master/lib/rules/no-fallthrough.js),
+[consistent-return](https://github.com/eslint/eslint/blob/master/lib/rules/consistent-return.js)
+
+### To check state of a code path
+
+This example is checking whether or not the parameter `cb` is called in every path.
+Instances of `CodePath` and `CodePathSegment` are shared to every rule.
+So a rule must not modify those instances.
+Please use a map of information instead.
+
+```js
+var getLast = require("../ast-utils").getLast;
+
+function hasCb(node, context) {
+    if (node.type.indexOf("Function") !== -1) {
+        return context.getDeclaredVariables(node).some(function(v) {
+            return v.type === "Parameter" && v.name === "cb";
+        });
+    }
+    return false;
+}
+
+function isCbCalled(info) {
+    return info.cbCalled;
+}
+
+module.exports = function(context) {
+    var funcInfoStack = [];
+    var segmentInfoMap = Object.create(null);
+
+    return {
+        // Checks `cb`.
+        "onCodePathStart": function(codePath, node) {
+            funcInfoStack.push({
+                codePath: codePath,
+                hasCb: hasCb(node, context)
+            });
+        },
+        "onCodePathEnd": function(codePath, node) {
+            funcInfoStack.pop();
+
+            // Checks `cb` was called in every paths.
+            var cbCalled = codePath.finalSegments.every(function(segment) {
+                var info = segmentInfoMap[segment.id];
+                return info.cbCalled;
+            });
+
+            if (!cbCalled) {
+                context.report({
+                    message: "`cb` should be called in every path.",
+                    node: node
+                });
+            }
+        },
+
+        // Manages state of code paths.
+        "onCodePathSegmentStart": function(segment) {
+            // Ignores if `cb` doesn't exist.
+            if (!getLast(funcInfoStack).hasCb) {
+                return;
+            }
+
+            // Initialize state of this path.
+            var info = segmentInfoMap[segment.id] = {
+                cbCalled: false
+            };
+
+            // If there are the previous paths, merges state.
+            // Checks `cb` was called in every previous path.
+            if (segment.prevSegments.length > 0) {
+                info.cbCalled = segment.prevSegments.every(isCbCalled);
+            }
+        },
+
+        // Checks reachable or not.
+        "CallExpression": function(node) {
+            var funcInfo = getLast(funcInfoStack);
+
+            // Ignores if `cb` doesn't exist.
+            if (!funcInfo.hasCb) {
+                return;
+            }
+
+            // Sets marks that `cb` was called.
+            var callee = node.callee;
+            if (callee.type === "Identifier" && callee.name === "cb") {
+                funcInfo.codePath.currentSegments.forEach(function(segment) {
+                    var info = segmentInfoMap[segment.id];
+                    info.cbCalled = true;
+                });
+            }
+        }
+    };
+};
+```
+
+See Also:
+[constructor-super](https://github.com/eslint/eslint/blob/master/lib/rules/constructor-super.js),
+[no-this-before-super](https://github.com/eslint/eslint/blob/master/lib/rules/no-this-before-super.js)
+
+## Code Path Examples
+
+### Hello World
+
+```js
+console.log("Hello world!");
+```
+
+![Hello World](./code-path-analysis/example-hello-world.svg)
+
+### `IfStatement`
+
+```js
+if (a) {
+    foo();
+} else {
+    bar();
+}
+```
+
+![`IfStatement`](./code-path-analysis/example-ifstatement.svg)
+
+### `IfStatement` (chain)
+
+```js
+if (a) {
+    foo();
+} else if (b) {
+    bar();
+} else if (c) {
+    hoge();
+}
+```
+
+![`IfStatement` (chain)](./code-path-analysis/example-ifstatement-chain.svg)
+
+### `SwitchStatement`
+
+```js
+switch (a) {
+    case 0:
+        foo();
+        break;
+
+    case 1:
+    case 2:
+        bar();
+        // fallthrough
+
+    case 3:
+        hoge();
+        break;
+}
+```
+
+![`SwitchStatement`](./code-path-analysis/example-switchstatement.svg)
+
+### `SwitchStatement` (has `default`)
+
+```js
+switch (a) {
+    case 0:
+        foo();
+        break;
+
+    case 1:
+    case 2:
+        bar();
+        // fallthrough
+
+    case 3:
+        hoge();
+        break;
+
+    default:
+        fuga();
+        break;
+}
+```
+
+![`SwitchStatement` (has `default`)](./code-path-analysis/example-switchstatement-has-default.svg)
+
+### `TryStatement` (try-catch)
+
+```js
+try {
+    foo();
+    if (a) {
+        throw new Error();
+    }
+    bar();
+} catch (err) {
+    hoge(err);
+}
+last();
+```
+
+It creates the paths from `try` block to `catch` block at:
+
+* `throw` statements.
+* The first throwable node (e.g. a function call) in the `try` block.
+* The end of the `try` block.
+
+![`TryStatement` (try-catch)](./code-path-analysis/example-trystatement-try-catch.svg)
+
+### `TryStatement` (try-finally)
+
+```js
+try {
+    foo();
+    bar();
+} finally {
+    fuga();
+}
+last();
+```
+
+If there is not `catch` block, `finally` block has two current segments.
+At this time, `CodePath.currentSegments.length` is `2`.
+One is the normal path, and another is the leaving path (`throw` or `return`).
+
+![`TryStatement` (try-finally)](./code-path-analysis/example-trystatement-try-finally.svg)
+
+### `TryStatement` (try-catch-finally)
+
+```js
+try {
+    foo();
+    bar();
+} catch (err) {
+    hoge(err);
+} finally {
+    fuga();
+}
+last();
+```
+
+![`TryStatement` (try-catch-finally)](./code-path-analysis/example-trystatement-try-catch-finally.svg)
+
+### `WhileStatement`
+
+```js
+while (a) {
+    foo();
+    if (b) {
+        continue;
+    }
+    bar();
+}
+```
+
+![`WhileStatement`](./code-path-analysis/example-whilestatement.svg)
+
+### `DoWhileStatement`
+
+```js
+do {
+    foo();
+    bar();
+} while (a);
+```
+
+![`DoWhileStatement`](./code-path-analysis/example-dowhilestatement.svg)
+
+### `ForStatement`
+
+```js
+for (let i = 0; i < 10; ++i) {
+    foo();
+    if (b) {
+        break;
+    }
+    bar();
+}
+```
+
+![`ForStatement`](./code-path-analysis/example-forstatement.svg)
+
+### `ForStatement` (for ever)
+
+```js
+for (;;) {
+    foo();
+}
+bar();
+```
+
+![`ForStatement` (for ever)](./code-path-analysis/example-forstatement-for-ever.svg)
+
+### `ForInStatement`
+
+```js
+for (let key in obj) {
+    foo(key);
+}
+```
+
+![`ForInStatement`](./code-path-analysis/example-forinstatement.svg)
+
+### When there is a function
+
+```js
+function foo(a) {
+    if (a) {
+        return;
+    }
+    bar();
+}
+
+foo(false);
+```
+
+It creates two code paths.
+
+* The global's
+
+  ![When there is a function](./code-path-analysis/example-when-there-is-a-function-g.svg)
+
+* The function's
+
+  ![When there is a function](./code-path-analysis/example-when-there-is-a-function-f.svg)

--- a/docs/developer-guide/code-path-analysis/example-dowhilestatement.svg
+++ b/docs/developer-guide/code-path-analysis/example-dowhilestatement.svg
@@ -1,0 +1,100 @@
+<?xml version="1.0"?>
+<svg width="167pt" height="422pt" viewBox="0.00 0.00 167.00 422.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 418)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="74" cy="-405" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="123.479,-359.602 24.5211,-359.602 12.5211,-347.602 12.5211,-330.398 24.5211,-318.398 123.479,-318.398 135.479,-330.398 135.479,-347.602 123.479,-359.602"></polygon>
+<path fill="white" stroke="white" d="M24.5211,-359.602C18.5211,-359.602 12.5211,-353.602 12.5211,-347.602"></path>
+<path fill="white" stroke="white" d="M12.5211,-330.398C12.5211,-324.398 18.5211,-318.398 24.5211,-318.398"></path>
+<path fill="white" stroke="white" d="M123.479,-318.398C129.479,-318.398 135.479,-324.398 135.479,-330.398"></path>
+<path fill="white" stroke="white" d="M135.479,-347.602C135.479,-353.602 129.479,-359.602 123.479,-359.602"></path>
+<polyline fill="none" stroke="black" points="123.479,-359.602 24.5211,-359.602 "></polyline>
+<path fill="none" stroke="black" d="M24.5211,-359.602C18.5211,-359.602 12.5211,-353.602 12.5211,-347.602"></path>
+<polyline fill="none" stroke="black" points="12.5211,-347.602 12.5211,-330.398 "></polyline>
+<path fill="none" stroke="black" d="M12.5211,-330.398C12.5211,-324.398 18.5211,-318.398 24.5211,-318.398"></path>
+<polyline fill="none" stroke="black" points="24.5211,-318.398 123.479,-318.398 "></polyline>
+<path fill="none" stroke="black" d="M123.479,-318.398C129.479,-318.398 135.479,-324.398 135.479,-330.398"></path>
+<polyline fill="none" stroke="black" points="135.479,-330.398 135.479,-347.602 "></polyline>
+<path fill="none" stroke="black" d="M135.479,-347.602C135.479,-353.602 129.479,-359.602 123.479,-359.602"></path>
+<text text-anchor="middle" x="74" y="-343.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="74" y="-326.4" font-family="Times,serif" font-size="14.00">DoWhileStatement</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M74,-395.894C74,-389.274 74,-379.485 74,-369.94"></path>
+<polygon fill="black" stroke="black" points="77.5001,-369.842 74,-359.842 70.5001,-369.842 77.5001,-369.842"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="74" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="74" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="129.147,-282.401 18.8526,-282.401 6.85263,-270.401 6.85263,-151.599 18.8526,-139.599 129.147,-139.599 141.147,-151.599 141.147,-270.401 129.147,-282.401"></polygon>
+<path fill="white" stroke="white" d="M18.8526,-282.401C12.8526,-282.401 6.85263,-276.401 6.85263,-270.401"></path>
+<path fill="white" stroke="white" d="M6.85263,-151.599C6.85263,-145.599 12.8526,-139.599 18.8526,-139.599"></path>
+<path fill="white" stroke="white" d="M129.147,-139.599C135.147,-139.599 141.147,-145.599 141.147,-151.599"></path>
+<path fill="white" stroke="white" d="M141.147,-270.401C141.147,-276.401 135.147,-282.401 129.147,-282.401"></path>
+<polyline fill="none" stroke="black" points="129.147,-282.401 18.8526,-282.401 "></polyline>
+<path fill="none" stroke="black" d="M18.8526,-282.401C12.8526,-282.401 6.85263,-276.401 6.85263,-270.401"></path>
+<polyline fill="none" stroke="black" points="6.85263,-270.401 6.85263,-151.599 "></polyline>
+<path fill="none" stroke="black" d="M6.85263,-151.599C6.85263,-145.599 12.8526,-139.599 18.8526,-139.599"></path>
+<polyline fill="none" stroke="black" points="18.8526,-139.599 129.147,-139.599 "></polyline>
+<path fill="none" stroke="black" d="M129.147,-139.599C135.147,-139.599 141.147,-145.599 141.147,-151.599"></path>
+<polyline fill="none" stroke="black" points="141.147,-151.599 141.147,-270.401 "></polyline>
+<path fill="none" stroke="black" d="M141.147,-270.401C141.147,-276.401 135.147,-282.401 129.147,-282.401"></path>
+<text text-anchor="middle" x="74" y="-265.6" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="74" y="-248.8" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="74" y="-232" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="74" y="-215.2" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="74" y="-198.4" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="74" y="-181.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="74" y="-164.8" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+<text text-anchor="middle" x="74" y="-148" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M74,-318.313C74,-310.915 74,-301.974 74,-292.455"></path>
+<polygon fill="black" stroke="black" points="77.5001,-292.368 74,-282.368 70.5001,-292.368 77.5001,-292.368"></polygon>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M141.337,-232.995C151.84,-229.707 159,-222.375 159,-211 159,-203.357 155.768,-197.54 150.461,-193.548"></path>
+<polygon fill="black" stroke="black" points="151.849,-190.329 141.337,-189.005 148.729,-196.596 151.849,-190.329"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="136.144,-103.602 11.8558,-103.602 -0.144212,-91.6019 -0.144212,-74.3981 11.8558,-62.3981 136.144,-62.3981 148.144,-74.3981 148.144,-91.6019 136.144,-103.602"></polygon>
+<path fill="white" stroke="white" d="M11.8558,-103.602C5.85579,-103.602 -0.144212,-97.6019 -0.144212,-91.6019"></path>
+<path fill="white" stroke="white" d="M-0.144212,-74.3981C-0.144212,-68.3981 5.85579,-62.3981 11.8558,-62.3981"></path>
+<path fill="white" stroke="white" d="M136.144,-62.3981C142.144,-62.3981 148.144,-68.3981 148.144,-74.3981"></path>
+<path fill="white" stroke="white" d="M148.144,-91.6019C148.144,-97.6019 142.144,-103.602 136.144,-103.602"></path>
+<polyline fill="none" stroke="black" points="136.144,-103.602 11.8558,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M11.8558,-103.602C5.85579,-103.602 -0.144212,-97.6019 -0.144212,-91.6019"></path>
+<polyline fill="none" stroke="black" points="-0.144212,-91.6019 -0.144212,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M-0.144212,-74.3981C-0.144212,-68.3981 5.85579,-62.3981 11.8558,-62.3981"></path>
+<polyline fill="none" stroke="black" points="11.8558,-62.3981 136.144,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M136.144,-62.3981C142.144,-62.3981 148.144,-68.3981 148.144,-74.3981"></path>
+<polyline fill="none" stroke="black" points="148.144,-74.3981 148.144,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M148.144,-91.6019C148.144,-97.6019 142.144,-103.602 136.144,-103.602"></path>
+<text text-anchor="middle" x="74" y="-87.2" font-family="Times,serif" font-size="14.00">DoWhileStatement:exit</text>
+<text text-anchor="middle" x="74" y="-70.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M74,-139.632C74,-130.564 74,-121.701 74,-113.811"></path>
+<polygon fill="black" stroke="black" points="77.5001,-113.726 74,-103.726 70.5001,-113.726 77.5001,-113.726"></polygon>
+</g>
+
+<g id="edge6" class="edge"><title>s1_3-&gt;final</title>
+<path fill="none" stroke="black" d="M74,-62.3316C74,-54.2587 74,-44.8663 74,-36.5198"></path>
+<polygon fill="black" stroke="black" points="77.5001,-36.3487 74,-26.3488 70.5001,-36.3488 77.5001,-36.3487"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-forinstatement.svg
+++ b/docs/developer-guide/code-path-analysis/example-forinstatement.svg
@@ -1,0 +1,148 @@
+<?xml version="1.0"?>
+<svg width="185pt" height="538pt" viewBox="0.00 0.00 185.00 538.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 534)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="114" cy="-521" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="153.319,-475.602 74.6808,-475.602 62.6808,-463.602 62.6808,-446.398 74.6808,-434.398 153.319,-434.398 165.319,-446.398 165.319,-463.602 153.319,-475.602"></polygon>
+<path fill="white" stroke="white" d="M74.6808,-475.602C68.6808,-475.602 62.6808,-469.602 62.6808,-463.602"></path>
+<path fill="white" stroke="white" d="M62.6808,-446.398C62.6808,-440.398 68.6808,-434.398 74.6808,-434.398"></path>
+<path fill="white" stroke="white" d="M153.319,-434.398C159.319,-434.398 165.319,-440.398 165.319,-446.398"></path>
+<path fill="white" stroke="white" d="M165.319,-463.602C165.319,-469.602 159.319,-475.602 153.319,-475.602"></path>
+<polyline fill="none" stroke="black" points="153.319,-475.602 74.6808,-475.602 "></polyline>
+<path fill="none" stroke="black" d="M74.6808,-475.602C68.6808,-475.602 62.6808,-469.602 62.6808,-463.602"></path>
+<polyline fill="none" stroke="black" points="62.6808,-463.602 62.6808,-446.398 "></polyline>
+<path fill="none" stroke="black" d="M62.6808,-446.398C62.6808,-440.398 68.6808,-434.398 74.6808,-434.398"></path>
+<polyline fill="none" stroke="black" points="74.6808,-434.398 153.319,-434.398 "></polyline>
+<path fill="none" stroke="black" d="M153.319,-434.398C159.319,-434.398 165.319,-440.398 165.319,-446.398"></path>
+<polyline fill="none" stroke="black" points="165.319,-446.398 165.319,-463.602 "></polyline>
+<path fill="none" stroke="black" d="M165.319,-463.602C165.319,-469.602 159.319,-475.602 153.319,-475.602"></path>
+<text text-anchor="middle" x="114" y="-459.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="114" y="-442.4" font-family="Times,serif" font-size="14.00">ForInStatement</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M114,-511.894C114,-505.274 114,-495.485 114,-485.94"></path>
+<polygon fill="black" stroke="black" points="117.5,-485.842 114,-475.842 110.5,-485.842 117.5,-485.842"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="114" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="114" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="151.097,-398 76.9034,-398 64.9034,-386 64.9034,-374 76.9034,-362 151.097,-362 163.097,-374 163.097,-386 151.097,-398"></polygon>
+<path fill="white" stroke="white" d="M76.9034,-398C70.9034,-398 64.9034,-392 64.9034,-386"></path>
+<path fill="white" stroke="white" d="M64.9034,-374C64.9034,-368 70.9034,-362 76.9034,-362"></path>
+<path fill="white" stroke="white" d="M151.097,-362C157.097,-362 163.097,-368 163.097,-374"></path>
+<path fill="white" stroke="white" d="M163.097,-386C163.097,-392 157.097,-398 151.097,-398"></path>
+<polyline fill="none" stroke="black" points="151.097,-398 76.9034,-398 "></polyline>
+<path fill="none" stroke="black" d="M76.9034,-398C70.9034,-398 64.9034,-392 64.9034,-386"></path>
+<polyline fill="none" stroke="black" points="64.9034,-386 64.9034,-374 "></polyline>
+<path fill="none" stroke="black" d="M64.9034,-374C64.9034,-368 70.9034,-362 76.9034,-362"></path>
+<polyline fill="none" stroke="black" points="76.9034,-362 151.097,-362 "></polyline>
+<path fill="none" stroke="black" d="M151.097,-362C157.097,-362 163.097,-368 163.097,-374"></path>
+<polyline fill="none" stroke="black" points="163.097,-374 163.097,-386 "></polyline>
+<path fill="none" stroke="black" d="M163.097,-386C163.097,-392 157.097,-398 151.097,-398"></path>
+<text text-anchor="middle" x="114" y="-375.8" font-family="Times,serif" font-size="14.00">Identifier (obj)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M114,-434.052C114,-426.216 114,-417.089 114,-408.636"></path>
+<polygon fill="black" stroke="black" points="117.5,-408.439 114,-398.439 110.5,-408.439 117.5,-408.439"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="119.617,-326.401 14.3833,-326.401 2.38328,-314.401 2.38328,-279.599 14.3833,-267.599 119.617,-267.599 131.617,-279.599 131.617,-314.401 119.617,-326.401"></polygon>
+<path fill="white" stroke="white" d="M14.3833,-326.401C8.38328,-326.401 2.38328,-320.401 2.38328,-314.401"></path>
+<path fill="white" stroke="white" d="M2.38328,-279.599C2.38328,-273.599 8.38328,-267.599 14.3833,-267.599"></path>
+<path fill="white" stroke="white" d="M119.617,-267.599C125.617,-267.599 131.617,-273.599 131.617,-279.599"></path>
+<path fill="white" stroke="white" d="M131.617,-314.401C131.617,-320.401 125.617,-326.401 119.617,-326.401"></path>
+<polyline fill="none" stroke="black" points="119.617,-326.401 14.3833,-326.401 "></polyline>
+<path fill="none" stroke="black" d="M14.3833,-326.401C8.38328,-326.401 2.38328,-320.401 2.38328,-314.401"></path>
+<polyline fill="none" stroke="black" points="2.38328,-314.401 2.38328,-279.599 "></polyline>
+<path fill="none" stroke="black" d="M2.38328,-279.599C2.38328,-273.599 8.38328,-267.599 14.3833,-267.599"></path>
+<polyline fill="none" stroke="black" points="14.3833,-267.599 119.617,-267.599 "></polyline>
+<path fill="none" stroke="black" d="M119.617,-267.599C125.617,-267.599 131.617,-273.599 131.617,-279.599"></path>
+<polyline fill="none" stroke="black" points="131.617,-279.599 131.617,-314.401 "></polyline>
+<path fill="none" stroke="black" d="M131.617,-314.401C131.617,-320.401 125.617,-326.401 119.617,-326.401"></path>
+<text text-anchor="middle" x="67" y="-309.6" font-family="Times,serif" font-size="14.00">VariableDeclaration</text>
+<text text-anchor="middle" x="67" y="-292.8" font-family="Times,serif" font-size="14.00">VariableDeclarator</text>
+<text text-anchor="middle" x="67" y="-276" font-family="Times,serif" font-size="14.00">Identifier (key)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_3-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M104.033,-361.822C99.4992,-354.009 93.9468,-344.44 88.5344,-335.112"></path>
+<polygon fill="black" stroke="black" points="91.4721,-333.201 83.4259,-326.309 85.4175,-336.715 91.4721,-333.201"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_5</title>
+<polygon fill="white" stroke="white" points="165.484,-103.602 62.5157,-103.602 50.5157,-91.6019 50.5157,-74.3981 62.5157,-62.3981 165.484,-62.3981 177.484,-74.3981 177.484,-91.6019 165.484,-103.602"></polygon>
+<path fill="white" stroke="white" d="M62.5157,-103.602C56.5157,-103.602 50.5157,-97.6019 50.5157,-91.6019"></path>
+<path fill="white" stroke="white" d="M50.5157,-74.3981C50.5157,-68.3981 56.5157,-62.3981 62.5157,-62.3981"></path>
+<path fill="white" stroke="white" d="M165.484,-62.3981C171.484,-62.3981 177.484,-68.3981 177.484,-74.3981"></path>
+<path fill="white" stroke="white" d="M177.484,-91.6019C177.484,-97.6019 171.484,-103.602 165.484,-103.602"></path>
+<polyline fill="none" stroke="black" points="165.484,-103.602 62.5157,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M62.5157,-103.602C56.5157,-103.602 50.5157,-97.6019 50.5157,-91.6019"></path>
+<polyline fill="none" stroke="black" points="50.5157,-91.6019 50.5157,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M50.5157,-74.3981C50.5157,-68.3981 56.5157,-62.3981 62.5157,-62.3981"></path>
+<polyline fill="none" stroke="black" points="62.5157,-62.3981 165.484,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M165.484,-62.3981C171.484,-62.3981 177.484,-68.3981 177.484,-74.3981"></path>
+<polyline fill="none" stroke="black" points="177.484,-74.3981 177.484,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M177.484,-91.6019C177.484,-97.6019 171.484,-103.602 165.484,-103.602"></path>
+<text text-anchor="middle" x="114" y="-87.2" font-family="Times,serif" font-size="14.00">ForInStatement:exit</text>
+<text text-anchor="middle" x="114" y="-70.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge8" class="edge"><title>s1_3-&gt;s1_5</title>
+<path fill="none" stroke="black" d="M124.891,-361.573C130.533,-351.566 136.88,-338.531 140,-326 159.973,-245.771 162.566,-220.329 143,-140 140.717,-130.626 136.569,-121.069 132.111,-112.567"></path>
+<polygon fill="black" stroke="black" points="135.155,-110.84 127.225,-103.814 129.043,-114.251 135.155,-110.84"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="122.147,-232 11.8526,-232 -0.147372,-220 -0.147372,-152 11.8526,-140 122.147,-140 134.147,-152 134.147,-220 122.147,-232"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-232C5.85263,-232 -0.147372,-226 -0.147372,-220"></path>
+<path fill="white" stroke="white" d="M-0.147372,-152C-0.147372,-146 5.85263,-140 11.8526,-140"></path>
+<path fill="white" stroke="white" d="M122.147,-140C128.147,-140 134.147,-146 134.147,-152"></path>
+<path fill="white" stroke="white" d="M134.147,-220C134.147,-226 128.147,-232 122.147,-232"></path>
+<polyline fill="none" stroke="black" points="122.147,-232 11.8526,-232 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-232C5.85263,-232 -0.147372,-226 -0.147372,-220"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-220 -0.147372,-152 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-152C-0.147372,-146 5.85263,-140 11.8526,-140"></path>
+<polyline fill="none" stroke="black" points="11.8526,-140 122.147,-140 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-140C128.147,-140 134.147,-146 134.147,-152"></path>
+<polyline fill="none" stroke="black" points="134.147,-152 134.147,-220 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-220C134.147,-226 128.147,-232 122.147,-232"></path>
+<text text-anchor="middle" x="67" y="-215.4" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-198.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-181.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-165" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-148.2" font-family="Times,serif" font-size="14.00">Identifier (key)</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M60.9942,-267.646C60.5136,-259.848 60.2658,-251.114 60.2507,-242.351"></path>
+<polygon fill="black" stroke="black" points="63.7527,-242.134 60.34,-232.104 56.7529,-242.073 63.7527,-242.134"></polygon>
+</g>
+
+<g id="edge6" class="edge"><title>s1_4-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M73.66,-232.104C73.8235,-240.564 73.7642,-249.334 73.4822,-257.568"></path>
+<polygon fill="black" stroke="black" points="69.982,-257.492 73.0058,-267.646 76.9742,-257.823 69.982,-257.492"></polygon>
+</g>
+
+<g id="edge10" class="edge"><title>s1_4-&gt;s1_5</title>
+<path fill="none" stroke="black" d="M88.0256,-139.817C92.2417,-130.757 96.5653,-121.466 100.445,-113.128"></path>
+<polygon fill="black" stroke="black" points="103.718,-114.392 104.763,-103.849 97.3711,-111.439 103.718,-114.392"></polygon>
+</g>
+
+<g id="edge11" class="edge"><title>s1_5-&gt;final</title>
+<path fill="none" stroke="black" d="M114,-62.3316C114,-54.2587 114,-44.8663 114,-36.5198"></path>
+<polygon fill="black" stroke="black" points="117.5,-36.3487 114,-26.3488 110.5,-36.3488 117.5,-36.3487"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-forstatement-for-ever.svg
+++ b/docs/developer-guide/code-path-analysis/example-forstatement-for-ever.svg
@@ -1,0 +1,63 @@
+<?xml version="1.0"?>
+<svg width="160pt" height="216pt" viewBox="0.00 0.00 160.00 216.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 212)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="67" cy="-199" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node2" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="100.573,-153.602 33.4267,-153.602 21.4267,-141.602 21.4267,-124.398 33.4267,-112.398 100.573,-112.398 112.573,-124.398 112.573,-141.602 100.573,-153.602"></polygon>
+<path fill="white" stroke="white" d="M33.4267,-153.602C27.4267,-153.602 21.4267,-147.602 21.4267,-141.602"></path>
+<path fill="white" stroke="white" d="M21.4267,-124.398C21.4267,-118.398 27.4267,-112.398 33.4267,-112.398"></path>
+<path fill="white" stroke="white" d="M100.573,-112.398C106.573,-112.398 112.573,-118.398 112.573,-124.398"></path>
+<path fill="white" stroke="white" d="M112.573,-141.602C112.573,-147.602 106.573,-153.602 100.573,-153.602"></path>
+<polyline fill="none" stroke="black" points="100.573,-153.602 33.4267,-153.602 "></polyline>
+<path fill="none" stroke="black" d="M33.4267,-153.602C27.4267,-153.602 21.4267,-147.602 21.4267,-141.602"></path>
+<polyline fill="none" stroke="black" points="21.4267,-141.602 21.4267,-124.398 "></polyline>
+<path fill="none" stroke="black" d="M21.4267,-124.398C21.4267,-118.398 27.4267,-112.398 33.4267,-112.398"></path>
+<polyline fill="none" stroke="black" points="33.4267,-112.398 100.573,-112.398 "></polyline>
+<path fill="none" stroke="black" d="M100.573,-112.398C106.573,-112.398 112.573,-118.398 112.573,-124.398"></path>
+<polyline fill="none" stroke="black" points="112.573,-124.398 112.573,-141.602 "></polyline>
+<path fill="none" stroke="black" d="M112.573,-141.602C112.573,-147.602 106.573,-153.602 100.573,-153.602"></path>
+<text text-anchor="middle" x="67" y="-137.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="67" y="-120.4" font-family="Times,serif" font-size="14.00">ForStatement</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M67,-189.894C67,-183.274 67,-173.485 67,-163.94"></path>
+<polygon fill="black" stroke="black" points="70.5001,-163.842 67,-153.842 63.5001,-163.842 70.5001,-163.842"></polygon>
+</g>
+
+<g id="node3" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="122.147,-75.7003 11.8526,-75.7003 -0.147372,-63.7003 -0.147372,-12.2997 11.8526,-0.299733 122.147,-0.299733 134.147,-12.2997 134.147,-63.7003 122.147,-75.7003"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-75.7003C5.85263,-75.7003 -0.147372,-69.7003 -0.147372,-63.7003"></path>
+<path fill="white" stroke="white" d="M-0.147372,-12.2997C-0.147372,-6.29973 5.85263,-0.299733 11.8526,-0.299733"></path>
+<path fill="white" stroke="white" d="M122.147,-0.299733C128.147,-0.299733 134.147,-6.29973 134.147,-12.2997"></path>
+<path fill="white" stroke="white" d="M134.147,-63.7003C134.147,-69.7003 128.147,-75.7003 122.147,-75.7003"></path>
+<polyline fill="none" stroke="black" points="122.147,-75.7003 11.8526,-75.7003 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-75.7003C5.85263,-75.7003 -0.147372,-69.7003 -0.147372,-63.7003"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-63.7003 -0.147372,-12.2997 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-12.2997C-0.147372,-6.29973 5.85263,-0.299733 11.8526,-0.299733"></path>
+<polyline fill="none" stroke="black" points="11.8526,-0.299733 122.147,-0.299733 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-0.299733C128.147,-0.299733 134.147,-6.29973 134.147,-12.2997"></path>
+<polyline fill="none" stroke="black" points="134.147,-12.2997 134.147,-63.7003 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-63.7003C134.147,-69.7003 128.147,-75.7003 122.147,-75.7003"></path>
+<text text-anchor="middle" x="67" y="-59" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-42.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-25.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-8.6" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M67,-112.277C67,-104.524 67,-95.2648 67,-85.9799"></path>
+<polygon fill="black" stroke="black" points="70.5001,-85.9648 67,-75.9648 63.5001,-85.9648 70.5001,-85.9648"></polygon>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M134.337,-54.1523C144.84,-51.7376 152,-46.3535 152,-38 152,-32.518 148.916,-28.3148 143.828,-25.3905"></path>
+<polygon fill="black" stroke="black" points="144.93,-22.0659 134.337,-21.8477 142.482,-28.6239 144.93,-22.0659"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-forstatement.svg
+++ b/docs/developer-guide/code-path-analysis/example-forstatement.svg
@@ -1,0 +1,201 @@
+<?xml version="1.0"?>
+<svg width="350pt" height="646pt" viewBox="0.00 0.00 350.00 646.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 642)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="174" cy="-629" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="226.617,-583.3 121.383,-583.3 109.383,-571.3 109.383,-486.7 121.383,-474.7 226.617,-474.7 238.617,-486.7 238.617,-571.3 226.617,-583.3"></polygon>
+<path fill="white" stroke="white" d="M121.383,-583.3C115.383,-583.3 109.383,-577.3 109.383,-571.3"></path>
+<path fill="white" stroke="white" d="M109.383,-486.7C109.383,-480.7 115.383,-474.7 121.383,-474.7"></path>
+<path fill="white" stroke="white" d="M226.617,-474.7C232.617,-474.7 238.617,-480.7 238.617,-486.7"></path>
+<path fill="white" stroke="white" d="M238.617,-571.3C238.617,-577.3 232.617,-583.3 226.617,-583.3"></path>
+<polyline fill="none" stroke="black" points="226.617,-583.3 121.383,-583.3 "></polyline>
+<path fill="none" stroke="black" d="M121.383,-583.3C115.383,-583.3 109.383,-577.3 109.383,-571.3"></path>
+<polyline fill="none" stroke="black" points="109.383,-571.3 109.383,-486.7 "></polyline>
+<path fill="none" stroke="black" d="M109.383,-486.7C109.383,-480.7 115.383,-474.7 121.383,-474.7"></path>
+<polyline fill="none" stroke="black" points="121.383,-474.7 226.617,-474.7 "></polyline>
+<path fill="none" stroke="black" d="M226.617,-474.7C232.617,-474.7 238.617,-480.7 238.617,-486.7"></path>
+<polyline fill="none" stroke="black" points="238.617,-486.7 238.617,-571.3 "></polyline>
+<path fill="none" stroke="black" d="M238.617,-571.3C238.617,-577.3 232.617,-583.3 226.617,-583.3"></path>
+<text text-anchor="middle" x="174" y="-566.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="174" y="-550" font-family="Times,serif" font-size="14.00">ForStatement</text>
+<text text-anchor="middle" x="174" y="-533.2" font-family="Times,serif" font-size="14.00">VariableDeclaration</text>
+<text text-anchor="middle" x="174" y="-516.4" font-family="Times,serif" font-size="14.00">VariableDeclarator</text>
+<text text-anchor="middle" x="174" y="-499.6" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="174" y="-482.8" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M174,-619.98C174,-613.675 174,-604.238 174,-593.813"></path>
+<polygon fill="black" stroke="black" points="177.5,-593.586 174,-583.586 170.5,-593.586 177.5,-593.586"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="58" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="58" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="220.233,-438.401 127.767,-438.401 115.767,-426.401 115.767,-391.599 127.767,-379.599 220.233,-379.599 232.233,-391.599 232.233,-426.401 220.233,-438.401"></polygon>
+<path fill="white" stroke="white" d="M127.767,-438.401C121.767,-438.401 115.767,-432.401 115.767,-426.401"></path>
+<path fill="white" stroke="white" d="M115.767,-391.599C115.767,-385.599 121.767,-379.599 127.767,-379.599"></path>
+<path fill="white" stroke="white" d="M220.233,-379.599C226.233,-379.599 232.233,-385.599 232.233,-391.599"></path>
+<path fill="white" stroke="white" d="M232.233,-426.401C232.233,-432.401 226.233,-438.401 220.233,-438.401"></path>
+<polyline fill="none" stroke="black" points="220.233,-438.401 127.767,-438.401 "></polyline>
+<path fill="none" stroke="black" d="M127.767,-438.401C121.767,-438.401 115.767,-432.401 115.767,-426.401"></path>
+<polyline fill="none" stroke="black" points="115.767,-426.401 115.767,-391.599 "></polyline>
+<path fill="none" stroke="black" d="M115.767,-391.599C115.767,-385.599 121.767,-379.599 127.767,-379.599"></path>
+<polyline fill="none" stroke="black" points="127.767,-379.599 220.233,-379.599 "></polyline>
+<path fill="none" stroke="black" d="M220.233,-379.599C226.233,-379.599 232.233,-385.599 232.233,-391.599"></path>
+<polyline fill="none" stroke="black" points="232.233,-391.599 232.233,-426.401 "></polyline>
+<path fill="none" stroke="black" d="M232.233,-426.401C232.233,-432.401 226.233,-438.401 220.233,-438.401"></path>
+<text text-anchor="middle" x="174" y="-421.6" font-family="Times,serif" font-size="14.00">BinaryExpression</text>
+<text text-anchor="middle" x="174" y="-404.8" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="174" y="-388" font-family="Times,serif" font-size="14.00">Literal (10)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M174,-474.524C174,-465.777 174,-456.867 174,-448.572"></path>
+<polygon fill="black" stroke="black" points="177.5,-448.452 174,-438.452 170.5,-448.452 177.5,-448.452"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="229.147,-343.3 118.853,-343.3 106.853,-331.3 106.853,-246.7 118.853,-234.7 229.147,-234.7 241.147,-246.7 241.147,-331.3 229.147,-343.3"></polygon>
+<path fill="white" stroke="white" d="M118.853,-343.3C112.853,-343.3 106.853,-337.3 106.853,-331.3"></path>
+<path fill="white" stroke="white" d="M106.853,-246.7C106.853,-240.7 112.853,-234.7 118.853,-234.7"></path>
+<path fill="white" stroke="white" d="M229.147,-234.7C235.147,-234.7 241.147,-240.7 241.147,-246.7"></path>
+<path fill="white" stroke="white" d="M241.147,-331.3C241.147,-337.3 235.147,-343.3 229.147,-343.3"></path>
+<polyline fill="none" stroke="black" points="229.147,-343.3 118.853,-343.3 "></polyline>
+<path fill="none" stroke="black" d="M118.853,-343.3C112.853,-343.3 106.853,-337.3 106.853,-331.3"></path>
+<polyline fill="none" stroke="black" points="106.853,-331.3 106.853,-246.7 "></polyline>
+<path fill="none" stroke="black" d="M106.853,-246.7C106.853,-240.7 112.853,-234.7 118.853,-234.7"></path>
+<polyline fill="none" stroke="black" points="118.853,-234.7 229.147,-234.7 "></polyline>
+<path fill="none" stroke="black" d="M229.147,-234.7C235.147,-234.7 241.147,-240.7 241.147,-246.7"></path>
+<polyline fill="none" stroke="black" points="241.147,-246.7 241.147,-331.3 "></polyline>
+<path fill="none" stroke="black" d="M241.147,-331.3C241.147,-337.3 235.147,-343.3 229.147,-343.3"></path>
+<text text-anchor="middle" x="174" y="-326.8" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="174" y="-310" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="174" y="-293.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="174" y="-276.4" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="174" y="-259.6" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="174" y="-242.8" font-family="Times,serif" font-size="14.00">Identifier (b)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M174,-379.736C174,-371.725 174,-362.664 174,-353.458"></path>
+<polygon fill="black" stroke="black" points="177.5,-353.454 174,-343.454 170.5,-353.454 177.5,-353.454"></polygon>
+</g>
+
+<g id="node9" class="node"><title>s1_8</title>
+<polygon fill="white" stroke="white" points="104.239,-103.602 11.761,-103.602 -0.239018,-91.6019 -0.239018,-74.3981 11.761,-62.3981 104.239,-62.3981 116.239,-74.3981 116.239,-91.6019 104.239,-103.602"></polygon>
+<path fill="white" stroke="white" d="M11.761,-103.602C5.76098,-103.602 -0.239018,-97.6019 -0.239018,-91.6019"></path>
+<path fill="white" stroke="white" d="M-0.239018,-74.3981C-0.239018,-68.3981 5.76098,-62.3981 11.761,-62.3981"></path>
+<path fill="white" stroke="white" d="M104.239,-62.3981C110.239,-62.3981 116.239,-68.3981 116.239,-74.3981"></path>
+<path fill="white" stroke="white" d="M116.239,-91.6019C116.239,-97.6019 110.239,-103.602 104.239,-103.602"></path>
+<polyline fill="none" stroke="black" points="104.239,-103.602 11.761,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M11.761,-103.602C5.76098,-103.602 -0.239018,-97.6019 -0.239018,-91.6019"></path>
+<polyline fill="none" stroke="black" points="-0.239018,-91.6019 -0.239018,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M-0.239018,-74.3981C-0.239018,-68.3981 5.76098,-62.3981 11.761,-62.3981"></path>
+<polyline fill="none" stroke="black" points="11.761,-62.3981 104.239,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M104.239,-62.3981C110.239,-62.3981 116.239,-68.3981 116.239,-74.3981"></path>
+<polyline fill="none" stroke="black" points="116.239,-74.3981 116.239,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M116.239,-91.6019C116.239,-97.6019 110.239,-103.602 104.239,-103.602"></path>
+<text text-anchor="middle" x="58" y="-87.2" font-family="Times,serif" font-size="14.00">ForStatement:exit</text>
+<text text-anchor="middle" x="58" y="-70.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge9" class="edge"><title>s1_2-&gt;s1_8</title>
+<path fill="none" stroke="black" d="M133.184,-379.539C120.713,-369.392 107.737,-357.181 98,-344 56.1121,-287.297 50.0603,-267.081 36,-198 30.8588,-172.74 31.2034,-165.328 36,-140 37.7044,-131.001 40.8223,-121.596 44.1855,-113.12"></path>
+<polygon fill="black" stroke="black" points="47.5078,-114.249 48.1762,-103.676 41.0598,-111.525 47.5078,-114.249"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_5</title>
+<polygon fill="white" stroke="white" points="138.572,-189.602 57.4276,-189.602 45.4276,-177.602 45.4276,-160.398 57.4276,-148.398 138.572,-148.398 150.572,-160.398 150.572,-177.602 138.572,-189.602"></polygon>
+<path fill="white" stroke="white" d="M57.4276,-189.602C51.4276,-189.602 45.4276,-183.602 45.4276,-177.602"></path>
+<path fill="white" stroke="white" d="M45.4276,-160.398C45.4276,-154.398 51.4276,-148.398 57.4276,-148.398"></path>
+<path fill="white" stroke="white" d="M138.572,-148.398C144.572,-148.398 150.572,-154.398 150.572,-160.398"></path>
+<path fill="white" stroke="white" d="M150.572,-177.602C150.572,-183.602 144.572,-189.602 138.572,-189.602"></path>
+<polyline fill="none" stroke="black" points="138.572,-189.602 57.4276,-189.602 "></polyline>
+<path fill="none" stroke="black" d="M57.4276,-189.602C51.4276,-189.602 45.4276,-183.602 45.4276,-177.602"></path>
+<polyline fill="none" stroke="black" points="45.4276,-177.602 45.4276,-160.398 "></polyline>
+<path fill="none" stroke="black" d="M45.4276,-160.398C45.4276,-154.398 51.4276,-148.398 57.4276,-148.398"></path>
+<polyline fill="none" stroke="black" points="57.4276,-148.398 138.572,-148.398 "></polyline>
+<path fill="none" stroke="black" d="M138.572,-148.398C144.572,-148.398 150.572,-154.398 150.572,-160.398"></path>
+<polyline fill="none" stroke="black" points="150.572,-160.398 150.572,-177.602 "></polyline>
+<path fill="none" stroke="black" d="M150.572,-177.602C150.572,-183.602 144.572,-189.602 138.572,-189.602"></path>
+<text text-anchor="middle" x="98" y="-173.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="98" y="-156.4" font-family="Times,serif" font-size="14.00">BreakStatement</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_3-&gt;s1_5</title>
+<path fill="none" stroke="black" d="M139.558,-234.524C131.519,-222.042 123.266,-209.228 116.254,-198.342"></path>
+<polygon fill="black" stroke="black" points="119.046,-196.213 110.689,-189.701 113.161,-200.003 119.046,-196.213"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_7</title>
+<polygon fill="white" stroke="white" points="291.147,-198.401 180.853,-198.401 168.853,-186.401 168.853,-151.599 180.853,-139.599 291.147,-139.599 303.147,-151.599 303.147,-186.401 291.147,-198.401"></polygon>
+<path fill="white" stroke="white" d="M180.853,-198.401C174.853,-198.401 168.853,-192.401 168.853,-186.401"></path>
+<path fill="white" stroke="white" d="M168.853,-151.599C168.853,-145.599 174.853,-139.599 180.853,-139.599"></path>
+<path fill="white" stroke="white" d="M291.147,-139.599C297.147,-139.599 303.147,-145.599 303.147,-151.599"></path>
+<path fill="white" stroke="white" d="M303.147,-186.401C303.147,-192.401 297.147,-198.401 291.147,-198.401"></path>
+<polyline fill="none" stroke="black" points="291.147,-198.401 180.853,-198.401 "></polyline>
+<path fill="none" stroke="black" d="M180.853,-198.401C174.853,-198.401 168.853,-192.401 168.853,-186.401"></path>
+<polyline fill="none" stroke="black" points="168.853,-186.401 168.853,-151.599 "></polyline>
+<path fill="none" stroke="black" d="M168.853,-151.599C168.853,-145.599 174.853,-139.599 180.853,-139.599"></path>
+<polyline fill="none" stroke="black" points="180.853,-139.599 291.147,-139.599 "></polyline>
+<path fill="none" stroke="black" d="M291.147,-139.599C297.147,-139.599 303.147,-145.599 303.147,-151.599"></path>
+<polyline fill="none" stroke="black" points="303.147,-151.599 303.147,-186.401 "></polyline>
+<path fill="none" stroke="black" d="M303.147,-186.401C303.147,-192.401 297.147,-198.401 291.147,-198.401"></path>
+<text text-anchor="middle" x="236" y="-181.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="236" y="-164.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="236" y="-148" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge11" class="edge"><title>s1_3-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M202.098,-234.524C206.898,-225.389 211.791,-216.075 216.313,-207.47"></path>
+<polygon fill="black" stroke="black" points="219.498,-208.932 221.051,-198.452 213.301,-205.676 219.498,-208.932"></polygon>
+</g>
+
+<g id="edge13" class="edge"><title>s1_5-&gt;s1_8</title>
+<path fill="none" stroke="black" d="M88.5206,-148.093C83.5391,-137.632 77.3402,-124.615 71.833,-113.049"></path>
+<polygon fill="black" stroke="black" points="74.8708,-111.288 67.4114,-103.764 68.5508,-114.297 74.8708,-111.288"></polygon>
+</g>
+
+<g id="node8" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="329.977,-103.602 236.023,-103.602 224.023,-91.6019 224.023,-74.3981 236.023,-62.3981 329.977,-62.3981 341.977,-74.3981 341.977,-91.6019 329.977,-103.602"></polygon>
+<path fill="white" stroke="white" d="M236.023,-103.602C230.023,-103.602 224.023,-97.6019 224.023,-91.6019"></path>
+<path fill="white" stroke="white" d="M224.023,-74.3981C224.023,-68.3981 230.023,-62.3981 236.023,-62.3981"></path>
+<path fill="white" stroke="white" d="M329.977,-62.3981C335.977,-62.3981 341.977,-68.3981 341.977,-74.3981"></path>
+<path fill="white" stroke="white" d="M341.977,-91.6019C341.977,-97.6019 335.977,-103.602 329.977,-103.602"></path>
+<polyline fill="none" stroke="black" points="329.977,-103.602 236.023,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M236.023,-103.602C230.023,-103.602 224.023,-97.6019 224.023,-91.6019"></path>
+<polyline fill="none" stroke="black" points="224.023,-91.6019 224.023,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M224.023,-74.3981C224.023,-68.3981 230.023,-62.3981 236.023,-62.3981"></path>
+<polyline fill="none" stroke="black" points="236.023,-62.3981 329.977,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M329.977,-62.3981C335.977,-62.3981 341.977,-68.3981 341.977,-74.3981"></path>
+<polyline fill="none" stroke="black" points="341.977,-74.3981 341.977,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M341.977,-91.6019C341.977,-97.6019 335.977,-103.602 329.977,-103.602"></path>
+<text text-anchor="middle" x="283" y="-87.2" font-family="Times,serif" font-size="14.00">UpdateExpression</text>
+<text text-anchor="middle" x="283" y="-70.4" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge7" class="edge"><title>s1_7-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M251.912,-139.561C256.814,-130.801 262.209,-121.158 267.109,-112.4"></path>
+<polygon fill="black" stroke="black" points="270.167,-114.104 271.995,-103.668 264.058,-110.686 270.167,-114.104"></polygon>
+</g>
+
+<g id="edge8" class="edge"><title>s1_4-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M296.225,-103.814C302.324,-114.132 308.891,-127.235 312,-140 318.1,-165.046 317.141,-172.74 312,-198 297.94,-267.081 291.888,-287.297 250,-344 242.317,-354.4 232.617,-364.197 222.74,-372.853"></path>
+<polygon fill="black" stroke="black" points="220.202,-370.415 214.816,-379.539 224.716,-375.765 220.202,-370.415"></polygon>
+</g>
+
+<g id="edge14" class="edge"><title>s1_8-&gt;final</title>
+<path fill="none" stroke="black" d="M58,-62.3316C58,-54.2587 58,-44.8663 58,-36.5198"></path>
+<polygon fill="black" stroke="black" points="61.5001,-36.3487 58,-26.3488 54.5001,-36.3488 61.5001,-36.3487"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-hello-world.svg
+++ b/docs/developer-guide/code-path-analysis/example-hello-world.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<svg width="146pt" height="250pt" viewBox="0.00 0.00 146.00 250.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 246)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="69" cy="-233" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="126.042,-187.601 11.9578,-187.601 -0.0421557,-175.601 -0.0421557,-74.3994 11.9578,-62.3994 126.042,-62.3994 138.042,-74.3994 138.042,-175.601 126.042,-187.601"></polygon>
+<path fill="white" stroke="white" d="M11.9578,-187.601C5.95784,-187.601 -0.0421557,-181.601 -0.0421557,-175.601"></path>
+<path fill="white" stroke="white" d="M-0.0421557,-74.3994C-0.0421557,-68.3994 5.95784,-62.3994 11.9578,-62.3994"></path>
+<path fill="white" stroke="white" d="M126.042,-62.3994C132.042,-62.3994 138.042,-68.3994 138.042,-74.3994"></path>
+<path fill="white" stroke="white" d="M138.042,-175.601C138.042,-181.601 132.042,-187.601 126.042,-187.601"></path>
+<polyline fill="none" stroke="black" points="126.042,-187.601 11.9578,-187.601 "></polyline>
+<path fill="none" stroke="black" d="M11.9578,-187.601C5.95784,-187.601 -0.0421557,-181.601 -0.0421557,-175.601"></path>
+<polyline fill="none" stroke="black" points="-0.0421557,-175.601 -0.0421557,-74.3994 "></polyline>
+<path fill="none" stroke="black" d="M-0.0421557,-74.3994C-0.0421557,-68.3994 5.95784,-62.3994 11.9578,-62.3994"></path>
+<polyline fill="none" stroke="black" points="11.9578,-62.3994 126.042,-62.3994 "></polyline>
+<path fill="none" stroke="black" d="M126.042,-62.3994C132.042,-62.3994 138.042,-68.3994 138.042,-74.3994"></path>
+<polyline fill="none" stroke="black" points="138.042,-74.3994 138.042,-175.601 "></polyline>
+<path fill="none" stroke="black" d="M138.042,-175.601C138.042,-181.601 132.042,-187.601 126.042,-187.601"></path>
+<text text-anchor="middle" x="69" y="-171.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="69" y="-154.4" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="69" y="-137.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="69" y="-120.8" font-family="Times,serif" font-size="14.00">MemberExpression</text>
+<text text-anchor="middle" x="69" y="-104" font-family="Times,serif" font-size="14.00">Identifier (console)</text>
+<text text-anchor="middle" x="69" y="-87.2" font-family="Times,serif" font-size="14.00">Identifier (log)</text>
+<text text-anchor="middle" x="69" y="-70.4" font-family="Times,serif" font-size="14.00">Literal (Hello world!)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M69,-223.682C69,-217.432 69,-208.196 69,-197.86"></path>
+<polygon fill="black" stroke="black" points="72.5001,-197.675 69,-187.675 65.5001,-197.675 72.5001,-197.675"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="69" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="69" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;final</title>
+<path fill="none" stroke="black" d="M69,-62.2476C69,-53.0345 69,-44.0781 69,-36.4335"></path>
+<polygon fill="black" stroke="black" points="72.5001,-36.2949 69,-26.2949 65.5001,-36.2949 72.5001,-36.2949"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-ifstatement-chain.svg
+++ b/docs/developer-guide/code-path-analysis/example-ifstatement-chain.svg
@@ -1,0 +1,203 @@
+<?xml version="1.0"?>
+<svg width="371pt" height="562pt" viewBox="0.00 0.00 371.00 562.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 558)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="114" cy="-545" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="145.339,-500.401 82.6614,-500.401 70.6614,-488.401 70.6614,-453.599 82.6614,-441.599 145.339,-441.599 157.339,-453.599 157.339,-488.401 145.339,-500.401"></polygon>
+<path fill="white" stroke="white" d="M82.6614,-500.401C76.6614,-500.401 70.6614,-494.401 70.6614,-488.401"></path>
+<path fill="white" stroke="white" d="M70.6614,-453.599C70.6614,-447.599 76.6614,-441.599 82.6614,-441.599"></path>
+<path fill="white" stroke="white" d="M145.339,-441.599C151.339,-441.599 157.339,-447.599 157.339,-453.599"></path>
+<path fill="white" stroke="white" d="M157.339,-488.401C157.339,-494.401 151.339,-500.401 145.339,-500.401"></path>
+<polyline fill="none" stroke="black" points="145.339,-500.401 82.6614,-500.401 "></polyline>
+<path fill="none" stroke="black" d="M82.6614,-500.401C76.6614,-500.401 70.6614,-494.401 70.6614,-488.401"></path>
+<polyline fill="none" stroke="black" points="70.6614,-488.401 70.6614,-453.599 "></polyline>
+<path fill="none" stroke="black" d="M70.6614,-453.599C70.6614,-447.599 76.6614,-441.599 82.6614,-441.599"></path>
+<polyline fill="none" stroke="black" points="82.6614,-441.599 145.339,-441.599 "></polyline>
+<path fill="none" stroke="black" d="M145.339,-441.599C151.339,-441.599 157.339,-447.599 157.339,-453.599"></path>
+<polyline fill="none" stroke="black" points="157.339,-453.599 157.339,-488.401 "></polyline>
+<path fill="none" stroke="black" d="M157.339,-488.401C157.339,-494.401 151.339,-500.401 145.339,-500.401"></path>
+<text text-anchor="middle" x="114" y="-483.6" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="114" y="-466.8" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="114" y="-450" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M114,-535.741C114,-529.393 114,-520.126 114,-510.615"></path>
+<polygon fill="black" stroke="black" points="117.5,-510.324 114,-500.324 110.5,-510.324 117.5,-510.324"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="181" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="181" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="122.147,-215.7 11.8526,-215.7 -0.147372,-203.7 -0.147372,-152.3 11.8526,-140.3 122.147,-140.3 134.147,-152.3 134.147,-203.7 122.147,-215.7"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-215.7C5.85263,-215.7 -0.147372,-209.7 -0.147372,-203.7"></path>
+<path fill="white" stroke="white" d="M-0.147372,-152.3C-0.147372,-146.3 5.85263,-140.3 11.8526,-140.3"></path>
+<path fill="white" stroke="white" d="M122.147,-140.3C128.147,-140.3 134.147,-146.3 134.147,-152.3"></path>
+<path fill="white" stroke="white" d="M134.147,-203.7C134.147,-209.7 128.147,-215.7 122.147,-215.7"></path>
+<polyline fill="none" stroke="black" points="122.147,-215.7 11.8526,-215.7 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-215.7C5.85263,-215.7 -0.147372,-209.7 -0.147372,-203.7"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-203.7 -0.147372,-152.3 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-152.3C-0.147372,-146.3 5.85263,-140.3 11.8526,-140.3"></path>
+<polyline fill="none" stroke="black" points="11.8526,-140.3 122.147,-140.3 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-140.3C128.147,-140.3 134.147,-146.3 134.147,-152.3"></path>
+<polyline fill="none" stroke="black" points="134.147,-152.3 134.147,-203.7 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-203.7C134.147,-209.7 128.147,-215.7 122.147,-215.7"></path>
+<text text-anchor="middle" x="67" y="-199" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-182.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-165.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-148.6" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M107.798,-441.544C101.706,-412.948 92.4152,-367.562 86,-328 80.4738,-293.921 75.5819,-255.241 72.1462,-225.832"></path>
+<polygon fill="black" stroke="black" points="75.6165,-225.373 70.993,-215.84 68.6626,-226.175 75.6165,-225.373"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="193.429,-405.602 130.571,-405.602 118.571,-393.602 118.571,-376.398 130.571,-364.398 193.429,-364.398 205.429,-376.398 205.429,-393.602 193.429,-405.602"></polygon>
+<path fill="white" stroke="white" d="M130.571,-405.602C124.571,-405.602 118.571,-399.602 118.571,-393.602"></path>
+<path fill="white" stroke="white" d="M118.571,-376.398C118.571,-370.398 124.571,-364.398 130.571,-364.398"></path>
+<path fill="white" stroke="white" d="M193.429,-364.398C199.429,-364.398 205.429,-370.398 205.429,-376.398"></path>
+<path fill="white" stroke="white" d="M205.429,-393.602C205.429,-399.602 199.429,-405.602 193.429,-405.602"></path>
+<polyline fill="none" stroke="black" points="193.429,-405.602 130.571,-405.602 "></polyline>
+<path fill="none" stroke="black" d="M130.571,-405.602C124.571,-405.602 118.571,-399.602 118.571,-393.602"></path>
+<polyline fill="none" stroke="black" points="118.571,-393.602 118.571,-376.398 "></polyline>
+<path fill="none" stroke="black" d="M118.571,-376.398C118.571,-370.398 124.571,-364.398 130.571,-364.398"></path>
+<polyline fill="none" stroke="black" points="130.571,-364.398 193.429,-364.398 "></polyline>
+<path fill="none" stroke="black" d="M193.429,-364.398C199.429,-364.398 205.429,-370.398 205.429,-376.398"></path>
+<polyline fill="none" stroke="black" points="205.429,-376.398 205.429,-393.602 "></polyline>
+<path fill="none" stroke="black" d="M205.429,-393.602C205.429,-399.602 199.429,-405.602 193.429,-405.602"></path>
+<text text-anchor="middle" x="162" y="-389.2" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="162" y="-372.4" font-family="Times,serif" font-size="14.00">Identifier (b)</text>
+</g>
+
+<g id="edge6" class="edge"><title>s1_1-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M130.251,-441.561C135.257,-432.801 140.767,-423.158 145.771,-414.4"></path>
+<polygon fill="black" stroke="black" points="148.839,-416.087 150.761,-405.668 142.761,-412.614 148.839,-416.087"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_9</title>
+<polygon fill="white" stroke="white" points="222.147,-103.602 139.853,-103.602 127.853,-91.6019 127.853,-74.3981 139.853,-62.3981 222.147,-62.3981 234.147,-74.3981 234.147,-91.6019 222.147,-103.602"></polygon>
+<path fill="white" stroke="white" d="M139.853,-103.602C133.853,-103.602 127.853,-97.6019 127.853,-91.6019"></path>
+<path fill="white" stroke="white" d="M127.853,-74.3981C127.853,-68.3981 133.853,-62.3981 139.853,-62.3981"></path>
+<path fill="white" stroke="white" d="M222.147,-62.3981C228.147,-62.3981 234.147,-68.3981 234.147,-74.3981"></path>
+<path fill="white" stroke="white" d="M234.147,-91.6019C234.147,-97.6019 228.147,-103.602 222.147,-103.602"></path>
+<polyline fill="none" stroke="black" points="222.147,-103.602 139.853,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M139.853,-103.602C133.853,-103.602 127.853,-97.6019 127.853,-91.6019"></path>
+<polyline fill="none" stroke="black" points="127.853,-91.6019 127.853,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M127.853,-74.3981C127.853,-68.3981 133.853,-62.3981 139.853,-62.3981"></path>
+<polyline fill="none" stroke="black" points="139.853,-62.3981 222.147,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M222.147,-62.3981C228.147,-62.3981 234.147,-68.3981 234.147,-74.3981"></path>
+<polyline fill="none" stroke="black" points="234.147,-74.3981 234.147,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M234.147,-91.6019C234.147,-97.6019 228.147,-103.602 222.147,-103.602"></path>
+<text text-anchor="middle" x="181" y="-87.2" font-family="Times,serif" font-size="14.00">IfStatement:exit</text>
+<text text-anchor="middle" x="181" y="-70.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M112.056,-140.244C124.376,-130.194 137.475,-119.507 148.909,-110.179"></path>
+<polygon fill="black" stroke="black" points="151.37,-112.689 156.906,-103.655 146.945,-107.265 151.37,-112.689"></polygon>
+</g>
+
+<g id="edge15" class="edge"><title>s1_9-&gt;final</title>
+<path fill="none" stroke="black" d="M181,-62.3316C181,-54.2587 181,-44.8663 181,-36.5198"></path>
+<polygon fill="black" stroke="black" points="184.5,-36.3487 181,-26.3488 177.5,-36.3488 184.5,-36.3487"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="217.147,-327.7 106.853,-327.7 94.8526,-315.7 94.8526,-264.3 106.853,-252.3 217.147,-252.3 229.147,-264.3 229.147,-315.7 217.147,-327.7"></polygon>
+<path fill="white" stroke="white" d="M106.853,-327.7C100.853,-327.7 94.8526,-321.7 94.8526,-315.7"></path>
+<path fill="white" stroke="white" d="M94.8526,-264.3C94.8526,-258.3 100.853,-252.3 106.853,-252.3"></path>
+<path fill="white" stroke="white" d="M217.147,-252.3C223.147,-252.3 229.147,-258.3 229.147,-264.3"></path>
+<path fill="white" stroke="white" d="M229.147,-315.7C229.147,-321.7 223.147,-327.7 217.147,-327.7"></path>
+<polyline fill="none" stroke="black" points="217.147,-327.7 106.853,-327.7 "></polyline>
+<path fill="none" stroke="black" d="M106.853,-327.7C100.853,-327.7 94.8526,-321.7 94.8526,-315.7"></path>
+<polyline fill="none" stroke="black" points="94.8526,-315.7 94.8526,-264.3 "></polyline>
+<path fill="none" stroke="black" d="M94.8526,-264.3C94.8526,-258.3 100.853,-252.3 106.853,-252.3"></path>
+<polyline fill="none" stroke="black" points="106.853,-252.3 217.147,-252.3 "></polyline>
+<path fill="none" stroke="black" d="M217.147,-252.3C223.147,-252.3 229.147,-258.3 229.147,-264.3"></path>
+<polyline fill="none" stroke="black" points="229.147,-264.3 229.147,-315.7 "></polyline>
+<path fill="none" stroke="black" d="M229.147,-315.7C229.147,-321.7 223.147,-327.7 217.147,-327.7"></path>
+<text text-anchor="middle" x="162" y="-311" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="162" y="-294.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="162" y="-277.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="162" y="-260.6" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge7" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M162,-364.277C162,-356.524 162,-347.265 162,-337.98"></path>
+<polygon fill="black" stroke="black" points="165.5,-337.965 162,-327.965 158.5,-337.965 165.5,-337.965"></polygon>
+</g>
+
+<g id="node8" class="node"><title>s1_5</title>
+<polygon fill="white" stroke="white" points="322.339,-310.602 259.661,-310.602 247.661,-298.602 247.661,-281.398 259.661,-269.398 322.339,-269.398 334.339,-281.398 334.339,-298.602 322.339,-310.602"></polygon>
+<path fill="white" stroke="white" d="M259.661,-310.602C253.661,-310.602 247.661,-304.602 247.661,-298.602"></path>
+<path fill="white" stroke="white" d="M247.661,-281.398C247.661,-275.398 253.661,-269.398 259.661,-269.398"></path>
+<path fill="white" stroke="white" d="M322.339,-269.398C328.339,-269.398 334.339,-275.398 334.339,-281.398"></path>
+<path fill="white" stroke="white" d="M334.339,-298.602C334.339,-304.602 328.339,-310.602 322.339,-310.602"></path>
+<polyline fill="none" stroke="black" points="322.339,-310.602 259.661,-310.602 "></polyline>
+<path fill="none" stroke="black" d="M259.661,-310.602C253.661,-310.602 247.661,-304.602 247.661,-298.602"></path>
+<polyline fill="none" stroke="black" points="247.661,-298.602 247.661,-281.398 "></polyline>
+<path fill="none" stroke="black" d="M247.661,-281.398C247.661,-275.398 253.661,-269.398 259.661,-269.398"></path>
+<polyline fill="none" stroke="black" points="259.661,-269.398 322.339,-269.398 "></polyline>
+<path fill="none" stroke="black" d="M322.339,-269.398C328.339,-269.398 334.339,-275.398 334.339,-281.398"></path>
+<polyline fill="none" stroke="black" points="334.339,-281.398 334.339,-298.602 "></polyline>
+<path fill="none" stroke="black" d="M334.339,-298.602C334.339,-304.602 328.339,-310.602 322.339,-310.602"></path>
+<text text-anchor="middle" x="291" y="-294.2" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="291" y="-277.4" font-family="Times,serif" font-size="14.00">Identifier (c)</text>
+</g>
+
+<g id="edge10" class="edge"><title>s1_3-&gt;s1_5</title>
+<path fill="none" stroke="black" d="M189.358,-364.277C208.598,-350.406 234.528,-331.712 255.382,-316.678"></path>
+<polygon fill="black" stroke="black" points="257.617,-319.382 263.682,-310.694 253.523,-313.703 257.617,-319.382"></polygon>
+</g>
+
+<g id="edge8" class="edge"><title>s1_4-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M165.397,-252.35C169.069,-212.728 174.851,-150.341 178.25,-113.673"></path>
+<polygon fill="black" stroke="black" points="181.744,-113.893 179.182,-103.613 174.774,-113.247 181.744,-113.893"></polygon>
+</g>
+
+<g id="edge14" class="edge"><title>s1_5-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M266.084,-269.392C250.495,-255.908 231.136,-236.742 219,-216 200.205,-183.878 190.203,-141.864 185.259,-113.957"></path>
+<polygon fill="black" stroke="black" points="188.697,-113.293 183.604,-104.002 181.791,-114.441 188.697,-113.293"></polygon>
+</g>
+
+<g id="node9" class="node"><title>s1_6</title>
+<polygon fill="white" stroke="white" points="350.147,-215.7 239.853,-215.7 227.853,-203.7 227.853,-152.3 239.853,-140.3 350.147,-140.3 362.147,-152.3 362.147,-203.7 350.147,-215.7"></polygon>
+<path fill="white" stroke="white" d="M239.853,-215.7C233.853,-215.7 227.853,-209.7 227.853,-203.7"></path>
+<path fill="white" stroke="white" d="M227.853,-152.3C227.853,-146.3 233.853,-140.3 239.853,-140.3"></path>
+<path fill="white" stroke="white" d="M350.147,-140.3C356.147,-140.3 362.147,-146.3 362.147,-152.3"></path>
+<path fill="white" stroke="white" d="M362.147,-203.7C362.147,-209.7 356.147,-215.7 350.147,-215.7"></path>
+<polyline fill="none" stroke="black" points="350.147,-215.7 239.853,-215.7 "></polyline>
+<path fill="none" stroke="black" d="M239.853,-215.7C233.853,-215.7 227.853,-209.7 227.853,-203.7"></path>
+<polyline fill="none" stroke="black" points="227.853,-203.7 227.853,-152.3 "></polyline>
+<path fill="none" stroke="black" d="M227.853,-152.3C227.853,-146.3 233.853,-140.3 239.853,-140.3"></path>
+<polyline fill="none" stroke="black" points="239.853,-140.3 350.147,-140.3 "></polyline>
+<path fill="none" stroke="black" d="M350.147,-140.3C356.147,-140.3 362.147,-146.3 362.147,-152.3"></path>
+<polyline fill="none" stroke="black" points="362.147,-152.3 362.147,-203.7 "></polyline>
+<path fill="none" stroke="black" d="M362.147,-203.7C362.147,-209.7 356.147,-215.7 350.147,-215.7"></path>
+<text text-anchor="middle" x="295" y="-199" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="295" y="-182.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="295" y="-165.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="295" y="-148.6" font-family="Times,serif" font-size="14.00">Identifier (hoge)</text>
+</g>
+
+<g id="edge11" class="edge"><title>s1_5-&gt;s1_6</title>
+<path fill="none" stroke="black" d="M291.715,-269.334C292.153,-257.284 292.734,-241.309 293.286,-226.147"></path>
+<polygon fill="black" stroke="black" points="296.795,-225.959 293.66,-215.839 289.799,-225.705 296.795,-225.959"></polygon>
+</g>
+
+<g id="edge12" class="edge"><title>s1_6-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M249.944,-140.244C237.624,-130.194 224.525,-119.507 213.091,-110.179"></path>
+<polygon fill="black" stroke="black" points="215.055,-107.265 205.094,-103.655 210.63,-112.689 215.055,-107.265"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-ifstatement.svg
+++ b/docs/developer-guide/code-path-analysis/example-ifstatement.svg
@@ -1,0 +1,122 @@
+<?xml version="1.0"?>
+<svg width="294pt" height="372pt" viewBox="0.00 0.00 294.00 372.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 368)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="143" cy="-355" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="174.339,-310.401 111.661,-310.401 99.6614,-298.401 99.6614,-263.599 111.661,-251.599 174.339,-251.599 186.339,-263.599 186.339,-298.401 174.339,-310.401"></polygon>
+<path fill="white" stroke="white" d="M111.661,-310.401C105.661,-310.401 99.6614,-304.401 99.6614,-298.401"></path>
+<path fill="white" stroke="white" d="M99.6614,-263.599C99.6614,-257.599 105.661,-251.599 111.661,-251.599"></path>
+<path fill="white" stroke="white" d="M174.339,-251.599C180.339,-251.599 186.339,-257.599 186.339,-263.599"></path>
+<path fill="white" stroke="white" d="M186.339,-298.401C186.339,-304.401 180.339,-310.401 174.339,-310.401"></path>
+<polyline fill="none" stroke="black" points="174.339,-310.401 111.661,-310.401 "></polyline>
+<path fill="none" stroke="black" d="M111.661,-310.401C105.661,-310.401 99.6614,-304.401 99.6614,-298.401"></path>
+<polyline fill="none" stroke="black" points="99.6614,-298.401 99.6614,-263.599 "></polyline>
+<path fill="none" stroke="black" d="M99.6614,-263.599C99.6614,-257.599 105.661,-251.599 111.661,-251.599"></path>
+<polyline fill="none" stroke="black" points="111.661,-251.599 174.339,-251.599 "></polyline>
+<path fill="none" stroke="black" d="M174.339,-251.599C180.339,-251.599 186.339,-257.599 186.339,-263.599"></path>
+<polyline fill="none" stroke="black" points="186.339,-263.599 186.339,-298.401 "></polyline>
+<path fill="none" stroke="black" d="M186.339,-298.401C186.339,-304.401 180.339,-310.401 174.339,-310.401"></path>
+<text text-anchor="middle" x="143" y="-293.6" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="143" y="-276.8" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="143" y="-260" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M143,-345.741C143,-339.393 143,-330.126 143,-320.615"></path>
+<polygon fill="black" stroke="black" points="146.5,-320.324 143,-310.324 139.5,-320.324 146.5,-320.324"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="143" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="143" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="122.147,-215.7 11.8526,-215.7 -0.147372,-203.7 -0.147372,-152.3 11.8526,-140.3 122.147,-140.3 134.147,-152.3 134.147,-203.7 122.147,-215.7"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-215.7C5.85263,-215.7 -0.147372,-209.7 -0.147372,-203.7"></path>
+<path fill="white" stroke="white" d="M-0.147372,-152.3C-0.147372,-146.3 5.85263,-140.3 11.8526,-140.3"></path>
+<path fill="white" stroke="white" d="M122.147,-140.3C128.147,-140.3 134.147,-146.3 134.147,-152.3"></path>
+<path fill="white" stroke="white" d="M134.147,-203.7C134.147,-209.7 128.147,-215.7 122.147,-215.7"></path>
+<polyline fill="none" stroke="black" points="122.147,-215.7 11.8526,-215.7 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-215.7C5.85263,-215.7 -0.147372,-209.7 -0.147372,-203.7"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-203.7 -0.147372,-152.3 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-152.3C-0.147372,-146.3 5.85263,-140.3 11.8526,-140.3"></path>
+<polyline fill="none" stroke="black" points="11.8526,-140.3 122.147,-140.3 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-140.3C128.147,-140.3 134.147,-146.3 134.147,-152.3"></path>
+<polyline fill="none" stroke="black" points="134.147,-152.3 134.147,-203.7 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-203.7C134.147,-209.7 128.147,-215.7 122.147,-215.7"></path>
+<text text-anchor="middle" x="67" y="-199" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-182.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-165.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-148.6" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M121.628,-251.597C115.176,-243.023 107.927,-233.39 100.871,-224.013"></path>
+<polygon fill="black" stroke="black" points="103.554,-221.757 94.7444,-215.871 97.9604,-225.966 103.554,-221.757"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="274.147,-215.7 163.853,-215.7 151.853,-203.7 151.853,-152.3 163.853,-140.3 274.147,-140.3 286.147,-152.3 286.147,-203.7 274.147,-215.7"></polygon>
+<path fill="white" stroke="white" d="M163.853,-215.7C157.853,-215.7 151.853,-209.7 151.853,-203.7"></path>
+<path fill="white" stroke="white" d="M151.853,-152.3C151.853,-146.3 157.853,-140.3 163.853,-140.3"></path>
+<path fill="white" stroke="white" d="M274.147,-140.3C280.147,-140.3 286.147,-146.3 286.147,-152.3"></path>
+<path fill="white" stroke="white" d="M286.147,-203.7C286.147,-209.7 280.147,-215.7 274.147,-215.7"></path>
+<polyline fill="none" stroke="black" points="274.147,-215.7 163.853,-215.7 "></polyline>
+<path fill="none" stroke="black" d="M163.853,-215.7C157.853,-215.7 151.853,-209.7 151.853,-203.7"></path>
+<polyline fill="none" stroke="black" points="151.853,-203.7 151.853,-152.3 "></polyline>
+<path fill="none" stroke="black" d="M151.853,-152.3C151.853,-146.3 157.853,-140.3 163.853,-140.3"></path>
+<polyline fill="none" stroke="black" points="163.853,-140.3 274.147,-140.3 "></polyline>
+<path fill="none" stroke="black" d="M274.147,-140.3C280.147,-140.3 286.147,-146.3 286.147,-152.3"></path>
+<polyline fill="none" stroke="black" points="286.147,-152.3 286.147,-203.7 "></polyline>
+<path fill="none" stroke="black" d="M286.147,-203.7C286.147,-209.7 280.147,-215.7 274.147,-215.7"></path>
+<text text-anchor="middle" x="219" y="-199" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="219" y="-182.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="219" y="-165.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="219" y="-148.6" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge6" class="edge"><title>s1_1-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M164.372,-251.597C170.824,-243.023 178.073,-233.39 185.129,-224.013"></path>
+<polygon fill="black" stroke="black" points="188.04,-225.966 191.256,-215.871 182.446,-221.757 188.04,-225.966"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="184.147,-103.602 101.853,-103.602 89.8526,-91.6019 89.8526,-74.3981 101.853,-62.3981 184.147,-62.3981 196.147,-74.3981 196.147,-91.6019 184.147,-103.602"></polygon>
+<path fill="white" stroke="white" d="M101.853,-103.602C95.8526,-103.602 89.8526,-97.6019 89.8526,-91.6019"></path>
+<path fill="white" stroke="white" d="M89.8526,-74.3981C89.8526,-68.3981 95.8526,-62.3981 101.853,-62.3981"></path>
+<path fill="white" stroke="white" d="M184.147,-62.3981C190.147,-62.3981 196.147,-68.3981 196.147,-74.3981"></path>
+<path fill="white" stroke="white" d="M196.147,-91.6019C196.147,-97.6019 190.147,-103.602 184.147,-103.602"></path>
+<polyline fill="none" stroke="black" points="184.147,-103.602 101.853,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M101.853,-103.602C95.8526,-103.602 89.8526,-97.6019 89.8526,-91.6019"></path>
+<polyline fill="none" stroke="black" points="89.8526,-91.6019 89.8526,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M89.8526,-74.3981C89.8526,-68.3981 95.8526,-62.3981 101.853,-62.3981"></path>
+<polyline fill="none" stroke="black" points="101.853,-62.3981 184.147,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M184.147,-62.3981C190.147,-62.3981 196.147,-68.3981 196.147,-74.3981"></path>
+<polyline fill="none" stroke="black" points="196.147,-74.3981 196.147,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M196.147,-91.6019C196.147,-97.6019 190.147,-103.602 184.147,-103.602"></path>
+<text text-anchor="middle" x="143" y="-87.2" font-family="Times,serif" font-size="14.00">IfStatement:exit</text>
+<text text-anchor="middle" x="143" y="-70.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M97.0372,-140.244C104.852,-130.681 113.137,-120.543 120.488,-111.547"></path>
+<polygon fill="black" stroke="black" points="123.32,-113.613 126.938,-103.655 117.899,-109.184 123.32,-113.613"></polygon>
+</g>
+
+<g id="edge8" class="edge"><title>s1_4-&gt;final</title>
+<path fill="none" stroke="black" d="M143,-62.3316C143,-54.2587 143,-44.8663 143,-36.5198"></path>
+<polygon fill="black" stroke="black" points="146.5,-36.3487 143,-26.3488 139.5,-36.3488 146.5,-36.3487"></polygon>
+</g>
+
+<g id="edge7" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M188.963,-140.244C181.148,-130.681 172.863,-120.543 165.512,-111.547"></path>
+<polygon fill="black" stroke="black" points="168.101,-109.184 159.062,-103.655 162.68,-113.613 168.101,-109.184"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-switchstatement-has-default.svg
+++ b/docs/developer-guide/code-path-analysis/example-switchstatement-has-default.svg
@@ -1,0 +1,279 @@
+<?xml version="1.0"?>
+<svg width="347pt" height="802pt" viewBox="0.00 0.00 347.00 802.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 798)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="121" cy="-785" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="164.156,-740 77.8443,-740 65.8443,-728 65.8443,-660 77.8443,-648 164.156,-648 176.156,-660 176.156,-728 164.156,-740"></polygon>
+<path fill="white" stroke="white" d="M77.8443,-740C71.8443,-740 65.8443,-734 65.8443,-728"></path>
+<path fill="white" stroke="white" d="M65.8443,-660C65.8443,-654 71.8443,-648 77.8443,-648"></path>
+<path fill="white" stroke="white" d="M164.156,-648C170.156,-648 176.156,-654 176.156,-660"></path>
+<path fill="white" stroke="white" d="M176.156,-728C176.156,-734 170.156,-740 164.156,-740"></path>
+<polyline fill="none" stroke="black" points="164.156,-740 77.8443,-740 "></polyline>
+<path fill="none" stroke="black" d="M77.8443,-740C71.8443,-740 65.8443,-734 65.8443,-728"></path>
+<polyline fill="none" stroke="black" points="65.8443,-728 65.8443,-660 "></polyline>
+<path fill="none" stroke="black" d="M65.8443,-660C65.8443,-654 71.8443,-648 77.8443,-648"></path>
+<polyline fill="none" stroke="black" points="77.8443,-648 164.156,-648 "></polyline>
+<path fill="none" stroke="black" d="M164.156,-648C170.156,-648 176.156,-654 176.156,-660"></path>
+<polyline fill="none" stroke="black" points="176.156,-660 176.156,-728 "></polyline>
+<path fill="none" stroke="black" d="M176.156,-728C176.156,-734 170.156,-740 164.156,-740"></path>
+<text text-anchor="middle" x="121" y="-723.4" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="121" y="-706.6" font-family="Times,serif" font-size="14.00">SwitchStatement</text>
+<text text-anchor="middle" x="121" y="-689.8" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+<text text-anchor="middle" x="121" y="-673" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="121" y="-656.2" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M121,-775.787C121,-769.525 121,-760.299 121,-750.297"></path>
+<polygon fill="black" stroke="black" points="124.5,-750.119 121,-740.119 117.5,-750.119 124.5,-750.119"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="162" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="162" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="122.147,-533.7 11.8526,-533.7 -0.147372,-521.7 -0.147372,-470.3 11.8526,-458.3 122.147,-458.3 134.147,-470.3 134.147,-521.7 122.147,-533.7"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-533.7C5.85263,-533.7 -0.147372,-527.7 -0.147372,-521.7"></path>
+<path fill="white" stroke="white" d="M-0.147372,-470.3C-0.147372,-464.3 5.85263,-458.3 11.8526,-458.3"></path>
+<path fill="white" stroke="white" d="M122.147,-458.3C128.147,-458.3 134.147,-464.3 134.147,-470.3"></path>
+<path fill="white" stroke="white" d="M134.147,-521.7C134.147,-527.7 128.147,-533.7 122.147,-533.7"></path>
+<polyline fill="none" stroke="black" points="122.147,-533.7 11.8526,-533.7 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-533.7C5.85263,-533.7 -0.147372,-527.7 -0.147372,-521.7"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-521.7 -0.147372,-470.3 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-470.3C-0.147372,-464.3 5.85263,-458.3 11.8526,-458.3"></path>
+<polyline fill="none" stroke="black" points="11.8526,-458.3 122.147,-458.3 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-458.3C128.147,-458.3 134.147,-464.3 134.147,-470.3"></path>
+<polyline fill="none" stroke="black" points="134.147,-470.3 134.147,-521.7 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-521.7C134.147,-527.7 128.147,-533.7 122.147,-533.7"></path>
+<text text-anchor="middle" x="67" y="-517" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-500.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-483.4" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-466.6" font-family="Times,serif" font-size="14.00">BreakStatement</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M108.476,-647.541C99.8727,-616.316 88.4862,-574.987 79.8204,-543.533"></path>
+<polygon fill="black" stroke="black" points="83.14,-542.405 77.1095,-533.694 76.3914,-544.264 83.14,-542.405"></polygon>
+</g>
+
+<g id="node9" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="191.072,-611.602 132.928,-611.602 120.928,-599.602 120.928,-582.398 132.928,-570.398 191.072,-570.398 203.072,-582.398 203.072,-599.602 191.072,-611.602"></polygon>
+<path fill="white" stroke="white" d="M132.928,-611.602C126.928,-611.602 120.928,-605.602 120.928,-599.602"></path>
+<path fill="white" stroke="white" d="M120.928,-582.398C120.928,-576.398 126.928,-570.398 132.928,-570.398"></path>
+<path fill="white" stroke="white" d="M191.072,-570.398C197.072,-570.398 203.072,-576.398 203.072,-582.398"></path>
+<path fill="white" stroke="white" d="M203.072,-599.602C203.072,-605.602 197.072,-611.602 191.072,-611.602"></path>
+<polyline fill="none" stroke="black" points="191.072,-611.602 132.928,-611.602 "></polyline>
+<path fill="none" stroke="black" d="M132.928,-611.602C126.928,-611.602 120.928,-605.602 120.928,-599.602"></path>
+<polyline fill="none" stroke="black" points="120.928,-599.602 120.928,-582.398 "></polyline>
+<path fill="none" stroke="black" d="M120.928,-582.398C120.928,-576.398 126.928,-570.398 132.928,-570.398"></path>
+<polyline fill="none" stroke="black" points="132.928,-570.398 191.072,-570.398 "></polyline>
+<path fill="none" stroke="black" d="M191.072,-570.398C197.072,-570.398 203.072,-576.398 203.072,-582.398"></path>
+<polyline fill="none" stroke="black" points="203.072,-582.398 203.072,-599.602 "></polyline>
+<path fill="none" stroke="black" d="M203.072,-599.602C203.072,-605.602 197.072,-611.602 191.072,-611.602"></path>
+<text text-anchor="middle" x="162" y="-595.2" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="162" y="-578.4" font-family="Times,serif" font-size="14.00">Literal (1)</text>
+</g>
+
+<g id="edge7" class="edge"><title>s1_1-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M139.341,-647.817C143.019,-638.757 146.791,-629.466 150.176,-621.128"></path>
+<polygon fill="black" stroke="black" points="153.424,-622.431 153.943,-611.849 146.938,-619.798 153.424,-622.431"></polygon>
+</g>
+
+<g id="node8" class="node"><title>s1_14</title>
+<polygon fill="white" stroke="white" points="217.321,-103.602 106.679,-103.602 94.6789,-91.6019 94.6789,-74.3981 106.679,-62.3981 217.321,-62.3981 229.321,-74.3981 229.321,-91.6019 217.321,-103.602"></polygon>
+<path fill="white" stroke="white" d="M106.679,-103.602C100.679,-103.602 94.6789,-97.6019 94.6789,-91.6019"></path>
+<path fill="white" stroke="white" d="M94.6789,-74.3981C94.6789,-68.3981 100.679,-62.3981 106.679,-62.3981"></path>
+<path fill="white" stroke="white" d="M217.321,-62.3981C223.321,-62.3981 229.321,-68.3981 229.321,-74.3981"></path>
+<path fill="white" stroke="white" d="M229.321,-91.6019C229.321,-97.6019 223.321,-103.602 217.321,-103.602"></path>
+<polyline fill="none" stroke="black" points="217.321,-103.602 106.679,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M106.679,-103.602C100.679,-103.602 94.6789,-97.6019 94.6789,-91.6019"></path>
+<polyline fill="none" stroke="black" points="94.6789,-91.6019 94.6789,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M94.6789,-74.3981C94.6789,-68.3981 100.679,-62.3981 106.679,-62.3981"></path>
+<polyline fill="none" stroke="black" points="106.679,-62.3981 217.321,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M217.321,-62.3981C223.321,-62.3981 229.321,-68.3981 229.321,-74.3981"></path>
+<polyline fill="none" stroke="black" points="229.321,-74.3981 229.321,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M229.321,-91.6019C229.321,-97.6019 223.321,-103.602 217.321,-103.602"></path>
+<text text-anchor="middle" x="162" y="-87.2" font-family="Times,serif" font-size="14.00">SwitchStatement:exit</text>
+<text text-anchor="middle" x="162" y="-70.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge11" class="edge"><title>s1_2-&gt;s1_14</title>
+<path fill="none" stroke="black" d="M65.9609,-458.127C65.4872,-409.946 67.6815,-323.315 86,-252 99.1928,-200.639 127.133,-145.406 145.212,-112.816"></path>
+<polygon fill="black" stroke="black" points="148.402,-114.284 150.254,-103.852 142.301,-110.852 148.402,-114.284"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_7</title>
+<polygon fill="white" stroke="white" points="217.147,-422.401 106.853,-422.401 94.8526,-410.401 94.8526,-375.599 106.853,-363.599 217.147,-363.599 229.147,-375.599 229.147,-410.401 217.147,-422.401"></polygon>
+<path fill="white" stroke="white" d="M106.853,-422.401C100.853,-422.401 94.8526,-416.401 94.8526,-410.401"></path>
+<path fill="white" stroke="white" d="M94.8526,-375.599C94.8526,-369.599 100.853,-363.599 106.853,-363.599"></path>
+<path fill="white" stroke="white" d="M217.147,-363.599C223.147,-363.599 229.147,-369.599 229.147,-375.599"></path>
+<path fill="white" stroke="white" d="M229.147,-410.401C229.147,-416.401 223.147,-422.401 217.147,-422.401"></path>
+<polyline fill="none" stroke="black" points="217.147,-422.401 106.853,-422.401 "></polyline>
+<path fill="none" stroke="black" d="M106.853,-422.401C100.853,-422.401 94.8526,-416.401 94.8526,-410.401"></path>
+<polyline fill="none" stroke="black" points="94.8526,-410.401 94.8526,-375.599 "></polyline>
+<path fill="none" stroke="black" d="M94.8526,-375.599C94.8526,-369.599 100.853,-363.599 106.853,-363.599"></path>
+<polyline fill="none" stroke="black" points="106.853,-363.599 217.147,-363.599 "></polyline>
+<path fill="none" stroke="black" d="M217.147,-363.599C223.147,-363.599 229.147,-369.599 229.147,-375.599"></path>
+<polyline fill="none" stroke="black" points="229.147,-375.599 229.147,-410.401 "></polyline>
+<path fill="none" stroke="black" d="M229.147,-410.401C229.147,-416.401 223.147,-422.401 217.147,-422.401"></path>
+<text text-anchor="middle" x="162" y="-405.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="162" y="-388.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="162" y="-372" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="node6" class="node"><title>s1_9</title>
+<polygon fill="white" stroke="white" points="217.147,-327.7 106.853,-327.7 94.8526,-315.7 94.8526,-264.3 106.853,-252.3 217.147,-252.3 229.147,-264.3 229.147,-315.7 217.147,-327.7"></polygon>
+<path fill="white" stroke="white" d="M106.853,-327.7C100.853,-327.7 94.8526,-321.7 94.8526,-315.7"></path>
+<path fill="white" stroke="white" d="M94.8526,-264.3C94.8526,-258.3 100.853,-252.3 106.853,-252.3"></path>
+<path fill="white" stroke="white" d="M217.147,-252.3C223.147,-252.3 229.147,-258.3 229.147,-264.3"></path>
+<path fill="white" stroke="white" d="M229.147,-315.7C229.147,-321.7 223.147,-327.7 217.147,-327.7"></path>
+<polyline fill="none" stroke="black" points="217.147,-327.7 106.853,-327.7 "></polyline>
+<path fill="none" stroke="black" d="M106.853,-327.7C100.853,-327.7 94.8526,-321.7 94.8526,-315.7"></path>
+<polyline fill="none" stroke="black" points="94.8526,-315.7 94.8526,-264.3 "></polyline>
+<path fill="none" stroke="black" d="M94.8526,-264.3C94.8526,-258.3 100.853,-252.3 106.853,-252.3"></path>
+<polyline fill="none" stroke="black" points="106.853,-252.3 217.147,-252.3 "></polyline>
+<path fill="none" stroke="black" d="M217.147,-252.3C223.147,-252.3 229.147,-258.3 229.147,-264.3"></path>
+<polyline fill="none" stroke="black" points="229.147,-264.3 229.147,-315.7 "></polyline>
+<path fill="none" stroke="black" d="M229.147,-315.7C229.147,-321.7 223.147,-327.7 217.147,-327.7"></path>
+<text text-anchor="middle" x="162" y="-311" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="162" y="-294.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="162" y="-277.4" font-family="Times,serif" font-size="14.00">Identifier (hoge)</text>
+<text text-anchor="middle" x="162" y="-260.6" font-family="Times,serif" font-size="14.00">BreakStatement</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_7-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M162,-363.597C162,-355.629 162,-346.747 162,-338.005"></path>
+<polygon fill="black" stroke="black" points="165.5,-337.871 162,-327.871 158.5,-337.871 165.5,-337.871"></polygon>
+</g>
+
+<g id="edge13" class="edge"><title>s1_9-&gt;s1_14</title>
+<path fill="none" stroke="black" d="M162,-252.35C162,-212.728 162,-150.341 162,-113.673"></path>
+<polygon fill="black" stroke="black" points="165.5,-113.613 162,-103.613 158.5,-113.613 165.5,-113.613"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_12</title>
+<polygon fill="white" stroke="white" points="327.147,-215.7 216.853,-215.7 204.853,-203.7 204.853,-152.3 216.853,-140.3 327.147,-140.3 339.147,-152.3 339.147,-203.7 327.147,-215.7"></polygon>
+<path fill="white" stroke="white" d="M216.853,-215.7C210.853,-215.7 204.853,-209.7 204.853,-203.7"></path>
+<path fill="white" stroke="white" d="M204.853,-152.3C204.853,-146.3 210.853,-140.3 216.853,-140.3"></path>
+<path fill="white" stroke="white" d="M327.147,-140.3C333.147,-140.3 339.147,-146.3 339.147,-152.3"></path>
+<path fill="white" stroke="white" d="M339.147,-203.7C339.147,-209.7 333.147,-215.7 327.147,-215.7"></path>
+<polyline fill="none" stroke="black" points="327.147,-215.7 216.853,-215.7 "></polyline>
+<path fill="none" stroke="black" d="M216.853,-215.7C210.853,-215.7 204.853,-209.7 204.853,-203.7"></path>
+<polyline fill="none" stroke="black" points="204.853,-203.7 204.853,-152.3 "></polyline>
+<path fill="none" stroke="black" d="M204.853,-152.3C204.853,-146.3 210.853,-140.3 216.853,-140.3"></path>
+<polyline fill="none" stroke="black" points="216.853,-140.3 327.147,-140.3 "></polyline>
+<path fill="none" stroke="black" d="M327.147,-140.3C333.147,-140.3 339.147,-146.3 339.147,-152.3"></path>
+<polyline fill="none" stroke="black" points="339.147,-152.3 339.147,-203.7 "></polyline>
+<path fill="none" stroke="black" d="M339.147,-203.7C339.147,-209.7 333.147,-215.7 327.147,-215.7"></path>
+<text text-anchor="middle" x="272" y="-199" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="272" y="-182.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="272" y="-165.4" font-family="Times,serif" font-size="14.00">Identifier (fuga)</text>
+<text text-anchor="middle" x="272" y="-148.6" font-family="Times,serif" font-size="14.00">BreakStatement</text>
+</g>
+
+<g id="edge15" class="edge"><title>s1_12-&gt;s1_14</title>
+<path fill="none" stroke="black" d="M228.525,-140.244C216.638,-130.194 203.998,-119.507 192.965,-110.179"></path>
+<polygon fill="black" stroke="black" points="195.145,-107.439 185.248,-103.655 190.625,-112.785 195.145,-107.439"></polygon>
+</g>
+
+<g id="edge25" class="edge"><title>s1_14-&gt;final</title>
+<path fill="none" stroke="black" d="M162,-62.3316C162,-54.2587 162,-44.8663 162,-36.5198"></path>
+<polygon fill="black" stroke="black" points="165.5,-36.3487 162,-26.3488 158.5,-36.3488 165.5,-36.3487"></polygon>
+</g>
+
+<g id="edge17" class="edge"><title>s1_4-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M162,-570.128C162,-537.987 162,-474.03 162,-432.674"></path>
+<polygon fill="black" stroke="black" points="165.5,-432.424 162,-422.424 158.5,-432.424 165.5,-432.424"></polygon>
+</g>
+
+<g id="node10" class="node"><title>s1_6</title>
+<polygon fill="white" stroke="white" points="260.072,-516.602 201.928,-516.602 189.928,-504.602 189.928,-487.398 201.928,-475.398 260.072,-475.398 272.072,-487.398 272.072,-504.602 260.072,-516.602"></polygon>
+<path fill="white" stroke="white" d="M201.928,-516.602C195.928,-516.602 189.928,-510.602 189.928,-504.602"></path>
+<path fill="white" stroke="white" d="M189.928,-487.398C189.928,-481.398 195.928,-475.398 201.928,-475.398"></path>
+<path fill="white" stroke="white" d="M260.072,-475.398C266.072,-475.398 272.072,-481.398 272.072,-487.398"></path>
+<path fill="white" stroke="white" d="M272.072,-504.602C272.072,-510.602 266.072,-516.602 260.072,-516.602"></path>
+<polyline fill="none" stroke="black" points="260.072,-516.602 201.928,-516.602 "></polyline>
+<path fill="none" stroke="black" d="M201.928,-516.602C195.928,-516.602 189.928,-510.602 189.928,-504.602"></path>
+<polyline fill="none" stroke="black" points="189.928,-504.602 189.928,-487.398 "></polyline>
+<path fill="none" stroke="black" d="M189.928,-487.398C189.928,-481.398 195.928,-475.398 201.928,-475.398"></path>
+<polyline fill="none" stroke="black" points="201.928,-475.398 260.072,-475.398 "></polyline>
+<path fill="none" stroke="black" d="M260.072,-475.398C266.072,-475.398 272.072,-481.398 272.072,-487.398"></path>
+<polyline fill="none" stroke="black" points="272.072,-487.398 272.072,-504.602 "></polyline>
+<path fill="none" stroke="black" d="M272.072,-504.602C272.072,-510.602 266.072,-516.602 260.072,-516.602"></path>
+<text text-anchor="middle" x="231" y="-500.2" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="231" y="-483.4" font-family="Times,serif" font-size="14.00">Literal (2)</text>
+</g>
+
+<g id="edge8" class="edge"><title>s1_4-&gt;s1_6</title>
+<path fill="none" stroke="black" d="M176.633,-570.277C186.422,-557.084 199.447,-539.528 210.294,-524.908"></path>
+<polygon fill="black" stroke="black" points="213.24,-526.811 216.388,-516.694 207.619,-522.64 213.24,-526.811"></polygon>
+</g>
+
+<g id="edge9" class="edge"><title>s1_6-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M217.368,-475.046C208.766,-462.455 197.392,-445.806 187.191,-430.874"></path>
+<polygon fill="black" stroke="black" points="189.882,-428.608 181.351,-422.325 184.102,-432.557 189.882,-428.608"></polygon>
+</g>
+
+<g id="node11" class="node"><title>s1_8</title>
+<polygon fill="white" stroke="white" points="317.072,-413.602 258.928,-413.602 246.928,-401.602 246.928,-384.398 258.928,-372.398 317.072,-372.398 329.072,-384.398 329.072,-401.602 317.072,-413.602"></polygon>
+<path fill="white" stroke="white" d="M258.928,-413.602C252.928,-413.602 246.928,-407.602 246.928,-401.602"></path>
+<path fill="white" stroke="white" d="M246.928,-384.398C246.928,-378.398 252.928,-372.398 258.928,-372.398"></path>
+<path fill="white" stroke="white" d="M317.072,-372.398C323.072,-372.398 329.072,-378.398 329.072,-384.398"></path>
+<path fill="white" stroke="white" d="M329.072,-401.602C329.072,-407.602 323.072,-413.602 317.072,-413.602"></path>
+<polyline fill="none" stroke="black" points="317.072,-413.602 258.928,-413.602 "></polyline>
+<path fill="none" stroke="black" d="M258.928,-413.602C252.928,-413.602 246.928,-407.602 246.928,-401.602"></path>
+<polyline fill="none" stroke="black" points="246.928,-401.602 246.928,-384.398 "></polyline>
+<path fill="none" stroke="black" d="M246.928,-384.398C246.928,-378.398 252.928,-372.398 258.928,-372.398"></path>
+<polyline fill="none" stroke="black" points="258.928,-372.398 317.072,-372.398 "></polyline>
+<path fill="none" stroke="black" d="M317.072,-372.398C323.072,-372.398 329.072,-378.398 329.072,-384.398"></path>
+<polyline fill="none" stroke="black" points="329.072,-384.398 329.072,-401.602 "></polyline>
+<path fill="none" stroke="black" d="M329.072,-401.602C329.072,-407.602 323.072,-413.602 317.072,-413.602"></path>
+<text text-anchor="middle" x="288" y="-397.2" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="288" y="-380.4" font-family="Times,serif" font-size="14.00">Literal (3)</text>
+</g>
+
+<g id="edge19" class="edge"><title>s1_6-&gt;s1_8</title>
+<path fill="none" stroke="black" d="M242.261,-475.046C250.693,-460.106 262.349,-439.452 271.784,-422.734"></path>
+<polygon fill="black" stroke="black" points="274.895,-424.342 276.762,-413.913 268.799,-420.902 274.895,-424.342"></polygon>
+</g>
+
+<g id="edge20" class="edge"><title>s1_8-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M263.407,-372.286C249.805,-361.383 232.341,-347.384 215.751,-334.086"></path>
+<polygon fill="black" stroke="black" points="217.69,-331.155 207.698,-327.631 213.312,-336.617 217.69,-331.155"></polygon>
+</g>
+
+<g id="node12" class="node"><title>s1_11</title>
+<polygon fill="white" stroke="white" points="317.072,-308 258.928,-308 246.928,-296 246.928,-284 258.928,-272 317.072,-272 329.072,-284 329.072,-296 317.072,-308"></polygon>
+<path fill="white" stroke="white" d="M258.928,-308C252.928,-308 246.928,-302 246.928,-296"></path>
+<path fill="white" stroke="white" d="M246.928,-284C246.928,-278 252.928,-272 258.928,-272"></path>
+<path fill="white" stroke="white" d="M317.072,-272C323.072,-272 329.072,-278 329.072,-284"></path>
+<path fill="white" stroke="white" d="M329.072,-296C329.072,-302 323.072,-308 317.072,-308"></path>
+<polyline fill="none" stroke="black" points="317.072,-308 258.928,-308 "></polyline>
+<path fill="none" stroke="black" d="M258.928,-308C252.928,-308 246.928,-302 246.928,-296"></path>
+<polyline fill="none" stroke="black" points="246.928,-296 246.928,-284 "></polyline>
+<path fill="none" stroke="black" d="M246.928,-284C246.928,-278 252.928,-272 258.928,-272"></path>
+<polyline fill="none" stroke="black" points="258.928,-272 317.072,-272 "></polyline>
+<path fill="none" stroke="black" d="M317.072,-272C323.072,-272 329.072,-278 329.072,-284"></path>
+<polyline fill="none" stroke="black" points="329.072,-284 329.072,-296 "></polyline>
+<path fill="none" stroke="black" d="M329.072,-296C329.072,-302 323.072,-308 317.072,-308"></path>
+<text text-anchor="middle" x="288" y="-285.8" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+</g>
+
+<g id="edge22" class="edge"><title>s1_8-&gt;s1_11</title>
+<path fill="none" stroke="black" d="M288,-372.046C288,-356.766 288,-335.511 288,-318.601"></path>
+<polygon fill="black" stroke="black" points="291.5,-318.223 288,-308.223 284.5,-318.223 291.5,-318.223"></polygon>
+</g>
+
+<g id="edge23" class="edge"><title>s1_11-&gt;s1_12</title>
+<path fill="none" stroke="black" d="M285.5,-271.813C283.695,-259.403 281.166,-242.015 278.784,-225.64"></path>
+<polygon fill="black" stroke="black" points="282.231,-225.02 277.328,-215.628 275.304,-226.028 282.231,-225.02"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-switchstatement.svg
+++ b/docs/developer-guide/code-path-analysis/example-switchstatement.svg
@@ -1,0 +1,232 @@
+<?xml version="1.0"?>
+<svg width="337pt" height="690pt" viewBox="0.00 0.00 337.00 690.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 686)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="121" cy="-673" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="164.156,-628 77.8443,-628 65.8443,-616 65.8443,-548 77.8443,-536 164.156,-536 176.156,-548 176.156,-616 164.156,-628"></polygon>
+<path fill="white" stroke="white" d="M77.8443,-628C71.8443,-628 65.8443,-622 65.8443,-616"></path>
+<path fill="white" stroke="white" d="M65.8443,-548C65.8443,-542 71.8443,-536 77.8443,-536"></path>
+<path fill="white" stroke="white" d="M164.156,-536C170.156,-536 176.156,-542 176.156,-548"></path>
+<path fill="white" stroke="white" d="M176.156,-616C176.156,-622 170.156,-628 164.156,-628"></path>
+<polyline fill="none" stroke="black" points="164.156,-628 77.8443,-628 "></polyline>
+<path fill="none" stroke="black" d="M77.8443,-628C71.8443,-628 65.8443,-622 65.8443,-616"></path>
+<polyline fill="none" stroke="black" points="65.8443,-616 65.8443,-548 "></polyline>
+<path fill="none" stroke="black" d="M65.8443,-548C65.8443,-542 71.8443,-536 77.8443,-536"></path>
+<polyline fill="none" stroke="black" points="77.8443,-536 164.156,-536 "></polyline>
+<path fill="none" stroke="black" d="M164.156,-536C170.156,-536 176.156,-542 176.156,-548"></path>
+<polyline fill="none" stroke="black" points="176.156,-548 176.156,-616 "></polyline>
+<path fill="none" stroke="black" d="M176.156,-616C176.156,-622 170.156,-628 164.156,-628"></path>
+<text text-anchor="middle" x="121" y="-611.4" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="121" y="-594.6" font-family="Times,serif" font-size="14.00">SwitchStatement</text>
+<text text-anchor="middle" x="121" y="-577.8" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+<text text-anchor="middle" x="121" y="-561" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="121" y="-544.2" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M121,-663.787C121,-657.525 121,-648.299 121,-638.297"></path>
+<polygon fill="black" stroke="black" points="124.5,-638.119 121,-628.119 117.5,-638.119 124.5,-638.119"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="170" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="170" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="122.147,-421.7 11.8526,-421.7 -0.147372,-409.7 -0.147372,-358.3 11.8526,-346.3 122.147,-346.3 134.147,-358.3 134.147,-409.7 122.147,-421.7"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-421.7C5.85263,-421.7 -0.147372,-415.7 -0.147372,-409.7"></path>
+<path fill="white" stroke="white" d="M-0.147372,-358.3C-0.147372,-352.3 5.85263,-346.3 11.8526,-346.3"></path>
+<path fill="white" stroke="white" d="M122.147,-346.3C128.147,-346.3 134.147,-352.3 134.147,-358.3"></path>
+<path fill="white" stroke="white" d="M134.147,-409.7C134.147,-415.7 128.147,-421.7 122.147,-421.7"></path>
+<polyline fill="none" stroke="black" points="122.147,-421.7 11.8526,-421.7 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-421.7C5.85263,-421.7 -0.147372,-415.7 -0.147372,-409.7"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-409.7 -0.147372,-358.3 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-358.3C-0.147372,-352.3 5.85263,-346.3 11.8526,-346.3"></path>
+<polyline fill="none" stroke="black" points="11.8526,-346.3 122.147,-346.3 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-346.3C128.147,-346.3 134.147,-352.3 134.147,-358.3"></path>
+<polyline fill="none" stroke="black" points="134.147,-358.3 134.147,-409.7 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-409.7C134.147,-415.7 128.147,-421.7 122.147,-421.7"></path>
+<text text-anchor="middle" x="67" y="-405" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-388.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-371.4" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-354.6" font-family="Times,serif" font-size="14.00">BreakStatement</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M108.476,-535.541C99.8727,-504.316 88.4862,-462.987 79.8204,-431.533"></path>
+<polygon fill="black" stroke="black" points="83.14,-430.405 77.1095,-421.694 76.3914,-432.264 83.14,-430.405"></polygon>
+</g>
+
+<g id="node8" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="191.072,-499.602 132.928,-499.602 120.928,-487.602 120.928,-470.398 132.928,-458.398 191.072,-458.398 203.072,-470.398 203.072,-487.602 191.072,-499.602"></polygon>
+<path fill="white" stroke="white" d="M132.928,-499.602C126.928,-499.602 120.928,-493.602 120.928,-487.602"></path>
+<path fill="white" stroke="white" d="M120.928,-470.398C120.928,-464.398 126.928,-458.398 132.928,-458.398"></path>
+<path fill="white" stroke="white" d="M191.072,-458.398C197.072,-458.398 203.072,-464.398 203.072,-470.398"></path>
+<path fill="white" stroke="white" d="M203.072,-487.602C203.072,-493.602 197.072,-499.602 191.072,-499.602"></path>
+<polyline fill="none" stroke="black" points="191.072,-499.602 132.928,-499.602 "></polyline>
+<path fill="none" stroke="black" d="M132.928,-499.602C126.928,-499.602 120.928,-493.602 120.928,-487.602"></path>
+<polyline fill="none" stroke="black" points="120.928,-487.602 120.928,-470.398 "></polyline>
+<path fill="none" stroke="black" d="M120.928,-470.398C120.928,-464.398 126.928,-458.398 132.928,-458.398"></path>
+<polyline fill="none" stroke="black" points="132.928,-458.398 191.072,-458.398 "></polyline>
+<path fill="none" stroke="black" d="M191.072,-458.398C197.072,-458.398 203.072,-464.398 203.072,-470.398"></path>
+<polyline fill="none" stroke="black" points="203.072,-470.398 203.072,-487.602 "></polyline>
+<path fill="none" stroke="black" d="M203.072,-487.602C203.072,-493.602 197.072,-499.602 191.072,-499.602"></path>
+<text text-anchor="middle" x="162" y="-483.2" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="162" y="-466.4" font-family="Times,serif" font-size="14.00">Literal (1)</text>
+</g>
+
+<g id="edge7" class="edge"><title>s1_1-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M139.341,-535.817C143.019,-526.757 146.791,-517.466 150.176,-509.128"></path>
+<polygon fill="black" stroke="black" points="153.424,-510.431 153.943,-499.849 146.938,-507.798 153.424,-510.431"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_11</title>
+<polygon fill="white" stroke="white" points="225.321,-103.602 114.679,-103.602 102.679,-91.6019 102.679,-74.3981 114.679,-62.3981 225.321,-62.3981 237.321,-74.3981 237.321,-91.6019 225.321,-103.602"></polygon>
+<path fill="white" stroke="white" d="M114.679,-103.602C108.679,-103.602 102.679,-97.6019 102.679,-91.6019"></path>
+<path fill="white" stroke="white" d="M102.679,-74.3981C102.679,-68.3981 108.679,-62.3981 114.679,-62.3981"></path>
+<path fill="white" stroke="white" d="M225.321,-62.3981C231.321,-62.3981 237.321,-68.3981 237.321,-74.3981"></path>
+<path fill="white" stroke="white" d="M237.321,-91.6019C237.321,-97.6019 231.321,-103.602 225.321,-103.602"></path>
+<polyline fill="none" stroke="black" points="225.321,-103.602 114.679,-103.602 "></polyline>
+<path fill="none" stroke="black" d="M114.679,-103.602C108.679,-103.602 102.679,-97.6019 102.679,-91.6019"></path>
+<polyline fill="none" stroke="black" points="102.679,-91.6019 102.679,-74.3981 "></polyline>
+<path fill="none" stroke="black" d="M102.679,-74.3981C102.679,-68.3981 108.679,-62.3981 114.679,-62.3981"></path>
+<polyline fill="none" stroke="black" points="114.679,-62.3981 225.321,-62.3981 "></polyline>
+<path fill="none" stroke="black" d="M225.321,-62.3981C231.321,-62.3981 237.321,-68.3981 237.321,-74.3981"></path>
+<polyline fill="none" stroke="black" points="237.321,-74.3981 237.321,-91.6019 "></polyline>
+<path fill="none" stroke="black" d="M237.321,-91.6019C237.321,-97.6019 231.321,-103.602 225.321,-103.602"></path>
+<text text-anchor="middle" x="170" y="-87.2" font-family="Times,serif" font-size="14.00">SwitchStatement:exit</text>
+<text text-anchor="middle" x="170" y="-70.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge11" class="edge"><title>s1_2-&gt;s1_11</title>
+<path fill="none" stroke="black" d="M62.3638,-346.027C57.9153,-295.816 56.5654,-204.896 94,-140 100.985,-127.891 111.753,-117.634 123.007,-109.339"></path>
+<polygon fill="black" stroke="black" points="125.004,-112.213 131.24,-103.648 121.024,-106.455 125.004,-112.213"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_7</title>
+<polygon fill="white" stroke="white" points="217.147,-310.401 106.853,-310.401 94.8526,-298.401 94.8526,-263.599 106.853,-251.599 217.147,-251.599 229.147,-263.599 229.147,-298.401 217.147,-310.401"></polygon>
+<path fill="white" stroke="white" d="M106.853,-310.401C100.853,-310.401 94.8526,-304.401 94.8526,-298.401"></path>
+<path fill="white" stroke="white" d="M94.8526,-263.599C94.8526,-257.599 100.853,-251.599 106.853,-251.599"></path>
+<path fill="white" stroke="white" d="M217.147,-251.599C223.147,-251.599 229.147,-257.599 229.147,-263.599"></path>
+<path fill="white" stroke="white" d="M229.147,-298.401C229.147,-304.401 223.147,-310.401 217.147,-310.401"></path>
+<polyline fill="none" stroke="black" points="217.147,-310.401 106.853,-310.401 "></polyline>
+<path fill="none" stroke="black" d="M106.853,-310.401C100.853,-310.401 94.8526,-304.401 94.8526,-298.401"></path>
+<polyline fill="none" stroke="black" points="94.8526,-298.401 94.8526,-263.599 "></polyline>
+<path fill="none" stroke="black" d="M94.8526,-263.599C94.8526,-257.599 100.853,-251.599 106.853,-251.599"></path>
+<polyline fill="none" stroke="black" points="106.853,-251.599 217.147,-251.599 "></polyline>
+<path fill="none" stroke="black" d="M217.147,-251.599C223.147,-251.599 229.147,-257.599 229.147,-263.599"></path>
+<polyline fill="none" stroke="black" points="229.147,-263.599 229.147,-298.401 "></polyline>
+<path fill="none" stroke="black" d="M229.147,-298.401C229.147,-304.401 223.147,-310.401 217.147,-310.401"></path>
+<text text-anchor="middle" x="162" y="-293.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="162" y="-276.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="162" y="-260" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="node6" class="node"><title>s1_9</title>
+<polygon fill="white" stroke="white" points="225.147,-215.7 114.853,-215.7 102.853,-203.7 102.853,-152.3 114.853,-140.3 225.147,-140.3 237.147,-152.3 237.147,-203.7 225.147,-215.7"></polygon>
+<path fill="white" stroke="white" d="M114.853,-215.7C108.853,-215.7 102.853,-209.7 102.853,-203.7"></path>
+<path fill="white" stroke="white" d="M102.853,-152.3C102.853,-146.3 108.853,-140.3 114.853,-140.3"></path>
+<path fill="white" stroke="white" d="M225.147,-140.3C231.147,-140.3 237.147,-146.3 237.147,-152.3"></path>
+<path fill="white" stroke="white" d="M237.147,-203.7C237.147,-209.7 231.147,-215.7 225.147,-215.7"></path>
+<polyline fill="none" stroke="black" points="225.147,-215.7 114.853,-215.7 "></polyline>
+<path fill="none" stroke="black" d="M114.853,-215.7C108.853,-215.7 102.853,-209.7 102.853,-203.7"></path>
+<polyline fill="none" stroke="black" points="102.853,-203.7 102.853,-152.3 "></polyline>
+<path fill="none" stroke="black" d="M102.853,-152.3C102.853,-146.3 108.853,-140.3 114.853,-140.3"></path>
+<polyline fill="none" stroke="black" points="114.853,-140.3 225.147,-140.3 "></polyline>
+<path fill="none" stroke="black" d="M225.147,-140.3C231.147,-140.3 237.147,-146.3 237.147,-152.3"></path>
+<polyline fill="none" stroke="black" points="237.147,-152.3 237.147,-203.7 "></polyline>
+<path fill="none" stroke="black" d="M237.147,-203.7C237.147,-209.7 231.147,-215.7 225.147,-215.7"></path>
+<text text-anchor="middle" x="170" y="-199" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="170" y="-182.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="170" y="-165.4" font-family="Times,serif" font-size="14.00">Identifier (hoge)</text>
+<text text-anchor="middle" x="170" y="-148.6" font-family="Times,serif" font-size="14.00">BreakStatement</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_7-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M164.25,-251.597C164.881,-243.629 165.584,-234.747 166.277,-226.005"></path>
+<polygon fill="black" stroke="black" points="169.779,-226.116 167.08,-215.871 162.801,-225.563 169.779,-226.116"></polygon>
+</g>
+
+<g id="edge13" class="edge"><title>s1_9-&gt;s1_11</title>
+<path fill="none" stroke="black" d="M170,-140.244C170,-131.462 170,-122.195 170,-113.772"></path>
+<polygon fill="black" stroke="black" points="173.5,-113.655 170,-103.655 166.5,-113.655 173.5,-113.655"></polygon>
+</g>
+
+<g id="edge21" class="edge"><title>s1_11-&gt;final</title>
+<path fill="none" stroke="black" d="M170,-62.3316C170,-54.2587 170,-44.8663 170,-36.5198"></path>
+<polygon fill="black" stroke="black" points="173.5,-36.3487 170,-26.3488 166.5,-36.3488 173.5,-36.3487"></polygon>
+</g>
+
+<g id="edge15" class="edge"><title>s1_4-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M162,-458.128C162,-425.987 162,-362.03 162,-320.674"></path>
+<polygon fill="black" stroke="black" points="165.5,-320.424 162,-310.424 158.5,-320.424 165.5,-320.424"></polygon>
+</g>
+
+<g id="node9" class="node"><title>s1_6</title>
+<polygon fill="white" stroke="white" points="260.072,-404.602 201.928,-404.602 189.928,-392.602 189.928,-375.398 201.928,-363.398 260.072,-363.398 272.072,-375.398 272.072,-392.602 260.072,-404.602"></polygon>
+<path fill="white" stroke="white" d="M201.928,-404.602C195.928,-404.602 189.928,-398.602 189.928,-392.602"></path>
+<path fill="white" stroke="white" d="M189.928,-375.398C189.928,-369.398 195.928,-363.398 201.928,-363.398"></path>
+<path fill="white" stroke="white" d="M260.072,-363.398C266.072,-363.398 272.072,-369.398 272.072,-375.398"></path>
+<path fill="white" stroke="white" d="M272.072,-392.602C272.072,-398.602 266.072,-404.602 260.072,-404.602"></path>
+<polyline fill="none" stroke="black" points="260.072,-404.602 201.928,-404.602 "></polyline>
+<path fill="none" stroke="black" d="M201.928,-404.602C195.928,-404.602 189.928,-398.602 189.928,-392.602"></path>
+<polyline fill="none" stroke="black" points="189.928,-392.602 189.928,-375.398 "></polyline>
+<path fill="none" stroke="black" d="M189.928,-375.398C189.928,-369.398 195.928,-363.398 201.928,-363.398"></path>
+<polyline fill="none" stroke="black" points="201.928,-363.398 260.072,-363.398 "></polyline>
+<path fill="none" stroke="black" d="M260.072,-363.398C266.072,-363.398 272.072,-369.398 272.072,-375.398"></path>
+<polyline fill="none" stroke="black" points="272.072,-375.398 272.072,-392.602 "></polyline>
+<path fill="none" stroke="black" d="M272.072,-392.602C272.072,-398.602 266.072,-404.602 260.072,-404.602"></path>
+<text text-anchor="middle" x="231" y="-388.2" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="231" y="-371.4" font-family="Times,serif" font-size="14.00">Literal (2)</text>
+</g>
+
+<g id="edge8" class="edge"><title>s1_4-&gt;s1_6</title>
+<path fill="none" stroke="black" d="M176.633,-458.277C186.422,-445.084 199.447,-427.528 210.294,-412.908"></path>
+<polygon fill="black" stroke="black" points="213.24,-414.811 216.388,-404.694 207.619,-410.64 213.24,-414.811"></polygon>
+</g>
+
+<g id="edge9" class="edge"><title>s1_6-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M217.368,-363.046C208.766,-350.455 197.392,-333.806 187.191,-318.874"></path>
+<polygon fill="black" stroke="black" points="189.882,-316.608 181.351,-310.325 184.102,-320.557 189.882,-316.608"></polygon>
+</g>
+
+<g id="node10" class="node"><title>s1_8</title>
+<polygon fill="white" stroke="white" points="317.072,-301.602 258.928,-301.602 246.928,-289.602 246.928,-272.398 258.928,-260.398 317.072,-260.398 329.072,-272.398 329.072,-289.602 317.072,-301.602"></polygon>
+<path fill="white" stroke="white" d="M258.928,-301.602C252.928,-301.602 246.928,-295.602 246.928,-289.602"></path>
+<path fill="white" stroke="white" d="M246.928,-272.398C246.928,-266.398 252.928,-260.398 258.928,-260.398"></path>
+<path fill="white" stroke="white" d="M317.072,-260.398C323.072,-260.398 329.072,-266.398 329.072,-272.398"></path>
+<path fill="white" stroke="white" d="M329.072,-289.602C329.072,-295.602 323.072,-301.602 317.072,-301.602"></path>
+<polyline fill="none" stroke="black" points="317.072,-301.602 258.928,-301.602 "></polyline>
+<path fill="none" stroke="black" d="M258.928,-301.602C252.928,-301.602 246.928,-295.602 246.928,-289.602"></path>
+<polyline fill="none" stroke="black" points="246.928,-289.602 246.928,-272.398 "></polyline>
+<path fill="none" stroke="black" d="M246.928,-272.398C246.928,-266.398 252.928,-260.398 258.928,-260.398"></path>
+<polyline fill="none" stroke="black" points="258.928,-260.398 317.072,-260.398 "></polyline>
+<path fill="none" stroke="black" d="M317.072,-260.398C323.072,-260.398 329.072,-266.398 329.072,-272.398"></path>
+<polyline fill="none" stroke="black" points="329.072,-272.398 329.072,-289.602 "></polyline>
+<path fill="none" stroke="black" d="M329.072,-289.602C329.072,-295.602 323.072,-301.602 317.072,-301.602"></path>
+<text text-anchor="middle" x="288" y="-285.2" font-family="Times,serif" font-size="14.00">SwitchCase</text>
+<text text-anchor="middle" x="288" y="-268.4" font-family="Times,serif" font-size="14.00">Literal (3)</text>
+</g>
+
+<g id="edge17" class="edge"><title>s1_6-&gt;s1_8</title>
+<path fill="none" stroke="black" d="M242.261,-363.046C250.693,-348.106 262.349,-327.452 271.784,-310.734"></path>
+<polygon fill="black" stroke="black" points="274.895,-312.342 276.762,-301.913 268.799,-308.902 274.895,-312.342"></polygon>
+</g>
+
+<g id="edge18" class="edge"><title>s1_8-&gt;s1_9</title>
+<path fill="none" stroke="black" d="M264.968,-260.286C252.403,-249.531 236.318,-235.764 220.972,-222.628"></path>
+<polygon fill="black" stroke="black" points="222.909,-219.68 213.036,-215.836 218.358,-224.998 222.909,-219.68"></polygon>
+</g>
+
+<g id="edge20" class="edge"><title>s1_8-&gt;s1_11</title>
+<path fill="none" stroke="black" d="M286.047,-260.183C282.381,-231.387 272.302,-177.344 246,-140 237.722,-128.247 226.195,-117.974 214.617,-109.546"></path>
+<polygon fill="black" stroke="black" points="216.439,-106.551 206.223,-103.741 212.457,-112.308 216.439,-106.551"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-trystatement-try-catch-finally.svg
+++ b/docs/developer-guide/code-path-analysis/example-trystatement-try-catch-finally.svg
@@ -1,0 +1,137 @@
+<?xml version="1.0"?>
+<svg width="237pt" height="652pt" viewBox="0.00 0.00 237.00 652.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 648)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="114" cy="-635" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="169.147,-589.3 58.8526,-589.3 46.8526,-577.3 46.8526,-492.7 58.8526,-480.7 169.147,-480.7 181.147,-492.7 181.147,-577.3 169.147,-589.3"></polygon>
+<path fill="white" stroke="white" d="M58.8526,-589.3C52.8526,-589.3 46.8526,-583.3 46.8526,-577.3"></path>
+<path fill="white" stroke="white" d="M46.8526,-492.7C46.8526,-486.7 52.8526,-480.7 58.8526,-480.7"></path>
+<path fill="white" stroke="white" d="M169.147,-480.7C175.147,-480.7 181.147,-486.7 181.147,-492.7"></path>
+<path fill="white" stroke="white" d="M181.147,-577.3C181.147,-583.3 175.147,-589.3 169.147,-589.3"></path>
+<polyline fill="none" stroke="black" points="169.147,-589.3 58.8526,-589.3 "></polyline>
+<path fill="none" stroke="black" d="M58.8526,-589.3C52.8526,-589.3 46.8526,-583.3 46.8526,-577.3"></path>
+<polyline fill="none" stroke="black" points="46.8526,-577.3 46.8526,-492.7 "></polyline>
+<path fill="none" stroke="black" d="M46.8526,-492.7C46.8526,-486.7 52.8526,-480.7 58.8526,-480.7"></path>
+<polyline fill="none" stroke="black" points="58.8526,-480.7 169.147,-480.7 "></polyline>
+<path fill="none" stroke="black" d="M169.147,-480.7C175.147,-480.7 181.147,-486.7 181.147,-492.7"></path>
+<polyline fill="none" stroke="black" points="181.147,-492.7 181.147,-577.3 "></polyline>
+<path fill="none" stroke="black" d="M181.147,-577.3C181.147,-583.3 175.147,-589.3 169.147,-589.3"></path>
+<text text-anchor="middle" x="114" y="-572.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="114" y="-556" font-family="Times,serif" font-size="14.00">TryStatement</text>
+<text text-anchor="middle" x="114" y="-539.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="114" y="-522.4" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="114" y="-505.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="114" y="-488.8" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M114,-625.98C114,-619.675 114,-610.238 114,-599.813"></path>
+<polygon fill="black" stroke="black" points="117.5,-599.586 114,-589.586 110.5,-599.586 117.5,-599.586"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="114" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="114" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="217.147,-444.401 106.853,-444.401 94.8526,-432.401 94.8526,-397.599 106.853,-385.599 217.147,-385.599 229.147,-397.599 229.147,-432.401 217.147,-444.401"></polygon>
+<path fill="white" stroke="white" d="M106.853,-444.401C100.853,-444.401 94.8526,-438.401 94.8526,-432.401"></path>
+<path fill="white" stroke="white" d="M94.8526,-397.599C94.8526,-391.599 100.853,-385.599 106.853,-385.599"></path>
+<path fill="white" stroke="white" d="M217.147,-385.599C223.147,-385.599 229.147,-391.599 229.147,-397.599"></path>
+<path fill="white" stroke="white" d="M229.147,-432.401C229.147,-438.401 223.147,-444.401 217.147,-444.401"></path>
+<polyline fill="none" stroke="black" points="217.147,-444.401 106.853,-444.401 "></polyline>
+<path fill="none" stroke="black" d="M106.853,-444.401C100.853,-444.401 94.8526,-438.401 94.8526,-432.401"></path>
+<polyline fill="none" stroke="black" points="94.8526,-432.401 94.8526,-397.599 "></polyline>
+<path fill="none" stroke="black" d="M94.8526,-397.599C94.8526,-391.599 100.853,-385.599 106.853,-385.599"></path>
+<polyline fill="none" stroke="black" points="106.853,-385.599 217.147,-385.599 "></polyline>
+<path fill="none" stroke="black" d="M217.147,-385.599C223.147,-385.599 229.147,-391.599 229.147,-397.599"></path>
+<polyline fill="none" stroke="black" points="229.147,-397.599 229.147,-432.401 "></polyline>
+<path fill="none" stroke="black" d="M229.147,-432.401C229.147,-438.401 223.147,-444.401 217.147,-444.401"></path>
+<text text-anchor="middle" x="162" y="-427.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="162" y="-410.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="162" y="-394" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M135.753,-480.524C139.43,-471.486 143.177,-462.273 146.646,-453.744"></path>
+<polygon fill="black" stroke="black" points="149.9,-455.033 150.426,-444.452 143.416,-452.396 149.9,-455.033"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="122.147,-349.601 11.8526,-349.601 -0.147372,-337.601 -0.147372,-236.399 11.8526,-224.399 122.147,-224.399 134.147,-236.399 134.147,-337.601 122.147,-349.601"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-349.601C5.85263,-349.601 -0.147372,-343.601 -0.147372,-337.601"></path>
+<path fill="white" stroke="white" d="M-0.147372,-236.399C-0.147372,-230.399 5.85263,-224.399 11.8526,-224.399"></path>
+<path fill="white" stroke="white" d="M122.147,-224.399C128.147,-224.399 134.147,-230.399 134.147,-236.399"></path>
+<path fill="white" stroke="white" d="M134.147,-337.601C134.147,-343.601 128.147,-349.601 122.147,-349.601"></path>
+<polyline fill="none" stroke="black" points="122.147,-349.601 11.8526,-349.601 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-349.601C5.85263,-349.601 -0.147372,-343.601 -0.147372,-337.601"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-337.601 -0.147372,-236.399 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-236.399C-0.147372,-230.399 5.85263,-224.399 11.8526,-224.399"></path>
+<polyline fill="none" stroke="black" points="11.8526,-224.399 122.147,-224.399 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-224.399C128.147,-224.399 134.147,-230.399 134.147,-236.399"></path>
+<polyline fill="none" stroke="black" points="134.147,-236.399 134.147,-337.601 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-337.601C134.147,-343.601 128.147,-349.601 122.147,-349.601"></path>
+<text text-anchor="middle" x="67" y="-333.2" font-family="Times,serif" font-size="14.00">CatchClause</text>
+<text text-anchor="middle" x="67" y="-316.4" font-family="Times,serif" font-size="14.00">Identifier (err)</text>
+<text text-anchor="middle" x="67" y="-299.6" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-282.8" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-266" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-249.2" font-family="Times,serif" font-size="14.00">Identifier (hoge)</text>
+<text text-anchor="middle" x="67" y="-232.4" font-family="Times,serif" font-size="14.00">Identifier (err)</text>
+</g>
+
+<g id="edge7" class="edge"><title>s1_1-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M95.6637,-480.644C92.0449,-468.693 88.5753,-456 86,-444 80.162,-416.798 75.9602,-386.514 73.0174,-359.921"></path>
+<polygon fill="black" stroke="black" points="76.492,-359.495 71.9505,-349.923 69.5315,-360.238 76.492,-359.495"></polygon>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M140.68,-385.723C134.355,-377.334 127.129,-367.75 119.731,-357.939"></path>
+<polygon fill="black" stroke="black" points="122.308,-355.543 113.493,-349.665 116.719,-359.757 122.308,-355.543"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="169.147,-187.601 58.8526,-187.601 46.8526,-175.601 46.8526,-74.3994 58.8526,-62.3994 169.147,-62.3994 181.147,-74.3994 181.147,-175.601 169.147,-187.601"></polygon>
+<path fill="white" stroke="white" d="M58.8526,-187.601C52.8526,-187.601 46.8526,-181.601 46.8526,-175.601"></path>
+<path fill="white" stroke="white" d="M46.8526,-74.3994C46.8526,-68.3994 52.8526,-62.3994 58.8526,-62.3994"></path>
+<path fill="white" stroke="white" d="M169.147,-62.3994C175.147,-62.3994 181.147,-68.3994 181.147,-74.3994"></path>
+<path fill="white" stroke="white" d="M181.147,-175.601C181.147,-181.601 175.147,-187.601 169.147,-187.601"></path>
+<polyline fill="none" stroke="black" points="169.147,-187.601 58.8526,-187.601 "></polyline>
+<path fill="none" stroke="black" d="M58.8526,-187.601C52.8526,-187.601 46.8526,-181.601 46.8526,-175.601"></path>
+<polyline fill="none" stroke="black" points="46.8526,-175.601 46.8526,-74.3994 "></polyline>
+<path fill="none" stroke="black" d="M46.8526,-74.3994C46.8526,-68.3994 52.8526,-62.3994 58.8526,-62.3994"></path>
+<polyline fill="none" stroke="black" points="58.8526,-62.3994 169.147,-62.3994 "></polyline>
+<path fill="none" stroke="black" d="M169.147,-62.3994C175.147,-62.3994 181.147,-68.3994 181.147,-74.3994"></path>
+<polyline fill="none" stroke="black" points="181.147,-74.3994 181.147,-175.601 "></polyline>
+<path fill="none" stroke="black" d="M181.147,-175.601C181.147,-181.601 175.147,-187.601 169.147,-187.601"></path>
+<text text-anchor="middle" x="114" y="-171.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="114" y="-154.4" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="114" y="-137.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="114" y="-120.8" font-family="Times,serif" font-size="14.00">Identifier (fuga)</text>
+<text text-anchor="middle" x="114" y="-104" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="114" y="-87.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="114" y="-70.4" font-family="Times,serif" font-size="14.00">Identifier (last)</text>
+</g>
+
+<g id="edge9" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M160.835,-385.75C158.918,-348.425 154.135,-280.766 143,-224 141.313,-215.398 139.196,-206.466 136.88,-197.651"></path>
+<polygon fill="black" stroke="black" points="140.195,-196.504 134.191,-187.774 133.441,-198.342 140.195,-196.504"></polygon>
+</g>
+
+<g id="edge5" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M85.1714,-224.14C87.7514,-215.357 90.4217,-206.266 93.0491,-197.322"></path>
+<polygon fill="black" stroke="black" points="96.4165,-198.277 95.8769,-187.696 89.7003,-196.304 96.4165,-198.277"></polygon>
+</g>
+
+<g id="edge10" class="edge"><title>s1_4-&gt;final</title>
+<path fill="none" stroke="black" d="M114,-62.2476C114,-53.0345 114,-44.0781 114,-36.4335"></path>
+<polygon fill="black" stroke="black" points="117.5,-36.2949 114,-26.2949 110.5,-36.2949 117.5,-36.2949"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-trystatement-try-catch.svg
+++ b/docs/developer-guide/code-path-analysis/example-trystatement-try-catch.svg
@@ -1,0 +1,186 @@
+<?xml version="1.0"?>
+<svg width="323pt" height="680pt" viewBox="0.00 0.00 323.00 680.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 676)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="248" cy="-663" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="303.147,-617.3 192.853,-617.3 180.853,-605.3 180.853,-520.7 192.853,-508.7 303.147,-508.7 315.147,-520.7 315.147,-605.3 303.147,-617.3"></polygon>
+<path fill="white" stroke="white" d="M192.853,-617.3C186.853,-617.3 180.853,-611.3 180.853,-605.3"></path>
+<path fill="white" stroke="white" d="M180.853,-520.7C180.853,-514.7 186.853,-508.7 192.853,-508.7"></path>
+<path fill="white" stroke="white" d="M303.147,-508.7C309.147,-508.7 315.147,-514.7 315.147,-520.7"></path>
+<path fill="white" stroke="white" d="M315.147,-605.3C315.147,-611.3 309.147,-617.3 303.147,-617.3"></path>
+<polyline fill="none" stroke="black" points="303.147,-617.3 192.853,-617.3 "></polyline>
+<path fill="none" stroke="black" d="M192.853,-617.3C186.853,-617.3 180.853,-611.3 180.853,-605.3"></path>
+<polyline fill="none" stroke="black" points="180.853,-605.3 180.853,-520.7 "></polyline>
+<path fill="none" stroke="black" d="M180.853,-520.7C180.853,-514.7 186.853,-508.7 192.853,-508.7"></path>
+<polyline fill="none" stroke="black" points="192.853,-508.7 303.147,-508.7 "></polyline>
+<path fill="none" stroke="black" d="M303.147,-508.7C309.147,-508.7 315.147,-514.7 315.147,-520.7"></path>
+<polyline fill="none" stroke="black" points="315.147,-520.7 315.147,-605.3 "></polyline>
+<path fill="none" stroke="black" d="M315.147,-605.3C315.147,-611.3 309.147,-617.3 303.147,-617.3"></path>
+<text text-anchor="middle" x="248" y="-600.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="248" y="-584" font-family="Times,serif" font-size="14.00">TryStatement</text>
+<text text-anchor="middle" x="248" y="-567.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="248" y="-550.4" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="248" y="-533.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="248" y="-516.8" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M248,-653.98C248,-647.675 248,-638.238 248,-627.813"></path>
+<polygon fill="black" stroke="black" points="251.5,-627.586 248,-617.586 244.5,-627.586 251.5,-627.586"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="142" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="142" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="238.339,-471.602 175.661,-471.602 163.661,-459.602 163.661,-442.398 175.661,-430.398 238.339,-430.398 250.339,-442.398 250.339,-459.602 238.339,-471.602"></polygon>
+<path fill="white" stroke="white" d="M175.661,-471.602C169.661,-471.602 163.661,-465.602 163.661,-459.602"></path>
+<path fill="white" stroke="white" d="M163.661,-442.398C163.661,-436.398 169.661,-430.398 175.661,-430.398"></path>
+<path fill="white" stroke="white" d="M238.339,-430.398C244.339,-430.398 250.339,-436.398 250.339,-442.398"></path>
+<path fill="white" stroke="white" d="M250.339,-459.602C250.339,-465.602 244.339,-471.602 238.339,-471.602"></path>
+<polyline fill="none" stroke="black" points="238.339,-471.602 175.661,-471.602 "></polyline>
+<path fill="none" stroke="black" d="M175.661,-471.602C169.661,-471.602 163.661,-465.602 163.661,-459.602"></path>
+<polyline fill="none" stroke="black" points="163.661,-459.602 163.661,-442.398 "></polyline>
+<path fill="none" stroke="black" d="M163.661,-442.398C163.661,-436.398 169.661,-430.398 175.661,-430.398"></path>
+<polyline fill="none" stroke="black" points="175.661,-430.398 238.339,-430.398 "></polyline>
+<path fill="none" stroke="black" d="M238.339,-430.398C244.339,-430.398 250.339,-436.398 250.339,-442.398"></path>
+<polyline fill="none" stroke="black" points="250.339,-442.398 250.339,-459.602 "></polyline>
+<path fill="none" stroke="black" d="M250.339,-459.602C250.339,-465.602 244.339,-471.602 238.339,-471.602"></path>
+<text text-anchor="middle" x="207" y="-455.2" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="207" y="-438.4" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M228.101,-508.611C224.581,-499.169 221.038,-489.663 217.887,-481.208"></path>
+<polygon fill="black" stroke="black" points="221.164,-479.98 214.392,-471.833 214.605,-482.425 221.164,-479.98"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_6</title>
+<polygon fill="white" stroke="white" points="250.147,-281.601 139.853,-281.601 127.853,-269.601 127.853,-168.399 139.853,-156.399 250.147,-156.399 262.147,-168.399 262.147,-269.601 250.147,-281.601"></polygon>
+<path fill="white" stroke="white" d="M139.853,-281.601C133.853,-281.601 127.853,-275.601 127.853,-269.601"></path>
+<path fill="white" stroke="white" d="M127.853,-168.399C127.853,-162.399 133.853,-156.399 139.853,-156.399"></path>
+<path fill="white" stroke="white" d="M250.147,-156.399C256.147,-156.399 262.147,-162.399 262.147,-168.399"></path>
+<path fill="white" stroke="white" d="M262.147,-269.601C262.147,-275.601 256.147,-281.601 250.147,-281.601"></path>
+<polyline fill="none" stroke="black" points="250.147,-281.601 139.853,-281.601 "></polyline>
+<path fill="none" stroke="black" d="M139.853,-281.601C133.853,-281.601 127.853,-275.601 127.853,-269.601"></path>
+<polyline fill="none" stroke="black" points="127.853,-269.601 127.853,-168.399 "></polyline>
+<path fill="none" stroke="black" d="M127.853,-168.399C127.853,-162.399 133.853,-156.399 139.853,-156.399"></path>
+<polyline fill="none" stroke="black" points="139.853,-156.399 250.147,-156.399 "></polyline>
+<path fill="none" stroke="black" d="M250.147,-156.399C256.147,-156.399 262.147,-162.399 262.147,-168.399"></path>
+<polyline fill="none" stroke="black" points="262.147,-168.399 262.147,-269.601 "></polyline>
+<path fill="none" stroke="black" d="M262.147,-269.601C262.147,-275.601 256.147,-281.601 250.147,-281.601"></path>
+<text text-anchor="middle" x="195" y="-265.2" font-family="Times,serif" font-size="14.00">CatchClause</text>
+<text text-anchor="middle" x="195" y="-248.4" font-family="Times,serif" font-size="14.00">Identifier (err)</text>
+<text text-anchor="middle" x="195" y="-231.6" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="195" y="-214.8" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="195" y="-198" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="195" y="-181.2" font-family="Times,serif" font-size="14.00">Identifier (hoge)</text>
+<text text-anchor="middle" x="195" y="-164.4" font-family="Times,serif" font-size="14.00">Identifier (err)</text>
+</g>
+
+<g id="edge9" class="edge"><title>s1_1-&gt;s1_6</title>
+<path fill="none" stroke="black" d="M265.496,-508.624C279.169,-458.161 292.566,-381 271,-318 267.758,-308.528 263.185,-299.263 257.874,-290.444"></path>
+<polygon fill="black" stroke="black" points="260.672,-288.323 252.338,-281.781 254.774,-292.092 260.672,-288.323"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="250.329,-393.7 163.671,-393.7 151.671,-381.7 151.671,-330.3 163.671,-318.3 250.329,-318.3 262.329,-330.3 262.329,-381.7 250.329,-393.7"></polygon>
+<path fill="white" stroke="white" d="M163.671,-393.7C157.671,-393.7 151.671,-387.7 151.671,-381.7"></path>
+<path fill="white" stroke="white" d="M151.671,-330.3C151.671,-324.3 157.671,-318.3 163.671,-318.3"></path>
+<path fill="white" stroke="white" d="M250.329,-318.3C256.329,-318.3 262.329,-324.3 262.329,-330.3"></path>
+<path fill="white" stroke="white" d="M262.329,-381.7C262.329,-387.7 256.329,-393.7 250.329,-393.7"></path>
+<polyline fill="none" stroke="black" points="250.329,-393.7 163.671,-393.7 "></polyline>
+<path fill="none" stroke="black" d="M163.671,-393.7C157.671,-393.7 151.671,-387.7 151.671,-381.7"></path>
+<polyline fill="none" stroke="black" points="151.671,-381.7 151.671,-330.3 "></polyline>
+<path fill="none" stroke="black" d="M151.671,-330.3C151.671,-324.3 157.671,-318.3 163.671,-318.3"></path>
+<polyline fill="none" stroke="black" points="163.671,-318.3 250.329,-318.3 "></polyline>
+<path fill="none" stroke="black" d="M250.329,-318.3C256.329,-318.3 262.329,-324.3 262.329,-330.3"></path>
+<polyline fill="none" stroke="black" points="262.329,-330.3 262.329,-381.7 "></polyline>
+<path fill="none" stroke="black" d="M262.329,-381.7C262.329,-387.7 256.329,-393.7 250.329,-393.7"></path>
+<text text-anchor="middle" x="207" y="-377" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="207" y="-360.2" font-family="Times,serif" font-size="14.00">ThrowStatement</text>
+<text text-anchor="middle" x="207" y="-343.4" font-family="Times,serif" font-size="14.00">NewExpression</text>
+<text text-anchor="middle" x="207" y="-326.6" font-family="Times,serif" font-size="14.00">Identifier (Error)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M207,-430.277C207,-422.524 207,-413.265 207,-403.98"></path>
+<polygon fill="black" stroke="black" points="210.5,-403.965 207,-393.965 203.5,-403.965 210.5,-403.965"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_5</title>
+<polygon fill="white" stroke="white" points="122.147,-385.401 11.8526,-385.401 -0.147372,-373.401 -0.147372,-338.599 11.8526,-326.599 122.147,-326.599 134.147,-338.599 134.147,-373.401 122.147,-385.401"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-385.401C5.85263,-385.401 -0.147372,-379.401 -0.147372,-373.401"></path>
+<path fill="white" stroke="white" d="M-0.147372,-338.599C-0.147372,-332.599 5.85263,-326.599 11.8526,-326.599"></path>
+<path fill="white" stroke="white" d="M122.147,-326.599C128.147,-326.599 134.147,-332.599 134.147,-338.599"></path>
+<path fill="white" stroke="white" d="M134.147,-373.401C134.147,-379.401 128.147,-385.401 122.147,-385.401"></path>
+<polyline fill="none" stroke="black" points="122.147,-385.401 11.8526,-385.401 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-385.401C5.85263,-385.401 -0.147372,-379.401 -0.147372,-373.401"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-373.401 -0.147372,-338.599 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-338.599C-0.147372,-332.599 5.85263,-326.599 11.8526,-326.599"></path>
+<polyline fill="none" stroke="black" points="11.8526,-326.599 122.147,-326.599 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-326.599C128.147,-326.599 134.147,-332.599 134.147,-338.599"></path>
+<polyline fill="none" stroke="black" points="134.147,-338.599 134.147,-373.401 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-373.401C134.147,-379.401 128.147,-385.401 122.147,-385.401"></path>
+<text text-anchor="middle" x="67" y="-368.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-351.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-335" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge11" class="edge"><title>s1_2-&gt;s1_5</title>
+<path fill="none" stroke="black" d="M177.31,-430.277C160.103,-418.847 137.967,-404.142 118.045,-390.909"></path>
+<polygon fill="black" stroke="black" points="119.93,-387.959 109.664,-385.341 116.057,-393.79 119.93,-387.959"></polygon>
+</g>
+
+<g id="edge13" class="edge"><title>s1_3-&gt;s1_6</title>
+<path fill="none" stroke="black" d="M203.721,-318.111C202.995,-309.943 202.201,-301.016 201.398,-291.982"></path>
+<polygon fill="black" stroke="black" points="204.863,-291.422 200.491,-281.771 197.89,-292.042 204.863,-291.422"></polygon>
+</g>
+
+<g id="edge6" class="edge"><title>s1_5-&gt;s1_6</title>
+<path fill="none" stroke="black" d="M93.833,-326.7C104.348,-315.609 116.912,-302.359 129.551,-289.029"></path>
+<polygon fill="black" stroke="black" points="132.227,-291.293 136.567,-281.628 127.147,-286.477 132.227,-291.293"></polygon>
+</g>
+
+<g id="node8" class="node"><title>s1_7</title>
+<polygon fill="white" stroke="white" points="197.147,-120.401 86.8526,-120.401 74.8526,-108.401 74.8526,-73.5986 86.8526,-61.5986 197.147,-61.5986 209.147,-73.5986 209.147,-108.401 197.147,-120.401"></polygon>
+<path fill="white" stroke="white" d="M86.8526,-120.401C80.8526,-120.401 74.8526,-114.401 74.8526,-108.401"></path>
+<path fill="white" stroke="white" d="M74.8526,-73.5986C74.8526,-67.5986 80.8526,-61.5986 86.8526,-61.5986"></path>
+<path fill="white" stroke="white" d="M197.147,-61.5986C203.147,-61.5986 209.147,-67.5986 209.147,-73.5986"></path>
+<path fill="white" stroke="white" d="M209.147,-108.401C209.147,-114.401 203.147,-120.401 197.147,-120.401"></path>
+<polyline fill="none" stroke="black" points="197.147,-120.401 86.8526,-120.401 "></polyline>
+<path fill="none" stroke="black" d="M86.8526,-120.401C80.8526,-120.401 74.8526,-114.401 74.8526,-108.401"></path>
+<polyline fill="none" stroke="black" points="74.8526,-108.401 74.8526,-73.5986 "></polyline>
+<path fill="none" stroke="black" d="M74.8526,-73.5986C74.8526,-67.5986 80.8526,-61.5986 86.8526,-61.5986"></path>
+<polyline fill="none" stroke="black" points="86.8526,-61.5986 197.147,-61.5986 "></polyline>
+<path fill="none" stroke="black" d="M197.147,-61.5986C203.147,-61.5986 209.147,-67.5986 209.147,-73.5986"></path>
+<polyline fill="none" stroke="black" points="209.147,-73.5986 209.147,-108.401 "></polyline>
+<path fill="none" stroke="black" d="M209.147,-108.401C209.147,-114.401 203.147,-120.401 197.147,-120.401"></path>
+<text text-anchor="middle" x="142" y="-103.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="142" y="-86.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="142" y="-70" font-family="Times,serif" font-size="14.00">Identifier (last)</text>
+</g>
+
+<g id="edge15" class="edge"><title>s1_5-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M73.536,-326.764C82.7028,-287.987 100.357,-216.205 119,-156 121.611,-147.569 124.658,-138.605 127.664,-130.139"></path>
+<polygon fill="black" stroke="black" points="131.044,-131.083 131.145,-120.489 124.459,-128.708 131.044,-131.083"></polygon>
+</g>
+
+<g id="edge7" class="edge"><title>s1_6-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M168.966,-156.107C165.165,-147.072 161.351,-138.005 157.838,-129.652"></path>
+<polygon fill="black" stroke="black" points="160.974,-128.08 153.87,-120.219 154.521,-130.794 160.974,-128.08"></polygon>
+</g>
+
+<g id="edge16" class="edge"><title>s1_7-&gt;final</title>
+<path fill="none" stroke="black" d="M142,-61.7004C142,-53.2282 142,-44.0665 142,-36.0585"></path>
+<polygon fill="black" stroke="black" points="145.5,-36.0267 142,-26.0267 138.5,-36.0267 145.5,-36.0267"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-trystatement-try-finally.svg
+++ b/docs/developer-guide/code-path-analysis/example-trystatement-try-finally.svg
@@ -1,0 +1,139 @@
+<?xml version="1.0"?>
+<svg width="294pt" height="490pt" viewBox="0.00 0.00 294.00 490.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 486)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="171" cy="-473" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="226.147,-427.3 115.853,-427.3 103.853,-415.3 103.853,-330.7 115.853,-318.7 226.147,-318.7 238.147,-330.7 238.147,-415.3 226.147,-427.3"></polygon>
+<path fill="white" stroke="white" d="M115.853,-427.3C109.853,-427.3 103.853,-421.3 103.853,-415.3"></path>
+<path fill="white" stroke="white" d="M103.853,-330.7C103.853,-324.7 109.853,-318.7 115.853,-318.7"></path>
+<path fill="white" stroke="white" d="M226.147,-318.7C232.147,-318.7 238.147,-324.7 238.147,-330.7"></path>
+<path fill="white" stroke="white" d="M238.147,-415.3C238.147,-421.3 232.147,-427.3 226.147,-427.3"></path>
+<polyline fill="none" stroke="black" points="226.147,-427.3 115.853,-427.3 "></polyline>
+<path fill="none" stroke="black" d="M115.853,-427.3C109.853,-427.3 103.853,-421.3 103.853,-415.3"></path>
+<polyline fill="none" stroke="black" points="103.853,-415.3 103.853,-330.7 "></polyline>
+<path fill="none" stroke="black" d="M103.853,-330.7C103.853,-324.7 109.853,-318.7 115.853,-318.7"></path>
+<polyline fill="none" stroke="black" points="115.853,-318.7 226.147,-318.7 "></polyline>
+<path fill="none" stroke="black" d="M226.147,-318.7C232.147,-318.7 238.147,-324.7 238.147,-330.7"></path>
+<polyline fill="none" stroke="black" points="238.147,-330.7 238.147,-415.3 "></polyline>
+<path fill="none" stroke="black" d="M238.147,-415.3C238.147,-421.3 232.147,-427.3 226.147,-427.3"></path>
+<text text-anchor="middle" x="171" y="-410.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="171" y="-394" font-family="Times,serif" font-size="14.00">TryStatement</text>
+<text text-anchor="middle" x="171" y="-377.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="171" y="-360.4" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="171" y="-343.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="171" y="-326.8" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M171,-463.98C171,-457.675 171,-448.238 171,-437.813"></path>
+<polygon fill="black" stroke="black" points="174.5,-437.586 171,-427.586 167.5,-437.586 174.5,-437.586"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="67" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="67" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>thrown</title>
+<ellipse fill="white" stroke="black" cx="219" cy="-13" rx="11" ry="11"></ellipse>
+<text text-anchor="middle" x="219" y="-8.8" font-family="Times,serif" font-size="14.00">✘</text>
+</g>
+
+<g id="node5" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="179.147,-282.401 68.8526,-282.401 56.8526,-270.401 56.8526,-235.599 68.8526,-223.599 179.147,-223.599 191.147,-235.599 191.147,-270.401 179.147,-282.401"></polygon>
+<path fill="white" stroke="white" d="M68.8526,-282.401C62.8526,-282.401 56.8526,-276.401 56.8526,-270.401"></path>
+<path fill="white" stroke="white" d="M56.8526,-235.599C56.8526,-229.599 62.8526,-223.599 68.8526,-223.599"></path>
+<path fill="white" stroke="white" d="M179.147,-223.599C185.147,-223.599 191.147,-229.599 191.147,-235.599"></path>
+<path fill="white" stroke="white" d="M191.147,-270.401C191.147,-276.401 185.147,-282.401 179.147,-282.401"></path>
+<polyline fill="none" stroke="black" points="179.147,-282.401 68.8526,-282.401 "></polyline>
+<path fill="none" stroke="black" d="M68.8526,-282.401C62.8526,-282.401 56.8526,-276.401 56.8526,-270.401"></path>
+<polyline fill="none" stroke="black" points="56.8526,-270.401 56.8526,-235.599 "></polyline>
+<path fill="none" stroke="black" d="M56.8526,-235.599C56.8526,-229.599 62.8526,-223.599 68.8526,-223.599"></path>
+<polyline fill="none" stroke="black" points="68.8526,-223.599 179.147,-223.599 "></polyline>
+<path fill="none" stroke="black" d="M179.147,-223.599C185.147,-223.599 191.147,-229.599 191.147,-235.599"></path>
+<polyline fill="none" stroke="black" points="191.147,-235.599 191.147,-270.401 "></polyline>
+<path fill="none" stroke="black" d="M191.147,-270.401C191.147,-276.401 185.147,-282.401 179.147,-282.401"></path>
+<text text-anchor="middle" x="124" y="-265.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="124" y="-248.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="124" y="-232" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M149.7,-318.524C146.1,-309.486 142.431,-300.273 139.034,-291.744"></path>
+<polygon fill="black" stroke="black" points="142.284,-290.447 135.332,-282.452 135.781,-293.037 142.284,-290.447"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="274.147,-162.7 163.853,-162.7 151.853,-150.7 151.853,-99.2997 163.853,-87.2997 274.147,-87.2997 286.147,-99.2997 286.147,-150.7 274.147,-162.7"></polygon>
+<path fill="white" stroke="white" d="M163.853,-162.7C157.853,-162.7 151.853,-156.7 151.853,-150.7"></path>
+<path fill="white" stroke="white" d="M151.853,-99.2997C151.853,-93.2997 157.853,-87.2997 163.853,-87.2997"></path>
+<path fill="white" stroke="white" d="M274.147,-87.2997C280.147,-87.2997 286.147,-93.2997 286.147,-99.2997"></path>
+<path fill="white" stroke="white" d="M286.147,-150.7C286.147,-156.7 280.147,-162.7 274.147,-162.7"></path>
+<polyline fill="none" stroke="black" points="274.147,-162.7 163.853,-162.7 "></polyline>
+<path fill="none" stroke="black" d="M163.853,-162.7C157.853,-162.7 151.853,-156.7 151.853,-150.7"></path>
+<polyline fill="none" stroke="black" points="151.853,-150.7 151.853,-99.2997 "></polyline>
+<path fill="none" stroke="black" d="M151.853,-99.2997C151.853,-93.2997 157.853,-87.2997 163.853,-87.2997"></path>
+<polyline fill="none" stroke="black" points="163.853,-87.2997 274.147,-87.2997 "></polyline>
+<path fill="none" stroke="black" d="M274.147,-87.2997C280.147,-87.2997 286.147,-93.2997 286.147,-99.2997"></path>
+<polyline fill="none" stroke="black" points="286.147,-99.2997 286.147,-150.7 "></polyline>
+<path fill="none" stroke="black" d="M286.147,-150.7C286.147,-156.7 280.147,-162.7 274.147,-162.7"></path>
+<text text-anchor="middle" x="219" y="-146" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="219" y="-129.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="219" y="-112.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="219" y="-95.6" font-family="Times,serif" font-size="14.00">Identifier (fuga)</text>
+</g>
+
+<g id="edge6" class="edge"><title>s1_1-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M190.026,-318.681C193.772,-306.729 197.356,-294.025 200,-282 207.95,-245.85 212.809,-204.204 215.622,-173.04"></path>
+<polygon fill="black" stroke="black" points="219.124,-173.16 216.499,-162.896 212.15,-172.557 219.124,-173.16"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="122.147,-187.601 11.8526,-187.601 -0.147372,-175.601 -0.147372,-74.3994 11.8526,-62.3994 122.147,-62.3994 134.147,-74.3994 134.147,-175.601 122.147,-187.601"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-187.601C5.85263,-187.601 -0.147372,-181.601 -0.147372,-175.601"></path>
+<path fill="white" stroke="white" d="M-0.147372,-74.3994C-0.147372,-68.3994 5.85263,-62.3994 11.8526,-62.3994"></path>
+<path fill="white" stroke="white" d="M122.147,-62.3994C128.147,-62.3994 134.147,-68.3994 134.147,-74.3994"></path>
+<path fill="white" stroke="white" d="M134.147,-175.601C134.147,-181.601 128.147,-187.601 122.147,-187.601"></path>
+<polyline fill="none" stroke="black" points="122.147,-187.601 11.8526,-187.601 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-187.601C5.85263,-187.601 -0.147372,-181.601 -0.147372,-175.601"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-175.601 -0.147372,-74.3994 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-74.3994C-0.147372,-68.3994 5.85263,-62.3994 11.8526,-62.3994"></path>
+<polyline fill="none" stroke="black" points="11.8526,-62.3994 122.147,-62.3994 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-62.3994C128.147,-62.3994 134.147,-68.3994 134.147,-74.3994"></path>
+<polyline fill="none" stroke="black" points="134.147,-74.3994 134.147,-175.601 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-175.601C134.147,-181.601 128.147,-187.601 122.147,-187.601"></path>
+<text text-anchor="middle" x="67" y="-171.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-154.4" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-137.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-120.8" font-family="Times,serif" font-size="14.00">Identifier (fuga)</text>
+<text text-anchor="middle" x="67" y="-104" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-87.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-70.4" font-family="Times,serif" font-size="14.00">Identifier (last)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M111.208,-223.723C107.527,-215.585 103.337,-206.324 99.038,-196.821"></path>
+<polygon fill="black" stroke="black" points="102.207,-195.333 94.896,-187.665 95.8289,-198.219 102.207,-195.333"></polygon>
+</g>
+
+<g id="edge8" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M145.32,-223.723C156.979,-208.26 171.698,-188.737 184.91,-171.214"></path>
+<polygon fill="black" stroke="black" points="188.029,-172.891 191.255,-162.799 182.44,-168.677 188.029,-172.891"></polygon>
+</g>
+
+<g id="edge10" class="edge"><title>s1_3-&gt;final</title>
+<path fill="none" stroke="black" d="M67,-62.2476C67,-53.0345 67,-44.0781 67,-36.4335"></path>
+<polygon fill="black" stroke="black" points="70.5001,-36.2949 67,-26.2949 63.5001,-36.2949 70.5001,-36.2949"></polygon>
+</g>
+
+<g id="edge12" class="edge"><title>s1_4-&gt;thrown</title>
+<path fill="none" stroke="black" d="M219,-87.3716C219,-69.6416 219,-49.034 219,-34.1808"></path>
+<polygon fill="black" stroke="black" points="222.5,-34.087 219,-24.087 215.5,-34.087 222.5,-34.087"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-when-there-is-a-function-f.svg
+++ b/docs/developer-guide/code-path-analysis/example-when-there-is-a-function-f.svg
@@ -1,0 +1,99 @@
+<?xml version="1.0"?>
+<svg width="270pt" height="328pt" viewBox="0.00 0.00 270.00 328.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 324)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="125" cy="-311" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s2_1</title>
+<polygon fill="white" stroke="white" points="178.307,-265.3 71.6933,-265.3 59.6933,-253.3 59.6933,-168.7 71.6933,-156.7 178.307,-156.7 190.307,-168.7 190.307,-253.3 178.307,-265.3"></polygon>
+<path fill="white" stroke="white" d="M71.6933,-265.3C65.6933,-265.3 59.6933,-259.3 59.6933,-253.3"></path>
+<path fill="white" stroke="white" d="M59.6933,-168.7C59.6933,-162.7 65.6933,-156.7 71.6933,-156.7"></path>
+<path fill="white" stroke="white" d="M178.307,-156.7C184.307,-156.7 190.307,-162.7 190.307,-168.7"></path>
+<path fill="white" stroke="white" d="M190.307,-253.3C190.307,-259.3 184.307,-265.3 178.307,-265.3"></path>
+<polyline fill="none" stroke="black" points="178.307,-265.3 71.6933,-265.3 "></polyline>
+<path fill="none" stroke="black" d="M71.6933,-265.3C65.6933,-265.3 59.6933,-259.3 59.6933,-253.3"></path>
+<polyline fill="none" stroke="black" points="59.6933,-253.3 59.6933,-168.7 "></polyline>
+<path fill="none" stroke="black" d="M59.6933,-168.7C59.6933,-162.7 65.6933,-156.7 71.6933,-156.7"></path>
+<polyline fill="none" stroke="black" points="71.6933,-156.7 178.307,-156.7 "></polyline>
+<path fill="none" stroke="black" d="M178.307,-156.7C184.307,-156.7 190.307,-162.7 190.307,-168.7"></path>
+<polyline fill="none" stroke="black" points="190.307,-168.7 190.307,-253.3 "></polyline>
+<path fill="none" stroke="black" d="M190.307,-253.3C190.307,-259.3 184.307,-265.3 178.307,-265.3"></path>
+<text text-anchor="middle" x="125" y="-248.8" font-family="Times,serif" font-size="14.00">FunctionDeclaration</text>
+<text text-anchor="middle" x="125" y="-232" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="125" y="-215.2" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+<text text-anchor="middle" x="125" y="-198.4" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="125" y="-181.6" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="125" y="-164.8" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s2_1</title>
+<path fill="none" stroke="black" d="M125,-301.98C125,-295.675 125,-286.238 125,-275.813"></path>
+<polygon fill="black" stroke="black" points="128.5,-275.586 125,-265.586 121.5,-275.586 128.5,-275.586"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="125" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="125" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s2_2</title>
+<polygon fill="white" stroke="white" points="98.0684,-111.602 11.9316,-111.602 -0.0684189,-99.6019 -0.0684189,-82.3981 11.9316,-70.3981 98.0684,-70.3981 110.068,-82.3981 110.068,-99.6019 98.0684,-111.602"></polygon>
+<path fill="white" stroke="white" d="M11.9316,-111.602C5.93158,-111.602 -0.0684189,-105.602 -0.0684189,-99.6019"></path>
+<path fill="white" stroke="white" d="M-0.0684189,-82.3981C-0.0684189,-76.3981 5.93158,-70.3981 11.9316,-70.3981"></path>
+<path fill="white" stroke="white" d="M98.0684,-70.3981C104.068,-70.3981 110.068,-76.3981 110.068,-82.3981"></path>
+<path fill="white" stroke="white" d="M110.068,-99.6019C110.068,-105.602 104.068,-111.602 98.0684,-111.602"></path>
+<polyline fill="none" stroke="black" points="98.0684,-111.602 11.9316,-111.602 "></polyline>
+<path fill="none" stroke="black" d="M11.9316,-111.602C5.93158,-111.602 -0.0684189,-105.602 -0.0684189,-99.6019"></path>
+<polyline fill="none" stroke="black" points="-0.0684189,-99.6019 -0.0684189,-82.3981 "></polyline>
+<path fill="none" stroke="black" d="M-0.0684189,-82.3981C-0.0684189,-76.3981 5.93158,-70.3981 11.9316,-70.3981"></path>
+<polyline fill="none" stroke="black" points="11.9316,-70.3981 98.0684,-70.3981 "></polyline>
+<path fill="none" stroke="black" d="M98.0684,-70.3981C104.068,-70.3981 110.068,-76.3981 110.068,-82.3981"></path>
+<polyline fill="none" stroke="black" points="110.068,-82.3981 110.068,-99.6019 "></polyline>
+<path fill="none" stroke="black" d="M110.068,-99.6019C110.068,-105.602 104.068,-111.602 98.0684,-111.602"></path>
+<text text-anchor="middle" x="55" y="-95.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="55" y="-78.4" font-family="Times,serif" font-size="14.00">ReturnStatement</text>
+</g>
+
+<g id="edge3" class="edge"><title>s2_1-&gt;s2_2</title>
+<path fill="none" stroke="black" d="M93.277,-156.524C85.8726,-144.042 78.2709,-131.228 71.813,-120.342"></path>
+<polygon fill="black" stroke="black" points="74.7991,-118.516 66.6869,-111.701 68.7787,-122.087 74.7991,-118.516"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s2_4</title>
+<polygon fill="white" stroke="white" points="250.147,-120.401 139.853,-120.401 127.853,-108.401 127.853,-73.5986 139.853,-61.5986 250.147,-61.5986 262.147,-73.5986 262.147,-108.401 250.147,-120.401"></polygon>
+<path fill="white" stroke="white" d="M139.853,-120.401C133.853,-120.401 127.853,-114.401 127.853,-108.401"></path>
+<path fill="white" stroke="white" d="M127.853,-73.5986C127.853,-67.5986 133.853,-61.5986 139.853,-61.5986"></path>
+<path fill="white" stroke="white" d="M250.147,-61.5986C256.147,-61.5986 262.147,-67.5986 262.147,-73.5986"></path>
+<path fill="white" stroke="white" d="M262.147,-108.401C262.147,-114.401 256.147,-120.401 250.147,-120.401"></path>
+<polyline fill="none" stroke="black" points="250.147,-120.401 139.853,-120.401 "></polyline>
+<path fill="none" stroke="black" d="M139.853,-120.401C133.853,-120.401 127.853,-114.401 127.853,-108.401"></path>
+<polyline fill="none" stroke="black" points="127.853,-108.401 127.853,-73.5986 "></polyline>
+<path fill="none" stroke="black" d="M127.853,-73.5986C127.853,-67.5986 133.853,-61.5986 139.853,-61.5986"></path>
+<polyline fill="none" stroke="black" points="139.853,-61.5986 250.147,-61.5986 "></polyline>
+<path fill="none" stroke="black" d="M250.147,-61.5986C256.147,-61.5986 262.147,-67.5986 262.147,-73.5986"></path>
+<polyline fill="none" stroke="black" points="262.147,-73.5986 262.147,-108.401 "></polyline>
+<path fill="none" stroke="black" d="M262.147,-108.401C262.147,-114.401 256.147,-120.401 250.147,-120.401"></path>
+<text text-anchor="middle" x="195" y="-103.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="195" y="-86.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="195" y="-70" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge5" class="edge"><title>s2_1-&gt;s2_4</title>
+<path fill="none" stroke="black" d="M156.723,-156.524C162.2,-147.291 167.785,-137.877 172.935,-129.195"></path>
+<polygon fill="black" stroke="black" points="176.03,-130.838 178.122,-120.452 170.01,-127.267 176.03,-130.838"></polygon>
+</g>
+
+<g id="edge7" class="edge"><title>s2_2-&gt;final</title>
+<path fill="none" stroke="black" d="M73.3917,-70.0319C84.6046,-57.8578 98.7782,-42.4693 109.434,-30.9007"></path>
+<polygon fill="black" stroke="black" points="112.278,-32.9792 116.478,-23.2526 107.129,-28.2369 112.278,-32.9792"></polygon>
+</g>
+
+<g id="edge9" class="edge"><title>s2_4-&gt;final</title>
+<path fill="none" stroke="black" d="M168.935,-61.7004C159.292,-51.2315 148.68,-39.7098 140.301,-30.6129"></path>
+<polygon fill="black" stroke="black" points="142.676,-28.0244 133.326,-23.0401 137.527,-32.7668 142.676,-28.0244"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-when-there-is-a-function-g.svg
+++ b/docs/developer-guide/code-path-analysis/example-when-there-is-a-function-g.svg
@@ -1,0 +1,47 @@
+<?xml version="1.0"?>
+<svg width="142pt" height="234pt" viewBox="0.00 0.00 142.00 234.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 230)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="67" cy="-217" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="122.147,-171.3 11.8526,-171.3 -0.147372,-159.3 -0.147372,-74.6998 11.8526,-62.6998 122.147,-62.6998 134.147,-74.6998 134.147,-159.3 122.147,-171.3"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-171.3C5.85263,-171.3 -0.147372,-165.3 -0.147372,-159.3"></path>
+<path fill="white" stroke="white" d="M-0.147372,-74.6998C-0.147372,-68.6998 5.85263,-62.6998 11.8526,-62.6998"></path>
+<path fill="white" stroke="white" d="M122.147,-62.6998C128.147,-62.6998 134.147,-68.6998 134.147,-74.6998"></path>
+<path fill="white" stroke="white" d="M134.147,-159.3C134.147,-165.3 128.147,-171.3 122.147,-171.3"></path>
+<polyline fill="none" stroke="black" points="122.147,-171.3 11.8526,-171.3 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-171.3C5.85263,-171.3 -0.147372,-165.3 -0.147372,-159.3"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-159.3 -0.147372,-74.6998 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-74.6998C-0.147372,-68.6998 5.85263,-62.6998 11.8526,-62.6998"></path>
+<polyline fill="none" stroke="black" points="11.8526,-62.6998 122.147,-62.6998 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-62.6998C128.147,-62.6998 134.147,-68.6998 134.147,-74.6998"></path>
+<polyline fill="none" stroke="black" points="134.147,-74.6998 134.147,-159.3 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-159.3C134.147,-165.3 128.147,-171.3 122.147,-171.3"></path>
+<text text-anchor="middle" x="67" y="-154.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="67" y="-138" font-family="Times,serif" font-size="14.00">FunctionDeclaration</text>
+<text text-anchor="middle" x="67" y="-121.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-104.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-87.6" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-70.8" font-family="Times,serif" font-size="14.00">Literal (false)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M67,-207.98C67,-201.675 67,-192.238 67,-181.813"></path>
+<polygon fill="black" stroke="black" points="70.5001,-181.586 67,-171.586 63.5001,-181.586 70.5001,-181.586"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="67" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="67" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;final</title>
+<path fill="none" stroke="black" d="M67,-62.6102C67,-53.3058 67,-44.1078 67,-36.2584"></path>
+<polygon fill="black" stroke="black" points="70.5001,-36.1896 67,-26.1896 63.5001,-36.1897 70.5001,-36.1896"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/example-whilestatement.svg
+++ b/docs/developer-guide/code-path-analysis/example-whilestatement.svg
@@ -1,0 +1,172 @@
+<?xml version="1.0"?>
+<svg width="408pt" height="416pt" viewBox="0.00 0.00 408.00 416.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 412)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="193" cy="-399" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="234.149,-353.602 151.851,-353.602 139.851,-341.602 139.851,-324.398 151.851,-312.398 234.149,-312.398 246.149,-324.398 246.149,-341.602 234.149,-353.602"></polygon>
+<path fill="white" stroke="white" d="M151.851,-353.602C145.851,-353.602 139.851,-347.602 139.851,-341.602"></path>
+<path fill="white" stroke="white" d="M139.851,-324.398C139.851,-318.398 145.851,-312.398 151.851,-312.398"></path>
+<path fill="white" stroke="white" d="M234.149,-312.398C240.149,-312.398 246.149,-318.398 246.149,-324.398"></path>
+<path fill="white" stroke="white" d="M246.149,-341.602C246.149,-347.602 240.149,-353.602 234.149,-353.602"></path>
+<polyline fill="none" stroke="black" points="234.149,-353.602 151.851,-353.602 "></polyline>
+<path fill="none" stroke="black" d="M151.851,-353.602C145.851,-353.602 139.851,-347.602 139.851,-341.602"></path>
+<polyline fill="none" stroke="black" points="139.851,-341.602 139.851,-324.398 "></polyline>
+<path fill="none" stroke="black" d="M139.851,-324.398C139.851,-318.398 145.851,-312.398 151.851,-312.398"></path>
+<polyline fill="none" stroke="black" points="151.851,-312.398 234.149,-312.398 "></polyline>
+<path fill="none" stroke="black" d="M234.149,-312.398C240.149,-312.398 246.149,-318.398 246.149,-324.398"></path>
+<polyline fill="none" stroke="black" points="246.149,-324.398 246.149,-341.602 "></polyline>
+<path fill="none" stroke="black" d="M246.149,-341.602C246.149,-347.602 240.149,-353.602 234.149,-353.602"></path>
+<text text-anchor="middle" x="193" y="-337.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="193" y="-320.4" font-family="Times,serif" font-size="14.00">WhileStatement</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M193,-389.894C193,-383.274 193,-373.485 193,-363.94"></path>
+<polygon fill="black" stroke="black" points="196.5,-363.842 193,-353.842 189.5,-363.842 196.5,-363.842"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="335" cy="-29" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="335" cy="-29" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="224.339,-276 161.661,-276 149.661,-264 149.661,-252 161.661,-240 224.339,-240 236.339,-252 236.339,-264 224.339,-276"></polygon>
+<path fill="white" stroke="white" d="M161.661,-276C155.661,-276 149.661,-270 149.661,-264"></path>
+<path fill="white" stroke="white" d="M149.661,-252C149.661,-246 155.661,-240 161.661,-240"></path>
+<path fill="white" stroke="white" d="M224.339,-240C230.339,-240 236.339,-246 236.339,-252"></path>
+<path fill="white" stroke="white" d="M236.339,-264C236.339,-270 230.339,-276 224.339,-276"></path>
+<polyline fill="none" stroke="black" points="224.339,-276 161.661,-276 "></polyline>
+<path fill="none" stroke="black" d="M161.661,-276C155.661,-276 149.661,-270 149.661,-264"></path>
+<polyline fill="none" stroke="black" points="149.661,-264 149.661,-252 "></polyline>
+<path fill="none" stroke="black" d="M149.661,-252C149.661,-246 155.661,-240 161.661,-240"></path>
+<polyline fill="none" stroke="black" points="161.661,-240 224.339,-240 "></polyline>
+<path fill="none" stroke="black" d="M224.339,-240C230.339,-240 236.339,-246 236.339,-252"></path>
+<polyline fill="none" stroke="black" points="236.339,-252 236.339,-264 "></polyline>
+<path fill="none" stroke="black" d="M236.339,-264C236.339,-270 230.339,-276 224.339,-276"></path>
+<text text-anchor="middle" x="193" y="-253.8" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M193,-312.052C193,-304.216 193,-295.089 193,-286.636"></path>
+<polygon fill="black" stroke="black" points="196.5,-286.439 193,-276.439 189.5,-286.439 196.5,-286.439"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="201.147,-203.3 90.8526,-203.3 78.8526,-191.3 78.8526,-106.7 90.8526,-94.6998 201.147,-94.6998 213.147,-106.7 213.147,-191.3 201.147,-203.3"></polygon>
+<path fill="white" stroke="white" d="M90.8526,-203.3C84.8526,-203.3 78.8526,-197.3 78.8526,-191.3"></path>
+<path fill="white" stroke="white" d="M78.8526,-106.7C78.8526,-100.7 84.8526,-94.6998 90.8526,-94.6998"></path>
+<path fill="white" stroke="white" d="M201.147,-94.6998C207.147,-94.6998 213.147,-100.7 213.147,-106.7"></path>
+<path fill="white" stroke="white" d="M213.147,-191.3C213.147,-197.3 207.147,-203.3 201.147,-203.3"></path>
+<polyline fill="none" stroke="black" points="201.147,-203.3 90.8526,-203.3 "></polyline>
+<path fill="none" stroke="black" d="M90.8526,-203.3C84.8526,-203.3 78.8526,-197.3 78.8526,-191.3"></path>
+<polyline fill="none" stroke="black" points="78.8526,-191.3 78.8526,-106.7 "></polyline>
+<path fill="none" stroke="black" d="M78.8526,-106.7C78.8526,-100.7 84.8526,-94.6998 90.8526,-94.6998"></path>
+<polyline fill="none" stroke="black" points="90.8526,-94.6998 201.147,-94.6998 "></polyline>
+<path fill="none" stroke="black" d="M201.147,-94.6998C207.147,-94.6998 213.147,-100.7 213.147,-106.7"></path>
+<polyline fill="none" stroke="black" points="213.147,-106.7 213.147,-191.3 "></polyline>
+<path fill="none" stroke="black" d="M213.147,-191.3C213.147,-197.3 207.147,-203.3 201.147,-203.3"></path>
+<text text-anchor="middle" x="146" y="-186.8" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="146" y="-170" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="146" y="-153.2" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="146" y="-136.4" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="146" y="-119.6" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="146" y="-102.8" font-family="Times,serif" font-size="14.00">Identifier (b)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M185.449,-239.809C182.111,-232.21 177.961,-222.761 173.617,-212.872"></path>
+<polygon fill="black" stroke="black" points="176.817,-211.454 169.59,-203.706 170.408,-214.269 176.817,-211.454"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_7</title>
+<polygon fill="white" stroke="white" points="388.314,-169.602 281.686,-169.602 269.686,-157.602 269.686,-140.398 281.686,-128.398 388.314,-128.398 400.314,-140.398 400.314,-157.602 388.314,-169.602"></polygon>
+<path fill="white" stroke="white" d="M281.686,-169.602C275.686,-169.602 269.686,-163.602 269.686,-157.602"></path>
+<path fill="white" stroke="white" d="M269.686,-140.398C269.686,-134.398 275.686,-128.398 281.686,-128.398"></path>
+<path fill="white" stroke="white" d="M388.314,-128.398C394.314,-128.398 400.314,-134.398 400.314,-140.398"></path>
+<path fill="white" stroke="white" d="M400.314,-157.602C400.314,-163.602 394.314,-169.602 388.314,-169.602"></path>
+<polyline fill="none" stroke="black" points="388.314,-169.602 281.686,-169.602 "></polyline>
+<path fill="none" stroke="black" d="M281.686,-169.602C275.686,-169.602 269.686,-163.602 269.686,-157.602"></path>
+<polyline fill="none" stroke="black" points="269.686,-157.602 269.686,-140.398 "></polyline>
+<path fill="none" stroke="black" d="M269.686,-140.398C269.686,-134.398 275.686,-128.398 281.686,-128.398"></path>
+<polyline fill="none" stroke="black" points="281.686,-128.398 388.314,-128.398 "></polyline>
+<path fill="none" stroke="black" d="M388.314,-128.398C394.314,-128.398 400.314,-134.398 400.314,-140.398"></path>
+<polyline fill="none" stroke="black" points="400.314,-140.398 400.314,-157.602 "></polyline>
+<path fill="none" stroke="black" d="M400.314,-157.602C400.314,-163.602 394.314,-169.602 388.314,-169.602"></path>
+<text text-anchor="middle" x="335" y="-153.2" font-family="Times,serif" font-size="14.00">WhileStatement:exit</text>
+<text text-anchor="middle" x="335" y="-136.4" font-family="Times,serif" font-size="14.00">Program:exit</text>
+</g>
+
+<g id="edge7" class="edge"><title>s1_2-&gt;s1_7</title>
+<path fill="none" stroke="black" d="M215.815,-239.809C238.735,-222.537 274.341,-195.708 300.672,-175.867"></path>
+<polygon fill="black" stroke="black" points="302.987,-178.505 308.867,-169.692 298.774,-172.914 302.987,-178.505"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="110.49,-49.6019 11.5095,-49.6019 -0.490457,-37.6019 -0.490457,-20.3981 11.5095,-8.3981 110.49,-8.3981 122.49,-20.3981 122.49,-37.6019 110.49,-49.6019"></polygon>
+<path fill="white" stroke="white" d="M11.5095,-49.6019C5.50954,-49.6019 -0.490457,-43.6019 -0.490457,-37.6019"></path>
+<path fill="white" stroke="white" d="M-0.490457,-20.3981C-0.490457,-14.3981 5.50954,-8.3981 11.5095,-8.3981"></path>
+<path fill="white" stroke="white" d="M110.49,-8.3981C116.49,-8.3981 122.49,-14.3981 122.49,-20.3981"></path>
+<path fill="white" stroke="white" d="M122.49,-37.6019C122.49,-43.6019 116.49,-49.6019 110.49,-49.6019"></path>
+<polyline fill="none" stroke="black" points="110.49,-49.6019 11.5095,-49.6019 "></polyline>
+<path fill="none" stroke="black" d="M11.5095,-49.6019C5.50954,-49.6019 -0.490457,-43.6019 -0.490457,-37.6019"></path>
+<polyline fill="none" stroke="black" points="-0.490457,-37.6019 -0.490457,-20.3981 "></polyline>
+<path fill="none" stroke="black" d="M-0.490457,-20.3981C-0.490457,-14.3981 5.50954,-8.3981 11.5095,-8.3981"></path>
+<polyline fill="none" stroke="black" points="11.5095,-8.3981 110.49,-8.3981 "></polyline>
+<path fill="none" stroke="black" d="M110.49,-8.3981C116.49,-8.3981 122.49,-14.3981 122.49,-20.3981"></path>
+<polyline fill="none" stroke="black" points="122.49,-20.3981 122.49,-37.6019 "></polyline>
+<path fill="none" stroke="black" d="M122.49,-37.6019C122.49,-43.6019 116.49,-49.6019 110.49,-49.6019"></path>
+<text text-anchor="middle" x="61" y="-33.2" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="61" y="-16.4" font-family="Times,serif" font-size="14.00">ContinueStatement</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M107.479,-94.524C98.3982,-81.9176 89.0729,-68.9717 81.181,-58.0159"></path>
+<polygon fill="black" stroke="black" points="83.876,-55.7691 75.1912,-49.7007 78.1962,-59.8605 83.876,-55.7691"></polygon>
+</g>
+
+<g id="node8" class="node"><title>s1_6</title>
+<polygon fill="white" stroke="white" points="282.147,-58.4014 171.853,-58.4014 159.853,-46.4014 159.853,-11.5986 171.853,0.401379 282.147,0.401379 294.147,-11.5986 294.147,-46.4014 282.147,-58.4014"></polygon>
+<path fill="white" stroke="white" d="M171.853,-58.4014C165.853,-58.4014 159.853,-52.4014 159.853,-46.4014"></path>
+<path fill="white" stroke="white" d="M159.853,-11.5986C159.853,-5.59862 165.853,0.401379 171.853,0.401379"></path>
+<path fill="white" stroke="white" d="M282.147,0.401379C288.147,0.401379 294.147,-5.59862 294.147,-11.5986"></path>
+<path fill="white" stroke="white" d="M294.147,-46.4014C294.147,-52.4014 288.147,-58.4014 282.147,-58.4014"></path>
+<polyline fill="none" stroke="black" points="282.147,-58.4014 171.853,-58.4014 "></polyline>
+<path fill="none" stroke="black" d="M171.853,-58.4014C165.853,-58.4014 159.853,-52.4014 159.853,-46.4014"></path>
+<polyline fill="none" stroke="black" points="159.853,-46.4014 159.853,-11.5986 "></polyline>
+<path fill="none" stroke="black" d="M159.853,-11.5986C159.853,-5.59862 165.853,0.401379 171.853,0.401379"></path>
+<polyline fill="none" stroke="black" points="171.853,0.401379 282.147,0.401379 "></polyline>
+<path fill="none" stroke="black" d="M282.147,0.401379C288.147,0.401379 294.147,-5.59862 294.147,-11.5986"></path>
+<polyline fill="none" stroke="black" points="294.147,-11.5986 294.147,-46.4014 "></polyline>
+<path fill="none" stroke="black" d="M294.147,-46.4014C294.147,-52.4014 288.147,-58.4014 282.147,-58.4014"></path>
+<text text-anchor="middle" x="227" y="-41.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="227" y="-24.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="227" y="-8" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge9" class="edge"><title>s1_3-&gt;s1_6</title>
+<path fill="none" stroke="black" d="M182.708,-94.524C189.112,-85.1942 195.644,-75.6786 201.656,-66.9212"></path>
+<polygon fill="black" stroke="black" points="204.696,-68.677 207.47,-58.4517 198.925,-64.7154 204.696,-68.677"></polygon>
+</g>
+
+<g id="edge6" class="edge"><title>s1_4-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M55.8178,-49.8729C48.0052,-84.5943 37.3518,-157.069 70,-204 86.0013,-227.001 114.192,-240.092 139.552,-247.506"></path>
+<polygon fill="black" stroke="black" points="138.9,-250.955 149.466,-250.168 140.715,-244.194 138.9,-250.955"></polygon>
+</g>
+
+<g id="edge12" class="edge"><title>s1_7-&gt;final</title>
+<path fill="none" stroke="black" d="M335,-128.249C335,-107.258 335,-74.136 335,-52.2408"></path>
+<polygon fill="black" stroke="black" points="338.5,-52.2172 335,-42.2173 331.5,-52.2173 338.5,-52.2172"></polygon>
+</g>
+
+<g id="edge10" class="edge"><title>s1_6-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M230.184,-58.3131C233.209,-93.2424 235.52,-154.122 222,-204 219.488,-213.268 215.064,-222.685 210.417,-230.959"></path>
+<polygon fill="black" stroke="black" points="207.291,-229.367 205.165,-239.747 213.299,-232.958 207.291,-229.367"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/helo.svg
+++ b/docs/developer-guide/code-path-analysis/helo.svg
@@ -1,0 +1,113 @@
+<?xml version="1.0"?>
+<svg width="238pt" height="478pt" viewBox="0.00 0.00 238.00 478.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 474)">
+<title>Code Path 1</title>
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="164" cy="-461" rx="9" ry="9"></ellipse>
+</g>
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="212.228,-415.7 115.772,-415.7 103.772,-403.7 103.772,-352.3 115.772,-340.3 212.228,-340.3 224.228,-352.3 224.228,-403.7 212.228,-415.7"></polygon>
+<path fill="white" stroke="white" d="M115.772,-415.7C109.772,-415.7 103.772,-409.7 103.772,-403.7"></path>
+<path fill="white" stroke="white" d="M103.772,-352.3C103.772,-346.3 109.772,-340.3 115.772,-340.3"></path>
+<path fill="white" stroke="white" d="M212.228,-340.3C218.228,-340.3 224.228,-346.3 224.228,-352.3"></path>
+<path fill="white" stroke="white" d="M224.228,-403.7C224.228,-409.7 218.228,-415.7 212.228,-415.7"></path>
+<polyline fill="none" stroke="black" points="212.228,-415.7 115.772,-415.7 "></polyline>
+<path fill="none" stroke="black" d="M115.772,-415.7C109.772,-415.7 103.772,-409.7 103.772,-403.7"></path>
+<polyline fill="none" stroke="black" points="103.772,-403.7 103.772,-352.3 "></polyline>
+<path fill="none" stroke="black" d="M103.772,-352.3C103.772,-346.3 109.772,-340.3 115.772,-340.3"></path>
+<polyline fill="none" stroke="black" points="115.772,-340.3 212.228,-340.3 "></polyline>
+<path fill="none" stroke="black" d="M212.228,-340.3C218.228,-340.3 224.228,-346.3 224.228,-352.3"></path>
+<polyline fill="none" stroke="black" points="224.228,-352.3 224.228,-403.7 "></polyline>
+<path fill="none" stroke="black" d="M224.228,-403.7C224.228,-409.7 218.228,-415.7 212.228,-415.7"></path>
+<text text-anchor="middle" x="164" y="-399" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="164" y="-382.2" font-family="Times,serif" font-size="14.00">IfStatement</text>
+<text text-anchor="middle" x="164" y="-365.4" font-family="Times,serif" font-size="14.00">LogicalExpression</text>
+<text text-anchor="middle" x="164" y="-348.6" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M164,-451.937C164,-445.515 164,-435.952 164,-425.848"></path>
+<polygon fill="black" stroke="black" points="167.5,-425.66 164,-415.66 160.5,-425.66 167.5,-425.66"></polygon>
+</g>
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="162" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="162" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="159.429,-304 96.5714,-304 84.5714,-292 84.5714,-280 96.5714,-268 159.429,-268 171.429,-280 171.429,-292 159.429,-304"></polygon>
+<path fill="white" stroke="white" d="M96.5714,-304C90.5714,-304 84.5714,-298 84.5714,-292"></path>
+<path fill="white" stroke="white" d="M84.5714,-280C84.5714,-274 90.5714,-268 96.5714,-268"></path>
+<path fill="white" stroke="white" d="M159.429,-268C165.429,-268 171.429,-274 171.429,-280"></path>
+<path fill="white" stroke="white" d="M171.429,-292C171.429,-298 165.429,-304 159.429,-304"></path>
+<polyline fill="none" stroke="black" points="159.429,-304 96.5714,-304 "></polyline>
+<path fill="none" stroke="black" d="M96.5714,-304C90.5714,-304 84.5714,-298 84.5714,-292"></path>
+<polyline fill="none" stroke="black" points="84.5714,-292 84.5714,-280 "></polyline>
+<path fill="none" stroke="black" d="M84.5714,-280C84.5714,-274 90.5714,-268 96.5714,-268"></path>
+<polyline fill="none" stroke="black" points="96.5714,-268 159.429,-268 "></polyline>
+<path fill="none" stroke="black" d="M159.429,-268C165.429,-268 171.429,-274 171.429,-280"></path>
+<polyline fill="none" stroke="black" points="171.429,-280 171.429,-292 "></polyline>
+<path fill="none" stroke="black" d="M171.429,-292C171.429,-298 165.429,-304 159.429,-304"></path>
+<text text-anchor="middle" x="128" y="-281.8" font-family="Times,serif" font-size="14.00">Identifier (b)</text>
+</g>
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M149.357,-340.394C145.815,-331.536 142.092,-322.229 138.765,-313.912"></path>
+<polygon fill="black" stroke="black" points="141.905,-312.338 134.941,-304.353 135.405,-314.938 141.905,-312.338"></polygon>
+</g>
+<g id="node6" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="217.147,-120.401 106.853,-120.401 94.8526,-108.401 94.8526,-73.5986 106.853,-61.5986 217.147,-61.5986 229.147,-73.5986 229.147,-108.401 217.147,-120.401"></polygon>
+<path fill="white" stroke="white" d="M106.853,-120.401C100.853,-120.401 94.8526,-114.401 94.8526,-108.401"></path>
+<path fill="white" stroke="white" d="M94.8526,-73.5986C94.8526,-67.5986 100.853,-61.5986 106.853,-61.5986"></path>
+<path fill="white" stroke="white" d="M217.147,-61.5986C223.147,-61.5986 229.147,-67.5986 229.147,-73.5986"></path>
+<path fill="white" stroke="white" d="M229.147,-108.401C229.147,-114.401 223.147,-120.401 217.147,-120.401"></path>
+<polyline fill="none" stroke="black" points="217.147,-120.401 106.853,-120.401 "></polyline>
+<path fill="none" stroke="black" d="M106.853,-120.401C100.853,-120.401 94.8526,-114.401 94.8526,-108.401"></path>
+<polyline fill="none" stroke="black" points="94.8526,-108.401 94.8526,-73.5986 "></polyline>
+<path fill="none" stroke="black" d="M94.8526,-73.5986C94.8526,-67.5986 100.853,-61.5986 106.853,-61.5986"></path>
+<polyline fill="none" stroke="black" points="106.853,-61.5986 217.147,-61.5986 "></polyline>
+<path fill="none" stroke="black" d="M217.147,-61.5986C223.147,-61.5986 229.147,-67.5986 229.147,-73.5986"></path>
+<polyline fill="none" stroke="black" points="229.147,-73.5986 229.147,-108.401 "></polyline>
+<path fill="none" stroke="black" d="M229.147,-108.401C229.147,-114.401 223.147,-120.401 217.147,-120.401"></path>
+<text text-anchor="middle" x="162" y="-103.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="162" y="-86.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="162" y="-70" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+<g id="edge7" class="edge"><title>s1_1-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M173.704,-340.118C176.287,-328.633 178.715,-315.867 180,-304 186.559,-243.442 177.199,-172.935 169.707,-130.425"></path>
+<polygon fill="black" stroke="black" points="173.135,-129.714 167.902,-120.501 166.248,-130.966 173.135,-129.714"></polygon>
+</g>
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="122.147,-231.7 11.8526,-231.7 -0.147372,-219.7 -0.147372,-168.3 11.8526,-156.3 122.147,-156.3 134.147,-168.3 134.147,-219.7 122.147,-231.7"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-231.7C5.85263,-231.7 -0.147372,-225.7 -0.147372,-219.7"></path>
+<path fill="white" stroke="white" d="M-0.147372,-168.3C-0.147372,-162.3 5.85263,-156.3 11.8526,-156.3"></path>
+<path fill="white" stroke="white" d="M122.147,-156.3C128.147,-156.3 134.147,-162.3 134.147,-168.3"></path>
+<path fill="white" stroke="white" d="M134.147,-219.7C134.147,-225.7 128.147,-231.7 122.147,-231.7"></path>
+<polyline fill="none" stroke="black" points="122.147,-231.7 11.8526,-231.7 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-231.7C5.85263,-231.7 -0.147372,-225.7 -0.147372,-219.7"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-219.7 -0.147372,-168.3 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-168.3C-0.147372,-162.3 5.85263,-156.3 11.8526,-156.3"></path>
+<polyline fill="none" stroke="black" points="11.8526,-156.3 122.147,-156.3 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-156.3C128.147,-156.3 134.147,-162.3 134.147,-168.3"></path>
+<polyline fill="none" stroke="black" points="134.147,-168.3 134.147,-219.7 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-219.7C134.147,-225.7 128.147,-231.7 122.147,-231.7"></path>
+<text text-anchor="middle" x="67" y="-215" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-198.2" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-181.4" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-164.6" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M116.239,-267.647C110.883,-259.746 104.269,-249.988 97.6462,-240.216"></path>
+<polygon fill="black" stroke="black" points="100.363,-237.985 91.855,-231.671 94.5683,-241.913 100.363,-237.985"></polygon>
+</g>
+<g id="edge9" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M133.482,-267.966C136.637,-257.648 140.465,-244.17 143,-232 150.074,-198.038 155.131,-158.871 158.24,-130.616"></path>
+<polygon fill="black" stroke="black" points="161.754,-130.67 159.337,-120.355 154.794,-129.926 161.754,-130.67"></polygon>
+</g>
+<g id="edge5" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M101.566,-156.251C110.27,-146.997 119.601,-137.077 128.264,-127.867"></path>
+<polygon fill="black" stroke="black" points="131.053,-130.01 135.355,-120.328 125.954,-125.214 131.053,-130.01"></polygon>
+</g>
+<g id="edge10" class="edge"><title>s1_4-&gt;final</title>
+<path fill="none" stroke="black" d="M162,-61.7004C162,-53.2282 162,-44.0665 162,-36.0585"></path>
+<polygon fill="black" stroke="black" points="165.5,-36.0267 162,-26.0267 158.5,-36.0267 165.5,-36.0267"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-for-1.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-for-1.svg
@@ -1,0 +1,84 @@
+<?xml version="1.0"?>
+<svg width="136pt" height="344pt" viewBox="0.00 0.00 136.00 344.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 340)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="64" cy="-327" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node2" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="116.617,-281.3 11.3833,-281.3 -0.616716,-269.3 -0.616716,-184.7 11.3833,-172.7 116.617,-172.7 128.617,-184.7 128.617,-269.3 116.617,-281.3"></polygon>
+<path fill="white" stroke="white" d="M11.3833,-281.3C5.38328,-281.3 -0.616716,-275.3 -0.616716,-269.3"></path>
+<path fill="white" stroke="white" d="M-0.616716,-184.7C-0.616716,-178.7 5.38328,-172.7 11.3833,-172.7"></path>
+<path fill="white" stroke="white" d="M116.617,-172.7C122.617,-172.7 128.617,-178.7 128.617,-184.7"></path>
+<path fill="white" stroke="white" d="M128.617,-269.3C128.617,-275.3 122.617,-281.3 116.617,-281.3"></path>
+<polyline fill="none" stroke="black" points="116.617,-281.3 11.3833,-281.3 "></polyline>
+<path fill="none" stroke="black" d="M11.3833,-281.3C5.38328,-281.3 -0.616716,-275.3 -0.616716,-269.3"></path>
+<polyline fill="none" stroke="black" points="-0.616716,-269.3 -0.616716,-184.7 "></polyline>
+<path fill="none" stroke="black" d="M-0.616716,-184.7C-0.616716,-178.7 5.38328,-172.7 11.3833,-172.7"></path>
+<polyline fill="none" stroke="black" points="11.3833,-172.7 116.617,-172.7 "></polyline>
+<path fill="none" stroke="black" d="M116.617,-172.7C122.617,-172.7 128.617,-178.7 128.617,-184.7"></path>
+<polyline fill="none" stroke="black" points="128.617,-184.7 128.617,-269.3 "></polyline>
+<path fill="none" stroke="black" d="M128.617,-269.3C128.617,-275.3 122.617,-281.3 116.617,-281.3"></path>
+<text text-anchor="middle" x="64" y="-264.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="64" y="-248" font-family="Times,serif" font-size="14.00">ForStatement</text>
+<text text-anchor="middle" x="64" y="-231.2" font-family="Times,serif" font-size="14.00">VariableDeclaration</text>
+<text text-anchor="middle" x="64" y="-214.4" font-family="Times,serif" font-size="14.00">VariableDeclarator</text>
+<text text-anchor="middle" x="64" y="-197.6" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="64" y="-180.8" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M64,-317.98C64,-311.675 64,-302.238 64,-291.813"></path>
+<polygon fill="black" stroke="black" points="67.5001,-291.586 64,-281.586 60.5001,-291.586 67.5001,-291.586"></polygon>
+</g>
+
+<g id="node3" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="110.233,-136.401 17.7673,-136.401 5.76729,-124.401 5.76729,-89.5986 17.7673,-77.5986 110.233,-77.5986 122.233,-89.5986 122.233,-124.401 110.233,-136.401"></polygon>
+<path fill="white" stroke="white" d="M17.7673,-136.401C11.7673,-136.401 5.76729,-130.401 5.76729,-124.401"></path>
+<path fill="white" stroke="white" d="M5.76729,-89.5986C5.76729,-83.5986 11.7673,-77.5986 17.7673,-77.5986"></path>
+<path fill="white" stroke="white" d="M110.233,-77.5986C116.233,-77.5986 122.233,-83.5986 122.233,-89.5986"></path>
+<path fill="white" stroke="white" d="M122.233,-124.401C122.233,-130.401 116.233,-136.401 110.233,-136.401"></path>
+<polyline fill="none" stroke="black" points="110.233,-136.401 17.7673,-136.401 "></polyline>
+<path fill="none" stroke="black" d="M17.7673,-136.401C11.7673,-136.401 5.76729,-130.401 5.76729,-124.401"></path>
+<polyline fill="none" stroke="black" points="5.76729,-124.401 5.76729,-89.5986 "></polyline>
+<path fill="none" stroke="black" d="M5.76729,-89.5986C5.76729,-83.5986 11.7673,-77.5986 17.7673,-77.5986"></path>
+<polyline fill="none" stroke="black" points="17.7673,-77.5986 110.233,-77.5986 "></polyline>
+<path fill="none" stroke="black" d="M110.233,-77.5986C116.233,-77.5986 122.233,-83.5986 122.233,-89.5986"></path>
+<polyline fill="none" stroke="black" points="122.233,-89.5986 122.233,-124.401 "></polyline>
+<path fill="none" stroke="black" d="M122.233,-124.401C122.233,-130.401 116.233,-136.401 110.233,-136.401"></path>
+<text text-anchor="middle" x="64" y="-119.6" font-family="Times,serif" font-size="14.00">BinaryExpression</text>
+<text text-anchor="middle" x="64" y="-102.8" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="64" y="-86" font-family="Times,serif" font-size="14.00">Literal (10)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M64,-172.524C64,-163.777 64,-154.867 64,-146.572"></path>
+<polygon fill="black" stroke="black" points="67.5001,-146.452 64,-136.452 60.5001,-146.452 67.5001,-146.452"></polygon>
+</g>
+
+<g id="node4" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="110.977,-41.6019 17.0234,-41.6019 5.02345,-29.6019 5.02345,-12.3981 17.0234,-0.398095 110.977,-0.398095 122.977,-12.3981 122.977,-29.6019 110.977,-41.6019"></polygon>
+<path fill="white" stroke="white" d="M17.0234,-41.6019C11.0234,-41.6019 5.02345,-35.6019 5.02345,-29.6019"></path>
+<path fill="white" stroke="white" d="M5.02345,-12.3981C5.02345,-6.3981 11.0234,-0.398095 17.0234,-0.398095"></path>
+<path fill="white" stroke="white" d="M110.977,-0.398095C116.977,-0.398095 122.977,-6.3981 122.977,-12.3981"></path>
+<path fill="white" stroke="white" d="M122.977,-29.6019C122.977,-35.6019 116.977,-41.6019 110.977,-41.6019"></path>
+<polyline fill="none" stroke="black" points="110.977,-41.6019 17.0234,-41.6019 "></polyline>
+<path fill="none" stroke="black" d="M17.0234,-41.6019C11.0234,-41.6019 5.02345,-35.6019 5.02345,-29.6019"></path>
+<polyline fill="none" stroke="black" points="5.02345,-29.6019 5.02345,-12.3981 "></polyline>
+<path fill="none" stroke="black" d="M5.02345,-12.3981C5.02345,-6.3981 11.0234,-0.398095 17.0234,-0.398095"></path>
+<polyline fill="none" stroke="black" points="17.0234,-0.398095 110.977,-0.398095 "></polyline>
+<path fill="none" stroke="black" d="M110.977,-0.398095C116.977,-0.398095 122.977,-6.3981 122.977,-12.3981"></path>
+<polyline fill="none" stroke="black" points="122.977,-12.3981 122.977,-29.6019 "></polyline>
+<path fill="none" stroke="black" d="M122.977,-29.6019C122.977,-35.6019 116.977,-41.6019 110.977,-41.6019"></path>
+<text text-anchor="middle" x="64" y="-25.2" font-family="Times,serif" font-size="14.00">UpdateExpression</text>
+<text text-anchor="middle" x="64" y="-8.4" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="none" d="M64,-77.5614C64,-69.2619 64,-60.1709 64,-51.7903"></path>
+<polygon fill="none" stroke="none" points="67.5001,-51.6677 64,-41.6677 60.5001,-51.6678 67.5001,-51.6677"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-for-2.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-for-2.svg
@@ -1,0 +1,110 @@
+<?xml version="1.0"?>
+<svg width="278pt" height="394pt" viewBox="0.00 0.00 278.00 394.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 390)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="139" cy="-377" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node2" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="191.617,-331.3 86.3833,-331.3 74.3833,-319.3 74.3833,-234.7 86.3833,-222.7 191.617,-222.7 203.617,-234.7 203.617,-319.3 191.617,-331.3"></polygon>
+<path fill="white" stroke="white" d="M86.3833,-331.3C80.3833,-331.3 74.3833,-325.3 74.3833,-319.3"></path>
+<path fill="white" stroke="white" d="M74.3833,-234.7C74.3833,-228.7 80.3833,-222.7 86.3833,-222.7"></path>
+<path fill="white" stroke="white" d="M191.617,-222.7C197.617,-222.7 203.617,-228.7 203.617,-234.7"></path>
+<path fill="white" stroke="white" d="M203.617,-319.3C203.617,-325.3 197.617,-331.3 191.617,-331.3"></path>
+<polyline fill="none" stroke="black" points="191.617,-331.3 86.3833,-331.3 "></polyline>
+<path fill="none" stroke="black" d="M86.3833,-331.3C80.3833,-331.3 74.3833,-325.3 74.3833,-319.3"></path>
+<polyline fill="none" stroke="black" points="74.3833,-319.3 74.3833,-234.7 "></polyline>
+<path fill="none" stroke="black" d="M74.3833,-234.7C74.3833,-228.7 80.3833,-222.7 86.3833,-222.7"></path>
+<polyline fill="none" stroke="black" points="86.3833,-222.7 191.617,-222.7 "></polyline>
+<path fill="none" stroke="black" d="M191.617,-222.7C197.617,-222.7 203.617,-228.7 203.617,-234.7"></path>
+<polyline fill="none" stroke="black" points="203.617,-234.7 203.617,-319.3 "></polyline>
+<path fill="none" stroke="black" d="M203.617,-319.3C203.617,-325.3 197.617,-331.3 191.617,-331.3"></path>
+<text text-anchor="middle" x="139" y="-314.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="139" y="-298" font-family="Times,serif" font-size="14.00">ForStatement</text>
+<text text-anchor="middle" x="139" y="-281.2" font-family="Times,serif" font-size="14.00">VariableDeclaration</text>
+<text text-anchor="middle" x="139" y="-264.4" font-family="Times,serif" font-size="14.00">VariableDeclarator</text>
+<text text-anchor="middle" x="139" y="-247.6" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="139" y="-230.8" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M139,-367.98C139,-361.675 139,-352.238 139,-341.813"></path>
+<polygon fill="black" stroke="black" points="142.5,-341.586 139,-331.586 135.5,-341.586 142.5,-341.586"></polygon>
+</g>
+
+<g id="node3" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="185.233,-186.401 92.7673,-186.401 80.7673,-174.401 80.7673,-139.599 92.7673,-127.599 185.233,-127.599 197.233,-139.599 197.233,-174.401 185.233,-186.401"></polygon>
+<path fill="white" stroke="white" d="M92.7673,-186.401C86.7673,-186.401 80.7673,-180.401 80.7673,-174.401"></path>
+<path fill="white" stroke="white" d="M80.7673,-139.599C80.7673,-133.599 86.7673,-127.599 92.7673,-127.599"></path>
+<path fill="white" stroke="white" d="M185.233,-127.599C191.233,-127.599 197.233,-133.599 197.233,-139.599"></path>
+<path fill="white" stroke="white" d="M197.233,-174.401C197.233,-180.401 191.233,-186.401 185.233,-186.401"></path>
+<polyline fill="none" stroke="black" points="185.233,-186.401 92.7673,-186.401 "></polyline>
+<path fill="none" stroke="black" d="M92.7673,-186.401C86.7673,-186.401 80.7673,-180.401 80.7673,-174.401"></path>
+<polyline fill="none" stroke="black" points="80.7673,-174.401 80.7673,-139.599 "></polyline>
+<path fill="none" stroke="black" d="M80.7673,-139.599C80.7673,-133.599 86.7673,-127.599 92.7673,-127.599"></path>
+<polyline fill="none" stroke="black" points="92.7673,-127.599 185.233,-127.599 "></polyline>
+<path fill="none" stroke="black" d="M185.233,-127.599C191.233,-127.599 197.233,-133.599 197.233,-139.599"></path>
+<polyline fill="none" stroke="black" points="197.233,-139.599 197.233,-174.401 "></polyline>
+<path fill="none" stroke="black" d="M197.233,-174.401C197.233,-180.401 191.233,-186.401 185.233,-186.401"></path>
+<text text-anchor="middle" x="139" y="-169.6" font-family="Times,serif" font-size="14.00">BinaryExpression</text>
+<text text-anchor="middle" x="139" y="-152.8" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="139" y="-136" font-family="Times,serif" font-size="14.00">Literal (10)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M139,-222.524C139,-213.777 139,-204.867 139,-196.572"></path>
+<polygon fill="black" stroke="black" points="142.5,-196.452 139,-186.452 135.5,-196.452 142.5,-196.452"></polygon>
+</g>
+
+<g id="node4" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="122.147,-92 11.8526,-92 -0.147372,-80 -0.147372,-12 11.8526,0 122.147,0 134.147,-12 134.147,-80 122.147,-92"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-92C5.85263,-92 -0.147372,-86 -0.147372,-80"></path>
+<path fill="white" stroke="white" d="M-0.147372,-12C-0.147372,-6 5.85263,0 11.8526,0"></path>
+<path fill="white" stroke="white" d="M122.147,0C128.147,0 134.147,-6 134.147,-12"></path>
+<path fill="white" stroke="white" d="M134.147,-80C134.147,-86 128.147,-92 122.147,-92"></path>
+<polyline fill="none" stroke="black" points="122.147,-92 11.8526,-92 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-92C5.85263,-92 -0.147372,-86 -0.147372,-80"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-80 -0.147372,-12 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-12C-0.147372,-6 5.85263,0 11.8526,0"></path>
+<polyline fill="none" stroke="black" points="11.8526,0 122.147,0 "></polyline>
+<path fill="none" stroke="black" d="M122.147,0C128.147,0 134.147,-6 134.147,-12"></path>
+<polyline fill="none" stroke="black" points="134.147,-12 134.147,-80 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-80C134.147,-86 128.147,-92 122.147,-92"></path>
+<text text-anchor="middle" x="67" y="-75.4" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-58.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-41.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-25" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-8.2" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M120.271,-127.646C114.784,-119.339 108.595,-109.971 102.429,-100.636"></path>
+<polygon fill="black" stroke="black" points="105.226,-98.519 96.7935,-92.1041 99.3848,-102.377 105.226,-98.519"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="257.977,-66.6019 164.023,-66.6019 152.023,-54.6019 152.023,-37.3981 164.023,-25.3981 257.977,-25.3981 269.977,-37.3981 269.977,-54.6019 257.977,-66.6019"></polygon>
+<path fill="white" stroke="white" d="M164.023,-66.6019C158.023,-66.6019 152.023,-60.6019 152.023,-54.6019"></path>
+<path fill="white" stroke="white" d="M152.023,-37.3981C152.023,-31.3981 158.023,-25.3981 164.023,-25.3981"></path>
+<path fill="white" stroke="white" d="M257.977,-25.3981C263.977,-25.3981 269.977,-31.3981 269.977,-37.3981"></path>
+<path fill="white" stroke="white" d="M269.977,-54.6019C269.977,-60.6019 263.977,-66.6019 257.977,-66.6019"></path>
+<polyline fill="none" stroke="black" points="257.977,-66.6019 164.023,-66.6019 "></polyline>
+<path fill="none" stroke="black" d="M164.023,-66.6019C158.023,-66.6019 152.023,-60.6019 152.023,-54.6019"></path>
+<polyline fill="none" stroke="black" points="152.023,-54.6019 152.023,-37.3981 "></polyline>
+<path fill="none" stroke="black" d="M152.023,-37.3981C152.023,-31.3981 158.023,-25.3981 164.023,-25.3981"></path>
+<polyline fill="none" stroke="black" points="164.023,-25.3981 257.977,-25.3981 "></polyline>
+<path fill="none" stroke="black" d="M257.977,-25.3981C263.977,-25.3981 269.977,-31.3981 269.977,-37.3981"></path>
+<polyline fill="none" stroke="black" points="269.977,-37.3981 269.977,-54.6019 "></polyline>
+<path fill="none" stroke="black" d="M269.977,-54.6019C269.977,-60.6019 263.977,-66.6019 257.977,-66.6019"></path>
+<text text-anchor="middle" x="211" y="-50.2" font-family="Times,serif" font-size="14.00">UpdateExpression</text>
+<text text-anchor="middle" x="211" y="-33.4" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge6" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="none" d="M157.729,-127.646C168.417,-111.466 181.766,-91.2577 192.427,-75.1175"></path>
+<polygon fill="none" stroke="none" points="195.448,-76.8939 198.039,-66.6208 189.607,-73.0357 195.448,-76.8939"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-for-3.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-for-3.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0"?>
+<svg width="186pt" height="472pt" viewBox="0.00 0.00 186.00 472.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 468)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="114" cy="-455" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node2" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="166.617,-409.3 61.3833,-409.3 49.3833,-397.3 49.3833,-312.7 61.3833,-300.7 166.617,-300.7 178.617,-312.7 178.617,-397.3 166.617,-409.3"></polygon>
+<path fill="white" stroke="white" d="M61.3833,-409.3C55.3833,-409.3 49.3833,-403.3 49.3833,-397.3"></path>
+<path fill="white" stroke="white" d="M49.3833,-312.7C49.3833,-306.7 55.3833,-300.7 61.3833,-300.7"></path>
+<path fill="white" stroke="white" d="M166.617,-300.7C172.617,-300.7 178.617,-306.7 178.617,-312.7"></path>
+<path fill="white" stroke="white" d="M178.617,-397.3C178.617,-403.3 172.617,-409.3 166.617,-409.3"></path>
+<polyline fill="none" stroke="black" points="166.617,-409.3 61.3833,-409.3 "></polyline>
+<path fill="none" stroke="black" d="M61.3833,-409.3C55.3833,-409.3 49.3833,-403.3 49.3833,-397.3"></path>
+<polyline fill="none" stroke="black" points="49.3833,-397.3 49.3833,-312.7 "></polyline>
+<path fill="none" stroke="black" d="M49.3833,-312.7C49.3833,-306.7 55.3833,-300.7 61.3833,-300.7"></path>
+<polyline fill="none" stroke="black" points="61.3833,-300.7 166.617,-300.7 "></polyline>
+<path fill="none" stroke="black" d="M166.617,-300.7C172.617,-300.7 178.617,-306.7 178.617,-312.7"></path>
+<polyline fill="none" stroke="black" points="178.617,-312.7 178.617,-397.3 "></polyline>
+<path fill="none" stroke="black" d="M178.617,-397.3C178.617,-403.3 172.617,-409.3 166.617,-409.3"></path>
+<text text-anchor="middle" x="114" y="-392.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="114" y="-376" font-family="Times,serif" font-size="14.00">ForStatement</text>
+<text text-anchor="middle" x="114" y="-359.2" font-family="Times,serif" font-size="14.00">VariableDeclaration</text>
+<text text-anchor="middle" x="114" y="-342.4" font-family="Times,serif" font-size="14.00">VariableDeclarator</text>
+<text text-anchor="middle" x="114" y="-325.6" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="114" y="-308.8" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M114,-445.98C114,-439.675 114,-430.238 114,-419.813"></path>
+<polygon fill="black" stroke="black" points="117.5,-419.586 114,-409.586 110.5,-419.586 117.5,-419.586"></polygon>
+</g>
+
+<g id="node3" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="160.233,-264.401 67.7673,-264.401 55.7673,-252.401 55.7673,-217.599 67.7673,-205.599 160.233,-205.599 172.233,-217.599 172.233,-252.401 160.233,-264.401"></polygon>
+<path fill="white" stroke="white" d="M67.7673,-264.401C61.7673,-264.401 55.7673,-258.401 55.7673,-252.401"></path>
+<path fill="white" stroke="white" d="M55.7673,-217.599C55.7673,-211.599 61.7673,-205.599 67.7673,-205.599"></path>
+<path fill="white" stroke="white" d="M160.233,-205.599C166.233,-205.599 172.233,-211.599 172.233,-217.599"></path>
+<path fill="white" stroke="white" d="M172.233,-252.401C172.233,-258.401 166.233,-264.401 160.233,-264.401"></path>
+<polyline fill="none" stroke="black" points="160.233,-264.401 67.7673,-264.401 "></polyline>
+<path fill="none" stroke="black" d="M67.7673,-264.401C61.7673,-264.401 55.7673,-258.401 55.7673,-252.401"></path>
+<polyline fill="none" stroke="black" points="55.7673,-252.401 55.7673,-217.599 "></polyline>
+<path fill="none" stroke="black" d="M55.7673,-217.599C55.7673,-211.599 61.7673,-205.599 67.7673,-205.599"></path>
+<polyline fill="none" stroke="black" points="67.7673,-205.599 160.233,-205.599 "></polyline>
+<path fill="none" stroke="black" d="M160.233,-205.599C166.233,-205.599 172.233,-211.599 172.233,-217.599"></path>
+<polyline fill="none" stroke="black" points="172.233,-217.599 172.233,-252.401 "></polyline>
+<path fill="none" stroke="black" d="M172.233,-252.401C172.233,-258.401 166.233,-264.401 160.233,-264.401"></path>
+<text text-anchor="middle" x="114" y="-247.6" font-family="Times,serif" font-size="14.00">BinaryExpression</text>
+<text text-anchor="middle" x="114" y="-230.8" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="114" y="-214" font-family="Times,serif" font-size="14.00">Literal (10)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M114,-300.524C114,-291.777 114,-282.867 114,-274.572"></path>
+<polygon fill="black" stroke="black" points="117.5,-274.452 114,-264.452 110.5,-274.452 117.5,-274.452"></polygon>
+</g>
+
+<g id="node4" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="122.147,-170 11.8526,-170 -0.147372,-158 -0.147372,-90 11.8526,-78 122.147,-78 134.147,-90 134.147,-158 122.147,-170"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-170C5.85263,-170 -0.147372,-164 -0.147372,-158"></path>
+<path fill="white" stroke="white" d="M-0.147372,-90C-0.147372,-84 5.85263,-78 11.8526,-78"></path>
+<path fill="white" stroke="white" d="M122.147,-78C128.147,-78 134.147,-84 134.147,-90"></path>
+<path fill="white" stroke="white" d="M134.147,-158C134.147,-164 128.147,-170 122.147,-170"></path>
+<polyline fill="none" stroke="black" points="122.147,-170 11.8526,-170 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-170C5.85263,-170 -0.147372,-164 -0.147372,-158"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-158 -0.147372,-90 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-90C-0.147372,-84 5.85263,-78 11.8526,-78"></path>
+<polyline fill="none" stroke="black" points="11.8526,-78 122.147,-78 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-78C128.147,-78 134.147,-84 134.147,-90"></path>
+<polyline fill="none" stroke="black" points="134.147,-90 134.147,-158 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-158C134.147,-164 128.147,-170 122.147,-170"></path>
+<text text-anchor="middle" x="67" y="-153.4" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-136.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-119.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-103" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-86.2" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M101.774,-205.646C98.3019,-197.594 94.3994,-188.543 90.4971,-179.493"></path>
+<polygon fill="black" stroke="black" points="93.6221,-177.901 86.4485,-170.104 87.1942,-180.673 93.6221,-177.901"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="160.977,-41.6019 67.0234,-41.6019 55.0234,-29.6019 55.0234,-12.3981 67.0234,-0.398095 160.977,-0.398095 172.977,-12.3981 172.977,-29.6019 160.977,-41.6019"></polygon>
+<path fill="white" stroke="white" d="M67.0234,-41.6019C61.0234,-41.6019 55.0234,-35.6019 55.0234,-29.6019"></path>
+<path fill="white" stroke="white" d="M55.0234,-12.3981C55.0234,-6.3981 61.0234,-0.398095 67.0234,-0.398095"></path>
+<path fill="white" stroke="white" d="M160.977,-0.398095C166.977,-0.398095 172.977,-6.3981 172.977,-12.3981"></path>
+<path fill="white" stroke="white" d="M172.977,-29.6019C172.977,-35.6019 166.977,-41.6019 160.977,-41.6019"></path>
+<polyline fill="none" stroke="black" points="160.977,-41.6019 67.0234,-41.6019 "></polyline>
+<path fill="none" stroke="black" d="M67.0234,-41.6019C61.0234,-41.6019 55.0234,-35.6019 55.0234,-29.6019"></path>
+<polyline fill="none" stroke="black" points="55.0234,-29.6019 55.0234,-12.3981 "></polyline>
+<path fill="none" stroke="black" d="M55.0234,-12.3981C55.0234,-6.3981 61.0234,-0.398095 67.0234,-0.398095"></path>
+<polyline fill="none" stroke="black" points="67.0234,-0.398095 160.977,-0.398095 "></polyline>
+<path fill="none" stroke="black" d="M160.977,-0.398095C166.977,-0.398095 172.977,-6.3981 172.977,-12.3981"></path>
+<polyline fill="none" stroke="black" points="172.977,-12.3981 172.977,-29.6019 "></polyline>
+<path fill="none" stroke="black" d="M172.977,-29.6019C172.977,-35.6019 166.977,-41.6019 160.977,-41.6019"></path>
+<text text-anchor="middle" x="114" y="-25.2" font-family="Times,serif" font-size="14.00">UpdateExpression</text>
+<text text-anchor="middle" x="114" y="-8.4" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge6" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="red" d="M88.0256,-77.8174C92.2417,-68.7572 96.5653,-59.4661 100.445,-51.1281"></path>
+<polygon fill="red" stroke="red" points="103.718,-52.392 104.763,-41.8489 97.3711,-49.4386 103.718,-52.392"></polygon>
+</g>
+
+<g id="edge8" class="edge"><title>s1_4-&gt;s1_2</title>
+<path fill="none" stroke="none" d="M127.225,-41.8137C133.324,-52.1325 139.891,-65.235 143,-78 152.676,-117.727 151.633,-130.033 143,-170 141.091,-178.837 137.857,-187.92 134.226,-196.368"></path>
+<polygon fill="none" stroke="none" points="130.985,-195.038 130.005,-205.588 137.35,-197.952 130.985,-195.038"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-for-4.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-for-4.svg
@@ -1,0 +1,115 @@
+<?xml version="1.0"?>
+<svg width="186pt" height="472pt" viewBox="0.00 0.00 186.00 472.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 468)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="114" cy="-455" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node2" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="166.617,-409.3 61.3833,-409.3 49.3833,-397.3 49.3833,-312.7 61.3833,-300.7 166.617,-300.7 178.617,-312.7 178.617,-397.3 166.617,-409.3"></polygon>
+<path fill="white" stroke="white" d="M61.3833,-409.3C55.3833,-409.3 49.3833,-403.3 49.3833,-397.3"></path>
+<path fill="white" stroke="white" d="M49.3833,-312.7C49.3833,-306.7 55.3833,-300.7 61.3833,-300.7"></path>
+<path fill="white" stroke="white" d="M166.617,-300.7C172.617,-300.7 178.617,-306.7 178.617,-312.7"></path>
+<path fill="white" stroke="white" d="M178.617,-397.3C178.617,-403.3 172.617,-409.3 166.617,-409.3"></path>
+<polyline fill="none" stroke="black" points="166.617,-409.3 61.3833,-409.3 "></polyline>
+<path fill="none" stroke="black" d="M61.3833,-409.3C55.3833,-409.3 49.3833,-403.3 49.3833,-397.3"></path>
+<polyline fill="none" stroke="black" points="49.3833,-397.3 49.3833,-312.7 "></polyline>
+<path fill="none" stroke="black" d="M49.3833,-312.7C49.3833,-306.7 55.3833,-300.7 61.3833,-300.7"></path>
+<polyline fill="none" stroke="black" points="61.3833,-300.7 166.617,-300.7 "></polyline>
+<path fill="none" stroke="black" d="M166.617,-300.7C172.617,-300.7 178.617,-306.7 178.617,-312.7"></path>
+<polyline fill="none" stroke="black" points="178.617,-312.7 178.617,-397.3 "></polyline>
+<path fill="none" stroke="black" d="M178.617,-397.3C178.617,-403.3 172.617,-409.3 166.617,-409.3"></path>
+<text text-anchor="middle" x="114" y="-392.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="114" y="-376" font-family="Times,serif" font-size="14.00">ForStatement</text>
+<text text-anchor="middle" x="114" y="-359.2" font-family="Times,serif" font-size="14.00">VariableDeclaration</text>
+<text text-anchor="middle" x="114" y="-342.4" font-family="Times,serif" font-size="14.00">VariableDeclarator</text>
+<text text-anchor="middle" x="114" y="-325.6" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="114" y="-308.8" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M114,-445.98C114,-439.675 114,-430.238 114,-419.813"></path>
+<polygon fill="black" stroke="black" points="117.5,-419.586 114,-409.586 110.5,-419.586 117.5,-419.586"></polygon>
+</g>
+
+<g id="node3" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="160.233,-264.401 67.7673,-264.401 55.7673,-252.401 55.7673,-217.599 67.7673,-205.599 160.233,-205.599 172.233,-217.599 172.233,-252.401 160.233,-264.401"></polygon>
+<path fill="white" stroke="white" d="M67.7673,-264.401C61.7673,-264.401 55.7673,-258.401 55.7673,-252.401"></path>
+<path fill="white" stroke="white" d="M55.7673,-217.599C55.7673,-211.599 61.7673,-205.599 67.7673,-205.599"></path>
+<path fill="white" stroke="white" d="M160.233,-205.599C166.233,-205.599 172.233,-211.599 172.233,-217.599"></path>
+<path fill="white" stroke="white" d="M172.233,-252.401C172.233,-258.401 166.233,-264.401 160.233,-264.401"></path>
+<polyline fill="none" stroke="black" points="160.233,-264.401 67.7673,-264.401 "></polyline>
+<path fill="none" stroke="black" d="M67.7673,-264.401C61.7673,-264.401 55.7673,-258.401 55.7673,-252.401"></path>
+<polyline fill="none" stroke="black" points="55.7673,-252.401 55.7673,-217.599 "></polyline>
+<path fill="none" stroke="black" d="M55.7673,-217.599C55.7673,-211.599 61.7673,-205.599 67.7673,-205.599"></path>
+<polyline fill="none" stroke="black" points="67.7673,-205.599 160.233,-205.599 "></polyline>
+<path fill="none" stroke="black" d="M160.233,-205.599C166.233,-205.599 172.233,-211.599 172.233,-217.599"></path>
+<polyline fill="none" stroke="black" points="172.233,-217.599 172.233,-252.401 "></polyline>
+<path fill="none" stroke="black" d="M172.233,-252.401C172.233,-258.401 166.233,-264.401 160.233,-264.401"></path>
+<text text-anchor="middle" x="114" y="-247.6" font-family="Times,serif" font-size="14.00">BinaryExpression</text>
+<text text-anchor="middle" x="114" y="-230.8" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="114" y="-214" font-family="Times,serif" font-size="14.00">Literal (10)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M114,-300.524C114,-291.777 114,-282.867 114,-274.572"></path>
+<polygon fill="black" stroke="black" points="117.5,-274.452 114,-264.452 110.5,-274.452 117.5,-274.452"></polygon>
+</g>
+
+<g id="node4" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="122.147,-170 11.8526,-170 -0.147372,-158 -0.147372,-90 11.8526,-78 122.147,-78 134.147,-90 134.147,-158 122.147,-170"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-170C5.85263,-170 -0.147372,-164 -0.147372,-158"></path>
+<path fill="white" stroke="white" d="M-0.147372,-90C-0.147372,-84 5.85263,-78 11.8526,-78"></path>
+<path fill="white" stroke="white" d="M122.147,-78C128.147,-78 134.147,-84 134.147,-90"></path>
+<path fill="white" stroke="white" d="M134.147,-158C134.147,-164 128.147,-170 122.147,-170"></path>
+<polyline fill="none" stroke="black" points="122.147,-170 11.8526,-170 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-170C5.85263,-170 -0.147372,-164 -0.147372,-158"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-158 -0.147372,-90 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-90C-0.147372,-84 5.85263,-78 11.8526,-78"></path>
+<polyline fill="none" stroke="black" points="11.8526,-78 122.147,-78 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-78C128.147,-78 134.147,-84 134.147,-90"></path>
+<polyline fill="none" stroke="black" points="134.147,-90 134.147,-158 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-158C134.147,-164 128.147,-170 122.147,-170"></path>
+<text text-anchor="middle" x="67" y="-153.4" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-136.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-119.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-103" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-86.2" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M101.774,-205.646C98.3019,-197.594 94.3994,-188.543 90.4971,-179.493"></path>
+<polygon fill="black" stroke="black" points="93.6221,-177.901 86.4485,-170.104 87.1942,-180.673 93.6221,-177.901"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="160.977,-41.6019 67.0234,-41.6019 55.0234,-29.6019 55.0234,-12.3981 67.0234,-0.398095 160.977,-0.398095 172.977,-12.3981 172.977,-29.6019 160.977,-41.6019"></polygon>
+<path fill="white" stroke="white" d="M67.0234,-41.6019C61.0234,-41.6019 55.0234,-35.6019 55.0234,-29.6019"></path>
+<path fill="white" stroke="white" d="M55.0234,-12.3981C55.0234,-6.3981 61.0234,-0.398095 67.0234,-0.398095"></path>
+<path fill="white" stroke="white" d="M160.977,-0.398095C166.977,-0.398095 172.977,-6.3981 172.977,-12.3981"></path>
+<path fill="white" stroke="white" d="M172.977,-29.6019C172.977,-35.6019 166.977,-41.6019 160.977,-41.6019"></path>
+<polyline fill="none" stroke="black" points="160.977,-41.6019 67.0234,-41.6019 "></polyline>
+<path fill="none" stroke="black" d="M67.0234,-41.6019C61.0234,-41.6019 55.0234,-35.6019 55.0234,-29.6019"></path>
+<polyline fill="none" stroke="black" points="55.0234,-29.6019 55.0234,-12.3981 "></polyline>
+<path fill="none" stroke="black" d="M55.0234,-12.3981C55.0234,-6.3981 61.0234,-0.398095 67.0234,-0.398095"></path>
+<polyline fill="none" stroke="black" points="67.0234,-0.398095 160.977,-0.398095 "></polyline>
+<path fill="none" stroke="black" d="M160.977,-0.398095C166.977,-0.398095 172.977,-6.3981 172.977,-12.3981"></path>
+<polyline fill="none" stroke="black" points="172.977,-12.3981 172.977,-29.6019 "></polyline>
+<path fill="none" stroke="black" d="M172.977,-29.6019C172.977,-35.6019 166.977,-41.6019 160.977,-41.6019"></path>
+<text text-anchor="middle" x="114" y="-25.2" font-family="Times,serif" font-size="14.00">UpdateExpression</text>
+<text text-anchor="middle" x="114" y="-8.4" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M88.0256,-77.8174C92.2417,-68.7572 96.5653,-59.4661 100.445,-51.1281"></path>
+<polygon fill="black" stroke="black" points="103.718,-52.392 104.763,-41.8489 97.3711,-49.4386 103.718,-52.392"></polygon>
+</g>
+
+<g id="edge7" class="edge"><title>s1_4-&gt;s1_2</title>
+<path fill="none" stroke="red" d="M127.225,-41.8137C133.324,-52.1325 139.891,-65.235 143,-78 152.676,-117.727 151.633,-130.033 143,-170 141.091,-178.837 137.857,-187.92 134.226,-196.368"></path>
+<polygon fill="red" stroke="red" points="130.985,-195.038 130.005,-205.588 137.35,-197.952 130.985,-195.038"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-for-5.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-for-5.svg
@@ -1,0 +1,149 @@
+<?xml version="1.0"?>
+<svg width="332pt" height="472pt" viewBox="0.00 0.00 332.00 472.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 468)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="162" cy="-455" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="214.617,-409.3 109.383,-409.3 97.3833,-397.3 97.3833,-312.7 109.383,-300.7 214.617,-300.7 226.617,-312.7 226.617,-397.3 214.617,-409.3"></polygon>
+<path fill="white" stroke="white" d="M109.383,-409.3C103.383,-409.3 97.3833,-403.3 97.3833,-397.3"></path>
+<path fill="white" stroke="white" d="M97.3833,-312.7C97.3833,-306.7 103.383,-300.7 109.383,-300.7"></path>
+<path fill="white" stroke="white" d="M214.617,-300.7C220.617,-300.7 226.617,-306.7 226.617,-312.7"></path>
+<path fill="white" stroke="white" d="M226.617,-397.3C226.617,-403.3 220.617,-409.3 214.617,-409.3"></path>
+<polyline fill="none" stroke="black" points="214.617,-409.3 109.383,-409.3 "></polyline>
+<path fill="none" stroke="black" d="M109.383,-409.3C103.383,-409.3 97.3833,-403.3 97.3833,-397.3"></path>
+<polyline fill="none" stroke="black" points="97.3833,-397.3 97.3833,-312.7 "></polyline>
+<path fill="none" stroke="black" d="M97.3833,-312.7C97.3833,-306.7 103.383,-300.7 109.383,-300.7"></path>
+<polyline fill="none" stroke="black" points="109.383,-300.7 214.617,-300.7 "></polyline>
+<path fill="none" stroke="black" d="M214.617,-300.7C220.617,-300.7 226.617,-306.7 226.617,-312.7"></path>
+<polyline fill="none" stroke="black" points="226.617,-312.7 226.617,-397.3 "></polyline>
+<path fill="none" stroke="black" d="M226.617,-397.3C226.617,-403.3 220.617,-409.3 214.617,-409.3"></path>
+<text text-anchor="middle" x="162" y="-392.8" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="162" y="-376" font-family="Times,serif" font-size="14.00">ForStatement</text>
+<text text-anchor="middle" x="162" y="-359.2" font-family="Times,serif" font-size="14.00">VariableDeclaration</text>
+<text text-anchor="middle" x="162" y="-342.4" font-family="Times,serif" font-size="14.00">VariableDeclarator</text>
+<text text-anchor="middle" x="162" y="-325.6" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="162" y="-308.8" font-family="Times,serif" font-size="14.00">Literal (0)</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M162,-445.98C162,-439.675 162,-430.238 162,-419.813"></path>
+<polygon fill="black" stroke="black" points="165.5,-419.586 162,-409.586 158.5,-419.586 165.5,-419.586"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="257" cy="-21" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="257" cy="-21" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="208.233,-264.401 115.767,-264.401 103.767,-252.401 103.767,-217.599 115.767,-205.599 208.233,-205.599 220.233,-217.599 220.233,-252.401 208.233,-264.401"></polygon>
+<path fill="white" stroke="white" d="M115.767,-264.401C109.767,-264.401 103.767,-258.401 103.767,-252.401"></path>
+<path fill="white" stroke="white" d="M103.767,-217.599C103.767,-211.599 109.767,-205.599 115.767,-205.599"></path>
+<path fill="white" stroke="white" d="M208.233,-205.599C214.233,-205.599 220.233,-211.599 220.233,-217.599"></path>
+<path fill="white" stroke="white" d="M220.233,-252.401C220.233,-258.401 214.233,-264.401 208.233,-264.401"></path>
+<polyline fill="none" stroke="black" points="208.233,-264.401 115.767,-264.401 "></polyline>
+<path fill="none" stroke="black" d="M115.767,-264.401C109.767,-264.401 103.767,-258.401 103.767,-252.401"></path>
+<polyline fill="none" stroke="black" points="103.767,-252.401 103.767,-217.599 "></polyline>
+<path fill="none" stroke="black" d="M103.767,-217.599C103.767,-211.599 109.767,-205.599 115.767,-205.599"></path>
+<polyline fill="none" stroke="black" points="115.767,-205.599 208.233,-205.599 "></polyline>
+<path fill="none" stroke="black" d="M208.233,-205.599C214.233,-205.599 220.233,-211.599 220.233,-217.599"></path>
+<polyline fill="none" stroke="black" points="220.233,-217.599 220.233,-252.401 "></polyline>
+<path fill="none" stroke="black" d="M220.233,-252.401C220.233,-258.401 214.233,-264.401 208.233,-264.401"></path>
+<text text-anchor="middle" x="162" y="-247.6" font-family="Times,serif" font-size="14.00">BinaryExpression</text>
+<text text-anchor="middle" x="162" y="-230.8" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+<text text-anchor="middle" x="162" y="-214" font-family="Times,serif" font-size="14.00">Literal (10)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M162,-300.524C162,-291.777 162,-282.867 162,-274.572"></path>
+<polygon fill="black" stroke="black" points="165.5,-274.452 162,-264.452 158.5,-274.452 165.5,-274.452"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="122.147,-170 11.8526,-170 -0.147372,-158 -0.147372,-90 11.8526,-78 122.147,-78 134.147,-90 134.147,-158 122.147,-170"></polygon>
+<path fill="white" stroke="white" d="M11.8526,-170C5.85263,-170 -0.147372,-164 -0.147372,-158"></path>
+<path fill="white" stroke="white" d="M-0.147372,-90C-0.147372,-84 5.85263,-78 11.8526,-78"></path>
+<path fill="white" stroke="white" d="M122.147,-78C128.147,-78 134.147,-84 134.147,-90"></path>
+<path fill="white" stroke="white" d="M134.147,-158C134.147,-164 128.147,-170 122.147,-170"></path>
+<polyline fill="none" stroke="black" points="122.147,-170 11.8526,-170 "></polyline>
+<path fill="none" stroke="black" d="M11.8526,-170C5.85263,-170 -0.147372,-164 -0.147372,-158"></path>
+<polyline fill="none" stroke="black" points="-0.147372,-158 -0.147372,-90 "></polyline>
+<path fill="none" stroke="black" d="M-0.147372,-90C-0.147372,-84 5.85263,-78 11.8526,-78"></path>
+<polyline fill="none" stroke="black" points="11.8526,-78 122.147,-78 "></polyline>
+<path fill="none" stroke="black" d="M122.147,-78C128.147,-78 134.147,-84 134.147,-90"></path>
+<polyline fill="none" stroke="black" points="134.147,-90 134.147,-158 "></polyline>
+<path fill="none" stroke="black" d="M134.147,-158C134.147,-164 128.147,-170 122.147,-170"></path>
+<text text-anchor="middle" x="67" y="-153.4" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="67" y="-136.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="67" y="-119.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="67" y="-103" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+<text text-anchor="middle" x="67" y="-86.2" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M137.288,-205.646C129.826,-197.085 121.382,-187.396 113,-177.779"></path>
+<polygon fill="black" stroke="black" points="115.52,-175.343 106.311,-170.104 110.243,-179.942 115.52,-175.343"></polygon>
+</g>
+
+<g id="node7" class="node"><title>s1_5</title>
+<polygon fill="white" stroke="white" points="312.147,-153.401 201.853,-153.401 189.853,-141.401 189.853,-106.599 201.853,-94.5986 312.147,-94.5986 324.147,-106.599 324.147,-141.401 312.147,-153.401"></polygon>
+<path fill="white" stroke="white" d="M201.853,-153.401C195.853,-153.401 189.853,-147.401 189.853,-141.401"></path>
+<path fill="white" stroke="white" d="M189.853,-106.599C189.853,-100.599 195.853,-94.5986 201.853,-94.5986"></path>
+<path fill="white" stroke="white" d="M312.147,-94.5986C318.147,-94.5986 324.147,-100.599 324.147,-106.599"></path>
+<path fill="white" stroke="white" d="M324.147,-141.401C324.147,-147.401 318.147,-153.401 312.147,-153.401"></path>
+<polyline fill="none" stroke="black" points="312.147,-153.401 201.853,-153.401 "></polyline>
+<path fill="none" stroke="black" d="M201.853,-153.401C195.853,-153.401 189.853,-147.401 189.853,-141.401"></path>
+<polyline fill="none" stroke="black" points="189.853,-141.401 189.853,-106.599 "></polyline>
+<path fill="none" stroke="black" d="M189.853,-106.599C189.853,-100.599 195.853,-94.5986 201.853,-94.5986"></path>
+<polyline fill="none" stroke="black" points="201.853,-94.5986 312.147,-94.5986 "></polyline>
+<path fill="none" stroke="black" d="M312.147,-94.5986C318.147,-94.5986 324.147,-100.599 324.147,-106.599"></path>
+<polyline fill="none" stroke="black" points="324.147,-106.599 324.147,-141.401 "></polyline>
+<path fill="none" stroke="black" d="M324.147,-141.401C324.147,-147.401 318.147,-153.401 312.147,-153.401"></path>
+<text text-anchor="middle" x="257" y="-136.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="257" y="-119.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="257" y="-103" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge7" class="edge"><title>s1_2-&gt;s1_5</title>
+<path fill="none" stroke="black" d="M186.712,-205.646C198.587,-192.021 212.952,-175.539 225.593,-161.035"></path>
+<polygon fill="black" stroke="black" points="228.48,-163.05 232.412,-153.212 223.203,-158.451 228.48,-163.05"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="160.977,-41.6019 67.0234,-41.6019 55.0234,-29.6019 55.0234,-12.3981 67.0234,-0.398095 160.977,-0.398095 172.977,-12.3981 172.977,-29.6019 160.977,-41.6019"></polygon>
+<path fill="white" stroke="white" d="M67.0234,-41.6019C61.0234,-41.6019 55.0234,-35.6019 55.0234,-29.6019"></path>
+<path fill="white" stroke="white" d="M55.0234,-12.3981C55.0234,-6.3981 61.0234,-0.398095 67.0234,-0.398095"></path>
+<path fill="white" stroke="white" d="M160.977,-0.398095C166.977,-0.398095 172.977,-6.3981 172.977,-12.3981"></path>
+<path fill="white" stroke="white" d="M172.977,-29.6019C172.977,-35.6019 166.977,-41.6019 160.977,-41.6019"></path>
+<polyline fill="none" stroke="black" points="160.977,-41.6019 67.0234,-41.6019 "></polyline>
+<path fill="none" stroke="black" d="M67.0234,-41.6019C61.0234,-41.6019 55.0234,-35.6019 55.0234,-29.6019"></path>
+<polyline fill="none" stroke="black" points="55.0234,-29.6019 55.0234,-12.3981 "></polyline>
+<path fill="none" stroke="black" d="M55.0234,-12.3981C55.0234,-6.3981 61.0234,-0.398095 67.0234,-0.398095"></path>
+<polyline fill="none" stroke="black" points="67.0234,-0.398095 160.977,-0.398095 "></polyline>
+<path fill="none" stroke="black" d="M160.977,-0.398095C166.977,-0.398095 172.977,-6.3981 172.977,-12.3981"></path>
+<polyline fill="none" stroke="black" points="172.977,-12.3981 172.977,-29.6019 "></polyline>
+<path fill="none" stroke="black" d="M172.977,-29.6019C172.977,-35.6019 166.977,-41.6019 160.977,-41.6019"></path>
+<text text-anchor="middle" x="114" y="-25.2" font-family="Times,serif" font-size="14.00">UpdateExpression</text>
+<text text-anchor="middle" x="114" y="-8.4" font-family="Times,serif" font-size="14.00">Identifier (i)</text>
+</g>
+
+<g id="edge5" class="edge"><title>s1_3-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M88.0256,-77.8174C92.2417,-68.7572 96.5653,-59.4661 100.445,-51.1281"></path>
+<polygon fill="black" stroke="black" points="103.718,-52.392 104.763,-41.8489 97.3711,-49.4386 103.718,-52.392"></polygon>
+</g>
+
+<g id="edge6" class="edge"><title>s1_4-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M126.427,-41.7344C132.399,-52.1392 139.091,-65.3421 143,-78 155.006,-116.879 159.472,-163.404 161.108,-195.471"></path>
+<polygon fill="black" stroke="black" points="157.624,-195.923 161.561,-205.76 164.618,-195.615 157.624,-195.923"></polygon>
+</g>
+
+<g id="edge8" class="edge"><title>s1_5-&gt;final</title>
+<path fill="none" stroke="black" d="M257,-94.5971C257,-78.6959 257,-59.1538 257,-44.3521"></path>
+<polygon fill="black" stroke="black" points="260.5,-44.0959 257,-34.0959 253.5,-44.096 260.5,-44.0959"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-while-1.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-while-1.svg
@@ -1,0 +1,82 @@
+<?xml version="1.0"?>
+<svg width="152pt" height="322pt" viewBox="0.00 0.00 152.00 322.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 318)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="72" cy="-305" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node2" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="113.149,-259.602 30.8505,-259.602 18.8505,-247.602 18.8505,-230.398 30.8505,-218.398 113.149,-218.398 125.149,-230.398 125.149,-247.602 113.149,-259.602"></polygon>
+<path fill="white" stroke="white" d="M30.8505,-259.602C24.8505,-259.602 18.8505,-253.602 18.8505,-247.602"></path>
+<path fill="white" stroke="white" d="M18.8505,-230.398C18.8505,-224.398 24.8505,-218.398 30.8505,-218.398"></path>
+<path fill="white" stroke="white" d="M113.149,-218.398C119.149,-218.398 125.149,-224.398 125.149,-230.398"></path>
+<path fill="white" stroke="white" d="M125.149,-247.602C125.149,-253.602 119.149,-259.602 113.149,-259.602"></path>
+<polyline fill="none" stroke="black" points="113.149,-259.602 30.8505,-259.602 "></polyline>
+<path fill="none" stroke="black" d="M30.8505,-259.602C24.8505,-259.602 18.8505,-253.602 18.8505,-247.602"></path>
+<polyline fill="none" stroke="black" points="18.8505,-247.602 18.8505,-230.398 "></polyline>
+<path fill="none" stroke="black" d="M18.8505,-230.398C18.8505,-224.398 24.8505,-218.398 30.8505,-218.398"></path>
+<polyline fill="none" stroke="black" points="30.8505,-218.398 113.149,-218.398 "></polyline>
+<path fill="none" stroke="black" d="M113.149,-218.398C119.149,-218.398 125.149,-224.398 125.149,-230.398"></path>
+<polyline fill="none" stroke="black" points="125.149,-230.398 125.149,-247.602 "></polyline>
+<path fill="none" stroke="black" d="M125.149,-247.602C125.149,-253.602 119.149,-259.602 113.149,-259.602"></path>
+<text text-anchor="middle" x="72" y="-243.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="72" y="-226.4" font-family="Times,serif" font-size="14.00">WhileStatement</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M72,-295.894C72,-289.274 72,-279.485 72,-269.94"></path>
+<polygon fill="black" stroke="black" points="75.5001,-269.842 72,-259.842 68.5001,-269.842 75.5001,-269.842"></polygon>
+</g>
+
+<g id="node3" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="103.339,-182 40.6614,-182 28.6614,-170 28.6614,-158 40.6614,-146 103.339,-146 115.339,-158 115.339,-170 103.339,-182"></polygon>
+<path fill="white" stroke="white" d="M40.6614,-182C34.6614,-182 28.6614,-176 28.6614,-170"></path>
+<path fill="white" stroke="white" d="M28.6614,-158C28.6614,-152 34.6614,-146 40.6614,-146"></path>
+<path fill="white" stroke="white" d="M103.339,-146C109.339,-146 115.339,-152 115.339,-158"></path>
+<path fill="white" stroke="white" d="M115.339,-170C115.339,-176 109.339,-182 103.339,-182"></path>
+<polyline fill="none" stroke="black" points="103.339,-182 40.6614,-182 "></polyline>
+<path fill="none" stroke="black" d="M40.6614,-182C34.6614,-182 28.6614,-176 28.6614,-170"></path>
+<polyline fill="none" stroke="black" points="28.6614,-170 28.6614,-158 "></polyline>
+<path fill="none" stroke="black" d="M28.6614,-158C28.6614,-152 34.6614,-146 40.6614,-146"></path>
+<polyline fill="none" stroke="black" points="40.6614,-146 103.339,-146 "></polyline>
+<path fill="none" stroke="black" d="M103.339,-146C109.339,-146 115.339,-152 115.339,-158"></path>
+<polyline fill="none" stroke="black" points="115.339,-158 115.339,-170 "></polyline>
+<path fill="none" stroke="black" d="M115.339,-170C115.339,-176 109.339,-182 103.339,-182"></path>
+<text text-anchor="middle" x="72" y="-159.8" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M72,-218.052C72,-210.216 72,-201.089 72,-192.636"></path>
+<polygon fill="black" stroke="black" points="75.5001,-192.439 72,-182.439 68.5001,-192.439 75.5001,-192.439"></polygon>
+</g>
+
+<g id="node4" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="132.317,-109.3 11.6828,-109.3 -0.317209,-97.3002 -0.317209,-12.6998 11.6828,-0.699817 132.317,-0.699817 144.317,-12.6998 144.317,-97.3002 132.317,-109.3"></polygon>
+<path fill="white" stroke="white" d="M11.6828,-109.3C5.68279,-109.3 -0.317209,-103.3 -0.317209,-97.3002"></path>
+<path fill="white" stroke="white" d="M-0.317209,-12.6998C-0.317209,-6.69982 5.68279,-0.699817 11.6828,-0.699817"></path>
+<path fill="white" stroke="white" d="M132.317,-0.699817C138.317,-0.699817 144.317,-6.69982 144.317,-12.6998"></path>
+<path fill="white" stroke="white" d="M144.317,-97.3002C144.317,-103.3 138.317,-109.3 132.317,-109.3"></path>
+<polyline fill="none" stroke="black" points="132.317,-109.3 11.6828,-109.3 "></polyline>
+<path fill="none" stroke="black" d="M11.6828,-109.3C5.68279,-109.3 -0.317209,-103.3 -0.317209,-97.3002"></path>
+<polyline fill="none" stroke="black" points="-0.317209,-97.3002 -0.317209,-12.6998 "></polyline>
+<path fill="none" stroke="black" d="M-0.317209,-12.6998C-0.317209,-6.69982 5.68279,-0.699817 11.6828,-0.699817"></path>
+<polyline fill="none" stroke="black" points="11.6828,-0.699817 132.317,-0.699817 "></polyline>
+<path fill="none" stroke="black" d="M132.317,-0.699817C138.317,-0.699817 144.317,-6.69982 144.317,-12.6998"></path>
+<polyline fill="none" stroke="black" points="144.317,-12.6998 144.317,-97.3002 "></polyline>
+<path fill="none" stroke="black" d="M144.317,-97.3002C144.317,-103.3 138.317,-109.3 132.317,-109.3"></path>
+<text text-anchor="middle" x="72" y="-92.8" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="72" y="-76" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="72" y="-59.2" font-family="Times,serif" font-size="14.00">AssignmentExpression</text>
+<text text-anchor="middle" x="72" y="-42.4" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+<text text-anchor="middle" x="72" y="-25.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="72" y="-8.8" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M72,-145.809C72,-138.443 72,-129.338 72,-119.779"></path>
+<polygon fill="black" stroke="black" points="75.5001,-119.706 72,-109.706 68.5001,-119.706 75.5001,-119.706"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-while-2.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-while-2.svg
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<svg width="152pt" height="322pt" viewBox="0.00 0.00 152.00 322.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 318)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="72" cy="-305" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node2" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="113.149,-259.602 30.8505,-259.602 18.8505,-247.602 18.8505,-230.398 30.8505,-218.398 113.149,-218.398 125.149,-230.398 125.149,-247.602 113.149,-259.602"></polygon>
+<path fill="white" stroke="white" d="M30.8505,-259.602C24.8505,-259.602 18.8505,-253.602 18.8505,-247.602"></path>
+<path fill="white" stroke="white" d="M18.8505,-230.398C18.8505,-224.398 24.8505,-218.398 30.8505,-218.398"></path>
+<path fill="white" stroke="white" d="M113.149,-218.398C119.149,-218.398 125.149,-224.398 125.149,-230.398"></path>
+<path fill="white" stroke="white" d="M125.149,-247.602C125.149,-253.602 119.149,-259.602 113.149,-259.602"></path>
+<polyline fill="none" stroke="black" points="113.149,-259.602 30.8505,-259.602 "></polyline>
+<path fill="none" stroke="black" d="M30.8505,-259.602C24.8505,-259.602 18.8505,-253.602 18.8505,-247.602"></path>
+<polyline fill="none" stroke="black" points="18.8505,-247.602 18.8505,-230.398 "></polyline>
+<path fill="none" stroke="black" d="M18.8505,-230.398C18.8505,-224.398 24.8505,-218.398 30.8505,-218.398"></path>
+<polyline fill="none" stroke="black" points="30.8505,-218.398 113.149,-218.398 "></polyline>
+<path fill="none" stroke="black" d="M113.149,-218.398C119.149,-218.398 125.149,-224.398 125.149,-230.398"></path>
+<polyline fill="none" stroke="black" points="125.149,-230.398 125.149,-247.602 "></polyline>
+<path fill="none" stroke="black" d="M125.149,-247.602C125.149,-253.602 119.149,-259.602 113.149,-259.602"></path>
+<text text-anchor="middle" x="72" y="-243.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="72" y="-226.4" font-family="Times,serif" font-size="14.00">WhileStatement</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M72,-295.894C72,-289.274 72,-279.485 72,-269.94"></path>
+<polygon fill="black" stroke="black" points="75.5001,-269.842 72,-259.842 68.5001,-269.842 75.5001,-269.842"></polygon>
+</g>
+
+<g id="node3" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="103.339,-182 40.6614,-182 28.6614,-170 28.6614,-158 40.6614,-146 103.339,-146 115.339,-158 115.339,-170 103.339,-182"></polygon>
+<path fill="white" stroke="white" d="M40.6614,-182C34.6614,-182 28.6614,-176 28.6614,-170"></path>
+<path fill="white" stroke="white" d="M28.6614,-158C28.6614,-152 34.6614,-146 40.6614,-146"></path>
+<path fill="white" stroke="white" d="M103.339,-146C109.339,-146 115.339,-152 115.339,-158"></path>
+<path fill="white" stroke="white" d="M115.339,-170C115.339,-176 109.339,-182 103.339,-182"></path>
+<polyline fill="none" stroke="black" points="103.339,-182 40.6614,-182 "></polyline>
+<path fill="none" stroke="black" d="M40.6614,-182C34.6614,-182 28.6614,-176 28.6614,-170"></path>
+<polyline fill="none" stroke="black" points="28.6614,-170 28.6614,-158 "></polyline>
+<path fill="none" stroke="black" d="M28.6614,-158C28.6614,-152 34.6614,-146 40.6614,-146"></path>
+<polyline fill="none" stroke="black" points="40.6614,-146 103.339,-146 "></polyline>
+<path fill="none" stroke="black" d="M103.339,-146C109.339,-146 115.339,-152 115.339,-158"></path>
+<polyline fill="none" stroke="black" points="115.339,-158 115.339,-170 "></polyline>
+<path fill="none" stroke="black" d="M115.339,-170C115.339,-176 109.339,-182 103.339,-182"></path>
+<text text-anchor="middle" x="72" y="-159.8" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M72,-218.052C72,-210.216 72,-201.089 72,-192.636"></path>
+<polygon fill="black" stroke="black" points="75.5001,-192.439 72,-182.439 68.5001,-192.439 75.5001,-192.439"></polygon>
+</g>
+
+<g id="node4" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="132.317,-109.3 11.6828,-109.3 -0.317209,-97.3002 -0.317209,-12.6998 11.6828,-0.699817 132.317,-0.699817 144.317,-12.6998 144.317,-97.3002 132.317,-109.3"></polygon>
+<path fill="white" stroke="white" d="M11.6828,-109.3C5.68279,-109.3 -0.317209,-103.3 -0.317209,-97.3002"></path>
+<path fill="white" stroke="white" d="M-0.317209,-12.6998C-0.317209,-6.69982 5.68279,-0.699817 11.6828,-0.699817"></path>
+<path fill="white" stroke="white" d="M132.317,-0.699817C138.317,-0.699817 144.317,-6.69982 144.317,-12.6998"></path>
+<path fill="white" stroke="white" d="M144.317,-97.3002C144.317,-103.3 138.317,-109.3 132.317,-109.3"></path>
+<polyline fill="none" stroke="black" points="132.317,-109.3 11.6828,-109.3 "></polyline>
+<path fill="none" stroke="black" d="M11.6828,-109.3C5.68279,-109.3 -0.317209,-103.3 -0.317209,-97.3002"></path>
+<polyline fill="none" stroke="black" points="-0.317209,-97.3002 -0.317209,-12.6998 "></polyline>
+<path fill="none" stroke="black" d="M-0.317209,-12.6998C-0.317209,-6.69982 5.68279,-0.699817 11.6828,-0.699817"></path>
+<polyline fill="none" stroke="black" points="11.6828,-0.699817 132.317,-0.699817 "></polyline>
+<path fill="none" stroke="black" d="M132.317,-0.699817C138.317,-0.699817 144.317,-6.69982 144.317,-12.6998"></path>
+<polyline fill="none" stroke="black" points="144.317,-12.6998 144.317,-97.3002 "></polyline>
+<path fill="none" stroke="black" d="M144.317,-97.3002C144.317,-103.3 138.317,-109.3 132.317,-109.3"></path>
+<text text-anchor="middle" x="72" y="-92.8" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="72" y="-76" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="72" y="-59.2" font-family="Times,serif" font-size="14.00">AssignmentExpression</text>
+<text text-anchor="middle" x="72" y="-42.4" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+<text text-anchor="middle" x="72" y="-25.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="72" y="-8.8" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M66.8852,-145.809C66.0803,-138.443 65.5726,-129.338 65.362,-119.779"></path>
+<polygon fill="black" stroke="black" points="68.861,-119.666 65.25,-109.706 61.8615,-119.744 68.861,-119.666"></polygon>
+</g>
+
+<g id="edge6" class="edge"><title>s1_3-&gt;s1_2</title>
+<path fill="none" stroke="red" d="M78.75,-109.706C78.7461,-118.71 78.4872,-127.707 77.9735,-135.675"></path>
+<polygon fill="red" stroke="red" points="74.4717,-135.549 77.1148,-145.809 81.4467,-136.14 74.4717,-135.549"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/code-path-analysis/loop-event-example-while-3.svg
+++ b/docs/developer-guide/code-path-analysis/loop-event-example-while-3.svg
@@ -1,0 +1,121 @@
+<?xml version="1.0"?>
+<svg width="305pt" height="384pt" viewBox="0.00 0.00 305.00 384.00" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+<g id="graph1" class="graph" transform="scale(1 1) rotate(0) translate(4 380)">
+<title>_anonymous_0</title>
+
+<g id="node1" class="node"><title>initial</title>
+<ellipse fill="black" stroke="black" cx="72" cy="-367" rx="9" ry="9"></ellipse>
+</g>
+
+<g id="node3" class="node"><title>s1_1</title>
+<polygon fill="white" stroke="white" points="113.149,-321.602 30.8505,-321.602 18.8505,-309.602 18.8505,-292.398 30.8505,-280.398 113.149,-280.398 125.149,-292.398 125.149,-309.602 113.149,-321.602"></polygon>
+<path fill="white" stroke="white" d="M30.8505,-321.602C24.8505,-321.602 18.8505,-315.602 18.8505,-309.602"></path>
+<path fill="white" stroke="white" d="M18.8505,-292.398C18.8505,-286.398 24.8505,-280.398 30.8505,-280.398"></path>
+<path fill="white" stroke="white" d="M113.149,-280.398C119.149,-280.398 125.149,-286.398 125.149,-292.398"></path>
+<path fill="white" stroke="white" d="M125.149,-309.602C125.149,-315.602 119.149,-321.602 113.149,-321.602"></path>
+<polyline fill="none" stroke="black" points="113.149,-321.602 30.8505,-321.602 "></polyline>
+<path fill="none" stroke="black" d="M30.8505,-321.602C24.8505,-321.602 18.8505,-315.602 18.8505,-309.602"></path>
+<polyline fill="none" stroke="black" points="18.8505,-309.602 18.8505,-292.398 "></polyline>
+<path fill="none" stroke="black" d="M18.8505,-292.398C18.8505,-286.398 24.8505,-280.398 30.8505,-280.398"></path>
+<polyline fill="none" stroke="black" points="30.8505,-280.398 113.149,-280.398 "></polyline>
+<path fill="none" stroke="black" d="M113.149,-280.398C119.149,-280.398 125.149,-286.398 125.149,-292.398"></path>
+<polyline fill="none" stroke="black" points="125.149,-292.398 125.149,-309.602 "></polyline>
+<path fill="none" stroke="black" d="M125.149,-309.602C125.149,-315.602 119.149,-321.602 113.149,-321.602"></path>
+<text text-anchor="middle" x="72" y="-305.2" font-family="Times,serif" font-size="14.00">Program</text>
+<text text-anchor="middle" x="72" y="-288.4" font-family="Times,serif" font-size="14.00">WhileStatement</text>
+</g>
+
+<g id="edge2" class="edge"><title>initial-&gt;s1_1</title>
+<path fill="none" stroke="black" d="M72,-357.894C72,-351.274 72,-341.485 72,-331.94"></path>
+<polygon fill="black" stroke="black" points="75.5001,-331.842 72,-321.842 68.5001,-331.842 75.5001,-331.842"></polygon>
+</g>
+
+<g id="node2" class="node"><title>final</title>
+<ellipse fill="black" stroke="black" cx="230" cy="-13" rx="9" ry="9"></ellipse>
+<ellipse fill="none" stroke="black" cx="230" cy="-13" rx="13" ry="13"></ellipse>
+</g>
+
+<g id="node4" class="node"><title>s1_2</title>
+<polygon fill="white" stroke="white" points="103.339,-244 40.6614,-244 28.6614,-232 28.6614,-220 40.6614,-208 103.339,-208 115.339,-220 115.339,-232 103.339,-244"></polygon>
+<path fill="white" stroke="white" d="M40.6614,-244C34.6614,-244 28.6614,-238 28.6614,-232"></path>
+<path fill="white" stroke="white" d="M28.6614,-220C28.6614,-214 34.6614,-208 40.6614,-208"></path>
+<path fill="white" stroke="white" d="M103.339,-208C109.339,-208 115.339,-214 115.339,-220"></path>
+<path fill="white" stroke="white" d="M115.339,-232C115.339,-238 109.339,-244 103.339,-244"></path>
+<polyline fill="none" stroke="black" points="103.339,-244 40.6614,-244 "></polyline>
+<path fill="none" stroke="black" d="M40.6614,-244C34.6614,-244 28.6614,-238 28.6614,-232"></path>
+<polyline fill="none" stroke="black" points="28.6614,-232 28.6614,-220 "></polyline>
+<path fill="none" stroke="black" d="M28.6614,-220C28.6614,-214 34.6614,-208 40.6614,-208"></path>
+<polyline fill="none" stroke="black" points="40.6614,-208 103.339,-208 "></polyline>
+<path fill="none" stroke="black" d="M103.339,-208C109.339,-208 115.339,-214 115.339,-220"></path>
+<polyline fill="none" stroke="black" points="115.339,-220 115.339,-232 "></polyline>
+<path fill="none" stroke="black" d="M115.339,-232C115.339,-238 109.339,-244 103.339,-244"></path>
+<text text-anchor="middle" x="72" y="-221.8" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+</g>
+
+<g id="edge3" class="edge"><title>s1_1-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M72,-280.052C72,-272.216 72,-263.089 72,-254.636"></path>
+<polygon fill="black" stroke="black" points="75.5001,-254.439 72,-244.439 68.5001,-254.439 75.5001,-254.439"></polygon>
+</g>
+
+<g id="node5" class="node"><title>s1_3</title>
+<polygon fill="white" stroke="white" points="132.317,-171.3 11.6828,-171.3 -0.317209,-159.3 -0.317209,-74.6998 11.6828,-62.6998 132.317,-62.6998 144.317,-74.6998 144.317,-159.3 132.317,-171.3"></polygon>
+<path fill="white" stroke="white" d="M11.6828,-171.3C5.68279,-171.3 -0.317209,-165.3 -0.317209,-159.3"></path>
+<path fill="white" stroke="white" d="M-0.317209,-74.6998C-0.317209,-68.6998 5.68279,-62.6998 11.6828,-62.6998"></path>
+<path fill="white" stroke="white" d="M132.317,-62.6998C138.317,-62.6998 144.317,-68.6998 144.317,-74.6998"></path>
+<path fill="white" stroke="white" d="M144.317,-159.3C144.317,-165.3 138.317,-171.3 132.317,-171.3"></path>
+<polyline fill="none" stroke="black" points="132.317,-171.3 11.6828,-171.3 "></polyline>
+<path fill="none" stroke="black" d="M11.6828,-171.3C5.68279,-171.3 -0.317209,-165.3 -0.317209,-159.3"></path>
+<polyline fill="none" stroke="black" points="-0.317209,-159.3 -0.317209,-74.6998 "></polyline>
+<path fill="none" stroke="black" d="M-0.317209,-74.6998C-0.317209,-68.6998 5.68279,-62.6998 11.6828,-62.6998"></path>
+<polyline fill="none" stroke="black" points="11.6828,-62.6998 132.317,-62.6998 "></polyline>
+<path fill="none" stroke="black" d="M132.317,-62.6998C138.317,-62.6998 144.317,-68.6998 144.317,-74.6998"></path>
+<polyline fill="none" stroke="black" points="144.317,-74.6998 144.317,-159.3 "></polyline>
+<path fill="none" stroke="black" d="M144.317,-159.3C144.317,-165.3 138.317,-171.3 132.317,-171.3"></path>
+<text text-anchor="middle" x="72" y="-154.8" font-family="Times,serif" font-size="14.00">BlockStatement</text>
+<text text-anchor="middle" x="72" y="-138" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="72" y="-121.2" font-family="Times,serif" font-size="14.00">AssignmentExpression</text>
+<text text-anchor="middle" x="72" y="-104.4" font-family="Times,serif" font-size="14.00">Identifier (a)</text>
+<text text-anchor="middle" x="72" y="-87.6" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="72" y="-70.8" font-family="Times,serif" font-size="14.00">Identifier (foo)</text>
+</g>
+
+<g id="edge4" class="edge"><title>s1_2-&gt;s1_3</title>
+<path fill="none" stroke="black" d="M66.8852,-207.809C66.0803,-200.443 65.5726,-191.338 65.362,-181.779"></path>
+<polygon fill="black" stroke="black" points="68.861,-181.666 65.25,-171.706 61.8615,-181.744 68.861,-181.666"></polygon>
+</g>
+
+<g id="node6" class="node"><title>s1_4</title>
+<polygon fill="white" stroke="white" points="285.147,-146.401 174.853,-146.401 162.853,-134.401 162.853,-99.5986 174.853,-87.5986 285.147,-87.5986 297.147,-99.5986 297.147,-134.401 285.147,-146.401"></polygon>
+<path fill="white" stroke="white" d="M174.853,-146.401C168.853,-146.401 162.853,-140.401 162.853,-134.401"></path>
+<path fill="white" stroke="white" d="M162.853,-99.5986C162.853,-93.5986 168.853,-87.5986 174.853,-87.5986"></path>
+<path fill="white" stroke="white" d="M285.147,-87.5986C291.147,-87.5986 297.147,-93.5986 297.147,-99.5986"></path>
+<path fill="white" stroke="white" d="M297.147,-134.401C297.147,-140.401 291.147,-146.401 285.147,-146.401"></path>
+<polyline fill="none" stroke="black" points="285.147,-146.401 174.853,-146.401 "></polyline>
+<path fill="none" stroke="black" d="M174.853,-146.401C168.853,-146.401 162.853,-140.401 162.853,-134.401"></path>
+<polyline fill="none" stroke="black" points="162.853,-134.401 162.853,-99.5986 "></polyline>
+<path fill="none" stroke="black" d="M162.853,-99.5986C162.853,-93.5986 168.853,-87.5986 174.853,-87.5986"></path>
+<polyline fill="none" stroke="black" points="174.853,-87.5986 285.147,-87.5986 "></polyline>
+<path fill="none" stroke="black" d="M285.147,-87.5986C291.147,-87.5986 297.147,-93.5986 297.147,-99.5986"></path>
+<polyline fill="none" stroke="black" points="297.147,-99.5986 297.147,-134.401 "></polyline>
+<path fill="none" stroke="black" d="M297.147,-134.401C297.147,-140.401 291.147,-146.401 285.147,-146.401"></path>
+<text text-anchor="middle" x="230" y="-129.6" font-family="Times,serif" font-size="14.00">ExpressionStatement</text>
+<text text-anchor="middle" x="230" y="-112.8" font-family="Times,serif" font-size="14.00">CallExpression</text>
+<text text-anchor="middle" x="230" y="-96" font-family="Times,serif" font-size="14.00">Identifier (bar)</text>
+</g>
+
+<g id="edge6" class="edge"><title>s1_2-&gt;s1_4</title>
+<path fill="none" stroke="black" d="M98.7745,-207.789C114.625,-197.523 135.053,-184.16 153,-172 162.409,-165.625 172.395,-158.724 181.947,-152.055"></path>
+<polygon fill="black" stroke="black" points="184.021,-154.875 190.205,-146.273 180.006,-149.141 184.021,-154.875"></polygon>
+</g>
+
+<g id="edge5" class="edge"><title>s1_3-&gt;s1_2</title>
+<path fill="none" stroke="black" d="M78.75,-171.706C78.7461,-180.71 78.4872,-189.707 77.9735,-197.675"></path>
+<polygon fill="black" stroke="black" points="74.4717,-197.549 77.1148,-207.809 81.4467,-198.14 74.4717,-197.549"></polygon>
+</g>
+
+<g id="edge7" class="edge"><title>s1_4-&gt;final</title>
+<path fill="none" stroke="black" d="M230,-87.5873C230,-71.4284 230,-51.4784 230,-36.4288"></path>
+<polygon fill="black" stroke="black" points="233.5,-36.0194 230,-26.0195 226.5,-36.0195 233.5,-36.0194"></polygon>
+</g>
+</g>
+</svg>

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -313,6 +313,13 @@ Keep in mind that comments are technically not a part of the AST and are only at
 
 **Note:** One of the libraries adds AST node properties for comments - do not use these properties. Always use `sourceCode.getComments()` as this is the only guaranteed API for accessing comments (we will likely change how comments are handled later).
 
+### Accessing Code Paths
+
+ESLint analyzes code paths while traversing AST.
+You can access that code path objects with five events related to code paths.
+
+[details here](./code-path-analysis.md)
+
 ## Rule Unit Tests
 
 Each rule must have a set of unit tests submitted with it to be accepted. The test file is named the same as the source file but lives in `tests/lib/`. For example, if your rule source file is `lib/rules/foo.js` then your test file should be `tests/lib/rules/foo.js`.

--- a/lib/code-path-analysis/code-path-analyzer.js
+++ b/lib/code-path-analysis/code-path-analyzer.js
@@ -1,0 +1,641 @@
+/**
+ * @fileoverview A class of the code path analyzer.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("assert"),
+    CodePath = require("./code-path"),
+    CodePathSegment = require("./code-path-segment"),
+    IdGenerator = require("./id-generator"),
+    debug = require("./debug-helpers");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a given node is a `case` node (not `default` node).
+ *
+ * @param {ASTNode} node - A `SwitchCase` node to check.
+ * @returns {boolean} `true` if the node is a `case` node (not `default` node).
+ */
+function isCaseNode(node) {
+    return Boolean(node.test);
+}
+
+/**
+ * Checks whether or not a given logical expression node goes different path
+ * between the `true` case and the `false` case.
+ *
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node is a test of a choice statement.
+ */
+function isForkingByTrueOrFalse(node) {
+    var parent = node.parent;
+    switch (parent.type) {
+        case "ConditionalExpression":
+        case "IfStatement":
+        case "WhileStatement":
+        case "DoWhileStatement":
+        case "ForStatement":
+            return parent.test === node;
+
+        case "LogicalExpression":
+            return true;
+
+        default:
+            return false;
+    }
+}
+
+/**
+ * Gets a label text from a given loop node.
+ *
+ * @param {ASTNode} node - A loop node to get. The node type is one of
+ *   `WhileStatement`, `DoWhileStatement`, `ForStatement`, `ForInStatement`,
+ *   and `ForOfStatement`.
+ * @returns {string|null} The label text of the given node. Or `null` if there
+ *   is not any label.
+ */
+function getLabel(node) {
+    if (node.parent.type === "LabeledStatement") {
+        return node.parent.label.name;
+    }
+    return null;
+}
+
+/**
+ * Gets the boolean value of a given literal node.
+ *
+ * This is used to detect infinity loops (e.g. `while (true) {}`).
+ * Statements preceded by an infinity loop are unreachable if the loop didn't
+ * have any `break` statement.
+ *
+ * @param {ASTNode} node - A node to get.
+ * @returns {boolean|undefined} a boolean value if the node is a Literal node,
+ *   otherwise `undefined`.
+ */
+function getBooleanValueIfSimpleConstant(node) {
+    if (node.type === "Literal") {
+        return Boolean(node.value);
+    }
+    return void 0;
+}
+
+/**
+ * Checks that a given identifier node is a reference or not.
+ *
+ * This is used to detect the first throwable node in a `try` block.
+ *
+ * @param {ASTNode} node - An Identifier node to check.
+ * @returns {boolean} `true` if the node is a reference.
+ */
+function isIdentifierReference(node) {
+    var parent = node.parent;
+
+    switch (parent.type) {
+        case "LabeledStatement":
+        case "BreakStatement":
+        case "ContinueStatement":
+        case "ArrayPattern":
+        case "RestElement":
+        case "ImportSpecifier":
+        case "ImportDefaultSpecifier":
+        case "ImportNamespaceSpecifier":
+        case "CatchClause":
+            return false;
+
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+        case "ClassDeclaration":
+        case "ClassExpression":
+        case "VariableDeclarator":
+            return parent.id !== node;
+
+        case "Property":
+        case "MethodDefinition":
+            return (
+                parent.key !== node ||
+                parent.computed ||
+                parent.shorthand
+            );
+
+        case "AssignmentPattern":
+            return parent.key !== node;
+
+        default:
+            return true;
+    }
+}
+
+/**
+ * Updates the current segment with the head segment.
+ * This is similar to local branches and tracking branches of git.
+ *
+ * To separate the current and the head is in order to not make useless segments.
+ *
+ * In this process, both "onCodePathSegmentStart" and "onCodePathSegmentEnd" events
+ * are fired.
+ *
+ * @param {CodePathAnalyzer} analyzer - The instance.
+ * @param {ASTNode} node - The current AST node.
+ * @returns {void}
+ */
+function forwardCurrentToHead(analyzer, node) {
+    var codePath = analyzer.codePath;
+    var state = CodePath.getState(codePath);
+    var currentSegments = state.currentSegments;
+    var headSegments = state.headSegments;
+    var end = end = Math.max(currentSegments.length, headSegments.length);
+    var i, currentSegment, headSegment;
+
+    // Fires leaving events.
+    for (i = 0; i < end; ++i) {
+        currentSegment = currentSegments[i];
+        headSegment = headSegments[i];
+
+        if (currentSegment !== headSegment && currentSegment) {
+            debug.dump("onCodePathSegmentEnd " + currentSegment.id);
+
+            if (currentSegment.reachable) {
+                analyzer.emitter.emit(
+                    "onCodePathSegmentEnd",
+                    currentSegment,
+                    node);
+            }
+        }
+    }
+
+    // Update state.
+    state.currentSegments = headSegments;
+
+    // Fires entering events.
+    for (i = 0; i < end; ++i) {
+        currentSegment = currentSegments[i];
+        headSegment = headSegments[i];
+
+        if (currentSegment !== headSegment && headSegment) {
+            debug.dump("onCodePathSegmentStart " + headSegment.id);
+
+            CodePathSegment.markUsed(headSegment);
+            if (headSegment.reachable) {
+                analyzer.emitter.emit(
+                    "onCodePathSegmentStart",
+                    headSegment,
+                    node);
+            }
+        }
+    }
+
+}
+
+/**
+ * Updates the current segment with empty.
+ * This is called at the last of functions or the program.
+ *
+ * @param {CodePathAnalyzer} analyzer - The instance.
+ * @param {ASTNode} node - The current AST node.
+ * @returns {void}
+ */
+function leaveFromCurrentSegment(analyzer, node) {
+    var state = CodePath.getState(analyzer.codePath);
+    var currentSegments = state.currentSegments;
+
+    for (var i = 0; i < currentSegments.length; ++i) {
+        var currentSegment = currentSegments[i];
+
+        debug.dump("onCodePathSegmentEnd " + currentSegment.id);
+        if (currentSegment.reachable) {
+            analyzer.emitter.emit(
+                "onCodePathSegmentEnd",
+                currentSegment,
+                node);
+        }
+    }
+    state.currentSegments = [];
+}
+
+/**
+ * Updates the code path due to the position of a given node in the parent node
+ * thereof.
+ *
+ * For example, if the node is `parent.consequent`, this creates a fork from the
+ * current path.
+ *
+ * @param {CodePathAnalyzer} analyzer - The instance.
+ * @param {ASTNode} node - The current AST node.
+ * @returns {void}
+ */
+function preprocess(analyzer, node) {
+    var codePath = analyzer.codePath;
+    var state = CodePath.getState(codePath);
+    var parent = node.parent;
+
+    switch (parent.type) {
+        case "LogicalExpression":
+            if (parent.right === node) {
+                state.makeLogicalRight();
+            }
+            break;
+
+        case "ConditionalExpression":
+        case "IfStatement":
+            // Fork if this node is at `consequent`/`alternate`.
+            // `popForkContext()` exists at `IfStatement:exit` and
+            // `ConditionalExpression:exit`.
+            if (parent.consequent === node) {
+                state.makeIfConsequent();
+            } else if (parent.alternate === node) {
+                state.makeIfAlternate();
+            }
+            break;
+
+        case "SwitchCase":
+            if (parent.consequent[0] === node) {
+                state.makeSwitchCaseBody(false, !parent.test);
+            }
+            break;
+
+        case "TryStatement":
+            if (parent.handler === node) {
+                state.makeCatchBlock();
+            } else if (parent.finalizer === node) {
+                state.makeFinallyBlock();
+            }
+            break;
+
+        case "WhileStatement":
+            if (parent.test === node) {
+                state.makeWhileTest(getBooleanValueIfSimpleConstant(node));
+            } else {
+                assert(parent.body === node);
+                state.makeWhileBody();
+            }
+            break;
+
+        case "DoWhileStatement":
+            if (parent.body === node) {
+                state.makeDoWhileBody();
+            } else {
+                assert(parent.test === node);
+                state.makeDoWhileTest(getBooleanValueIfSimpleConstant(node));
+            }
+            break;
+
+        case "ForStatement":
+            if (parent.test === node) {
+                state.makeForTest(getBooleanValueIfSimpleConstant(node));
+            } else if (parent.update === node) {
+                state.makeForUpdate();
+            } else if (parent.body === node) {
+                state.makeForBody();
+            }
+            break;
+
+        case "ForInStatement":
+        case "ForOfStatement":
+            if (parent.left === node) {
+                state.makeForInOfLeft();
+            } else if (parent.right === node) {
+                state.makeForInOfRight();
+            } else {
+                assert(parent.body === node);
+                state.makeForInOfBody();
+            }
+            break;
+
+        case "AssignmentPattern":
+            // Fork if this node is at `right`.
+            // `left` is executed always, so it uses the current path.
+            // `popForkContext()` exists at `AssignmentPattern:exit`.
+            if (parent.right === node) {
+                state.pushForkContext();
+                state.forkBypassPath();
+                state.forkPath();
+            }
+            break;
+
+        default:
+            break;
+    }
+}
+
+/**
+ * Updates the code path due to the type of a given node in entering.
+ *
+ * @param {CodePathAnalyzer} analyzer - The instance.
+ * @param {ASTNode} node - The current AST node.
+ * @returns {void}
+ */
+function processCodePathToEnter(analyzer, node) {
+    var codePath = analyzer.codePath;
+    var state = codePath && CodePath.getState(codePath);
+    var parent = node.parent;
+
+    switch (node.type) {
+        case "Program":
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+            if (codePath) {
+                // Emits onCodePathSegmentStart events if updated.
+                forwardCurrentToHead(analyzer, node);
+                debug.dumpState(node, state, false);
+            }
+
+            // Create the code path of this scope.
+            codePath = analyzer.codePath = new CodePath(
+                analyzer.idGenerator.next(),
+                codePath,
+                analyzer.onLooped
+            );
+            state = CodePath.getState(codePath);
+
+            // Emits onCodePathStart events.
+            debug.dump("onCodePathStart " + codePath.id);
+            analyzer.emitter.emit("onCodePathStart", codePath, node);
+            break;
+
+        case "LogicalExpression":
+            state.pushChoiceContext(node.operator, isForkingByTrueOrFalse(node));
+            break;
+
+        case "ConditionalExpression":
+        case "IfStatement":
+            state.pushChoiceContext("test", false);
+            break;
+
+        case "SwitchStatement":
+            state.pushSwitchContext(node.cases.some(isCaseNode));
+            break;
+
+        case "TryStatement":
+            state.pushTryContext(Boolean(node.finalizer));
+            break;
+
+        case "SwitchCase":
+            // Fork if this node is after the 2st node in `cases`.
+            // It's similar to `else` blocks.
+            // The next `test` node is processed in this path.
+            if (parent.discriminant !== node && parent.cases[0] !== node) {
+                state.forkPath();
+            }
+            break;
+
+        case "WhileStatement":
+        case "DoWhileStatement":
+        case "ForStatement":
+        case "ForInStatement":
+        case "ForOfStatement":
+            state.pushLoopContext(node.type, getLabel(node));
+            break;
+
+        default:
+            break;
+    }
+
+    // Emits onCodePathSegmentStart events if updated.
+    forwardCurrentToHead(analyzer, node);
+    debug.dumpState(node, state, false);
+}
+
+/**
+ * Updates the code path due to the type of a given node in leaving.
+ *
+ * @param {CodePathAnalyzer} analyzer - The instance.
+ * @param {ASTNode} node - The current AST node.
+ * @returns {void}
+ */
+function processCodePathToExit(analyzer, node) {
+    var codePath = analyzer.codePath;
+    var state = CodePath.getState(codePath);
+    var dontForward = false;
+
+    switch (node.type) {
+        case "IfStatement":
+        case "ConditionalExpression":
+        case "LogicalExpression":
+            state.popChoiceContext();
+            break;
+
+        case "SwitchStatement":
+            state.popSwitchContext();
+            break;
+
+        case "SwitchCase":
+            // This is the same as the process at the 1st `consequent` node in
+            // `preprocess` function.
+            // Must do if this `consequent` is empty.
+            if (node.consequent.length === 0) {
+                state.makeSwitchCaseBody(true, !node.test);
+            }
+            if (state.forkContext.reachable) {
+                dontForward = true;
+            }
+            break;
+
+        case "TryStatement":
+            state.popTryContext();
+            break;
+
+        case "BreakStatement":
+            forwardCurrentToHead(analyzer, node);
+            state.makeBreak(node.label && node.label.name);
+            dontForward = true;
+            break;
+
+        case "ContinueStatement":
+            forwardCurrentToHead(analyzer, node);
+            state.makeContinue(node.label && node.label.name);
+            dontForward = true;
+            break;
+
+        case "ReturnStatement":
+            forwardCurrentToHead(analyzer, node);
+            state.makeReturn();
+            dontForward = true;
+            break;
+
+        case "ThrowStatement":
+            forwardCurrentToHead(analyzer, node);
+            state.makeThrow();
+            dontForward = true;
+            break;
+
+        case "Identifier":
+            if (isIdentifierReference(node)) {
+                state.makeFirstThrowablePathInTryBlock();
+                dontForward = true;
+            }
+            break;
+
+        case "CallExpression":
+        case "MemberExpression":
+        case "NewExpression":
+            state.makeFirstThrowablePathInTryBlock();
+            break;
+
+        case "WhileStatement":
+        case "DoWhileStatement":
+        case "ForStatement":
+        case "ForInStatement":
+        case "ForOfStatement":
+            state.popLoopContext();
+            break;
+
+        case "AssignmentPattern":
+            state.popForkContext();
+            break;
+
+        default:
+            break;
+    }
+
+    // Skip updating the current segment to avoid creating useless segments if
+    // the node type is the same as the parent node type.
+    if (!dontForward && (!node.parent || node.type !== node.parent.type)) {
+        // Emits onCodePathSegmentStart events if updated.
+        forwardCurrentToHead(analyzer, node);
+    }
+    debug.dumpState(node, state, true);
+}
+
+/**
+ * Updates the code path to finalize the current code path.
+ *
+ * @param {CodePathAnalyzer} analyzer - The instance.
+ * @param {ASTNode} node - The current AST node.
+ * @returns {void}
+ */
+function postprocess(analyzer, node) {
+    switch (node.type) {
+        case "Program":
+        case "FunctionDeclaration":
+        case "FunctionExpression":
+        case "ArrowFunctionExpression":
+            var codePath = analyzer.codePath;
+
+            // Mark the current path as the final node.
+            CodePath.getState(codePath).makeFinal();
+
+            // Emits onCodePathSegmentEnd event of the current segments.
+            leaveFromCurrentSegment(analyzer, node);
+
+            // Emits onCodePathEnd event of this code path.
+            debug.dump("onCodePathEnd " + codePath.id);
+            analyzer.emitter.emit("onCodePathEnd", codePath, node);
+            debug.dumpDot(codePath);
+
+            codePath = analyzer.codePath = analyzer.codePath.upper;
+            if (codePath) {
+                debug.dumpState(node, CodePath.getState(codePath), true);
+            }
+            break;
+
+        default:
+            break;
+    }
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * The class to analyze code paths.
+ * This class implements the EventGenerator interface.
+ *
+ * @constructor
+ * @param {EventGenerator} eventGenerator - An event generator to wrap.
+ */
+function CodePathAnalyzer(eventGenerator) {
+    this.original = eventGenerator;
+    this.emitter = eventGenerator.emitter;
+    this.codePath = null;
+    this.idGenerator = new IdGenerator("s");
+    this.currentNode = null;
+    this.onLooped = this.onLooped.bind(this);
+}
+
+CodePathAnalyzer.prototype = {
+    constructor: CodePathAnalyzer,
+
+    /**
+     * Does the process to enter a given AST node.
+     * This updates state of analysis and calls `enterNode` of the wrapped.
+     *
+     * @param {ASTNode} node - A node which is entering.
+     * @returns {void}
+     */
+    enterNode: function(node) {
+        this.currentNode = node;
+
+        // Updates the code path due to node's position in its parent node.
+        if (node.parent) {
+            preprocess(this, node);
+        }
+
+        // Updates the code path.
+        // And emits onCodePathStart/onCodePathSegmentStart events.
+        processCodePathToEnter(this, node);
+
+        // Emits node events.
+        this.original.enterNode(node);
+
+        this.currentNode = null;
+    },
+
+    /**
+     * Does the process to leave a given AST node.
+     * This updates state of analysis and calls `leaveNode` of the wrapped.
+     *
+     * @param {ASTNode} node - A node which is leaving.
+     * @returns {void}
+     */
+    leaveNode: function(node) {
+        this.currentNode = node;
+
+        // Updates the code path.
+        // And emits onCodePathStart/onCodePathSegmentStart events.
+        processCodePathToExit(this, node);
+
+        // Emits node events.
+        this.original.leaveNode(node);
+
+        // Emits the last onCodePathStart/onCodePathSegmentStart events.
+        postprocess(this, node);
+
+        this.currentNode = null;
+    },
+
+    /**
+     * This is called on a code path looped.
+     * Then this raises a looped event.
+     *
+     * @param {CodePathSegment} fromSegment - A segment of prev.
+     * @param {CodePathSegment} toSegment - A segment of next.
+     * @returns {void}
+     */
+    onLooped: function(fromSegment, toSegment) {
+        if (fromSegment.reachable && toSegment.reachable) {
+            debug.dump("onCodePathSegmentLoop " + fromSegment.id + " -> " + toSegment.id);
+            this.emitter.emit(
+                "onCodePathSegmentLoop",
+                fromSegment,
+                toSegment,
+                this.currentNode
+            );
+        }
+    }
+};
+
+module.exports = CodePathAnalyzer;

--- a/lib/code-path-analysis/code-path-segment.js
+++ b/lib/code-path-analysis/code-path-segment.js
@@ -1,0 +1,208 @@
+/**
+ * @fileoverview A class of the code path segment.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("assert"),
+    debug = require("./debug-helpers");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Replaces unused segments with the previous segments of each unused segment.
+ *
+ * @param {CodePathSegment[]} segments - An array of segments to replace.
+ * @returns {CodePathSegment[]} The replaced array.
+ */
+function flattenUnusedSegments(segments) {
+    var done = Object.create(null);
+    var retv = [];
+
+    for (var i = 0; i < segments.length; ++i) {
+        var segment = segments[i];
+
+        // Ignores duplicated.
+        if (done[segment.id]) {
+            continue;
+        }
+
+        // Use previous segments if unused.
+        if (!segment.internal.used) {
+            for (var j = 0; j < segment.allPrevSegments.length; ++j) {
+                var prevSegment = segment.allPrevSegments[j];
+
+                if (!done[prevSegment.id]) {
+                    done[prevSegment.id] = true;
+                    retv.push(prevSegment);
+                }
+            }
+        } else {
+            done[segment.id] = true;
+            retv.push(segment);
+        }
+    }
+
+    return retv;
+}
+
+/**
+ * Checks whether or not a given segment is reachable.
+ *
+ * @param {CodePathSegment} segment - A segment to check.
+ * @returns {boolean} `true` if the segment is reachable.
+ */
+function isReachable(segment) {
+    return segment.reachable;
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * A code path segment.
+ *
+ * @constructor
+ * @param {string} id - An identifier.
+ * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+ *   This array includes unreachable segments.
+ * @param {boolean} reachable - A flag which shows this is reachable.
+ */
+function CodePathSegment(id, allPrevSegments, reachable) {
+    /**
+     * The identifier of this code path.
+     * Rules use it to store additional information of each rule.
+     * @type {string}
+     */
+    this.id = id;
+
+    /**
+     * An array of the next segments.
+     * @type {CodePathSegment[]}
+     */
+    this.nextSegments = [];
+
+    /**
+     * An array of the previous segments.
+     * @type {CodePathSegment[]}
+     */
+    this.prevSegments = allPrevSegments.filter(isReachable);
+
+    /**
+     * An array of the next segments.
+     * This array includes unreachable segments.
+     * @type {CodePathSegment[]}
+     */
+    this.allNextSegments = [];
+
+    /**
+     * An array of the previous segments.
+     * This array includes unreachable segments.
+     * @type {CodePathSegment[]}
+     */
+    this.allPrevSegments = allPrevSegments;
+
+    /**
+     * A flag which shows this is reachable.
+     * @type {boolean}
+     */
+    this.reachable = reachable;
+
+    // Internal data.
+    Object.defineProperty(this, "internal", {value: {
+        used: false
+    }});
+
+    /* istanbul ignore if */
+    if (debug.enabled) {
+        this.internal.nodes = [];
+        this.internal.exitNodes = [];
+    }
+}
+
+/**
+ * Creates the root segment.
+ *
+ * @param {string} id - An identifier.
+ * @returns {CodePathSegment} The created segment.
+ */
+CodePathSegment.newRoot = function(id) {
+    return new CodePathSegment(id, [], true);
+};
+
+/**
+ * Creates a segment that follows given segments.
+ *
+ * @param {string} id - An identifier.
+ * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+ * @returns {CodePathSegment} The created segment.
+ */
+CodePathSegment.newNext = function(id, allPrevSegments) {
+    return new CodePathSegment(
+        id,
+        flattenUnusedSegments(allPrevSegments),
+        allPrevSegments.some(isReachable));
+};
+
+/**
+ * Creates an unreachable segment that follows given segments.
+ *
+ * @param {string} id - An identifier.
+ * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+ * @returns {CodePathSegment} The created segment.
+ */
+CodePathSegment.newUnreachable = function(id, allPrevSegments) {
+    return new CodePathSegment(id, flattenUnusedSegments(allPrevSegments), false);
+};
+
+/**
+ * Creates a segment that follows given segments.
+ * This factory method does not connect with `allPrevSegments`.
+ * But this inherits `reachable` flag.
+ *
+ * @param {string} id - An identifier.
+ * @param {CodePathSegment[]} allPrevSegments - An array of the previous segments.
+ * @returns {CodePathSegment} The created segment.
+ */
+CodePathSegment.newDisconnected = function(id, allPrevSegments) {
+    return new CodePathSegment(id, [], allPrevSegments.some(isReachable));
+};
+
+/**
+ * Makes a given segment being used.
+ *
+ * And this function registers the segment into the previous segments as a next.
+ *
+ * @param {CodePathSegment} segment - A segment to mark.
+ * @returns {void}
+ */
+CodePathSegment.markUsed = function(segment) {
+    assert(!segment.internal.used, segment.id + " is marked twice.");
+    segment.internal.used = true;
+
+    var i;
+    if (segment.reachable) {
+        for (i = 0; i < segment.allPrevSegments.length; ++i) {
+            var prevSegment = segment.allPrevSegments[i];
+
+            prevSegment.allNextSegments.push(segment);
+            prevSegment.nextSegments.push(segment);
+        }
+    } else {
+        for (i = 0; i < segment.allPrevSegments.length; ++i) {
+            segment.allPrevSegments[i].allNextSegments.push(segment);
+        }
+    }
+};
+
+module.exports = CodePathSegment;

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -1,0 +1,1288 @@
+/**
+ * @fileoverview A class to manage state of generating a code path.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var CodePathSegment = require("./code-path-segment"),
+    ForkContext = require("./fork-context"),
+    getLast = require("../util").getLast;
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Adds given segments into the `dest` array.
+ * If the `others` array does not includes the given segments, adds to the `all`
+ * array as well.
+ *
+ * This adds only reachable and used segments.
+ *
+ * @param {CodePathSegment[]} dest - A destination array (`returnedSegments` or `thrownSegments`).
+ * @param {CodePathSegment[]} others - Another destination array (`returnedSegments` or `thrownSegments`).
+ * @param {CodePathSegment[]} all - The unified destination array (`finalSegments`).
+ * @param {CodePathSegment[]} segments - Segments to add.
+ * @returns {void}
+ */
+function addToReturnedOrThrown(dest, others, all, segments) {
+    for (var i = 0; i < segments.length; ++i) {
+        var segment = segments[i];
+
+        dest.push(segment);
+        if (others.indexOf(segment) === -1) {
+            all.push(segment);
+        }
+    }
+}
+
+/**
+ * Gets a loop-context for a `continue` statement.
+ *
+ * @param {CodePathState} state - A state to get.
+ * @param {string} label - The label of a `continue` statement.
+ * @returns {LoopContext} A loop-context for a `continue` statement.
+ */
+function getContinueContext(state, label) {
+    if (!label) {
+        return state.loopContext;
+    }
+
+    var context = state.loopContext;
+    while (context) {
+        if (context.label === label) {
+            return context;
+        }
+        context = context.upper;
+    }
+
+    /* istanbul ignore next: foolproof (syntax error) */
+    return null;
+}
+
+/**
+ * Gets a context for a `break` statement.
+ *
+ * @param {CodePathState} state - A state to get.
+ * @param {string} label - The label of a `break` statement.
+ * @returns {LoopContext|SwitchContext} A context for a `break` statement.
+ */
+function getBreakContext(state, label) {
+    if (label) {
+        return getContinueContext(state, label);
+    }
+
+    switch (getLast(state.breakKindStack)) {
+        case "loop": return state.loopContext;
+        case "switch": return state.switchContext;
+
+        /* istanbul ignore next: foolproof (syntax error) */
+        default: return null;
+    }
+}
+
+/**
+ * Gets a context for a `return` statement.
+ *
+ * @param {CodePathState} state - A state to get.
+ * @returns {TryContext|CodePathState} A context for a `return` statement.
+ */
+function getReturnContext(state) {
+    var context = state.tryContext;
+    while (context) {
+        if (context.hasFinalizer && context.position !== "finally") {
+            return context;
+        }
+        context = context.upper;
+    }
+
+    return state;
+}
+
+/**
+ * Gets a context for a `throw` statement.
+ *
+ * @param {CodePathState} state - A state to get.
+ * @returns {TryContext|CodePathState} A context for a `throw` statement.
+ */
+function getThrowContext(state) {
+    var context = state.tryContext;
+    while (context) {
+        if (context.position === "try" ||
+            (context.hasFinalizer && context.position === "catch")
+        ) {
+            return context;
+        }
+        context = context.upper;
+    }
+
+    return state;
+}
+
+/**
+ * Removes a given element from a given array.
+ *
+ * @param {any[]} xs - An array to remove the specific element.
+ * @param {any} x - An element to be removed.
+ * @returns {void}
+ */
+function remove(xs, x) {
+    xs.splice(xs.indexOf(x), 1);
+}
+
+/**
+ * Disconnect given segments.
+ *
+ * This is used in a process for switch statements.
+ * If there is the "default" chunk before other cases, the order is different
+ * between node's and running's.
+ *
+ * @param {CodePathSegment[]} prevSegments - Forward segments to disconnect.
+ * @param {CodePathSegment[]} nextSegments - Backward segments to disconnect.
+ * @returns {void}
+ */
+function removeConnection(prevSegments, nextSegments) {
+    for (var i = 0; i < prevSegments.length; ++i) {
+        var prevSegment = prevSegments[i];
+        var nextSegment = nextSegments[i];
+
+        remove(prevSegment.nextSegments, nextSegment);
+        remove(prevSegment.allNextSegments, nextSegment);
+        remove(nextSegment.prevSegments, prevSegment);
+        remove(nextSegment.allPrevSegments, prevSegment);
+    }
+}
+
+/**
+ * Creates looping path.
+ *
+ * @param {CodePathState} state - The instance.
+ * @param {CodePathSegment[]} fromSegments - Segments which are source.
+ * @param {CodePathSegment[]} toSegments - Segments which are destination.
+ * @returns {void}
+ */
+function makeLooped(state, fromSegments, toSegments) {
+    var end = end = Math.min(fromSegments.length, toSegments.length);
+    for (var i = 0; i < end; ++i) {
+        var fromSegment = fromSegments[i];
+        var toSegment = toSegments[i];
+
+        if (toSegment.reachable) {
+            fromSegment.nextSegments.push(toSegment);
+        }
+        if (fromSegment.reachable) {
+            toSegment.prevSegments.push(fromSegment);
+        }
+        fromSegment.allNextSegments.push(toSegment);
+        toSegment.allPrevSegments.push(fromSegment);
+
+        state.notifyLooped(fromSegment, toSegment);
+    }
+}
+
+/**
+ * Finalizes segments of `test` chunk of a ForStatement.
+ *
+ * - Adds `false` paths to paths which are leaving from the loop.
+ * - Sets `true` paths to paths which go to the body.
+ *
+ * @param {LoopContext} context - A loop context to modify.
+ * @param {ChoiceContext} choiceContext - A choice context of this loop.
+ * @param {CodePathSegment[]} head - The current head paths.
+ * @returns {void}
+ */
+function finalizeTestSegmentsOfFor(context, choiceContext, head) {
+    if (!choiceContext.processed) {
+        choiceContext.trueForkContext.add(head);
+        choiceContext.falseForkContext.add(head);
+    }
+
+    if (context.test !== true) {
+        context.brokenForkContext.addAll(choiceContext.falseForkContext);
+    }
+    context.endOfTestSegments = choiceContext.trueForkContext.makeNext(0, -1);
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * A class which manages state to analyze code paths.
+ *
+ * @constructor
+ * @param {IdGenerator} idGenerator - An id generator to generate id for code
+ *   path segments.
+ * @param {function} onLooped - A callback function to notify looping.
+ */
+function CodePathState(idGenerator, onLooped) {
+    this.idGenerator = idGenerator;
+    this.notifyLooped = onLooped;
+    this.forkContext = ForkContext.newRoot(idGenerator);
+    this.choiceContext = null;
+    this.switchContext = null;
+    this.tryContext = null;
+    this.loopContext = null;
+    this.breakKindStack = [];
+
+    this.currentSegments = [];
+    this.initialSegment = this.forkContext.head[0];
+
+    // returnedSegments and thrownSegments push elements into finalSegments also.
+    var final = this.finalSegments = [];
+    var returned = this.returnedForkContext = [];
+    var thrown = this.thrownForkContext = [];
+    returned.add = addToReturnedOrThrown.bind(null, returned, thrown, final);
+    thrown.add = addToReturnedOrThrown.bind(null, thrown, returned, final);
+}
+
+CodePathState.prototype = {
+    constructor: CodePathState,
+
+    /**
+     * The head segments.
+     * @type {CodePathSegment[]}
+     */
+    get headSegments() {
+        return this.forkContext.head;
+    },
+
+    /**
+     * The parent forking context.
+     * This is used for the root of new forks.
+     * @type {ForkContext}
+     */
+    get parentForkContext() {
+        var current = this.forkContext;
+        return current && current.upper;
+    },
+
+    /**
+     * Creates and stacks new forking context.
+     *
+     * @param {boolean} forkLeavingPath - A flag which shows being in a
+     *   "finally" block.
+     * @returns {ForkContext} The created context.
+     */
+    pushForkContext: function(forkLeavingPath) {
+        this.forkContext = ForkContext.newEmpty(
+            this.forkContext,
+            forkLeavingPath
+        );
+
+        return this.forkContext;
+    },
+
+    /**
+     * Pops and merges the last forking context.
+     * @returns {ForkContext} The last context.
+     */
+    popForkContext: function() {
+        var lastContext = this.forkContext;
+
+        this.forkContext = lastContext.upper;
+        this.forkContext.replaceHead(lastContext.makeNext(0, -1));
+
+        return lastContext;
+    },
+
+    /**
+     * Creates a new path.
+     * @returns {void}
+     */
+    forkPath: function() {
+        this.forkContext.add(this.parentForkContext.makeNext(-1, -1));
+    },
+
+    /**
+     * Creates a bypass path.
+     * This is used for such as IfStatement which does not have "else" chunk.
+     *
+     * @returns {void}
+     */
+    forkBypassPath: function() {
+        this.forkContext.add(this.parentForkContext.head);
+    },
+
+    //--------------------------------------------------------------------------
+    // ConditionalExpression, LogicalExpression, IfStatement
+    //--------------------------------------------------------------------------
+
+    /**
+     * Creates a context for ConditionalExpression, LogicalExpression,
+     * IfStatement, WhileStatement, DoWhileStatement, or ForStatement.
+     *
+     * LogicalExpressions have cases that it goes different paths between the
+     * `true` case and the `false` case.
+     *
+     * For Example:
+     *
+     *     if (a || b) {
+     *         foo();
+     *     } else {
+     *         bar();
+     *     }
+     *
+     * In this case, `b` is evaluated always in the code path of the `else`
+     * block, but it's not so in the code path of the `if` block.
+     * So there are 3 paths.
+     *
+     *     a -> foo();
+     *     a -> b -> foo();
+     *     a -> b -> bar();
+     *
+     * @param {string} kind - A kind string.
+     *   If the new context is LogicalExpression's, this is `"&&"` or `"||"`.
+     *   If it's IfStatement's or ConditionalExpression's, this is `"test"`.
+     *   Otherwise, this is `"loop"`.
+     * @param {boolean} isForkingAsResult - A flag that shows that goes different
+     *   paths between `true` and `false`.
+     * @returns {void}
+     */
+    pushChoiceContext: function(kind, isForkingAsResult) {
+        this.choiceContext = {
+            upper: this.choiceContext,
+            kind: kind,
+            isForkingAsResult: isForkingAsResult,
+            trueForkContext: ForkContext.newEmpty(this.forkContext),
+            falseForkContext: ForkContext.newEmpty(this.forkContext),
+            processed: false
+        };
+    },
+
+    /**
+     * Pops the last choice context and finalizes it.
+     *
+     * @returns {ChoiceContext} The popped context.
+     */
+    popChoiceContext: function() {
+        var context = this.choiceContext;
+        this.choiceContext = context.upper;
+
+        var forkContext = this.forkContext;
+        var headSegments = forkContext.head;
+
+        switch (context.kind) {
+            case "&&":
+            case "||":
+                // If any result were not transferred from child contexts,
+                // this sets the head segments to both cases.
+                // The head segments are the path of the right-hand operand.
+                if (!context.processed) {
+                    context.trueForkContext.add(headSegments);
+                    context.falseForkContext.add(headSegments);
+                }
+
+                // Transfers results to upper context if this context is in
+                // test chunk.
+                if (context.isForkingAsResult) {
+                    var parentContext = this.choiceContext;
+                    parentContext.trueForkContext.addAll(context.trueForkContext);
+                    parentContext.falseForkContext.addAll(context.falseForkContext);
+                    parentContext.processed = true;
+
+                    return context;
+                }
+                break;
+
+            case "test":
+                if (!context.processed) {
+                    // The head segments are the path of the `if` block here.
+                    // Updates the `true` path with the end of the `if` block.
+                    context.trueForkContext.clear();
+                    context.trueForkContext.add(headSegments);
+                } else {
+                    // The head segments are the path of the `else` block here.
+                    // Updates the `false` path with the end of the `else` block.
+                    context.falseForkContext.clear();
+                    context.falseForkContext.add(headSegments);
+                }
+                break;
+
+            case "loop":
+                // Loops are addressed in popLoopContext().
+                // This is called from popLoopContext().
+                return context;
+
+            /* istanbul ignore next */
+            default:
+                throw new Error("unreachable");
+        }
+
+        // Merges all paths.
+        var prevForkContext = context.trueForkContext;
+        prevForkContext.addAll(context.falseForkContext);
+        forkContext.replaceHead(prevForkContext.makeNext(0, -1));
+
+        return context;
+    },
+
+    /**
+     * Makes a code path segment of the right-hand operand of a logical
+     * expression.
+     *
+     * @returns {void}
+     */
+    makeLogicalRight: function() {
+        var context = this.choiceContext;
+        var forkContext = this.forkContext;
+
+        if (context.processed) {
+            // This got segments already from the child choice context.
+            // Creates the next path from own true/false fork context.
+            var prevForkContext =
+                context.kind === "&&" ? context.trueForkContext :
+                /* kind === "||" */ context.falseForkContext;
+
+            forkContext.replaceHead(prevForkContext.makeNext(0, -1));
+            prevForkContext.clear();
+
+            context.processed = false;
+        } else {
+            // This did not get segments from the child choice context.
+            // So addresses the head segments.
+            // The head segments are the path of the left-hand operand.
+            if (context.kind === "&&") {
+                // The path does short-circuit if false.
+                context.falseForkContext.add(forkContext.head);
+            } else {
+                // The path does short-circuit if true.
+                context.trueForkContext.add(forkContext.head);
+            }
+
+            forkContext.replaceHead(forkContext.makeNext(-1, -1));
+        }
+    },
+
+    /**
+     * Makes a code path segment of the `if` block.
+     *
+     * @returns {void}
+     */
+    makeIfConsequent: function() {
+        var context = this.choiceContext;
+        var forkContext = this.forkContext;
+
+        // If any result were not transferred from child contexts,
+        // this sets the head segments to both cases.
+        // The head segments are the path of the test expression.
+        if (!context.processed) {
+            context.trueForkContext.add(forkContext.head);
+            context.falseForkContext.add(forkContext.head);
+        }
+        context.processed = false;
+
+        // Creates new path from the `true` case.
+        forkContext.replaceHead(
+            context.trueForkContext.makeNext(0, -1)
+        );
+    },
+
+    /**
+     * Makes a code path segment of the `else` block.
+     *
+     * @returns {void}
+     */
+    makeIfAlternate: function() {
+        var context = this.choiceContext;
+        var forkContext = this.forkContext;
+
+        // The head segments are the path of the `if` block.
+        // Updates the `true` path with the end of the `if` block.
+        context.trueForkContext.clear();
+        context.trueForkContext.add(forkContext.head);
+        context.processed = true;
+
+        // Creates new path from the `false` case.
+        forkContext.replaceHead(
+            context.falseForkContext.makeNext(0, -1)
+        );
+    },
+
+    //--------------------------------------------------------------------------
+    // SwitchStatement
+    //--------------------------------------------------------------------------
+
+    /**
+     * Creates a context object of SwitchStatement and stacks it.
+     *
+     * @param {boolean} hasCase - `true` if the switch statement has one or more
+     *   case parts.
+     * @returns {void}
+     */
+    pushSwitchContext: function(hasCase) {
+        this.switchContext = {
+            upper: this.switchContext,
+            hasCase: hasCase,
+            brokenForkContext: ForkContext.newEmpty(this.forkContext),
+            defaultSegments: null,
+            defaultBodySegments: null,
+            foundDefault: false,
+            lastIsDefault: false,
+            countForks: 0
+        };
+        this.breakKindStack.push("switch");
+    },
+
+    /**
+     * Pops the last context of SwitchStatement and finalizes it.
+     *
+     * - Disposes all forking stack for `case` and `default`.
+     * - Creates the next code path segment from `context.brokenForkContext`.
+     * - If the last `SwitchCase` node is not a `default` part, creates a path
+     *   to the `default` body.
+     *
+     * @returns {void}
+     */
+    popSwitchContext: function() {
+        var context = this.switchContext;
+        this.switchContext = context.upper;
+        this.breakKindStack.pop();
+
+        var forkContext = this.forkContext;
+        var brokenForkContext = context.brokenForkContext;
+
+        if (context.countForks === 0) {
+            // When there is only one `default` chunk and there is one or more
+            // `break` statements, even if forks are nothing, it needs to merge
+            // those.
+            if (!brokenForkContext.empty) {
+                brokenForkContext.add(forkContext.makeNext(-1, -1));
+                forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
+            }
+            return;
+        }
+
+        var lastSegments = forkContext.head;
+        this.forkBypassPath();
+        var lastCaseSegments = forkContext.head;
+
+        // `brokenForkContext` is used to make the next segment.
+        // It must add the last segment into `brokenForkContext`.
+        brokenForkContext.add(lastSegments);
+
+        // A path which is failed in all case test should be connected to path
+        // of `default` chunk.
+        if (!context.lastIsDefault) {
+            if (context.defaultBodySegments) {
+                // Remove a link from `default` label to its chunk.
+                // It's false route.
+                removeConnection(context.defaultSegments, context.defaultBodySegments);
+                makeLooped(this, lastCaseSegments, context.defaultBodySegments);
+            } else {
+                // It handles the last case body as broken if `default` chunk
+                // does not exist.
+                brokenForkContext.add(lastCaseSegments);
+            }
+        }
+
+        // Pops the segment context stack until the entry segment.
+        for (var i = 0; i < context.countForks; ++i) {
+            this.forkContext = this.forkContext.upper;
+        }
+        // Creates a path from all brokenForkContext paths.
+        // This is a path after switch statement.
+        this.forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
+    },
+
+    /**
+     * Makes a code path segment for a `SwitchCase` node.
+     *
+     * @param {boolean} isEmpty - `true` if the body is empty.
+     * @param {boolean} isDefault - `true` if the body is the default case.
+     * @returns {void}
+     */
+    makeSwitchCaseBody: function(isEmpty, isDefault) {
+        var context = this.switchContext;
+        if (!context.hasCase) {
+            return;
+        }
+
+        // Merge forks.
+        // The parent fork context has two segments.
+        // Those are from the current case and the body of the previous case.
+        var parentForkContext = this.forkContext;
+        var forkContext = this.pushForkContext();
+        forkContext.add(parentForkContext.makeNext(0, -1));
+
+        // Save `default` chunk info.
+        // If the `default` label is not at the last, we must make a path from
+        // the last `case` to the `default` chunk.
+        if (isDefault) {
+            context.defaultSegments = parentForkContext.head;
+            if (isEmpty) {
+                context.foundDefault = true;
+            } else {
+                context.defaultBodySegments = forkContext.head;
+            }
+        } else {
+            if (!isEmpty && context.foundDefault) {
+                context.foundDefault = false;
+                context.defaultBodySegments = forkContext.head;
+            }
+        }
+        context.lastIsDefault = isDefault;
+        context.countForks += 1;
+    },
+
+    //--------------------------------------------------------------------------
+    // TryStatement
+    //--------------------------------------------------------------------------
+
+    /**
+     * Creates a context object of TryStatement and stacks it.
+     *
+     * @param {boolean} hasFinalizer - `true` if the try statement has a
+     *   `finally` block.
+     * @returns {void}
+     */
+    pushTryContext: function(hasFinalizer) {
+        this.tryContext = {
+            upper: this.tryContext,
+            position: "try",
+            hasFinalizer: hasFinalizer,
+            returnedForkContext: hasFinalizer
+                ? ForkContext.newEmpty(this.forkContext)
+                : null,
+            thrownForkContext: ForkContext.newEmpty(this.forkContext),
+            lastOfTryIsReachable: false,
+            lastOfCatchIsReachable: false
+        };
+    },
+
+    /**
+     * Pops the last context of TryStatement and finalizes it.
+     *
+     * @returns {void}
+     */
+    popTryContext: function() {
+        var context = this.tryContext;
+        this.tryContext = context.upper;
+
+        if (context.position === "catch") {
+            // Merges two paths from the `try` block and `catch` block merely.
+            this.popForkContext();
+            return;
+        }
+        // The following process is executed only when there is the `finally`
+        // block.
+
+        var returned = context.returnedForkContext;
+        var thrown = context.thrownForkContext;
+        if (returned.empty && thrown.empty) {
+            return;
+        }
+
+        // Separate head to normal paths and leaving paths.
+        var headSegments = this.forkContext.head;
+        this.forkContext = this.forkContext.upper;
+        var normalSegments = headSegments.slice(0, headSegments.length / 2 | 0);
+        var leavingSegments = headSegments.slice(headSegments.length / 2 | 0);
+
+        // Forwards the leaving path to upper contexts.
+        if (!returned.empty) {
+            getReturnContext(this).returnedForkContext.add(leavingSegments);
+        }
+        if (!thrown.empty) {
+            getThrowContext(this).thrownForkContext.add(leavingSegments);
+        }
+
+        // Sets the normal path as the next.
+        this.forkContext.replaceHead(normalSegments);
+
+        // If both paths of the `try` block and the `catch` block are
+        // unreachable, the next path becomes unreachable as well.
+        if (!context.lastOfTryIsReachable && !context.lastOfCatchIsReachable) {
+            this.forkContext.makeUnreachable();
+        }
+    },
+
+    /**
+     * Makes a code path segment for a `catch` block.
+     *
+     * @returns {void}
+     */
+    makeCatchBlock: function() {
+        var context = this.tryContext;
+        var forkContext = this.forkContext;
+        var thrown = context.thrownForkContext;
+
+        // Update state.
+        context.position = "catch";
+        context.thrownForkContext = ForkContext.newEmpty(forkContext);
+        context.lastOfTryIsReachable = forkContext.reachable;
+
+        // Merge thrown paths.
+        thrown.add(forkContext.head);
+        var thrownSegments = thrown.makeNext(0, -1);
+
+        // Fork to a bypass and the merged thrown path.
+        this.pushForkContext();
+        this.forkBypassPath();
+        this.forkContext.add(thrownSegments);
+    },
+
+    /**
+     * Makes a code path segment for a `finally` block.
+     *
+     * In the `finally` block, parallel paths are created. The parallel paths
+     * are used as leaving-paths. The leaving-paths are paths from `return`
+     * statements and `throw` statements in a `try` block or a `catch` block.
+     *
+     * @returns {void}
+     */
+    makeFinallyBlock: function() {
+        var context = this.tryContext;
+        var forkContext = this.forkContext;
+        var returned = context.returnedForkContext;
+        var thrown = context.thrownForkContext;
+        var headOfLeavingSegments = forkContext.head;
+
+        // Update state.
+        if (context.position === "catch") {
+            // Merges two paths from the `try` block and `catch` block.
+            this.popForkContext();
+            forkContext = this.forkContext;
+
+            context.lastOfCatchIsReachable = forkContext.reachable;
+        } else {
+            context.lastOfTryIsReachable = forkContext.reachable;
+        }
+        context.position = "finally";
+
+        if (returned.empty && thrown.empty) {
+            // This path does not leave.
+            return;
+        }
+
+        // Create a parallel segment from merging returned and thrown.
+        // This segment will leave at the end of this finally block.
+        var segments = forkContext.makeNext(-1, -1);
+        var j;
+        for (var i = 0; i < forkContext.count; ++i) {
+            var prevSegsOfLeavingSegment = [headOfLeavingSegments[i]];
+
+            for (j = 0; j < returned.segmentsList.length; ++j) {
+                prevSegsOfLeavingSegment.push(returned.segmentsList[j][i]);
+            }
+            for (j = 0; j < thrown.segmentsList.length; ++j) {
+                prevSegsOfLeavingSegment.push(thrown.segmentsList[j][i]);
+            }
+
+            segments.push(CodePathSegment.newNext(
+                this.idGenerator.next(),
+                prevSegsOfLeavingSegment));
+        }
+
+        this.pushForkContext(true);
+        this.forkContext.add(segments);
+    },
+
+    /**
+     * Makes a code path segment from the first throwable node to the `catch`
+     * block or the `finally` block.
+     *
+     * @returns {void}
+     */
+    makeFirstThrowablePathInTryBlock: function() {
+        var forkContext = this.forkContext;
+        if (!forkContext.reachable) {
+            return;
+        }
+
+        var context = getThrowContext(this);
+        if (context === this ||
+            context.position !== "try" ||
+            !context.thrownForkContext.empty
+        ) {
+            return;
+        }
+
+        context.thrownForkContext.add(forkContext.head);
+        forkContext.replaceHead(forkContext.makeNext(-1, -1));
+    },
+
+    //--------------------------------------------------------------------------
+    // Loop Statements
+    //--------------------------------------------------------------------------
+
+    /**
+     * Creates a context object of a loop statement and stacks it.
+     *
+     * @param {string} type - The type of the node which was triggered. One of
+     *   `WhileStatement`, `DoWhileStatement`, `ForStatement`, `ForInStatement`,
+     *   and `ForStatement`.
+     * @param {string|null} label - A label of the node which was triggered.
+     * @returns {void}
+     */
+    pushLoopContext: function(type, label) {
+        var forkContext = this.forkContext;
+
+        switch (type) {
+            case "WhileStatement":
+                this.pushChoiceContext("loop", false);
+                this.loopContext = {
+                    upper: this.loopContext,
+                    type: type,
+                    label: label,
+                    test: void 0,
+                    continueDestSegments: null,
+                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                };
+                break;
+
+            case "DoWhileStatement":
+                this.pushChoiceContext("loop", false);
+                this.loopContext = {
+                    upper: this.loopContext,
+                    type: type,
+                    label: label,
+                    test: void 0,
+                    entrySegments: null,
+                    continueForkContext: ForkContext.newEmpty(forkContext),
+                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                };
+                break;
+
+            case "ForStatement":
+                this.pushChoiceContext("loop", false);
+                this.loopContext = {
+                    upper: this.loopContext,
+                    type: type,
+                    label: label,
+                    test: void 0,
+                    endOfInitSegments: null,
+                    testSegments: null,
+                    endOfTestSegments: null,
+                    updateSegments: null,
+                    endOfUpdateSegments: null,
+                    continueDestSegments: null,
+                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                };
+                break;
+
+            case "ForInStatement":
+            case "ForOfStatement":
+                this.loopContext = {
+                    upper: this.loopContext,
+                    type: type,
+                    label: label,
+                    prevSegments: null,
+                    leftSegments: null,
+                    endOfLeftSegments: null,
+                    continueDestSegments: null,
+                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                };
+                break;
+
+            /* istanbul ignore next */
+            default:
+                throw new Error("unknown type: \"" + type + "\"");
+        }
+
+        this.breakKindStack.push("loop");
+    },
+
+    /**
+     * Pops the last context of a loop statement and finalizes it.
+     *
+     * @returns {void}
+     */
+    popLoopContext: function() {
+        var context = this.loopContext;
+        this.loopContext = context.upper;
+        this.breakKindStack.pop();
+
+        var forkContext = this.forkContext;
+        var choiceContext;
+
+        // Creates a looped path.
+        switch (context.type) {
+            case "WhileStatement":
+            case "ForStatement":
+                choiceContext = this.popChoiceContext();
+                makeLooped(
+                    this,
+                    forkContext.head,
+                    context.continueDestSegments);
+                break;
+
+            case "DoWhileStatement":
+                choiceContext = this.popChoiceContext();
+
+                if (!choiceContext.processed) {
+                    choiceContext.trueForkContext.add(forkContext.head);
+                    choiceContext.falseForkContext.add(forkContext.head);
+                }
+                if (context.test !== true) {
+                    context.brokenForkContext.addAll(
+                        choiceContext.falseForkContext);
+                }
+
+                // `true` paths go to looping.
+                var segmentsList = choiceContext.trueForkContext.segmentsList;
+                for (var i = 0; i < segmentsList.length; ++i) {
+                    makeLooped(
+                        this,
+                        segmentsList[i],
+                        context.entrySegments);
+                }
+                break;
+
+            case "ForInStatement":
+            case "ForOfStatement":
+                context.brokenForkContext.add(forkContext.head);
+                makeLooped(
+                    this,
+                    forkContext.head,
+                    context.leftSegments);
+                break;
+
+            /* istanbul ignore next */
+            default:
+                throw new Error("unreachable");
+        }
+
+        // Go next.
+        if (context.brokenForkContext.empty) {
+            forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+        } else {
+            forkContext.replaceHead(context.brokenForkContext.makeNext(0, -1));
+        }
+    },
+
+    /**
+     * Makes a code path segment for the test part of a WhileStatement.
+     *
+     * @param {boolean|undefined} test - The test value (only when constant).
+     * @returns {void}
+     */
+    makeWhileTest: function(test) {
+        var context = this.loopContext;
+        var forkContext = this.forkContext;
+        var testSegments = forkContext.makeNext(0, -1);
+
+        // Update state.
+        context.test = test;
+        context.continueDestSegments = testSegments;
+        forkContext.replaceHead(testSegments);
+    },
+
+    /**
+     * Makes a code path segment for the body part of a WhileStatement.
+     *
+     * @returns {void}
+     */
+    makeWhileBody: function() {
+        var context = this.loopContext;
+        var choiceContext = this.choiceContext;
+        var forkContext = this.forkContext;
+
+        if (!choiceContext.processed) {
+            choiceContext.trueForkContext.add(forkContext.head);
+            choiceContext.falseForkContext.add(forkContext.head);
+        }
+
+        // Update state.
+        if (context.test !== true) {
+            context.brokenForkContext.addAll(choiceContext.falseForkContext);
+        }
+        forkContext.replaceHead(choiceContext.trueForkContext.makeNext(0, -1));
+    },
+
+    /**
+     * Makes a code path segment for the body part of a DoWhileStatement.
+     *
+     * @returns {void}
+     */
+    makeDoWhileBody: function() {
+        var context = this.loopContext;
+        var forkContext = this.forkContext;
+        var bodySegments = forkContext.makeNext(-1, -1);
+
+        // Update state.
+        context.entrySegments = bodySegments;
+        forkContext.replaceHead(bodySegments);
+    },
+
+    /**
+     * Makes a code path segment for the test part of a DoWhileStatement.
+     *
+     * @param {boolean|undefined} test - The test value (only when constant).
+     * @returns {void}
+     */
+    makeDoWhileTest: function(test) {
+        var context = this.loopContext;
+        var forkContext = this.forkContext;
+
+        context.test = test;
+
+        // Creates paths of `continue` statements.
+        if (!context.continueForkContext.empty) {
+            context.continueForkContext.add(forkContext.head);
+            var testSegments = context.continueForkContext.makeNext(0, -1);
+
+            forkContext.replaceHead(testSegments);
+        }
+    },
+
+    /**
+     * Makes a code path segment for the test part of a ForStatement.
+     *
+     * @param {boolean|undefined} test - The test value (only when constant).
+     * @returns {void}
+     */
+    makeForTest: function(test) {
+        var context = this.loopContext;
+        var forkContext = this.forkContext;
+        var endOfInitSegments = forkContext.head;
+        var testSegments = forkContext.makeNext(-1, -1);
+
+        // Update state.
+        context.test = test;
+        context.endOfInitSegments = endOfInitSegments;
+        context.continueDestSegments = context.testSegments = testSegments;
+        forkContext.replaceHead(testSegments);
+    },
+
+    /**
+     * Makes a code path segment for the update part of a ForStatement.
+     *
+     * @returns {void}
+     */
+    makeForUpdate: function() {
+        var context = this.loopContext;
+        var choiceContext = this.choiceContext;
+        var forkContext = this.forkContext;
+
+        // Make the next paths of the test.
+        if (context.testSegments) {
+            finalizeTestSegmentsOfFor(
+                context,
+                choiceContext,
+                forkContext.head);
+        } else {
+            context.endOfInitSegments = forkContext.head;
+        }
+
+        // Update state.
+        var updateSegments = forkContext.makeDisconnected(-1, -1);
+        context.continueDestSegments = context.updateSegments = updateSegments;
+        forkContext.replaceHead(updateSegments);
+    },
+
+    /**
+     * Makes a code path segment for the body part of a ForStatement.
+     *
+     * @returns {void}
+     */
+    makeForBody: function() {
+        var context = this.loopContext;
+        var choiceContext = this.choiceContext;
+        var forkContext = this.forkContext;
+
+        // Update state.
+        if (context.updateSegments) {
+            context.endOfUpdateSegments = forkContext.head;
+
+            // `update` -> `test`
+            if (context.testSegments) {
+                makeLooped(
+                    this,
+                    context.endOfUpdateSegments,
+                    context.testSegments);
+            }
+        } else if (context.testSegments) {
+            finalizeTestSegmentsOfFor(
+                context,
+                choiceContext,
+                forkContext.head);
+        } else {
+            context.endOfInitSegments = forkContext.head;
+        }
+
+        var bodySegments = context.endOfTestSegments;
+        if (!bodySegments) {
+            // If there is not the `test` part, the `body` path comes from the
+            // `init` part and the `update` part.
+            var prevForkContext = ForkContext.newEmpty(forkContext);
+            prevForkContext.add(context.endOfInitSegments);
+            if (context.endOfUpdateSegments) {
+                prevForkContext.add(context.endOfUpdateSegments);
+            }
+
+            bodySegments = prevForkContext.makeNext(0, -1);
+        }
+        context.continueDestSegments = context.continueDestSegments || bodySegments;
+        forkContext.replaceHead(bodySegments);
+    },
+
+    /**
+     * Makes a code path segment for the left part of a ForInStatement and a
+     * ForOfStatement.
+     *
+     * @returns {void}
+     */
+    makeForInOfLeft: function() {
+        var context = this.loopContext;
+        var forkContext = this.forkContext;
+        var leftSegments = forkContext.makeDisconnected(-1, -1);
+
+        // Update state.
+        context.prevSegments = forkContext.head;
+        context.leftSegments = context.continueDestSegments = leftSegments;
+        forkContext.replaceHead(leftSegments);
+    },
+
+    /**
+     * Makes a code path segment for the right part of a ForInStatement and a
+     * ForOfStatement.
+     *
+     * @returns {void}
+     */
+    makeForInOfRight: function() {
+        var context = this.loopContext;
+        var forkContext = this.forkContext;
+        var temp = ForkContext.newEmpty(forkContext);
+        temp.add(context.prevSegments);
+        var rightSegments = temp.makeNext(-1, -1);
+
+        // Update state.
+        context.endOfLeftSegments = forkContext.head;
+        forkContext.replaceHead(rightSegments);
+    },
+
+    /**
+     * Makes a code path segment for the body part of a ForInStatement and a
+     * ForOfStatement.
+     *
+     * @returns {void}
+     */
+    makeForInOfBody: function() {
+        var context = this.loopContext;
+        var forkContext = this.forkContext;
+        var temp = ForkContext.newEmpty(forkContext);
+        temp.add(context.endOfLeftSegments);
+        var bodySegments = temp.makeNext(-1, -1);
+
+        // Make a path: `right` -> `left`.
+        makeLooped(this, forkContext.head, context.leftSegments);
+
+        // Update state.
+        context.brokenForkContext.add(forkContext.head);
+        forkContext.replaceHead(bodySegments);
+    },
+
+    //--------------------------------------------------------------------------
+    // Control Statements
+    //--------------------------------------------------------------------------
+
+    /**
+     * Makes a path for a `break` statement.
+     *
+     * It registers the head segment to a context of `break`.
+     * It makes new unreachable segment, then it set the head with the segment.
+     *
+     * @param {string} label - A label of the break statement.
+     * @returns {void}
+     */
+    makeBreak: function(label) {
+        var forkContext = this.forkContext;
+        if (!forkContext.reachable) {
+            return;
+        }
+
+        var context = getBreakContext(this, label);
+        /* istanbul ignore else: foolproof (syntax error) */
+        if (context) {
+            context.brokenForkContext.add(forkContext.head);
+        }
+        forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+    },
+
+    /**
+     * Makes a path for a `continue` statement.
+     *
+     * It makes a looping path.
+     * It makes new unreachable segment, then it set the head with the segment.
+     *
+     * @param {string} label - A label of the continue statement.
+     * @returns {void}
+     */
+    makeContinue: function(label) {
+        var forkContext = this.forkContext;
+        if (!forkContext.reachable) {
+            return;
+        }
+
+        var context = getContinueContext(this, label);
+        /* istanbul ignore else: foolproof (syntax error) */
+        if (context) {
+            if (context.continueDestSegments) {
+                makeLooped(this, forkContext.head, context.continueDestSegments);
+
+                // If the context is a for-in/of loop, this effects a break also.
+                if (context.type === "ForInStatement" ||
+                    context.type === "ForOfStatement"
+                ) {
+                    context.brokenForkContext.add(forkContext.head);
+                }
+            } else {
+                context.continueForkContext.add(forkContext.head);
+            }
+        }
+        forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+    },
+
+    /**
+     * Makes a path for a `return` statement.
+     *
+     * It registers the head segment to a context of `return`.
+     * It makes new unreachable segment, then it set the head with the segment.
+     *
+     * @returns {void}
+     */
+    makeReturn: function() {
+        var forkContext = this.forkContext;
+        if (forkContext.reachable) {
+            getReturnContext(this).returnedForkContext.add(forkContext.head);
+            forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+        }
+    },
+
+    /**
+     * Makes a path for a `throw` statement.
+     *
+     * It registers the head segment to a context of `throw`.
+     * It makes new unreachable segment, then it set the head with the segment.
+     *
+     * @returns {void}
+     */
+    makeThrow: function() {
+        var forkContext = this.forkContext;
+        if (forkContext.reachable) {
+            getThrowContext(this).thrownForkContext.add(forkContext.head);
+            forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
+        }
+    },
+
+    /**
+     * Makes the final path.
+     * @returns {void}
+     */
+    makeFinal: function() {
+        var segments = this.currentSegments;
+        if (segments.length > 0 && segments[0].reachable) {
+            this.returnedForkContext.add(segments);
+        }
+    }
+};
+
+module.exports = CodePathState;

--- a/lib/code-path-analysis/code-path.js
+++ b/lib/code-path-analysis/code-path.js
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview A class of the code path.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var CodePathState = require("./code-path-state");
+var IdGenerator = require("./id-generator");
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * A code path.
+ *
+ * @constructor
+ * @param {string} id - An identifier.
+ * @param {CodePath|null} upper - The code path of the upper function scope.
+ * @param {function} onLooped - A callback function to notify looping.
+ */
+function CodePath(id, upper, onLooped) {
+    /**
+     * The identifier of this code path.
+     * Rules use it to store additional information of each rule.
+     * @type {string}
+     */
+    this.id = id;
+
+    /**
+     * The code path of the upper function scope.
+     * @type {CodePath|null}
+     */
+    this.upper = upper;
+
+    /**
+     * The code paths of nested function scopes.
+     * @type {CodePath[]}
+     */
+    this.childCodePaths = [];
+
+    // Initializes internal state.
+    Object.defineProperty(
+        this,
+        "internal",
+        {value: new CodePathState(new IdGenerator(id + "_"), onLooped)});
+
+    // Adds this into `childCodePaths` of `upper`.
+    if (upper) {
+        upper.childCodePaths.push(this);
+    }
+}
+
+CodePath.prototype = {
+    constructor: CodePath,
+
+    /**
+     * The initial code path segment.
+     * @type {CodePathSegment}
+     */
+    get initialSegment() {
+        return this.internal.initialSegment;
+    },
+
+    /**
+     * Final code path segments.
+     * This array is a mix of `returnedSegments` and `thrownSegments`.
+     * @type {CodePathSegment[]}
+     */
+    get finalSegments() {
+        return this.internal.finalSegments;
+    },
+
+    /**
+     * Final code path segments which is with `return` statements.
+     * This array contains the last path segment if it's reachable.
+     * Since the reachable last path returns `undefined`.
+     * @type {CodePathSegment[]}
+     */
+    get returnedSegments() {
+        return this.internal.returnedForkContext;
+    },
+
+    /**
+     * Final code path segments which is with `throw` statements.
+     * @type {CodePathSegment[]}
+     */
+    get thrownSegments() {
+        return this.internal.thrownForkContext;
+    },
+
+    /**
+     * Current code path segments.
+     * @type {CodePathSegment[]}
+     */
+    get currentSegments() {
+        return this.internal.currentSegments;
+    }
+};
+
+/**
+ * Gets the state of a given code path.
+ *
+ * @param {CodePath} codePath - A code path to get.
+ * @returns {CodePathState} The state of the code path.
+ */
+CodePath.getState = function getState(codePath) {
+    return codePath.internal;
+};
+
+module.exports = CodePath;

--- a/lib/code-path-analysis/debug-helpers.js
+++ b/lib/code-path-analysis/debug-helpers.js
@@ -1,0 +1,197 @@
+/**
+ * @fileoverview Helpers to debug for code path analysis.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var debug = require("debug")("eslint:code-path");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets id of a given segment.
+ * @param {CodePathSegment} segment - A segment to get.
+ * @returns {string} Id of the segment.
+ */
+/* istanbul ignore next */
+function getId(segment) { // eslint-disable-line require-jsdoc
+    return segment.id + (segment.reachable ? "" : "!");
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = {
+    /**
+     * A flag that debug dumping is enabled or not.
+     * @type {boolean}
+     */
+    enabled: debug.enabled,
+
+    /**
+     * Dumps given objects.
+     *
+     * @param {...any} args - objects to dump.
+     * @returns {void}
+     */
+    dump: debug,
+
+    /**
+     * Dumps the current analyzing state.
+     *
+     * @param {ASTNode} node - A node to dump.
+     * @param {CodePathState} state - A state to dump.
+     * @param {boolean} leaving - A flag whether or not it's leaving
+     * @returns {void}
+     */
+    dumpState: !debug.enabled ? debug : /* istanbul ignore next */ function(node, state, leaving) {
+        for (var i = 0; i < state.currentSegments.length; ++i) {
+            var segInternal = state.currentSegments[i].internal;
+            if (leaving) {
+                segInternal.exitNodes.push(node);
+            } else {
+                segInternal.nodes.push(node);
+            }
+        }
+
+        debug(
+            state.currentSegments.map(getId).join(",") + ") " +
+            node.type + (leaving ? ":exit" : "")
+        );
+    },
+
+    /**
+     * Dumps a DOT code of a given code path.
+     * The DOT code can be visialized with Graphvis.
+     *
+     * @param {CodePath} codePath - A code path to dump.
+     * @returns {void}
+     * @see http://www.graphviz.org
+     * @see http://www.webgraphviz.com
+     */
+    dumpDot: !debug.enabled ? debug : /* istanbul ignore next */ function(codePath) {
+        var text =
+            "\n" +
+            "digraph {\n" +
+            "node[shape=box,style=\"rounded,filled\",fillcolor=white];\n" +
+            "initial[label=\"\",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];\n";
+
+        if (codePath.returnedSegments.length > 0) {
+            text += "final[label=\"\",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];\n";
+        }
+        if (codePath.thrownSegments.length > 0) {
+            text += "thrown[label=\"✘\",shape=circle,width=0.3,height=0.3,fixedsize];\n";
+        }
+
+        var traceMap = Object.create(null);
+        var arrows = this.makeDotArrows(codePath, traceMap);
+
+        for (var id in traceMap) { // eslint-disable-line guard-for-in
+            var segment = traceMap[id];
+
+            text += id + "[";
+
+            if (segment.reachable) {
+                text += "label=\"";
+            } else {
+                text += "style=\"rounded,dashed,filled\",fillcolor=\"#FF9800\",label=\"<<unreachable>>\\n";
+            }
+
+            if (segment.internal.nodes.length > 0) {
+                text += segment.internal.nodes.map(function(node) {
+                    switch (node.type) {
+                        case "Identifier": return node.type + " (" + node.name + ")";
+                        case "Literal": return node.type + " (" + node.value + ")";
+                        default: return node.type;
+                    }
+                }).join("\\n");
+            } else if (segment.internal.exitNodes.length > 0) {
+                text += segment.internal.exitNodes.map(function(node) {
+                    switch (node.type) {
+                        case "Identifier": return node.type + ":exit (" + node.name + ")";
+                        case "Literal": return node.type + ":exit (" + node.value + ")";
+                        default: return node.type + ":exit";
+                    }
+                }).join("\\n");
+            } else {
+                text += "????";
+            }
+
+            text += "\"];\n";
+        }
+
+        text += arrows + "\n";
+        text += "}";
+        debug("DOT", text);
+    },
+
+    /**
+     * Makes a DOT code of a given code path.
+     * The DOT code can be visialized with Graphvis.
+     *
+     * @param {CodePath} codePath - A code path to make DOT.
+     * @param {object} traceMap - Optional. A map to check whether or not segments had been done.
+     * @returns {string} A DOT code of the code path.
+     */
+    makeDotArrows: function(codePath, traceMap) {
+        var stack = [[codePath.initialSegment, 0]];
+        var done = traceMap || Object.create(null);
+        var lastId = codePath.initialSegment.id;
+        var text = "initial->" + codePath.initialSegment.id;
+
+        while (stack.length > 0) {
+            var item = stack.pop();
+            var segment = item[0];
+            var index = item[1];
+            if (done[segment.id] && index === 0) {
+                continue;
+            }
+            done[segment.id] = segment;
+
+            var nextSegment = segment.allNextSegments[index];
+            if (!nextSegment) {
+                continue;
+            }
+
+            if (lastId === segment.id) {
+                text += "->" + nextSegment.id;
+            } else {
+                text += ";\n" + segment.id + "->" + nextSegment.id;
+            }
+            lastId = nextSegment.id;
+
+            stack.unshift([segment, 1 + index]);
+            stack.push([nextSegment, 0]);
+        }
+
+        codePath.returnedSegments.forEach(function(finalSegment) {
+            if (lastId === finalSegment.id) {
+                text += "->final";
+            } else {
+                text += ";\n" + finalSegment.id + "->final";
+            }
+            lastId = null;
+        });
+
+        codePath.thrownSegments.forEach(function(finalSegment) {
+            if (lastId === finalSegment.id) {
+                text += "->thrown";
+            } else {
+                text += ";\n" + finalSegment.id + "->thrown";
+            }
+            lastId = null;
+        });
+
+        return text + ";";
+    }
+};

--- a/lib/code-path-analysis/fork-context.js
+++ b/lib/code-path-analysis/fork-context.js
@@ -1,0 +1,258 @@
+/**
+ * @fileoverview A class to operate forking.
+ *
+ * This is state of forking.
+ * This has a fork list and manages it.
+ *
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("assert"),
+    CodePathSegment = require("./code-path-segment");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets whether or not a given segment is reachable.
+ *
+ * @param {CodePathSegment} segment - A segment to get.
+ * @returns {boolean} `true` if the segment is reachable.
+ */
+function isReachable(segment) {
+    return segment.reachable;
+}
+
+/**
+ * Creates new segments from the specific range of `context.segmentsList`.
+ *
+ * When `context.segmentsList` is `[[a, b], [c, d], [e, f]]`, `begin` is `0`, and
+ * `end` is `-1`, this creates `[g, h]`. This `g` is from `a`, `c`, and `e`.
+ * This `h` is from `b`, `d`, and `f`.
+ *
+ * @param {ForkContext} context - An instance.
+ * @param {number} begin - The first index of the previous segments.
+ * @param {number} end - The last index of the previous segments.
+ * @param {function} create - A factory function of new segments.
+ * @returns {CodePathSegment[]} New segments.
+ */
+function makeSegments(context, begin, end, create) {
+    var list = context.segmentsList;
+    if (begin < 0) {
+        begin = list.length + begin;
+    }
+    if (end < 0) {
+        end = list.length + end;
+    }
+
+    var segments = [];
+    for (var i = 0; i < context.count; ++i) {
+        var allPrevSegments = [];
+
+        for (var j = begin; j <= end; ++j) {
+            allPrevSegments.push(list[j][i]);
+        }
+
+        segments.push(create(context.idGenerator.next(), allPrevSegments));
+    }
+
+    return segments;
+}
+
+/**
+ * `segments` becomes doubly in a `finally` block. Then if a code path exits by a
+ * control statement (such as `break`, `continue`) from the `finally` block, the
+ * destination's segments may be half of the source segments. In that case, this
+ * merges segments.
+ *
+ * @param {ForkContext} context - An instance.
+ * @param {CodePathSegment[]} segments - Segments to merge.
+ * @returns {CodePathSegment[]} The merged segments.
+ */
+function mergeExtraSegments(context, segments) {
+    while (segments.length > context.count) {
+        var merged = [];
+        for (var i = 0, length = segments.length / 2 | 0; i < length; ++i) {
+            merged.push(CodePathSegment.newNext(
+                context.idGenerator.next(),
+                [segments[i], segments[i + length]]
+            ));
+        }
+        segments = merged;
+    }
+    return segments;
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * A class to manage forking.
+ *
+ * @constructor
+ * @param {IdGenerator} idGenerator - An identifier generator for segments.
+ * @param {ForkContext|null} upper - An upper fork context.
+ * @param {number} count - A number of parallel segments.
+ */
+function ForkContext(idGenerator, upper, count) {
+    this.idGenerator = idGenerator;
+    this.upper = upper;
+    this.count = count;
+    this.segmentsList = [];
+}
+
+ForkContext.prototype = {
+    constructor: ForkContext,
+
+    /**
+     * The head segments.
+     * @type {CodePathSegment[]}
+     */
+    get head() {
+        var list = this.segmentsList;
+        return list.length === 0 ? [] : list[list.length - 1];
+    },
+
+    /**
+     * A flag which shows empty.
+     * @type {boolean}
+     */
+    get empty() {
+        return this.segmentsList.length === 0;
+    },
+
+    /**
+     * A flag which shows reachable.
+     * @type {boolean}
+     */
+    get reachable() {
+        var segments = this.head;
+        return segments.length > 0 && segments.some(isReachable);
+    },
+
+    /**
+     * Creates new segments from this context.
+     *
+     * @param {number} begin - The first index of previous segments.
+     * @param {number} end - The last index of previous segments.
+     * @returns {CodePathSegment[]} New segments.
+     */
+    makeNext: function(begin, end) {
+        return makeSegments(this, begin, end, CodePathSegment.newNext);
+    },
+
+    /**
+     * Creates new segments from this context.
+     * The new segments is always unreachable.
+     *
+     * @param {number} begin - The first index of previous segments.
+     * @param {number} end - The last index of previous segments.
+     * @returns {CodePathSegment[]} New segments.
+     */
+    makeUnreachable: function(begin, end) {
+        return makeSegments(this, begin, end, CodePathSegment.newUnreachable);
+    },
+
+    /**
+     * Creates new segments from this context.
+     * The new segments don't have connections for previous segments.
+     * But these inherit the reachable flag from this context.
+     *
+     * @param {number} begin - The first index of previous segments.
+     * @param {number} end - The last index of previous segments.
+     * @returns {CodePathSegment[]} New segments.
+     */
+    makeDisconnected: function(begin, end) {
+        return makeSegments(this, begin, end, CodePathSegment.newDisconnected);
+    },
+
+    /**
+     * Adds segments into this context.
+     * The added segments become the head.
+     *
+     * @param {CodePathSegment[]} segments - Segments to add.
+     * @returns {void}
+     */
+    add: function(segments) {
+        assert(segments.length >= this.count, segments.length + " >= " + this.count);
+
+        this.segmentsList.push(mergeExtraSegments(this, segments));
+    },
+
+    /**
+     * Replaces the head segments with given segments.
+     * The current head segments are removed.
+     *
+     * @param {CodePathSegment[]} segments - Segments to add.
+     * @returns {void}
+     */
+    replaceHead: function(segments) {
+        assert(segments.length >= this.count, segments.length + " >= " + this.count);
+
+        this.segmentsList.splice(-1, 1, mergeExtraSegments(this, segments));
+    },
+
+    /**
+     * Adds all segments of a given fork context into this context.
+     *
+     * @param {ForkContext} context - A fork context to add.
+     * @returns {void}
+     */
+    addAll: function(context) {
+        assert(context.count === this.count);
+
+        var source = context.segmentsList;
+        for (var i = 0; i < source.length; ++i) {
+            this.segmentsList.push(source[i]);
+        }
+    },
+
+    /**
+     * Clears all secments in this context.
+     *
+     * @returns {void}
+     */
+    clear: function() {
+        this.segmentsList = [];
+    }
+};
+
+/**
+ * Creates the root fork context.
+ *
+ * @param {IdGenerator} idGenerator - An identifier generator for segments.
+ * @returns {ForkContext} New fork context.
+ */
+ForkContext.newRoot = function(idGenerator) {
+    var context = new ForkContext(idGenerator, null, 1);
+
+    context.add([CodePathSegment.newRoot(idGenerator.next())]);
+
+    return context;
+};
+
+/**
+ * Creates an empty fork context preceded by a given context.
+ *
+ * @param {ForkContext} parentContext - The parent fork context.
+ * @param {boolean} forkLeavingPath - A flag which shows inside of `finally` block.
+ * @returns {ForkContext} New fork context.
+ */
+ForkContext.newEmpty = function(parentContext, forkLeavingPath) {
+    return new ForkContext(
+        parentContext.idGenerator,
+        parentContext,
+        (forkLeavingPath ? 2 : 1) * parentContext.count);
+};
+
+module.exports = ForkContext;

--- a/lib/code-path-analysis/id-generator.js
+++ b/lib/code-path-analysis/id-generator.js
@@ -1,0 +1,43 @@
+/**
+ * @fileoverview A class of identifiers generator for code path segments.
+ *
+ * Each rule uses the identifier of code path segments to store additional
+ * information of the code path.
+ *
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+/**
+ * A generator for unique ids.
+ *
+ * @constructor
+ * @param {string} prefix - Optional. A prefix of generated ids.
+ */
+function IdGenerator(prefix) {
+    this.prefix = String(prefix);
+    this.n = 0;
+}
+
+/**
+ * Generates id.
+ *
+ * @returns {string} A generated id.
+ */
+IdGenerator.prototype.next = function() {
+    this.n = 1 + this.n | 0;
+    /* istanbul ignore if */
+    if (this.n < 0) {
+        this.n = 1;
+    }
+    return this.prefix + this.n;
+};
+
+module.exports = IdGenerator;

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -25,7 +25,8 @@ var estraverse = require("./util/estraverse"),
     EventEmitter = require("events").EventEmitter,
     validator = require("./config-validator"),
     replacements = require("../conf/replacements.json"),
-    assert = require("assert");
+    assert = require("assert"),
+    CodePathAnalyzer = require("./code-path-analysis/code-path-analyzer");
 
 var DEFAULT_PARSER = require("../conf/eslint.json").parser;
 
@@ -765,6 +766,7 @@ module.exports = (function() {
             }
 
             var eventGenerator = new NodeEventGenerator(api);
+            eventGenerator = new CodePathAnalyzer(eventGenerator);
             eventGenerator = new CommentEventGenerator(eventGenerator, sourceCode);
 
             /*
@@ -781,7 +783,6 @@ module.exports = (function() {
                     eventGenerator.leaveNode(node);
                 }
             });
-
         }
 
         // sort by line and column

--- a/lib/util.js
+++ b/lib/util.js
@@ -132,10 +132,21 @@ function removeNameSpace(pluginName) {
     return pluginName.replace(NAMESPACE_REGEX, "");
 }
 
+/**
+ * Gets the last element of a given array.
+ * @param {any[]} xs - An array to get.
+ * @returns {any|null} The last element, or `null` if the array is empty.
+ */
+function getLast(xs) {
+    var length = xs.length;
+    return (length === 0 ? null : xs[length - 1]);
+}
+
 module.exports = {
     mergeConfigs: deepmerge,
     removePluginPrefix: removePluginPrefix,
     getNamespace: getNamespace,
     removeNameSpace: removeNameSpace,
-    "PLUGIN_NAME_PREFIX": PLUGIN_NAME_PREFIX
+    "PLUGIN_NAME_PREFIX": PLUGIN_NAME_PREFIX,
+    getLast: getLast
 };

--- a/package.json
+++ b/package.json
@@ -94,6 +94,7 @@
     "mocha-phantomjs": "4.0.1",
     "npm-license": "^0.3.1",
     "phantomjs": "1.9.18",
+    "phantomjs-polyfill": "0.0.1",
     "proxyquire": "^1.0.0",
     "rewire": "^2.3.4",
     "semver": "^5.0.3",

--- a/tests/fixtures/code-path-analysis/default-params--nest.js
+++ b/tests/fixtures/code-path-analysis/default-params--nest.js
@@ -1,0 +1,32 @@
+/*expected
+initial->s2_1->s2_2->s2_3->s2_4->s2_5;
+s2_1->s2_3->s2_5->final;
+*/
+/*expected
+initial->s1_1->final;
+*/
+function foo({a: {b = 0} = {}}) {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionDeclaration\nIdentifier (foo)\nObjectPattern\nProperty\nIdentifier (a)\nAssignmentPattern\nObjectPattern\nProperty\nIdentifier (b)\nAssignmentPattern\nIdentifier (b)"];
+    s2_2[label="Literal (0)"];
+    s2_3[label="AssignmentPattern:exit\nProperty:exit\nObjectPattern:exit"];
+    s2_4[label="ObjectExpression"];
+    s2_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s2_1->s2_2->s2_3->s2_4->s2_5;
+    s2_1->s2_3->s2_5->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nFunctionDeclaration\nEmptyStatement"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/default-params--simple.js
+++ b/tests/fixtures/code-path-analysis/default-params--simple.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s2_1->s2_2->s2_3;
+s2_1->s2_3->final;
+*/
+/*expected
+initial->s1_1->final;
+*/
+function foo(a = 0) {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionDeclaration\nIdentifier (foo)\nAssignmentPattern\nIdentifier (a)"];
+    s2_2[label="Literal (0)"];
+    s2_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s2_1->s2_2->s2_3;
+    s2_1->s2_3->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nFunctionDeclaration\nEmptyStatement"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--break-always.js
+++ b/tests/fixtures/code-path-analysis/do-while--break-always.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_4;
+s1_3->s1_4->final;
+*/
+do {
+    foo();
+    break;
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nIdentifier (a)"];
+    s1_4[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_4;
+    s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--break-label.js
+++ b/tests/fixtures/code-path-analysis/do-while--break-label.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_3->s1_6;
+s1_4->s1_11;
+s1_6->s1_9;
+s1_7->s1_10->s1_2;
+s1_9->s1_10->s1_11->final;
+*/
+A: do {
+    B: do {
+        if (c) {
+            break A;
+        }
+        if (d) {
+            break B;
+        }
+        foo();
+    } while (b);
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nDoWhileStatement"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_4[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="IfStatement\nIdentifier (d)"];
+    s1_7[label="BlockStatement\nBreakStatement\nIdentifier (B)"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_9[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier (b)"];
+    s1_11[label="DoWhileStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_10[label="Identifier (a)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_3->s1_6;
+    s1_4->s1_11;
+    s1_6->s1_9;
+    s1_7->s1_10->s1_2;
+    s1_9->s1_10->s1_11->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--break-nest.js
+++ b/tests/fixtures/code-path-analysis/do-while--break-nest.js
@@ -1,0 +1,32 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_3->s1_6;
+s1_4->s1_7->s1_2;
+s1_6->s1_7->s1_8->final;
+*/
+do {
+    do {
+        if (c) {
+            break;
+        }
+        foo();
+    } while (b);
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nDoWhileStatement"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_4[label="BlockStatement\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier (b)"];
+    s1_7[label="Identifier (a)"];
+    s1_8[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_3->s1_6;
+    s1_4->s1_7->s1_2;
+    s1_6->s1_7->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--break-simple.js
+++ b/tests/fixtures/code-path-analysis/do-while--break-simple.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_5;
+s1_3->s1_6;
+s1_5->s1_6->final;
+*/
+do {
+    if (b) {
+        break;
+    }
+    foo();
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_3[label="BlockStatement\nBreakStatement"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_5[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier (a)"];
+    s1_6[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_5;
+    s1_3->s1_6;
+    s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--continue-always.js
+++ b/tests/fixtures/code-path-analysis/do-while--continue-always.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4->s1_5->final;
+*/
+do {
+    foo();
+    continue;
+} while (a)
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nContinueStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_4[label="Identifier (a)"];
+    s1_5[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--continue-label.js
+++ b/tests/fixtures/code-path-analysis/do-while--continue-label.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_3->s1_6;
+s1_4->s1_12->s1_2;
+s1_6->s1_9;
+s1_7->s1_10->s1_11->s1_12->s1_13->final;
+*/
+A: do {
+    B: do {
+        if (c) {
+            continue A;
+        }
+        if (d) {
+            continue B;
+        }
+        foo();
+    } while (b);
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nDoWhileStatement"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_4[label="BlockStatement\nContinueStatement\nIdentifier (A)"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="IfStatement\nIdentifier (d)"];
+    s1_7[label="BlockStatement\nContinueStatement\nIdentifier (B)"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_9[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_10[label="Identifier (b)"];
+    s1_12[label="Identifier (a)"];
+    s1_11[label="DoWhileStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    s1_13[label="DoWhileStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_3->s1_6;
+    s1_4->s1_12->s1_2;
+    s1_6->s1_9;
+    s1_7->s1_10->s1_11->s1_12->s1_13->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--continue-nest.js
+++ b/tests/fixtures/code-path-analysis/do-while--continue-nest.js
@@ -1,0 +1,33 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_3->s1_6;
+s1_4->s1_7->s1_8->s1_2;
+s1_8->s1_9->final;
+*/
+do {
+    do {
+        if (c) {
+            continue;
+        }
+        foo();
+    } while (b);
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nDoWhileStatement"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_4[label="BlockStatement\nContinueStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="Identifier (b)"];
+    s1_8[label="Identifier (a)"];
+    s1_9[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_3->s1_6;
+    s1_4->s1_7->s1_8->s1_2;
+    s1_8->s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--continue-simple.js
+++ b/tests/fixtures/code-path-analysis/do-while--continue-simple.js
@@ -1,0 +1,27 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_5;
+s1_3->s1_6->s1_7->final;
+*/
+do {
+    if (b) {
+        continue;
+    }
+    foo();
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_3[label="BlockStatement\nContinueStatement"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_5[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="Identifier (a)"];
+    s1_7[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_5;
+    s1_3->s1_6->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--empty.js
+++ b/tests/fixtures/code-path-analysis/do-while--empty.js
@@ -1,0 +1,17 @@
+/*expected
+initial->s1_1->s1_2->s1_2->s1_3->final;
+*/
+do {
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nIdentifier (a)"];
+    s1_3[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_2->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/do-while--simple.js
+++ b/tests/fixtures/code-path-analysis/do-while--simple.js
@@ -1,0 +1,18 @@
+/*expected
+initial->s1_1->s1_2->s1_2->s1_3->final;
+*/
+do {
+    foo();
+} while (a);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier (a)"];
+    s1_3[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_2->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--break-always.js
+++ b/tests/fixtures/code-path-analysis/for--break-always.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_4->s1_2->s1_6;
+s1_3->s1_6->final;
+*/
+for (var i = 0; i < 10; ++i) {
+    foo();
+    break;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_4->s1_2->s1_6;
+    s1_3->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--break-label.js
+++ b/tests/fixtures/code-path-analysis/for--break-label.js
@@ -1,0 +1,52 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_9->s1_10->s1_11->s1_12->s1_13->s1_7->s1_5;
+s1_2->s1_15;
+s1_5->s1_14->s1_4->s1_2;
+s1_6->s1_10;
+s1_8->s1_15;
+s1_10->s1_13;
+s1_11->s1_14;
+s1_15->final;
+*/
+A: for (var i = 0; i < 10; ++i) {
+    B: for (var j = 0; j < 10; ++j) {
+        if (c) {
+            break A;
+        }
+        if (d) {
+            break B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (j)\nLiteral (0)"];
+    s1_5[label="BinaryExpression\nIdentifier (j)\nLiteral (10)"];
+    s1_6[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_10[label="IfStatement\nIdentifier (d)"];
+    s1_11[label="BlockStatement\nBreakStatement\nIdentifier (B)"];
+    s1_12[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_13[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="UpdateExpression\nIdentifier (j)"];
+    s1_15[label="ForStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_14[label="ForStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_9->s1_10->s1_11->s1_12->s1_13->s1_7->s1_5;
+    s1_2->s1_15;
+    s1_5->s1_14->s1_4->s1_2;
+    s1_6->s1_10;
+    s1_8->s1_15;
+    s1_10->s1_13;
+    s1_11->s1_14;
+    s1_15->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--break-nest.js
+++ b/tests/fixtures/code-path-analysis/for--break-nest.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_9->s1_10->s1_7->s1_5;
+s1_2->s1_12;
+s1_5->s1_11->s1_4->s1_2;
+s1_6->s1_10;
+s1_8->s1_11;
+s1_12->final;
+*/
+for (var i = 0; i < 10; ++i) {
+    for (var j = 0; j < 10; ++j) {
+        if (c) {
+            break;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (j)\nLiteral (0)"];
+    s1_5[label="BinaryExpression\nIdentifier (j)\nLiteral (10)"];
+    s1_6[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nBreakStatement"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="UpdateExpression\nIdentifier (j)"];
+    s1_12[label="ForStatement:exit\nProgram:exit"];
+    s1_11[label="ForStatement:exit\nBlockStatement:exit"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_9->s1_10->s1_7->s1_5;
+    s1_2->s1_12;
+    s1_5->s1_11->s1_4->s1_2;
+    s1_6->s1_10;
+    s1_8->s1_11;
+    s1_12->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--break-simple-no-test.js
+++ b/tests/fixtures/code-path-analysis/for--break-simple-no-test.js
@@ -1,0 +1,27 @@
+/*expected
+initial->s1_1->s1_3->s1_4->s1_5->s1_6->s1_2->s1_3->s1_6;
+s1_4->s1_7->final;
+*/
+for (var i = 0; ; ++i) {
+    if (b) {
+        break;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_2[label="UpdateExpression\nIdentifier (i)"];
+    s1_7[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_4->s1_5->s1_6->s1_2->s1_3->s1_6;
+    s1_4->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--break-simple-no-update.js
+++ b/tests/fixtures/code-path-analysis/for--break-simple-no-update.js
@@ -1,0 +1,29 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_7;
+s1_3->s1_6;
+s1_4->s1_7->final;
+*/
+for (var i = 0; i < 10;) {
+    if (b) {
+        break;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_7;
+    s1_3->s1_6;
+    s1_4->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--break-simple.js
+++ b/tests/fixtures/code-path-analysis/for--break-simple.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_7->s1_4->s1_2->s1_8;
+s1_3->s1_7;
+s1_5->s1_8->final;
+*/
+for (var i = 0; i < 10; ++i) {
+    if (b) {
+        break;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_5[label="BlockStatement\nBreakStatement"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_8[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_7->s1_4->s1_2->s1_8;
+    s1_3->s1_7;
+    s1_5->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--continue-always.js
+++ b/tests/fixtures/code-path-analysis/for--continue-always.js
@@ -1,0 +1,26 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_6;
+s1_3->s1_5->s1_4;
+s1_6->final;
+*/
+for (var i = 0; i < 10; ++i) {
+    foo();
+    continue;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nContinueStatement"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_6;
+    s1_3->s1_5->s1_4;
+    s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--continue-label.js
+++ b/tests/fixtures/code-path-analysis/for--continue-label.js
@@ -1,0 +1,48 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_4->s1_2->s1_15;
+s1_5->s1_14->s1_4;
+s1_6->s1_10->s1_11->s1_7->s1_5;
+s1_8->s1_9->s1_10->s1_13->s1_7;
+s1_11->s1_12->s1_13;
+s1_15->final;
+*/
+A: for (var i = 0; i < 10; ++i) {
+    B: for (var i = 0; i < 10; ++i) {
+        if (c) {
+            continue A;
+        }
+        if (d) {
+            continue B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_5[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_6[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nContinueStatement\nIdentifier (A)"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_15[label="ForStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_14[label="ForStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    s1_10[label="IfStatement\nIdentifier (d)"];
+    s1_11[label="BlockStatement\nContinueStatement\nIdentifier (B)"];
+    s1_7[label="UpdateExpression\nIdentifier (i)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_13[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_12[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_4->s1_2->s1_15;
+    s1_5->s1_14->s1_4;
+    s1_6->s1_10->s1_11->s1_7->s1_5;
+    s1_8->s1_9->s1_10->s1_13->s1_7;
+    s1_11->s1_12->s1_13;
+    s1_15->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--continue-nest.js
+++ b/tests/fixtures/code-path-analysis/for--continue-nest.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_7->s1_5;
+s1_2->s1_12;
+s1_5->s1_11->s1_4->s1_2;
+s1_6->s1_10->s1_7;
+s1_8->s1_9->s1_10;
+s1_12->final;
+*/
+for (var i = 0; i < 10; ++i) {
+    for (var i = 0; i < 10; ++i) {
+        if (c) {
+            continue;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_5[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_6[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nContinueStatement"];
+    s1_7[label="UpdateExpression\nIdentifier (i)"];
+    s1_12[label="ForStatement:exit\nProgram:exit"];
+    s1_11[label="ForStatement:exit\nBlockStatement:exit"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_8->s1_7->s1_5;
+    s1_2->s1_12;
+    s1_5->s1_11->s1_4->s1_2;
+    s1_6->s1_10->s1_7;
+    s1_8->s1_9->s1_10;
+    s1_12->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--continue-simple-no-test.js
+++ b/tests/fixtures/code-path-analysis/for--continue-simple-no-test.js
@@ -1,0 +1,26 @@
+/*expected
+initial->s1_1->s1_3->s1_4->s1_2->s1_3->s1_6->s1_2;
+s1_4->s1_5->s1_6->s1_7;
+*/
+for (var i = 0; ; ++i) {
+    if (b) {
+        continue;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nContinueStatement"];
+    s1_2[label="UpdateExpression\nIdentifier (i)"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_4->s1_2->s1_3->s1_6->s1_2;
+    s1_4->s1_5->s1_6->s1_7;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--continue-simple-no-update.js
+++ b/tests/fixtures/code-path-analysis/for--continue-simple-no-update.js
@@ -1,0 +1,31 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_7;
+s1_3->s1_6->s1_2;
+s1_4->s1_5->s1_6;
+s1_7->final;
+*/
+for (var i = 0; i < 10;) {
+    if (b) {
+        continue;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nContinueStatement"];
+    s1_7[label="ForStatement:exit\nProgram:exit"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_7;
+    s1_3->s1_6->s1_2;
+    s1_4->s1_5->s1_6;
+    s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--continue-simple.js
+++ b/tests/fixtures/code-path-analysis/for--continue-simple.js
@@ -1,0 +1,32 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_4->s1_2->s1_8;
+s1_3->s1_7->s1_4;
+s1_5->s1_6->s1_7;
+s1_8->final;
+*/
+for (var i = 0; i < 10; ++i) {
+    if (b) {
+        continue;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_5[label="BlockStatement\nContinueStatement"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_8[label="ForStatement:exit\nProgram:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_4->s1_2->s1_8;
+    s1_3->s1_7->s1_4;
+    s1_5->s1_6->s1_7;
+    s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--empty.js
+++ b/tests/fixtures/code-path-analysis/for--empty.js
@@ -1,0 +1,16 @@
+/*expected
+initial->s1_1->s1_2->s1_2->s1_3;
+*/
+for (;;) {
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement"];
+    s1_2[label="BlockStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_2->s1_3;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--simple-fork-in-test-update.js
+++ b/tests/fixtures/code-path-analysis/for--simple-fork-in-test-update.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_7->s1_8->s1_10->s1_2->s1_4->s1_5->s1_11;
+s1_7->s1_9->s1_10;
+s1_11->final;
+*/
+for (var i = 0; i < 10 ? true : false; ++i ? 1 : 2) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="ConditionalExpression\nBinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="Literal (true)"];
+    s1_5[label="ConditionalExpression:exit"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="ConditionalExpression\nUpdateExpression\nIdentifier (i)"];
+    s1_8[label="Literal (1)"];
+    s1_10[label="ConditionalExpression:exit"];
+    s1_4[label="Literal (false)"];
+    s1_11[label="ForStatement:exit\nProgram:exit"];
+    s1_9[label="Literal (2)"];
+    initial->s1_1->s1_2->s1_3->s1_5->s1_6->s1_7->s1_8->s1_10->s1_2->s1_4->s1_5->s1_11;
+    s1_7->s1_9->s1_10;
+    s1_11->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--simple-no-test.js
+++ b/tests/fixtures/code-path-analysis/for--simple-no-test.js
@@ -1,0 +1,18 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_3->s1_4;
+*/
+for (var i = 0; ; ++i) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_2[label="UpdateExpression\nIdentifier (i)"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_3->s1_4;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--simple-no-update.js
+++ b/tests/fixtures/code-path-analysis/for--simple-no-update.js
@@ -1,0 +1,19 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_4->final;
+*/
+for (var i = 0; i < 10;) {
+    ++i;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nUpdateExpression\nIdentifier (i)"];
+    s1_4[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--simple-test-true.js
+++ b/tests/fixtures/code-path-analysis/for--simple-test-true.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2;
+s1_3->s1_5;
+*/
+for (var i = 0; true; ++i) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="Literal (true)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2;
+    s1_3->s1_5;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for--simple.js
+++ b/tests/fixtures/code-path-analysis/for--simple.js
@@ -1,0 +1,20 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5->final;
+*/
+for (var i = 0; i < 10; ++i) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_4[label="UpdateExpression\nIdentifier (i)"];
+    s1_5[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--break-always.js
+++ b/tests/fixtures/code-path-analysis/for-in--break-always.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+s1_3->s1_6;
+s1_4->s1_6;
+s1_5->s1_6->final;
+*/
+for (var a in [0]) {
+    foo();
+    break;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+    s1_3->s1_6;
+    s1_4->s1_6;
+    s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--break-label.js
+++ b/tests/fixtures/code-path-analysis/for-in--break-label.js
@@ -1,0 +1,52 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_11->s1_12->s1_13->s1_5;
+s1_3->s1_15;
+s1_6->s1_14->s1_2;
+s1_7->s1_10;
+s1_8->s1_15;
+s1_10->s1_13;
+s1_11->s1_14;
+s1_13->s1_14->s1_15->final;
+*/
+A: for (var a in [0]) {
+    B: for (var b in [1]) {
+        if (c) {
+            break A;
+        }
+        if (d) {
+            break B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_10[label="IfStatement\nIdentifier (d)"];
+    s1_11[label="BlockStatement\nBreakStatement\nIdentifier (B)"];
+    s1_12[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_13[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_15[label="ForInStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_14[label="ForInStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_11->s1_12->s1_13->s1_5;
+    s1_3->s1_15;
+    s1_6->s1_14->s1_2;
+    s1_7->s1_10;
+    s1_8->s1_15;
+    s1_10->s1_13;
+    s1_11->s1_14;
+    s1_13->s1_14->s1_15->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--break-nest.js
+++ b/tests/fixtures/code-path-analysis/for-in--break-nest.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_5;
+s1_3->s1_12;
+s1_6->s1_11->s1_2;
+s1_7->s1_10;
+s1_8->s1_11;
+s1_10->s1_11->s1_12->final;
+*/
+for (var a in [0]) {
+    for (var b in [1]) {
+        if (c) {
+            break;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nBreakStatement"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_12[label="ForInStatement:exit\nProgram:exit"];
+    s1_11[label="ForInStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_5;
+    s1_3->s1_12;
+    s1_6->s1_11->s1_2;
+    s1_7->s1_10;
+    s1_8->s1_11;
+    s1_10->s1_11->s1_12->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--break-simple.js
+++ b/tests/fixtures/code-path-analysis/for-in--break-simple.js
@@ -1,0 +1,34 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_6->s1_7->s1_2;
+s1_3->s1_8;
+s1_4->s1_7;
+s1_5->s1_8;
+s1_7->s1_8->final;
+*/
+for (var a in [0]) {
+    if (b) {
+        break;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_5[label="BlockStatement\nBreakStatement"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_8[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_6->s1_7->s1_2;
+    s1_3->s1_8;
+    s1_4->s1_7;
+    s1_5->s1_8;
+    s1_7->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--continue-always.js
+++ b/tests/fixtures/code-path-analysis/for-in--continue-always.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+s1_3->s1_6;
+s1_4->s1_5->s1_2;
+s1_4->s1_6;
+s1_5->s1_6->final;
+*/
+for (var a in [0]) {
+    foo();
+    continue;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nContinueStatement"];
+    s1_6[label="ForInStatement:exit\nProgram:exit"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+    s1_3->s1_6;
+    s1_4->s1_5->s1_2;
+    s1_4->s1_6;
+    s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--continue-label.js
+++ b/tests/fixtures/code-path-analysis/for-in--continue-label.js
@@ -1,0 +1,60 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_2;
+s1_3->s1_15;
+s1_6->s1_14->s1_2;
+s1_7->s1_10->s1_11->s1_5;
+s1_8->s1_9->s1_10;
+s1_14->s1_15;
+s1_10->s1_13->s1_5;
+s1_11->s1_12->s1_13;
+s1_8->s1_15;
+s1_13->s1_14;
+s1_11->s1_14;
+s1_15->final;
+*/
+A: for (var a in [0]) {
+    B: for (var b in [1]) {
+        if (c) {
+            continue A;
+        }
+        if (d) {
+            continue B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nContinueStatement\nIdentifier (A)"];
+    s1_15[label="ForInStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_14[label="ForInStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    s1_10[label="IfStatement\nIdentifier (d)"];
+    s1_11[label="BlockStatement\nContinueStatement\nIdentifier (B)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_13[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_12[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_2;
+    s1_3->s1_15;
+    s1_6->s1_14->s1_2;
+    s1_7->s1_10->s1_11->s1_5;
+    s1_8->s1_9->s1_10;
+    s1_14->s1_15;
+    s1_10->s1_13->s1_5;
+    s1_11->s1_12->s1_13;
+    s1_8->s1_15;
+    s1_13->s1_14;
+    s1_11->s1_14;
+    s1_15->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--continue-nest.js
+++ b/tests/fixtures/code-path-analysis/for-in--continue-nest.js
@@ -1,0 +1,48 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_5;
+s1_3->s1_12;
+s1_6->s1_11->s1_2;
+s1_7->s1_10->s1_5;
+s1_8->s1_9->s1_10;
+s1_11->s1_12;
+s1_10->s1_11;
+s1_8->s1_11;
+s1_12->final;
+*/
+for (var a in [0]) {
+    for (var b in [1]) {
+        if (c) {
+            continue;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nContinueStatement"];
+    s1_12[label="ForInStatement:exit\nProgram:exit"];
+    s1_11[label="ForInStatement:exit\nBlockStatement:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_5;
+    s1_3->s1_12;
+    s1_6->s1_11->s1_2;
+    s1_7->s1_10->s1_5;
+    s1_8->s1_9->s1_10;
+    s1_11->s1_12;
+    s1_10->s1_11;
+    s1_8->s1_11;
+    s1_12->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--continue-simple.js
+++ b/tests/fixtures/code-path-analysis/for-in--continue-simple.js
@@ -1,0 +1,34 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+s1_3->s1_8;
+s1_4->s1_7->s1_2;
+s1_5->s1_6->s1_7->s1_8;
+s1_5->s1_8->final;
+*/
+for (var a in [0]) {
+    if (b) {
+        continue;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_5[label="BlockStatement\nContinueStatement"];
+    s1_8[label="ForInStatement:exit\nProgram:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+    s1_3->s1_8;
+    s1_4->s1_7->s1_2;
+    s1_5->s1_6->s1_7->s1_8;
+    s1_5->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--empty.js
+++ b/tests/fixtures/code-path-analysis/for-in--empty.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+s1_3->s1_5;
+s1_4->s1_5->final;
+*/
+for (var a in [0]) {
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement"];
+    s1_5[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+    s1_3->s1_5;
+    s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-in--simple.js
+++ b/tests/fixtures/code-path-analysis/for-in--simple.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+s1_3->s1_5;
+s1_4->s1_5->final;
+*/
+for (var a in [0]) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+    s1_3->s1_5;
+    s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--break-always.js
+++ b/tests/fixtures/code-path-analysis/for-of--break-always.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+s1_3->s1_6;
+s1_4->s1_6;
+s1_5->s1_6->final;
+*/
+for (var a of [0]) {
+    foo();
+    break;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+    s1_3->s1_6;
+    s1_4->s1_6;
+    s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--break-label.js
+++ b/tests/fixtures/code-path-analysis/for-of--break-label.js
@@ -1,0 +1,52 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_11->s1_12->s1_13->s1_5;
+s1_3->s1_15;
+s1_6->s1_14->s1_2;
+s1_7->s1_10;
+s1_8->s1_15;
+s1_10->s1_13;
+s1_11->s1_14;
+s1_13->s1_14->s1_15->final;
+*/
+A: for (var a of [0]) {
+    B: for (var b of [1]) {
+        if (c) {
+            break A;
+        }
+        if (d) {
+            break B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_10[label="IfStatement\nIdentifier (d)"];
+    s1_11[label="BlockStatement\nBreakStatement\nIdentifier (B)"];
+    s1_12[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_13[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_15[label="ForInStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_14[label="ForInStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_11->s1_12->s1_13->s1_5;
+    s1_3->s1_15;
+    s1_6->s1_14->s1_2;
+    s1_7->s1_10;
+    s1_8->s1_15;
+    s1_10->s1_13;
+    s1_11->s1_14;
+    s1_13->s1_14->s1_15->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--break-nest.js
+++ b/tests/fixtures/code-path-analysis/for-of--break-nest.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_5;
+s1_3->s1_12;
+s1_6->s1_11->s1_2;
+s1_7->s1_10;
+s1_8->s1_11;
+s1_10->s1_11->s1_12->final;
+*/
+for (var a of [0]) {
+    for (var b of [1]) {
+        if (c) {
+            break;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nBreakStatement"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_12[label="ForInStatement:exit\nProgram:exit"];
+    s1_11[label="ForInStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_9->s1_10->s1_5;
+    s1_3->s1_12;
+    s1_6->s1_11->s1_2;
+    s1_7->s1_10;
+    s1_8->s1_11;
+    s1_10->s1_11->s1_12->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--break-simple.js
+++ b/tests/fixtures/code-path-analysis/for-of--break-simple.js
@@ -1,0 +1,34 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_6->s1_7->s1_2;
+s1_3->s1_8;
+s1_4->s1_7;
+s1_5->s1_8;
+s1_7->s1_8->final;
+*/
+for (var a of [0]) {
+    if (b) {
+        break;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_5[label="BlockStatement\nBreakStatement"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_8[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_6->s1_7->s1_2;
+    s1_3->s1_8;
+    s1_4->s1_7;
+    s1_5->s1_8;
+    s1_7->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--continue-always.js
+++ b/tests/fixtures/code-path-analysis/for-of--continue-always.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+s1_3->s1_6;
+s1_4->s1_5->s1_2;
+s1_4->s1_6;
+s1_5->s1_6->final;
+*/
+for (var a of [0]) {
+    foo();
+    continue;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nContinueStatement"];
+    s1_6[label="ForInStatement:exit\nProgram:exit"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+    s1_3->s1_6;
+    s1_4->s1_5->s1_2;
+    s1_4->s1_6;
+    s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--continue-label.js
+++ b/tests/fixtures/code-path-analysis/for-of--continue-label.js
@@ -1,0 +1,60 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_2;
+s1_3->s1_15;
+s1_6->s1_14->s1_2;
+s1_7->s1_10->s1_11->s1_5;
+s1_8->s1_9->s1_10;
+s1_14->s1_15;
+s1_10->s1_13->s1_5;
+s1_11->s1_12->s1_13;
+s1_8->s1_15;
+s1_13->s1_14;
+s1_11->s1_14;
+s1_15->final;
+*/
+A: for (var a of [0]) {
+    B: for (var b of [1]) {
+        if (c) {
+            continue A;
+        }
+        if (d) {
+            continue B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nContinueStatement\nIdentifier (A)"];
+    s1_15[label="ForInStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_14[label="ForInStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    s1_10[label="IfStatement\nIdentifier (d)"];
+    s1_11[label="BlockStatement\nContinueStatement\nIdentifier (B)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_13[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_12[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_2;
+    s1_3->s1_15;
+    s1_6->s1_14->s1_2;
+    s1_7->s1_10->s1_11->s1_5;
+    s1_8->s1_9->s1_10;
+    s1_14->s1_15;
+    s1_10->s1_13->s1_5;
+    s1_11->s1_12->s1_13;
+    s1_8->s1_15;
+    s1_13->s1_14;
+    s1_11->s1_14;
+    s1_15->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--continue-nest.js
+++ b/tests/fixtures/code-path-analysis/for-of--continue-nest.js
@@ -1,0 +1,48 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_5;
+s1_3->s1_12;
+s1_6->s1_11->s1_2;
+s1_7->s1_10->s1_5;
+s1_8->s1_9->s1_10;
+s1_11->s1_12;
+s1_10->s1_11;
+s1_8->s1_11;
+s1_12->final;
+*/
+for (var a of [0]) {
+    for (var b of [1]) {
+        if (c) {
+            continue;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nForInStatement"];
+    s1_6[label="ArrayExpression\nLiteral (1)"];
+    s1_5[label="VariableDeclaration\nVariableDeclarator\nIdentifier (b)"];
+    s1_7[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_8[label="BlockStatement\nContinueStatement"];
+    s1_12[label="ForInStatement:exit\nProgram:exit"];
+    s1_11[label="ForInStatement:exit\nBlockStatement:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_9[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_6->s1_5->s1_7->s1_8->s1_5;
+    s1_3->s1_12;
+    s1_6->s1_11->s1_2;
+    s1_7->s1_10->s1_5;
+    s1_8->s1_9->s1_10;
+    s1_11->s1_12;
+    s1_10->s1_11;
+    s1_8->s1_11;
+    s1_12->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--continue-simple.js
+++ b/tests/fixtures/code-path-analysis/for-of--continue-simple.js
@@ -1,0 +1,34 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+s1_3->s1_8;
+s1_4->s1_7->s1_2;
+s1_5->s1_6->s1_7->s1_8;
+s1_5->s1_8->final;
+*/
+for (var a of [0]) {
+    if (b) {
+        continue;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_5[label="BlockStatement\nContinueStatement"];
+    s1_8[label="ForInStatement:exit\nProgram:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_5->s1_2;
+    s1_3->s1_8;
+    s1_4->s1_7->s1_2;
+    s1_5->s1_6->s1_7->s1_8;
+    s1_5->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--empty.js
+++ b/tests/fixtures/code-path-analysis/for-of--empty.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+s1_3->s1_5;
+s1_4->s1_5->final;
+*/
+for (var a of [0]) {
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement"];
+    s1_5[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+    s1_3->s1_5;
+    s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/for-of--simple.js
+++ b/tests/fixtures/code-path-analysis/for-of--simple.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+s1_3->s1_5;
+s1_4->s1_5->final;
+*/
+for (var a of [0]) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForInStatement"];
+    s1_3[label="ArrayExpression\nLiteral (0)"];
+    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (a)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="ForInStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+    s1_3->s1_5;
+    s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/function--in-condition-expr.js
+++ b/tests/fixtures/code-path-analysis/function--in-condition-expr.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s2_1->final;
+*/
+/*expected
+initial->s3_1->final;
+*/
+/*expected
+initial->s1_1->s1_2->s1_4;
+s1_1->s1_3->s1_4->final;
+*/
+(
+    foo ? function foo() {}
+        : function bar() {}
+)();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionExpression\nIdentifier (foo)\nBlockStatement"];
+    initial->s2_1->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s3_1[label="FunctionExpression\nIdentifier (bar)\nBlockStatement"];
+    initial->s3_1->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nExpressionStatement\nCallExpression\nConditionalExpression\nIdentifier (foo)"];
+    s1_2[label="FunctionExpression"];
+    s1_4[label="ConditionalExpression:exit\nCallExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    s1_3[label="FunctionExpression"];
+    initial->s1_1->s1_2->s1_4;
+    s1_1->s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/function--in-logical-right.js
+++ b/tests/fixtures/code-path-analysis/function--in-logical-right.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s2_1->final;
+*/
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_3->final;
+*/
+var foo = native || function foo() {};
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionExpression\nIdentifier (foo)\nBlockStatement"];
+    initial->s2_1->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nVariableDeclaration\nVariableDeclarator\nIdentifier (foo)\nLogicalExpression\nIdentifier (native)"];
+    s1_2[label="FunctionExpression"];
+    s1_3[label="LogicalExpression:exit\nVariableDeclarator:exit\nVariableDeclaration:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/function--simple.js
+++ b/tests/fixtures/code-path-analysis/function--simple.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s2_1->final;
+*/
+/*expected
+initial->s1_1->final;
+*/
+foo(0);
+
+function foo(a) {
+    console.log(a);
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionDeclaration\nIdentifier (foo)\nIdentifier (a)\nBlockStatement\nExpressionStatement\nCallExpression\nMemberExpression\nIdentifier (console)\nIdentifier (log)\nIdentifier (a)"];
+    initial->s2_1->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nExpressionStatement\nCallExpression\nIdentifier (foo)\nLiteral (0)"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/if-1.js
+++ b/tests/fixtures/code-path-analysis/if-1.js
@@ -1,0 +1,20 @@
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_3->final;
+*/
+if (a) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_3[label="IfStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/if-2.js
+++ b/tests/fixtures/code-path-analysis/if-2.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_4;
+s1_1->s1_3->s1_4->final;
+*/
+if (a) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_4[label="IfStatement:exit\nProgram:exit"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_4;
+    s1_1->s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/if-3.js
+++ b/tests/fixtures/code-path-analysis/if-3.js
@@ -1,0 +1,37 @@
+/*expected
+initial->s1_1->s1_2->s1_9;
+s1_1->s1_3->s1_4->s1_5->s1_6->s1_9;
+s1_3->s1_7->s1_9;
+s1_4->s1_6;
+s1_9->final;
+*/
+if (a) {
+    foo();
+} else if (b) {
+    if (c) {
+        bar();
+    }
+} else {
+    hoge();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_3[label="IfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    s1_6[label="IfStatement:exit\nBlockStatement:exit"];
+    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (hoge)"];
+    initial->s1_1->s1_2->s1_9;
+    s1_1->s1_3->s1_4->s1_5->s1_6->s1_9;
+    s1_3->s1_7->s1_9;
+    s1_4->s1_6;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/if-4.js
+++ b/tests/fixtures/code-path-analysis/if-4.js
@@ -1,0 +1,31 @@
+/*eslint-env node*/
+/*expected
+initial->s1_1->s1_2->s1_3->s1_6;
+s1_1->s1_4->s1_5->s1_6;
+s1_2->final;
+s1_4->thrown;
+*/
+if (a) {
+    return 0;
+} else {
+    throw new Error("err");
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize];
+    s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+    s1_2[label="BlockStatement\nReturnStatement\nLiteral (0)"];
+    s1_3[label="BlockStatement:exit"];
+    s1_6[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="BlockStatement\nThrowStatement\nNewExpression\nIdentifier (Error)\nLiteral (err)"];
+    s1_5[label="BlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_6;
+    s1_1->s1_4->s1_5->s1_6;
+    s1_2->final;
+    s1_4->thrown;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--do-while-and-1.js
+++ b/tests/fixtures/code-path-analysis/logical--do-while-and-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_4;
+s1_3->s1_4->final;
+*/
+do {
+    foo();
+} while (a && b);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_4;
+    s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--do-while-and-2.js
+++ b/tests/fixtures/code-path-analysis/logical--do-while-and-2.js
@@ -1,0 +1,27 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_6;
+s1_3->s1_6;
+s1_4->s1_6;
+s1_5->s1_6->final;
+*/
+do {
+    foo();
+} while (a && b && c && d);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nLogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_6;
+    s1_3->s1_6;
+    s1_4->s1_6;
+    s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--do-while-mix-1.js
+++ b/tests/fixtures/code-path-analysis/logical--do-while-mix-1.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+s1_3->s1_2;
+s1_4->s1_5->final;
+*/
+do {
+    foo();
+} while (a && b || c);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+    s1_3->s1_2;
+    s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--do-while-mix-2.js
+++ b/tests/fixtures/code-path-analysis/logical--do-while-mix-2.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_2;
+s1_3->s1_5;
+s1_4->s1_5->final;
+*/
+do {
+    foo();
+} while (a || b && c);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="LogicalExpression\nIdentifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_2;
+    s1_3->s1_5;
+    s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--do-while-or-1.js
+++ b/tests/fixtures/code-path-analysis/logical--do-while-or-1.js
@@ -1,0 +1,21 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_2;
+s1_3->s1_4->final;
+*/
+do {
+    foo();
+} while (a || b);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_2;
+    s1_3->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--do-while-or-2.js
+++ b/tests/fixtures/code-path-analysis/logical--do-while-or-2.js
@@ -1,0 +1,27 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_2;
+s1_3->s1_2;
+s1_4->s1_2;
+s1_5->s1_6->final;
+*/
+do {
+    foo();
+} while (a || b || c || d);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nDoWhileStatement"];
+    s1_2[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nLogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="DoWhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_2;
+    s1_3->s1_2;
+    s1_4->s1_2;
+    s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-and-1.js
+++ b/tests/fixtures/code-path-analysis/logical--for-and-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_6;
+s1_3->s1_6->final;
+*/
+for (init; a && b; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="Identifier (update)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_6;
+    s1_3->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-and-2.js
+++ b/tests/fixtures/code-path-analysis/logical--for-and-2.js
@@ -1,0 +1,29 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_2->s1_8;
+s1_3->s1_8;
+s1_4->s1_8;
+s1_5->s1_8->final;
+*/
+for (init; a && b && c && d; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="Identifier (update)"];
+    s1_8[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_2->s1_8;
+    s1_3->s1_8;
+    s1_4->s1_8;
+    s1_5->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-and-3.js
+++ b/tests/fixtures/code-path-analysis/logical--for-and-3.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+for (init; a && b;) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-mix-1.js
+++ b/tests/fixtures/code-path-analysis/logical--for-mix-1.js
@@ -1,0 +1,26 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_4;
+s1_3->s1_5;
+s1_4->s1_7->final;
+*/
+for (init; a && b || c; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="Identifier (update)"];
+    s1_7[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_4;
+    s1_3->s1_5;
+    s1_4->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-mix-2.js
+++ b/tests/fixtures/code-path-analysis/logical--for-mix-2.js
@@ -1,0 +1,26 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_5;
+s1_3->s1_7;
+s1_4->s1_7->final;
+*/
+for (init; a || b && c; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nIdentifier (a)"];
+    s1_3[label="LogicalExpression\nIdentifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="Identifier (update)"];
+    s1_7[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_5;
+    s1_3->s1_7;
+    s1_4->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-mix-3.js
+++ b/tests/fixtures/code-path-analysis/logical--for-mix-3.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+s1_3->s1_5;
+s1_4->s1_6->final;
+*/
+for (init; a && b || c;) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+    s1_3->s1_5;
+    s1_4->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-or-1.js
+++ b/tests/fixtures/code-path-analysis/logical--for-or-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+s1_3->s1_6->final;
+*/
+for (init; a || b; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="Identifier (update)"];
+    s1_6[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+    s1_3->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-or-2.js
+++ b/tests/fixtures/code-path-analysis/logical--for-or-2.js
@@ -1,0 +1,29 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_2->s1_6;
+s1_3->s1_6;
+s1_4->s1_6;
+s1_5->s1_8->final;
+*/
+for (init; a || b || c || d; update) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="Identifier (update)"];
+    s1_8[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_2->s1_6;
+    s1_3->s1_6;
+    s1_4->s1_6;
+    s1_5->s1_8->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--for-or-3.js
+++ b/tests/fixtures/code-path-analysis/logical--for-or-3.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+s1_3->s1_5->final;
+*/
+for (init; a || b;) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nForStatement\nIdentifier (init)"];
+    s1_2[label="LogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="ForStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-and-1.js
+++ b/tests/fixtures/code-path-analysis/logical--if-and-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+if (a && b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_4[label="IfStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-and-2.js
+++ b/tests/fixtures/code-path-analysis/logical--if-and-2.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5;
+s1_1->s1_4->s1_5;
+s1_2->s1_4;
+s1_5->final;
+*/
+if (a && b) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_5;
+    s1_1->s1_4->s1_5;
+    s1_2->s1_4;
+    s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-and-3.js
+++ b/tests/fixtures/code-path-analysis/logical--if-and-3.js
@@ -1,0 +1,35 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_9;
+s1_1->s1_4->s1_5->s1_6->s1_9;
+s1_2->s1_4->s1_7->s1_9;
+s1_5->s1_7;
+s1_9->final;
+*/
+if (a && b) {
+    foo();
+} else if (c && d) {
+    bar();
+} else {
+    qiz();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="IfStatement\nLogicalExpression\nIdentifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)"];
+    initial->s1_1->s1_2->s1_3->s1_9;
+    s1_1->s1_4->s1_5->s1_6->s1_9;
+    s1_2->s1_4->s1_7->s1_9;
+    s1_5->s1_7;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-and-4.js
+++ b/tests/fixtures/code-path-analysis/logical--if-and-4.js
@@ -1,0 +1,34 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7;
+s1_1->s1_6->s1_7;
+s1_2->s1_6;
+s1_3->s1_6;
+s1_4->s1_6;
+s1_7->final;
+*/
+if (a && b && c && d) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="Identifier (d)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="IfStatement:exit\nProgram:exit"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7;
+    s1_1->s1_6->s1_7;
+    s1_2->s1_6;
+    s1_3->s1_6;
+    s1_4->s1_6;
+    s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-and-5.js
+++ b/tests/fixtures/code-path-analysis/logical--if-and-5.js
@@ -1,0 +1,40 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+s1_1->s1_8->s1_9;
+s1_2->s1_8;
+s1_3->s1_6->s1_7;
+s1_4->s1_6;
+s1_9->final;
+*/
+if (a && b) {
+    if (c && d) {
+        foo();
+    } else {
+        bar();
+    }
+} else {
+    qiz();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nIfStatement\nLogicalExpression\nIdentifier (c)"];
+    s1_4[label="Identifier (d)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="IfStatement:exit\nBlockStatement:exit"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_8[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+    s1_1->s1_8->s1_9;
+    s1_2->s1_8;
+    s1_3->s1_6->s1_7;
+    s1_4->s1_6;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-mix-1.js
+++ b/tests/fixtures/code-path-analysis/logical--if-mix-1.js
@@ -1,0 +1,29 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_6;
+s1_1->s1_3;
+s1_2->s1_4;
+s1_3->s1_5->s1_6->final;
+*/
+if (a && b || c) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="IfStatement:exit\nProgram:exit"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_6;
+    s1_1->s1_3;
+    s1_2->s1_4;
+    s1_3->s1_5->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-mix-2.js
+++ b/tests/fixtures/code-path-analysis/logical--if-mix-2.js
@@ -1,0 +1,31 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_6;
+s1_1->s1_4;
+s1_2->s1_5->s1_6;
+s1_3->s1_5;
+s1_6->final;
+*/
+if (a || b && c) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="LogicalExpression\nIdentifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="IfStatement:exit\nProgram:exit"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_6;
+    s1_1->s1_4;
+    s1_2->s1_5->s1_6;
+    s1_3->s1_5;
+    s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-or-1.js
+++ b/tests/fixtures/code-path-analysis/logical--if-or-1.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4->final;
+*/
+if (a || b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_4[label="IfStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-or-2.js
+++ b/tests/fixtures/code-path-analysis/logical--if-or-2.js
@@ -1,0 +1,26 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5;
+s1_1->s1_3;
+s1_2->s1_4->s1_5->final;
+*/
+if (a || b) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_5;
+    s1_1->s1_3;
+    s1_2->s1_4->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-or-3.js
+++ b/tests/fixtures/code-path-analysis/logical--if-or-3.js
@@ -1,0 +1,35 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_9;
+s1_1->s1_3;
+s1_2->s1_4->s1_5->s1_6->s1_9;
+s1_4->s1_6;
+s1_5->s1_7->s1_9->final;
+*/
+if (a || b) {
+    foo();
+} else if (c || d) {
+    bar();
+} else {
+    qiz();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_4[label="IfStatement\nLogicalExpression\nIdentifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)"];
+    initial->s1_1->s1_2->s1_3->s1_9;
+    s1_1->s1_3;
+    s1_2->s1_4->s1_5->s1_6->s1_9;
+    s1_4->s1_6;
+    s1_5->s1_7->s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-or-4.js
+++ b/tests/fixtures/code-path-analysis/logical--if-or-4.js
@@ -1,0 +1,32 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7;
+s1_1->s1_5;
+s1_2->s1_5;
+s1_3->s1_5;
+s1_4->s1_6->s1_7->final;
+*/
+if (a || b || c || d) {
+    foo();
+} else {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="Identifier (d)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="IfStatement:exit\nProgram:exit"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7;
+    s1_1->s1_5;
+    s1_2->s1_5;
+    s1_3->s1_5;
+    s1_4->s1_6->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--if-or-5.js
+++ b/tests/fixtures/code-path-analysis/logical--if-or-5.js
@@ -1,0 +1,40 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+s1_1->s1_3;
+s1_2->s1_8->s1_9;
+s1_3->s1_5;
+s1_4->s1_6->s1_7;
+s1_9->final;
+*/
+if (a || b) {
+    if (c || d) {
+        foo();
+    } else {
+        bar();
+    }
+} else {
+    qiz();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="BlockStatement\nIfStatement\nLogicalExpression\nIdentifier (c)"];
+    s1_4[label="Identifier (d)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="IfStatement:exit\nBlockStatement:exit"];
+    s1_9[label="IfStatement:exit\nProgram:exit"];
+    s1_8[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (qiz)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_7->s1_9;
+    s1_1->s1_3;
+    s1_2->s1_8->s1_9;
+    s1_3->s1_5;
+    s1_4->s1_6->s1_7;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--simple-1.js
+++ b/tests/fixtures/code-path-analysis/logical--simple-1.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+s1_1->s1_5;
+s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+a || b || c || d;
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nExpressionStatement\nLogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="Identifier (c)"];
+    s1_4[label="Identifier (d)"];
+    s1_5[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+    s1_1->s1_5;
+    s1_2->s1_5;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--simple-2.js
+++ b/tests/fixtures/code-path-analysis/logical--simple-2.js
@@ -1,0 +1,24 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+s1_1->s1_5;
+s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+a || b || (c || d);
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nExpressionStatement\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_2[label="Identifier (b)"];
+    s1_3[label="LogicalExpression\nIdentifier (c)"];
+    s1_4[label="Identifier (d)"];
+    s1_5[label="LogicalExpression:exit\nExpressionStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+    s1_1->s1_5;
+    s1_2->s1_5;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--while-and-1.js
+++ b/tests/fixtures/code-path-analysis/logical--while-and-1.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+while (a && b) {
+    foo();
+}
+
+/*DOT
+digraph {
+node[shape=box,style="rounded,filled",fillcolor=white];
+initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+s1_1[label="Program\nWhileStatement"];
+s1_2[label="LogicalExpression\nIdentifier (a)"];
+s1_3[label="Identifier (b)"];
+s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+s1_5[label="WhileStatement:exit\nProgram:exit"];
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--while-and-2.js
+++ b/tests/fixtures/code-path-analysis/logical--while-and-2.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_7;
+s1_3->s1_7;
+s1_4->s1_7;
+s1_5->s1_7->final;
+*/
+while (a && b && c && d) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="LogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_7;
+    s1_3->s1_7;
+    s1_4->s1_7;
+    s1_5->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--while-mix-1.js
+++ b/tests/fixtures/code-path-analysis/logical--while-mix-1.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+s1_3->s1_5;
+s1_4->s1_6->final;
+*/
+while (a && b || c) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="LogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_4;
+    s1_3->s1_5;
+    s1_4->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--while-mix-2.js
+++ b/tests/fixtures/code-path-analysis/logical--while-mix-2.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_5;
+s1_3->s1_6;
+s1_4->s1_6->final;
+*/
+while (a || b && c) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="LogicalExpression\nIdentifier (a)"];
+    s1_3[label="LogicalExpression\nIdentifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_6[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_2->s1_5;
+    s1_3->s1_6;
+    s1_4->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--while-or-1.js
+++ b/tests/fixtures/code-path-analysis/logical--while-or-1.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+s1_3->s1_5->final;
+*/
+while (a || b) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="LogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_4;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/logical--while-or-2.js
+++ b/tests/fixtures/code-path-analysis/logical--while-or-2.js
@@ -1,0 +1,28 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_6;
+s1_3->s1_6;
+s1_4->s1_6;
+s1_5->s1_7->final;
+*/
+while (a || b || c || d) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="LogicalExpression\nLogicalExpression\nLogicalExpression\nIdentifier (a)"];
+    s1_3[label="Identifier (b)"];
+    s1_4[label="Identifier (c)"];
+    s1_5[label="Identifier (d)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_6;
+    s1_3->s1_6;
+    s1_4->s1_6;
+    s1_5->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--cases-1.js
+++ b/tests/fixtures/code-path-analysis/switch--cases-1.js
@@ -1,0 +1,53 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13;
+s1_1->s1_4->s1_6->s1_7;
+s1_2->s1_13;
+s1_7->s1_13;
+s1_4->s1_7;
+s1_6->s1_9->s1_10;
+s1_9->s1_11->s1_12;
+s1_11->s1_13->final;
+*/
+switch (a) {
+    case 0:
+        foo();
+        break;
+
+    case 1:
+    case 2:
+        bar();
+        break;
+
+    case 3:
+        hoge();
+    case 4:
+        fuga();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (bar)\nBreakStatement"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (hoge)"];
+    s1_12[label="ExpressionStatement\nCallExpression\nIdentifier (fuga)"];
+    s1_13[label="SwitchStatement:exit\nProgram:exit"];
+    s1_4[label="SwitchCase\nLiteral (1)"];
+    s1_6[label="SwitchCase\nLiteral (2)"];
+    s1_9[label="SwitchCase\nLiteral (3)"];
+    s1_11[label="SwitchCase\nLiteral (4)"];
+    initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13;
+    s1_1->s1_4->s1_6->s1_7;
+    s1_2->s1_13;
+    s1_7->s1_13;
+    s1_4->s1_7;
+    s1_6->s1_9->s1_10;
+    s1_9->s1_11->s1_12;
+    s1_11->s1_13->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--cases-2.js
+++ b/tests/fixtures/code-path-analysis/switch--cases-2.js
@@ -1,0 +1,61 @@
+/* eslint-env node */
+/*expected
+initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13->s1_14;
+s1_1->s1_4->s1_6->s1_7;
+s1_12->s1_14;
+s1_4->s1_7;
+s1_6->s1_9->s1_10;
+s1_9->s1_11->s1_12;
+s1_11->s1_14;
+s1_2->final;
+s1_7->final;
+s1_14->final;
+*/
+
+switch (a) {
+    case 0:
+        foo();
+        return;
+
+    case 1:
+    case 2:
+        bar();
+        return;
+
+    case 3:
+        hoge();
+    case 4:
+        fuga();
+        break;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nReturnStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (bar)\nReturnStatement"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (hoge)"];
+    s1_12[label="ExpressionStatement\nCallExpression\nIdentifier (fuga)\nBreakStatement"];
+    s1_13[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_14[label="SwitchStatement:exit\nProgram:exit"];
+    s1_4[label="SwitchCase\nLiteral (1)"];
+    s1_6[label="SwitchCase\nLiteral (2)"];
+    s1_9[label="SwitchCase\nLiteral (3)"];
+    s1_11[label="SwitchCase\nLiteral (4)"];
+    initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13->s1_14;
+    s1_1->s1_4->s1_6->s1_7;
+    s1_12->s1_14;
+    s1_4->s1_7;
+    s1_6->s1_9->s1_10;
+    s1_9->s1_11->s1_12;
+    s1_11->s1_14;
+    s1_2->final;
+    s1_7->final;
+    s1_14->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--cases-and-default-1.js
+++ b/tests/fixtures/code-path-analysis/switch--cases-and-default-1.js
@@ -1,0 +1,54 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13;
+s1_1->s1_4->s1_6->s1_7;
+s1_2->s1_13;
+s1_7->s1_13;
+s1_4->s1_7;
+s1_6->s1_9->s1_10;
+s1_9->s1_11->s1_12;
+s1_13->final;
+*/
+
+switch (a) {
+    case 0:
+        foo();
+        break;
+
+    case 1:
+    case 2:
+        bar();
+        break;
+
+    case 3:
+        hoge();
+    default:
+        fuga();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (bar)\nBreakStatement"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (hoge)"];
+    s1_12[label="ExpressionStatement\nCallExpression\nIdentifier (fuga)"];
+    s1_13[label="SwitchStatement:exit\nProgram:exit"];
+    s1_4[label="SwitchCase\nLiteral (1)"];
+    s1_6[label="SwitchCase\nLiteral (2)"];
+    s1_9[label="SwitchCase\nLiteral (3)"];
+    s1_11[label="SwitchCase"];
+    initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13;
+    s1_1->s1_4->s1_6->s1_7;
+    s1_2->s1_13;
+    s1_7->s1_13;
+    s1_4->s1_7;
+    s1_6->s1_9->s1_10;
+    s1_9->s1_11->s1_12;
+    s1_13->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--cases-and-default-2.js
+++ b/tests/fixtures/code-path-analysis/switch--cases-and-default-2.js
@@ -1,0 +1,54 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13;
+s1_1->s1_4->s1_6->s1_7;
+s1_2->s1_13;
+s1_7->s1_13;
+s1_4->s1_7;
+s1_6->s1_9->s1_11->s1_12;
+s1_11->s1_10;
+s1_13->final;
+*/
+
+switch (a) {
+    case 0:
+        foo();
+        break;
+
+    case 1:
+    case 2:
+        bar();
+        break;
+
+    default:
+        hoge();
+    case 3:
+        fuga();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (bar)\nBreakStatement"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_10[label="ExpressionStatement\nCallExpression\nIdentifier (hoge)"];
+    s1_12[label="ExpressionStatement\nCallExpression\nIdentifier (fuga)"];
+    s1_13[label="SwitchStatement:exit\nProgram:exit"];
+    s1_4[label="SwitchCase\nLiteral (1)"];
+    s1_6[label="SwitchCase\nLiteral (2)"];
+    s1_9[label="SwitchCase"];
+    s1_11[label="SwitchCase\nLiteral (3)"];
+    initial->s1_1->s1_2->s1_3->s1_7->s1_8->s1_10->s1_12->s1_13;
+    s1_1->s1_4->s1_6->s1_7;
+    s1_2->s1_13;
+    s1_7->s1_13;
+    s1_4->s1_7;
+    s1_6->s1_9->s1_11->s1_12;
+    s1_11->s1_10;
+    s1_13->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--cases-and-default-3.js
+++ b/tests/fixtures/code-path-analysis/switch--cases-and-default-3.js
@@ -1,0 +1,52 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_9->s1_10->s1_12->s1_13;
+s1_1->s1_4->s1_6->s1_8->s1_9;
+s1_2->s1_13;
+s1_9->s1_13;
+s1_6->s1_9;
+s1_8->s1_11->s1_12;
+s1_11->s1_9;
+s1_13->final;
+*/
+
+switch (a) {
+    case 0:
+        foo();
+        break;
+
+    default:
+    case 1:
+    case 2:
+        bar();
+        break;
+
+    case 3:
+        fuga();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_9[label="ExpressionStatement\nCallExpression\nIdentifier (bar)\nBreakStatement"];
+    s1_10[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_12[label="ExpressionStatement\nCallExpression\nIdentifier (fuga)"];
+    s1_13[label="SwitchStatement:exit\nProgram:exit"];
+    s1_4[label="SwitchCase"];
+    s1_6[label="SwitchCase\nLiteral (1)"];
+    s1_8[label="SwitchCase\nLiteral (2)"];
+    s1_11[label="SwitchCase\nLiteral (3)"];
+    initial->s1_1->s1_2->s1_3->s1_9->s1_10->s1_12->s1_13;
+    s1_1->s1_4->s1_6->s1_8->s1_9;
+    s1_2->s1_13;
+    s1_9->s1_13;
+    s1_6->s1_9;
+    s1_8->s1_11->s1_12;
+    s1_11->s1_9;
+    s1_13->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--default-only-1.js
+++ b/tests/fixtures/code-path-analysis/switch--default-only-1.js
@@ -1,0 +1,16 @@
+/*expected
+initial->s1_1->final;
+*/
+switch (a) {
+    default:
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--default-only-2.js
+++ b/tests/fixtures/code-path-analysis/switch--default-only-2.js
@@ -1,0 +1,22 @@
+/*expected
+initial->s1_1->s1_2->s1_4;
+s1_1->s1_4->final;
+*/
+switch (a) {
+    default:
+        foo();
+        break;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_2[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_4[label="SwitchStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_4;
+    s1_1->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--empty.js
+++ b/tests/fixtures/code-path-analysis/switch--empty.js
@@ -1,0 +1,15 @@
+/*expected
+initial->s1_1->final;
+*/
+switch (a) {
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--precedence.js
+++ b/tests/fixtures/code-path-analysis/switch--precedence.js
@@ -1,0 +1,272 @@
+/*expected
+initial->s2_1->s2_2->s2_3->s2_9->s2_10->s2_12->s2_13->s2_15->s2_16->s2_17->s2_19->s2_20->s2_21->s2_23->s2_24->s2_25->s2_27->s2_28->s2_30->s2_31->s2_39->s2_40->s2_52->s2_53->s2_59->s2_60->s2_64->s2_65->s2_71->s2_72->s2_73->s2_75->s2_76->s2_78->s2_79->s2_81->s2_82->s2_83->s2_84->s2_85->s2_87->s2_88->s2_89->s2_90;
+s2_1->s2_4->s2_6->s2_8->s2_9;
+s2_15->s2_18->s2_19;
+s2_23->s2_26->s2_27;
+s2_81->s2_84;
+s2_4->s2_9;
+s2_6->s2_9;
+s2_8->s2_11->s2_12;
+s2_18->s2_21;
+s2_26->s2_29->s2_30;
+s2_11->s2_14->s2_15;
+s2_29->s2_32->s2_34->s2_36->s2_38->s2_39;
+s2_14->s2_22->s2_23;
+s2_32->s2_39;
+s2_34->s2_39;
+s2_36->s2_39;
+s2_38->s2_41->s2_43->s2_45->s2_47->s2_49->s2_51->s2_52;
+s2_22->s2_74->s2_75;
+s2_41->s2_52;
+s2_43->s2_52;
+s2_45->s2_52;
+s2_47->s2_52;
+s2_49->s2_52;
+s2_51->s2_54->s2_56->s2_58->s2_59;
+s2_74->s2_77->s2_78;
+s2_54->s2_59;
+s2_56->s2_59;
+s2_58->s2_61->s2_63->s2_64;
+s2_77->s2_80->s2_81;
+s2_61->s2_64;
+s2_63->s2_66->s2_68->s2_70->s2_71;
+s2_80->s2_86->s2_87;
+s2_66->s2_71;
+s2_68->s2_71;
+s2_70->s2_73;
+s2_86->s2_89;
+s2_2->final;
+s2_9->final;
+s2_12->final;
+s2_16->final;
+s2_19->final;
+s2_24->final;
+s2_27->final;
+s2_30->final;
+s2_39->final;
+s2_52->final;
+s2_59->final;
+s2_64->final;
+s2_71->final;
+s2_75->final;
+s2_78->final;
+s2_82->final;
+s2_84->final;
+s2_87->final;
+s2_89->final;
+*/
+/*expected
+initial->s1_1->final;
+*/
+
+function precedence(node) {
+    switch (node.type) {
+        case "SequenceExpression":
+            return 0;
+
+        case "AssignmentExpression":
+        case "ArrowFunctionExpression":
+        case "YieldExpression":
+            return 1;
+
+        case "ConditionalExpression":
+            return 3;
+
+        case "LogicalExpression":
+            switch (node.operator) {
+                case "||":
+                    return 4;
+                case "&&":
+                    return 5;
+                // no default
+            }
+
+            /* falls through */
+        case "BinaryExpression":
+            switch (node.operator) {
+                case "|":
+                    return 6;
+                case "^":
+                    return 7;
+                case "&":
+                    return 8;
+                case "==":
+                case "!=":
+                case "===":
+                case "!==":
+                    return 9;
+                case "<":
+                case "<=":
+                case ">":
+                case ">=":
+                case "in":
+                case "instanceof":
+                    return 10;
+                case "<<":
+                case ">>":
+                case ">>>":
+                    return 11;
+                case "+":
+                case "-":
+                    return 12;
+                case "*":
+                case "/":
+                case "%":
+                    return 13;
+                // no default
+            }
+            /* falls through */
+        case "UnaryExpression":
+            return 14;
+        case "UpdateExpression":
+            return 15;
+        case "CallExpression":
+            // IIFE is allowed to have parens in any position (#655)
+            if (node.callee.type === "FunctionExpression") {
+                return -1;
+            }
+            return 16;
+        case "NewExpression":
+            return 17;
+        // no default
+    }
+    return 18;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionDeclaration\nIdentifier (precedence)\nIdentifier (node)\nBlockStatement\nSwitchStatement\nMemberExpression\nIdentifier (node)\nIdentifier (type)\nSwitchCase\nLiteral (SequenceExpression)"];
+    s2_2[label="ReturnStatement\nLiteral (0)"];
+    s2_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_9[label="ReturnStatement\nLiteral (1)"];
+    s2_10[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_12[label="ReturnStatement\nLiteral (3)"];
+    s2_13[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_15[label="SwitchStatement\nMemberExpression\nIdentifier (node)\nIdentifier (operator)\nSwitchCase\nLiteral (||)"];
+    s2_16[label="ReturnStatement\nLiteral (4)"];
+    s2_17[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_19[label="ReturnStatement\nLiteral (5)"];
+    s2_20[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_21[label="SwitchStatement:exit\nSwitchCase:exit"];
+    s2_23[label="SwitchStatement\nMemberExpression\nIdentifier (node)\nIdentifier (operator)\nSwitchCase\nLiteral (|)"];
+    s2_24[label="ReturnStatement\nLiteral (6)"];
+    s2_25[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_27[label="ReturnStatement\nLiteral (7)"];
+    s2_28[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_30[label="ReturnStatement\nLiteral (8)"];
+    s2_31[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_39[label="ReturnStatement\nLiteral (9)"];
+    s2_40[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_52[label="ReturnStatement\nLiteral (10)"];
+    s2_53[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_59[label="ReturnStatement\nLiteral (11)"];
+    s2_60[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_64[label="ReturnStatement\nLiteral (12)"];
+    s2_65[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_71[label="ReturnStatement\nLiteral (13)"];
+    s2_72[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_73[label="SwitchStatement:exit\nSwitchCase:exit"];
+    s2_75[label="ReturnStatement\nLiteral (14)"];
+    s2_76[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_78[label="ReturnStatement\nLiteral (15)"];
+    s2_79[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_81[label="IfStatement\nBinaryExpression\nMemberExpression\nMemberExpression\nIdentifier (node)\nIdentifier (callee)\nIdentifier (type)\nLiteral (FunctionExpression)"];
+    s2_82[label="BlockStatement\nReturnStatement\nUnaryExpression\nLiteral (1)"];
+    s2_83[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s2_84[label="ReturnStatement\nLiteral (16)"];
+    s2_85[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_87[label="ReturnStatement\nLiteral (17)"];
+    s2_88[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s2_89[label="ReturnStatement\nLiteral (18)"];
+    s2_90[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit\nFunctionDeclaration:exit"];
+    s2_4[label="SwitchCase\nLiteral (AssignmentExpression)"];
+    s2_6[label="SwitchCase\nLiteral (ArrowFunctionExpression)"];
+    s2_8[label="SwitchCase\nLiteral (YieldExpression)"];
+    s2_18[label="SwitchCase\nLiteral (&&)"];
+    s2_26[label="SwitchCase\nLiteral (^)"];
+    s2_11[label="SwitchCase\nLiteral (ConditionalExpression)"];
+    s2_29[label="SwitchCase\nLiteral (&)"];
+    s2_14[label="SwitchCase\nLiteral (LogicalExpression)"];
+    s2_32[label="SwitchCase\nLiteral (==)"];
+    s2_34[label="SwitchCase\nLiteral (!=)"];
+    s2_36[label="SwitchCase\nLiteral (===)"];
+    s2_38[label="SwitchCase\nLiteral (!==)"];
+    s2_22[label="SwitchCase\nLiteral (BinaryExpression)"];
+    s2_41[label="SwitchCase\nLiteral (<)"];
+    s2_43[label="SwitchCase\nLiteral (<=)"];
+    s2_45[label="SwitchCase\nLiteral (>)"];
+    s2_47[label="SwitchCase\nLiteral (>=)"];
+    s2_49[label="SwitchCase\nLiteral (in)"];
+    s2_51[label="SwitchCase\nLiteral (instanceof)"];
+    s2_74[label="SwitchCase\nLiteral (UnaryExpression)"];
+    s2_54[label="SwitchCase\nLiteral (<<)"];
+    s2_56[label="SwitchCase\nLiteral (>>)"];
+    s2_58[label="SwitchCase\nLiteral (>>>)"];
+    s2_77[label="SwitchCase\nLiteral (UpdateExpression)"];
+    s2_61[label="SwitchCase\nLiteral (+)"];
+    s2_63[label="SwitchCase\nLiteral (-)"];
+    s2_80[label="SwitchCase\nLiteral (CallExpression)"];
+    s2_66[label="SwitchCase\nLiteral (*)"];
+    s2_68[label="SwitchCase\nLiteral (/)"];
+    s2_70[label="SwitchCase\nLiteral (%)"];
+    s2_86[label="SwitchCase\nLiteral (NewExpression)"];
+    initial->s2_1->s2_2->s2_3->s2_9->s2_10->s2_12->s2_13->s2_15->s2_16->s2_17->s2_19->s2_20->s2_21->s2_23->s2_24->s2_25->s2_27->s2_28->s2_30->s2_31->s2_39->s2_40->s2_52->s2_53->s2_59->s2_60->s2_64->s2_65->s2_71->s2_72->s2_73->s2_75->s2_76->s2_78->s2_79->s2_81->s2_82->s2_83->s2_84->s2_85->s2_87->s2_88->s2_89->s2_90;
+    s2_1->s2_4->s2_6->s2_8->s2_9;
+    s2_15->s2_18->s2_19;
+    s2_23->s2_26->s2_27;
+    s2_81->s2_84;
+    s2_4->s2_9;
+    s2_6->s2_9;
+    s2_8->s2_11->s2_12;
+    s2_18->s2_21;
+    s2_26->s2_29->s2_30;
+    s2_11->s2_14->s2_15;
+    s2_29->s2_32->s2_34->s2_36->s2_38->s2_39;
+    s2_14->s2_22->s2_23;
+    s2_32->s2_39;
+    s2_34->s2_39;
+    s2_36->s2_39;
+    s2_38->s2_41->s2_43->s2_45->s2_47->s2_49->s2_51->s2_52;
+    s2_22->s2_74->s2_75;
+    s2_41->s2_52;
+    s2_43->s2_52;
+    s2_45->s2_52;
+    s2_47->s2_52;
+    s2_49->s2_52;
+    s2_51->s2_54->s2_56->s2_58->s2_59;
+    s2_74->s2_77->s2_78;
+    s2_54->s2_59;
+    s2_56->s2_59;
+    s2_58->s2_61->s2_63->s2_64;
+    s2_77->s2_80->s2_81;
+    s2_61->s2_64;
+    s2_63->s2_66->s2_68->s2_70->s2_71;
+    s2_80->s2_86->s2_87;
+    s2_66->s2_71;
+    s2_68->s2_71;
+    s2_70->s2_73;
+    s2_86->s2_89;
+    s2_2->final;
+    s2_9->final;
+    s2_12->final;
+    s2_16->final;
+    s2_19->final;
+    s2_24->final;
+    s2_27->final;
+    s2_30->final;
+    s2_39->final;
+    s2_52->final;
+    s2_59->final;
+    s2_64->final;
+    s2_71->final;
+    s2_75->final;
+    s2_78->final;
+    s2_82->final;
+    s2_84->final;
+    s2_87->final;
+    s2_89->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--single-case-1.js
+++ b/tests/fixtures/code-path-analysis/switch--single-case-1.js
@@ -1,0 +1,17 @@
+/*expected
+initial->s1_1->s1_3->final;
+*/
+switch (a) {
+    case 0:
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+    s1_3[label="SwitchStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/switch--single-case-2.js
+++ b/tests/fixtures/code-path-analysis/switch--single-case-2.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+switch (a) {
+    case 0:
+        foo();
+        break;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+    s1_4[label="SwitchStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-catch-1.js
+++ b/tests/fixtures/code-path-analysis/try--try-catch-1.js
@@ -1,0 +1,26 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4->final;
+*/
+
+try {
+    foo();
+} catch (err) {
+    bar();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_2[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_3[label="CatchClause\nIdentifier (err)\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    s1_4[label="TryStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-catch-2.js
+++ b/tests/fixtures/code-path-analysis/try--try-catch-2.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+s1_1->s1_3;
+s1_2->s1_5->final;
+s1_3->thrown;
+*/
+
+try {
+    foo();
+} catch (err) {
+    throw err;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_2[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_3[label="CatchClause\nIdentifier (err)\nBlockStatement\nThrowStatement\nIdentifier (err)"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit\nCatchClause:exit"];
+    s1_5[label="TryStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+    s1_1->s1_3;
+    s1_2->s1_5->final;
+    s1_3->thrown;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-catch-3.js
+++ b/tests/fixtures/code-path-analysis/try--try-catch-3.js
@@ -1,0 +1,43 @@
+/* eslint-env node */
+/*expected
+initial->s1_1->s1_3->s1_4->s1_7->s1_8->s1_9;
+s1_1->s1_5->s1_6->s1_7->s1_9;
+s1_1->s1_8;
+s1_5->s1_8;
+s1_3->final;
+s1_9->final;
+*/
+
+try {
+    if (a) {
+        return a;
+    } else {
+        throw b;
+    }
+} catch (err) {
+    // do nothing.
+}
+
+foo();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nIfStatement\nIdentifier (a)"];
+    s1_3[label="BlockStatement\nReturnStatement\nIdentifier (a)"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nIfStatement:exit\nBlockStatement:exit"];
+    s1_8[label="CatchClause\nIdentifier (err)\nBlockStatement"];
+    s1_9[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="BlockStatement\nThrowStatement\nIdentifier (b)"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_3->s1_4->s1_7->s1_8->s1_9;
+    s1_1->s1_5->s1_6->s1_7->s1_9;
+    s1_1->s1_8;
+    s1_5->s1_8;
+    s1_3->final;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-catch-4.js
+++ b/tests/fixtures/code-path-analysis/try--try-catch-4.js
@@ -1,0 +1,55 @@
+/*expected
+initial->s1_1->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_11->s1_12;
+s1_1->s1_5;
+s1_3->s1_6;
+s1_5->s1_9;
+s1_6->s1_10;
+s1_7->s1_10;
+s1_9->s1_12;
+s1_1->s1_6;
+s1_12->final;
+s1_10->thrown;
+*/
+
+try {
+    try {
+        if (a) {
+            throw err;
+        }
+    } catch (err) {
+        throw err;
+    }
+} catch (err) {
+    throw err;
+}
+
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nTryStatement\nBlockStatement\nIfStatement\nIdentifier (a)"];
+    s1_3[label="BlockStatement\nThrowStatement\nIdentifier (err)"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_5[label="IfStatement:exit\nBlockStatement:exit"];
+    s1_6[label="CatchClause\nIdentifier (err)\nBlockStatement\nThrowStatement\nIdentifier (err)"];
+    s1_7[label="ThrowStatement:exit"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit\nCatchClause:exit"];
+    s1_9[label="TryStatement:exit\nBlockStatement:exit"];
+    s1_10[label="CatchClause\nIdentifier (err)\nBlockStatement\nThrowStatement\nIdentifier (err)"];
+    s1_11[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit\nCatchClause:exit"];
+    s1_12[label="TryStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_11->s1_12;
+    s1_1->s1_5;
+    s1_3->s1_6;
+    s1_5->s1_9;
+    s1_6->s1_10;
+    s1_7->s1_10;
+    s1_9->s1_12;
+    s1_1->s1_6;
+    s1_12->final;
+    s1_10->thrown;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-catch-finally-1.js
+++ b/tests/fixtures/code-path-analysis/try--try-catch-finally-1.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_3;
+s1_2->s1_4->final;
+*/
+
+try {
+    foo();
+} catch (err) {
+    bar();
+} finally {
+    baz();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_2[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_3[label="CatchClause\nIdentifier (err)\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (baz)\nExpressionStatement\nCallExpression\nIdentifier (last)"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_3;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-catch-finally-2.js
+++ b/tests/fixtures/code-path-analysis/try--try-catch-finally-2.js
@@ -1,0 +1,34 @@
+/*eslint-env node*/
+/*expected
+initial->s1_1->s1_2->s1_3->s1_5;
+s1_1->s1_6;
+s1_2->s1_5;
+s1_3->s1_6->final;
+*/
+
+try {
+    return;
+} catch (err) {
+    foo();
+} finally {
+    bar();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nReturnStatement"];
+    s1_2[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nCatchClause\nIdentifier (err)\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nExpressionStatement\nCallExpression\nIdentifier (last)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_5;
+    s1_1->s1_6;
+    s1_2->s1_5;
+    s1_3->s1_6->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-catch-finally-3.js
+++ b/tests/fixtures/code-path-analysis/try--try-catch-finally-3.js
@@ -1,0 +1,52 @@
+/*eslint-env node*/
+/*expected
+initial->s1_1->s1_3->s1_4->s1_7->s1_8->s1_10;
+s1_1->s1_5->s1_6->s1_7;
+s1_3->s1_11;
+s1_7->s1_10;
+s1_8->s1_11;
+s1_1->s1_8;
+s1_5->s1_8;
+s1_11->final;
+s1_10->final;
+*/
+
+try {
+    if (a) {
+        return;
+    } else {
+        throw 0;
+    }
+} catch (err) {
+    b();
+} finally {
+    c();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nIfStatement\nIdentifier (a)"];
+    s1_3[label="BlockStatement\nReturnStatement"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nIfStatement:exit\nBlockStatement:exit"];
+    s1_8[label="CatchClause\nIdentifier (err)\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (b)"];
+    s1_10[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (c)\nExpressionStatement\nCallExpression\nIdentifier (last)"];
+    s1_5[label="BlockStatement\nThrowStatement\nLiteral (0)"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_11[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (c)"];
+    initial->s1_1->s1_3->s1_4->s1_7->s1_8->s1_10;
+    s1_1->s1_5->s1_6->s1_7;
+    s1_3->s1_11;
+    s1_7->s1_10;
+    s1_8->s1_11;
+    s1_1->s1_8;
+    s1_5->s1_8;
+    s1_11->final;
+    s1_10->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-finally-1.js
+++ b/tests/fixtures/code-path-analysis/try--try-finally-1.js
@@ -1,0 +1,33 @@
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_4;
+s1_2->s1_4;
+s1_3->final;
+s1_4->thrown;
+*/
+
+try {
+    foo();
+} finally {
+    bar();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_2[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nExpressionStatement\nCallExpression\nIdentifier (last)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_4;
+    s1_2->s1_4;
+    s1_3->final;
+    s1_4->thrown;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-finally-2.js
+++ b/tests/fixtures/code-path-analysis/try--try-finally-2.js
@@ -1,0 +1,29 @@
+/*eslint-env node*/
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_4;
+s1_2->s1_4->final;
+*/
+
+try {
+    return;
+} finally {
+    bar();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nReturnStatement"];
+    s1_2[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nExpressionStatement\nCallExpression\nIdentifier (last)"];
+    s1_4[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_4;
+    s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-finally-3.js
+++ b/tests/fixtures/code-path-analysis/try--try-finally-3.js
@@ -1,0 +1,31 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_5;
+s1_2->s1_5;
+s1_3->s1_5->thrown;
+*/
+
+try {
+    throw err;
+} finally {
+    bar();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nThrowStatement\nIdentifier (err)"];
+    s1_2[label="ThrowStatement:exit"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nExpressionStatement\nCallExpression\nIdentifier (last)"];
+    s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_5;
+    s1_2->s1_5;
+    s1_3->s1_5->thrown;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-finally-4.js
+++ b/tests/fixtures/code-path-analysis/try--try-finally-4.js
@@ -1,0 +1,60 @@
+/*eslint-env node*/
+/*expected
+initial->s1_1->s1_3->s1_4->s1_7->s1_8->s1_11->s1_14;
+s1_1->s1_5->s1_6->s1_7;
+s1_3->s1_9->s1_12->s1_15;
+s1_7->s1_9;
+s1_8->s1_15;
+s1_11->s1_15;
+s1_1->s1_9;
+s1_5->s1_9->s1_15->final;
+s1_15->thrown;
+*/
+
+try {
+    try {
+        if (a) {
+            return;
+        } else {
+            throw err;
+        }
+    } finally {
+        foo();
+    }
+} finally {
+    bar();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nTryStatement\nBlockStatement\nIfStatement\nIdentifier (a)"];
+    s1_3[label="BlockStatement\nReturnStatement"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nIfStatement:exit\nBlockStatement:exit"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_11[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nCallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nTryStatement
+    :exit\nBlockStatement:exit"];
+    s1_14[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nExpressio
+    nStatement\nCallExpression\nIdentifier (last)"];
+    s1_5[label="BlockStatement\nThrowStatement\nIdentifier (err)"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_9[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_12[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_15[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_3->s1_4->s1_7->s1_8->s1_11->s1_14;
+    s1_1->s1_5->s1_6->s1_7;
+    s1_3->s1_9->s1_12->s1_15;
+    s1_7->s1_9;
+    s1_8->s1_15;
+    s1_11->s1_15;
+    s1_1->s1_9;
+    s1_5->s1_9->s1_15->final;
+    s1_15->thrown;
+}
+*/

--- a/tests/fixtures/code-path-analysis/try--try-finally-5.js
+++ b/tests/fixtures/code-path-analysis/try--try-finally-5.js
@@ -1,0 +1,55 @@
+/*eslint-env node*/
+/*expected
+initial->s1_1->s1_3->s1_4->s1_5->s1_6->s1_9->s1_11;
+s1_1->s1_5;
+s1_3->s1_7->s1_10->s1_12;
+s1_5->s1_7;
+s1_6->s1_12;
+s1_9->s1_12;
+s1_1->s1_7->s1_12->final;
+s1_11->final;
+s1_12->thrown;
+*/
+
+try {
+    try {
+        if (a) {
+            return;
+        }
+        abc();
+    } finally {
+        foo();
+    }
+} finally {
+    bar();
+}
+
+last();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    thrown[label="✘",shape=circle,width=0.3,height=0.3,fixedsize];
+    s1_1[label="Program\nTryStatement\nBlockStatement\nTryStatement\nBlockStatement\nIfStatement\nIdentifier (a)"];
+    s1_3[label="BlockStatement\nReturnStatement"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_5[label="ExpressionStatement\nCallExpression\nIdentifier (abc)"];
+    s1_6[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_9[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit\nTryStatement:exit\nBlockStatement:exit"];
+    s1_11[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)\nExpressionStatement\nCallExpression\nIdentifier (last)"];
+    s1_7[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_10[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+    s1_12[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_3->s1_4->s1_5->s1_6->s1_9->s1_11;
+    s1_1->s1_5;
+    s1_3->s1_7->s1_10->s1_12;
+    s1_5->s1_7;
+    s1_6->s1_12;
+    s1_9->s1_12;
+    s1_1->s1_7->s1_12->final;
+    s1_11->final;
+    s1_12->thrown;
+}
+*/

--- a/tests/fixtures/code-path-analysis/unreachable-controls.js
+++ b/tests/fixtures/code-path-analysis/unreachable-controls.js
@@ -1,0 +1,42 @@
+/*expected
+initial->s2_1->s2_2->s2_3->s2_4->s2_3;
+s2_4->s2_5;
+s2_1->final;
+*/
+/*expected
+initial->s1_1->final;
+*/
+function foo() {
+    return;
+
+    // Unreachable control statements.
+    return;
+    throw new Error();
+    while (true) {
+        continue;
+        break;
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s2_1[label="FunctionDeclaration\nIdentifier (foo)\nBlockStatement\nReturnStatement"];
+    s2_2[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nReturnStatement\nThrowStatement\nNewExpression\nIdentifier (Error)\nWhileStatement"];
+    s2_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nLiteral (true)"];
+    s2_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement\nContinueStatement\nBreakStatement"];
+    s2_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nWhileStatement:exit\nBlockStatement:exit\nFunctionDeclaration:exit"];
+    initial->s2_1->s2_2->s2_3->s2_4->s2_3;
+    s2_4->s2_5;
+    s2_1->final;
+}
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nFunctionDeclaration"];
+    initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--break-always.js
+++ b/tests/fixtures/code-path-analysis/while--break-always.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+s1_3->s1_5->final;
+*/
+while (a) {
+    foo();
+    break;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_5[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5;
+    s1_3->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--break-label.js
+++ b/tests/fixtures/code-path-analysis/while--break-label.js
@@ -1,0 +1,50 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_11->s1_4;
+s1_2->s1_13;
+s1_4->s1_12->s1_2;
+s1_5->s1_8;
+s1_6->s1_13;
+s1_8->s1_11;
+s1_9->s1_12;
+s1_13->final;
+*/
+A: while (a) {
+    B: while (b) {
+        if (c) {
+            break A;
+        }
+        if (d) {
+            break B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nWhileStatement"];
+    s1_4[label="Identifier (b)"];
+    s1_5[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_6[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_8[label="IfStatement\nIdentifier (d)"];
+    s1_9[label="BlockStatement\nBreakStatement\nIdentifier (B)"];
+    s1_10[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_11[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_13[label="WhileStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_12[label="WhileStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_11->s1_4;
+    s1_2->s1_13;
+    s1_4->s1_12->s1_2;
+    s1_5->s1_8;
+    s1_6->s1_13;
+    s1_8->s1_11;
+    s1_9->s1_12;
+    s1_13->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--break-nest.js
+++ b/tests/fixtures/code-path-analysis/while--break-nest.js
@@ -1,0 +1,40 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_4;
+s1_2->s1_10;
+s1_4->s1_9->s1_2;
+s1_5->s1_8;
+s1_6->s1_9;
+s1_10->final;
+*/
+while (a) {
+    while (b) {
+        if (c) {
+            break;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nWhileStatement"];
+    s1_4[label="Identifier (b)"];
+    s1_5[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_6[label="BlockStatement\nBreakStatement"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_8[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_10[label="WhileStatement:exit\nProgram:exit"];
+    s1_9[label="WhileStatement:exit\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_4;
+    s1_2->s1_10;
+    s1_4->s1_9->s1_2;
+    s1_5->s1_8;
+    s1_6->s1_9;
+    s1_10->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--break-simple.js
+++ b/tests/fixtures/code-path-analysis/while--break-simple.js
@@ -1,0 +1,29 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_7;
+s1_3->s1_6;
+s1_4->s1_7->final;
+*/
+while (a) {
+    if (b) {
+        break;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_7;
+    s1_3->s1_6;
+    s1_4->s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--continue-always.js
+++ b/tests/fixtures/code-path-analysis/while--continue-always.js
@@ -1,0 +1,25 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_5;
+s1_3->s1_4->s1_2;
+s1_5->final;
+*/
+while (a) {
+    foo();
+    continue;
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)\nContinueStatement"];
+    s1_5[label="WhileStatement:exit\nProgram:exit"];
+    s1_4[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_5;
+    s1_3->s1_4->s1_2;
+    s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--continue-label.js
+++ b/tests/fixtures/code-path-analysis/while--continue-label.js
@@ -1,0 +1,46 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_13;
+s1_4->s1_12->s1_2;
+s1_5->s1_8->s1_9->s1_4;
+s1_6->s1_7->s1_8->s1_11->s1_4;
+s1_9->s1_10->s1_11;
+s1_13->final;
+*/
+A: while (a) {
+    B: while (b) {
+        if (c) {
+            continue A;
+        }
+        if (d) {
+            continue B;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nLabeledStatement\nIdentifier (B)\nWhileStatement"];
+    s1_4[label="Identifier (b)"];
+    s1_5[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_6[label="BlockStatement\nContinueStatement\nIdentifier (A)"];
+    s1_13[label="WhileStatement:exit\nLabeledStatement:exit\nProgram:exit"];
+    s1_12[label="WhileStatement:exit\nLabeledStatement:exit\nBlockStatement:exit"];
+    s1_8[label="IfStatement\nIdentifier (d)"];
+    s1_9[label="BlockStatement\nContinueStatement\nIdentifier (B)"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_11[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_10[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_2->s1_13;
+    s1_4->s1_12->s1_2;
+    s1_5->s1_8->s1_9->s1_4;
+    s1_6->s1_7->s1_8->s1_11->s1_4;
+    s1_9->s1_10->s1_11;
+    s1_13->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--continue-nest.js
+++ b/tests/fixtures/code-path-analysis/while--continue-nest.js
@@ -1,0 +1,40 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_4;
+s1_2->s1_10;
+s1_4->s1_9->s1_2;
+s1_5->s1_8->s1_4;
+s1_6->s1_7->s1_8;
+s1_10->final;
+*/
+while (a) {
+    while (b) {
+        if (c) {
+            continue;
+        }
+        foo();
+    }
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nWhileStatement"];
+    s1_4[label="Identifier (b)"];
+    s1_5[label="BlockStatement\nIfStatement\nIdentifier (c)"];
+    s1_6[label="BlockStatement\nContinueStatement"];
+    s1_10[label="WhileStatement:exit\nProgram:exit"];
+    s1_9[label="WhileStatement:exit\nBlockStatement:exit"];
+    s1_8[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_7[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_4;
+    s1_2->s1_10;
+    s1_4->s1_9->s1_2;
+    s1_5->s1_8->s1_4;
+    s1_6->s1_7->s1_8;
+    s1_10->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--continue-simple.js
+++ b/tests/fixtures/code-path-analysis/while--continue-simple.js
@@ -1,0 +1,31 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_7;
+s1_3->s1_6->s1_2;
+s1_4->s1_5->s1_6;
+s1_7->final;
+*/
+while (a) {
+    if (b) {
+        continue;
+    }
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nContinueStatement"];
+    s1_7[label="WhileStatement:exit\nProgram:exit"];
+    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_7;
+    s1_3->s1_6->s1_2;
+    s1_4->s1_5->s1_6;
+    s1_7->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--empty.js
+++ b/tests/fixtures/code-path-analysis/while--empty.js
@@ -1,0 +1,18 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_4->final;
+*/
+while (a) {
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement"];
+    s1_4[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_4->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--simple.js
+++ b/tests/fixtures/code-path-analysis/while--simple.js
@@ -1,0 +1,19 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_2->s1_4->final;
+*/
+while (a) {
+    foo();
+}
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_4[label="WhileStatement:exit\nProgram:exit"];
+    initial->s1_1->s1_2->s1_3->s1_2->s1_4->final;
+}
+*/

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -1,0 +1,592 @@
+/**
+ * @fileoverview Tests for CodePathAnalyzer.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("assert"),
+    EventEmitter = require("events").EventEmitter,
+    fs = require("fs"),
+    path = require("path"),
+    eslint = require("../../../lib/eslint"),
+    EventGeneratorTester = require("../../../lib/testers/event-generator-tester"),
+    debug = require("../../../lib/code-path-analysis/debug-helpers"),
+    CodePath = require("../../../lib/code-path-analysis/code-path"),
+    CodePathAnalyzer = require("../../../lib/code-path-analysis/code-path-analyzer"),
+    CodePathSegment = require("../../../lib/code-path-analysis/code-path-segment"),
+    NodeEventGenerator = require("../../../lib/util/node-event-generator");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var expectedPattern = /\/\*expected\s+((?:.|[\r\n])+?)\s*\*\//g;
+var lineEndingPattern = /\r?\n/g;
+
+/**
+ * Extracts the content of `/*expected` comments from a given source code.
+ * It's expected DOT arrows.
+ *
+ * @param {string} source - A source code text.
+ * @returns {string[]} DOT arrows.
+ */
+function getExpectedDotArrows(source) {
+    expectedPattern.lastIndex = 0;
+
+    var retv = [];
+    var m;
+    while ((m = expectedPattern.exec(source)) !== null) {
+        retv.push(m[1].replace(lineEndingPattern, "\n"));
+    }
+
+    return retv;
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("CodePathAnalyzer", function() {
+
+    afterEach(function() {
+        eslint.reset();
+    });
+
+    EventGeneratorTester.testEventGeneratorInterface(
+        new CodePathAnalyzer(new NodeEventGenerator(new EventEmitter()))
+    );
+
+    describe("interface of code paths", function() {
+        var actual = [];
+
+        beforeEach(function() {
+            actual = [];
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathStart": function(codePath) {
+                        actual.push(codePath);
+                    }
+                };
+            });
+            eslint.verify(
+                "function foo(a) { if (a) return 0; else throw new Error(); }",
+                {rules: {test: 2}}
+            );
+        });
+
+        it("should have `id` as unique string", function() {
+            assert(typeof actual[0].id === "string");
+            assert(typeof actual[1].id === "string");
+            assert(actual[0].id !== actual[1].id);
+        });
+
+        it("should have `upper` as CodePath", function() {
+            assert(actual[0].upper === null);
+            assert(actual[1].upper === actual[0]);
+        });
+
+        it("should have `childCodePaths` as CodePath[]", function() {
+            assert(Array.isArray(actual[0].childCodePaths));
+            assert(Array.isArray(actual[1].childCodePaths));
+            assert(actual[0].childCodePaths.length === 1);
+            assert(actual[1].childCodePaths.length === 0);
+            assert(actual[0].childCodePaths[0] === actual[1]);
+        });
+
+        it("should have `initialSegment` as CodePathSegment", function() {
+            assert(actual[0].initialSegment instanceof CodePathSegment);
+            assert(actual[1].initialSegment instanceof CodePathSegment);
+            assert(actual[0].initialSegment.prevSegments.length === 0);
+            assert(actual[1].initialSegment.prevSegments.length === 0);
+        });
+
+        it("should have `finalSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].finalSegments));
+            assert(Array.isArray(actual[1].finalSegments));
+            assert(actual[0].finalSegments.length === 1);
+            assert(actual[1].finalSegments.length === 2);
+            assert(actual[0].finalSegments[0].nextSegments.length === 0);
+            assert(actual[1].finalSegments[0].nextSegments.length === 0);
+            assert(actual[1].finalSegments[1].nextSegments.length === 0);
+
+            // finalSegments should include returnedSegments and thrownSegments.
+            assert(actual[0].finalSegments[0] === actual[0].returnedSegments[0]);
+            assert(actual[1].finalSegments[0] === actual[1].returnedSegments[0]);
+            assert(actual[1].finalSegments[1] === actual[1].thrownSegments[0]);
+        });
+
+        it("should have `returnedSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].returnedSegments));
+            assert(Array.isArray(actual[1].returnedSegments));
+            assert(actual[0].returnedSegments.length === 1);
+            assert(actual[1].returnedSegments.length === 1);
+            assert(actual[0].returnedSegments[0] instanceof CodePathSegment);
+            assert(actual[1].returnedSegments[0] instanceof CodePathSegment);
+        });
+
+        it("should have `thrownSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].thrownSegments));
+            assert(Array.isArray(actual[1].thrownSegments));
+            assert(actual[0].thrownSegments.length === 0);
+            assert(actual[1].thrownSegments.length === 1);
+            assert(actual[1].thrownSegments[0] instanceof CodePathSegment);
+        });
+
+        it("should have `currentSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].currentSegments));
+            assert(Array.isArray(actual[1].currentSegments));
+            assert(actual[0].currentSegments.length === 0);
+            assert(actual[1].currentSegments.length === 0);
+
+            // there is the current segment in progress.
+            eslint.defineRule("test", function() {
+                var codePath = null;
+                return {
+                    "onCodePathStart": function(cp) {
+                        codePath = cp;
+                    },
+                    "ReturnStatement": function() {
+                        assert(codePath.currentSegments.length === 1);
+                        assert(codePath.currentSegments[0] instanceof CodePathSegment);
+                    },
+                    "ThrowStatement": function() {
+                        assert(codePath.currentSegments.length === 1);
+                        assert(codePath.currentSegments[0] instanceof CodePathSegment);
+                    }
+                };
+            });
+            eslint.verify(
+                "function foo(a) { if (a) return 0; else throw new Error(); }",
+                {rules: {test: 2}}
+            );
+        });
+    });
+
+    describe("interface of code path segments", function() {
+        var actual = [];
+
+        beforeEach(function() {
+            actual = [];
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentStart": function(segment) {
+                        actual.push(segment);
+                    }
+                };
+            });
+            eslint.verify(
+                "function foo(a) { if (a) return 0; else throw new Error(); }",
+                {rules: {test: 2}}
+            );
+        });
+
+        it("should have `id` as unique string", function() {
+            assert(typeof actual[0].id === "string");
+            assert(typeof actual[1].id === "string");
+            assert(typeof actual[2].id === "string");
+            assert(typeof actual[3].id === "string");
+            assert(actual[0].id !== actual[1].id);
+            assert(actual[0].id !== actual[2].id);
+            assert(actual[0].id !== actual[3].id);
+            assert(actual[1].id !== actual[2].id);
+            assert(actual[1].id !== actual[3].id);
+            assert(actual[2].id !== actual[3].id);
+        });
+
+        it("should have `nextSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].nextSegments));
+            assert(Array.isArray(actual[1].nextSegments));
+            assert(Array.isArray(actual[2].nextSegments));
+            assert(Array.isArray(actual[3].nextSegments));
+            assert(actual[0].nextSegments.length === 0);
+            assert(actual[1].nextSegments.length === 2);
+            assert(actual[2].nextSegments.length === 0);
+            assert(actual[3].nextSegments.length === 0);
+            assert(actual[1].nextSegments[0] === actual[2]);
+            assert(actual[1].nextSegments[1] === actual[3]);
+        });
+
+        it("should have `allNextSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].allNextSegments));
+            assert(Array.isArray(actual[1].allNextSegments));
+            assert(Array.isArray(actual[2].allNextSegments));
+            assert(Array.isArray(actual[3].allNextSegments));
+            assert(actual[0].allNextSegments.length === 0);
+            assert(actual[1].allNextSegments.length === 2);
+            assert(actual[2].allNextSegments.length === 1);
+            assert(actual[3].allNextSegments.length === 1);
+            assert(actual[2].allNextSegments[0].reachable === false);
+            assert(actual[3].allNextSegments[0].reachable === false);
+        });
+
+        it("should have `prevSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].prevSegments));
+            assert(Array.isArray(actual[1].prevSegments));
+            assert(Array.isArray(actual[2].prevSegments));
+            assert(Array.isArray(actual[3].prevSegments));
+            assert(actual[0].prevSegments.length === 0);
+            assert(actual[1].prevSegments.length === 0);
+            assert(actual[2].prevSegments.length === 1);
+            assert(actual[3].prevSegments.length === 1);
+            assert(actual[2].prevSegments[0] === actual[1]);
+            assert(actual[3].prevSegments[0] === actual[1]);
+        });
+
+        it("should have `allPrevSegments` as CodePathSegment[]", function() {
+            assert(Array.isArray(actual[0].allPrevSegments));
+            assert(Array.isArray(actual[1].allPrevSegments));
+            assert(Array.isArray(actual[2].allPrevSegments));
+            assert(Array.isArray(actual[3].allPrevSegments));
+            assert(actual[0].allPrevSegments.length === 0);
+            assert(actual[1].allPrevSegments.length === 0);
+            assert(actual[2].allPrevSegments.length === 1);
+            assert(actual[3].allPrevSegments.length === 1);
+        });
+
+        it("should have `reachable` as boolean", function() {
+            assert(actual[0].reachable === true);
+            assert(actual[1].reachable === true);
+            assert(actual[2].reachable === true);
+            assert(actual[3].reachable === true);
+        });
+    });
+
+    describe("onCodePathStart", function() {
+        it("should be fired at the head of programs/functions", function() {
+            var count = 0;
+            var lastCodePathNodeType = null;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathStart": function(cp, node) {
+                        count += 1;
+                        lastCodePathNodeType = node.type;
+
+                        assert(cp instanceof CodePath);
+                        if (count === 1) {
+                            assert(node.type === "Program");
+                        } else if (count === 2) {
+                            assert(node.type === "FunctionDeclaration");
+                        } else if (count === 3) {
+                            assert(node.type === "FunctionExpression");
+                        } else if (count === 4) {
+                            assert(node.type === "ArrowFunctionExpression");
+                        }
+                    },
+                    "Program": function() {
+                        assert(lastCodePathNodeType === "Program");
+                    },
+                    "FunctionDeclaration": function() {
+                        assert(lastCodePathNodeType === "FunctionDeclaration");
+                    },
+                    "FunctionExpression": function() {
+                        assert(lastCodePathNodeType === "FunctionExpression");
+                    },
+                    "ArrowFunctionExpression": function() {
+                        assert(lastCodePathNodeType === "ArrowFunctionExpression");
+                    }
+                };
+            });
+            eslint.verify(
+                "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
+                {rules: {test: 2}, env: {es6: true}}
+            );
+
+            assert(count === 4);
+        });
+    });
+
+    describe("onCodePathEnd", function() {
+        it("should be fired at the end of programs/functions", function() {
+            var count = 0;
+            var lastNodeType = null;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathEnd": function(cp, node) {
+                        count += 1;
+
+                        assert(cp instanceof CodePath);
+                        if (count === 4) {
+                            assert(node.type === "Program");
+                        } else if (count === 1) {
+                            assert(node.type === "FunctionDeclaration");
+                        } else if (count === 2) {
+                            assert(node.type === "FunctionExpression");
+                        } else if (count === 3) {
+                            assert(node.type === "ArrowFunctionExpression");
+                        }
+                        assert(node.type === lastNodeType);
+                    },
+                    "Program:exit": function() {
+                        lastNodeType = "Program";
+                    },
+                    "FunctionDeclaration:exit": function() {
+                        lastNodeType = "FunctionDeclaration";
+                    },
+                    "FunctionExpression:exit": function() {
+                        lastNodeType = "FunctionExpression";
+                    },
+                    "ArrowFunctionExpression:exit": function() {
+                        lastNodeType = "ArrowFunctionExpression";
+                    }
+                };
+            });
+            eslint.verify(
+                "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
+                {rules: {test: 2}, env: {es6: true}}
+            );
+
+            assert(count === 4);
+        });
+    });
+
+    describe("onCodePathSegmentStart", function() {
+        it("should be fired at the head of programs/functions for the initial segment", function() {
+            var count = 0;
+            var lastCodePathNodeType = null;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentStart": function(segment, node) {
+                        count += 1;
+                        lastCodePathNodeType = node.type;
+
+                        assert(segment instanceof CodePathSegment);
+                        if (count === 1) {
+                            assert(node.type === "Program");
+                        } else if (count === 2) {
+                            assert(node.type === "FunctionDeclaration");
+                        } else if (count === 3) {
+                            assert(node.type === "FunctionExpression");
+                        } else if (count === 4) {
+                            assert(node.type === "ArrowFunctionExpression");
+                        }
+                    },
+                    "Program": function() {
+                        assert(lastCodePathNodeType === "Program");
+                    },
+                    "FunctionDeclaration": function() {
+                        assert(lastCodePathNodeType === "FunctionDeclaration");
+                    },
+                    "FunctionExpression": function() {
+                        assert(lastCodePathNodeType === "FunctionExpression");
+                    },
+                    "ArrowFunctionExpression": function() {
+                        assert(lastCodePathNodeType === "ArrowFunctionExpression");
+                    }
+                };
+            });
+            eslint.verify(
+                "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
+                {rules: {test: 2}, env: {es6: true}}
+            );
+
+            assert(count === 4);
+        });
+    });
+
+    describe("onCodePathSegmentEnd", function() {
+        it("should be fired at the end of programs/functions for the final segment", function() {
+            var count = 0;
+            var lastNodeType = null;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentEnd": function(cp, node) {
+                        count += 1;
+
+                        assert(cp instanceof CodePathSegment);
+                        if (count === 4) {
+                            assert(node.type === "Program");
+                        } else if (count === 1) {
+                            assert(node.type === "FunctionDeclaration");
+                        } else if (count === 2) {
+                            assert(node.type === "FunctionExpression");
+                        } else if (count === 3) {
+                            assert(node.type === "ArrowFunctionExpression");
+                        }
+                        assert(node.type === lastNodeType);
+                    },
+                    "Program:exit": function() {
+                        lastNodeType = "Program";
+                    },
+                    "FunctionDeclaration:exit": function() {
+                        lastNodeType = "FunctionDeclaration";
+                    },
+                    "FunctionExpression:exit": function() {
+                        lastNodeType = "FunctionExpression";
+                    },
+                    "ArrowFunctionExpression:exit": function() {
+                        lastNodeType = "ArrowFunctionExpression";
+                    }
+                };
+            });
+            eslint.verify(
+                "foo(); function foo() {} var foo = function() {}; var foo = () => {};",
+                {rules: {test: 2}, env: {es6: true}}
+            );
+
+            assert(count === 4);
+        });
+    });
+
+    describe("onCodePathSegmentLoop", function() {
+        it("should be fired in `while` loops", function() {
+            var count = 0;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentLoop": function(fromSegment, toSegment, node) {
+                        count += 1;
+                        assert(fromSegment instanceof CodePathSegment);
+                        assert(toSegment instanceof CodePathSegment);
+                        assert(node.type === "WhileStatement");
+                    }
+                };
+            });
+            eslint.verify(
+                "while (a) { foo(); }",
+                {rules: {test: 2}}
+            );
+
+            assert(count === 1);
+        });
+
+        it("should be fired in `do-while` loops", function() {
+            var count = 0;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentLoop": function(fromSegment, toSegment, node) {
+                        count += 1;
+                        assert(fromSegment instanceof CodePathSegment);
+                        assert(toSegment instanceof CodePathSegment);
+                        assert(node.type === "DoWhileStatement");
+                    }
+                };
+            });
+            eslint.verify(
+                "do { foo(); } while (a);",
+                {rules: {test: 2}}
+            );
+
+            assert(count === 1);
+        });
+
+        it("should be fired in `for` loops", function() {
+            var count = 0;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentLoop": function(fromSegment, toSegment, node) {
+                        count += 1;
+                        assert(fromSegment instanceof CodePathSegment);
+                        assert(toSegment instanceof CodePathSegment);
+                        if (count === 1) {
+                            // connect path: "update" -> "test"
+                            assert(node.parent.type === "ForStatement");
+                        } else if (count === 2) {
+                            assert(node.type === "ForStatement");
+                        }
+                    }
+                };
+            });
+            eslint.verify(
+                "for (var i = 0; i < 10; ++i) { foo(); }",
+                {rules: {test: 2}}
+            );
+
+            assert(count === 2);
+        });
+
+        it("should be fired in `for-in` loops", function() {
+            var count = 0;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentLoop": function(fromSegment, toSegment, node) {
+                        count += 1;
+                        assert(fromSegment instanceof CodePathSegment);
+                        assert(toSegment instanceof CodePathSegment);
+                        if (count === 1) {
+                            // connect path: "right" -> "left"
+                            assert(node.parent.type === "ForInStatement");
+                        } else if (count === 2) {
+                            assert(node.type === "ForInStatement");
+                        }
+                    }
+                };
+            });
+            eslint.verify(
+                "for (var k in obj) { foo(); }",
+                {rules: {test: 2}}
+            );
+
+            assert(count === 2);
+        });
+
+        it("should be fired in `for-of` loops", function() {
+            var count = 0;
+
+            eslint.defineRule("test", function() {
+                return {
+                    "onCodePathSegmentLoop": function(fromSegment, toSegment, node) {
+                        count += 1;
+                        assert(fromSegment instanceof CodePathSegment);
+                        assert(toSegment instanceof CodePathSegment);
+                        if (count === 1) {
+                            // connect path: "right" -> "left"
+                            assert(node.parent.type === "ForOfStatement");
+                        } else if (count === 2) {
+                            assert(node.type === "ForOfStatement");
+                        }
+                    }
+                };
+            });
+            eslint.verify(
+                "for (var x of xs) { foo(); }",
+                {rules: {test: 2}, env: {es6: true}}
+            );
+
+            assert(count === 2);
+        });
+    });
+
+    describe("completed code paths are correct", function() {
+        var testDataDir = path.join(__dirname, "../../fixtures/code-path-analysis/");
+        var testDataFiles = fs.readdirSync(testDataDir);
+
+        testDataFiles.forEach(function(file) {
+            it(file, function() {
+                var source = fs.readFileSync(path.join(testDataDir, file), {encoding: "utf8"});
+                var expected = getExpectedDotArrows(source);
+                var actual = [];
+
+                assert(expected.length > 0, "/*expected */ comments not found.");
+
+                eslint.defineRule("test", function() {
+                    return {
+                        "onCodePathEnd": function(codePath) {
+                            actual.push(debug.makeDotArrows(codePath));
+                        }
+                    };
+                });
+                var messages = eslint.verify(source, {rules: {test: 2}, env: {es6: true}});
+                assert.equal(messages.length, 0);
+                assert.equal(actual.length, expected.length, "a count of code paths is wrong.");
+
+                for (var i = 0; i < actual.length; ++i) {
+                    assert.equal(actual[i], expected[i]);
+                }
+            });
+        });
+    });
+});

--- a/tests/tests.htm
+++ b/tests/tests.htm
@@ -11,6 +11,7 @@
     <script src="../node_modules/mocha/mocha.js"></script>
     <script src="../node_modules/chai/chai.js"></script>
     <script src="../node_modules/sinon/pkg/sinon.js"></script>
+    <script src="../node_modules/phantomjs-polyfill/bind-polyfill.js"></script>
 
     <!-- source -->
     <script src="../build/eslint.js"></script>


### PR DESCRIPTION
Fixes #3530 

- [x] Decide API (new events style v.s. `context.getCodePath()` style)
- [x] Add JSDoc comments.
- [x] Add more tests.
  - [x] logical expressions.
  - [x] if statements.
  - [x] switch statements.
  - [x] try-catch-finally statements.
  - [x] while statements.
  - [x] do-while statements.
  - [x] for statements.
  - [x] for-in/of statements.
  - [x] functions.
  - [x] default parameters.
  - [x] default values of destructuring assignments
- [x] Add documents.
- [x] Remake some rules with the code path analysis.
  - [x] `no-unreachable`
  - [x] `no-fallthrough`
  - [x] `constructor-super`
  - [x] `no-this-before-super`
  - [x] `consistent-return`