### PR TITLE
Fix: line number for duplicate object keys error (fixes #3573)

### DIFF
--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -33,7 +33,7 @@ module.exports = function(context) {
 
                 if (checkProperty) {
                     if (nodeProps[key]) {
-                        context.report(node, "Duplicate key '{{key}}'.", { key: keyName });
+                        context.report(node, property.loc.start, "Duplicate key '{{key}}'.", { key: keyName });
                     } else {
                         nodeProps[key] = true;
                     }

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -31,6 +31,7 @@ ruleTester.run("no-dupe-keys", rule, {
         { code: "var x = { a: b, ['a']: b };", ecmaFeatures: { objectLiteralComputedProperties: true }, errors: [{ message: "Duplicate key 'a'.", type: "ObjectExpression"}] },
         { code: "var x = { y: 1, y: 2 };", errors: [{ message: "Duplicate key 'y'.", type: "ObjectExpression"}] },
         { code: "var foo = { 0x1: 1, 1: 2};", errors: [{ message: "Duplicate key '1'.", type: "ObjectExpression"}] },
-        { code: "var x = { \"z\": 1, z: 2 };", errors: [{ message: "Duplicate key 'z'.", type: "ObjectExpression"}] }
+        { code: "var x = { \"z\": 1, z: 2 };", errors: [{ message: "Duplicate key 'z'.", type: "ObjectExpression"}] },
+        { code: "var foo = {\n  bar: 1,\n  bar: 1,\n}", errors: [{ message: "Duplicate key 'bar'.", line: 3, column: 3}]}
     ]
 });


### PR DESCRIPTION
At Facebook, our linters only warn you about issues on lines that you changed. This caused an issue for us because the line number for a duplicate key in an object had the line number of the *start* of the object instead of the actual duplicate key. For example:

```javascript
var foo = { // this was where the error was reported
  bar: 1,
  // ...
  // possibly many other lines here
  // ...
  bar: 1, // this line was added
};
```