### PR TITLE
Fix: Indent rule crash on comment-only file (fixes #3570)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -109,6 +109,10 @@ module.exports = function(context) {
      */
     function getNodeIndent(node, byLastLine, excludeCommas) {
         var token = byLastLine ? context.getLastToken(node) : context.getFirstToken(node);
+        if (!token) {
+            return 0;
+        }
+
         var src = context.getSource(token, token.loc.start.column);
 
         var skip = excludeCommas ? "," : "";

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -777,6 +777,14 @@ ruleTester.run("indent", rule, {
                 "    \n" +
                 "}\n",
             options: [2]
+        },
+        {
+            code: "//",
+            options: [2]
+        },
+        {
+            code: "/* */",
+            options: [2]
         }
     ],
     invalid: [


### PR DESCRIPTION
A file of only comments will crash the indent rule.