### PR TITLE
New: `space-before-keywords` rule (fixes #1631)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -164,6 +164,7 @@
         "semi-spacing": [0, {"before": false, "after": true}],
         "sort-vars": 0,
         "space-after-keywords": [0, "always"],
+        "space-before-keywords": [0, "always"],
         "space-before-blocks": [0, "always"],
         "space-before-function-paren": [0, "always"],
         "space-in-parens": [0, "never"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -178,6 +178,7 @@ These rules are purely matters of style and are quite subjective.
 * [semi](semi.md) - require or disallow use of semicolons instead of ASI
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block
 * [space-after-keywords](space-after-keywords.md) - require a space after certain keywords
+* [space-before-keywords](space-before-keywords.md) - require a space before certain keywords
 * [space-before-blocks](space-before-blocks.md) - require or disallow a space before blocks
 * [space-before-function-paren](space-before-function-paren.md) - require or disallow a space before function opening parenthesis
 * [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -1,0 +1,90 @@
+# Require or disallow spaces before keywords (space-before-keywords)
+
+Some styleguides require or disallow spaces preceding certain keywords.
+
+## Rule Details
+
+This rule will enforce consistency of spacing before the keywords `if`, `else`, `for`,
+`while`, `do`, `switch`, `throw`, `try`, `catch`, `finally`, `with`, `break`, `continue`,
+`return`, `function`, `yield`, `class`, `super` and variable declarations (`let`, `const`, `var`)
+and label statements.
+
+This rule takes one argument: `"always"` or `"never"`. If `"always"` then the keywords
+must be followed by at least one space. If `"never"` then no spaces will be allowed before
+the keywords `else`, `while` (do...while), `finally` and `catch`. The default value is `"always"`.
+
+The following patterns are considered errors when configured `"never"`:
+
+```js
+/*eslint space-before-keywords: [2, "never"]*/
+
+if (foo) {
+    // ...
+} else {} /*error Unexpected space before keyword "else".*/
+
+do {
+
+}
+while (foo) /*error Unexpected space before keyword "while".*/
+
+try {} finally {} /*error Unexpected space before keyword "finally".*/
+
+try {} catch(e) {} /*error Unexpected space before keyword "catch".*/
+```
+
+The following patterns are not considered errors when configured `"never"`:
+
+```js
+/*eslint space-before-keywords: [2, "never"]*/
+
+if (foo) {
+    // ...
+}else {}
+
+do {}while (foo)
+
+try {}finally {}
+
+try{}catch(e) {}
+```
+
+The following patterns are considered errors when configured `"always"`:
+
+```js
+/*eslint space-before-keywords: [2, "always"]*/
+
+if (foo) {
+    // ...
+}else {} /*error Missing space before keyword "else".*/
+
+const foo = 'bar';let baz = 'qux'; /*error Missing space before keyword "let".*/
+
+var foo =function bar () {} /*error Missing space before keyword "function".*/
+
+if (foo) {return; } /*error Missing space before keyword "return".*/
+```
+
+The following patterns are not considered errors when configured `"always"`:
+
+```js
+/*eslint space-before-keywords: [2, "always"]*/
+
+if (foo) {
+    // ...
+} else {}
+
+(function() {})()
+
+for (let foo of ['bar', 'baz', 'qux']) {}
+```
+
+## When Not To Use It
+
+If you do not wish to enforce consistency on keyword spacing.
+
+## Related Rules
+
+* [space-after-keywords](space-after-keywords.md)
+* [space-return-throw-case](space-return-throw-case.md)
+* [space-unary-ops](space-unary-ops.md)
+* [space-infix-ops](space-infix-ops.md)

--- a/lib/rules/space-before-keywords.js
+++ b/lib/rules/space-before-keywords.js
@@ -1,0 +1,185 @@
+/**
+ * @fileoverview Require or disallow spaces before keywords
+ * @author Marko Raatikka
+ * @copyright 2015 Marko Raatikka. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict";
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+var ERROR_MSG_SPACE_EXPECTED = "Missing space before keyword \"{{keyword}}\".";
+var ERROR_MSG_NO_SPACE_EXPECTED = "Unexpected space before keyword \"{{keyword}}\".";
+
+module.exports = function(context) {
+
+    var SPACE_REQUIRED = context.options[0] !== "never";
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Check if a token meets the criteria
+     *
+     * @param   {ASTNode} node    The node to check
+     * @param   {Object}  left    The left-hand side token of the node
+     * @param   {Object}  right   The right-hand side token of the node
+     * @param   {Object}  options See check()
+     * @returns {void}
+     */
+    function checkTokens(node, left, right, options) {
+
+        if (!left) {
+            return;
+        }
+
+        if (left.type === "Keyword") {
+            return;
+        }
+
+        if (!SPACE_REQUIRED && typeof options.requireSpace === "undefined") {
+            return;
+        }
+
+        options = options || {};
+        options.allowedPrecedingChars = options.allowedPrecedingChars || [];
+        options.requireSpace = typeof options.requireSpace === "undefined" ? SPACE_REQUIRED : options.requireSpace;
+
+        var hasSpace = astUtils.isTokenSpaced(left, right);
+        var spaceOk = hasSpace === options.requireSpace;
+
+        if (spaceOk) {
+            return;
+        }
+
+        if (!astUtils.isTokenOnSameLine(left, right)) {
+            if (!options.requireSpace) {
+                context.report(node, ERROR_MSG_NO_SPACE_EXPECTED, { keyword: right.value });
+            }
+            return;
+        }
+
+        if (!options.requireSpace) {
+            context.report(node, ERROR_MSG_NO_SPACE_EXPECTED, { keyword: right.value });
+            return;
+        }
+
+        if (options.allowedPrecedingChars.indexOf(left.value) !== -1) {
+            return;
+        }
+
+        context.report(node, ERROR_MSG_SPACE_EXPECTED, { keyword: right.value });
+
+    }
+
+    /**
+     * Get right and left tokens of a node and check to see if they meet the given criteria
+     *
+     * @param   {ASTNode}  node                          The node to check
+     * @param   {Object}   options                       Options to validate the node against
+     * @param   {Array}    options.allowedPrecedingChars Characters that can precede the right token
+     * @param   {Boolean}  options.requireSpace          Whether or not the right token needs to be
+     *                                                   preceded by a space
+     * @returns {void}
+     */
+    function check(node, options) {
+
+        options = options || {};
+
+        var left = context.getTokenBefore(node);
+        var right = context.getFirstToken(node);
+
+        checkTokens(node, left, right, options);
+
+    }
+
+    //--------------------------------------------------------------------------
+    // Public
+    //--------------------------------------------------------------------------
+
+    return {
+
+        "IfStatement": function(node) {
+            // if
+            check(node);
+            // else
+            if (node.alternate) {
+                check(context.getTokenBefore(node.alternate), { requireSpace: SPACE_REQUIRED });
+            }
+        },
+        "ForStatement": check,
+        "ForInStatement": check,
+        "WhileStatement": check,
+        "DoWhileStatement": function(node) {
+            var whileNode = context.getTokenAfter(node.body);
+            // do
+            check(node);
+            // while
+            check(whileNode, { requireSpace: SPACE_REQUIRED });
+        },
+        "SwitchStatement": function(node) {
+            // switch
+            check(node);
+            // case/default
+            node.cases.forEach(function(caseNode) {
+                check(caseNode);
+            });
+        },
+        ThrowStatement: check,
+        "TryStatement": function(node) {
+            // try
+            check(node);
+            // finally
+            if (node.finalizer) {
+                check(context.getTokenBefore(node.finalizer), { requireSpace: SPACE_REQUIRED });
+            }
+        },
+        "CatchClause": function(node) {
+            check(node, { requireSpace: SPACE_REQUIRED });
+        },
+        "WithStatement": check,
+        "VariableDeclaration": function(node) {
+            check(node, { allowedPrecedingChars: [ "(" ] });
+        },
+        "ReturnStatement": check,
+        "BreakStatement": check,
+        "LabeledStatement": check,
+        "ContinueStatement": check,
+        "FunctionDeclaration": check,
+        "FunctionExpression": function(node) {
+
+            var left = context.getTokenBefore(node);
+            var right = null;
+
+            if (left.type === "Identifier") {
+                right = left;
+                left = context.getTokenBefore(node, 1);
+            } else {
+                right = context.getFirstToken(node);
+            }
+
+            checkTokens(node, left, right, { allowedPrecedingChars: [ "(" ] });
+        },
+        "YieldExpression": function(node) {
+            check(node, { allowedPrecedingChars: [ "(" ] });
+        },
+        "ForOfStatement": check,
+        "ClassBody": function(node) {
+            check(context.getTokenBefore(node, 1));
+        },
+        "Super": check
+
+    };
+
+};
+
+module.exports.schema = [
+    {
+        "enum": ["always", "never"]
+    }
+];

--- a/tests/lib/rules/space-before-keywords.js
+++ b/tests/lib/rules/space-before-keywords.js
@@ -1,0 +1,376 @@
+/**
+ * @fileoverview Require or disallow spaces before keywords
+ * @author Marko Raatikka
+ * @copyright 2015 Marko Raatikka. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/space-before-keywords"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+var never = [ "never" ];
+
+function expectedSpacingErrorMessageTpl(keyword) {
+    return "Missing space before keyword \"" + keyword + "\".";
+}
+
+function expectedNoSpacingErrorMessageTpl(keyword) {
+    return "Unexpected space before keyword \"" + keyword + "\".";
+}
+
+ruleTester.run("space-before-keywords", rule, {
+    valid: [
+        // IfStatement
+        { code: "; if ('') {}" },
+        { code: ";\nif ('') {}" },
+        { code: "if ('') {} else {}" },
+        { code: "if ('') {}\nelse {}" },
+        { code: "; if ('') {}", options: never },
+        { code: ";\nif ('') {}", options: never },
+        { code: "if ('') {}else {}", options: never },
+        // ForStatement
+        { code: "; for (;;) {}" },
+        { code: ";\nfor (;;) {}" },
+        { code: "; for (;;) {}", options: never },
+        { code: ";\nfor (;;) {}", options: never },
+        // ForInStatement
+        { code: "; for (var foo in [1, 2, 3]) {}" },
+        { code: ";\nfor (var foo in [1, 2, 3]) {}" },
+        { code: "; for (var foo in [1, 2, 3]) {}", options: never },
+        { code: ";\nfor (var foo in [1, 2, 3]) {}", options: never },
+        // WhileStatement
+        { code: "; while (false) {}" },
+        { code: ";\nwhile (false) {}" },
+        { code: "; while (false) {}", options: never },
+        { code: ";\nwhile (false) {}", options: never },
+        // DoWhileStatement
+        { code: "; do {} while (false)" },
+        { code: ";\ndo {} while (false)" },
+        { code: "do {}\nwhile (false)" },
+        { code: "; do {}while (false)", options: never },
+        // SwitchStatement
+        { code: "; switch ('') {}" },
+        { code: ";\nswitch ('') {}" },
+        { code: "switch ('') { case 'foo': '' }" },
+        { code: "switch ('') {\ncase 'foo': '' }" },
+        { code: "; switch ('') {}", options: never },
+        { code: ";\nswitch ('') {}", options: never },
+        { code: "switch ('') { case 'foo': '' }", options: never },
+        { code: "switch ('') {\ncase 'foo': '' }", options: never },
+        // ThrowStatement
+        { code: "; throw new Error()" },
+        { code: ";\nthrow new Error()" },
+        { code: "; throw new Error()", options: never },
+        { code: ";\nthrow new Error()", options: never },
+        // TryStatement
+        { code: "; try {} finally {}" },
+        { code: ";\ntry {} finally {}" },
+        { code: "try {}\nfinally {}" },
+        { code: "; try {}finally {}", options: never },
+        { code: ";\ntry {}finally {}", options: never },
+        // CatchStatement
+        { code: "try {} catch (e) {}" },
+        { code: "try {}\ncatch (e) {}" },
+        { code: "try {}catch (e) {}", options: never },
+        // WithStatement
+        { code: "; with (false) {}" },
+        { code: ";\nwith (false) {}" },
+        { code: "; with (false) {}", options: never },
+        { code: ";\nwith (false) {}", options: never },
+        // VariableDeclaration
+        { code: "; var foo = 1" },
+        { code: ";\nvar foo = 1" },
+        { code: "for (var foo in [1, 2, 3]) {}" },
+        { code: "; var foo = 1", options: never },
+        { code: ";\nvar foo = 1", options: never },
+        // BreakStatement
+        { code: "for (;;) { break }"},
+        { code: "for (;;) {\nbreak }"},
+        { code: "for (;;) {\nbreak }", options: never},
+        // LabeledStatement
+        { code: "foo: for (;;) { bar: for (;;) {} }" },
+        { code: "foo: for (;;) {\nbar: for (;;) {} }" },
+        { code: "foo: for (;;) { bar: for (;;) {} }", options: never },
+        { code: "foo: for (;;) {\nbar: for (;;) {} }", options: never },
+        // ContinueStatement
+        { code: "for (;;) { continue }" },
+        { code: "for (;;) {\ncontinue }" },
+        { code: "for (;;) { continue }", options: never },
+        { code: "for (;;) {\ncontinue }", options: never },
+        // ReturnStatement
+        { code: "function foo() { return }" },
+        { code: "function foo() {\nreturn }" },
+        { code: "function foo() { return }", options: never },
+        { code: "function foo() {\nreturn }", options: never },
+        // FunctionDeclaration
+        { code: "; function foo () {}" },
+        { code: ";\nfunction foo () {}" },
+        { code: "; function foo () {}", options: never },
+        { code: ";\nfunction foo () {}", options: never },
+        // FunctionExpression
+        { code: "var foo = function bar () {}" },
+        { code: "var foo =\nfunction bar () {}" },
+        { code: "function foo () { return function () {} }" },
+        { code: "var foo = (function bar () {})()" },
+        { code: "var foo = function bar () {}", options: never },
+        { code: "var foo =\nfunction bar () {}", options: never },
+        { code: "function foo () { return function () {} }", options: never },
+        // YieldExpression
+        {
+            code: "function* foo() { yield 0; }",
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function* foo() { if (yield 0) {} }",
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function* foo() {\nyield 0; }",
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function* foo() { yield 0; }",
+            ecmaFeatures: { generators: true },
+            options: never
+        },
+        {
+            code: "function* foo() {\nyield 0; }",
+            ecmaFeatures: { generators: true },
+            options: never
+        },
+        // ForOfStatement
+        {
+            code: "; for (var foo of [1, 2, 3]) {}",
+            ecmaFeatures: { forOf: true }
+        },
+        {
+            code: ";\nfor (var foo of [1, 2, 3]) {}",
+            ecmaFeatures: { forOf: true }
+        },
+        {
+            code: "; for (var foo of [1, 2, 3]) {}",
+            ecmaFeatures: { forOf: true },
+            options: never
+        },
+        {
+            code: ";\nfor (var foo of [1, 2, 3]) {}",
+            ecmaFeatures: { forOf: true },
+            options: never
+        },
+        // ClassBody
+        {
+            code: "; class Bar {}",
+            ecmaFeatures: { classes: true }
+        },
+        {
+            code: ";\nclass Bar {}",
+            ecmaFeatures: { classes: true }
+        },
+        {
+            code: "; class Bar {}",
+            ecmaFeatures: { classes: true },
+            options: never
+        },
+        {
+            code: ";\nclass Bar {}",
+            ecmaFeatures: { classes: true },
+            options: never
+        },
+        // Super
+        {
+            code: "class Bar { constructor() { super(); } }",
+            ecmaFeatures: { classes: true }
+        },
+        {
+            code: "class Bar { constructor() {\nsuper(); } }",
+            ecmaFeatures: { classes: true }
+        },
+        {
+            code: "class Bar { constructor() { super(); } }",
+            ecmaFeatures: { classes: true },
+            options: never
+        },
+        {
+            code: "class Bar { constructor() {\nsuper(); } }",
+            ecmaFeatures: { classes: true },
+            options: never
+        }
+    ],
+    invalid: [
+        // IfStatement
+        {
+            code: ";if ('') {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("if"), type: "IfStatement" } ]
+        },
+        {
+            code: "if ('') {}else {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("else"), type: "Keyword", line: 1, column: 11 } ]
+        },
+        {
+            code: "if ('') {} else {}",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("else"), type: "Keyword", line: 1, column: 12 } ],
+            options: never
+        },
+        {
+            code: "if ('') {}\nelse {}",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("else"), type: "Keyword", line: 2, column: 1 } ],
+            options: never
+        },
+        // ForStatement
+        {
+            code: ";for (;;) {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("for"), type: "ForStatement" } ]
+        },
+        // ForInStatement
+        {
+            code: ";for (var foo in [1, 2, 3]) {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("for"), type: "ForInStatement" } ]
+        },
+        // WhileStatement
+        {
+            code: ";while (false) {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("while"), type: "WhileStatement" } ]
+        },
+        // DoWhileStatement
+        {
+            code: ";do {} while (false)",
+            errors: [ { message: expectedSpacingErrorMessageTpl("do"), type: "DoWhileStatement" } ]
+        },
+        {
+            code: "do {}while (false)",
+            errors: [ { message: expectedSpacingErrorMessageTpl("while"), type: "Keyword", line: 1, column: 6 } ]
+        },
+        {
+            code: "do {} while (false)",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("while"), type: "Keyword", line: 1, column: 7 } ],
+            options: never
+        },
+        {
+            code: "do {}\nwhile (false)",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("while"), type: "Keyword", line: 2, column: 1 } ],
+            options: never
+        },
+        // SwitchStatement
+        {
+            code: ";switch ('') {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("switch"), type: "SwitchStatement" } ]
+        },
+        {
+            code: "switch ('') {case 'foo': '' }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("case"), type: "SwitchCase", line: 1, column: 14 } ]
+        },
+        // ThrowStatement
+        {
+            code: ";throw new Error()",
+            errors: [ { message: expectedSpacingErrorMessageTpl("throw"), type: "ThrowStatement" } ]
+        },
+        // TryStatement
+        {
+            code: ";try {} finally {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("try"), type: "TryStatement" } ]
+        },
+        {
+            code: "try {}finally {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("finally"), type: "Keyword", line: 1, column: 7 } ]
+        },
+        {
+            code: "try {} finally {}",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("finally"), type: "Keyword", line: 1, column: 8 } ],
+            options: never
+        },
+        {
+            code: "try {}\nfinally {}",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("finally"), type: "Keyword", line: 2, column: 1 } ],
+            options: never
+        },
+        // CatchClause
+        {
+            code: "try {}catch (e) {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("catch"), type: "CatchClause", line: 1, column: 7 } ]
+        },
+        {
+            code: "try {} catch (e) {}",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("catch"), type: "CatchClause", line: 1, column: 8 } ],
+            options: never
+        },
+        {
+            code: "try {}\ncatch (e) {}",
+            errors: [ { message: expectedNoSpacingErrorMessageTpl("catch"), type: "CatchClause", line: 2, column: 1 } ],
+            options: never
+        },
+        // WithStatement
+        {
+            code: ";with (false) {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("with"), type: "WithStatement" } ]
+        },
+        // VariableDeclaration
+        {
+            code: ";var foo = 1",
+            errors: [ { message: expectedSpacingErrorMessageTpl("var"), type: "VariableDeclaration" } ]
+        },
+        // BreakStatement
+        {
+            code: "for (;;) {break; }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("break"), type: "BreakStatement" } ]
+        },
+        // LabeledStatement
+        {
+            code: "foo: for (;;) {bar: for (;;) {} }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("bar"), type: "LabeledStatement" } ]
+        },
+        // ContinueStatement
+        {
+            code: "for (;;) {continue; }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("continue"), type: "ContinueStatement" } ]
+        },
+        // ReturnStatement
+        {
+            code: "function foo() {return; }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("return"), type: "ReturnStatement" } ]
+        },
+        // FunctionDeclaration
+        {
+            code: ";function foo () {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("function"), type: "FunctionDeclaration" } ]
+        },
+        // FunctionExpression
+        {
+            code: "var foo =function bar () {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("function"), type: "FunctionExpression" } ]
+        },
+        // YieldExpression
+        {
+            code: "function* foo() {yield 0; }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("yield"), type: "YieldExpression" } ],
+            ecmaFeatures: { generators: true }
+        },
+        // ForOfStatement
+        {
+            code: ";for (var b of [1, 2, 3]) {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("for"), type: "ForOfStatement" } ],
+            ecmaFeatures: { forOf: true }
+        },
+        // ClassBody
+        {
+            code: ";class Bar {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("class"), type: "Keyword" } ],
+            ecmaFeatures: { classes: true }
+        },
+        // Super
+        {
+            code: "class Bar { constructor() {super.foo(); } }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("super"), type: "Super" } ],
+            ecmaFeatures: { classes: true }
+        }
+    ]
+});


### PR DESCRIPTION
Enforce spacing before keywords... 
* `if`, `else`, `for`, `while`, `do`, `switch`, `try`, `catch`, `finally`, `with`, `return` and `throw` (w.r.t. [space-after-keywords](eslint/blob/master/lib/rules/space-after-keywords.js) and [space-return-throw-case](eslint/blob/master/lib/rules/space-return-throw-case.js))
* as well as `function`, `yield`, `class`, `super`, variable declarations and label statements