### PR TITLE
prefer-const add option onlyPrimitive

### DIFF
--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -11,6 +11,8 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var options = context.options[0] || {};
+    var onlyPrimitive = !!options.onlyPrimitive;
 
     /**
      * Checks whether a reference is the initializer.
@@ -47,6 +49,7 @@ module.exports = function(context) {
             var def = variable.defs[0];
             var declaration = def && def.parent;
             var statement = declaration && declaration.parent;
+            var init = def && def.node && def.node.init;
             var references = variable.references;
             var identifier = variable.identifiers[0];
 
@@ -54,6 +57,7 @@ module.exports = function(context) {
                 identifier != null &&
                 declaration.type === "VariableDeclaration" &&
                 declaration.kind === "let" &&
+                (!onlyPrimitive || !init || init.type === "Literal") &&
                 (statement.type !== "ForStatement" || statement.init !== declaration) &&
                 references.some(isInitializer) &&
                 references.every(isReadOnlyOrInitializer)
@@ -88,4 +92,14 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "onlyPrimitive": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -36,7 +36,12 @@ ruleTester.run("prefer-const", rule, {
         { code: "(function() { for (let i = 0, end = 10; i < end; ++i) {} })();", ecmaFeatures: {blockBindings: true} },
         { code: "(function() { for (let i in [1,2,3]) { i = 0; } })();", ecmaFeatures: {blockBindings: true} },
         { code: "(function() { for (let x of [1,2,3]) { x = 0; } })();", ecmaFeatures: {blockBindings: true, forOf: true} },
-        { code: "(function(x = 0) { })();", ecmaFeatures: {defaultParams: true} }
+        { code: "(function(x = 0) { })();", ecmaFeatures: {defaultParams: true} },
+        {
+            code: "let x = {};",
+            ecmaFeatures: {blockBindings: true},
+            options: [{ onlyPrimitive: true }]
+        }
     ],
     invalid: [
         {
@@ -106,6 +111,12 @@ ruleTester.run("prefer-const", rule, {
                 { message: "`i` is never modified, use `const` instead.", type: "Identifier"},
                 { message: "`x` is never modified, use `const` instead.", type: "Identifier"}
             ]
+        },
+        {
+            code: "let x = 0;",
+            ecmaFeatures: {blockBindings: true},
+            options: [{ onlyPrimitive: true }],
+            errors: [{ message: "`x` is never modified, use `const` instead.", type: "Identifier"}]
         }
     ]
 });


### PR DESCRIPTION
Dear all,

I'd like to propose an option for the *prefer-const* rule.

I really like enforcing const on unchanged primitives. Not so much on unchanged objects. Because const doesn't protect object members I find this an illogical thing to do.

Proposed option: *onlyPrimitive*. This would allow the following code

```json
{
    "rules": {
        "prefer-const": [1, { "onlyPrimitive": true }]
    }
}
```

```javascript
let x = {};
```

I'd like to hear your thoughts on this.

CC @mysticatea 