### PR TITLE
Fix: `no-useless-concat` to check if same types (fixes #3575)

### DIFF
--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -9,22 +9,20 @@ This rule aims to flag the concenation of 2 literals when they could be combined
 The following patterns are considered warnings:
 
 ```js
-
 // these are the same as "10"
 var a = `some` + `string`;
 var a = '1' + '0';
 var a = '1' + `0`;
 var a = `1` + '0';
 var a = `1` + `0`;
-var a = 1 + '0';
-var a = '1' + 0;
-
 ```
 
 The following patterns are not warnings:
 
 ```js
-
+// not checking if different types
+var a = 1 + '0';
+var a = number + 1 + 'px'
 // a and b are identifiers
 var c = a + b;
 // a is an identifier
@@ -35,7 +33,6 @@ var c = 1 - 2;
 // exception for multiline string concatenation
 var c = "foo" +
     "bar";
-
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -23,6 +23,19 @@ function getLeft(node) {
     return left;
 }
 
+/**
+ * Get's the node's type if a Literal or string if a TemplateLiteral
+ * @param {ASTNode} node - the node to check.
+ * @returns {String} string
+ */
+function getType(node) {
+    if (node.type === "Literal") {
+        return typeof node.value;
+    } else if (node.type === "TemplateLiteral") {
+        return "string";
+    }
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -47,8 +60,16 @@ module.exports = function(context) {
                     return;
                 }
 
+                var leftType = getType(left);
+                var rightType = getType(right);
+
+                // check for same types
+                if (leftType !== rightType) {
+                    return;
+                }
+
                 // check for addition
-                if (typeof left.value === "number" && typeof right.value === "number") {
+                if (leftType === "number" && rightType === "number") {
                     return;
                 }
 

--- a/tests/lib/rules/no-useless-concat.js
+++ b/tests/lib/rules/no-useless-concat.js
@@ -23,29 +23,22 @@ var ruleTester = new RuleTester();
 ruleTester.run("no-useless-concat", rule, {
 
     valid: [
-        { code: "var a = 1 + 1;" },
         { code: "var a = 1 * '2';" },
         { code: "var a = 1 - 2;" },
         { code: "var a = foo + bar;" },
         { code: "var a = 'foo' + bar;" },
-        { code: "var foo = 'foo' +\n 'bar';" }
+        { code: "var a = 1 + 1;" },
+        { code: "var foo = 'foo' +\n 'bar';" },
+        { code: "var string = (number + 1) + 'px';" },
+        { code: "var string = '1' + 1 + 'px';" },
+        { code: "'a' + 1" },
+        { code: "1 + `1`", ecmaFeatures: {templateStrings: true} },
+        { code: "`1` + 1", ecmaFeatures: {templateStrings: true} }
     ],
 
     invalid: [
         {
             code: "'a' + 'b'",
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "'a' + 1",
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "1 + '1'",
             errors: [
                 { message: "Unexpected string concatenation of literals."}
             ]
@@ -73,20 +66,6 @@ ruleTester.run("no-useless-concat", rule, {
         },
         {
             code: "`a` + 'b'",
-            ecmaFeatures: {templateStrings: true},
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "1 + `1`",
-            ecmaFeatures: {templateStrings: true},
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "`1` + 1",
             ecmaFeatures: {templateStrings: true},
             errors: [
                 { message: "Unexpected string concatenation of literals."}


### PR DESCRIPTION
Ref #3575 

Can use something like this if we can't come up with a way to evaluate the types, otherwise will close.