### PR TITLE
New: Add --max-warnings flag to CLI (fixes #2769)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -39,6 +39,7 @@ Options:
   --no-color                  Disable color in piped output
   -o, --output-file path::String  Specify file to write report to
   --quiet                     Report errors only - default: false
+  --max-warnings Number       Number of warnings to trigger nonzero exit code
   --stdin                     Lint code provided on <STDIN> - default: false
   --stdin-filename            Specify filename to process STDIN as
   --init                      Run config initialization wizard
@@ -180,6 +181,16 @@ This option allows you to disable reporting on warnings. If you enable this opti
 Example:
 
     eslint --quiet file.js
+
+### `--max-warnings`
+
+This option allows you to specify a warning threshold, which can be used to force ESLint to exit with an error status if there are too many warning-level rule violations in your project.
+
+Normally, if ESLint runs and finds no errors (only warnings), it will exit with a success exit status. However, if this option is specified and the total warning count is greater than the specified threshold, ESLint will exit with an error status. Specifying a threshold of `-1` or omitting this option will prevent this behavior.
+
+Example:
+
+    eslint --max-warnings 10 file.js
 
 ### `--rule`
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -121,7 +121,8 @@ var cli = {
         var currentOptions,
             files,
             result,
-            engine;
+            engine,
+            tooManyWarnings;
 
         try {
             currentOptions = options.parse(args);
@@ -151,7 +152,13 @@ var cli = {
             }
 
             if (printResults(engine, result.results, currentOptions.format, currentOptions.outputFile)) {
-                return result.errorCount ? 1 : 0;
+                tooManyWarnings = currentOptions.maxWarnings >= 0 && result.warningCount > currentOptions.maxWarnings;
+
+                if (!result.errorCount && tooManyWarnings) {
+                    console.error("ESLint found too many warnings (maximum: %s).", currentOptions.maxWarnings);
+                }
+
+                return (result.errorCount || tooManyWarnings) ? 1 : 0;
             } else {
                 return 1;
             }

--- a/lib/options.js
+++ b/lib/options.js
@@ -108,6 +108,12 @@ module.exports = optionator({
         description: "Report errors only"
     },
     {
+        option: "max-warnings",
+        type: "Number",
+        default: "-1",
+        description: "Number of warnings to trigger nonzero exit code"
+    },
+    {
         option: "stdin",
         type: "Boolean",
         default: "false",

--- a/tests/fixtures/max-warnings/.eslintrc
+++ b/tests/fixtures/max-warnings/.eslintrc
@@ -1,0 +1,6 @@
+{
+    "rules": {
+        "quotes": [1, "single"]
+    },
+    "root": true
+}

--- a/tests/fixtures/max-warnings/six-warnings.js
+++ b/tests/fixtures/max-warnings/six-warnings.js
@@ -1,0 +1,6 @@
+var one = "One!";
+var two = "Two!";
+var three = "Three!";
+var four = "Four!";
+var five = "Five!";
+var six = "Six!";

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -565,4 +565,44 @@ describe("cli", function() {
         });
     });
 
+    describe("when given the max-warnings flag", function() {
+        it("should not change exit code if warning count under threshold", function() {
+            var filePath = getFixturePath("max-warnings"),
+                exitCode;
+
+            exitCode = cli.execute("--max-warnings 10 " + filePath);
+
+            assert.equal(exitCode, 0);
+        });
+
+        it("should exit with exit code 1 if warning count exceeds threshold", function() {
+            var filePath = getFixturePath("max-warnings"),
+                exitCode;
+
+            exitCode = cli.execute("--max-warnings 5 " + filePath);
+
+            assert.equal(exitCode, 1);
+            assert.ok(console.error.calledOnce);
+            assert.include(console.error.getCall(0).args[0], "ESLint found too many warnings");
+        });
+
+        it("should not change exit code if warning count equals threshold", function() {
+            var filePath = getFixturePath("max-warnings"),
+                exitCode;
+
+            exitCode = cli.execute("--max-warnings 6 " + filePath);
+
+            assert.equal(exitCode, 0);
+        });
+
+        it("should not change exit code if flag is not specified and there are warnings", function() {
+            var filePath = getFixturePath("max-warnings"),
+                exitCode;
+
+            exitCode = cli.execute(filePath);
+
+            assert.equal(exitCode, 0);
+        });
+    });
+
 });

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -230,6 +230,18 @@ describe("options", function() {
         });
     });
 
+    describe("--max-warnings", function() {
+        it("should return correct value for .maxWarnings when passed", function() {
+            var currentOptions = options.parse("--max-warnings 10");
+            assert.equal(currentOptions.maxWarnings, 10);
+        });
+
+        it("should return -1 for .maxWarnings when not passed", function() {
+            var currentOptions = options.parse("");
+            assert.equal(currentOptions.maxWarnings, -1);
+        });
+    });
+
     describe("--init", function() {
         it("should return true for --init when passed", function() {
             var currentOptions = options.parse("--init");


### PR DESCRIPTION
User can now specify `--max-warnings` CLI option. If no errors are found but warning count exceeds the specified value, ESLint will exit with an error. If option is not specified, ESLint will continue to exit with an error if and only if at least one error is found in linted files.

Fixes #2769. Includes unit tests and docs.