### PR TITLE
Docs: Including for(;;) as valid case in no-constant-condition

### DIFF
--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -72,3 +72,11 @@ do {
     something();
 } while (x)
 ```
+
+```js
+/*eslint no-constant-condition: 2*/
+
+for (;;) {
+    something();
+}
+```


### PR DESCRIPTION
Seems worthwhile to show `for(;;)` as a legal way to do an infinite loop under this rule (and it is called out as a valid case in the unit tests for this rule).

No issue available.