### PR TITLE
Fix: `no-useless-concat` only check useless concat of literals on actual string concat (fixes #3575)

### DIFF
--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -11,6 +11,34 @@
 //------------------------------------------------------------------------------
 
 /**
+ * Get's the node's type if a Literal or string if a TemplateLiteral
+ * @param {ASTNode} node - the node to check.
+ * @returns {String} string
+ */
+function getType(node) {
+    if (node.type === "Literal") {
+        return typeof node.value;
+    } else if (node.type === "TemplateLiteral") {
+        return "string";
+    }
+}
+
+/**
+ * Checks whether or not a given binary expression has a string literal.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node has a string literal.
+ */
+function hasStringLiteral(node) {
+    if (node.type === "BinaryExpression") {
+        return node.operator === "+" && (hasStringLiteral(node.left) || hasStringLiteral(node.right));
+    }
+    if (node.type === "UnaryExpression") {
+        return false;
+    }
+    return getType(node) === "string";
+}
+
+/**
  * Get's the right most node on the left side of a BinaryExpression with + operator.
  * @param {ASTNode} node - A BinaryExpression node to check.
  * @returns {ASTNode} node
@@ -38,10 +66,10 @@ module.exports = function(context) {
             // account for the `foo + "a" + "b"` case
             var left = getLeft(node);
             var right = node.right;
+            var leftWillBeString = hasStringLiteral(node.left);
 
-            if ((left.type === "Literal" || left.type === "TemplateLiteral") &&
-                (right.type === "Literal" || right.type === "TemplateLiteral")
-            ) {
+            if (leftWillBeString && (left.type === "Literal" || left.type === "TemplateLiteral") &&
+                (right.type === "Literal" || right.type === "TemplateLiteral")) {
                 // check for multiline string concatenation
                 if (left.loc.start.line !== right.loc.start.line) {
                     return;

--- a/tests/lib/rules/no-useless-concat.js
+++ b/tests/lib/rules/no-useless-concat.js
@@ -28,6 +28,7 @@ ruleTester.run("no-useless-concat", rule, {
         { code: "var a = 1 - 2;" },
         { code: "var a = foo + bar;" },
         { code: "var a = 'foo' + bar;" },
+        { code: "var a = foo + 1 + 'bar';" },
         { code: "var foo = 'foo' +\n 'bar';" }
     ],
 
@@ -40,12 +41,6 @@ ruleTester.run("no-useless-concat", rule, {
         },
         {
             code: "'a' + 1",
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "1 + '1'",
             errors: [
                 { message: "Unexpected string concatenation of literals."}
             ]
@@ -73,13 +68,6 @@ ruleTester.run("no-useless-concat", rule, {
         },
         {
             code: "`a` + 'b'",
-            ecmaFeatures: {templateStrings: true},
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "1 + `1`",
             ecmaFeatures: {templateStrings: true},
             errors: [
                 { message: "Unexpected string concatenation of literals."}


### PR DESCRIPTION
Fixes #3575

Uses behaviour based on this description: https://github.com/eslint/eslint/issues/3575#issuecomment-136003933

Adapted from and is an alternative to PR https://github.com/eslint/eslint/pull/3579

----

@hzoo can you check if this patch is good enough?