### PR TITLE
Fix: `quote-props` should not crash for object rest spread syntax (fixes #3595)

### DIFF
--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -123,7 +123,7 @@ module.exports = function(context) {
             var key = property.key,
                 tokens;
 
-            if (property.method || property.computed || property.shorthand) {
+            if (!key || property.method || property.computed || property.shorthand) {
                 return;
             }
 

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -66,7 +66,10 @@ ruleTester.run("quote-props", rule, {
         { code: "({'unnecessary': 1, 'if': 0})", options: ["as-needed", {keywords: true, unnecessary: false}] },
         { code: "({'1': 1})", options: ["as-needed", {numbers: true}] },
         { code: "({1: 1, x: 2})", options: ["consistent", {numbers: true}]},
-        { code: "({1: 1, x: 2})", options: ["consistent-as-needed", {numbers: true}]}
+        { code: "({1: 1, x: 2})", options: ["consistent-as-needed", {numbers: true}]},
+        { code: "({ ...x })", options: ["as-needed"], ecmaFeatures: { experimentalObjectRestSpread: true }},
+        { code: "({ ...x })", options: ["consistent"], ecmaFeatures: { experimentalObjectRestSpread: true }},
+        { code: "({ ...x })", options: ["consistent-as-needed"], ecmaFeatures: { experimentalObjectRestSpread: true }}
     ],
     invalid: [{
         code: "({ a: 0 })",


### PR DESCRIPTION
```bash
$> eslint -v
v1.3.1
```

Having the following `.eslintrc`:

```json
{
  "ecmaFeatures": {
    "experimentalObjectRestSpread": true
  },
  "rules": {
    "quote-props": [2, "consistent"]
  }
}
```

And using object rest spread syntax:

```javascript
var x = {a: 1};
({...x});
```

Results in the following stacktrace when running `eslint`:

```bash
/Code/node_modules/eslint/lib/rules/quote-props.js:130
            if (key.type === "Literal" && typeof key.value === "string") {
                   ^

TypeError: Cannot read property 'type' of undefined
    at /Code/node_modules/eslint/lib/rules/quote-props.js:130:20
    at Array.forEach (native)
    at checkConsistency (/Code/node_modules/eslint/lib/rules/quote-props.js:122:25)
    at EventEmitter.ObjectExpression (/Code/node_modules/eslint/lib/rules/quote-props.js:171:17)
    at emitOne (events.js:77:13)
    at EventEmitter.emit (events.js:169:7)
    at Controller.controller.traverse.enter (/Code/node_modules/eslint/lib/eslint.js:815:25)
    at Controller.__execute (/Code/node_modules/eslint/node_modules/estraverse/estraverse.js:397:31)
    at Controller.traverse (/Code/node_modules/eslint/node_modules/estraverse/estraverse.js:495:28)
    at EventEmitter.module.exports.api.verify (/Code/node_modules/eslint/lib/eslint.js:808:24)
```

Which is what this PR fixes.