### PR TITLE
New: Implement cache in order to only operate on changed files since previous run. (fixes #2998)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,5 @@ tmp/
 jsdoc/
 versions.json
 *.iml
+.eslintcache
+.cache

--- a/Makefile.js
+++ b/Makefile.js
@@ -390,10 +390,20 @@ target.all = function() {
 
 target.lint = function() {
     var errors = 0,
+        makeFileCache = " ",
+        jsCache = " ",
+        testCache = " ",
         lastReturn;
 
+    // using the cache locally to speed up linting process
+    if (!process.env.TRAVIS) {
+        makeFileCache = " --cache --cache-file .cache/makefile_cache ";
+        jsCache = " --cache --cache-file .cache/js_cache ";
+        testCache = " --cache --cache-file .cache/test_cache ";
+    }
+
     echo("Validating Makefile.js");
-    lastReturn = exec(ESLINT + MAKEFILE);
+    lastReturn = exec(ESLINT + makeFileCache + MAKEFILE);
     if (lastReturn.code !== 0) {
         errors++;
     }
@@ -411,13 +421,13 @@ target.lint = function() {
     }
 
     echo("Validating JavaScript files");
-    lastReturn = exec(ESLINT + JS_FILES);
+    lastReturn = exec(ESLINT + jsCache + JS_FILES);
     if (lastReturn.code !== 0) {
         errors++;
     }
 
     echo("Validating JavaScript test files");
-    lastReturn = exec(ESLINT + TEST_FILES);
+    lastReturn = exec(ESLINT + testCache + TEST_FILES);
     if (lastReturn.code !== 0) {
         errors++;
     }

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -122,6 +122,8 @@ The `CLIEngine` is a constructor, and you can create a new instance by passing i
 * `rules` - An object of rules to use (default: null). Corresponds to `--rule`.
 * `useEslintrc` - Set to false to disable use of `.eslintrc` files (default: true). Corresponds to `--no-eslintrc`.
 * `parser` - Specify the parser to be used (default: `espree`). Corresponds to `--parser`.
+* `cache` - Operate only on changed files (default: `false`). Corresponds to `--cache`.
+* `cacheFile` - Name of the file where the cache will be stored (default: `.eslintcache`). Corresponds to `--cache-file`.
 
 For example:
 

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -30,6 +30,8 @@ Basic configuration:
   --ext [String]              Specify JavaScript file extensions - default: .js
   --global [String]           Define global variables
   --parser String             Specify the parser to be used - default: espree
+  --cache                     Only check changed files - default: false
+  --cache-file String         Path to the cache file - default: .eslintcache
 
 Specifying rules and plugins:
   --rulesdir [path::String]   Use additional rules from this directory
@@ -58,6 +60,7 @@ Miscellaneous:
   --init                      Run config initialization wizard - default: false
   -h, --help                  Show help
   -v, --version               Outputs the version number
+
 ```
 
 ### Basic configuration
@@ -274,6 +277,14 @@ This option outputs the current ESLint version onto the console. All other optio
 Example:
 
     eslint -v
+
+### `--cache`
+
+Store the info about processed files in order to only operate on the changed ones.
+
+### `--cache-file`
+
+Path to the cache file. If none specified `.eslintcache` will be used. The file will be created in the directory where the `eslint` command is executed.
 
 ## Ignoring files from linting
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -29,7 +29,8 @@ var fs = require("fs"),
     IgnoredPaths = require("./ignored-paths"),
     Config = require("./config"),
     util = require("./util"),
-    validator = require("./config-validator");
+    validator = require("./config-validator"),
+    fileEntryCache = require("file-entry-cache");
 
 var DEFAULT_PARSER = require("../conf/eslint.json").parser;
 
@@ -81,7 +82,9 @@ var defaultOptions = {
         extensions: [".js"],
         ignore: true,
         ignorePath: null,
-        parser: DEFAULT_PARSER
+        parser: DEFAULT_PARSER,
+        cache: false,
+        cacheFile: ".eslintcache"
     },
     loadedPlugins = Object.create(null);
 
@@ -302,6 +305,17 @@ function CLIEngine(options) {
      */
     this.options = assign(Object.create(defaultOptions), options || {});
 
+    /**
+     * cache used to not operate on files that haven't changed since last successful
+     * execution (e.g. file passed with no errors and no warnings
+     * @type {Object}
+     */
+    this._fileCache = fileEntryCache.create(path.resolve(this.options.cacheFile)); // eslint-disable-line no-underscore-dangle
+
+    if (!this.options.useCache) {
+        this._fileCache.destroy(); // eslint-disable-line no-underscore-dangle
+    }
+
     // load in additional rules
     if (this.options.rulePaths) {
         this.options.rulePaths.forEach(function(rulesdir) {
@@ -399,17 +413,20 @@ CLIEngine.prototype = {
      * @returns {Object} The results for all files that were linted.
      */
     executeOnFiles: function(files) {
-
         var results = [],
             processed = {},
             options = this.options,
+            fileCache = this._fileCache, // eslint-disable-line no-underscore-dangle
             configHelper = new Config(options),
             ignoredPaths = options.ignore ? IgnoredPaths.load(options).patterns : [],
             extensions = options.extensions.map(function(ext) {
                 return ext.charAt(0) === "." ? ext : "." + ext;
             }),
             globOptions,
-            stats;
+            stats,
+            startTime;
+
+        startTime = Date.now();
 
         files = files.map(processPath);
         ignoredPaths = ignoredPaths.map(processPath);
@@ -431,10 +448,52 @@ CLIEngine.prototype = {
                 return;
             }
 
+            if (options.useCache) {
+                // get the descriptor for this file
+                // with the metadata and the flag that determines if
+                // the file has changed
+                var descriptor = fileCache.getFileDescriptor(filename);
+                if (!descriptor.changed) {
+                    debug("Skipping file since hasn't changed: " + filename);
+
+                    // Adding the filename to the processed hashmap
+                    // so the reporting is not affected (showing a warning about .eslintignore being used
+                    // when it is not really used)
+
+                    processed[filename] = true;
+
+                    // Add the the cached results (always will be 0 error and 0 warnings)
+                    // cause we don't save to cache files that failed
+                    // to guarantee that next execution will process those files as well
+                    results.push(descriptor.meta.results);
+
+                    // move to the next file
+                    return;
+                }
+            }
+
             debug("Processing " + filename);
 
             processed[filename] = true;
-            results.push(processFile(filename, configHelper));
+            var res = processFile(filename, configHelper);
+
+            if (options.useCache) {
+                // if a file contains errors or warnings we don't want to
+                // store the file in the cache so we can guarantee that
+                // next execution will also operate on this file
+                if ( res.errorCount > 0 || res.warningCount > 0 ) {
+                    debug("File has problems, skipping it: " + filename);
+                    // remove the entry from the cache
+                    fileCache.removeEntry( filename );
+                } else {
+                    // since the file passed we store the result here
+                    // TODO: check this as we might not need to store the
+                    // successful runs as it will always should be 0 error 0 warnings
+                    descriptor.meta.results = res;
+                }
+            }
+
+            results.push(res);
         }
 
         files.forEach(function(pattern) {
@@ -452,6 +511,13 @@ CLIEngine.prototype = {
         }
 
         stats = calculateStatsPerRun(results);
+
+        if (options.useCache) {
+            // persist the cache to disk
+            fileCache.reconcile();
+        }
+
+        debug("Linting complete in: " + (Date.now() - startTime) + "ms");
 
         return {
             results: results,

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -49,7 +49,9 @@ function translateOptions(cliOptions) {
         configFile: cliOptions.config,
         rulePaths: cliOptions.rulesdir,
         useEslintrc: cliOptions.eslintrc,
-        parser: cliOptions.parser
+        parser: cliOptions.parser,
+        useCache: cliOptions.cache,
+        cacheFile: cliOptions.cacheFile
     };
 }
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -58,6 +58,18 @@ module.exports = optionator({
             description: "Specify the parser to be used"
         },
         {
+            option: "cache",
+            type: "Boolean",
+            default: "false",
+            description: "Only check changed files"
+        },
+        {
+            option: "cache-file",
+            type: "String",
+            default: ".eslintcache",
+            description: "Path to the cache file"
+        },
+        {
             heading: "Specifying rules and plugins"
         },
         {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "globals": "^8.6.0",
     "handlebars": "^3.0.3",
     "inquirer": "^0.9.0",
+    "file-entry-cache": "^1.1.1",
     "is-my-json-valid": "^2.10.0",
     "is-resolvable": "^1.0.0",
     "js-yaml": "^3.2.5",

--- a/tests/fixtures/cache/src/fail-file.js
+++ b/tests/fixtures/cache/src/fail-file.js
@@ -1,0 +1,2 @@
+var abc = 'some value'
+console.log(foo);

--- a/tests/fixtures/cache/src/test-file.js
+++ b/tests/fixtures/cache/src/test-file.js
@@ -1,0 +1,3 @@
+var abc = 2;
+
+console.log(abc);

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -15,7 +15,8 @@ var assert = require("chai").assert,
     proxyquire = require("proxyquire"),
     sinon = require("sinon"),
     rules = require("../../lib/rules"),
-    Config = require("../../lib/config");
+    Config = require("../../lib/config"),
+    fs = require("fs");
 
 require("shelljs/global");
 proxyquire = proxyquire.noCallThru().noPreserveCache();
@@ -274,7 +275,7 @@ describe("CLIEngine", function() {
                 configFile: getFixturePath("configurations", "quotes-error.json")
             });
 
-            var report = engine.executeOnFiles([getFixturePath("single-quoted.js")]);
+            var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("single-quoted.js"))]);
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].messages.length, 1);
             assert.equal(report.errorCount, 1);
@@ -309,7 +310,7 @@ describe("CLIEngine", function() {
                 configFile: getFixturePath("configurations", "env-browser.json")
             });
 
-            var report = engine.executeOnFiles([getFixturePath("globals-browser.js")]);
+            var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].messages.length, 0);
         });
@@ -324,7 +325,7 @@ describe("CLIEngine", function() {
                 }
             });
 
-            var report = engine.executeOnFiles([getFixturePath("globals-browser.js")]);
+            var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-browser.js"))]);
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].messages.length, 0);
         });
@@ -335,7 +336,7 @@ describe("CLIEngine", function() {
                 configFile: getFixturePath("configurations", "env-node.json")
             });
 
-            var report = engine.executeOnFiles([getFixturePath("globals-node.js")]);
+            var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("globals-node.js"))]);
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].messages.length, 0);
         });
@@ -349,8 +350,8 @@ describe("CLIEngine", function() {
                 }
             });
 
-            var failFilePath = getFixturePath("missing-semicolon.js");
-            var passFilePath = getFixturePath("passing.js");
+            var failFilePath = fs.realpathSync(getFixturePath("missing-semicolon.js"));
+            var passFilePath = fs.realpathSync(getFixturePath("passing.js"));
 
             var report = engine.executeOnFiles([failFilePath]);
             assert.equal(report.results.length, 1);
@@ -413,7 +414,7 @@ describe("CLIEngine", function() {
                 }
             });
 
-            var filePath = getFixturePath("undef.js");
+            var filePath = fs.realpathSync(getFixturePath("undef.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -476,7 +477,7 @@ describe("CLIEngine", function() {
                 configFile: getFixturePath("rules", "eslint.json")
             });
 
-            var filePath = getFixturePath("rules", "test", "test-custom-rule.js");
+            var filePath = fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -497,7 +498,7 @@ describe("CLIEngine", function() {
                 configFile: getFixturePath("rules", "multi-rulesdirs.json")
             });
 
-            var filePath = getFixturePath("rules", "test-multi-rulesdirs.js");
+            var filePath = fs.realpathSync(getFixturePath("rules", "test-multi-rulesdirs.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -516,7 +517,7 @@ describe("CLIEngine", function() {
                 useEslintrc: false
             });
 
-            var filePath = getFixturePath("missing-semicolon.js");
+            var filePath = fs.realpathSync(getFixturePath("missing-semicolon.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -532,7 +533,7 @@ describe("CLIEngine", function() {
                 envs: ["node"]
             });
 
-            var filePath = getFixturePath("process-exit.js");
+            var filePath = fs.realpathSync(getFixturePath("process-exit.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -548,7 +549,7 @@ describe("CLIEngine", function() {
                 useEslintrc: false
             });
 
-            var filePath = getFixturePath("missing-semicolon.js");
+            var filePath = fs.realpathSync(getFixturePath("missing-semicolon.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -564,7 +565,7 @@ describe("CLIEngine", function() {
                 envs: ["node"]
             });
 
-            var filePath = getFixturePath("eslintrc", "quotes.js");
+            var filePath = fs.realpathSync(getFixturePath("eslintrc", "quotes.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -580,8 +581,7 @@ describe("CLIEngine", function() {
                 envs: ["node"]
             });
 
-            var filePath = getFixturePath("packagejson", "quotes.js");
-
+            var filePath = fs.realpathSync(getFixturePath("packagejson", "quotes.js"));
 
             var report = engine.executeOnFiles([filePath]);
             assert.equal(report.results.length, 1);
@@ -600,7 +600,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
             });
@@ -613,7 +613,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes-node.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes-node.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
             });
@@ -623,7 +623,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/process-exit.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/process-exit.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
             });
@@ -633,7 +633,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/process-exit.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/process-exit.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
             });
@@ -643,7 +643,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -655,7 +655,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "no-console");
@@ -667,7 +667,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -679,7 +679,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/subdir/wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -691,7 +691,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
             });
@@ -701,7 +701,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -713,7 +713,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine();
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/packagejson/wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -727,7 +727,7 @@ describe("CLIEngine", function() {
                     configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -743,7 +743,7 @@ describe("CLIEngine", function() {
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
             });
@@ -755,7 +755,7 @@ describe("CLIEngine", function() {
                     configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
                 assert.equal(report.results[0].messages[0].ruleId, "no-console");
@@ -771,7 +771,7 @@ describe("CLIEngine", function() {
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "no-console");
@@ -785,7 +785,7 @@ describe("CLIEngine", function() {
                     configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
             });
@@ -800,7 +800,7 @@ describe("CLIEngine", function() {
                     }
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -817,7 +817,7 @@ describe("CLIEngine", function() {
                     }
                 });
 
-                var report = engine.executeOnFiles([fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js"]);
+                var report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
                 assert.equal(report.results[0].messages[0].ruleId, "quotes");
@@ -833,7 +833,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                var report = engine.executeOnFiles([getFixturePath("rules", "test/test-custom-rule.js")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test/test-custom-rule.js"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -846,7 +846,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                var report = engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -859,7 +859,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                var report = engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -872,7 +872,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                var report = engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -903,7 +903,7 @@ describe("CLIEngine", function() {
                     rules: { "example/example-rule": 1 }
                 });
 
-                var report = engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -919,11 +919,194 @@ describe("CLIEngine", function() {
 
                 engine.addPlugin("eslint-plugin-test", { rules: { "example-rule": require("../fixtures/rules/custom-rule") } });
 
-                var report = engine.executeOnFiles([getFixturePath("rules", "test", "test-custom-rule.js")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("rules", "test", "test-custom-rule.js"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
                 assert.equal(report.results[0].messages[0].ruleId, "test/example-rule");
+            });
+        });
+
+        describe("useCache", function() {
+            var sandbox;
+            /**
+             * helper method to delete the cache files created during testing
+             * @returns {void}
+             */
+            function delCache() {
+                try {
+                    fs.unlinkSync(path.resolve(".eslintcache"));
+                    fs.unlinkSync(path.resolve(".cache/custom-cache"));
+                } catch(ex) {
+                    // we don't care if the file didn't exist
+                    // since our intention was to remove the file
+                }
+            }
+
+            beforeEach(function() {
+                delCache();
+                sandbox = sinon.sandbox.create();
+            });
+            afterEach(function() {
+                sandbox.restore();
+                delCache();
+            });
+            it("should remember the files from a previous run and do not operate on them if not changed", function() {
+
+                assert.isFalse(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint does not exist");
+
+                engine = new CLIEngine({
+                    useEslintrc: false,
+                    // specifying useCache true the cache will be created
+                    useCache: true,
+                    rules: {
+                        "no-console": 0,
+                        "no-unused-vars": 2
+                    },
+                    extensions: ["js"]
+                });
+
+                var spy = sandbox.spy(fs, "readFileSync");
+
+                var file = getFixturePath("cache/src", "test-file.js");
+                file = fs.realpathSync(file);
+
+                var result = engine.executeOnFiles([file]);
+
+                assert.equal(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
+                assert.isTrue(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint was created");
+
+                // destroy the spy
+                sandbox.restore();
+
+                engine = new CLIEngine({
+                    useEslintrc: false,
+                    // specifying useCache true the cache will be created
+                    useCache: true,
+                    rules: {
+                        "no-console": 0,
+                        "no-unused-vars": 2
+                    },
+                    extensions: ["js"]
+                });
+
+                // create a new spy
+                spy = sandbox.spy(fs, "readFileSync");
+
+                var cachedResult = engine.executeOnFiles([file]);
+
+                assert.deepEqual(result, cachedResult, "the result is the same regardless of using cache or not");
+
+                // assert the file was not processed because the cache was used
+                assert.isFalse(spy.called, "the file was not loaded because it used the cache");
+            });
+
+            it("should remember the files from a previous run and do not operate on then if not changed", function() {
+
+                assert.isFalse(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint does not exist");
+
+                engine = new CLIEngine({
+                    useEslintrc: false,
+                    // specifying useCache true the cache will be created
+                    useCache: true,
+                    rules: {
+                        "no-console": 0,
+                        "no-unused-vars": 2
+                    },
+                    extensions: ["js"]
+                });
+
+                var file = getFixturePath("cache/src", "test-file.js");
+                file = fs.realpathSync(file);
+
+                engine.executeOnFiles([file]);
+
+                assert.isTrue(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint was created");
+
+                engine = new CLIEngine({
+                    useEslintrc: false,
+                    // specifying useCache true the cache will be created
+                    useCache: false,
+                    rules: {
+                        "no-console": 0,
+                        "no-unused-vars": 2
+                    },
+                    extensions: ["js"]
+                });
+
+                engine.executeOnFiles([file]);
+
+                assert.isFalse(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint was deleted since last run did not used the cache");
+            });
+            it("should not store in the cache a file that failed the test", function() {
+
+                assert.isFalse(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint does not exist");
+
+                engine = new CLIEngine({
+                    useEslintrc: false,
+                    // specifying useCache true the cache will be created
+                    useCache: true,
+                    rules: {
+                        "no-console": 0,
+                        "no-unused-vars": 2
+                    },
+                    extensions: ["js"]
+                });
+
+                var badFile = fs.realpathSync(getFixturePath("cache/src", "fail-file.js"));
+                var goodFile = fs.realpathSync(getFixturePath("cache/src", "test-file.js"));
+
+                var result = engine.executeOnFiles([badFile, goodFile]);
+
+                assert.isTrue(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint was created");
+
+                var cache = JSON.parse(fs.readFileSync(path.resolve(".eslintcache")));
+
+                assert.isTrue(typeof cache[goodFile] === "object", "the entry for the good file is in the cache");
+
+                assert.isTrue(typeof cache[badFile] === "undefined", "the entry for the bad file is not in the cache");
+
+                var cachedResult = engine.executeOnFiles([badFile, goodFile]);
+
+                assert.deepEqual(result, cachedResult, "result is the same with or without cache");
+            });
+
+            describe("cacheFile", function() {
+                it("should use the specified cache file", function() {
+                    var customCacheFile = path.resolve(".cache/custom-cache");
+
+                    assert.isFalse(fs.existsSync(customCacheFile), "the cache for eslint does not exist");
+
+                    engine = new CLIEngine({
+                        useEslintrc: false,
+                        // specify a custom cache file
+                        cacheFile: customCacheFile,
+                        // specifying useCache true the cache will be created
+                        useCache: true,
+                        rules: {
+                            "no-console": 0,
+                            "no-unused-vars": 2
+                        },
+                        extensions: ["js"]
+                    });
+
+                    var badFile = fs.realpathSync(getFixturePath("cache/src", "fail-file.js"));
+                    var goodFile = fs.realpathSync(getFixturePath("cache/src", "test-file.js"));
+
+                    var result = engine.executeOnFiles([badFile, goodFile]);
+
+                    assert.isTrue(fs.existsSync(customCacheFile), "the cache for eslint was created");
+
+                    var cache = JSON.parse(fs.readFileSync(customCacheFile));
+
+                    assert.isTrue(typeof cache[goodFile] === "object", "the entry for the good file is in the cache");
+
+                    assert.isTrue(typeof cache[badFile] === "undefined", "the entry for the bad file is not in the cache");
+
+                    var cachedResult = engine.executeOnFiles([badFile, goodFile]);
+
+                    assert.deepEqual(result, cachedResult, "result is the same with or without cache");
+                });
             });
         });
 
@@ -935,7 +1118,7 @@ describe("CLIEngine", function() {
                     extensions: ["js", "txt"]
                 });
 
-                var report = engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -964,7 +1147,7 @@ describe("CLIEngine", function() {
                     }
                 });
 
-                var report = engine.executeOnFiles([getFixturePath("processors", "test", "test-processor.txt")]);
+                var report = engine.executeOnFiles([fs.realpathSync(getFixturePath("processors", "test", "test-processor.txt"))]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -1097,7 +1280,6 @@ describe("CLIEngine", function() {
             assert.isFalse(engine.isPathIgnored("undef.js"));
             assert.isFalse(engine.isPathIgnored("passing.js"));
         });
-
     });
 
     describe("getFormatter()", function() {

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -318,8 +318,8 @@ describe("cli", function() {
 
     describe("when given a pattern to ignore", function() {
         it("should not process any files", function() {
-            var ignorePath = getFixturePath("syntax-error.js");
-            var filePath = getFixturePath("passing.js");
+            var ignorePath = fs.realpathSync(getFixturePath("syntax-error.js"));
+            var filePath = fs.realpathSync(getFixturePath("passing.js"));
             var exit = cli.execute("--ignore-pattern " + ignorePath + " " + ignorePath + " " + filePath);
 
             // a warning about the ignored file

--- a/tests/lib/file-finder.js
+++ b/tests/lib/file-finder.js
@@ -174,7 +174,6 @@ describe("FileFinder", function() {
                 expected = path.join(process.cwd(), "package.json");
                 finder = new FileFinder("package.json");
                 actual = finder.findAllInDirectoryAndParents(fileFinderDir);
-
                 assert.equal(actual, expected);
             });
         });


### PR DESCRIPTION
This is the first draft of adding a cache to Eslint.

- The basic detection of a changed file is deferred to file-entry-cache.
- The file cache is stored in the current working directory (`process.cwd()`) where the command is executed. The file created is called `.eslintcache`
- The cache only stores files that successfully passed validation. The ones that failed are removed to guarantee they will be processed the next run.

an easy way to test is run this in the project

```bash
./bin/eslint.js lib/ --cache # this will take 3.5s aprox

./bin/eslint.js lib/ --cache # this will take 150ms aprox. Obviously because the results are cached

# touch a couple of files, introduce some errors on purpose
./bin/eslint.js lib/ --cache # this will take 200ms aprox. 
```
