### PR TITLE
New: Added no-negated-instanceof-lhs rule, largely based on no-negated-in-lhs. (fixes #2716)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -57,6 +57,7 @@
         "no-multiple-empty-lines": [0, {"max": 2}],
         "no-native-reassign": 0,
         "no-negated-in-lhs": 2,
+        "no-negated-instanceof-lhs": 0,
         "no-nested-ternary": 0,
         "no-new": 0,
         "no-new-func": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -26,6 +26,7 @@ The following rules point out areas where you might have made mistakes.
 * [no-invalid-regexp](no-invalid-regexp.md) - disallow invalid regular expression strings in the `RegExp` constructor (recommended)
 * [no-irregular-whitespace](no-irregular-whitespace.md) - disallow irregular whitespace outside of strings and comments (recommended)
 * [no-negated-in-lhs](no-negated-in-lhs.md) - disallow negation of the left operand of an `in` expression (recommended)
+* [no-negated-instanceof-lhs](no-negated-instanceof-lhs.md) - disallow negation of the left operand of an `instanceof` expression
 * [no-obj-calls](no-obj-calls.md) - disallow the use of object properties of the global object (`Math` and `JSON`) as functions (recommended)
 * [no-regex-spaces](no-regex-spaces.md) - disallow multiple spaces in a regular expression literal (recommended)
 * [no-sparse-arrays](no-sparse-arrays.md) - disallow sparse arrays (recommended)

--- a/docs/rules/no-negated-instanceof-lhs.md
+++ b/docs/rules/no-negated-instanceof-lhs.md
@@ -1,0 +1,25 @@
+# Disallow negated left operand of `instanceof` operator (no-negated-instanceof-lhs)
+
+## Rule Details
+
+This error is raised to highlight a potential error. Commonly, when a developer intends to write
+
+```js
+if(!(a instanceof b)) // do something
+```
+
+they will instead write
+
+```js
+if(!a instanceof b) // do something
+```
+
+This is very often not what the developer wants and should be avoided.
+
+## When Not To Use It
+
+Never.
+
+## Further Reading
+
+None.

--- a/lib/rules/no-negated-instanceof-lhs.js
+++ b/lib/rules/no-negated-instanceof-lhs.js
@@ -1,0 +1,25 @@
+/**
+ * @fileoverview A rule to disallow negated left operands of the `in` operator
+ * @author Kevin Partington
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    return {
+
+        "BinaryExpression": function(node) {
+            if (node.operator === "instanceof" && node.left.type === "UnaryExpression" && node.left.operator === "!") {
+                context.report(node, "The `instanceof` expression's left operand is negated");
+            }
+        }
+    };
+
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-negated-instanceof-lhs.js
+++ b/tests/lib/rules/no-negated-instanceof-lhs.js
@@ -1,0 +1,32 @@
+/**
+ * @fileoverview Tests for the no-negated-instanceof-lhs rule
+ * @author Kevin Partington
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-negated-instanceof-lhs"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-negated-instanceof-lhs", rule, {
+    valid: [
+        "a instanceof b",
+        "!(a instanceof b)"
+    ],
+    invalid: [{
+        code: "!a instanceof b",
+        errors: [{
+            message: "The `instanceof` expression's left operand is negated",
+            type: "BinaryExpression"
+        }]
+    }]
+});


### PR DESCRIPTION
I basically decided to emulate `no-negated-in-lhs` completely, down to making it a "(recommended)" rule and setting it to 2 in `conf/eslint.json`.

Fixes #2716.