### PR TITLE
Fix: `no-useless-concat` false positive at numbers

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -71,6 +71,7 @@ rules:
     no-unused-expressions: 2
     no-unused-vars: [2, {vars: "all", args: "after-used"}]
     no-use-before-define: 2
+    no-useless-concat: 2
     no-with: 2
     quotes: [2, "double"]
     radix: 2

--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -4,38 +4,30 @@ It is unncessary to concatenate two strings together when they are on the same l
 
 ## Rule Details
 
-This rule aims to flag the concenation of 2 literals when they could be combined into a single literal. Literals can be strings, numbers, or template literals.
+This rule aims to flag the concenation of 2 literals when they could be combined into a single literal. Literals can be strings or template literals.
 
 The following patterns are considered warnings:
 
 ```js
-
 // these are the same as "10"
 var a = `some` + `string`;
 var a = '1' + '0';
 var a = '1' + `0`;
 var a = `1` + '0';
 var a = `1` + `0`;
-var a = 1 + '0';
-var a = '1' + 0;
-
 ```
 
 The following patterns are not warnings:
 
 ```js
-
-// a and b are identifiers
+// when a non string is included
 var c = a + b;
-// a is an identifier
-var c= '1' + a;
-// addition/subtraction
-var a = 1 + 1;
+var c = '1' + a;
+var a = 1 + '1';
 var c = 1 - 2;
-// exception for multiline string concatenation
+// when the string concatenation is multiline
 var c = "foo" +
     "bar";
-
 ```
 
 ## When Not To Use It

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -18,16 +18,18 @@ The following patterns are considered warnings:
 
 ```js
 var str = "Hello, " + name + "!";
+var str = "Time: " + (12 * 60 * 60 * 1000);
 ```
 
 The following patterns are not considered warnings:
 
 ```js
 var str = "Hello World!";
-```
-
-```js
 var str = `Hello, ${name}!`;
+var str = `Time: ${12 * 60 * 60}`;
+
+// This is reported by `no-useless-concat`.
+var str = "Hello, " + "World!";
 ```
 
 ## When Not to Use It

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -74,6 +74,18 @@ module.exports = {
     },
 
     /**
+     * Checks whether or not a given node is a string literal.
+     * @param {ASTNode} node - A node to check.
+     * @returns {boolean} `true` if the node is a string literal.
+     */
+    isStringLiteral: function(node) {
+        return (
+            (node.type === "Literal" && typeof node.value === "string") ||
+            node.type === "TemplateLiteral"
+        );
+    },
+
+    /**
      * Gets references which are non initializer and writable.
      * @param {Reference[]} references - An array of references.
      * @returns {Reference[]} An array of only references which are non initializer and writable.

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -7,8 +7,23 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a given node is a concatenation.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node is a concatenation.
+ */
+function isConcatenation(node) {
+    return node.type === "BinaryExpression" && node.operator === "+";
+}
 
 /**
  * Get's the right most node on the left side of a BinaryExpression with + operator.
@@ -17,10 +32,23 @@
  */
 function getLeft(node) {
     var left = node.left;
-    while (left.type === "BinaryExpression" && left.operator === "+") {
+    while (isConcatenation(left)) {
         left = left.right;
     }
     return left;
+}
+
+/**
+ * Get's the left most node on the right side of a BinaryExpression with + operator.
+ * @param {ASTNode} node - A BinaryExpression node to check.
+ * @returns {ASTNode} node
+ */
+function getRight(node) {
+    var right = node.right;
+    while (isConcatenation(right)) {
+        right = right.left;
+    }
+    return right;
 }
 
 //------------------------------------------------------------------------------
@@ -37,21 +65,12 @@ module.exports = function(context) {
 
             // account for the `foo + "a" + "b"` case
             var left = getLeft(node);
-            var right = node.right;
+            var right = getRight(node);
 
-            if ((left.type === "Literal" || left.type === "TemplateLiteral") &&
-                (right.type === "Literal" || right.type === "TemplateLiteral")
+            if (astUtils.isStringLiteral(left) &&
+                astUtils.isStringLiteral(right) &&
+                astUtils.isTokenOnSameLine(left, right)
             ) {
-                // check for multiline string concatenation
-                if (left.loc.start.line !== right.loc.start.line) {
-                    return;
-                }
-
-                // check for addition
-                if (typeof left.value === "number" && typeof right.value === "number") {
-                    return;
-                }
-
                 // move warning location to operator
                 var operatorToken = context.getTokenAfter(left);
                 while (operatorToken.value !== "+") {
@@ -65,7 +84,6 @@ module.exports = function(context) {
             }
         }
     };
-
 };
 
 module.exports.schema = [];

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -7,34 +7,47 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
 /**
- * Gets the top binary expression node in parents of a given node.
+ * Checks whether or not a given node is a concatenation.
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node is a concatenation.
+ */
+function isConcatenation(node) {
+    return node.type === "BinaryExpression" && node.operator === "+";
+}
+
+/**
+ * Gets the top binary expression node for concatenation in parents of a given node.
  * @param {ASTNode} node - A node to get.
  * @returns {ASTNode} the top binary expression node in parents of a given node.
  */
-function getTopBinaryExpression(node) {
-    while (node.parent.type === "BinaryExpression") {
+function getTopConcatBinaryExpression(node) {
+    while (isConcatenation(node.parent)) {
         node = node.parent;
     }
     return node;
 }
 
 /**
- * Checks whether or not a given binary expression has non literal.
+ * Checks whether or not a given binary expression has non string literals.
  * @param {ASTNode} node - A node to check.
- * @returns {boolean} `true` if the node has non literal.
+ * @returns {boolean} `true` if the node has non string literals.
  */
-function hasNonLiteral(node) {
-    if (node.type === "BinaryExpression") {
-        return hasNonLiteral(node.left) || hasNonLiteral(node.right);
+function hasNonStringLiteral(node) {
+    if (isConcatenation(node)) {
+        // `left` is deeper than `right` normally.
+        return hasNonStringLiteral(node.right) || hasNonStringLiteral(node.left);
     }
-    if (node.type === "UnaryExpression") {
-        return hasNonLiteral(node.argument);
-    }
-    return node.type !== "Literal" && node.type !== "TemplateLiteral";
+    return !astUtils.isStringLiteral(node);
 }
 
 //------------------------------------------------------------------------------
@@ -44,33 +57,39 @@ function hasNonLiteral(node) {
 module.exports = function(context) {
     var done = Object.create(null);
 
+    /**
+     * Reports if a given node is string concatenation with non string literals.
+     *
+     * @param {ASTNode} node - A node to check.
+     * @returns {void}
+     */
+    function checkForStringConcat(node) {
+        if (!astUtils.isStringLiteral(node) || !isConcatenation(node.parent)) {
+            return;
+        }
+
+        var topBinaryExpr = getTopConcatBinaryExpression(node.parent);
+
+        // Checks whether or not this node had been checked already.
+        if (done[topBinaryExpr.range[0]]) {
+            return;
+        }
+        done[topBinaryExpr.range[0]] = true;
+
+        if (hasNonStringLiteral(topBinaryExpr)) {
+            context.report(
+                topBinaryExpr,
+                "Unexpected string concatenation.");
+        }
+    }
+
     return {
         Program: function() {
             done = Object.create(null);
         },
 
-        Literal: function(node) {
-            if (typeof node.value !== "string" ||
-                node.parent.type !== "BinaryExpression" ||
-                node.parent.operator !== "+"
-            ) {
-                return;
-            }
-
-            var topBinaryExpr = getTopBinaryExpression(node.parent);
-
-            // Checks whether or not this node had been checked already.
-            if (done[topBinaryExpr.range[0]]) {
-                return;
-            }
-            done[topBinaryExpr.range[0]] = true;
-
-            if (hasNonLiteral(topBinaryExpr)) {
-                context.report(
-                    topBinaryExpr,
-                    "Unexpected string concatenation.");
-            }
-        }
+        Literal: checkForStringConcat,
+        TemplateLiteral: checkForStringConcat
     };
 };
 

--- a/tests/lib/rules/no-useless-concat.js
+++ b/tests/lib/rules/no-useless-concat.js
@@ -28,24 +28,20 @@ ruleTester.run("no-useless-concat", rule, {
         { code: "var a = 1 - 2;" },
         { code: "var a = foo + bar;" },
         { code: "var a = 'foo' + bar;" },
-        { code: "var foo = 'foo' +\n 'bar';" }
+        { code: "var foo = 'foo' +\n 'bar';" },
+
+        // https://github.com/eslint/eslint/issues/3575
+        { code: "var string = (number + 1) + 'px';" },
+        { code: "'a' + 1" },
+        { code: "1 + '1'" },
+        { code: "1 + `1`", ecmaFeatures: {templateStrings: true} },
+        { code: "`1` + 1", ecmaFeatures: {templateStrings: true} },
+        { code: "(1 + +2) + `b`", ecmaFeatures: {templateStrings: true} }
     ],
 
     invalid: [
         {
             code: "'a' + 'b'",
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "'a' + 1",
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "1 + '1'",
             errors: [
                 { message: "Unexpected string concatenation of literals."}
             ]
@@ -72,21 +68,14 @@ ruleTester.run("no-useless-concat", rule, {
             ]
         },
         {
+            code: "(foo + 'a') + ('b' + 'c')",
+            errors: [
+                { column: 13, message: "Unexpected string concatenation of literals."},
+                { column: 20, message: "Unexpected string concatenation of literals."}
+            ]
+        },
+        {
             code: "`a` + 'b'",
-            ecmaFeatures: {templateStrings: true},
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "1 + `1`",
-            ecmaFeatures: {templateStrings: true},
-            errors: [
-                { message: "Unexpected string concatenation of literals."}
-            ]
-        },
-        {
-            code: "`1` + 1",
             ecmaFeatures: {templateStrings: true},
             errors: [
                 { message: "Unexpected string concatenation of literals."}

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -28,7 +28,6 @@ ruleTester.run("prefer-template", rule, {
         {code: "'use strict';"},
         {code: "var foo = 'bar';"},
         {code: "var foo = 'bar' + 'baz';"},
-        {code: "var foo = +100 + 'yen';"},
         {code: "var foo = foo + +'100';"},
         {code: "var foo = `bar`;", ecmaFeatures: {templateStrings: true}},
         {code: "var foo = `hello, ${name}!`;", ecmaFeatures: {templateStrings: true}},
@@ -40,8 +39,11 @@ ruleTester.run("prefer-template", rule, {
     invalid: [
         {code: "var foo = 'hello, ' + name + '!';", errors: errors},
         {code: "var foo = bar + 'baz';", errors: errors},
+        {code: "var foo = bar + `baz`;", ecmaFeatures: {templateStrings: true}, errors: errors},
+        {code: "var foo = +100 + 'yen';", errors: errors},
         {code: "var foo = 'bar' + baz;", errors: errors},
         {code: "var foo = '￥' + (n * 1000) + '-'", errors: errors},
-        {code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;", errors: [errors[0], errors[0]]}
+        {code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;", errors: [errors[0], errors[0]]},
+        {code: "var string = (number + 1) + 'px';", errors: errors}
     ]
 });


### PR DESCRIPTION
Fixes #3575, #3589.

- Removed handling literals of non strings from `no-useless-concat`.
- Added covering those into `prefer-template`.
- Added `isStringLiteral` utility into ast-utils.js.
- Added `no-useless-concat` into `.eslintrc` for ESLint project.

cc/ @hzoo @Dashed