### PR TITLE
Update: `space-infix-ops`: new option for PEP8-style default parameters

### DIFF
--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -9,7 +9,9 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var int32Hint = context.options[0] ? context.options[0].int32Hint === true : false;
+    var options = context.options[0];
+    var int32Hint = Boolean(options && options.int32Hint);
+    var compactDefaultParams = Boolean(options && options.compactDefaultParams);
 
     var OPERATORS = [
         "*", "/", "%", "+", "-", "<<", ">>", ">>>", "<", "<=", ">", ">=", "in",
@@ -54,11 +56,15 @@ module.exports = function(context) {
     function checkBinary(node) {
         var nonSpacedNode = getFirstNonSpacedToken(node.left, node.right);
 
-        if (nonSpacedNode) {
-            if (!(int32Hint && context.getSource(node).substr(-2) === "|0")) {
-                report(node, nonSpacedNode);
-            }
+        if (
+            !nonSpacedNode ||
+            int32Hint && context.getSource(node).substr(-2) === "|0" ||
+            compactDefaultParams && (node.parent.type === "FunctionDeclaration" || node.parent.type === "FunctionExpression")
+        ) {
+            return;
         }
+
+        report(node, nonSpacedNode);
     }
 
     function checkConditional(node) {
@@ -99,6 +105,9 @@ module.exports.schema = [
         "type": "object",
         "properties": {
             "int32Hint": {
+                "type": "boolean"
+            },
+            "compactDefaultParams": {
                 "type": "boolean"
             }
         },

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -28,6 +28,7 @@ ruleTester.run("space-infix-ops", rule, {
         { code: "const my_object = {key: 'value'};", ecmaFeatures: { blockBindings: true } },
         { code: "var {a = 0} = bar;", ecmaFeatures: { destructuring: true } },
         { code: "function foo(a = 0) { }", ecmaFeatures: { defaultParams: true } },
+        { code: "function foo(a=0) { }", ecmaFeatures: { defaultParams: true }, options: [{ compactDefaultParams: true }] },
         { code: "a|0", options: [{ int32Hint: true }] },
         { code: "a |0", options: [{ int32Hint: true }] }
     ],


### PR DESCRIPTION
Fixes #3587 

Sort of a WIP due to 2 reasons:

1. The new option name is not certain yet
2. Whether to enforce no spaces or simply ignore them is not determined yet