### PR TITLE
Update: Use `globals` module for the `commonjs` globals (fixes #3606)

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -27,11 +27,7 @@ module.exports = {
         }
     },
     commonjs: {
-        globals: {
-            module: false,
-            require: false,
-            exports: false
-        },
+        globals: globals.commonjs,
         ecmaFeatures: {
             globalReturn: true
         }

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "espree": "^2.2.4",
     "estraverse": "^4.1.0",
     "estraverse-fb": "^1.3.1",
-    "globals": "^8.5.0",
+    "globals": "^8.6.0",
     "handlebars": "^3.0.3",
     "inquirer": "^0.9.0",
     "is-my-json-valid": "^2.10.0",


### PR DESCRIPTION
Fixes #3606.