### PR TITLE
Fix: `indent` should only indent chain calls if the first call is single line

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -238,7 +238,7 @@ module.exports = function(context) {
         //     });
         var calleeLoc = calleeNode.type === "CallExpression" && calleeNode.callee.loc;
         if (calleeLoc &&
-            calleeNode.loc.start.line < calleeLoc.end.line &&
+            calleeLoc.end.line - calleeLoc.start.line === 1 &&
             calleeLoc.end.line < node.loc.start.line
         ) {
             indent += indentSize;
@@ -246,15 +246,17 @@ module.exports = function(context) {
 
         indent += indentSize;
         // If function content is not empty
+        var bodyIndent;
         if (node.body.length > 0) {
+            bodyIndent = getNodeIndent(node.body[0]);
             // Calculate left shift position don't require strict indent
             // allow function body align to (indentSize * X)
-            while (getNodeIndent(node.body[0]) > indent) {
+            while (bodyIndent > indent) {
                 indent += indentSize;
             }
-        }
 
-        checkNodesIndent(node.body, indent);
+            checkNodesIndent(node.body, indent);
+        }
 
         checkLastNodeLineIndent(node, indent - indentSize);
     }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -783,9 +783,25 @@ ruleTester.run("indent", rule, {
                 "      \n" +
                 "  }\n" +
                 "\n" +
-                "function hello () { // <-- eslint complains about this line\n" +
+                "function hello () {\n" +
                 "    \n" +
                 "}\n",
+            options: [2]
+        },
+        {
+            code:
+                "var obj = {\n" +
+                "  send: function () {\n" +
+                "    return P.resolve({\n" +
+                "      type: 'POST'\n" +
+                "    })\n" +
+                "    .then(function () {\n" +
+                "      return true;\n" +
+                "    }, function () {\n" +
+                "      return false;\n" +
+                "    });\n" +
+                "  }\n" +
+                "};\n",
             options: [2]
         }
     ],


### PR DESCRIPTION
Fixes #3591