### PR TITLE
Docs: Replace to npmjs.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Join our [Mailing List](https://groups.google.com/group/eslint) or [Chatroom](ht
 
 
 [npm-image]: https://img.shields.io/npm/v/eslint.svg?style=flat-square
-[npm-url]: https://npmjs.org/package/eslint
+[npm-url]: https://www.npmjs.com/package/eslint
 [travis-image]: https://img.shields.io/travis/eslint/eslint/master.svg?style=flat-square
 [travis-url]: https://travis-ci.org/eslint/eslint
 [coveralls-image]: https://img.shields.io/coveralls/eslint/eslint/master.svg?style=flat-square
 [coveralls-url]: https://coveralls.io/r/eslint/eslint?branch=master
 [downloads-image]: http://img.shields.io/npm/dm/eslint.svg?style=flat-square
-[downloads-url]: https://npmjs.org/package/eslint
+[downloads-url]: https://www.npmjs.com/package/eslint

--- a/docs/developer-guide/shareable-configs.md
+++ b/docs/developer-guide/shareable-configs.md
@@ -155,4 +155,4 @@ In the last file, you'll once again see that to properly resolve your config, yo
 
 ## Further Reading
 
-* [npm Developer Guide](https://www.npmjs.org/doc/misc/npm-developers.html)
+* [npm Developer Guide](https://docs.npmjs.com/misc/developers)

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -130,4 +130,4 @@ Add these keywords into your `package.json` file to make it easy for others to f
 
 ## Further Reading
 
-* [npm Developer Guide](https://www.npmjs.org/doc/misc/npm-developers.html)
+* [npm Developer Guide](https://docs.npmjs.com/misc/developers)

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -166,7 +166,7 @@ If your project will not be using one true comma style, turn this rule off.
 For the first option in comma-style rule:
 
 * [A better coding convention for lists and object literals in JavaScript by isaacs](https://gist.github.com/isaacs/357981)
-* [npm coding style guideline](https://www.npmjs.org/doc/misc/npm-coding-style.html)
+* [npm coding style guideline](https://docs.npmjs.com/misc/coding-style)
 
 
 ## Related Rules

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -1,6 +1,6 @@
 # Command line Interface
 
-To run ESLint on Node.js, you must have npm installed. If npm is not installed, follow the instructions here: http://npmjs.org/
+To run ESLint on Node.js, you must have npm installed. If npm is not installed, follow the instructions here: https://www.npmjs.com/
 
 Once npm is installed, run the following
 


### PR DESCRIPTION
npmjs.org has been moved to npmjs.com now.