### PR TITLE
Fix: `consistent-as-needed` mode with `keyword: true` (fixes #3636)

### DIFF
--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -141,6 +141,9 @@ module.exports = function(context) {
 
                     necessaryQuotes = necessaryQuotes || !areQuotesRedundant(tokens) || KEYWORDS && isKeyword(tokens[0].value);
                 }
+            } else if (KEYWORDS && checkQuotesRedundancy && key.type === "Identifier" && isKeyword(key.name)) {
+                necessaryQuotes = true;
+                context.report(node, "Properties should be quoted as `{{property}}` is a reserved word.", {property: key.name});
             } else {
                 lackOfQuotes = true;
             }

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -156,6 +156,18 @@ ruleTester.run("quote-props", rule, {
             message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
         }]
     }, {
+        code: "({ while: 0, b: 0 })",
+        options: ["consistent-as-needed", {keywords: true}],
+        errors: [{
+            message: "Properties should be quoted as `while` is a reserved word.", type: "ObjectExpression"
+        }]
+    }, {
+        code: "({ while: 0, 'b': 0 })",
+        options: ["consistent-as-needed", {keywords: true}],
+        errors: [{
+            message: "Properties should be quoted as `while` is a reserved word.", type: "ObjectExpression"
+        }]
+    }, {
         code: "({'if': 0})",
         options: ["as-needed"],
         errors: [{


### PR DESCRIPTION
Changes made:

- Crete a test to check if the following code returns an error as described in [ESLint docs][1]:
```js
/*eslint quote-props: [2, "consistent-as-needed", {"keywords": true}]*/

var x = {
    while: 1, // `while` is a reserved word. This should return an error but it doesn't.
    volatile: "foo"
};
```
- Implement behavior to return an error if previous case occurs

[1]: http://eslint.org/docs/rules/quote-props.html#consistent-as-needed

Fixes #3636