### PR TITLE
Docs: Fixing typos in plugin processor section. (fixes #3648)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -55,8 +55,8 @@ The `preprocess` method takes the file contents and filename as arguments, and r
 The `postprocess` method takes a two-dimensional array of arrays of lint messages and the filename. Each item in the input
 array corresponds to the part that was returned from the `preprocess` method. The `postprocess` method must adjust the location of all errors and aggregate them into a single flat array and return it.
 
-You can have both rules and processor in a single plugin. You can also have multiple preprocessors in one plugin.
-To support multiple extensions add each one to `preprocessors` element and point them to the same object.
+You can have both rules and processors in a single plugin. You can also have multiple processors in one plugin.
+To support multiple extensions, add each one to the `processors` element and point them to the same object.
 
 ### Default Configuration for Plugins
 


### PR DESCRIPTION
Pretty self-explanatory. Fixes #3648.