### PR TITLE
Fix: `comma-dangle` with `"always"`/`"always-multiline"` false positive after a rest element

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -1,55 +1,165 @@
 /**
  * @fileoverview Rule to forbid or enforce dangling commas.
  * @author Ian Christian Myers
+ * @copyright 2015 Toru Nagashima
  * @copyright 2015 Mathias Schreck
  * @copyright 2013 Ian Christian Myers
+ * See LICENSE file in root directory for full license.
  */
 
 "use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the last element of a given array.
+ *
+ * @param {any[]} xs - An array to get.
+ * @returns {any} The last element, or undefined.
+ */
+function getLast(xs) {
+    if (xs.length === 0) {
+        return void 0;
+    }
+    return xs[xs.length - 1];
+}
+
+/**
+ * Checks whether or not a trailing comma is allowed in a given node.
+ * `ArrayPattern` which has `RestElement` disallows it.
+ *
+ * @param {ASTNode} node - A node to check.
+ * @param {ASTNode} lastItem - The node of the last element in the given node.
+ * @returns {boolean} `true` if a trailing comma is allowed.
+ */
+function isTrailingCommaAllowed(node, lastItem) {
+    switch (node.type) {
+        case "ArrayPattern":
+            // TODO(t-nagashima): Remove SpreadElement after https://github.com/eslint/espree/issues/194 was fixed.
+            return (
+                lastItem.type !== "RestElement" &&
+                lastItem.type !== "SpreadElement"
+            );
+
+        // TODO(t-nagashima): Remove this case after https://github.com/eslint/espree/issues/195 was fixed.
+        case "ArrayExpression":
+            return (
+                node.parent.type !== "ForOfStatement" ||
+                node.parent.left !== node ||
+                lastItem.type !== "SpreadElement"
+            );
+
+        default:
+            return true;
+    }
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var allowDangle = context.options[0];
-    var forbidDangle = allowDangle !== "always-multiline" && allowDangle !== "always";
+    var mode = context.options[0];
     var UNEXPECTED_MESSAGE = "Unexpected trailing comma.";
     var MISSING_MESSAGE = "Missing trailing comma.";
 
     /**
-     * Checks the given node for trailing comma and reports violations.
-     * @param {ASTNode} node The node of an ObjectExpression or ArrayExpression
+     * Checks whether or not a given node is multiline.
+     * This rule handles a given node as multiline when the closing parenthesis
+     * and the last element are not on the same line.
+     *
+     * @param {ASTNode} node - A ndoe to check.
+     * @returns {boolean} `true` if the node is multiline.
+     */
+    function isMultiline(node) {
+        var sourceCode = context.getSourceCode();
+        var lastToken = sourceCode.getLastToken(node);
+        var penultimateToken = sourceCode.getLastToken(node, 1);
+
+        return lastToken.loc.end.line !== penultimateToken.loc.end.line;
+    }
+
+    /**
+     * Reports a trailing comma if it exists.
+     *
+     * @param {ASTNode} node - A node to check. Its type is one of
+     *   ObjectExpression, ObjectPattern, ArrayExpression, and ArrayPattern.
      * @returns {void}
      */
-    function checkForTrailingComma(node) {
-        var items = node.properties || node.elements,
-            length = items.length,
-            lastTokenOnNewLine,
-            lastItem,
-            penultimateToken,
-            hasDanglingComma;
-
-        if (length) {
-            lastItem = items[length - 1];
-            if (lastItem) {
-                penultimateToken = context.getLastToken(node, 1);
-                hasDanglingComma = penultimateToken.value === ",";
-
-                if (forbidDangle && hasDanglingComma) {
-                    context.report(lastItem, penultimateToken.loc.start, UNEXPECTED_MESSAGE);
-                } else if (allowDangle === "always-multiline") {
-                    lastTokenOnNewLine = node.loc.end.line !== penultimateToken.loc.end.line;
-                    if (hasDanglingComma && !lastTokenOnNewLine) {
-                        context.report(lastItem, penultimateToken.loc.start, UNEXPECTED_MESSAGE);
-                    } else if (!hasDanglingComma && lastTokenOnNewLine) {
-                        context.report(lastItem, penultimateToken.loc.end, MISSING_MESSAGE);
-                    }
-                } else if (allowDangle === "always" && !hasDanglingComma) {
-                    context.report(lastItem, lastItem.loc.end, MISSING_MESSAGE);
-                }
-            }
+    function forbidTrailingComma(node) {
+        var lastItem = getLast(node.properties || node.elements);
+        if (lastItem == null) {
+            return;
         }
+
+        var sourceCode = context.getSourceCode();
+        var trailingToken = sourceCode.getTokenAfter(lastItem);
+        if (trailingToken.value === ",") {
+            context.report(
+                lastItem,
+                trailingToken.loc.start,
+                UNEXPECTED_MESSAGE);
+        }
+    }
+
+    /**
+     * Reports the last element of a given node if it does not have a trailing
+     * comma.
+     *
+     * If a given node is `ArrayPattern` which has `RestElement`, the trailing
+     * comma is disallowed, so report if it exists.
+     *
+     * @param {ASTNode} node - A node to check. Its type is one of
+     *   ObjectExpression, ObjectPattern, ArrayExpression, and ArrayPattern.
+     * @returns {void}
+     */
+    function forceTrailingComma(node) {
+        var lastItem = getLast(node.properties || node.elements);
+        if (lastItem == null) {
+            return;
+        }
+        if (!isTrailingCommaAllowed(node, lastItem)) {
+            forbidTrailingComma(node);
+            return;
+        }
+
+        var sourceCode = context.getSourceCode();
+        var trailingToken = sourceCode.getTokenAfter(lastItem);
+        if (trailingToken.value !== ",") {
+            context.report(
+                lastItem,
+                lastItem.loc.end,
+                MISSING_MESSAGE);
+        }
+    }
+
+    /**
+     * If a given node is multiline, reports the last element of a given node
+     * when it does not have a trailing comma.
+     * Otherwise, reports a trailing comma if it exists.
+     *
+     * @param {ASTNode} node - A node to check. Its type is one of
+     *   ObjectExpression, ObjectPattern, ArrayExpression, and ArrayPattern.
+     * @returns {void}
+     */
+    function forceTrailingCommaIfMultiline(node) {
+        if (isMultiline(node)) {
+            forceTrailingComma(node);
+        } else {
+            forbidTrailingComma(node);
+        }
+    }
+
+    // Chooses a checking function.
+    var checkForTrailingComma;
+    if (mode === "always") {
+        checkForTrailingComma = forceTrailingComma;
+    } else if (mode === "always-multiline") {
+        checkForTrailingComma = forceTrailingCommaIfMultiline;
+    } else {
+        checkForTrailingComma = forbidTrailingComma;
     }
 
     return {

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -66,7 +66,39 @@ ruleTester.run("comma-dangle", rule, {
         { code: "[,]", options: [ "always" ] },
         { code: "[\n,\n]", options: [ "always" ] },
         { code: "[]", options: [ "always" ] },
-        { code: "[\n]", options: [ "always" ] }
+        { code: "[\n]", options: [ "always" ] },
+
+        // https://github.com/eslint/eslint/issues/3627
+        {
+            code: "var [a, ...rest] = [];",
+            ecmaFeatures: {destructuring: true, spread: true},
+            options: ["always"]
+        },
+        {
+            code: "var [\n    a,\n    ...rest\n] = [];",
+            ecmaFeatures: {destructuring: true, spread: true},
+            options: ["always"]
+        },
+        {
+            code: "var [\n    a,\n    ...rest\n] = [];",
+            ecmaFeatures: {destructuring: true, spread: true},
+            options: ["always-multiline"]
+        },
+        {
+            code: "[a, ...rest] = [];",
+            ecmaFeatures: {destructuring: true, spread: true},
+            options: ["always"]
+        },
+        {
+            code: "for ([a, ...rest] of []);",
+            ecmaFeatures: {destructuring: true, spread: true, forOf: true},
+            options: ["always"]
+        },
+        {
+            code: "var a = [b, ...spread,];",
+            ecmaFeatures: {spread: true},
+            options: ["always"]
+        }
     ],
     invalid: [
         {


### PR DESCRIPTION
Fixes #3627.

I refactored this rule for simple flow.