### PR TITLE
Fix: Indent rule VariableDeclarator doesn't apply to arrow functions

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -416,7 +416,11 @@ module.exports = function(context) {
             return;
         }
 
-        if (node.parent && (node.parent.type === "FunctionExpression" || node.parent.type === "FunctionDeclaration")) {
+        if (node.parent && (
+                node.parent.type === "FunctionExpression" ||
+                node.parent.type === "FunctionDeclaration" ||
+                node.parent.type === "ArrowFunctionExpression"
+        )) {
             checkIndentInFunctionBlock(node);
             return;
         }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -810,6 +810,14 @@ ruleTester.run("indent", rule, {
                 "  }\n" +
                 "};\n",
             options: [2]
+        },
+        {
+            code:
+                "const someOtherFunction = argument => {\n" +
+                "        console.log(argument);\n" +
+                "    },\n" +
+                "    someOtherValue = 'someOtherValue';\n",
+            ecmaFeatures: { arrowFunctions: true, blockBindings: true }
         }
     ],
     invalid: [


### PR DESCRIPTION
Fixes #3661