### PR TITLE
Fix: `object-curly-spacing` had been crashing on an empty object pattern

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -5,6 +5,8 @@
  * @copyright 2014 Michael Ficarra. No rights reserved.
  * @copyright 2014 Vignesh Anand. All rights reserved.
  * @copyright 2015 Jamund Ferguson. All rights reserved.
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
  */
 "use strict";
 
@@ -79,7 +81,7 @@ module.exports = function(context) {
     */
     function reportRequiredEndingSpace(node, token) {
         context.report(node, token.loc.start,
-                    "A space is required before '" + token.value + "'");
+            "A space is required before '" + token.value + "'");
     }
 
     /**
@@ -119,107 +121,103 @@ module.exports = function(context) {
         }
     }
 
+    /**
+     * Reports a given object node if spacing in curly braces is invalid.
+     * @param {ASTNode} node - An ObjectExpression or ObjectPattern node to check.
+     * @returns {void}
+     */
+    function checkForObject(node) {
+        if (node.properties.length === 0) {
+            return;
+        }
+
+        var sourceCode = context.getSourceCode(),
+            first = sourceCode.getFirstToken(node),
+            last = sourceCode.getLastToken(node),
+            second = sourceCode.getTokenAfter(first),
+            penultimate = sourceCode.getTokenBefore(last);
+
+        validateBraceSpacing(node, first, second, penultimate, last);
+    }
+
+    /**
+     * Reports a given import node if spacing in curly braces is invalid.
+     * @param {ASTNode} node - An ImportDeclaration node to check.
+     * @returns {void}
+     */
+    function checkForImport(node) {
+        if (node.specifiers.length === 0) {
+            return;
+        }
+
+        var sourceCode = context.getSourceCode(),
+            firstSpecifier = node.specifiers[0],
+            lastSpecifier = node.specifiers[node.specifiers.length - 1];
+
+        if (lastSpecifier.type !== "ImportSpecifier") {
+            return;
+        }
+        if (firstSpecifier.type !== "ImportSpecifier") {
+            firstSpecifier = node.specifiers[1];
+        }
+
+        var first = sourceCode.getTokenBefore(firstSpecifier),
+            last = sourceCode.getTokenAfter(lastSpecifier);
+
+        // to support a trailing comma.
+        if (last.value === ",") {
+            last = sourceCode.getTokenAfter(last);
+        }
+
+        var second = sourceCode.getTokenAfter(first),
+            penultimate = sourceCode.getTokenBefore(last);
+
+        validateBraceSpacing(node, first, second, penultimate, last);
+    }
+
+    /**
+     * Reports a given export node if spacing in curly braces is invalid.
+     * @param {ASTNode} node - An ExportNamedDeclaration node to check.
+     * @returns {void}
+     */
+    function checkForExport(node) {
+        if (node.specifiers.length === 0) {
+            return;
+        }
+
+        var sourceCode = context.getSourceCode(),
+            firstSpecifier = node.specifiers[0],
+            lastSpecifier = node.specifiers[node.specifiers.length - 1],
+            first = sourceCode.getTokenBefore(firstSpecifier),
+            last = sourceCode.getTokenAfter(lastSpecifier);
+
+        // to support a trailing comma.
+        if (last.value === ",") {
+            last = sourceCode.getTokenAfter(last);
+        }
+
+        var second = sourceCode.getTokenAfter(first),
+            penultimate = sourceCode.getTokenBefore(last);
+
+        validateBraceSpacing(node, first, second, penultimate, last);
+    }
+
     //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
 
     return {
-
         // var {x} = y;
-        ObjectPattern: function(node) {
-            var firstSpecifier = node.properties[0],
-                lastSpecifier = node.properties[node.properties.length - 1];
-
-            var first = context.getTokenBefore(firstSpecifier),
-                second = context.getFirstToken(firstSpecifier),
-                penultimate = context.getLastToken(lastSpecifier),
-                last = context.getTokenAfter(lastSpecifier);
-
-            // support trailing commas
-            if (last.value === ",") {
-                penultimate = last;
-                last = context.getTokenAfter(last);
-            }
-
-            validateBraceSpacing(node, first, second, penultimate, last);
-        },
-
-        // import {y} from 'x';
-        ImportDeclaration: function(node) {
-
-            var firstSpecifier = node.specifiers[0],
-                lastSpecifier = node.specifiers[node.specifiers.length - 1],
-                importSpecifiers = node.specifiers.filter(function(specifier) {
-                    return specifier.type === "ImportSpecifier";
-                }),
-                first, second, penultimate, last;
-
-            // import { x, y } from 'foo'
-            if (firstSpecifier && lastSpecifier && firstSpecifier.type === "ImportSpecifier" && lastSpecifier.type === "ImportSpecifier") {
-                first = context.getTokenBefore(firstSpecifier);
-                second = context.getFirstToken(firstSpecifier);
-                penultimate = context.getLastToken(lastSpecifier);
-                last = context.getTokenAfter(lastSpecifier);
-
-                // support trailing commas
-                if (last.value === ",") {
-                    penultimate = last;
-                    last = context.getTokenAfter(last);
-                }
-
-                validateBraceSpacing(node, first, second, penultimate, last);
-                return;
-            }
-
-            // import a, { b, c } from 'foo'
-            if (lastSpecifier && lastSpecifier.type === "ImportSpecifier") {
-                first = context.getTokenBefore(importSpecifiers[0]);
-                second = context.getFirstToken(importSpecifiers[0]);
-                penultimate = context.getLastToken(importSpecifiers[importSpecifiers.length - 1]);
-                last = context.getTokenAfter(importSpecifiers[importSpecifiers.length - 1]);
-
-                // support trailing commas
-                if (last.value === ",") {
-                    penultimate = last;
-                    last = context.getTokenAfter(last);
-                }
-
-                validateBraceSpacing(node, first, second, penultimate, last);
-            }
-
-        },
-
-        // export {name} from 'yo';
-        ExportNamedDeclaration: function(node) {
-            if (!node.specifiers.length) {
-                return;
-            }
-
-            var firstSpecifier = node.specifiers[0],
-                lastSpecifier = node.specifiers[node.specifiers.length - 1],
-                first = context.getTokenBefore(firstSpecifier),
-                second = context.getFirstToken(firstSpecifier),
-                penultimate = context.getLastToken(lastSpecifier),
-                last = context.getTokenAfter(lastSpecifier);
-
-            validateBraceSpacing(node, first, second, penultimate, last);
-
-        },
+        ObjectPattern: checkForObject,
 
         // var y = {x: 'y'}
-        ObjectExpression: function(node) {
-            if (node.properties.length === 0) {
-                return;
-            }
+        ObjectExpression: checkForObject,
 
-            var first = context.getFirstToken(node),
-                second = context.getFirstToken(node, 1),
-                penultimate = context.getLastToken(node, 1),
-                last = context.getLastToken(node);
+        // import {y} from 'x';
+        ImportDeclaration: checkForImport,
 
-            validateBraceSpacing(node, first, second, penultimate, last);
-        }
-
+        // export {name} from 'yo';
+        ExportNamedDeclaration: checkForExport
     };
 
 };

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -40,6 +40,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "var { y: x } = x", options: ["always"], ecmaFeatures: { destructuring: true } },
 
         // always - import / export
+        { code: "import door from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "import * as door from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import { door } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import {\ndoor } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "export { door } from 'room'", options: ["always"], ecmaFeatures: { modules: true } },
@@ -51,6 +53,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "import { bar as x } from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import { x, } from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
         { code: "import {\nx,\n} from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "export { x, } from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
+        { code: "export {\nx,\n} from 'foo';", options: ["always"], ecmaFeatures: { modules: true } },
 
         // always - empty object
         { code: "var foo = {};", options: ["always"] },
@@ -92,6 +96,8 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "var {y:x} = x", options: ["never"], ecmaFeatures: { destructuring: true } },
 
         // never - import / export
+        { code: "import door from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import * as door from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "import {door} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "export {door} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "import {\ndoor} from 'room'", options: ["never"], ecmaFeatures: { modules: true } },
@@ -103,14 +109,34 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "import x, {bar} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "import x, {bar, baz} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
         { code: "import {bar as y} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import {x,} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "import {\nx,\n} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "export {x,} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
+        { code: "export {\nx,\n} from 'foo';", options: ["never"], ecmaFeatures: { modules: true } },
 
 
         // never - empty object
         { code: "var foo = {};", options: ["never"] },
 
         // never - objectsInObjects
-        { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", {"objectsInObjects": true}]}
+        { code: "var obj = {'foo': {'bar': 1, 'baz': 2} };", options: ["never", {"objectsInObjects": true}]},
 
+        // https://github.com/eslint/eslint/issues/3658
+        // Empty cases.
+        { code: "var {} = foo;", ecmaFeatures: {destructuring: true}},
+        { code: "var [] = foo;", ecmaFeatures: {destructuring: true}},
+        { code: "var {a: {}} = foo;", ecmaFeatures: {destructuring: true}},
+        { code: "var {a: []} = foo;", ecmaFeatures: {destructuring: true}},
+        { code: "import {} from 'foo';", ecmaFeatures: {modules: true}},
+        { code: "export {} from 'foo';", ecmaFeatures: {modules: true}},
+        { code: "export {};", ecmaFeatures: {modules: true}},
+        { code: "var {} = foo;", options: ["never"], ecmaFeatures: {destructuring: true}},
+        { code: "var [] = foo;", options: ["never"], ecmaFeatures: {destructuring: true}},
+        { code: "var {a: {}} = foo;", options: ["never"], ecmaFeatures: {destructuring: true}},
+        { code: "var {a: []} = foo;", options: ["never"], ecmaFeatures: {destructuring: true}},
+        { code: "import {} from 'foo';", options: ["never"], ecmaFeatures: {modules: true}},
+        { code: "export {} from 'foo';", options: ["never"], ecmaFeatures: {modules: true}},
+        { code: "export {};", options: ["never"], ecmaFeatures: {modules: true}}
     ],
 
     invalid: [


### PR DESCRIPTION
Fixes #3658.

I refactored:

- I merged processes of `ObjectExpression` and `ObjectPattern`.
- I simplified the process of `ImportDeclaration`.
- I fixed missing process of a tailing comma for `ExportNamedDeclaration`.
- And I made using `SourceCode` object.