### PR TITLE
New: no ES6 syntax? no ES6 rules (fixes #3686)

### DIFF
--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -61,6 +61,8 @@ class Foo {
 
 ## When Not to Use It
 
-This rule should not be used in ES3/5 environments.
+Your ESLint settings must enable either all ES2015 (ES6) features (`env.es6: true`),
+or specifically the `class` syntax (`ecmaFeatures.classes: true`).
+Otherwise, this rule is automatically disabled for convenience.
 
 In ES2015 (ES6) or later, if you don't want to be notified about duplicate names in class members, you can safely disable this rule.

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -44,5 +44,9 @@ which will give ESLint the ability to read `let` and `const` variables.
 
 ## When Not To Use It
 
+Your ESLint settings must enable either all ES2015 (ES6) features (`env.es6: true`),
+or specifically the `let` and `const` keywords (`ecmaFeatures.blockBindings: true`).
+Otherwise, this rule is automatically disabled for convenience.
+
 In addition to non-ES6 environments, existing JavaScript projects that are beginning to introduce ES6 into their
 codebase may not want to apply this rule if the cost of migrating from `var` to `let` is too costly.

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -93,6 +93,11 @@ You can set the option in configuration like this:
 
 ## When Not To Use It
 
+Your ESLint settings must enable either all ES2015 (ES6) features (`env.es6: true`),
+or specifically the Object literal shorthand syntax
+(`ecmaFeatures: { objectLiteralShorthandMethods: true, objectLiteralShorthandProperties: true }`).
+Otherwise, this rule is automatically disabled for convenience.
+
 Anyone not yet in an ES6 environment would not want to apply this rule. Others may find the terseness of the shorthand
 syntax harder to read and may not want to encourage it with this rule.
 

--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -38,6 +38,9 @@ foo(function bar(n) { return n && n + bar(n - 1); });
 
 ## When Not to Use It
 
-This rule should not be used in ES3/5 environments.
+Your ESLint settings must enable either all ES2015 (ES6) features (`env.es6: true`),
+or specifically the arrow function syntax
+(`ecmaFeatures.arrowFunctions: true`).
+Otherwise, this rule is automatically disabled for convenience.
 
 In ES2015 (ES6) or later, if you don't want to be notified about function expressions in an argument list, you can safely disable this rule.

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -64,7 +64,10 @@ a[++i].foo.apply(a[i], args);
 
 ## When Not to Use It
 
-This rule should not be used in ES3/5 environments.
+Your ESLint settings must enable either all ES2015 (ES6) features (`env.es6: true`),
+or specifically the spread operator syntax for arrays
+(`ecmaFeatures.spread: true`).
+Otherwise, this rule is automatically disabled for convenience.
 
 In ES2015 (ES6) or later, if you don't want to be notified about `Function.prototype.apply()` callings, you can safely disable this rule.
 

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -38,6 +38,9 @@ var str = "Hello, " + "World!";
 
 ## When Not to Use It
 
-This rule should not be used in ES3/5 environments.
+Your ESLint settings must enable either all ES2015 (ES6) features (`env.es6: true`),
+or specifically the template strings syntax
+(`ecmaFeatures.templateStrings: true`).
+Otherwise, this rule is automatically disabled for convenience.
 
 In ES2015 (ES6) or later, if you don't want to be notified about string concatenation, you can safely disable this rule.

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -36,6 +36,10 @@ module.exports = function(context) {
         return stateMap[key][isStatic ? "static" : "nonStatic"];
     }
 
+    if (!context.ecmaFeatures.classes) {
+        return {}; // noop when rule is used in wrong environment
+    }
+
     return {
         // Initializes the stack of state of member declarations.
         "Program": function() {

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -12,6 +12,10 @@
 
 module.exports = function(context) {
 
+    if (!context.ecmaFeatures.blockBindings) {
+        return {}; // noop when rule is used in wrong environment
+    }
+
     return {
         "VariableDeclaration": function(node) {
             if (node.kind === "var") {

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -28,6 +28,10 @@ module.exports = function(context) {
     // Public
     //--------------------------------------------------------------------------
 
+    if (!context.ecmaFeatures.objectLiteralShorthandMethods || !context.ecmaFeatures.objectLiteralShorthandProperties) {
+        return {}; // noop when rule is used in wrong environment
+    }
+
     return {
         "Property": function(node) {
             var isConciseProperty = node.method || node.shorthand,

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -102,6 +102,10 @@ module.exports = function(context) {
         return stack.pop();
     }
 
+    if (!context.ecmaFeatures.arrowFunctions) {
+        return {}; // noop when rule is used in wrong environment
+    }
+
     return {
         Program: function() {
             stack = [];

--- a/lib/rules/prefer-spread.js
+++ b/lib/rules/prefer-spread.js
@@ -72,6 +72,11 @@ function isValidThisArg(expectedThis, thisArg, context) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
+    if (!context.ecmaFeatures.spread) {
+        return {}; // noop when rule is used in wrong environment
+    }
+
     return {
         "CallExpression": function(node) {
             if (!isVariadicApplyCalling(node)) {

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -83,6 +83,10 @@ module.exports = function(context) {
         }
     }
 
+    if (!context.ecmaFeatures.templateStrings) {
+        return {}; // noop when rule is used in wrong environment
+    }
+
     return {
         Program: function() {
             done = Object.create(null);

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -166,6 +166,9 @@ describe("cli", function() {
         it("should execute without any errors", function() {
             var stubbedConfig = proxyquire("../../lib/config", {
                 "eslint-config-xo": {
+                    ecmaFeatures: {
+                        blockBindings: true
+                    },
                     rules: {
                         "no-var": 2
                     }

--- a/tests/lib/rules/no-var.js
+++ b/tests/lib/rules/no-var.js
@@ -27,6 +27,12 @@ ruleTester.run("no-var", rule, {
         {
             code: "let moo = 'car';",
             ecmaFeatures: { blockBindings: true }
+        },
+
+        // noop when rule is used in wrong environment
+        {
+            code: "var foo = bar;",
+            ecmaFeatures: { blockBindings: false }
         }
     ],
 

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -80,8 +80,11 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {y}", ecmaFeatures: features, options: ["properties"] },
         { code: "var x = {y: {b}}", ecmaFeatures: features, options: ["properties"] },
         { code: "var x = {a: n, c: d, f: g}", ecmaFeatures: features, options: ["never"] },
-        { code: "var x = {a: function(){}, b: {c: d}}", ecmaFeatures: features, options: ["never"] }
+        { code: "var x = {a: function(){}, b: {c: d}}", ecmaFeatures: features, options: ["never"] },
 
+        // noop when rule is used in wrong environment
+        { code: "var x = {x: x}", ecmaFeatures: { objectLiteralShorthandProperties: false } },
+        { code: "var x = {y: function() {}}", ecmaFeatures: { objectLiteralShorthandMethods: false } }
     ],
     invalid: [
         { code: "var x = {x: x}", ecmaFeatures: features, errors: [{ message: "Expected property shorthand.", type: "Property" }] },

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -27,23 +27,26 @@ ruleTester.run("prefer-arrow-callback", rule, {
     valid: [
         {code: "foo(a => a);", ecmaFeatures: {arrowFunctions: true}},
         {code: "foo(function*() {});", ecmaFeatures: {generators: true}},
-        {code: "foo(function() { this; });"},
+        {code: "foo(function() { this; });", ecmaFeatures: {arrowFunctions: true}},
         {code: "foo(function() { (() => this); });", ecmaFeatures: {arrowFunctions: true}},
-        {code: "foo(function() { this; }.bind(obj));"},
-        {code: "foo(function() { this; }.call(this));"},
+        {code: "foo(function() { this; }.bind(obj));", ecmaFeatures: {arrowFunctions: true}},
+        {code: "foo(function() { this; }.call(this));", ecmaFeatures: {arrowFunctions: true}},
         {code: "foo(a => { (function() {}); });", ecmaFeatures: {arrowFunctions: true}},
-        {code: "var foo = function foo() {};"},
-        {code: "(function foo() {})();"},
-        {code: "foo(function bar() { bar; });"}
+        {code: "var foo = function foo() {};", ecmaFeatures: {arrowFunctions: true}},
+        {code: "(function foo() {})();", ecmaFeatures: {arrowFunctions: true}},
+        {code: "foo(function bar() { bar; });", ecmaFeatures: {arrowFunctions: true}},
+
+        // noop when rule is used in wrong environment
+        {code: "foo(function() { this; }.bind(this));", ecmaFeatures: {arrowFunctions: false}}
     ],
     invalid: [
-        {code: "foo(function() {});", errors: errors},
-        {code: "foo(nativeCb || function() {});", errors: errors},
-        {code: "foo(bar ? function() {} : function() {});", errors: [errors[0], errors[0]]},
-        {code: "foo(function() { (function() { this; }); });", errors: errors},
-        {code: "foo(function() { this; }.bind(this));", errors: errors},
+        {code: "foo(function() {});", ecmaFeatures: {arrowFunctions: true}, errors: errors},
+        {code: "foo(nativeCb || function() {});", ecmaFeatures: {arrowFunctions: true}, errors: errors},
+        {code: "foo(bar ? function() {} : function() {});", ecmaFeatures: {arrowFunctions: true}, errors: [errors[0], errors[0]]},
+        {code: "foo(function() { (function() { this; }); });", ecmaFeatures: {arrowFunctions: true}, errors: errors},
+        {code: "foo(function() { this; }.bind(this));", ecmaFeatures: {arrowFunctions: true}, errors: errors},
         {code: "foo(function() { (() => this); }.bind(this));", ecmaFeatures: {arrowFunctions: true}, errors: errors},
-        {code: "foo(function bar(a) { a; });", errors: errors},
-        {code: "foo(function(a) { a; });", errors: errors}
+        {code: "foo(function bar(a) { a; });", ecmaFeatures: {arrowFunctions: true}, errors: errors},
+        {code: "foo(function(a) { a; });", ecmaFeatures: {arrowFunctions: true}, errors: errors}
     ]
 });

--- a/tests/lib/rules/prefer-spread.js
+++ b/tests/lib/rules/prefer-spread.js
@@ -22,32 +22,35 @@ var errors = [{message: "use the spread operator instead of the \".apply()\".", 
 var ruleTester = new RuleTester();
 ruleTester.run("prefer-spread", rule, {
     valid: [
-        {code: "foo.apply(obj, args);"},
-        {code: "obj.foo.apply(null, args);"},
-        {code: "obj.foo.apply(otherObj, args);"},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, z).c, args);"},
-        {code: "a.b.foo.apply(a.b.c, args);"},
+        {code: "foo.apply(obj, args);", ecmaFeatures: {spread: true}},
+        {code: "obj.foo.apply(null, args);", ecmaFeatures: {spread: true}},
+        {code: "obj.foo.apply(otherObj, args);", ecmaFeatures: {spread: true}},
+        {code: "a.b(x, y).c.foo.apply(a.b(x, z).c, args);", ecmaFeatures: {spread: true}},
+        {code: "a.b.foo.apply(a.b.c, args);", ecmaFeatures: {spread: true}},
 
         // ignores non variadic.
-        {code: "foo.apply(undefined, [1, 2]);"},
-        {code: "foo.apply(null, [1, 2]);"},
-        {code: "obj.foo.apply(obj, [1, 2]);"},
+        {code: "foo.apply(undefined, [1, 2]);", ecmaFeatures: {spread: true}},
+        {code: "foo.apply(null, [1, 2]);", ecmaFeatures: {spread: true}},
+        {code: "obj.foo.apply(obj, [1, 2]);", ecmaFeatures: {spread: true}},
 
         // ignores computed property.
-        {code: "var apply; foo[apply](null, args);"},
+        {code: "var apply; foo[apply](null, args);", ecmaFeatures: {spread: true}},
 
         // ignores incomplete things.
-        {code: "foo.apply();"},
-        {code: "obj.foo.apply();"}
+        {code: "foo.apply();", ecmaFeatures: {spread: true}},
+        {code: "obj.foo.apply();", ecmaFeatures: {spread: true}},
+
+        // noop when rule is used in wrong environment
+        {code: "foo.apply(undefined, args);", ecmaFeatures: {spread: false}}
     ],
     invalid: [
-        {code: "foo.apply(undefined, args);", errors: errors},
-        {code: "foo.apply(void 0, args);", errors: errors},
-        {code: "foo.apply(null, args);", errors: errors},
-        {code: "obj.foo.apply(obj, args);", errors: errors},
-        {code: "a.b.c.foo.apply(a.b.c, args);", errors: errors},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors: errors},
-        {code: "[].concat.apply([ ], args);", errors: errors},
-        {code: "[].concat.apply([\n/*empty*/\n], args);", errors: errors}
+        {code: "foo.apply(undefined, args);", ecmaFeatures: {spread: true}, errors: errors},
+        {code: "foo.apply(void 0, args);", ecmaFeatures: {spread: true}, errors: errors},
+        {code: "foo.apply(null, args);", ecmaFeatures: {spread: true}, errors: errors},
+        {code: "obj.foo.apply(obj, args);", ecmaFeatures: {spread: true}, errors: errors},
+        {code: "a.b.c.foo.apply(a.b.c, args);", ecmaFeatures: {spread: true}, errors: errors},
+        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", ecmaFeatures: {spread: true}, errors: errors},
+        {code: "[].concat.apply([ ], args);", ecmaFeatures: {spread: true}, errors: errors},
+        {code: "[].concat.apply([\n/*empty*/\n], args);", ecmaFeatures: {spread: true}, errors: errors}
     ]
 });

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -25,25 +25,28 @@ var errors = [{
 var ruleTester = new RuleTester();
 ruleTester.run("prefer-template", rule, {
     valid: [
-        {code: "'use strict';"},
-        {code: "var foo = 'bar';"},
-        {code: "var foo = 'bar' + 'baz';"},
-        {code: "var foo = foo + +'100';"},
+        {code: "'use strict';", ecmaFeatures: {templateStrings: true}},
+        {code: "var foo = 'bar';", ecmaFeatures: {templateStrings: true}},
+        {code: "var foo = 'bar' + 'baz';", ecmaFeatures: {templateStrings: true}},
+        {code: "var foo = foo + +'100';", ecmaFeatures: {templateStrings: true}},
         {code: "var foo = `bar`;", ecmaFeatures: {templateStrings: true}},
         {code: "var foo = `hello, ${name}!`;", ecmaFeatures: {templateStrings: true}},
 
         // https://github.com/eslint/eslint/issues/3507
         {code: "var foo = `foo` + `bar` + \"hoge\";", ecmaFeatures: {templateStrings: true}},
-        {code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";", ecmaFeatures: {templateStrings: true}}
+        {code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";", ecmaFeatures: {templateStrings: true}},
+
+        // noop when rule is used in wrong environment
+        {code: "var foo = bar + 'baz';", ecmaFeatures: {templateStrings: false}}
     ],
     invalid: [
-        {code: "var foo = 'hello, ' + name + '!';", errors: errors},
-        {code: "var foo = bar + 'baz';", errors: errors},
+        {code: "var foo = 'hello, ' + name + '!';", ecmaFeatures: {templateStrings: true}, errors: errors},
+        {code: "var foo = bar + 'baz';", ecmaFeatures: {templateStrings: true}, errors: errors},
         {code: "var foo = bar + `baz`;", ecmaFeatures: {templateStrings: true}, errors: errors},
-        {code: "var foo = +100 + 'yen';", errors: errors},
-        {code: "var foo = 'bar' + baz;", errors: errors},
-        {code: "var foo = '￥' + (n * 1000) + '-'", errors: errors},
-        {code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;", errors: [errors[0], errors[0]]},
-        {code: "var string = (number + 1) + 'px';", errors: errors}
+        {code: "var foo = +100 + 'yen';", ecmaFeatures: {templateStrings: true}, errors: errors},
+        {code: "var foo = 'bar' + baz;", ecmaFeatures: {templateStrings: true}, errors: errors},
+        {code: "var foo = '￥' + (n * 1000) + '-'", ecmaFeatures: {templateStrings: true}, errors: errors},
+        {code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;", ecmaFeatures: {templateStrings: true}, errors: [errors[0], errors[0]]},
+        {code: "var string = (number + 1) + 'px';", ecmaFeatures: {templateStrings: true}, errors: errors}
     ]
 });


### PR DESCRIPTION
The following rules depend on ES2015 syntax:
- no-dupe-class-members
- no-var
- object-shorthand
- prefer-arrow-callback
- prefer-spread
- prefer-template

If the appropriate "ecmaFeatures" flag is not enabled, these rules automatically become no-ops.

From the discussion in #3686, this allows a single shared config to be used for both ES5 and ES2015 projects. Otherwise, these ES2015 rules would enforce practices that introduce syntax errors in an ES5 codebase.