### PR TITLE
Fix: make getScope acquire innermost scope (fixes #3700)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -964,7 +964,8 @@ module.exports = (function() {
             // Ascend the current node's parents
             for (var i = parents.length - 1; i >= 0; --i) {
 
-                scope = scopeManager.acquire(parents[i]);
+                // Get the innermost scope
+                scope = scopeManager.acquire(parents[i], true);
                 if (scope) {
                     if (scope.type === "function-expression-name") {
                         return scope.childScopes[0];

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -564,6 +564,30 @@ describe("eslint", function() {
 
             eslint.verify("try {} catch (err) {}", config, filename, true);
         });
+
+        it("should retrieve module scope correctly from an ES6 module", function() {
+            var config = { rules: {}, ecmaFeatures: { modules: true } };
+
+            eslint.reset();
+            eslint.on("AssignmentExpression", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "module");
+            });
+
+            eslint.verify("var foo = {}; foo.bar = 1;", config, filename, true);
+        });
+
+        it("should retrieve function scope correctly when globalReturn is true", function() {
+            var config = { rules: {}, ecmaFeatures: { globalReturn: true } };
+
+            eslint.reset();
+            eslint.on("AssignmentExpression", function() {
+                var scope = eslint.getScope();
+                assert.equal(scope.type, "function");
+            });
+
+            eslint.verify("var foo = {}; foo.bar = 1;", config, filename, true);
+        });
     });
 
     describe("marking variables as used", function() {


### PR DESCRIPTION
I'm not sure if this is the best way to do it, but it fixes #3700 and doesn't break anything else. I've also added a unit test that fails without this change and passes with.