### PR TITLE
Fix: Eqeqeq rule with no option does not warn on 'a == null' (fixes #3699)

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@ rules:
     default-case: 2
     dot-notation: [2, { allowKeywords: true }]
     eol-last: 2
-    eqeqeq: 2
+    eqeqeq: [2, "allow-null"]
     func-style: [2, "declaration"]
     guard-for-in: 2
     key-spacing: [2, { beforeColon: false, afterColon: true }]

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -71,7 +71,7 @@ module.exports = function(context) {
             }
 
             if (context.options[0] === "smart" && (isTypeOfBinary(node) ||
-                    areLiteralsAndSameType(node)) || isNullCheck(node)) {
+                    areLiteralsAndSameType(node) || isNullCheck(node))) {
                 return;
             }
 

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -34,6 +34,13 @@ ruleTester.run("eqeqeq", rule, {
     invalid: [
         { code: "a == b", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
         { code: "a != b", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression"}] },
+        { code: "typeof a == 'number'", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
+        { code: "'string' != typeof a", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression"}] },
+        { code: "true == true", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
+        { code: "2 == 3", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
+        { code: "'hello' != 'world'", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression"}] },
+        { code: "a == null", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
+        { code: "null != a", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression"}] },
         { code: "true == 1", options: ["smart"], errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
         { code: "0 != '1'", options: ["smart"], errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression"}] },
         { code: "'wee' == /wee/", options: ["smart"], errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },


### PR DESCRIPTION
Fixes #3699