### PR TITLE
Fix: Allow leading/trailing whitespace in rule message parameters. (fixes #3690)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -113,9 +113,11 @@ The main method you'll use is `context.report()`, which publishes a warning or e
 
 or {% raw %}
 
-    context.report(node, "`{{identifier}}` is unexpected!", { identifier: node.name });
+    context.report(node, "`{{ identifier }}` is unexpected!", { identifier: node.name });
 
 {% endraw %}
+
+Note that leading and trailing whitespace is optional in message parameters.
 
 The node contains all of the information necessary to figure out the line and column number of the offending text as well the source text representing the node.
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -21,7 +21,6 @@ var estraverse = require("estraverse-fb"),
     timing = require("./timing"),
     SourceCode = require("./util/source-code"),
     EventEmitter = require("events").EventEmitter,
-    escapeRegExp = require("escape-string-regexp"),
     validator = require("./config-validator"),
     replacements = require("../conf/replacements.json");
 
@@ -874,14 +873,18 @@ module.exports = (function() {
             location = node.loc.start;
         }
 
-        Object.keys(opts || {}).forEach(function(key) {
-            var rx = new RegExp(escapeRegExp("{{" + key + "}}"), "g");
-            message = message.replace(rx, opts[key]);
-        });
-
         if (isDisabledByReportingConfig(reportingConfig, ruleId, location)) {
             return;
         }
+
+        message = message.replace(/\{\{\s*(.+?)\s*\}\}/g, function(fullMatch, term) {
+            if (term in opts) {
+                return opts[term];
+            }
+
+            // Preserve old behavior: If parameter name not provided, don't replace it.
+            return fullMatch;
+        });
 
         messages.push({
             ruleId: ruleId,

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -723,6 +723,137 @@ describe("eslint", function() {
             var messages = eslint.verify("0", config);
             assert.equal(messages[0].message, "my message testing!");
         });
+
+        it("should allow template parameter with inner whitespace", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{parameter name}}", {
+                            "parameter name": "yay!"
+                        });
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message yay!");
+        });
+
+        it("should allow template parameter with non-identifier characters", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{parameter-name}}", {
+                            "parameter-name": "yay!"
+                        });
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message yay!");
+        });
+
+        it("should ignore template parameter with no specified value", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{parameter}}", {});
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message {{parameter}}");
+        });
+
+        it("should handle leading whitespace in template parameter", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{ parameter}}", {
+                            parameter: "yay!"
+                        });
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message yay!");
+        });
+
+        it("should handle trailing whitespace in template parameter", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{parameter }}", {
+                            parameter: "yay!"
+                        });
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message yay!");
+        });
+
+        it("should still allow inner whitespace as well as leading/trailing", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{ parameter name }}", {
+                            "parameter name": "yay!"
+                        });
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message yay!");
+        });
+
+        it("should still allow non-identifier characters as well as leading/trailing whitespace", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{ parameter-name }}", {
+                            "parameter-name": "yay!"
+                        });
+                    }
+                };
+            });
+
+            var config = { rules: {} };
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message yay!");
+        });
     });
 
     describe("when evaluating code", function() {


### PR DESCRIPTION
Also added a bunch of unit tests which do pass under the old version of the code, to show previously undocumented assumptions.

Some other notes:
1. I intentionally moved the message interpolation code *below* the code that checks if the rule is even on in the first place. I didn't see a lot of point in running regexes over the message if it wasn't even going to be used. If this is a problem, I can move it back.
2. Rather than iterating over keys and constructing a `new RegExp` each time, I chose to run a general regex over the whole pattern and do lookup from there. I [tested on jsperf][1] and it said my approach was loads faster, but I don't know how good my test cases are and furthermore I was testing my browser rather than Node. If anyone has any good tips on how to perf-test in Node, I'm all ears.

Fixes #3690.

  [1]: http://jsperf.com/eslint-interpolation-test