### PR TITLE
Fix: `no-unused-vars` had been crashed at `/*global $*/`

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -234,6 +234,23 @@ module.exports = function(context) {
     }
 
     /**
+     * Gets the index of a given variable name in a given comment.
+     * @param {escope.Variable} variable - A variable to get.
+     * @param {ASTNode} comment - A comment node which includes the variable name.
+     * @returns {number} The index of the variable name's location.
+     */
+    function getColumnInComment(variable, comment) {
+        var namePattern = new RegExp("[\\s,]" + escape(variable.name) + "(?:$|[\\s,:])", "g");
+
+        // To ignore the first text "global".
+        namePattern.lastIndex = comment.value.indexOf("global") + 6;
+
+        // Search a given variable name.
+        var match = namePattern.exec(comment.value);
+        return match ? match.index + 1 : 0;
+    }
+
+    /**
      * Creates the correct location of a given variables.
      * The location is at its name string in a `/*global` comment.
      *
@@ -242,11 +259,9 @@ module.exports = function(context) {
      */
     function getLocation(variable) {
         var comment = variable.eslintExplicitGlobalComment;
-        var content = comment.value;
         var baseLoc = comment.loc.start;
-        var namePattern = new RegExp("\\b" + escape(variable.name) + "\\b");
-        var column = namePattern.exec(content).index;
-        var prefix = content.slice(0, column);
+        var column = getColumnInComment(variable, comment);
+        var prefix = comment.value.slice(0, column);
         var lineInComment = (prefix.match(/\n/g) || []).length;
 
         if (lineInComment > 0) {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -184,6 +184,54 @@ ruleTester.run("no-unused-vars", rule, {
                 {line: 3, column: 4, message: "\"foo\" is defined but never used" },
                 {line: 4, column: 4, message: "\"bar\" is defined but never used" }
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/3714
+        {
+            code: "/* global a$fooz,$foo */\na$fooz;",
+            errors: [
+                {line: 1, column: 18, message: "\"$foo\" is defined but never used" }
+            ]
+        },
+        {
+            code: "/* globals a$fooz, $ */\na$fooz;",
+            errors: [
+                {line: 1, column: 20, message: "\"$\" is defined but never used" }
+            ]
+        },
+        {
+            code: "/*globals $foo*/",
+            errors: [
+                {line: 1, column: 11, message: "\"$foo\" is defined but never used" }
+            ]
+        },
+        {
+            code: "/* global global*/",
+            errors: [
+                {line: 1, column: 11, message: "\"global\" is defined but never used" }
+            ]
+        },
+        {
+            code: "/*global foo:true*/",
+            errors: [
+                {line: 1, column: 10, message: "\"foo\" is defined but never used" }
+            ]
+        },
+        // non ascii.
+        {
+            code: "/*global 変数, 数*/\n変数;",
+            errors: [
+                {line: 1, column: 14, message: "\"数\" is defined but never used" }
+            ]
         }
+        // surrogate pair.
+        // TODO: https://github.com/eslint/espree/issues/181
+        // {
+        //     code: "/*global 𠮷𩸽, 𠮷*/\n\\u{20BB7}\\u{29E3D};",
+        //     env: {es6: true},
+        //     errors: [
+        //         {line: 1, column: 16, message: "\"𠮷\" is defined but never used" }
+        //     ]
+        // }
     ]
 });


### PR DESCRIPTION
Fixes #3714.

`\b` (word boundary) could not be used to check boundaries if a variable name includes `$` at the edge.
So I make checking manually with espree.