### PR TITLE
Build: Generate formatter example docs (fixes #3560)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -297,7 +297,19 @@ var isIgnored = cli.isPathIgnored("foo/bar.js");
 
 ### getFormatter()
 
-Retrieves a formatter, which you can then use to format a report object. The argument is either the name of a built-in formatter ("stylish" (the default), "checkstyle", "compact", "html", "jslint-xml", "junit", "json", "tap", and "unix") or the full path to a JavaScript file containing a custom formatter. You can also omit the argument to retrieve the default formatter.
+Retrieves a formatter, which you can then use to format a report object. The argument is either the name of a built-in formatter:
+
+* "[stylish](./user-guide/formatters#stylish)" (the default)
+* "[checkstyle](./user-guide/formatters#checkstyle)"
+* "[compact](./user-guide/formatters#compact)"
+* "[html](./user-guide/formatters#html)"
+* "[jslint-xml](./user-guide/formatters#jslint-xml)"
+* "[json](./user-guide/formatters#json)"
+* "[junit](./user-guide/formatters#junit)"
+* "[tap](./user-guide/formatters#tap)"
+* "[unix](./user-guide/formatters#unix)"
+
+or the full path to a JavaScript file containing a custom formatter. You can also omit the argument to retrieve the default formatter.
 
 ```js
 var CLIEngine = require("eslint").CLIEngine;

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -248,7 +248,17 @@ When specified, the given format is output into the provided file name.
 
 #### `-f`, `--format`
 
-This option specifies the output format for the console. Possible formats are "stylish" (the default), "checkstyle", "compact", "html", "jslint-xml", "junit", "json", "tap" and "unix".
+This option specifies the output format for the console. Possible formats are:
+
+* [stylish](formatters/#stylish) (the default)
+* [checkstyle](formatters/#checkstyle)
+* [compact](formatters/#compact)
+* [html](formatters/#html)
+* [jslint-xml](formatters/#jslint-xml)
+* [json](formatters/#json)
+* [junit](formatters/#junit)
+* [tap](formatters/#tap)
+* [unix](formatters/#unix)
 
 Example:
 

--- a/templates/formatter-examples.md.ejs
+++ b/templates/formatter-examples.md.ejs
@@ -1,0 +1,57 @@
+---
+title: Documentation
+layout: doc
+---
+# ESLint Formatters
+
+ESLint comes with several built-in formatters to control the appearance of the linting results, and supports third-party formatters as well.
+
+The built-in formatter options are:
+
+<% Object.keys(formatterResults).forEach(function(formatterName) { -%>
+* [<%= formatterName %>](#<%= formatterName %>)
+<% }) -%>
+
+## Example Source
+
+Examples of each formatter were created from linting `fullOfProblems.js` using the `.eslintrc` configuration shown below.
+
+### `fullOfProblems.js`
+
+```js
+function addOne(i) {
+    if (i != NaN) {
+        return i ++
+    } else {
+      return
+    }
+};
+```
+
+### `.eslintrc`:
+
+```json
+{
+    "extends": "eslint:recommended",
+    "rules": {
+        "consistent-return": 2,
+        "indent"           : [1, 4],
+        "no-else-return"   : 1,
+        "semi"             : [1, "always"],
+        "space-unary-ops"  : 2
+    }
+}
+```
+
+## Output Examples
+<% Object.keys(formatterResults).forEach(function(formatterName) { -%>
+
+### <%= formatterName %>
+<% if (formatterName !== "html") { -%>
+```
+<%- formatterResults[formatterName].result %>
+```
+<% } else {-%>
+<iframe src="html-formatter-example.html" width="100%" height="460px"></iframe>
+<% } -%>
+<% }) -%>


### PR DESCRIPTION
Adds a step to `gensite` to generate a page showing examples of all built-in formatters.

Also breaks apart lists of formatters in a few places, at @gyandeeps' suggestion in https://github.com/eslint/eslint/pull/3736#issuecomment-139436594.

I'm not sure if user-guide is the best place to put the new page, and whether or not you'd like a link to this new page in the menu or from anything other than those I've added to the formatters.  

Any feedback/suggestions would be welcome!