### PR TITLE
Docs: Shorten and simplify autocomment for new issues

### DIFF
--- a/ISSUE_CREATE.md
+++ b/ISSUE_CREATE.md
@@ -1,23 +1,8 @@
-Thanks for the issue! We get a lot of issues, so this message is automatically posted to each one to help you check that you've included all of the information we need to help you.
-
-Reporting a bug? Please be sure to include:
+Thanks for the issue! If you're reporting a bug, please be sure to include:
 
 1. The version of ESLint you are using (run `eslint -v`)
-1. The source code that caused the problem
-1. The configuration you're using (for the rule or your entire config file)
-1. The actual ESLint output complete with line numbers
+2. What you did (the source code and ESLint configuration)
+3. The actual ESLint output complete with numbers
+4. What you expected to happen instead
 
-Requesting a new rule? Please be sure to include:
-
-1. The use case for the rule - what is it trying to prevent or flag?
-1. Whether the rule is trying to prevent an error or is purely stylistic
-1. Why you believe this rule is generic enough to be included
-
-Requesting a feature? Please be sure to include:
-
-1. The problem you want to solve (don't mention the solution)
-1. Your take on the correct solution to problem
-
-Including this information in your issue helps us to triage it and get you a response as quickly as possible.
-
-Thanks!
+Requesting a new rule? Please see [Proposing a New Rule](http://eslint.org/docs/developer-guide/contributing/new-rules) for instructions.


### PR DESCRIPTION
I'd like to shorten the autoposting comment because I don't think people are reading it in its current state. 