### PR TITLE
Fix CLIEngine default cache parameter

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -358,7 +358,7 @@ function CLIEngine(options) {
      */
     this._fileCache = fileEntryCache.create(path.resolve(this.options.cacheFile)); // eslint-disable-line no-underscore-dangle
 
-    if (!this.options.useCache) {
+    if (!this.options.cache) {
         this._fileCache.destroy(); // eslint-disable-line no-underscore-dangle
     }
 
@@ -508,7 +508,7 @@ CLIEngine.prototype = {
                 return;
             }
 
-            if (options.useCache) {
+            if (options.cache) {
                 // get the descriptor for this file
                 // with the metadata and the flag that determines if
                 // the file has changed
@@ -538,7 +538,7 @@ CLIEngine.prototype = {
 
             var res = processFile(filename, configHelper, options);
 
-            if (options.useCache) {
+            if (options.cache) {
                 // if a file contains errors or warnings we don't want to
                 // store the file in the cache so we can guarantee that
                 // next execution will also operate on this file
@@ -577,7 +577,7 @@ CLIEngine.prototype = {
 
         stats = calculateStatsPerRun(results);
 
-        if (options.useCache) {
+        if (options.cache) {
             // persist the cache to disk
             fileCache.reconcile();
         }

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -50,7 +50,7 @@ function translateOptions(cliOptions) {
         rulePaths: cliOptions.rulesdir,
         useEslintrc: cliOptions.eslintrc,
         parser: cliOptions.parser,
-        useCache: cliOptions.cache,
+        cache: cliOptions.cache,
         cacheFile: cliOptions.cacheFile,
         fix: cliOptions.fix
     };

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1057,7 +1057,7 @@ describe("CLIEngine", function() {
             });
         });
 
-        describe("useCache", function() {
+        describe("cache", function() {
             var sandbox;
             /**
              * helper method to delete the cache files created during testing
@@ -1087,8 +1087,8 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
-                    // specifying useCache true the cache will be created
-                    useCache: true,
+                    // specifying cache true the cache will be created
+                    cache: true,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1111,8 +1111,8 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
-                    // specifying useCache true the cache will be created
-                    useCache: true,
+                    // specifying cache true the cache will be created
+                    cache: true,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1137,8 +1137,8 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
-                    // specifying useCache true the cache will be created
-                    useCache: true,
+                    // specifying cache true the cache will be created
+                    cache: true,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1155,8 +1155,8 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
-                    // specifying useCache true the cache will be created
-                    useCache: false,
+                    // specifying cache true the cache will be created
+                    cache: false,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1174,8 +1174,8 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
-                    // specifying useCache true the cache will be created
-                    useCache: true,
+                    // specifying cache true the cache will be created
+                    cache: true,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1211,8 +1211,8 @@ describe("CLIEngine", function() {
                         useEslintrc: false,
                         // specify a custom cache file
                         cacheFile: customCacheFile,
-                        // specifying useCache true the cache will be created
-                        useCache: true,
+                        // specifying cache true the cache will be created
+                        cache: true,
                         rules: {
                             "no-console": 0,
                             "no-unused-vars": 2


### PR DESCRIPTION
This change fixes both the documented parameter name and the default setting
in the configuration object for the `CLIEngine`. The CLI takes a `--cache`
argument, which gets translated into `useCache`, however the CLIEngine
defaulted to using `options.cache` but then checked for `options.useCache`.
Hopefully this should prevent other developers from being confused!