### PR TITLE
Fix: `space-before-keywords` fails to handle class keyword & object literal shorthand method (fixes #3756)

### DIFF
--- a/lib/rules/space-before-keywords.js
+++ b/lib/rules/space-before-keywords.js
@@ -177,14 +177,18 @@ module.exports = function(context) {
         "FunctionExpression": function(node) {
 
             var left = context.getTokenBefore(node);
-            var right = null;
 
-            if (left.type === "Identifier") {
-                right = left;
-                left = context.getTokenBefore(node, 1);
-            } else {
-                right = context.getFirstToken(node);
+            // Check to see if the function expression is a class method
+            if (node.parent && node.parent.type === "MethodDefinition") {
+                return;
             }
+
+            // Check to see if the function expression is an object literal shorthand method
+            if (node.parent && node.parent.method && node.parent.type === "Property") {
+                return;
+            }
+
+            var right = context.getFirstToken(node);
 
             checkTokens(node, left, right, { allowedPrecedingChars: [ "(" ] });
         },
@@ -193,7 +197,13 @@ module.exports = function(context) {
         },
         "ForOfStatement": check,
         "ClassBody": function(node) {
-            check(context.getTokenBefore(node, 1));
+
+            // Find the 'class' token
+            while (node.value !== "class") {
+                node = context.getTokenBefore(node);
+            }
+
+            check(node);
         },
         "Super": check
 

--- a/tests/lib/rules/space-before-keywords.js
+++ b/tests/lib/rules/space-before-keywords.js
@@ -129,14 +129,19 @@ ruleTester.run("space-before-keywords", rule, {
         { code: ";\nfunction foo () {}" },
         { code: "; function foo () {}", options: never },
         { code: ";\nfunction foo () {}", options: never },
+        { code: "var foo = {bar() {}}", ecmaFeatures: { objectLiteralShorthandMethods: true } },
+        { code: "var foo = { bar() {} }", ecmaFeatures: { objectLiteralShorthandMethods: true }, options: never },
+        { code: "var foo = {\nbar() {}}", ecmaFeatures: { objectLiteralShorthandMethods: true }, options: never },
         // FunctionExpression
         { code: "var foo = function bar () {}" },
         { code: "var foo =\nfunction bar () {}" },
         { code: "function foo () { return function () {} }" },
         { code: "var foo = (function bar () {})()" },
+        { code: "var foo = { foo: function () {} }" },
         { code: "var foo = function bar () {}", options: never },
         { code: "var foo =\nfunction bar () {}", options: never },
         { code: "function foo () { return function () {} }", options: never },
+        { code: "var foo = { foo:function () {} }", options: never },
         // YieldExpression
         {
             code: "function* foo() { yield 0; }",
@@ -189,12 +194,21 @@ ruleTester.run("space-before-keywords", rule, {
             ecmaFeatures: { classes: true }
         },
         {
+            code: "; class Bar extends Foo.Baz {}",
+            ecmaFeatures: { classes: true }
+        },
+        {
             code: "; class Bar {}",
             ecmaFeatures: { classes: true },
             options: never
         },
         {
             code: ";\nclass Bar {}",
+            ecmaFeatures: { classes: true },
+            options: never
+        },
+        {
+            code: "; class Bar extends Foo.Baz {}",
             ecmaFeatures: { classes: true },
             options: never
         },
@@ -395,6 +409,11 @@ ruleTester.run("space-before-keywords", rule, {
             errors: [ { message: expectedSpacingErrorMessageTpl("function"), type: "FunctionExpression" } ],
             output: "var foo = function bar () {}"
         },
+        {
+            code: "var foo = { foo:function () {} }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("function"), type: "FunctionExpression" } ],
+            output: "var foo = { foo: function () {} }"
+        },
         // YieldExpression
         {
             code: "function* foo() {yield 0; }",
@@ -415,6 +434,12 @@ ruleTester.run("space-before-keywords", rule, {
             errors: [ { message: expectedSpacingErrorMessageTpl("class"), type: "Keyword" } ],
             ecmaFeatures: { classes: true },
             output: "; class Bar {}"
+        },
+        {
+            code: ";class Bar extends Foo.Baz {}",
+            errors: [ { message: expectedSpacingErrorMessageTpl("class"), type: "Keyword" } ],
+            ecmaFeatures: { classes: true },
+            output: "; class Bar extends Foo.Baz {}"
         },
         // Super
         {


### PR DESCRIPTION
Fixes #3756 (`class` keyword & object literal shorthand method).