### PR TITLE
Fix: `semi-spacing` had conflicted with `block-spacing`

### DIFF
--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -14,6 +14,9 @@ var c = "d";var e = "f";
 
 This rule aims to enforce spacing around a semicolon. This rule prevents the use of spaces before a semicolon in expressions.
 
+This rule doesn't check spacing which is after semicolons if the semicolon is before a closing parenthesis (`)` or `}`).
+That spacing is checked by `space-in-parens` or `block-spacing`.
+
 ### Options
 
 The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`.
@@ -94,3 +97,5 @@ You can turn this rule off if you are not concerned with the consistency of spac
 * [semi](semi.md)
 * [no-extra-semi](no-extra-semi.md)
 * [comma-spacing](comma-spacing.md)
+* [block-spacing](block-spacing.md)
+* [space-in-parens](space-in-parens.md)

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -58,6 +58,20 @@ module.exports = function(context) {
     }
 
     /**
+     * Checks if the next token of a given token is a closing parenthesis.
+     * @param {Token} token The token to check.
+     * @returns {boolean} Whether or not the next token of a given token is a closing parenthesis.
+     */
+    function isBeforeClosingParen(token) {
+        var nextToken = context.getTokenAfter(token);
+        return (
+            nextToken &&
+            nextToken.type === "Punctuator" &&
+            (nextToken.value === "}" || nextToken.value === ")")
+        );
+    }
+
+    /**
      * Checks if the given token is a semicolon.
      * @param {Token} token The token to check.
      * @returns {boolean} Whether or not the given token is a semicolon.
@@ -88,7 +102,7 @@ module.exports = function(context) {
                 }
             }
 
-            if (!isLastTokenInCurrentLine(token)) {
+            if (!isLastTokenInCurrentLine(token) && !isBeforeClosingParen(token)) {
                 if (hasTrailingSpace(token)) {
                     if (!requireSpaceAfter) {
                         context.report(node, location, "Unexpected whitespace after semicolon.");

--- a/tests/lib/rules/semi-spacing.js
+++ b/tests/lib/rules/semi-spacing.js
@@ -48,7 +48,13 @@ ruleTester.run("semi-spacing", rule, {
         {
             code: "for (var i = 0 ; i < 10 ; i++) {}",
             options: [ { before: true, after: true } ]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/3721
+        "function foo(){return 2;}",
+        "for(var i = 0; i < results.length;) {}",
+        {code: "function foo() { return 2; }", options: [{after: false}]},
+        {code: "for ( var i = 0;i < results.length; ) {}", options: [{after: false}]}
     ],
     invalid: [
         {


### PR DESCRIPTION
Fixes #3721.

I made `semi-spacing` ignoring spacing which is after semicolons if the semicolon is before a closing parenthesis (`}` or `)`).