### PR TITLE
Docs: Fix closing code fence on cli docs

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -65,7 +65,8 @@ Miscellaneous:
   --init                      Run config initialization wizard - default: false
   --fix                       Automatically fix problems
   -h, --help                  Show help
-  -v, --version               Outputs the version number```
+  -v, --version               Outputs the version number
+```
 
 ### Basic configuration
 


### PR DESCRIPTION
Code fences must be on their own line.  Was causing the entire rest of the page to be rendered as code.