### PR TITLE
Docs: add a couple more examples + tests for block-scoped-var (fixes #3791)

### DIFF
--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -33,6 +33,18 @@ function doSomething() {
 ```js
 /*eslint block-scoped-var: 2*/
 
+function doSomething() {
+    if (true) {
+        var build = true;
+    } else {
+        var build = false; /*error "build" used outside of binding context.*/
+    }
+}
+```
+
+```js
+/*eslint block-scoped-var: 2*/
+
 function doAnother() {
     try {
         var build = 1;
@@ -55,6 +67,20 @@ function doSomething() {
     }
 
     console.log(build);
+}
+```
+
+```js
+/*eslint block-scoped-var: 2*/
+
+function doSomething() {
+    var build;
+
+    if (true) {
+        build = true;
+    } else {
+        build = false;
+    }
 }
 ```
 

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -37,6 +37,10 @@ ruleTester.run("block-scoped-var", rule, {
         "function f() { var hasOwnProperty; { hasOwnProperty; } }",
         "function f(){ a; b; var a, b; }",
         "function f(){ g(); function g(){} }",
+        "if (true) { var a = 1; a; }",
+        "var a; if (true) { a; }",
+        "for (var i = 0; i < 10; i++) { i; }",
+        "var i; for(i; i; i) { i; }",
         { code: "function myFunc(foo) {  \"use strict\";  var { bar } = foo;  bar.hello();}", ecmaFeatures: { destructuring: true } },
         { code: "function myFunc(foo) {  \"use strict\";  var [ bar ]  = foo;  bar.hello();}", ecmaFeatures: { destructuring: true } },
         { code: "function myFunc(...foo) {  return foo;}", ecmaFeatures: { restParams: true } },
@@ -117,7 +121,7 @@ ruleTester.run("block-scoped-var", rule, {
             errors: [{ message: "\"c\" used outside of binding context.", type: "Identifier" }]
         },
         {
-            code: "function a() { for(var b of {}) { var c = b;} c; }",
+            code: "function a() { for(var b of {}) { var c = b; } c; }",
             ecmaFeatures: { forOf: true },
             errors: [{ message: "\"c\" used outside of binding context.", type: "Identifier" }]
         },
@@ -142,6 +146,24 @@ ruleTester.run("block-scoped-var", rule, {
             code: "{ var a = 0; } a;",
             ecmaFeatures: { modules: true },
             errors: [{ message: "\"a\" used outside of binding context.", type: "Identifier" }]
+        },
+        {
+            code: "if (true) { var a; } a;",
+            errors: [{ message: "\"a\" used outside of binding context.", type: "Identifier" }]
+        },
+        {
+            code: "if (true) { var a = 1; } else { var a = 2; }",
+            errors: [
+                { message: "\"a\" used outside of binding context.", type: "Identifier" },
+                { message: "\"a\" used outside of binding context.", type: "Identifier" }
+            ]
+        },
+        {
+            code: "for (var i = 0;;) {} for(var i = 0;;) {}",
+            errors: [
+                { message: "\"i\" used outside of binding context.", type: "Identifier" },
+                { message: "\"i\" used outside of binding context.", type: "Identifier" }
+            ]
         }
     ]
 });


### PR DESCRIPTION
This addresses my concerns in #3791 about how the desired behaviour for variables redeclared in sibling blocks was unclear.

Added in a couple of extra examples of if/else in docs to clarify that blocks don't have to be direct descendants/ancestors of each other to count as outside scope.

Also added in a few more tests that ensure this behaviour is properly defined and tested.