### PR TITLE
Update: Add configuration option to `space-before-blocks` (fixes #3758)

### DIFF
--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -14,7 +14,13 @@ This rule will enforce consistency of spacing before blocks. It is only applied 
 This rule ignores spacing which is between `=>` and a block. The spacing is handled by the `arrow-spacing` rule.
 
 This rule takes one argument. If it is `"always"` then blocks must always have at least one preceding space. If `"never"`
-then all blocks should never have any preceding space. The default is `"always"`.
+then all blocks should never have any preceding space. If different spacing is desired for function
+blocks and keyword blocks, an optional configuration object can be passed as the rule argument to
+configure the cases separately.
+
+( e.g. `{ "functions": "never", "keywords": "always" }` )
+
+The default is `"always"`.
 
 ### `"always"`
 
@@ -96,6 +102,70 @@ for (;;){
 }
 
 try{} catch(a){}
+```
+
+The following patterns are considered problems when configured `{ "functions": "never", "keywords": "always" }`:
+
+```js
+/*eslint space-before-blocks: [2, { "functions": "never", "keywords": "always" }]*/
+
+function a() {}    /*error Unexpected space before opening brace.*/
+
+try {} catch(a){}  /*error Missing space before opening brace.*/
+
+class Foo{         /*error Missing space before opening brace.*/
+  constructor() {} /*error Unexpected space before opening brace.*/
+}
+```
+
+
+The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "always" }`:
+
+```js
+/*eslint space-before-blocks: [2, { "functions": "never", "keywords": "always" }]*/
+
+for (;;) {
+  // ...
+}
+
+describe(function(){
+  // ...
+});
+
+class Foo {
+  constructor(){}
+}
+```
+
+The following patterns are considered problems when configured `{ "functions": "always", "keywords": "never" }`:
+
+```js
+/*eslint space-before-blocks: [2, { "functions": "always", "keywords": "never" }]*/
+
+function a(){}      /*error Missing space before opening brace.*/
+
+try {} catch(a) {}  /*error Unexpected space before opening brace.*/
+
+class Foo {         /*error Unexpected space before opening brace.*/
+  constructor(){}   /*error Missing space before opening brace.*/
+}
+```
+
+
+The following patterns are not considered problems when configured `{ "functions": "always", "keywords": "never" }`:
+
+```js
+/*eslint space-before-blocks: [2, { "functions": "always", "keywords": "never" }]*/
+
+if (a){
+  b();
+}
+
+var a = function() {}
+
+class Foo{
+  constructor() {}
+}
 ```
 
 ## When Not To Use It

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -13,8 +13,18 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var requireSpace = context.options[0] !== "never",
-        sourceCode = context.getSourceCode();
+    var config = context.options[0],
+        sourceCode = context.getSourceCode(),
+        checkFunctions = true,
+        checkKeywords = true;
+
+    if (typeof config === "object") {
+        checkFunctions = config.functions !== "never";
+        checkKeywords = config.keywords !== "never";
+    } else if (config === "never") {
+        checkFunctions = false;
+        checkKeywords = false;
+    }
 
     /**
      * Checks whether or not a given token is an arrow operator (=>).
@@ -33,10 +43,18 @@ module.exports = function(context) {
      */
     function checkPrecedingSpace(node) {
         var precedingToken = context.getTokenBefore(node),
-            hasSpace;
+            hasSpace,
+            parent,
+            requireSpace;
 
         if (precedingToken && !isArrow(precedingToken) && astUtils.isTokenOnSameLine(precedingToken, node)) {
             hasSpace = sourceCode.isSpaceBetweenTokens(precedingToken, node);
+            parent = context.getAncestors().pop();
+            if (parent.type === "FunctionExpression" || parent.type === "FunctionDeclaration") {
+                requireSpace = checkFunctions;
+            } else {
+                requireSpace = checkKeywords;
+            }
 
             if (requireSpace) {
                 if (!hasSpace) {
@@ -92,6 +110,22 @@ module.exports = function(context) {
 
 module.exports.schema = [
     {
-        "enum": ["always", "never"]
+        "oneOf": [
+            {
+                "enum": ["always", "never"]
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "keywords": {
+                        "enum": ["always", "never"]
+                    },
+                    "functions": {
+                        "enum": ["always", "never"]
+                    }
+                },
+                "additionalProperties": false
+            }
+        ]
     }
 ];

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -19,8 +19,11 @@ var rule = require("../../../lib/rules/space-before-blocks"),
 
 var ruleTester = new RuleTester(),
     neverArgs = ["never"],
+    functionsOnlyArgs = [ { functions: "always", keywords: "never" } ],
+    keywordOnlyArgs = [ { functions: "never", keywords: "always" } ],
     expectedSpacingErrorMessage = "Missing space before opening brace.",
     expectedSpacingError = { message: expectedSpacingErrorMessage },
+    expectedNoSpacingErrorMessage = "Unexpected space before opening brace.",
     expectedNoSpacingError = { message: "Unexpected space before opening brace."};
 
 ruleTester.run("space-before-blocks", rule, {
@@ -28,23 +31,100 @@ ruleTester.run("space-before-blocks", rule, {
         { code: "if(a) {}" },
         { code: "if(a)  {}" },
         { code: "if(a){}", options: neverArgs },
+        { code: "if(a){}", options: functionsOnlyArgs },
+        { code: "if(a) {}", options: keywordOnlyArgs },
+        { code: "if(a){ function b() {} }", options: functionsOnlyArgs },
+        { code: "if(a) { function b(){} }", options: keywordOnlyArgs },
         { code: "if(a)\n{}" },
         { code: "if(a)\n{}", options: neverArgs },
         { code: "if(a) {}else {}" },
         { code: "if(a){}else{}", options: neverArgs },
+        { code: "if(a){}else{}", options: functionsOnlyArgs },
+        { code: "if(a) {} else {}", options: keywordOnlyArgs },
+        { code: "if(a){ function b() {} }else{}", options: functionsOnlyArgs },
+        { code: "if(a) { function b(){} } else {}", options: keywordOnlyArgs },
         { code: "function a() {}" },
         { code: "function a(){}", options: neverArgs },
+        {
+            code: "export default class{}",
+            options: functionsOnlyArgs,
+            ecmaFeatures: { modules: true, classes: true }
+        },
+        {
+            code: "export default class {}",
+            options: keywordOnlyArgs,
+            ecmaFeatures: { modules: true, classes: true }
+        },
+        {
+            code: "export default function a() {}",
+            options: functionsOnlyArgs,
+            ecmaFeatures: { modules: true }
+        },
+        {
+            code: "export default function a(){}",
+            options: keywordOnlyArgs,
+            ecmaFeatures: { modules: true }
+        },
+        { code: "export function a(){}", options: keywordOnlyArgs, ecmaFeatures: {modules: true} },
+        { code: "export function a() {}", options: functionsOnlyArgs, ecmaFeatures: {modules: true} },
+        { code: "function a(){}", options: keywordOnlyArgs },
+        { code: "function a() {}", options: functionsOnlyArgs },
+        { code: "function a(){ if(b) {} }", options: keywordOnlyArgs },
+        { code: "function a() { if(b){} }", options: functionsOnlyArgs },
         { code: "switch(a.b(c < d)) { case 'foo': foo(); break; default: if (a) { bar(); } }" },
         { code: "switch(a) { }" },
         { code: "switch(a)  {}" },
         { code: "switch(a.b(c < d)){ case 'foo': foo(); break; default: if (a){ bar(); } }", options: neverArgs },
+        { code: "switch(a.b(c < d)){ case 'foo': foo(); break; default: if (a){ bar(); } }", options: functionsOnlyArgs },
         { code: "switch(a){}", options: neverArgs },
+        { code: "switch(a){}", options: functionsOnlyArgs },
+        { code: "switch(a) {}", options: keywordOnlyArgs },
         { code: "try {}catch(a) {}" },
         { code: "try{}catch(a){}", options: neverArgs },
+        { code: "try{}catch(a){}", options: functionsOnlyArgs },
+        { code: "try {} catch(a) {}", options: keywordOnlyArgs },
+        { code: "try{ function b() {} }catch(a){}", options: functionsOnlyArgs },
+        { code: "try { function b(){} } catch(a) {}", options: keywordOnlyArgs },
         { code: "for(;;) {}" },
         { code: "for(;;){}", options: neverArgs },
+        { code: "for(;;){}", options: functionsOnlyArgs },
+        { code: "for(;;) {}", options: keywordOnlyArgs },
+        { code: "for(;;){ function a() {} }", options: functionsOnlyArgs },
+        { code: "for(;;) { function a(){} }", options: keywordOnlyArgs },
         { code: "while(a) {}" },
         { code: "while(a){}", options: neverArgs },
+        { code: "while(a){}", options: functionsOnlyArgs },
+        { code: "while(a) {}", options: keywordOnlyArgs },
+        { code: "while(a){ function b() {} }", options: functionsOnlyArgs },
+        { code: "while(a) { function b(){} }", options: keywordOnlyArgs },
+        {
+            code: "class test { constructor(){} }",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            }
+        },
+        {
+            code: "class test{ constructor() {} }",
+            options: functionsOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            }
+        },
+        {
+            code: "class test {}",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            }
+        },
+        {
+            code: "class test{}",
+            options: functionsOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            }
+        },
         {
             code: "class test{}",
             options: neverArgs,
@@ -68,6 +148,30 @@ ruleTester.run("space-before-blocks", rule, {
             code: "if(a){}",
             errors: [ { message: expectedSpacingErrorMessage, line: 1, column: 6 } ],
             output: "if(a) {}"
+        },
+        {
+            code: "if(a){}",
+            options: keywordOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "if(a) {}"
+        },
+        {
+            code: "if(a) {}",
+            options: functionsOnlyArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "if(a){}"
+        },
+        {
+            code: "if(a) { function a() {} }",
+            options: functionsOnlyArgs,
+            errors: [ { message: expectedNoSpacingErrorMessage, line: 1, column: 7 } ],
+            output: "if(a){ function a() {} }"
+        },
+        {
+            code: "if(a) { function a() {} }",
+            options: keywordOnlyArgs,
+            errors: [ { message: expectedNoSpacingErrorMessage, line: 1, column: 22 } ],
+            output: "if(a) { function a(){} }"
         },
         {
             code: "if(a) {}",
@@ -104,6 +208,30 @@ ruleTester.run("space-before-blocks", rule, {
             output: "function a(){}"
         },
         {
+            code: "function a(){ if (a){} }",
+            options: functionsOnlyArgs,
+            errors: [ { message: expectedSpacingErrorMessage, line: 1, column: 13 } ],
+            output: "function a() { if (a){} }"
+        },
+        {
+            code: "function a() { if (a) {} }",
+            options: keywordOnlyArgs,
+            errors: [ { message: expectedNoSpacingErrorMessage, line: 1, column: 14 } ],
+            output: "function a(){ if (a) {} }"
+        },
+        {
+            code: "function a(){}",
+            options: functionsOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "function a() {}"
+        },
+        {
+            code: "function a() {}",
+            options: keywordOnlyArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "function a(){}"
+        },
+        {
             code: "switch(a){}",
             errors: [ expectedSpacingError ],
             output: "switch(a) {}"
@@ -111,6 +239,18 @@ ruleTester.run("space-before-blocks", rule, {
         {
             code: "switch(a) {}",
             options: neverArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "switch(a){}"
+        },
+        {
+            code: "switch(a){}",
+            options: keywordOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "switch(a) {}"
+        },
+        {
+            code: "switch(a) {}",
+            options: functionsOnlyArgs,
             errors: [ expectedNoSpacingError ],
             output: "switch(a){}"
         },
@@ -137,6 +277,30 @@ ruleTester.run("space-before-blocks", rule, {
             output: "try{}catch(a){}"
         },
         {
+            code: "try {}catch(a){}",
+            options: functionsOnlyArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "try{}catch(a){}"
+        },
+        {
+            code: "try {} catch(a){}",
+            options: keywordOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "try {} catch(a) {}"
+        },
+        {
+            code: "try { function b() {} } catch(a) {}",
+            options: keywordOnlyArgs,
+            errors: [ { message: expectedNoSpacingErrorMessage, line: 1, column: 20 } ],
+            output: "try { function b(){} } catch(a) {}"
+        },
+        {
+            code: "try{ function b(){} }catch(a){}",
+            options: functionsOnlyArgs,
+            errors: [ { message: expectedSpacingErrorMessage, line: 1, column: 18 } ],
+            output: "try{ function b() {} }catch(a){}"
+        },
+        {
             code: "for(;;){}",
             errors: [ expectedSpacingError ],
             output: "for(;;) {}"
@@ -146,6 +310,30 @@ ruleTester.run("space-before-blocks", rule, {
             options: neverArgs,
             errors: [ expectedNoSpacingError ],
             output: "for(;;){}"
+        },
+        {
+            code: "for(;;){}",
+            options: keywordOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "for(;;) {}"
+        },
+        {
+            code: "for(;;) {}",
+            options: functionsOnlyArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "for(;;){}"
+        },
+        {
+            code: "for(;;){ function a(){} }",
+            options: functionsOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "for(;;){ function a() {} }"
+        },
+        {
+            code: "for(;;) { function a() {} }",
+            options: keywordOnlyArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "for(;;) { function a(){} }"
         },
         {
             code: "while(a){}",
@@ -159,12 +347,127 @@ ruleTester.run("space-before-blocks", rule, {
             output: "while(a){}"
         },
         {
+            code: "while(a){}",
+            options: keywordOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "while(a) {}"
+        },
+        {
+            code: "while(a) {}",
+            options: functionsOnlyArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "while(a){}"
+        },
+        {
+            code: "while(a){ function a(){} }",
+            options: functionsOnlyArgs,
+            errors: [ expectedSpacingError ],
+            output: "while(a){ function a() {} }"
+        },
+        {
+            code: "while(a) { function a() {} }",
+            options: keywordOnlyArgs,
+            errors: [ expectedNoSpacingError ],
+            output: "while(a) { function a(){} }"
+        },
+        {
+            code: "export function a() { if(b) {} }",
+            options: functionsOnlyArgs,
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [ expectedNoSpacingError ],
+            output: "export function a() { if(b){} }"
+        },
+        {
+            code: "export function a(){ if(b){} }",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [ expectedSpacingError ],
+            output: "export function a(){ if(b) {} }"
+        },
+        {
+            code: "export function a(){}",
+            options: functionsOnlyArgs,
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [ expectedSpacingError ],
+            output: "export function a() {}"
+        },
+        {
+            code: "export default function (a) {}",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [ expectedNoSpacingError ],
+            output: "export default function (a){}"
+        },
+        {
+            code: "export function a() {}",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                modules: true
+            },
+            errors: [ expectedNoSpacingError ],
+            output: "export function a(){}"
+        },
+        {
+            code: "export default class{}",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                modules: true,
+                classes: true
+            },
+            errors: [ expectedSpacingError ],
+            output: "export default class {}"
+        },
+        {
             code: "class test{}",
             ecmaFeatures: {
                 classes: true
             },
             errors: [ expectedSpacingError ],
             output: "class test {}"
+        },
+        {
+            code: "class test{}",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            },
+            errors: [ expectedSpacingError ],
+            output: "class test {}"
+        },
+        {
+            code: "class test{ constructor(){} }",
+            options: functionsOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            },
+            errors: [ expectedSpacingError ],
+            output: "class test{ constructor() {} }"
+        },
+        {
+            code: "class test { constructor() {} }",
+            options: keywordOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            },
+            errors: [ expectedNoSpacingError ],
+            output: "class test { constructor(){} }"
+        },
+        {
+            code: "class test {}",
+            options: functionsOnlyArgs,
+            ecmaFeatures: {
+                classes: true
+            },
+            errors: [ expectedNoSpacingError ],
+            output: "class test{}"
         },
         {
             code: "class test {}",


### PR DESCRIPTION
Add an optional configuration for `space-before-blocks` that allows the user to distinguish between a function's block and a keyword's block.
address #3758 

my local tests are suffering from #3778 but were otherwise fine.

changes i made:
 - added branching logic to be able to detect if the block came from a function. this is accomplished by checking the type of the node's parent. after identification, the requirement for 'if a space is needed' is assigned based on the appropriate config option. 
 - Backwards compatibility is supported: the user can enter both `always`/`never` to apply the check to both cases, or the newly added configuration object to apply the check to one or the other.
 - added explanation in the docs with examples
 - boatloads of tests to check nearly every path the user could take

changes i didnt make:
- didnt make any jsdoc changes. was unsure if they were necessary
- sweeping / breaking changes. i tried to keep the existing code in tact as much as possible, and largely used the update to `space-before-function-paren` as a guide on implementing this change

as always, im open to feedback, editing, suggestions etc.
looking forward to your response!