### PR TITLE
Fix: invalidate cache when config changes. (fixes #3770)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -32,7 +32,10 @@ var fs = require("fs"),
     util = require("./util"),
     fileEntryCache = require("file-entry-cache"),
     SourceCodeFixer = require("./util/source-code-fixer"),
-    validator = require("./config-validator");
+    validator = require("./config-validator"),
+
+    crypto = require( "crypto" ),
+    pkg = require("../package.json");
 
 var DEFAULT_PARSER = require("../conf/eslint.json").parser;
 
@@ -496,7 +499,8 @@ CLIEngine.prototype = {
             ignoredPathsList = ignoredPaths.patterns || [],
             globOptions,
             stats,
-            startTime;
+            startTime,
+            prevConfig; // the previous configuration used
 
         startTime = Date.now();
         patterns = this.resolveFileGlobPatterns(patterns);
@@ -505,6 +509,44 @@ CLIEngine.prototype = {
             nodir: true,
             ignore: ignoredPathsList
         };
+
+        /**
+         * create a md5Hash of a given string
+         * @param  {string} str the string to calculate the hash for
+         * @returns {string}    the calculated hash
+         */
+        function md5Hash(str) {
+            return crypto
+                .createHash("md5")
+                .update(str)
+                .digest("hex");
+        }
+
+        /**
+         * Calculates the hash of the config file used to validate a given file
+         * @param  {string} filename The path of the file to retrieve a config object for to calculate the hash
+         * @returns {string}         the hash of the config
+         */
+        function hashOfConfigFor(filename) {
+            var config = configHelper.getConfig(filename);
+
+            if (!prevConfig) {
+                prevConfig = {};
+            }
+
+            // reuse the previously hashed config if the config hasn't changed
+            if (prevConfig.config !== config) {
+                // config changed so we need to calculate the hash of the config
+                // and the hash of the plugins being used
+                prevConfig.config = config;
+
+                var eslintVersion = pkg.version;
+
+                prevConfig.hash = md5Hash(eslintVersion + "_" + JSON.stringify(config));
+            }
+
+            return prevConfig.hash;
+        }
 
         /**
          * Executes the linter on a file defined by the `filename`. Skips
@@ -520,12 +562,19 @@ CLIEngine.prototype = {
                 return;
             }
 
+            var hashOfConfig;
+
             if (options.cache) {
                 // get the descriptor for this file
                 // with the metadata and the flag that determines if
                 // the file has changed
                 var descriptor = fileCache.getFileDescriptor(filename);
-                if (!descriptor.changed) {
+                var meta = descriptor.meta || {};
+
+                hashOfConfig = hashOfConfigFor(filename);
+
+                var changed = descriptor.changed || meta.hashOfConfig !== hashOfConfig;
+                if (!changed) {
                     debug("Skipping file since hasn't changed: " + filename);
 
                     // Adding the filename to the processed hashmap
@@ -562,6 +611,7 @@ CLIEngine.prototype = {
                     // since the file passed we store the result here
                     // TODO: check this as we might not need to store the
                     // successful runs as it will always should be 0 error 0 warnings
+                    descriptor.meta.hashOfConfig = hashOfConfig;
                     descriptor.meta.results = res;
                 }
             }


### PR DESCRIPTION
cache will be skipped if 

- config changed
- plugins version changed

