### PR TITLE
Fix: `space-before-blocks` had conflicted `arrow-spacing`

### DIFF
--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -11,6 +11,8 @@ Having an inconsistent style distracts the reader from seeing the important part
 
 This rule will enforce consistency of spacing before blocks. It is only applied on blocks that don’t begin on a new line.
 
+This rule ignores spacing which is between `=>` and a block. The spacing is handled by the `arrow-spacing` rule.
+
 This rule takes one argument. If it is `"always"` then blocks must always have at least one preceding space. If `"never"`
 then all blocks should never have any preceding space. The default is `"always"`.
 
@@ -99,4 +101,5 @@ You can turn this rule off if you are not concerned with the consistency of spac
 ## Related Rules
 
 * [space-after-keywords](space-after-keywords.md)
+* [arrow-spacing](arrow-spacing.md)
 * [brace-style](brace-style.md)

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -16,6 +16,16 @@ module.exports = function(context) {
     var requireSpace = context.options[0] !== "never";
 
     /**
+     * Checks whether or not a given token is an arrow operator (=>).
+     *
+     * @param {Token} token - A token to check.
+     * @returns {boolean} `true` if the token is an arrow operator.
+     */
+    function isArrow(token) {
+        return token.type === "Punctuator" && token.value === "=>";
+    }
+
+    /**
      * Checks the given BlockStatement node has a preceding space if it doesn’t start on a new line.
      * @param {ASTNode|Token} node The AST node of a BlockStatement.
      * @returns {void} undefined.
@@ -24,7 +34,7 @@ module.exports = function(context) {
         var precedingToken = context.getTokenBefore(node),
             hasSpace;
 
-        if (precedingToken && astUtils.isTokenOnSameLine(precedingToken, node)) {
+        if (precedingToken && !isArrow(precedingToken) && astUtils.isTokenOnSameLine(precedingToken, node)) {
             hasSpace = astUtils.isTokenSpaced(precedingToken, node);
 
             if (requireSpace) {

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -57,7 +57,11 @@ ruleTester.run("space-before-blocks", rule, {
             ecmaFeatures: {
                 classes: true
             }
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/3769
+        {code: "()=>{};", options: ["always"], ecmaFeatures: {arrowFunctions: true}},
+        {code: "() => {};", options: ["never"], ecmaFeatures: {arrowFunctions: true}}
     ],
     invalid: [
         {


### PR DESCRIPTION
Fixes #3769.
I made `space-before-blocks` ignoring spacing which is between `=>` and `{`.

I don't address #1338 in this PR.
I thought it can resolve #1338 that to ignore spacing merely if the previous token is a keyword.
But `class` keywords are not handled by `space-after-keywords`, so we need think about a ClassExpression `var Foo = class{ };`.

BTW, 72 is too short to include two rule names...