### PR TITLE
	Update: no-underscore-dangle allows dangle after `this` (fixes #3435)

### DIFF
--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -33,9 +33,9 @@ var _ = require('underscore');
 var obj = _.contains(items, item);
 obj.__proto__ = {};
 var file = __filename;
+this._bar();
 ```
 
 ## When Not To Use It
 
 If you want to allow dangling underscores in identifiers, then you can safely turn this rule off.
-

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -86,9 +86,10 @@ module.exports = function(context) {
      * @private
      */
     function checkForTrailingUnderscoreInMemberExpression(node) {
-        var identifier = node.property.name;
+        var identifier = node.property.name,
+            isMemberOfThis = node.object.type === "ThisExpression";
 
-        if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) &&
+        if (typeof identifier !== "undefined" && !isMemberOfThis && hasTrailingUnderscore(identifier) &&
             !isSpecialCaseIdentifierForMemberExpression(identifier)) {
             context.report(node, "Unexpected dangling \"_\" in \"" + identifier + "\".");
         }

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -25,6 +25,7 @@ ruleTester.run("no-underscore-dangle", rule, {
         "console.log(__filename); console.log(__dirname);",
         "var _ = require('underscore');",
         "var a = b._;",
+        "this._bar;",
         { code: "export default function() {}", ecmaFeatures: { modules: true }}
     ],
     invalid: [


### PR DESCRIPTION
Now it is possble to specify kinds disallowed underscore: leading or trailing. Added optional excection for this keyword
fixes #3435 