### PR TITLE
New: Add --debug flag to CLI (fixes #2692)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -1,11 +1,40 @@
 #!/usr/bin/env node
+
+/**
+ * @fileoverview Main CLI that is run via the eslint command.
+ * @author Nicholas C. Zakas
+ * @copyright 2013 Nicholas C. Zakas. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var exitCode = 0,
+    useStdIn = (process.argv.indexOf("--stdin") > -1),
+    init = (process.argv.indexOf("--init") > -1),
+    debug = (process.argv.indexOf("--debug") > -1);
+
+// must do this initialization *before* other requires in order to work
+if (debug) {
+    require("debug").enable("eslint:*");
+}
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+// now we can safely include the other modules that use debug
 var concat = require("concat-stream"),
     configInit = require("../lib/config-initializer"),
     cli = require("../lib/cli");
 
-var exitCode = 0,
-    useStdIn = (process.argv.indexOf("--stdin") > -1),
-    init = (process.argv.indexOf("--init") > -1);
+//------------------------------------------------------------------------------
+// Execution
+//------------------------------------------------------------------------------
 
 if (useStdIn) {
     process.stdin.pipe(concat({ encoding: "string" }, function(text) {

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -24,49 +24,50 @@ The command line utility has several options. You can view the options by runnin
 
 ```text
 Basic configuration:
-  -c, --config path::String   Use configuration from this file or shareable
-                              config
-  --no-eslintrc               Disable use of configuration from .eslintrc
-  --env [String]              Specify environments
-  --ext [String]              Specify JavaScript file extensions - default: .js
-  --global [String]           Define global variables
-  --parser String             Specify the parser to be used - default: espree
+  -c, --config path::String  Use configuration from this file or shareable
+                             config
+  --no-eslintrc              Disable use of configuration from .eslintrc
+  --env [String]             Specify environments
+  --ext [String]             Specify JavaScript file extensions - default: .js
+  --global [String]          Define global variables
+  --parser String            Specify the parser to be used - default: espree
 
 Caching:
-  --cache                     Only check changed files - default: false
-  --cache-file String         Path to the cache file - default: .eslintcache
+  --cache                    Only check changed files - default: false
+  --cache-file String        Path to the cache file - default: .eslintcache
 
 Specifying rules and plugins:
-  --rulesdir [path::String]   Use additional rules from this directory
-  --plugin [String]           Specify plugins
-  --rule Object               Specify rules
+  --rulesdir [path::String]  Use additional rules from this directory
+  --plugin [String]          Specify plugins
+  --rule Object              Specify rules
 
 Ignoring files:
   --ignore-path path::String  Specify path of ignore file
-  --no-ignore                 Disable use of .eslintignore
-  --ignore-pattern String     Pattern of files to ignore (in addition to those
-                              in .eslintignore)
+  --no-ignore                Disable use of .eslintignore
+  --ignore-pattern String    Pattern of files to ignore (in addition to those
+                             in .eslintignore)
 
 Using stdin:
-  --stdin                     Lint code provided on <STDIN> - default: false
-  --stdin-filename String     Specify filename to process STDIN as
+  --stdin                    Lint code provided on <STDIN> - default: false
+  --stdin-filename String    Specify filename to process STDIN as
 
 Handling warnings:
-  --quiet                     Report errors only - default: false
-  --max-warnings Number       Number of warnings to trigger nonzero exit code
-                              - default: -1
+  --quiet                    Report errors only - default: false
+  --max-warnings Number      Number of warnings to trigger nonzero exit code -
+                             default: -1
 
 Output:
   -o, --output-file path::String  Specify file to write report to
-  -f, --format String         Use a specific output format - default: stylish
-  --no-color                  Disable color in piped output
+  -f, --format String        Use a specific output format - default: stylish
+  --no-color                 Disable color in piped output
 
 Miscellaneous:
-  --init                      Run config initialization wizard - default: false
-  --fix                       Automatically fix problems
-  -h, --help                  Show help
-  -v, --version               Outputs the version number
-```
+  --init                     Run config initialization wizard - default: false
+  --fix                      Automatically fix problems
+  --debug                    Output debugging information
+  -h, --help                 Show help
+  -v, --version              Outputs the version number
+  ```
 
 ### Basic configuration
 
@@ -287,6 +288,10 @@ This option instructs ESLint to try to fix as many issues as possible. The fixes
 
 1. This option throws an error when code is piped to ESLint.
 1. This option has no effect on code that uses processors.
+
+#### `--debug`
+
+This option outputs debugging information to the console. This information is useful when you're seeing a problem and having a hard time pinpointing it. The ESLint team may ask for this debugging information to help solve bugs.
 
 #### `-h`, `--help`
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Options configuration for optionator.
  * @author George Zahariev
+ * See LICENSE in root directory for full license.
  */
 "use strict";
 
@@ -174,6 +175,12 @@ module.exports = optionator({
             type: "Boolean",
             default: false,
             description: "Automatically fix problems"
+        },
+        {
+            option: "debug",
+            type: "Boolean",
+            default: false,
+            description: "Output debugging information"
         },
         {
             option: "help",

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Tests for options.
  * @author George Zahariev
+ * See LICENSE in root directory for full license.
  */
 
 "use strict";
@@ -253,6 +254,13 @@ describe("options", function() {
         it("should return true for --fix when passed", function() {
             var currentOptions = options.parse("--fix");
             assert.isTrue(currentOptions.fix);
+        });
+    });
+
+    describe("--debug", function() {
+        it("should return true for --debug when passed", function() {
+            var currentOptions = options.parse("--debug");
+            assert.isTrue(currentOptions.debug);
         });
     });
 


### PR DESCRIPTION
Works the same as `DEBUG=eslint:*` without the funky syntax.