### PR TITLE
Fix: env-specified ecmaFeatures had been wrong

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -70,6 +70,44 @@ function isObject(item) {
 }
 
 /**
+ * Creates an environment config based on the specified environments.
+ * @param {Object<string,boolean>} envs The environment settings.
+ * @returns {Object} A configuration object with the appropriate rules and globals
+ *      set.
+ * @private
+ */
+function createEnvironmentConfig(envs) {
+
+    var envConfig = {
+        globals: {},
+        env: envs || {},
+        rules: {},
+        ecmaFeatures: {}
+    };
+
+    if (envs) {
+        Object.keys(envs).filter(function(name) {
+            return envs[name];
+        }).forEach(function(name) {
+            var environment = environments[name];
+
+            if (environment) {
+
+                if (environment.globals) {
+                    assign(envConfig.globals, environment.globals);
+                }
+
+                if (environment.ecmaFeatures) {
+                    assign(envConfig.ecmaFeatures, environment.ecmaFeatures);
+                }
+            }
+        });
+    }
+
+    return envConfig;
+}
+
+/**
  * Read the config from the config JSON file
  * @param {string} filePath the path to the JSON config file
  * @returns {Object} config object
@@ -175,6 +213,10 @@ function loadConfig(configToLoad) {
 
         }
 
+        if (config.env) {
+            // Merge in environment-specific globals and ecmaFeatures.
+            config = util.mergeConfigs(createEnvironmentConfig(config.env), config);
+        }
 
     }
 
@@ -291,44 +333,6 @@ function getLocalConfig(thisConfig, directory) {
     return found ? config : util.mergeConfigs(config, getPersonalConfig());
 }
 
-/**
- * Creates an environment config based on the specified environments.
- * @param {Object<string,boolean>} envs The environment settings.
- * @returns {Object} A configuration object with the appropriate rules and globals
- *      set.
- * @private
- */
-function createEnvironmentConfig(envs) {
-
-    var envConfig = {
-        globals: {},
-        env: envs || {},
-        rules: {},
-        ecmaFeatures: {}
-    };
-
-    if (envs) {
-        Object.keys(envs).filter(function(name) {
-            return envs[name];
-        }).forEach(function(name) {
-            var environment = environments[name];
-
-            if (environment) {
-
-                if (environment.globals) {
-                    assign(envConfig.globals, environment.globals);
-                }
-
-                if (environment.ecmaFeatures) {
-                    assign(envConfig.ecmaFeatures, environment.ecmaFeatures);
-                }
-            }
-        });
-    }
-
-    return envConfig;
-}
-
 //------------------------------------------------------------------------------
 // API
 //------------------------------------------------------------------------------
@@ -412,44 +416,37 @@ Config.prototype.getConfig = function(filePath) {
     // Step 2: Create a copy of the baseConfig
     config = util.mergeConfigs({parser: this.parser}, this.baseConfig);
 
-    // Step 3: Merge in environment-specific globals and rules from .eslintrc files
-    config = util.mergeConfigs(config, createEnvironmentConfig(userConfig.env));
-
-    // Step 4: Merge in the user-specified configuration from .eslintrc and package.json
+    // Step 3: Merge in the user-specified configuration from .eslintrc and package.json
     config = util.mergeConfigs(config, userConfig);
 
-    // Step 5: Merge in command line config file
+    // Step 4: Merge in command line config file
     if (this.useSpecificConfig) {
         debug("Merging command line config file");
-
-        if (this.useSpecificConfig.env) {
-            config = util.mergeConfigs(config, createEnvironmentConfig(this.useSpecificConfig.env));
-        }
 
         config = util.mergeConfigs(config, this.useSpecificConfig);
     }
 
-    // Step 6: Merge in command line environments
+    // Step 5: Merge in command line environments
     debug("Merging command line environment settings");
     config = util.mergeConfigs(config, createEnvironmentConfig(this.env));
 
-    // Step 7: Merge in command line rules
+    // Step 6: Merge in command line rules
     if (this.options.rules) {
         debug("Merging command line rules");
         config = util.mergeConfigs(config, { rules: this.options.rules });
     }
 
-    // Step 8: Merge in command line globals
+    // Step 7: Merge in command line globals
     config = util.mergeConfigs(config, { globals: this.globals });
 
-    // Step 9: Merge in command line plugins
+    // Step 8: Merge in command line plugins
     if (this.options.plugins) {
         debug("Merging command line plugins");
         pluginConfig = getPluginsConfig(this.options.plugins);
         config = util.mergeConfigs(config, { plugins: this.options.plugins });
     }
 
-    // Step 10: Merge in plugin specific rules in reverse
+    // Step 9: Merge in plugin specific rules in reverse
     if (config.plugins) {
         pluginConfig = getPluginsConfig(config.plugins);
         config = util.mergeConfigs(pluginConfig, config);

--- a/tests/fixtures/config-hierarchy/overwrite-ecmaFeatures/.eslintrc
+++ b/tests/fixtures/config-hierarchy/overwrite-ecmaFeatures/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "ecmaFeatures": {
+        "globalReturn": false
+    }
+}

--- a/tests/fixtures/config-hierarchy/overwrite-ecmaFeatures/child/.eslintrc
+++ b/tests/fixtures/config-hierarchy/overwrite-ecmaFeatures/child/.eslintrc
@@ -1,0 +1,5 @@
+{
+    "env": {
+        "commonjs": true
+    }
+}

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -35,6 +35,10 @@ function assertConfigsEqual(actual, expected) {
         assert.deepEqual(actual.env, expected.env);
     }
 
+    if (actual.ecmaFeatures && expected.ecmaFeatures) {
+        assert.deepEqual(actual.ecmaFeatures, expected.ecmaFeatures);
+    }
+
     if (actual.globals && expected.globals) {
         assert.deepEqual(actual.globals, expected.globals);
     }
@@ -1106,6 +1110,21 @@ describe("Config", function() {
                 var expected = configHelper.getConfig(file2);
 
                 assert(!("quotes" in expected.rules), "shared config should not be clobbered");
+            });
+        });
+
+        describe("with env in a child configuration file", function() {
+            it("should overwrite ecmaFeatures of the parent with env of the child", function() {
+                var config = new Config();
+                var targetPath = getFixturePath("overwrite-ecmaFeatures", "child", "foo.js");
+                var expected = {
+                    rules: {},
+                    env: {commonjs: true},
+                    ecmaFeatures: {globalReturn: true}
+                };
+                var actual = config.getConfig(targetPath);
+
+                assertConfigsEqual(actual, expected);
             });
         });
     });


### PR DESCRIPTION
Fixes #3735.

env-specified globals and ecmaFeatures had been handled after all
hierarchy configs merged. So it could not overwrite the parent config
with child's env-specified configs correctly.

This PR moves the process for env-specified config to the `loadConfig`
function. As the result, it can handle child's env-specified configs in
the regular overwriting process.