### PR TITLE
Fix: space checking between tokens (fixes #2211)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -228,6 +228,7 @@ Once you have an instance of `SourceCode`, you can use the methods on it to work
 * `getLastToken(node)` - returns the last token representing the given node.
 * `getLastTokens(node, count)` - returns the last `count` tokens representing the given node.
 * `getNodeByRangeIndex(index)` - returns the deepest node in the AST containing the given source index.
+* `isSpaceBetweenTokens(first, second)` - returns true if there is a whitespace character between the two tokens.
 * `getText(node)` - returns the source code for the given node. Omit `node` to get the whole source.
 * `getTokenAfter(nodeOrToken)` - returns the first token after the given node or token.
 * `getTokenBefore(nodeOrToken)` - returns the first token before the given node or token.

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -38,17 +38,6 @@ function isModifyingReference(reference, index, references) {
 module.exports = {
 
     /**
-     * Determines whether two adjacent tokens are have whitespace between them.
-     * @param {Object} left - The left token object.
-     * @param {Object} right - The right token object.
-     * @returns {boolean} Whether or not there is space between the tokens.
-     * @public
-     */
-    isTokenSpaced: function(left, right) {
-        return left.range[1] < right.range[0];
-    },
-
-    /**
      * Determines whether two adjacent tokens are on the same line.
      * @param {Object} left - The left token object.
      * @param {Object} right - The right token object.

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -15,7 +15,8 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var spaced = context.options[0] === "always";
+    var spaced = context.options[0] === "always",
+        sourceCode = context.getSourceCode();
 
     /**
      * Determines whether an option is set, relative to the spacing option.
@@ -111,19 +112,19 @@ module.exports = function(context) {
                 ? !options.spaced : options.spaced;
 
         if (astUtils.isTokenOnSameLine(first, second)) {
-            if (openingBracketMustBeSpaced && !astUtils.isTokenSpaced(first, second)) {
+            if (openingBracketMustBeSpaced && !sourceCode.isSpaceBetweenTokens(first, second)) {
                 reportRequiredBeginningSpace(node, first);
             }
-            if (!openingBracketMustBeSpaced && astUtils.isTokenSpaced(first, second)) {
+            if (!openingBracketMustBeSpaced && sourceCode.isSpaceBetweenTokens(first, second)) {
                 reportNoBeginningSpace(node, first);
             }
         }
 
         if (astUtils.isTokenOnSameLine(penultimate, last)) {
-            if (closingBracketMustBeSpaced && !astUtils.isTokenSpaced(penultimate, last)) {
+            if (closingBracketMustBeSpaced && !sourceCode.isSpaceBetweenTokens(penultimate, last)) {
                 reportRequiredEndingSpace(node, last);
             }
-            if (!closingBracketMustBeSpaced && astUtils.isTokenSpaced(penultimate, last)) {
+            if (!closingBracketMustBeSpaced && sourceCode.isSpaceBetweenTokens(penultimate, last)) {
                 reportNoEndingSpace(node, last);
             }
         }

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -13,8 +13,9 @@ var util = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var always = (context.options[0] !== "never");
-    var message = always ? "Requires a space" : "Unexpected space(s)";
+    var always = (context.options[0] !== "never"),
+        message = always ? "Requires a space" : "Unexpected space(s)",
+        sourceCode = context.getSourceCode();
 
     /**
      * Gets the open brace token from a given node.
@@ -45,7 +46,7 @@ module.exports = function(context) {
     function isValid(left, right) {
         return (
             !util.isTokenOnSameLine(left, right) ||
-            util.isTokenSpaced(left, right) === always
+            sourceCode.isSpaceBetweenTokens(left, right) === always
         );
     }
 

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -13,6 +13,8 @@ var astUtils = require("../ast-utils");
 
 module.exports = function(context) {
 
+    var sourceCode = context.getSourceCode();
+
     var options = {
         before: context.options[0] ? !!context.options[0].before : false,
         after: context.options[0] ? !!context.options[0].after : true
@@ -28,33 +30,6 @@ module.exports = function(context) {
 
     // list of comma tokens to ignore for the check of leading whitespace
     var commaTokensToIgnore = [];
-
-    /**
-     * Determines the length of comment between 2 tokens
-     * @param {Object} left - The left token object.
-     * @param {Object} right - The right token object.
-     * @returns {number} Length of comment in between tokens
-     */
-    function getCommentLengthBetweenTokens(left, right) {
-        return allComments.reduce(function(val, comment) {
-            if (left.range[1] <= comment.range[0] && comment.range[1] <= right.range[0]) {
-                val = val + comment.range[1] - comment.range[0];
-            }
-            return val;
-        }, 0);
-    }
-
-    /**
-     * Determines whether two adjacent tokens have whitespace between them.
-     * @param {Object} left - The left token object.
-     * @param {Object} right - The right token object.
-     * @returns {boolean} Whether or not there is space between the tokens.
-     */
-    function isSpaced(left, right) {
-        var punctuationLength = context.getTokensBetween(left, right).length; // the length of any parenthesis
-        var commentLenth = getCommentLengthBetweenTokens(left, right);
-        return (left.range[1] + punctuationLength + commentLenth) < right.range[0];
-    }
 
     /**
      * Determines if a given token is a comma operator.
@@ -91,12 +66,12 @@ module.exports = function(context) {
      */
     function validateCommaItemSpacing(tokens, reportItem) {
         if (tokens.left && astUtils.isTokenOnSameLine(tokens.left, tokens.comma) &&
-                (options.before !== isSpaced(tokens.left, tokens.comma))
+                (options.before !== sourceCode.isSpaceBetweenTokens(tokens.left, tokens.comma))
         ) {
             report(reportItem, "before");
         }
         if (tokens.right && astUtils.isTokenOnSameLine(tokens.comma, tokens.right) &&
-                (options.after !== isSpaced(tokens.comma, tokens.right))
+                (options.after !== sourceCode.isSpaceBetweenTokens(tokens.comma, tokens.right))
         ) {
             report(reportItem, "after");
         }

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -12,6 +12,7 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var sourceCode = context.getSourceCode();
     var propertyNameMustBeSpaced = context.options[0] === "always"; // default is "never"
 
     //--------------------------------------------------------------------------
@@ -83,11 +84,11 @@ module.exports = function(context) {
 
             if (astUtils.isTokenOnSameLine(before, first)) {
                 if (propertyNameMustBeSpaced) {
-                    if (!astUtils.isTokenSpaced(before, first) && astUtils.isTokenOnSameLine(before, first)) {
+                    if (!sourceCode.isSpaceBetweenTokens(before, first) && astUtils.isTokenOnSameLine(before, first)) {
                         reportRequiredBeginningSpace(node, before);
                     }
                 } else {
-                    if (astUtils.isTokenSpaced(before, first)) {
+                    if (sourceCode.isSpaceBetweenTokens(before, first)) {
                         reportNoBeginningSpace(node, before);
                     }
                 }
@@ -95,11 +96,11 @@ module.exports = function(context) {
 
             if (astUtils.isTokenOnSameLine(last, after)) {
                 if (propertyNameMustBeSpaced) {
-                    if (!astUtils.isTokenSpaced(last, after) && astUtils.isTokenOnSameLine(last, after)) {
+                    if (!sourceCode.isSpaceBetweenTokens(last, after) && astUtils.isTokenOnSameLine(last, after)) {
                         reportRequiredEndingSpace(node, after);
                     }
                 } else {
-                    if (astUtils.isTokenSpaced(last, after)) {
+                    if (sourceCode.isSpaceBetweenTokens(last, after)) {
                         reportNoEndingSpace(node, after);
                     }
                 }

--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -11,6 +11,8 @@
 
 module.exports = function(context) {
 
+    var sourceCode = context.getSourceCode();
+
     /**
      * Check if open space is present in a function name
      * @param {ASTNode} node node to evaluate
@@ -18,17 +20,21 @@ module.exports = function(context) {
      * @private
      */
     function detectOpenSpaces(node) {
-        var lastCalleeToken = context.getLastToken(node.callee);
-        var tokens = context.getTokens(node);
-        var i = tokens.indexOf(lastCalleeToken), l = tokens.length;
+        var lastCalleeToken = sourceCode.getLastToken(node.callee),
+            tokens = sourceCode.getTokens(node),
+            i = tokens.indexOf(lastCalleeToken),
+            l = tokens.length;
+
         while (i < l && tokens[i].value !== "(") {
             ++i;
         }
+
         if (i >= l) {
             return;
         }
+
         // look for a space between the callee and the open paren
-        if (tokens[i - 1].range[1] !== tokens[i].range[0]) {
+        if (sourceCode.isSpaceBetweenTokens(tokens[i - 1], tokens[i])) {
             context.report({
                 node: node,
                 loc: lastCalleeToken.loc.start,

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -17,7 +17,8 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var spaced = context.options[0] === "always";
+    var spaced = context.options[0] === "always",
+        sourceCode = context.getSourceCode();
 
     /**
      * Determines whether an option is set, relative to the spacing option.
@@ -101,7 +102,7 @@ module.exports = function(context) {
             firstSpaced, lastSpaced;
 
         if (astUtils.isTokenOnSameLine(first, second)) {
-            firstSpaced = astUtils.isTokenSpaced(first, second);
+            firstSpaced = sourceCode.isSpaceBetweenTokens(first, second);
             if (options.spaced && !firstSpaced) {
                 reportRequiredBeginningSpace(node, first);
             }
@@ -111,7 +112,7 @@ module.exports = function(context) {
         }
 
         if (astUtils.isTokenOnSameLine(penultimate, last)) {
-            lastSpaced = astUtils.isTokenSpaced(penultimate, last);
+            lastSpaced = sourceCode.isSpaceBetweenTokens(penultimate, last);
             if (closingCurlyBraceMustBeSpaced && !lastSpaced) {
                 reportRequiredEndingSpace(node, last);
             }
@@ -131,8 +132,7 @@ module.exports = function(context) {
             return;
         }
 
-        var sourceCode = context.getSourceCode(),
-            first = sourceCode.getFirstToken(node),
+        var first = sourceCode.getFirstToken(node),
             last = sourceCode.getLastToken(node),
             second = sourceCode.getTokenAfter(first),
             penultimate = sourceCode.getTokenBefore(last);
@@ -150,8 +150,7 @@ module.exports = function(context) {
             return;
         }
 
-        var sourceCode = context.getSourceCode(),
-            firstSpecifier = node.specifiers[0],
+        var firstSpecifier = node.specifiers[0],
             lastSpecifier = node.specifiers[node.specifiers.length - 1];
 
         if (lastSpecifier.type !== "ImportSpecifier") {
@@ -185,8 +184,7 @@ module.exports = function(context) {
             return;
         }
 
-        var sourceCode = context.getSourceCode(),
-            firstSpecifier = node.specifiers[0],
+        var firstSpecifier = node.specifiers[0],
             lastSpecifier = node.specifiers[node.specifiers.length - 1],
             first = sourceCode.getTokenBefore(firstSpecifier),
             last = sourceCode.getTokenAfter(lastSpecifier);

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -16,7 +16,8 @@ module.exports = function(context) {
 
     var config = context.options[0],
         requireSpaceBefore = false,
-        requireSpaceAfter = true;
+        requireSpaceAfter = true,
+        sourceCode = context.getSourceCode();
 
     if (typeof config === "object") {
         if (config.hasOwnProperty("before")) {
@@ -34,7 +35,7 @@ module.exports = function(context) {
      */
     function hasLeadingSpace(token) {
         var tokenBefore = context.getTokenBefore(token);
-        return tokenBefore && astUtils.isTokenOnSameLine(tokenBefore, token) && astUtils.isTokenSpaced(tokenBefore, token);
+        return tokenBefore && astUtils.isTokenOnSameLine(tokenBefore, token) && sourceCode.isSpaceBetweenTokens(tokenBefore, token);
     }
 
     /**
@@ -44,7 +45,7 @@ module.exports = function(context) {
      */
     function hasTrailingSpace(token) {
         var tokenAfter = context.getTokenAfter(token);
-        return tokenAfter && astUtils.isTokenOnSameLine(token, tokenAfter) && astUtils.isTokenSpaced(token, tokenAfter);
+        return tokenAfter && astUtils.isTokenOnSameLine(token, tokenAfter) && sourceCode.isSpaceBetweenTokens(token, tokenAfter);
     }
 
     /**

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -13,7 +13,8 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var requireSpace = context.options[0] !== "never";
+    var requireSpace = context.options[0] !== "never",
+        sourceCode = context.getSourceCode();
 
     /**
      * Checks whether or not a given token is an arrow operator (=>).
@@ -35,7 +36,7 @@ module.exports = function(context) {
             hasSpace;
 
         if (precedingToken && !isArrow(precedingToken) && astUtils.isTokenOnSameLine(precedingToken, node)) {
-            hasSpace = astUtils.isTokenSpaced(precedingToken, node);
+            hasSpace = sourceCode.isSpaceBetweenTokens(precedingToken, node);
 
             if (requireSpace) {
                 if (!hasSpace) {

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -2,6 +2,7 @@
  * @fileoverview Rule to validate spacing before function paren.
  * @author Mathias Schreck <https://github.com/lo1tuma>
  * @copyright 2015 Mathias Schreck
+ * See LICENSE in root directory for full license.
  */
 "use strict";
 
@@ -12,6 +13,7 @@
 module.exports = function(context) {
 
     var configuration = context.options[0],
+        sourceCode = context.getSourceCode(),
         requireAnonymousFunctionSpacing = true,
         requireNamedFunctionSpacing = true;
 
@@ -21,16 +23,6 @@ module.exports = function(context) {
     } else if (configuration === "never") {
         requireAnonymousFunctionSpacing = false;
         requireNamedFunctionSpacing = false;
-    }
-
-    /**
-     * Determines whether two adjacent tokens are have whitespace between them.
-     * @param {Object} left - The left token object.
-     * @param {Object} right - The right token object.
-     * @returns {boolean} Whether or not there is space between the tokens.
-     */
-    function isSpaced(left, right) {
-        return left.range[1] < right.range[0];
     }
 
     /**
@@ -99,7 +91,7 @@ module.exports = function(context) {
 
         location = leftToken.loc.end;
 
-        if (isSpaced(leftToken, rightToken)) {
+        if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken)) {
             if ((isNamed && !requireNamedFunctionSpacing) || (!isNamed && !requireAnonymousFunctionSpacing)) {
                 context.report({
                     node: node,

--- a/lib/rules/space-before-keywords.js
+++ b/lib/rules/space-before-keywords.js
@@ -17,6 +17,8 @@ var ERROR_MSG_NO_SPACE_EXPECTED = "Unexpected space before keyword \"{{keyword}}
 
 module.exports = function(context) {
 
+    var sourceCode = context.getSourceCode();
+
     var SPACE_REQUIRED = context.options[0] !== "never";
 
     //--------------------------------------------------------------------------
@@ -73,7 +75,7 @@ module.exports = function(context) {
         options.allowedPrecedingChars = options.allowedPrecedingChars || [];
         options.requireSpace = typeof options.requireSpace === "undefined" ? SPACE_REQUIRED : options.requireSpace;
 
-        var hasSpace = astUtils.isTokenSpaced(left, right);
+        var hasSpace = sourceCode.isSpaceBetweenTokens(left, right);
         var spaceOk = hasSpace === options.requireSpace;
 
         if (spaceOk) {

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -115,12 +115,6 @@ function SourceCode(text, ast) {
      */
     this.lines = text.split(/\r\n|\r|\n|\u2028|\u2029/g);
 
-    /**
-     * Fixes to be made later on.
-     * @type Object[]
-     */
-    this._fixes = [];
-
     // create token store methods
     var tokenStore = createTokenStore(ast.tokens);
     Object.keys(tokenStore).forEach(function(methodName) {
@@ -259,8 +253,21 @@ SourceCode.prototype = {
         });
 
         return result;
-    }
+    },
 
+    /**
+     * Determines if two tokens have at least one whitespace character
+     * between them. This completely disregards comments in making the
+     * determination, so comments count as zero-length substrings.
+     * @param {Token} first The token to check after.
+     * @param {Token} second The token to check before.
+     * @returns {boolean} True if there is only space between tokens, false
+     *  if there is anything other than whitespace between tokens.
+     */
+    isSpaceBetweenTokens: function(first, second) {
+        var text = this.text.slice(first.range[1], second.range[0]);
+        return /\s/.test(text.replace(/\/\*.*?\*\//g, ""));
+    }
 };
 
 

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -31,39 +31,6 @@ describe("ast-utils", function() {
         sandbox.verifyAndRestore();
     });
 
-
-    describe("isTokenSpaced", function() {
-        it("should return false if its not spaced", function() {
-            /**
-             * Check the node for tokens
-             * @param {ASTNode} node node to examine
-             * @returns {void}
-             */
-            function checker(node) {
-                assert.isFalse(astUtils.isTokenSpaced(eslint.getTokenBefore(node), node));
-            }
-
-            eslint.reset();
-            eslint.on("BlockStatement", checker);
-            eslint.verify("if(a){}", {}, filename, true);
-        });
-
-        it("should return true if its spaced", function() {
-            /**
-             * Check the node for tokens
-             * @param {ASTNode} node node to examine
-             * @returns {void}
-             */
-            function checker(node) {
-                assert.isTrue(astUtils.isTokenSpaced(eslint.getTokenBefore(node), node));
-            }
-
-            eslint.reset();
-            eslint.on("BlockStatement", checker);
-            eslint.verify("if(a) {}", {}, filename, true);
-        });
-    });
-
     describe("isTokenOnSameLine", function() {
         it("should return false if its not on sameline", function() {
             /**

--- a/tests/lib/rules/no-spaced-func.js
+++ b/tests/lib/rules/no-spaced-func.js
@@ -32,7 +32,8 @@ ruleTester.run("no-spaced-func", rule, {
         "( (f) )( (0) )",
         "( f()() )(0)",
         "(function(){ if (foo) { bar(); } }());",
-        "f(0, (1))"
+        "f(0, (1))",
+        "describe/*.only*/('foo', function () {});"
     ],
     invalid: [
         {

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -111,6 +111,18 @@ ruleTester.run("space-before-function-paren", rule, {
             output: "function foo () {}"
         },
         {
+            code: "function foo/* */() {}",
+            errors: [
+                {
+                    type: "FunctionDeclaration",
+                    message: "Missing space before function parentheses.",
+                    line: 1,
+                    column: 13
+                }
+            ],
+            output: "function foo /* */() {}"
+        },
+        {
             code: "var foo = function() {}",
             errors: [
                 {

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -13,6 +13,7 @@
 var assert = require("chai").assert,
     espree = require("espree"),
     sinon = require("sinon"),
+    leche = require("leche"),
     eslint = require("../../../lib/eslint"),
     SourceCode = require("../../../lib/util/source-code");
 
@@ -793,6 +794,36 @@ describe("SourceCode", function() {
             assert.notProperty(node.parent, "parent");
         });
 
+    });
+
+    describe("isSpaceBetweenTokens()", function() {
+
+        leche.withData([
+            ["let foo = bar;", true],
+            ["let  foo = bar;", true],
+            ["let /**/ foo = bar;", true],
+            ["let/**/foo = bar;", false],
+            ["a+b", false],
+            ["a/**/+b", false],
+            ["a/* */+b", false],
+            ["a/**/ +b", true],
+            ["a/**/ /**/+b", true],
+            ["a/**/\n/**/+b", true],
+            ["a +b", true]
+        ], function(code, expected) {
+
+            it("should return true when there is one space between tokens", function() {
+                var ast = espree.parse(code, DEFAULT_CONFIG),
+                    sourceCode = new SourceCode(code, ast);
+
+                assert.equal(
+                    sourceCode.isSpaceBetweenTokens(
+                        sourceCode.ast.tokens[0], sourceCode.ast.tokens[1]
+                    ),
+                    expected
+                );
+            });
+        });
     });
 
     // need to check that eslint.verify() works with SourceCode


### PR DESCRIPTION
Not sure about the function name, but `isTokenSpaced()` wasn't quite right, so I went with `isSpaceBetweenTokens()`. Alternative suggestions welcome.