### PR TITLE
Fix: `space-before-keywords`; allow opening curly braces (fixes #3789)

### DIFF
--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -15,6 +15,9 @@ This rule takes one argument: `"always"` or `"never"`. If `"always"` then the ke
 must be followed by at least one space. If `"never"` then no spaces will be allowed before
 the keywords `else`, `while` (do...while), `finally` and `catch`. The default value is `"always"`.
 
+This rule will allow keywords to be preceded by an opening curly brace (`{`). If you wish to alter
+this behaviour, consider using the [block-spacing](block-spacing.md) rule.
+
 The following patterns are considered errors when configured `"never"`:
 
 ```js
@@ -79,6 +82,8 @@ if (foo) {
 
 (function() {})()
 
+<Foo onClick={function bar() {}} />
+
 for (let foo of ['bar', 'baz', 'qux']) {}
 ```
 
@@ -89,6 +94,7 @@ If you do not wish to enforce consistency on keyword spacing.
 ## Related Rules
 
 * [space-after-keywords](space-after-keywords.md)
+* [block-spacing](block-spacing.md)
 * [space-return-throw-case](space-return-throw-case.md)
 * [space-unary-ops](space-unary-ops.md)
 * [space-infix-ops](space-infix-ops.md)

--- a/lib/rules/space-before-keywords.js
+++ b/lib/rules/space-before-keywords.js
@@ -72,7 +72,7 @@ module.exports = function(context) {
         }
 
         options = options || {};
-        options.allowedPrecedingChars = options.allowedPrecedingChars || [];
+        options.allowedPrecedingChars = options.allowedPrecedingChars || [ "{" ];
         options.requireSpace = typeof options.requireSpace === "undefined" ? SPACE_REQUIRED : options.requireSpace;
 
         var hasSpace = sourceCode.isSpaceBetweenTokens(left, right);
@@ -155,7 +155,7 @@ module.exports = function(context) {
                 check(caseNode);
             });
         },
-        ThrowStatement: check,
+        "ThrowStatement": check,
         "TryStatement": function(node) {
             // try
             check(node);
@@ -169,7 +169,7 @@ module.exports = function(context) {
         },
         "WithStatement": check,
         "VariableDeclaration": function(node) {
-            check(node, { allowedPrecedingChars: [ "(" ] });
+            check(node, { allowedPrecedingChars: [ "(", "{" ] });
         },
         "ReturnStatement": check,
         "BreakStatement": check,
@@ -179,23 +179,22 @@ module.exports = function(context) {
         "FunctionExpression": function(node) {
 
             var left = context.getTokenBefore(node);
-
-            // Check to see if the function expression is a class method
-            if (node.parent && node.parent.type === "MethodDefinition") {
-                return;
-            }
-
-            // Check to see if the function expression is an object literal shorthand method
-            if (node.parent && node.parent.method && node.parent.type === "Property") {
-                return;
-            }
-
             var right = context.getFirstToken(node);
+            var isClassMethod = node.parent && node.parent.type === "MethodDefinition";
+            var isObjectShorthandMethod = node.parent && node.parent.method && node.parent.type === "Property";
 
-            checkTokens(node, left, right, { allowedPrecedingChars: [ "(" ] });
+            // If the function expression is a class method or an object literal shorthand method
+            // the first token (`right`) will match the function parentheses while `left` will match
+            // the function identifier. Thus, we want to grab the tokens that are one more to the left.
+            if (isClassMethod || isObjectShorthandMethod) {
+                right = left;
+                left = context.getTokenBefore(left);
+            }
+
+            checkTokens(node, left, right, { allowedPrecedingChars: [ "(", "{" ] });
         },
         "YieldExpression": function(node) {
-            check(node, { allowedPrecedingChars: [ "(" ] });
+            check(node, { allowedPrecedingChars: [ "(", "{" ] });
         },
         "ForOfStatement": check,
         "ClassBody": function(node) {

--- a/tests/lib/rules/space-before-keywords.js
+++ b/tests/lib/rules/space-before-keywords.js
@@ -74,10 +74,12 @@ ruleTester.run("space-before-keywords", rule, {
         { code: "; switch ('') {}" },
         { code: ";\nswitch ('') {}" },
         { code: "switch ('') { case 'foo': '' }" },
+        { code: "switch ('') { case 'foo': break; case 'bar': '' }" },
         { code: "switch ('') {\ncase 'foo': '' }" },
         { code: "; switch ('') {}", options: never },
         { code: ";\nswitch ('') {}", options: never },
         { code: "switch ('') { case 'foo': '' }", options: never },
+        { code: "switch ('') { case 'foo': break; case 'bar': '' }", options: never },
         { code: "switch ('') {\ncase 'foo': '' }", options: never },
         // ThrowStatement
         { code: "; throw new Error()" },
@@ -138,6 +140,7 @@ ruleTester.run("space-before-keywords", rule, {
         { code: "function foo () { return function () {} }" },
         { code: "var foo = (function bar () {})()" },
         { code: "var foo = { foo: function () {} }" },
+        { code: "<Foo onClick={function () {}} />", ecmaFeatures: { jsx: true } },
         { code: "var foo = function bar () {}", options: never },
         { code: "var foo =\nfunction bar () {}", options: never },
         { code: "function foo () { return function () {} }", options: never },
@@ -310,9 +313,9 @@ ruleTester.run("space-before-keywords", rule, {
             output: "; switch ('') {}"
         },
         {
-            code: "switch ('') {case 'foo': '' }",
-            errors: [ { message: expectedSpacingErrorMessageTpl("case"), type: "SwitchCase", line: 1, column: 14 } ],
-            output: "switch ('') { case 'foo': '' }"
+            code: "switch ('') { case 'foo': break;case 'bar': break; }",
+            errors: [ { message: expectedSpacingErrorMessageTpl("case"), type: "SwitchCase", line: 1, column: 33 } ],
+            output: "switch ('') { case 'foo': break; case 'bar': break; }"
         },
         // ThrowStatement
         {
@@ -375,27 +378,27 @@ ruleTester.run("space-before-keywords", rule, {
         },
         // BreakStatement
         {
-            code: "for (;;) {break; }",
+            code: "for (;;) { var foo = 'bar';break; }",
             errors: [ { message: expectedSpacingErrorMessageTpl("break"), type: "BreakStatement" } ],
-            output: "for (;;) { break; }"
+            output: "for (;;) { var foo = 'bar'; break; }"
         },
         // LabeledStatement
         {
-            code: "foo: for (;;) {bar: for (;;) {} }",
+            code: "foo: for (;;) { var foo = 'bar';bar: for (;;) {} }",
             errors: [ { message: expectedSpacingErrorMessageTpl("bar"), type: "LabeledStatement" } ],
-            output: "foo: for (;;) { bar: for (;;) {} }"
+            output: "foo: for (;;) { var foo = 'bar'; bar: for (;;) {} }"
         },
         // ContinueStatement
         {
-            code: "for (;;) {continue; }",
+            code: "for (;;) { var foo = 'bar';continue; }",
             errors: [ { message: expectedSpacingErrorMessageTpl("continue"), type: "ContinueStatement" } ],
-            output: "for (;;) { continue; }"
+            output: "for (;;) { var foo = 'bar'; continue; }"
         },
         // ReturnStatement
         {
-            code: "function foo() {return; }",
+            code: "function foo() { var foo = 'bar';return foo; }",
             errors: [ { message: expectedSpacingErrorMessageTpl("return"), type: "ReturnStatement" } ],
-            output: "function foo() { return; }"
+            output: "function foo() { var foo = 'bar'; return foo; }"
         },
         // FunctionDeclaration
         {
@@ -416,10 +419,10 @@ ruleTester.run("space-before-keywords", rule, {
         },
         // YieldExpression
         {
-            code: "function* foo() {yield 0; }",
+            code: "function* foo() { var foo = 'bar';yield foo; }",
             errors: [ { message: expectedSpacingErrorMessageTpl("yield"), type: "YieldExpression" } ],
             ecmaFeatures: { generators: true },
-            output: "function* foo() { yield 0; }"
+            output: "function* foo() { var foo = 'bar'; yield foo; }"
         },
         // ForOfStatement
         {
@@ -443,10 +446,10 @@ ruleTester.run("space-before-keywords", rule, {
         },
         // Super
         {
-            code: "class Bar { constructor() {super.foo(); } }",
+            code: "class Bar { constructor() { var foo = 'bar';super.bar(foo); } }",
             errors: [ { message: expectedSpacingErrorMessageTpl("super"), type: "Super" } ],
             ecmaFeatures: { classes: true },
-            output: "class Bar { constructor() { super.foo(); } }"
+            output: "class Bar { constructor() { var foo = 'bar'; super.bar(foo); } }"
         }
     ]
 });


### PR DESCRIPTION
Fixes #3789 to allow keywords to be preceded by an opening curly brace. For example, previously this would throw an error:

```js
/* eslint space-before-keywords: [2, "always"] */

<Foo onClick={function bar() {}} /> /*error Missing space before keyword "function".*/
```

Users should use the [block-spacing](/eslint/eslint/blob/master/docs/rules/block-spacing.md) rule if they wish to enforce keyword spacing in these types of scenarios.

The trade-off of offloading this to `block-spacing` is that if the user doesn't use `block-spacing` but has `space-before-keywords` enabled, the following would pass:

```js
/* eslint space-before-keywords: [2, "always"], block-spacing: 0 */

if (foo) {return bar; }
```
Ideally, to cater for these type of odd scenarios `block-spacing` could support similar granularity as `space-before-blocks` (#3758).