### PR TITLE
Fix: `func-style` had been warning arrows with `this`

### DIFF
--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -12,32 +12,52 @@
 module.exports = function(context) {
 
     var style = context.options[0],
-        enforceDeclarations = (style === "declaration");
+        enforceDeclarations = (style === "declaration"),
+        stack = [];
 
     return {
+        "Program": function() {
+            stack = [];
+        },
 
         "FunctionDeclaration": function(node) {
+            stack.push(false);
+
             if (!enforceDeclarations) {
                 context.report(node, "Expected a function expression.");
             }
         },
+        "FunctionDeclaration:exit": function() {
+            stack.pop();
+        },
 
-        "FunctionExpression": function() {
-            var parent = context.getAncestors().pop();
+        "FunctionExpression": function(node) {
+            stack.push(false);
 
-            if (enforceDeclarations && parent.type === "VariableDeclarator") {
-                context.report(parent, "Expected a function declaration.");
+            if (enforceDeclarations && node.parent.type === "VariableDeclarator") {
+                context.report(node.parent, "Expected a function declaration.");
             }
+        },
+        "FunctionExpression:exit": function() {
+            stack.pop();
         },
 
         "ArrowFunctionExpression": function() {
-            var parent = context.getAncestors().pop();
+            stack.push(false);
+        },
+        "ArrowFunctionExpression:exit": function(node) {
+            var hasThisExpr = stack.pop();
 
-            if (enforceDeclarations && parent.type === "VariableDeclarator") {
-                context.report(parent, "Expected a function declaration.");
+            if (enforceDeclarations && !hasThisExpr && node.parent.type === "VariableDeclarator") {
+                context.report(node.parent, "Expected a function declaration.");
+            }
+        },
+
+        "ThisExpression": function() {
+            if (stack.length > 0) {
+                stack[stack.length - 1] = true;
             }
         }
-
     };
 
 };

--- a/tests/lib/rules/func-style.js
+++ b/tests/lib/rules/func-style.js
@@ -56,6 +56,17 @@ ruleTester.run("func-style", rule, {
             code: "var foo = () => {};\n var bar = () => {}",
             options: ["expression"],
             ecmaFeatures: { arrowFunctions: true }
+        },
+
+        // https://github.com/eslint/eslint/issues/3819
+        {
+            code: "var foo = function() { this; }.bind(this);",
+            options: ["declaration"]
+        },
+        {
+            code: "var foo = () => { this; };",
+            options: ["declaration"],
+            ecmaFeatures: { arrowFunctions: true }
         }
     ],
 
@@ -72,6 +83,17 @@ ruleTester.run("func-style", rule, {
         },
         {
             code: "var foo = () => {};",
+            options: ["declaration"],
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [
+                {
+                    message: "Expected a function declaration.",
+                    type: "VariableDeclarator"
+                }
+            ]
+        },
+        {
+            code: "var foo = () => { function foo() { this; } };",
             options: ["declaration"],
             ecmaFeatures: { arrowFunctions: true },
             errors: [


### PR DESCRIPTION
Fixes #3819

I made the `func-style` rule ignoring arrow functions which have
`ThisExpression` even if it's `declaration` mode.
Incidentally, I replaced `context.getAncestors().pop()` with
`node.parent`.