### PR TITLE
Docs: Add related ternary links (refs #3835)

### DIFF
--- a/docs/rules/no-nested-ternary.md
+++ b/docs/rules/no-nested-ternary.md
@@ -39,3 +39,4 @@ if (foo) {
 ## Related Rules
 
 * [no-ternary](no-ternary.md)
+* [no-unneeded-ternary](no-unneeded-ternary.md)

--- a/docs/rules/no-ternary.md
+++ b/docs/rules/no-ternary.md
@@ -55,3 +55,4 @@ function quux() {
 ## Related Rules
 
 * [no-nested-ternary](no-nested-ternary.md)
+* [no-unneeded-ternary](no-unneeded-ternary.md)

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -73,6 +73,11 @@ The following pattern is not considered a warning when `defaultAssignment` is `t
 var a = x ? x : 1;
 ```
 
+## Related Rules
+
+* [no-ternary](no-ternary.md)
+* [no-nested-ternary](no-nested-ternary.md)
+
 ## When Not To Use It
 
 You can turn this rule off if you are not concerned with unnecessary complexity in conditional expressions.


### PR DESCRIPTION
Adds references between all ternary rules.