### PR TITLE
Docs: Prepare for rule doc linting (refs #2271)

### DIFF
--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -4,6 +4,8 @@ A number of style guides require or disallow spaces between array brackets. This
 applies to both array literals and destructuring assignment (EcmaScript 6) using arrays.
 
 ```js
+/*eslint-env es6*/
+
 var arr = [ 'foo', 'bar' ];
 var [ x, y ] = z;
 
@@ -37,6 +39,7 @@ When `"never"` is set, the following patterns are considered problems:
 
 ```js
 /*eslint array-bracket-spacing: [2, "never"]*/
+/*eslint-env es6*/
 
 var arr = [ 'foo', 'bar' ];   /*error There should be no space after '['*/ /*error There should be no space before ']'*/
 var arr = ['foo', 'bar' ];                                                 /*error There should be no space before ']'*/
@@ -55,6 +58,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint array-bracket-spacing: [2, "never"]*/
+/*eslint-env es6*/
 
 var arr = [];
 var arr = ['foo', 'bar', 'baz'];
@@ -80,6 +84,7 @@ When `"always"` is used, the following patterns are considered problems:
 
 ```js
 /*eslint array-bracket-spacing: [2, "always"]*/
+/*eslint-env es6*/
 
 var arr = ['foo', 'bar'];      /*error A space is required after '['*/ /*error A space is required before ']'*/
 var arr = ['foo', 'bar' ];     /*error A space is required after '['*/
@@ -101,6 +106,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint array-bracket-spacing: [2, "always"]*/
+/*eslint-env es6*/
 
 var arr = [];
 var arr = [ 'foo', 'bar', 'baz' ];

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -8,6 +8,8 @@ be wrapped in parentheses. This rule enforces the consistent use of parentheses 
 This rule enforces parentheses around arrow function parameters regardless of arity. For example:
 
 ```js
+/*eslint-env es6*/
+
 // Bad
 a => {}
 
@@ -20,6 +22,8 @@ when a comparison such as `>=` was the intent.
 
 
 ```js
+/*eslint-env es6*/
+
 // Bad
 if (a => 2) {
 }
@@ -32,6 +36,8 @@ if (a >= 2) {
 The rule can also be configured to discourage the use of parens when they are not required:
 
 ```js
+/*eslint-env es6*/
+
 // Bad
 (a) => {}
 
@@ -53,6 +59,7 @@ When the rule is set to `"always"` the following patterns are considered problem
 
 ```js
 /*eslint arrow-parens: [2, "always"]*/
+/*eslint-env es6*/
 
 a => {};                     /*error Expected parentheses around arrow function argument.*/
 a => a;                      /*error Expected parentheses around arrow function argument.*/
@@ -66,6 +73,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint arrow-parens: [2, "always"]*/
+/*eslint-env es6*/
 
 () => {};
 (a) => {};
@@ -80,6 +88,8 @@ a.then((foo) => { if (true) {}; });
 One benefits of this option is that it prevents the incorrect use of arrow functions in conditionals:
 
 ```js
+/*eslint-env es6*/
+
 var a = 1;
 var b = 2;
 // ...
@@ -95,6 +105,8 @@ The contents of the `if` statement is an arrow function, not a comparison.
 If the arrow function is intentional, it should be wrapped in parens to remove ambiguity.
 
 ```js
+/*eslint-env es6*/
+
 var a = 1;
 var b = 0;
 // ...
@@ -109,6 +121,8 @@ if ((a) => b) {
 The following is another example of this behavior:
 
 ```js
+/*eslint-env es6*/
+
 var a = 1, b = 2, c = 3, d = 4;
 var f = a => b ? c: d;
 // f = ?
@@ -119,6 +133,8 @@ var f = a => b ? c: d;
 This should be rewritten like so:
 
 ```js
+/*eslint-env es6*/
+
 var a = 1, b = 2, c = 3, d = 4;
 var f = (a) => b ? c: d;
 ```
@@ -130,6 +146,7 @@ When the rule is set to `"as-needed"` the following patterns are considered prob
 
 ```js
 /*eslint arrow-parens: [2, "as-needed"]*/
+/*eslint-env es6*/
 
 (a) => {};                     /*error Unexpected parentheses around single function argument*/
 (a) => a;                      /*error Unexpected parentheses around single function argument*/
@@ -143,6 +160,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint arrow-parens: [2, "as-needed"]*/
+/*eslint-env es6*/
 
 () => {};
 a => {};

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -3,6 +3,8 @@
 This rule normalize style of spacing before/after an arrow function's arrow(`=>`).
 
 ```js
+/*eslint-env es6*/
+
 // { "before": true, "after": true }
 (a) => {}
 
@@ -22,6 +24,7 @@ The following patterns are considered problems if `{ "before": true, "after": tr
 
 ```js
 /*eslint arrow-spacing: 2*/
+/*eslint-env es6*/
 
 ()=> {};     /*error Missing space before =>*/
 () =>{};     /*error Missing space after =>*/
@@ -37,6 +40,7 @@ The following patterns are not considered problems if `{ "before": true, "after"
 
 ```js
 /*eslint arrow-spacing: 2*/
+/*eslint-env es6*/
 
 () => {};
 (a) => {};
@@ -48,6 +52,7 @@ The following patterns are not considered problems if `{ "before": false, "after
 
 ```js
 /*eslint arrow-spacing: [2, { "before": false, "after": false }]*/
+/*eslint-env es6*/
 
 ()=>{};
 (a)=>{};
@@ -59,6 +64,7 @@ The following patterns are not considered problems if `{ "before": true, "after"
 
 ```js
 /*eslint arrow-spacing: [2, { "before": true, "after": false }]*/
+/*eslint-env es6*/
 
 () =>{};
 (a) =>{};
@@ -70,6 +76,7 @@ The following patterns are not considered problems if `{ "before": false, "after
 
 ```js
 /*eslint arrow-spacing: [2, { "before": false, "after": true }]*/
+/*eslint-env es6*/
 
 ()=> {};
 (a)=> {};

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -35,7 +35,7 @@ function doSomething() {
 
 function doSomething() {
     if (true) {
-        var build = true;
+        var build = true;  /*error "build" used outside of binding context.*/
     } else {
         var build = false; /*error "build" used outside of binding context.*/
     }

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -4,6 +4,8 @@ While formatting preferences are very personal, a number of style guides require
 or disallow spaces between computed properties in the following situations:
 
 ```js
+/*eslint-env es6*/
+
 // computed properties
 var obj = { prop: "value" };
 var a = "prop";
@@ -40,6 +42,8 @@ When `"never"` is set, the following patterns will give a warning:
 
 ```js
 /*eslint computed-property-spacing: [2, "never"]*/
+/*eslint-env es6*/
+
 obj[foo ]                                                       /*error There should be no space before ']'*/
 obj[ 'foo']        /*error There should be no space after '['*/
 var x = {[ b ]: a} /*error There should be no space after '['*/ /*error There should be no space before ']'*/
@@ -50,6 +54,7 @@ The following patterns are considered correct:
 
 ```js
 /*eslint computed-property-spacing: [2, "never"]*/
+/*eslint-env es6*/
 
 obj[foo]
 obj['foo']
@@ -63,6 +68,7 @@ When `"always"` is used, the following patterns will give a warning:
 
 ```js
 /*eslint computed-property-spacing: [2, "always"]*/
+/*eslint-env es6*/
 
 obj[foo]          /*error A space is required after '['*/ /*error A space is required before ']'*/
 var x = {[b]: a}  /*error A space is required after '['*/ /*error A space is required before ']'*/
@@ -77,6 +83,7 @@ The following patterns are considered correct:
 
 ```js
 /*eslint computed-property-spacing: [2, "always"]*/
+/*eslint-env es6*/
 
 obj[ foo ]
 obj[ 'foo' ]

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -14,6 +14,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint constructor-super: 2*/
+/*eslint-env es6*/
 
 class A {
     constructor() {
@@ -36,6 +37,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint constructor-super: 2*/
+/*eslint-env es6*/
 
 class A {
     constructor() { }

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -6,6 +6,8 @@ These special functions are indicated by placing an `*` after the `function` key
 Here is an example of a generator function:
 
 ```js
+/*eslint-env es6*/
+
 function* generator() {
     yield "44";
     yield "55";
@@ -15,6 +17,8 @@ function* generator() {
 This is also valid:
 
 ```js
+/*eslint-env es6*/
+
 function *generator() {
     yield "44";
     yield "55";
@@ -24,6 +28,8 @@ function *generator() {
 This is valid as well:
 
 ```js
+/*eslint-env es6*/
+
 function * generator() {
     yield "44";
     yield "55";
@@ -69,6 +75,7 @@ When using `{"before": true, "after": false}` this placement will be enforced:
 
 ```js
 /*eslint generator-star-spacing: [2, {"before": true, "after": false}]*/
+/*eslint-env es6*/
 
 function *generator() {}
 
@@ -81,6 +88,7 @@ When using `{"before": false, "after": true}` this placement will be enforced:
 
 ```js
 /*eslint generator-star-spacing: [2, {"before": false, "after": true}]*/
+/*eslint-env es6*/
 
 function* generator() {}
 
@@ -93,6 +101,7 @@ When using `{"before": true, "after": true}` this placement will be enforced:
 
 ```js
 /*eslint generator-star-spacing: [2, {"before": true, "after": true}]*/
+/*eslint-env es6*/
 
 function * generator() {}
 
@@ -105,6 +114,7 @@ When using `{"before": false, "after": false}` this placement will be enforced:
 
 ```js
 /*eslint generator-star-spacing: [2, {"before": false, "after": false}]*/
+/*eslint-env es6*/
 
 function*generator() {}
 

--- a/docs/rules/generator-star.md
+++ b/docs/rules/generator-star.md
@@ -8,6 +8,8 @@ These special functions are indicated by placing an `*` after the `function` key
 Here is an example of a generator function:
 
 ```js
+/*eslint-env es6*/
+
 function* generator() {
     yield "44";
     yield "55";
@@ -17,6 +19,8 @@ function* generator() {
 This is also valid:
 
 ```js
+/*eslint-env es6*/
+
 function *generator() {
     yield "44";
     yield "55";
@@ -26,6 +30,8 @@ function *generator() {
 This is valid as well:
 
 ```js
+/*eslint-env es6*/
+
 function * generator() {
     yield "44";
     yield "55";
@@ -49,6 +55,8 @@ You can set the style in configuration like this:
 When using `"start"` this placement will be enforced:
 
 ```js
+/*eslint-env es6*/
+
 function* generator() {
 }
 ```
@@ -56,6 +64,8 @@ function* generator() {
 When using `"middle"` this placement will be enforced:
 
 ```js
+/*eslint-env es6*/
+
 function * generator() {
 }
 ```
@@ -63,6 +73,8 @@ function * generator() {
 When using `"end"` this placement will be enforced:
 
 ```js
+/*eslint-env es6*/
+
 function *generator() {
 }
 ```
@@ -70,6 +82,8 @@ function *generator() {
 When using the expression syntax `"start"` will be enforced here:
 
 ```js
+/*eslint-env es6*/
+
 var generator = function* () {
 }
 ```
@@ -77,6 +91,8 @@ var generator = function* () {
 When using the expression syntax `"middle"` will be enforced here:
 
 ```js
+/*eslint-env es6*/
+
 var generator = function * () {
 }
 ```
@@ -84,6 +100,8 @@ var generator = function * () {
 When using the expression syntax `"end"` will be enforced here:
 
 ```js
+/*eslint-env es6*/
+
 var generator = function *() {
 }
 ```
@@ -91,6 +109,8 @@ var generator = function *() {
 When using the expression syntax this is valid for both `"start"` and `"end"`:
 
 ```js
+/*eslint-env es6*/
+
 var generator = function*() {
 }
 ```

--- a/docs/rules/global-require.md
+++ b/docs/rules/global-require.md
@@ -19,38 +19,43 @@ You can enable this rule with the following syntax:
 "global-require": 2
 ```
 
-With the rule enabled enabled the following examples would warn:
+The following patterns are considered problems:
 
 ```js
+/*eslint global-require: 2*/
+/*eslint-env es6*/
+
 // calling require() inside of a function is not allowed
 function readFile(filename, callback) {
-    var fs = require('fs');
+    var fs = require('fs');                                /*error Unexpected require().*/
     fs.readFile(filename, callback)
 }
 
 // conditional requires like this are also not allowed
-if (DEBUG) { require('debug'); }
+if (DEBUG) { require('debug'); }                           /*error Unexpected require().*/
 
 // a require() in a switch statement is also flagged
-switch(x) { case '1': require('1'); break; }
+switch(x) { case '1': require('1'); break; }               /*error Unexpected require().*/
 
 // you may not require() inside an arrow function body
-var getModule = (name) => require(name);
+var getModule = (name) => require(name);                   /*error Unexpected require().*/
 
 // you may not require() inside of a function body as well
-function getModule(name) { return require(name); }
+function getModule(name) { return require(name); }         /*error Unexpected require().*/
 
 // you may not require() inside of a try/catch block
 try {
-    require(unsafeModule);
+    require(unsafeModule);                                 /*error Unexpected require().*/
 } catch(e) {
     console.log(e);
 }
 ```
 
-These following would **not** warn:
+The following patterns are not considered problems:
 
 ```js
+/*eslint global-require: 2*/
+
 // all these variations of require() are ok
 require('x');
 var y = require('y');
@@ -77,4 +82,3 @@ var x = require("x"),
 
 If you have a module that must be initialized with information that comes from the file-system or if a module
  is only used in very rare situations and will cause significant overhead to load it may make sense to disable the rule.
-

--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -17,6 +17,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint id-length: 2*/     // default is minimum 2-chars ({ min: 2})
+/*eslint-env es6*/
 
 var x = 5;                  /*error Identifier name 'x' is too short. (< 2)*/
 
@@ -48,20 +49,22 @@ var { x: a} = {};           /*error Identifier name 'x' is too short. (< 2)*/
 
 var { a: [x]} = {};         /*error Identifier name 'a' is too short. (< 2)*/
 
-import x from 'y';          /*error Identifier name 'x' is too short. (< 2)*/
-
-export var x = 0;           /*error Identifier name 'x' is too short. (< 2)*/
-
 ({ a: obj.x.y.z }) = {};    /*error Identifier name 'a' is too short. (< 2)*/ /*error Identifier name 'z' is too short. (< 2)*/
 
 ({ prop: obj.x }) = {};     /*error Identifier name 'x' is too short. (< 2)*/
+```
 
+```
+import x from 'y';          /*error Identifier name 'x' is too short. (< 2)*/
+
+export var x = 0;           /*error Identifier name 'x' is too short. (< 2)*/
 ```
 
 The following patterns are not considered problems:
 
 ```js
 /*eslint id-length: 2*/     // default is minimum 2-chars ({ min: 2})
+/*eslint-env es6*/
 
 var num = 5;
 
@@ -97,10 +100,6 @@ var { prop: a } = {};
 
 var { prop: [x] } = {};
 
-import something from "y";
-
-export var num = 0;
-
 ({ prop: obj.x.y.something }) = {};
 
 ({ prop: obj.longName }) = {};
@@ -108,6 +107,12 @@ export var num = 0;
 var data = { "x": 1 };  // excused because of quotes
 
 data["y"] = 3;  // excused because of calculated property access
+```
+
+```
+import something from "y";
+
+export var num = 0;
 ```
 
 
@@ -131,6 +136,7 @@ The following patterns will not be considered problems
 
 ```js
 /*eslint id-length: [2, {"properties": "never"}]*/
+/*eslint-env es6*/
 
 var myObj = { a: 1 };
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -78,7 +78,7 @@ The following patterns are considered problems:
 if (a) {
    b=c;            /*error Expected indentation of 2 space characters but found 3.*/
 function foo(d) {  /*error Expected indentation of 2 space characters but found 0.*/
-       e=f;        /*error Expected indentation of 8 space characters but found 7.*/
+       e=f;        /*error Expected indentation of 2 space characters but found 7.*/
 }                  /*error Expected indentation of 6 space characters but found 0.*/
 }
 ```
@@ -96,6 +96,7 @@ function foo(d) {  /*error Expected indentation of 1 tab character but found 0.*
 
 ```js
 /*eslint indent: [2, 2, {"VariableDeclarator": 1}]*/
+/*eslint-env es6*/
 
 var a,
     b,             /*error Expected indentation of 2 space characters but found 4.*/
@@ -145,6 +146,7 @@ if (a) {
 
 ```js
 /*eslint indent: [2, 2, {"VariableDeclarator": 2}]*/
+/*eslint-env es6*/
 
 var a,
     b,
@@ -159,6 +161,7 @@ const a = 1,
 
 ```js
 /*eslint indent: [2, 2, {"VariableDeclarator": { "var": 2, "let": 2, "const": 3}}]*/
+/*eslint-env es6*/
 
 var a,
     b,

--- a/docs/rules/init-declarations.md
+++ b/docs/rules/init-declarations.md
@@ -52,6 +52,7 @@ When configured with `"always"` (the default), the following patterns are consid
 
 ```js
 /*eslint init-declarations: [2, "always"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar;     /*error Variable 'bar' should be initialized on declaration.*/
@@ -63,6 +64,7 @@ The following patterns are not considered problems with `"always"`.
 
 ```js
 /*eslint init-declarations: [2, "always"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar = 1;
@@ -75,6 +77,7 @@ When configured with `"never"`, the following patterns are considered problems.
 
 ```js
 /*eslint init-declarations: [2, "never"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar = 1;   /*error Variable 'bar' should not be initialized on declaration.*/
@@ -86,6 +89,7 @@ The following patterns are not considered problems with `"never"`. Note that `co
 
 ```js
 /*eslint init-declarations: [2, "never"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar;

--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -2,7 +2,7 @@
 
 JSX attribute values can contain string literals, which are delimited with single or double quotes.
 
-```js
+```jsx
 <a b='c' />
 <a b="c" />
 ```
@@ -10,7 +10,7 @@ JSX attribute values can contain string literals, which are delimited with singl
 Unlike string literals in JavaScript, string literals within JSX attributes can’t contain escaped quotes.
 If you want to have e.g. a double quote within a JSX attribute value, you have to use single quotes as string delimiter.
 
-```js
+```jsx
 <a b="'" />
 <a b='"' />
 ```
@@ -25,26 +25,26 @@ The default is `"prefer-double"`.
 
 The following patterns are considered problems when set to `"prefer-double"`:
 
-```js
+```jsx
 <a b='c' />
 ```
 
 The following patterns are not considered problems when set to `"prefer-double"`:
 
-```js
+```jsx
 <a b="c" />
 <a b='"' />
 ```
 
 The following patterns are considered problems when set to `"prefer-single"`:
 
-```js
+```jsx
 <a b="c" />
 ```
 
 The following patterns are not considered problems when set to `"prefer-single"`:
 
-```js
+```jsx
 <a b='c' />
 <a b="'" />
 ```

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -34,6 +34,7 @@ console.log(greet, name);
 
 ```js
 /*eslint newline-after-var: [2, "never"]*/
+/*eslint-env es6*/
 
 let greet = "hello,",     /*error Unexpected blank line after variable declarations.*/
     name = "world";
@@ -43,6 +44,7 @@ console.log(greet, name);
 
 ```js
 /*eslint newline-after-var: 2*/  // defaults to always
+/*eslint-env es6*/
 
 var greet = "hello,";
 const NAME = "world";      /*error Expected blank line after variable declarations.*/
@@ -62,6 +64,7 @@ console.log(greet, name);
 
 ```js
 /*eslint newline-after-var: [2, "never"]*/
+/*eslint-env es6*/
 
 let greet = "hello,",
     name = "world";
@@ -70,6 +73,7 @@ console.log(greet, name);
 
 ```js
 /*eslint newline-after-var: 2*/  // defaults to always
+/*eslint-env es6*/
 
 var greet = "hello,";
 const NAME = "world";

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -3,6 +3,8 @@
 `ClassDeclaration` creates a variable, and we can modify the variable.
 
 ```js
+/*eslint-env es6*/
+
 class A { }
 A = 0;
 ```
@@ -17,6 +19,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-class-assign: 2*/
+/*eslint-env es6*/
 
 class A { }
 A = 0;         /*error `A` is a class.*/
@@ -24,6 +27,7 @@ A = 0;         /*error `A` is a class.*/
 
 ```js
 /*eslint no-class-assign: 2*/
+/*eslint-env es6*/
 
 A = 0;         /*error `A` is a class.*/
 class A { }
@@ -31,6 +35,7 @@ class A { }
 
 ```js
 /*eslint no-class-assign: 2*/
+/*eslint-env es6*/
 
 class A {
     b() {
@@ -41,6 +46,7 @@ class A {
 
 ```js
 /*eslint no-class-assign: 2*/
+/*eslint-env es6*/
 
 let A = class A {
     b() {
@@ -54,6 +60,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-class-assign: 2*/
+/*eslint-env es6*/
 
 let A = class A { }
 A = 0; // A is a variable.
@@ -61,6 +68,7 @@ A = 0; // A is a variable.
 
 ```js
 /*eslint no-class-assign: 2*/
+/*eslint-env es6*/
 
 let A = class {
     b() {
@@ -71,6 +79,7 @@ let A = class {
 
 ```js
 /*eslint no-class-assign: 2*/
+/*eslint-env es6*/
 
 class A {
     b(A) {

--- a/docs/rules/no-const-assign.md
+++ b/docs/rules/no-const-assign.md
@@ -13,6 +13,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-const-assign: 2*/
+/*eslint-env es6*/
 
 const a = 0;
 a = 1;       /*error `a` is constant.*/
@@ -20,6 +21,7 @@ a = 1;       /*error `a` is constant.*/
 
 ```js
 /*eslint no-const-assign: 2*/
+/*eslint-env es6*/
 
 const a = 0;
 a += 1;      /*error `a` is constant.*/
@@ -27,6 +29,7 @@ a += 1;      /*error `a` is constant.*/
 
 ```js
 /*eslint no-const-assign: 2*/
+/*eslint-env es6*/
 
 const a = 0;
 ++a;         /*error `a` is constant.*/
@@ -36,6 +39,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-const-assign: 2*/
+/*eslint-env es6*/
 
 const a = 0;
 console.log(a);
@@ -43,6 +47,7 @@ console.log(a);
 
 ```js
 /*eslint no-const-assign: 2*/
+/*eslint-env es6*/
 
 for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.
     console.log(a);
@@ -51,6 +56,7 @@ for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop st
 
 ```js
 /*eslint no-const-assign: 2*/
+/*eslint-env es6*/
 
 for (const a of [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.
     console.log(a);

--- a/docs/rules/no-delete-var.md
+++ b/docs/rules/no-delete-var.md
@@ -2,7 +2,7 @@
 
 This rule prevents the use of `delete` operator on variables:
 
-```
+```js
 /*eslint no-delete-var: 2*/
 
 var x;

--- a/docs/rules/no-dupe-args.md
+++ b/docs/rules/no-dupe-args.md
@@ -10,7 +10,7 @@ This rule prevents having duplicate param names.
 
 For example the following code will cause the rule to warn:
 
-```
+```js
 /*eslint no-dupe-args: 2*/
 
 function foo(a, b, a) {               /*error Duplicate param 'a'.*/

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -4,6 +4,8 @@ If there are declarations of the same name in class members, the last declaratio
 It can cause unexpected behaviors.
 
 ```js
+/*eslint-env es6*/
+
 class Foo {
   bar() { console.log("hello"); }
   bar() { console.log("goodbye"); }
@@ -21,6 +23,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-dupe-class-members: 2*/
+/*eslint-env es6*/
 
 class Foo {
   bar() { }
@@ -42,6 +45,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-dupe-class-members: 2*/
+/*eslint-env es6*/
 
 class Foo {
   bar() { }

--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -35,6 +35,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-extra-bind: 2*/
+/*eslint-env es6*/
 
 var x = function () {   /*error The function binding is unnecessary.*/
     foo();
@@ -42,11 +43,11 @@ var x = function () {   /*error The function binding is unnecessary.*/
 
 var x = (() => {        /*error The function binding is unnecessary.*/
     foo();
-}.bind(bar);
+}).bind(bar);
 
 var x = (() => {        /*error The function binding is unnecessary.*/
     this.foo();
-}.bind(bar);
+}).bind(bar);
 
 var x = function () {   /*error The function binding is unnecessary.*/
     (function () {

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -28,6 +28,8 @@ function anotherThing() {
 A variable declaration is permitted anywhere a statement can go, even nested deeply inside other blocks. This is often undesirable due to variable hoisting, and moving declarations to the root of the program or function body can increase clarity. Note that [block bindings](https://leanpub.com/understandinges6/read#leanpub-auto-block-bindings) (`let`, `const`) are not hoisted and therefore they are not affected by this rule.
 
 ```js
+/*eslint-env es6*/
+
 // Good
 var foo = 42;
 
@@ -102,6 +104,7 @@ The following patterns are considered valid:
 
 ```js
 /*eslint no-inner-declarations: 2*/
+/*eslint-env es6*/
 
 function doSomething() { }
 

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -34,6 +34,7 @@ Please note your code in ES2015 Modules/Classes is always the strict mode.
 
 ```js
 /*eslint no-invalid-this: 2*/
+/*eslint-env es6*/
 
 this.a = 0;            /*error Unexpected `this`.*/
 baz(() => this);       /*error Unexpected `this`.*/
@@ -90,6 +91,7 @@ foo.forEach(function() {
 
 ```js
 /*eslint no-invalid-regexp: 2*/
+/*eslint-env es6*/
 
 function Foo() {
     // OK, this is in a legacy style constructor.

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -34,8 +34,8 @@ function bar() {
     }
 }
 
-{
-    function foo() {} /*error Block is redundant.*/
+{                     /*error Block is redundant.*/
+    function foo() {}
 }
 ```
 

--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -15,6 +15,8 @@ In this case, you would expect each function created within the loop to return a
 `let` or `const` mitigate this problem.
 
 ```js
+/*eslint-env es6*/
+
 for (let i = 0; i < 10; i++) {
     funcs[i] = function() {
         return i;
@@ -33,6 +35,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-loop-func: 2*/
+/*eslint-env es6*/
 
 for (var i=10; i; i--) {
     (function() { return i; })();     /*error Don't make functions within a loop*/
@@ -60,6 +63,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-loop-func: 2*/
+/*eslint-env es6*/
 
 var a = function() {};
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -96,7 +96,7 @@ var someVar      = 'foo';
 var someOtherVar = 'barBaz';
 ```
 
-```js
+```
 /* eslint no-multi-spaces: [2, { exceptions: { "ImportDeclaration": true } }] */
 
 import mod          from 'mod';
@@ -116,4 +116,3 @@ If you don't want to check and disallow multiple spaces, then you should turn th
 * [space-after-keywords](space-after-keywords)
 * [space-unary-ops](space-unary-ops)
 * [space-return-throw-case](space-return-throw-case)
-

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -2,7 +2,7 @@
 
 As of version 5 of the ECMAScript specification, octal escape sequences are a deprecated feature and should not be used. It is recommended that Unicode escapes be used instead.
 
-```
+```js
 var foo = "Copyright \251";
 ```
 
@@ -12,7 +12,7 @@ The rule is aimed at preventing the use of a deprecated JavaScript feature, the 
 
 The following patterns are considered problems:
 
-```
+```js
 /*eslint no-octal-escape: 2*/
 
 var foo = "Copyright \251"; /*error Don't use octal: '\251'. Use '\u....' instead.*/
@@ -20,7 +20,7 @@ var foo = "Copyright \251"; /*error Don't use octal: '\251'. Use '\u....' instea
 
 The following patterns are not considered problems:
 
-```
+```js
 /*eslint no-octal-escape: 2*/
 
 var foo = "Copyright \u00A9";   // unicode

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -2,7 +2,7 @@
 
 Octal literals are numerals that begin with a leading zero, such as:
 
-```
+```js
 var num = 071;      // 57
 ```
 
@@ -16,7 +16,7 @@ The rule is aimed at preventing the use of a deprecated JavaScript feature, the 
 
 The following patterns are considered problems:
 
-```
+```js
 /*eslint no-octal: 2*/
 
 var num = 071;       /*error Octal literals should not be used.*/
@@ -25,7 +25,7 @@ var result = 5 + 07; /*error Octal literals should not be used.*/
 
 The following patterns are not considered problems:
 
-```
+```js
 /*eslint no-octal: 2*/
 
 var num  = "071";

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -20,7 +20,7 @@ This rule takes a list of strings where strings denote the node types:
 
 The following patterns are considered problems:
 
-```
+```js
 /* eslint no-restricted-syntax: [2, "FunctionExpression", "WithStatement"] */
 
 with (me) {                       /*error Using "WithStatement" is not allowed.*/

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -21,7 +21,7 @@ This rule forbids the use of the comma operator, with the following exceptions:
 
 The following patterns are considered problems:
 
-```
+```js
 /*eslint no-sequences: 2*/
 
 foo = doSomething, val;              /*error Unexpected use of comma operator.*/
@@ -41,7 +41,7 @@ with (doSomething(), val) {}         /*error Unexpected use of comma operator.*/
 
 The following patterns are not considered problems:
 
-```
+```js
 /*eslint no-sequences: 2*/
 
 foo = (doSomething(), val);

--- a/docs/rules/no-shadow-restricted-names.md
+++ b/docs/rules/no-shadow-restricted-names.md
@@ -12,7 +12,7 @@ Then any code used within the same scope would not get the global `undefined`, b
 
 The following patterns are considered problems:
 
-```
+```js
 /*eslint no-shadow-restricted-names: 2*/
 
 function NaN(){}       /*error Shadowing of global property "NaN".*/

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -19,6 +19,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-shadow: 2*/
+/*eslint-env es6*/
 
 var a = 3;
 function b() {
@@ -78,6 +79,7 @@ With `"hoist"` set to `"all"`, both `let a` and `let b` in the `if` statement ar
 
 ```js
 /*eslint no-shadow: [2, { "hoist": "all" }]*/
+/*eslint-env es6*/
 
 if (true) {
     let a = 3;    /*error a is already declared in the upper scope.*/
@@ -94,6 +96,7 @@ With `"hoist"` set to `"functions"`, `let b` is considered a warning. But `let a
 
 ```js
 /*eslint no-shadow: [2, { "hoist": "functions" }]*/
+/*eslint-env es6*/
 
 if (true) {
     let a = 3;
@@ -110,6 +113,7 @@ With `"hoist"` set to `"never"`, neither `let a` nor `let b` in the `if` stateme
 
 ```js
 /*eslint no-shadow: [2, { "hoist": "never" }]*/
+/*eslint-env es6*/
 
 if (true) {
     let a = 3;

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -12,6 +12,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-this-before-super: 2*/
+/*eslint-env es6*/
 
 class A extends B {
     constructor() {
@@ -45,6 +46,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-this-before-super: 2*/
+/*eslint-env es6*/
 
 class A {
     constructor() {

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -13,6 +13,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-throw-literal: 2*/
+/*eslint-env es6*/
 
 throw "error";         /*error Expected an object to be thrown.*/
 

--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -25,6 +25,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-undef-init: 2*/
+/*eslint-env es6*/
 
 var foo = undefined; /*error It's not necessary to initialize 'foo' to undefined.*/
 let bar = undefined; /*error It's not necessary to initialize 'bar' to undefined.*/
@@ -34,6 +35,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-undef-init: 2*/
+/*eslint-env es6*/
 
 var foo;
 let bar;

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -28,17 +28,19 @@ By default the following patterns are considered problems:
 ```js
 /*eslint no-unused-expressions: 2*/
 
-0        /*error Expected an assignment or function call and instead saw an expression.*/
+0         /*error Expected an assignment or function call and instead saw an expression.*/
 
-if(0) 0  /*error Expected an assignment or function call and instead saw an expression.*/
+if(0) 0   /*error Expected an assignment or function call and instead saw an expression.*/
 
-{0}      /*error Expected an assignment or function call and instead saw an expression.*/
+{0}       /*error Expected an assignment or function call and instead saw an expression.*/
 
-f(0), {} /*error Expected an assignment or function call and instead saw an expression.*/
+f(0), {}  /*error Expected an assignment or function call and instead saw an expression.*/
 
-a && b() /*error Expected an assignment or function call and instead saw an expression.*/
+a && b()  /*error Expected an assignment or function call and instead saw an expression.*/
 
-a, b()   /*error Expected an assignment or function call and instead saw an expression.*/
+a, b()    /*error Expected an assignment or function call and instead saw an expression.*/
+
+c = a, b; /*error Expected an assignment or function call and instead saw an expression.*/
 ```
 
 The following patterns are not considered problems by default:
@@ -57,8 +59,6 @@ new C
 delete a.b
 
 void a
-
-c = a, b;
 ```
 
 The following patterns are not considered problems if `allowShortCircuit` is enabled:

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -12,6 +12,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-use-before-define: 2*/
+/*eslint-env es6*/
 
 alert(a);       /*error a was used before it was defined*/
 var a = 10;
@@ -35,6 +36,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-use-before-define: 2*/
+/*eslint-env es6*/
 
 var a;
 a = 10;

--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -10,6 +10,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-useless-concat: 2*/
+/*eslint-env es6*/
 
 // these are the same as "10"
 var a = `some` + `string`; /*error Unexpected string concatenation of literals.*/

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -34,6 +34,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint no-var: 2*/
+/*eslint-env es6*/
 
 let x = "y";
 const CONFIG = {};

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -8,7 +8,7 @@ This rule is aimed at eliminating `with` statements.
 
 The following patterns are considered problems:
 
-```
+```js
 /*eslint no-with: 2*/
 with (foo) { /*error Unexpected use of 'with' statement.*/
     // ...

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -3,7 +3,7 @@
 While formatting preferences are very personal, a number of style guides require
 or disallow spaces between curly braces in the following situations:
 
-```js
+```
 // simple object literals
 var obj = { foo: "bar" };
 
@@ -43,7 +43,7 @@ Depending on your coding conventions, you can choose either option by specifying
 
 When `"never"` is set, the following patterns are considered problems:
 
-```js
+```
 /*eslint object-curly-spacing: [2, "never"]*/
 
 var obj = { 'foo': 'bar' };            /*error There should be no space after '{'*/ /*error There should be no space before '}'*/
@@ -56,7 +56,7 @@ import { foo } from 'bar';             /*error There should be no space after '{
 
 The following patterns are not considered problems:
 
-```js
+```
 /*eslint object-curly-spacing: [2, "never"]*/
 
 var obj = {'foo': 'bar'};
@@ -77,7 +77,7 @@ import {foo} from 'bar';
 
 When `"always"` is used, the following patterns are considered problems:
 
-```js
+```
 /*eslint object-curly-spacing: [2, "always"]*/
 
 var obj = {'foo': 'bar'};               /*error A space is required after '{'*/ /*error A space is required before '}'*/
@@ -94,7 +94,7 @@ import {foo } from 'bar';               /*error A space is required after '{'*/
 
 The following patterns are not considered problems:
 
-```js
+```
 /*eslint object-curly-spacing: [2, "always"]*/
 
 var obj = {};
@@ -174,4 +174,3 @@ You can turn this rule off if you are not concerned with the consistency of spac
 * [comma-spacing](comma-spacing.md)
 * [space-in-parens](space-in-parens.md)
 * [space-in-brackets](space-in-brackets.md) (deprecated)
-

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -23,6 +23,8 @@ var foo = {
 Now here are ES6 equivalents:
 
 ```js
+/*eslint-env es6*/
+
 // properties
 var foo = {x, y, z};
 
@@ -44,6 +46,7 @@ Each of the following properties would warn:
 
 ```js
 /*eslint object-shorthand: 2*/
+/*eslint-env es6*/
 
 var foo = {
     x: function() {},   /*error Expected method shorthand.*/
@@ -56,6 +59,7 @@ In that case the expected syntax would have been:
 
 ```js
 /*eslint object-shorthand: 2*/
+/*eslint-env es6*/
 
 var foo = {
     x() {},
@@ -69,6 +73,7 @@ The following will *not* warn:
 
 ```js
 /*eslint object-shorthand: 2*/
+/*eslint-env es6*/
 
 var foo = {
     x: (y) => y

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -82,6 +82,7 @@ When configured with `"always"` as the first option (the default), the following
 
 ```js
 /*eslint one-var: [2, "always"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar;
@@ -110,6 +111,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint one-var: [2, "always"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar,
@@ -147,6 +149,7 @@ When configured with `"never"` as the first option, the following patterns are c
 
 ```js
 /*eslint one-var: [2, "never"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar,          /*error Split 'var' declarations into multiple statements.*/
@@ -174,6 +177,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint one-var: [2, "never"]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar;
@@ -203,6 +207,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint one-var: [2, { var: "always", let: "never", const: "never" }]*/
+/*eslint-env es6*/
 
 function foo() {
     var bar,
@@ -235,6 +240,7 @@ If you are configuring the rule with an object, by default, if you didn't specif
 
 ```js
 /*eslint one-var: [2, { var: "always", let: "always" }]*/
+/*eslint-env es6*/
 
 function foo() {
     var a, b;

--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -22,6 +22,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint prefer-arrow-callback: 2*/
+/*eslint-env es6*/
 
 foo(a => a);
 foo(function*() { yield; });

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -12,6 +12,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint prefer-const: 2*/
+/*eslint-env es6*/
 
 let a = 3;               /*error `a` is never modified, use `const` instead.*/
 console.log(a);
@@ -31,6 +32,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint prefer-const: 2*/
+/*eslint-env es6*/
 
 let a; // there is no initialization.
 console.log(a);

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -279,7 +279,7 @@ delete foo.bar; /*error Avoid using the delete keyword, instead use Reflect.dele
 
 The following patterns are not considered problems:
 
-```
+```js
 /*eslint prefer-reflect: 2*/
 
 delete bar; // Does not reference an object, just a var
@@ -288,7 +288,7 @@ Reflect.deleteProperty(foo, 'bar');
 
 (Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md))
 
-```
+```js
 /*eslint prefer-reflect: [2, { exceptions: ["delete"] }]*/
 
 delete bar

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -10,6 +10,8 @@ Math.max.apply(Math, args);
 In ES2015, one can use the spread operator to call variadic functions.
 
 ```js
+/*eslint-env es6*/
+
 var args = [1, 2, 3, 4];
 Math.max(...args);
 ```

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -7,6 +7,8 @@ var str = "Hello, " + name + "!";
 ```
 
 ```js
+/*eslint-env es6*/
+
 var str = `Hello, ${name}!`;
 ```
 
@@ -27,6 +29,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint prefer-template: 2*/
+/*eslint-env es6*/
 
 var str = "Hello World!";
 var str = `Hello, ${name}!`;

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -92,6 +92,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint quote-props: [2, "always"]*/
+/*eslint-env es6*/
 
 var object1 = {
     "foo": "bar",
@@ -131,6 +132,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint quote-props: [2, "as-needed"]*/
+/*eslint-env es6*/
 
 var object1 = {
     "a-b": 0,

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -3,6 +3,8 @@
 JavaScript allows you to define strings in one of three ways: double quotes, single quotes, and backticks (as of ECMAScript 6). For example:
 
 ```js
+/*eslint-env es6*/
+
 var double = "double";
 var single = 'single';
 var backtick = `backtick`;    // ES6 only
@@ -76,6 +78,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint quotes: [2, "double"]*/
+/*eslint-env es6*/
 
 var double = "double";
 var backtick = `backtick`; // backticks are allowed
@@ -83,6 +86,7 @@ var backtick = `backtick`; // backticks are allowed
 
 ```js
 /*eslint quotes: [2, "single"]*/
+/*eslint-env es6*/
 
 var single = 'single';
 var backtick = `backtick`; // backticks are allowed
@@ -102,6 +106,7 @@ var double = "a string containing 'single' quotes";
 
 ```js
 /*eslint quotes: [2, "backtick"]*/
+/*eslint-env es6*/
 
 var backtick = `backtick`;
 ```
@@ -115,4 +120,3 @@ var double = "a string containing `backtick` quotes"
 ## When Not To Use It
 
 If you do not need consistency in your string styles, you can safely disable this rule.
-

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -8,6 +8,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint require-yield: 2*/
+/*eslint-env es6*/
 
 function* foo() { /*error This generator function does not have `yield`.*/
   return 10;
@@ -18,6 +19,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint require-yield: 2*/
+/*eslint-env es6*/
 
 function* foo() {
   yield 5;

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -108,6 +108,7 @@ The following patterns are considered problems when configured `{ "functions": "
 
 ```js
 /*eslint space-before-blocks: [2, { "functions": "never", "keywords": "always" }]*/
+/*eslint-env es6*/
 
 function a() {}    /*error Unexpected space before opening brace.*/
 
@@ -123,6 +124,7 @@ The following patterns are not considered problems when configured `{ "functions
 
 ```js
 /*eslint space-before-blocks: [2, { "functions": "never", "keywords": "always" }]*/
+/*eslint-env es6*/
 
 for (;;) {
   // ...
@@ -141,6 +143,7 @@ The following patterns are considered problems when configured `{ "functions": "
 
 ```js
 /*eslint space-before-blocks: [2, { "functions": "always", "keywords": "never" }]*/
+/*eslint-env es6*/
 
 function a(){}      /*error Missing space before opening brace.*/
 
@@ -156,6 +159,7 @@ The following patterns are not considered problems when configured `{ "functions
 
 ```js
 /*eslint space-before-blocks: [2, { "functions": "always", "keywords": "never" }]*/
+/*eslint-env es6*/
 
 if (a){
   b();

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -34,6 +34,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint space-before-function-paren: 2*/
+/*eslint-env es6*/
 
 function foo() {           /*error Missing space before function parentheses.*/
     // ...
@@ -64,6 +65,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint space-before-function-paren: 2*/
+/*eslint-env es6*/
 
 function foo () {
     // ...
@@ -96,6 +98,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint space-before-function-paren: [2, "never"]*/
+/*eslint-env es6*/
 
 function foo () {           /*error Unexpected space before function parentheses.*/
     // ...
@@ -126,6 +129,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint space-before-function-paren: [2, "never"]*/
+/*eslint-env es6*/
 
 function foo() {
     // ...
@@ -158,6 +162,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint space-before-function-paren: [2, { "anonymous": "always", "named": "never" }]*/
+/*eslint-env es6*/
 
 function foo () {      /*error Unexpected space before function parentheses.*/
     // ...
@@ -184,6 +189,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint space-before-function-paren: [2, { "anonymous": "always", "named": "never" }]*/
+/*eslint-env es6*/
 
 function foo() {
     // ...
@@ -212,6 +218,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint space-before-function-paren: [2, { "anonymous": "never", "named": "always" }]*/
+/*eslint-env es6*/
 
 function foo() {        /*error Missing space before function parentheses.*/
     // ...
@@ -238,6 +245,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint space-before-function-paren: [2, { "anonymous": "never", "named": "always" }]*/
+/*eslint-env es6*/
 
 function foo () {
     // ...

--- a/docs/rules/space-before-function-parentheses.md
+++ b/docs/rules/space-before-function-parentheses.md
@@ -31,6 +31,8 @@ The default configuration is `"always"`.
 The following patterns are considered problems when configured `"always"`:
 
 ```js
+/*eslint-env es6*/
+
 function foo() {
     // ...
 }
@@ -59,6 +61,8 @@ var foo = {
 The following patterns are not considered problems when configured `"always"`:
 
 ```js
+/*eslint-env es6*/
+
 function foo () {
     // ...
 }
@@ -87,6 +91,8 @@ var foo = {
 The following patterns are considered problems when configured `"never"`:
 
 ```js
+/*eslint-env es6*/
+
 function foo () {
     // ...
 }
@@ -115,6 +121,8 @@ var foo = {
 The following patterns are not considered problems when configured `"never"`:
 
 ```js
+/*eslint-env es6*/
+
 function foo() {
     // ...
 }
@@ -143,6 +151,8 @@ var foo = {
 The following patterns are considered problems when configured `{"anonymous": "always", "named": "never"}`:
 
 ```js
+/*eslint-env es6*/
+
 function foo () {
     // ...
 }
@@ -167,6 +177,8 @@ var foo = {
 The following patterns are not considered problems when configured `{"anonymous": "always", "named": "never"}`:
 
 ```js
+/*eslint-env es6*/
+
 function foo() {
     // ...
 }
@@ -191,6 +203,8 @@ var foo = {
 The following patterns are considered problems when configured `{"anonymous": "never", "named": "always"}`:
 
 ```js
+/*eslint-env es6*/
+
 function foo() {
     // ...
 }
@@ -215,6 +229,8 @@ var foo = {
 The following patterns are not considered problems when configured `{"anonymous": "never", "named": "always"}`:
 
 ```js
+/*eslint-env es6*/
+
 function foo () {
     // ...
 }

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -54,6 +54,7 @@ The following patterns are considered errors when configured `"always"`:
 
 ```js
 /*eslint space-before-keywords: [2, "always"]*/
+/*eslint-env es6*/
 
 if (foo) {
     // ...
@@ -72,6 +73,7 @@ The following patterns are not considered errors when configured `"always"`:
 
 ```js
 /*eslint space-before-keywords: [2, "always"]*/
+/*eslint-env es6*/
 
 if (foo) {
     // ...

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -36,6 +36,8 @@ Depending on your coding conventions, you can choose either option by specifying
 When `"never"` is set, the following patterns are considered problems:
 
 ```js
+/*eslint-env es6*/
+
 foo[ 'bar' ];
 foo['bar' ];
 
@@ -98,6 +100,8 @@ var obj = {};
 When `"always"` is used, the following patterns are considered problems:
 
 ```js
+/*eslint-env es6*/
+
 foo['bar'];
 foo['bar' ];
 foo[ 'bar'];

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -40,6 +40,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint space-infix-ops: 2*/
+/*eslint-env es6*/
 
 a+b                   /*error Infix operators must be spaced.*/
 
@@ -60,6 +61,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint space-infix-ops: 2*/
+/*eslint-env es6*/
 
 a + b
 

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -54,6 +54,7 @@ Given the default values `words`: `true`, `nonwords`: `false`, the following pat
 
 ```js
 /*eslint space-unary-ops: 2*/
+/*eslint-env es6*/
 
 typeof!foo;        /*error Unary word operator "typeof" must be followed by whitespace.*/
 


### PR DESCRIPTION
~~I've not squashed these commits yet, because I think it might be easier to review the commits separately.  Also, this is a mixture of `Build:` and `Docs:`, so I'm not sure the appropriate tag to use here.~~ 

Squashed commits listed below, build component removed.

The only blocked rules which are not being *fully* linted are the following (see https://github.com/eslint/eslint/issues/2271#issuecomment-141724453):

* indent (tabs fail our own markdown linting rules)
* no-trailing-spaces (trailing spaces fail our own markdown linting rules)
* no-void (purposely throws an error, can't be handled)
* id-length (requires ecmaFeatures: modules)
* no-multi-spaces (requires ecmaFeatures: modules)
* object-curly-spacing (requires ecmaFeatures: modules)
* jsx-quotes (requires ecmaFeatures: jsx)

I propose merging this after review, and we can revisit the rules listed above when we have solutions in place to handle them.

Squashed Commits:
* 4f9db2a - Remove js info string from blocks requiring modules
* edc6edf - Specify '/*eslint-env es6*/' as appropriate
* d3372e6 - Return js info string to rules which require non-strict mode
* df83b86 - Cleanup failing rule examples