### PR TITLE
Fix: `no-dupe-args` had been wrong for nested destructuring

### DIFF
--- a/lib/rules/no-dupe-args.js
+++ b/lib/rules/no-dupe-args.js
@@ -2,6 +2,8 @@
  * @fileoverview Rule to flag duplicate arguments
  * @author Jamund Ferguson
  * @copyright 2015 Jamund Ferguson. All rights reserved.
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
  */
 
 "use strict";
@@ -17,62 +19,44 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
 
     /**
+     * Checks whether or not a given definition is a parameter's.
+     * @param {escope.DefEntry} def - A definition to check.
+     * @returns {boolean} `true` if the definition is a parameter's.
+     */
+    function isParameter(def) {
+        return def.type === "Parameter";
+    }
+
+    /**
      * Determines if a given node has duplicate parameters.
      * @param {ASTNode} node The node to check.
      * @returns {void}
      * @private
      */
     function checkParams(node) {
-        var params = {},
-            dups = {};
+        var variables = context.getDeclaredVariables(node);
+        var keyMap = Object.create(null);
 
+        for (var i = 0; i < variables.length; ++i) {
+            var variable = variables[i];
 
-        /**
-         * Marks a given param as either seen or duplicated.
-         * @param {string} name The name of the param to mark.
-         * @returns {void}
-         * @private
-         */
-        function markParam(name) {
-            if (params.hasOwnProperty(name)) {
-                dups[name] = 1;
-            } else {
-                params[name] = 1;
+            // TODO(nagashima): Remove this duplication check after https://github.com/estools/escope/pull/79
+            var key = "$" + variable.name; // to avoid __proto__.
+            if (!isParameter(variable.defs[0]) || keyMap[key]) {
+                continue;
+            }
+            keyMap[key] = true;
+
+            // Checks and reports duplications.
+            var defs = variable.defs.filter(isParameter);
+            if (defs.length >= 2) {
+                context.report({
+                    node: node,
+                    message: "Duplicate param '{{name}}'.",
+                    data: {name: variable.name}
+                });
             }
         }
-
-        // loop through and find each duplicate param
-        node.params.forEach(function(param) {
-
-            switch (param.type) {
-                case "Identifier":
-                    markParam(param.name);
-                    break;
-
-                case "ObjectPattern":
-                    param.properties.forEach(function(property) {
-                        markParam(property.key.name);
-                    });
-                    break;
-
-                case "ArrayPattern":
-                    param.elements.forEach(function(element) {
-
-                        // Arrays can be sparse (unwanted arguments)
-                        if (element !== null) {
-                            markParam(element.name);
-                        }
-                    });
-                    break;
-
-                // no default
-            }
-        });
-
-        // log an error for each duplicate (not 2 for each)
-        Object.keys(dups).forEach(function(currentParam) {
-            context.report(node, "Duplicate param '{{key}}'.", { key: currentParam });
-        });
     }
 
     //--------------------------------------------------------------------------

--- a/tests/lib/rules/no-dupe-args.js
+++ b/tests/lib/rules/no-dupe-args.js
@@ -23,7 +23,8 @@ ruleTester.run("no-dupe-args", rule, {
         "function a(a, b, c){}",
         "var a = function(a, b, c){}",
         { code: "function a({a, b}, {c, d}){}", ecmaFeatures: { destructuring: true } },
-        { code: "function a([ , a]) {}", ecmaFeatures: { destructuring: true } }
+        { code: "function a([ , a]) {}", ecmaFeatures: { destructuring: true } },
+        { code: "function foo([[a, b], [c, d]]) {}", ecmaFeatures: { destructuring: true } }
     ],
     invalid: [
         { code: "function a(a, b, b) {}", errors: [{ message: "Duplicate param 'b'." }] },


### PR DESCRIPTION
Fixes #3867.

I changed the check process with using `escope.Variable`.