### PR TITLE
Fix: `space-before-keywords` had been wrong on getters

### DIFF
--- a/lib/rules/space-before-keywords.js
+++ b/lib/rules/space-before-keywords.js
@@ -177,18 +177,12 @@ module.exports = function(context) {
         "ContinueStatement": check,
         "FunctionDeclaration": check,
         "FunctionExpression": function(node) {
-
             var left = context.getTokenBefore(node);
             var right = context.getFirstToken(node);
-            var isClassMethod = node.parent && node.parent.type === "MethodDefinition";
-            var isObjectShorthandMethod = node.parent && node.parent.method && node.parent.type === "Property";
 
-            // If the function expression is a class method or an object literal shorthand method
-            // the first token (`right`) will match the function parentheses while `left` will match
-            // the function identifier. Thus, we want to grab the tokens that are one more to the left.
-            if (isClassMethod || isObjectShorthandMethod) {
-                right = left;
-                left = context.getTokenBefore(left);
+            // If it's a method, a getter, or a setter, the first token is not the `function` keyword.
+            if (right.type !== "Keyword") {
+                return;
             }
 
             checkTokens(node, left, right, { allowedPrecedingChars: [ "(", "{" ] });

--- a/tests/lib/rules/space-before-keywords.js
+++ b/tests/lib/rules/space-before-keywords.js
@@ -131,9 +131,6 @@ ruleTester.run("space-before-keywords", rule, {
         { code: ";\nfunction foo () {}" },
         { code: "; function foo () {}", options: never },
         { code: ";\nfunction foo () {}", options: never },
-        { code: "var foo = {bar() {}}", ecmaFeatures: { objectLiteralShorthandMethods: true } },
-        { code: "var foo = { bar() {} }", ecmaFeatures: { objectLiteralShorthandMethods: true }, options: never },
-        { code: "var foo = {\nbar() {}}", ecmaFeatures: { objectLiteralShorthandMethods: true }, options: never },
         // FunctionExpression
         { code: "var foo = function bar () {}" },
         { code: "var foo =\nfunction bar () {}" },
@@ -145,6 +142,13 @@ ruleTester.run("space-before-keywords", rule, {
         { code: "var foo =\nfunction bar () {}", options: never },
         { code: "function foo () { return function () {} }", options: never },
         { code: "var foo = { foo:function () {} }", options: never },
+        { code: "var foo = {bar() {}}", ecmaFeatures: { objectLiteralShorthandMethods: true } },
+        { code: "var foo = { bar() {} }", ecmaFeatures: { objectLiteralShorthandMethods: true }, options: never },
+        { code: "var foo = {\nbar() {}}", ecmaFeatures: { objectLiteralShorthandMethods: true }, options: never },
+        { code: "var foo = {get bar() {}}" },
+        { code: "var foo = {get bar() {}}", options: never },
+        { code: "var foo = {set bar(v) {}}" },
+        { code: "var foo = {set bar(v) {}}", options: never },
         // YieldExpression
         {
             code: "function* foo() { yield 0; }",


### PR DESCRIPTION
Fixes #3854.
I made `space-before-keywords` ignoring methods, getters, and setters.