### PR TITLE
WIP: Build: Lint rule documentation examples (fixes #2271)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -48,10 +48,12 @@ var NODE = "node ", // intentional extra space
     BUILD_DIR = "./build/",
     DOCS_DIR = "../eslint.github.io/docs",
     SITE_DIR = "../eslint.github.io/",
+    RULES_DOCS_DIR = "./docs/rules",
 
     // Utilities - intentional extra space at the end of each string
     MOCHA = NODE_MODULES + "mocha/bin/_mocha ",
     ESLINT = NODE + " bin/eslint.js ",
+    PLUGIN_MARKDOWN = "--plugin markdown ",
 
     // Files
     MAKEFILE = "./Makefile.js",
@@ -473,6 +475,12 @@ target.lint = function() {
 
     echo("Validating Markdown Files");
     lastReturn = lintMarkdown(MARKDOWN_FILES_ARRAY);
+    if (lastReturn.code !== 0) {
+        errors++;
+    }
+
+    echo("Validating Rule Doc Code Examples");
+    lastReturn = exec(ESLINT + PLUGIN_MARKDOWN + RULES_DOCS_DIR + " --no-eslintrc --ext .md");
     if (lastReturn.code !== 0) {
         errors++;
     }

--- a/package.json
+++ b/package.json
@@ -78,6 +78,8 @@
     "coveralls": "2.11.2",
     "dateformat": "^1.0.8",
     "ejs": "^2.3.3",
+    "eslint": "^1.5.0",
+    "eslint-plugin-markdown": "eslint/eslint-plugin-markdown",
     "esprima": "^2.4.1",
     "esprima-fb": "^10001.1.0-dev-harmony-fb",
     "gh-got": "^1.0.3",


### PR DESCRIPTION
A question is still outstanding here on how to handle the use of an ESLint plugin within ESLint itself, since plugins have a peer dependency on `eslint`.

Tests will not pass until https://github.com/eslint/eslint/pull/3866 lands.