### PR TITLE
Update: warn message use @return whe prefer.returns=return (refs #3872)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -167,7 +167,7 @@ module.exports = function(context) {
             // check for functions missing @returns
             if (!isOverride && !hasReturns && !hasConstructor && node.parent.kind !== "get") {
                 if (requireReturn || functionData.returnPresent) {
-                    context.report(jsdocNode, "Missing JSDoc @returns for function.");
+                    context.report(jsdocNode, "Missing JSDoc @" + (prefer.returns || "returns") + " for function.");
                 }
             }
 

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -156,6 +156,14 @@ ruleTester.run("valid-jsdoc", rule, {
             }]
         },
         {
+            code: "/** Foo \n */\nfunction foo(){}",
+            options: [{ prefer: { "returns": "return" }}],
+            errors: [{
+                message: "Missing JSDoc @return for function.",
+                type: "Block"
+            }]
+        },
+        {
             code: "/** Foo \n@return {void} Foo\n */\nfoo.bar = () => {}",
             options: [{ prefer: { "return": "returns" }}],
             ecmaFeatures: { arrowFunctions: true },


### PR DESCRIPTION
.eslintrc:

```json
{
    "valid-jsdoc": [2, {
      "prefer": {
        "returns": "return"
      }
    }]
}
```

When jsdoc missing `@return` and `@returns`, warn message will be:

```
Missing JSDoc @return for function  valid-jsdoc

// NOT:
Missing JSDoc @returns for function  valid-jsdoc
```