### PR TITLE
Update: Add env 'nashorn' to support Java 8 Nashorn Engine (fixes #3874)

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -74,6 +74,9 @@ module.exports = {
     applescript: {
         globals: globals.applescript
     },
+    nashorn: {
+        globals: globals.nashorn
+    },
     serviceworker: {
         globals: globals.serviceworker
     },

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -111,6 +111,7 @@ An environment defines global variables that are predefined. The available envir
 * `meteor` - Meteor global variables.
 * `mongo` - MongoDB global variables.
 * `applescript` - AppleScript global variables.
+* `nashorn` - Java 8 Nashorn global variables.
 * `serviceworker` - Service Worker global variables.
 * `embertest` - Ember test helper globals.
 * `es6` - enable all ECMAScript 6 features except for modules.

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "estraverse": "^4.1.0",
     "estraverse-fb": "^1.3.1",
     "glob": "^5.0.14",
-    "globals": "^8.6.0",
+    "globals": "^8.10.0",
     "handlebars": "^4.0.0",
     "inquirer": "^0.9.0",
     "file-entry-cache": "^1.1.1",

--- a/tests/fixtures/configurations/env-nashorn.json
+++ b/tests/fixtures/configurations/env-nashorn.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "nashorn": true
+  },
+  "rules": {
+    "no-undef": 2
+  }
+}

--- a/tests/fixtures/globals-nashorn.js
+++ b/tests/fixtures/globals-nashorn.js
@@ -1,0 +1,4 @@
+var path = __DIR__;
+print(path);
+load('something.js');
+loadWithNewGlobal('other.js');

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -164,6 +164,18 @@ describe("cli", function() {
         });
     });
 
+    describe("when given a config with environment set to Nashorn", function() {
+        it("should execute without any errors", function() {
+            var configPath = getFixturePath("configurations", "env-nashorn.json");
+            var filePath = getFixturePath("globals-nashorn.js");
+            var code = "--config " + configPath + " " + filePath;
+
+            var exit = cli.execute(code);
+
+            assert.equal(exit, 0);
+        });
+    });
+
     describe("when given a config that is a sharable config", function() {
         it("should execute without any errors", function() {
             var stubbedConfig = proxyquire("../../lib/config", {


### PR DESCRIPTION
This PR adds new env `nashorn` to support the global variables of the Java 8 Nashorn JavaScript Engine.