### PR TITLE
Fix: Crash in valid-jsdoc with invalid JSDoc @param (fixes #3893)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -111,6 +111,13 @@ module.exports = function(context) {
                     case "param":
                     case "arg":
                     case "argument":
+                        if (!tag.name) {
+                            context.report(jsdocNode, "Missing JSDoc parameter name for @{{title}} (description: '{{description}}').", {
+                                title: tag.title,
+                                description: tag.description
+                            });
+                        }
+
                         if (!tag.type) {
                             context.report(jsdocNode, "Missing JSDoc parameter type for '{{name}}'.", { name: tag.name });
                         }
@@ -121,7 +128,7 @@ module.exports = function(context) {
 
                         if (params[tag.name]) {
                             context.report(jsdocNode, "Duplicate JSDoc parameter '{{name}}'.", { name: tag.name });
-                        } else if (tag.name.indexOf(".") === -1) {
+                        } else if (tag.name && tag.name.indexOf(".") === -1) {
                             params[tag.name] = 1;
                         }
                         break;

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -317,6 +317,25 @@ ruleTester.run("valid-jsdoc", rule, {
                 message: "Unexpected @returns tag; function has no return statement.",
                 type: "Block"
             }]
+        },
+        {
+            code: "/**\n* Description\n* @param arg1 [optional] description */\nfunction foo(arg1){ }",
+            options: [{requireReturn: false}],
+            ecmaFeatures: {arrowFunctions: true},
+            errors: [
+                {
+                    message: "Missing JSDoc parameter name for @param (description: '[optional] description').",
+                    type: "Block"
+                },
+                {
+                    message: "Missing JSDoc parameter type for \'undefined\'.",
+                    type: "Block"
+                },
+                {
+                    message: "Missing JSDoc for parameter \'arg1\'.",
+                    type: "Block"
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
Ensure `tag.name` exists first, and report an error if it doesn't exist.

Also adds an `tag.name` existence check before doing `tag.name.indexOf`.

Includes tests.

Fixes https://github.com/eslint/eslint/issues/3893