### PR TITLE
Add note about typeof check for isNaN

### DIFF
--- a/docs/rules/no-self-compare.md
+++ b/docs/rules/no-self-compare.md
@@ -2,7 +2,7 @@
 
 Comparing a variable against itself is usually an error, either an typo or refactoring error. It is confusing to the reader and may potentially introduce a runtime error.
 
-The only time you would compare a variable against itself is when you are testing for `NaN`. However, it is far more appropriate to use the `isNaN()` function for that use case rather than leaving the reader of the code to determine the intent of self comparison.
+The only time you would compare a variable against itself is when you are testing for `NaN`. However, it is far more appropriate to use `typeof x === 'number' && isNaN(x)` or the [Number.isNaN ES2015 function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN) for that use case rather than leaving the reader of the code to determine the intent of self comparison.
 
 ## Rule Details
 


### PR DESCRIPTION
`isNaN` gives surprising results unless you also check the `typeof` the variable is `number`. Explicitly calling this out in the documentation so people don't end up writing broken checks:

```
isNaN('derp') // true
isNaN({}); // true
isNaN(undefined) // true
```