### PR TITLE
Ignored files should not throw errors during CLI

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -556,9 +556,12 @@ CLIEngine.prototype = {
          */
         function executeOnFile(filename) {
             var shouldIgnore = ignoredPaths.contains(filename);
-            filename = fs.realpathSync(filename);
+            if (shouldIgnore) {
+                return;
+            }
 
-            if (processed[filename] || shouldIgnore) {
+            filename = fs.realpathSync(filename);
+            if (processed[filename]) {
                 return;
             }
 

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -712,6 +712,27 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 0);
         });
 
+        it("should not fail if an ignored file cannot be resolved", function() {
+
+            var fakeFS = leche.fake(fs),
+                LocalCLIEngine = proxyquire("../../lib/cli-engine", {
+                    fs: fakeFS
+                });
+
+            fakeFS.realpathSync = function() {
+                throw new Error("this error should not happen");
+            };
+
+            engine = new LocalCLIEngine({
+                ignorePattern: "tests"
+            });
+
+            assert.doesNotThrow(function() {
+                engine.executeOnFiles(["tests/fixtures/single-quoted.js"]);
+            });
+
+        });
+
         describe("Fix Mode", function() {
 
             it("should return fixed text on multiple files when in fix mode", function() {


### PR DESCRIPTION
Sorry in advance for a PR that does not include any tests. The problem I came across was an extremely weird edge-case that I have not been able to reproduce manually. However, I think my fix is pretty simple and the rationale should make sense regardless.

At the point where my change has been made (ie: `executeOnFile()`), there is a `fs.realpathSync()` call that was throwing in the case described by #3978. The file in question was known by ESLint to be ignored, but the realpath call was happening before the early return. I've changed it to exit early once the file is known to be ignored, before running the risk of `fs.realpathSync()` throwing an uncaught exception.

I'm sure there are other (edge) cases where this `fs.realpathSync()` could throw in this small window, but this prevents errors happening for files that should be ignored in the first place. Not to mention, there's no reason to add the performance penalty of a sync fs call for a file that will just be ignored anyways.