### PR TITLE
Add rule no-unneeded-match

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -96,6 +96,7 @@
         "no-unexpected-multiline": 0,
         "no-underscore-dangle": 0,
         "no-unneeded-ternary": 0,
+        "no-unneeded-match": 0,
         "no-unreachable": 2,
         "no-unused-expressions": 0,
         "no-unused-vars": [2, {"vars": "all", "args": "after-used"}],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -173,6 +173,7 @@ These rules are purely matters of style and are quite subjective.
 * [no-ternary](no-ternary.md) - disallow the use of ternary operators
 * [no-trailing-spaces](no-trailing-spaces.md) - disallow trailing whitespace at the end of lines (fixable)
 * [no-underscore-dangle](no-underscore-dangle.md) - disallow dangling underscores in identifiers
+* [no-unneeded-match](no-unneeded-match.md) - disallow casting the result of `String.prototype.match` to boolean
 * [no-unneeded-ternary](no-unneeded-ternary.md) - disallow the use of ternary operators when a simpler alternative exists
 * [object-curly-spacing](object-curly-spacing.md) - require or disallow padding inside curly braces (fixable)
 * [one-var](one-var.md) - require or disallow one variable declaration per function

--- a/docs/rules/no-unneeded-match.md
+++ b/docs/rules/no-unneeded-match.md
@@ -1,0 +1,35 @@
+# Prefer `RegExp.prototype.test` over `String.prototype.match` (no-unneeded-match)
+
+While the `String.prototype.match` method is intended for retrieving matches of
+a regular expression, it is often used only to check if a string matches the
+full regular expression. In those cases, `RegExp.prototype.test` can be used
+instead, and has better performance.
+
+## Rule Details
+
+This rule is aimed to flag usages of `String.prototype.match` which are being
+cast to boolean, and therefore can be replaced with `RegExp.prototype.test`.
+
+The following patterns are considered problems:
+
+```js
+if ('some name'.match(/[adhnsy]+/i)) {
+  // ...
+}
+
+var doesMatch = Boolean(''.match(/a/))
+```
+
+The following patterns are not considered problems:
+
+```js
+if (/[adhnsy]+/i.test('some name')) {
+  // ...
+}
+
+var doesMatch = /a/.test('')
+```
+
+## Version
+
+This rule was introduced in eslint-plugin-wix-editor 1.0.0.

--- a/lib/rules/no-unneeded-match.js
+++ b/lib/rules/no-unneeded-match.js
@@ -1,0 +1,95 @@
+/**
+ * @fileoverview Rule to spot scenarios where `String.prototype.match` is used where only `RegExp.prototype.test` is needed.
+ * @author Dany Shaanan
+ * @copyright 2015 Dany Shaanan
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+module.exports = function(context) {
+
+    /**
+     * Reports on node if Check to see if a CallExpression node is a match call on a regex
+     * @param {ASTNode} node The node to report on.
+     * @param {Boolean} bool A boolean which indicates if to report or not.
+     * @returns {void}
+     * @private
+     */
+    function reportOn(node, bool) {
+        if (bool) {
+            context.report(node, "Use `Regex.test() instead`");
+        }
+    }
+
+    /**
+     * Check to see if a CallExpression node is a match call on a regex
+     * @param {ASTNode} node The node to check.
+     * @returns {Boolean} result
+     * @private
+     */
+    function isNodeMatchCall(node) {
+        return node &&
+            node.callee &&
+            node.callee.type === "MemberExpression" &&
+            node.callee.computed === false &&
+            node.callee.property &&
+            node.callee.property.type === "Identifier" &&
+            node.callee.property.name === "match" &&
+            node.arguments &&
+            node.arguments.length === 1 &&
+            node.arguments[0].type === "Literal" &&
+            node.arguments[0].regex;
+    }
+
+    /**
+     * Reports on node if it has a `test` that is a match call on a regex
+     * @param {ASTNode} node The node to report on.
+     * @returns {void}
+     * @private
+     */
+    function checkTestNode(node) {
+        try {
+            reportOn(node, node.test && node.test.type === "CallExpression" && isNodeMatchCall(node.test));
+        } catch (e) {
+            /* istanbul ignore next */
+            context.report(node, e.toString() + " " + e.stack);
+        }
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+    return {
+        IfStatement: checkTestNode,
+        WhileStatement: checkTestNode,
+        ForStatement: checkTestNode,
+        ConditionalExpression: checkTestNode,
+        UnaryExpression: function(node) {
+            try {
+                reportOn(node, node.operator === "!" && isNodeMatchCall(node.argument));
+            } catch (e) {
+                /* istanbul ignore next */
+                context.report(node, e.toString() + " " + e.stack);
+            }
+        },
+        CallExpression: function(node) {
+            try {
+                reportOn(node,
+                    node.callee &&
+                    node.callee.type === "Identifier" &&
+                    node.callee.name === "Boolean" &&
+                    node.arguments &&
+                    node.arguments.length &&
+                    isNodeMatchCall(node.arguments[0])
+                );
+            } catch (e) {
+                /* istanbul ignore next */
+                context.report(node, e.toString() + " " + e.stack);
+            }
+        }
+    };
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-unneeded-match.js
+++ b/tests/lib/rules/no-unneeded-match.js
@@ -1,0 +1,36 @@
+/**
+ * @fileoverview Test for no-unneeded-match rule
+ * @author Dany Shaanan <http://www.danyshaanan.com>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-unneeded-match"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+var useTest = "Use `Regex.test() instead`";
+
+ruleTester.run("no-unneeded-match", rule, {
+    valid: [
+        "''.match(/a/)",
+        "var m = ''.match(/a/)"
+    ],
+    invalid: [
+        {code: "if (''.match(/a/)) {}", errors: [{message: useTest}]},
+        {code: "while (''.match(/a/)) {}", errors: [{message: useTest}]},
+        {code: "for (;''.match(/a/);) {}", errors: [{message: useTest}]},
+        {code: "''.match(/a/) ? a : b", errors: [{message: useTest}]},
+        {code: "!(''.match(/a/))", errors: [{message: useTest}]},
+        {code: "!!(''.match(/a/))", errors: [{message: useTest}]},
+        {code: "Boolean(''.match(/a/))", errors: [{message: useTest}]}
+    ]
+});


### PR DESCRIPTION
`no-unneeded-match` catches uses of `String.prototype.match` which are used only for their boolean value, which therefore be better written with `RegExp.prototype.test`:

```js
if ('some name'.match(/[a-z ]+/i)) {
  // ...
}

// into:

if (/[a-z ]+/i.test('some name')) {
  // ...
}
```