### PR TITLE
Build: Add load performance check inside perf function (fixes #3994)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -20,7 +20,8 @@ var checker = require("npm-license"),
     os = require("os"),
     path = require("path"),
     semver = require("semver"),
-    ejs = require("ejs");
+    ejs = require("ejs"),
+    loadPerf = require("load-perf");
 
 //------------------------------------------------------------------------------
 // Settings
@@ -996,6 +997,28 @@ function time(cmd, runs, runNumber, results, cb) {
 
 }
 
+/**
+ * Run the load performance for eslint
+ * @returns {void}
+ * @private
+ */
+function loadPerformance() {
+    var results = [];
+    for (var cnt = 0; cnt < 5; cnt++) {
+        var loadPerfData = loadPerf({
+            checkDependencies: false
+        });
+
+        echo("Load performance Run #" + (cnt + 1) + ":  %dms", loadPerfData.loadTime);
+        results.push(loadPerfData.loadTime);
+    }
+    results.sort(function(a, b) {
+        return a - b;
+    });
+    var median = results[~~(results.length / 2)];
+    echo("\nLoad Performance median :  %dms", median);
+}
+
 target.perf = function() {
     var cpuSpeed = os.cpus()[0].speed,
         max = PERF_MULTIPLIER / cpuSpeed,
@@ -1012,10 +1035,11 @@ target.perf = function() {
 
         if (median > max) {
             echo("Performance budget exceeded: %dms (limit: %dms)", median, max);
-            exit(1);
         } else {
             echo("Performance budget ok:  %dms (limit: %dms)", median, max);
         }
+        echo("\n");
+        loadPerformance();
     });
 
 };

--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
     "jsonlint": "^1.6.2",
     "leche": "^2.1.1",
     "linefix": "^0.1.1",
+    "load-perf": "^0.2.0",
     "markdownlint": "^0.0.8",
     "mocha": "^2.1.0",
     "mocha-phantomjs": "3.6.0",


### PR DESCRIPTION
**Output:**

```sh
> node Makefile.js perf

CPU Speed is 2793 with multiplier 7500000
Performance Run #1:  1868.417686ms
Performance Run #2:  1840.1341579999998ms
Performance Run #3:  1878.664651ms
Performance Run #4:  1850.484123ms
Performance Run #5:  1843.7707209999999ms
Performance budget ok:  1850.484123ms (limit: 2685.2846401718584ms)


Load performance Run #1:  291.835235ms
Load performance Run #2:  290.304513ms
Load performance Run #3:  298.500252ms
Load performance Run #4:  292.96055ms
Load performance Run #5:  300.357205ms

Load Performance median :  292.96055ms
```
