### PR TITLE
Fix: `no-invalid-this` had been missing globals in node

### DIFF
--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -315,10 +315,17 @@ module.exports = function(context) {
         // `this` is invalid only under strict mode.
         // Modules is always strict mode.
         "Program": function(node) {
+            var scope = context.getScope();
+            var features = context.ecmaFeatures;
+
             stack.push({
                 init: true,
                 node: node,
-                valid: !(context.ecmaFeatures.modules || context.getScope().isStrict)
+                valid: !(
+                    scope.isStrict ||
+                    features.modules ||
+                    (features.globalReturn && scope.childScopes[0].isStrict)
+                )
             });
         },
         "Program:exit": function() {

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -93,6 +93,13 @@ var patterns = [
         valid: [NORMAL],
         invalid: [USE_STRICT, MODULES]
     },
+    {
+        code: "console.log(this); z(x => console.log(x, this));",
+        ecmaFeatures: {arrowFunctions: true, globalReturn: true},
+        errors: errors,
+        valid: [NORMAL],
+        invalid: [USE_STRICT, MODULES]
+    },
 
     // IIFE.
     {


### PR DESCRIPTION
Fixes #3961.