### PR TITLE
Fix: handle undefined source code correctly in source-code-fixer

### DIFF
--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -56,6 +56,15 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
 
     debug("Applying fixes");
 
+    if (!sourceCode) {
+        debug("No source code to fix");
+        return {
+            fixed: false,
+            messages: messages,
+            output: ""
+        };
+    }
+
     // clone the array
     var remainingMessages = [],
         fixes = [],


### PR DESCRIPTION
This PR contains a fix to handle cases when there is no source code present to fix.

#### Context

Source code fixer.

#### Problem background

When running `eslint src --fix` I encountered the following error:

```bash
$ eslint src --fix
/usr/local/lib/node_modules/eslint/lib/util/source-code-fixer.js:62
        text = sourceCode.text,
                         ^
TypeError: Cannot read property 'text' of null
    at Function.SourceCodeFixer.applyFixes (/usr/local/lib/node_modules/eslint/lib/util/source-code-fixer.js:62:26)
    at processText (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:224:43)
    at processFile (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:257:18)
    at executeOnFile (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:600:23)
    at Array.forEach (native)
    at /usr/local/lib/node_modules/eslint/lib/cli-engine.js:626:49
    at Array.forEach (native)
    at CLIEngine.executeOnFiles (/usr/local/lib/node_modules/eslint/lib/cli-engine.js:622:18)
    at Object.cli.execute (/usr/local/lib/node_modules/eslint/lib/cli.js:159:95)
    at Object.<anonymous> (/usr/local/lib/node_modules/eslint/bin/eslint.js:61:20)
```

#### Result after applying fix

After applying this PR, the command runs fine and fixes all problems that can be fixed.

#### CLA

I have signed the CLA.