### PR TITLE
New: required-modules rule (fixes #4021)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -167,6 +167,7 @@
         "id-match": 0,
         "require-jsdoc": 0,
         "require-yield": 0,
+        "required-modules": 0,
         "semi": 0,
         "semi-spacing": [0, {"before": false, "after": true}],
         "sort-vars": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -132,6 +132,7 @@ These rules are specific to JavaScript running on Node.js or using CommonJS in t
 * [no-process-exit](no-process-exit.md) - disallow `process.exit()`
 * [no-restricted-modules](no-restricted-modules.md) - restrict usage of specified node modules
 * [no-sync](no-sync.md) - disallow use of synchronous methods
+* [required-modules](required-modules.md) - require usage of specific node modules
 
 ## Stylistic Issues
 

--- a/docs/rules/required-modules.md
+++ b/docs/rules/required-modules.md
@@ -1,0 +1,23 @@
+# Require Node modules (required-modules)
+
+This rule can be used to mandate the usage of specific node modules in every file. For example, a project may wish to require that all test files load a particular module that performs specific runtime checks prior to program termination.
+
+## Rule Details
+
+This rule allows you to specify modules that must be loaded in every file.
+
+### Options
+
+The syntax to specify required modules looks like this:
+
+```json
+"required-modules": [2, <...moduleNames>]
+```
+
+### Examples
+
+To require the use of a module named `common`:
+
+```json
+    "required-modules": [2, "common"],
+```

--- a/lib/rules/required-modules.js
+++ b/lib/rules/required-modules.js
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Require usage of specified node modules.
+ * @author Rich Trott
+ */
+"use strict";
+
+var path = require("path");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    // trim required module names
+    var requiredModules = context.options;
+
+    var foundModules = [];
+
+    // if no modules are required we don't need to check the CallExpressions
+    if (requiredModules.length === 0) {
+        return {};
+    }
+
+    /**
+     * Function to check if a node is a string literal.
+     * @param {ASTNode} node The node to check.
+     * @returns {boolean} If the node is a string literal.
+     */
+    function isString(node) {
+        return node && node.type === "Literal" && typeof node.value === "string";
+    }
+
+    /**
+     * Function to check if a node is a require call.
+     * @param {ASTNode} node The node to check.
+     * @returns {boolean} If the node is a require call.
+     */
+    function isRequireCall(node) {
+        return node.callee.type === "Identifier" && node.callee.name === "require";
+    }
+
+    /**
+     * Function to check if a node has an argument that is a required module and return its name.
+     * @param {ASTNode} node The node to check
+     * @returns {undefined|String} required module name or undefined if node argument isn't required.
+     */
+    function getRequiredModuleName(node) {
+        var moduleName;
+
+        // node has arguments and first argument is string
+        if (node.arguments.length && isString(node.arguments[0])) {
+            var argValue = path.basename(node.arguments[0].value.trim());
+
+            // check if value is in required modules array
+            if (requiredModules.indexOf(argValue) !== -1) {
+                moduleName = argValue;
+            }
+        }
+
+        return moduleName;
+    }
+
+    return {
+        "CallExpression": function(node) {
+            if (isRequireCall(node)) {
+                var requiredModuleName = getRequiredModuleName(node);
+
+                if (requiredModuleName) {
+                    foundModules.push(requiredModuleName);
+                }
+            }
+        },
+        "Program:exit": function(node) {
+            if (foundModules.length < requiredModules.length) {
+                var missingModules = requiredModules.filter(
+                    function(module) {
+                        return foundModules.indexOf(module === -1);
+                    }
+                );
+                missingModules.forEach(function(moduleName) {
+                    context.report(
+                        node,
+                        "Mandatory module '{{moduleName}}' must be loaded.",
+                        { moduleName: moduleName }
+                    );
+                });
+            }
+        }
+    };
+};
+
+module.exports.schema = {
+    "type": "array",
+    "items": [
+        {
+            "enum": [0, 1, 2]
+        }
+    ],
+    "additionalItems": {
+        "type": "string"
+    },
+    "uniqueItems": true
+};

--- a/tests/lib/rules/required-modules.js
+++ b/tests/lib/rules/required-modules.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Tests for required-modules.
+ * @author Rich Trott
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/required-modules"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("required-modules", rule, {
+    valid: [
+        { code: "require('assert')", options: ["assert"]},
+        { code: "require('assert');\nrequire('this');", options: ["assert", "this"]},
+        { code: "require('assert');", options: []},
+        { code: "require('assert');\nrequire();", options: ["assert"]},
+        { code: "require('assert');\nrequire(2);", options: ["assert"]},
+        { code: "require('assert')", args: 0 },
+        { code: "require('../common')", args: ["common"]},
+        { code: "require('./../foo/bar/baz/common')", args: ["common"]},
+        { code: "var foo = require('assert');", options: ["assert"]},
+        { code: "require('assert');\nconsole.log('hi');", options: ["assert"]}
+    ],
+    invalid: [{
+        code: "require('assert')", options: ["common"],
+        errors: [{ message: "Mandatory module 'common' must be loaded.", type: "Program"}]
+    }]
+});


### PR DESCRIPTION
This rule can be used to mandate the usage of specific node modules in every file. For example, a project may wish to require that all test files load a particular module that performs specific runtime checks prior to program termination. (This is actually exactly what this rule was written to do on node core. Hoping it is deemed potentially useful to others.)