### PR TITLE
Fix: `no-redeclare` and `no-sahadow` for builtin globals

### DIFF
--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -15,32 +15,14 @@ module.exports = function(context) {
     };
 
     /**
-     * Gets the names of writeable built-in variables.
-     * @param {escope.Scope} scope - A scope to get.
-     * @returns {object} A map that its key is a variable name.
-     */
-    function getBuiltinGlobals(scope) {
-        return scope.variables.reduce(function(retv, variable) {
-            if ("writeable" in variable && variable.name !== "__proto__") {
-                retv[variable.name] = true;
-            }
-            return retv;
-        }, Object.create(null));
-    }
-
-    /**
      * Find variables in a given scope and flag redeclared ones.
      * @param {Scope} scope - An escope scope object.
-     * @param {object} builtins - A map that its key is a variable name.
      * @returns {void}
      * @private
      */
-    function findVariablesInScope(scope, builtins) {
+    function findVariablesInScope(scope) {
         scope.variables.forEach(function(variable) {
-            var hasBuiltin = (
-                options.builtinGlobals &&
-                ("writeable" in variable || Boolean(builtins && builtins[variable.name]))
-            );
+            var hasBuiltin = options.builtinGlobals && "writeable" in variable;
             var count = (hasBuiltin ? 1 : 0) + variable.identifiers.length;
 
             if (count >= 2) {
@@ -68,10 +50,8 @@ module.exports = function(context) {
         var scope = context.getScope();
 
         // Nodejs env or modules has a special scope.
-        // But built-in global variables are not there.
         if (context.ecmaFeatures.globalReturn || context.ecmaFeatures.modules) {
-            var builtins = (options.builtinGlobals ? getBuiltinGlobals(scope) : null);
-            findVariablesInScope(scope.childScopes[0], builtins);
+            findVariablesInScope(scope.childScopes[0]);
         } else {
             findVariablesInScope(scope);
         }

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -156,12 +156,7 @@ module.exports = function(context) {
 
     return {
         "Program:exit": function() {
-            // Nodejs env or modules has a special scope for globals.
             var globalScope = context.getScope();
-            if (context.ecmaFeatures.globalReturn || context.ecmaFeatures.modules) {
-                globalScope = globalScope.childScopes[0];
-            }
-
             var stack = globalScope.childScopes.slice();
             var scope;
 

--- a/tests/lib/rules/no-redeclare.js
+++ b/tests/lib/rules/no-redeclare.js
@@ -29,8 +29,12 @@ ruleTester.run("no-redeclare", rule, {
         },
         { code: "var Object = 0;" },
         { code: "var Object = 0;", options: [{builtinGlobals: false}] },
+        { code: "var Object = 0;", options: [{builtinGlobals: true}], ecmaFeatures: {modules: true} },
+        { code: "var Object = 0;", options: [{builtinGlobals: true}], ecmaFeatures: {globalReturn: true} },
         { code: "var top = 0;", env: {browser: true} },
-        { code: "var top = 0;", options: [{builtinGlobals: true}] }
+        { code: "var top = 0;", options: [{builtinGlobals: true}] },
+        { code: "var top = 0;", options: [{builtinGlobals: true}], env: {browser: true}, ecmaFeatures: {modules: true} },
+        { code: "var top = 0;", options: [{builtinGlobals: true}], env: {browser: true}, ecmaFeatures: {globalReturn: true} }
     ],
     invalid: [
         { code: "var a = 3; var a = 10;", ecmaFeatures: { globalReturn: true }, errors: [{ message: "\"a\" is already defined", type: "Identifier"}] },
@@ -71,15 +75,24 @@ ruleTester.run("no-redeclare", rule, {
             options: [{builtinGlobals: true}],
             ecmaFeatures: {modules: true, destructuring: true},
             errors: [
-                { message: "\"a\" is already defined", type: "Identifier"},
-                { message: "\"Object\" is already defined", type: "Identifier"}
+                { message: "\"a\" is already defined", type: "Identifier"}
+            ]
+        },
+        {
+            code: "var a; var {a = 0, b: Object = 0} = {};",
+            options: [{builtinGlobals: true}],
+            ecmaFeatures: {globalReturn: true, destructuring: true},
+            errors: [
+                { message: "\"a\" is already defined", type: "Identifier"}
             ]
         },
         {
             code: "var a; var {a = 0, b: Object = 0} = {};",
             options: [{builtinGlobals: false}],
-            ecmaFeatures: {modules: true, destructuring: true},
-            errors: [{ message: "\"a\" is already defined", type: "Identifier"}]
+            ecmaFeatures: {destructuring: true},
+            errors: [
+                { message: "\"a\" is already defined", type: "Identifier"}
+            ]
         }
     ]
 });

--- a/tests/lib/rules/no-shadow.js
+++ b/tests/lib/rules/no-shadow.js
@@ -54,8 +54,9 @@ ruleTester.run("no-shadow", rule, {
         { code: "function foo(a) { } let a;", ecmaFeatures: {blockBindings: true} },
         { code: "function foo(a) { } var a;", ecmaFeatures: {blockBindings: true} },
         { code: "function foo() { var Object = 0; }" },
-        { code: "function foo() { var top = 0; }" },
-        { code: "function foo() { var top = 0; }", options: [{builtinGlobals: true}] }
+        { code: "function foo() { var top = 0; }", env: {browser: true} },
+        { code: "var Object = 0;", options: [{builtinGlobals: true}] },
+        { code: "var top = 0;", options: [{builtinGlobals: true}], env: {browser: true} }
     ],
     invalid: [
         {
@@ -300,6 +301,32 @@ ruleTester.run("no-shadow", rule, {
             code: "function foo() { var top = 0; }",
             options: [{builtinGlobals: true}],
             env: {browser: true},
+            errors: [{ message: "top is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "var Object = 0;",
+            options: [{builtinGlobals: true}],
+            ecmaFeatures: {modules: true},
+            errors: [{ message: "Object is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "var top = 0;",
+            options: [{builtinGlobals: true}],
+            env: {browser: true},
+            ecmaFeatures: {modules: true},
+            errors: [{ message: "top is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "var Object = 0;",
+            options: [{builtinGlobals: true}],
+            ecmaFeatures: {globalReturn: true},
+            errors: [{ message: "Object is already declared in the upper scope.", type: "Identifier"}]
+        },
+        {
+            code: "var top = 0;",
+            options: [{builtinGlobals: true}],
+            env: {browser: true},
+            ecmaFeatures: {globalReturn: true},
             errors: [{ message: "top is already declared in the upper scope.", type: "Identifier"}]
         }
     ]


### PR DESCRIPTION
Fixes #3971.

When there is a special scope (`globalReturn` or `modules`), no longer
`no-redeclare` reports redeclarations of built-in globals. And when
that, `no-shadow` reports shadowing of built-in globals.