### PR TITLE
Added no-magic-number rule + test cases

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -106,6 +106,7 @@
         "no-var": 0,
         "no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }],
         "no-with": 0,
+        "no-magic-number": 0,
 
         "array-bracket-spacing": [0, "never"],
         "arrow-parens": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -92,6 +92,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-void](no-void.md) - disallow use of the `void` operator
 * [no-warning-comments](no-warning-comments.md) - disallow usage of configurable warning terms in comments - e.g. `TODO` or `FIXME`
 * [no-with](no-with.md) - disallow use of the `with` statement
+* [no-magic-number](no-magic-number.md) - disallow the use of magic numbers
 * [radix](radix.md) - require use of the second argument for `parseInt()`
 * [vars-on-top](vars-on-top.md) - require declaration of all vars at the top of their containing scope
 * [wrap-iife](wrap-iife.md) - require immediate function invocation to be wrapped in parentheses

--- a/docs/rules/no-magic-number.md
+++ b/docs/rules/no-magic-number.md
@@ -1,0 +1,50 @@
+# Disallow Magic Numbers (no-magic-number)
+
+'Magic numbers' are numbers that occur multiple time in code without an explicit meaning.
+They should preferably be replaced by named constants.
+
+```js
+if (foo == null) {
+  bar();
+}
+```
+
+## Rule Details
+
+The `no-magic-number` rule aims to make code more readable and refactoring easier by ensuring that special numbers
+are declared as constants to make their meaning explicit.
+
+The following pattern is considered a problem:
+
+```js
+/*eslint no-magic-number: 2*/
+
+var dutyFreePrice = 100,
+    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25); /*error No magic number: 0.25*/
+```
+
+The following pattern is considered okay:
+
+```js
+/*eslint no-magic-number: 2*/
+
+var TAX_PERCENTAGE = 0.25;
+
+var dutyFreePrice = 100,
+    finalPrice = dutyFreePrice + (dutyFreePrice * TAX_PERCENTAGE);
+```
+
+## Options
+
+### ignore
+
+An array of numbers to ignore. It's set to `[0, 1, 2]` by default.
+If provided, it must be an `Array`.
+
+### enforceConst
+
+A boolean to specify if we should check for the const keyword in variable declaration of numbers. `false` by default.
+
+### detectObjects
+
+A boolean to specify if we should detect numbers when setting object properties for example. `false` by default.

--- a/lib/rules/no-magic-number.js
+++ b/lib/rules/no-magic-number.js
@@ -1,0 +1,84 @@
+/**
+ * @fileoverview Rule to flag statements that use magic numbers (adapted from https://github.com/danielstjules/buddy.js)
+ * @author Vincent Lemeunier
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var config = context.options[0] || {},
+        ignore = config.ignore || [0, 1, 2],
+        detectObjects = !!config.detectObjects,
+        enforceConst = !!config.enforceConst;
+
+    /**
+     * Returns whether the node is number literal
+     * @param {Node} node - the node literal being evaluated
+     * @returns {boolean} true if the node is a number literal
+     */
+    function isNumber(node) {
+        return typeof node.value === "number";
+    }
+
+    /**
+     * Returns whether the number should be ignored
+     * @param {number} num - the number
+     * @returns {boolean} true if the number should be ignored
+     */
+    function shouldIgnoreNumber(num) {
+        return ignore.indexOf(num) !== -1;
+    }
+
+
+    return {
+        "Literal": function(node) {
+            var parent = node.parent,
+                okTypes = detectObjects ? [] : ["ObjectExpression", "Property", "AssignmentExpression"];
+
+            if (!isNumber(node)) {
+                return;
+            } else if (shouldIgnoreNumber(node.value)) {
+                return;
+            }
+
+            if (parent.type === "VariableDeclarator") {
+                if (enforceConst && parent.parent.kind !== "const") {
+                    context.report({
+                        node: node,
+                        message: "Number constants declarations must use 'const'"
+                    });
+                }
+            } else if (okTypes.indexOf(parent.type) === -1) {
+                context.report({
+                    node: node,
+                    message: "No magic number: " + node.raw
+                });
+            }
+        }
+    };
+};
+
+module.exports.schema = [{
+    "type": "object",
+    "properties": {
+        "detectObjects": {
+            "type": "boolean"
+        },
+        "enforceConst": {
+            "type": "boolean"
+        },
+        "ignore": {
+            "type": "array",
+            "items": {
+                "type": "number"
+            },
+            "uniqueItems": true
+        }
+    },
+    "additionalProperties": false
+}];

--- a/tests/lib/rules/no-magic-number.js
+++ b/tests/lib/rules/no-magic-number.js
@@ -1,0 +1,140 @@
+/**
+ * @fileoverview Tests for complexity rule.
+ * @author Vincent Lemeunier
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-magic-number"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-magic-number", rule, {
+    valid: [
+        {
+            code: "const foo = 42;",
+            env: { es6: true }
+        },
+        {
+            code: "var foo = 42;",
+            env: { es6: true },
+            options: [{
+                enforceConst: false
+            }]
+        },
+        {
+            code: "var foo = 0 + 1 + 2;"
+        },
+        {
+            code: "var foo = 0 + 1 + 2 + 3 + 4;",
+            options: [{
+                ignore: [0, 1, 2, 3, 4]
+            }]
+        },
+        {
+            code: "var min, max, mean; min = 1; max = 10; mean = 4;"
+        },
+        {
+            code: "var foo = { bar:10 }"
+        },
+        {
+            code: "setTimeout(function() {return 1;}, 0);"
+        }
+    ],
+    invalid: [
+        {
+            code: "var foo = 42",
+            env: { es6: true },
+            options: [{
+                enforceConst: true
+            }],
+            errors: [{
+                message: "Number constants declarations must use 'const'"
+            }]
+        },
+        {
+            code: "var foo = 0 + 1 + 2;",
+            options: [{
+                ignore: [0, 1]
+            }],
+            errors: [
+                { message: "No magic number: 2"}
+            ]
+        },
+        {
+            code: "var foo = { bar:10 }",
+            options: [{
+                detectObjects: true
+            }],
+            errors: [
+                { message: "No magic number: 10"}
+            ]
+        }, {
+            code: "console.log(0x1A + 0x02); console.log(071);",
+            errors: [
+                { message: "No magic number: 0x1A"},
+                { message: "No magic number: 071"}
+            ]
+        }, {
+            code: "var stats = {avg: 42};",
+            options: [{
+                detectObjects: true
+            }],
+            errors: [
+                { message: "No magic number: 42"}
+            ]
+        }, {
+            code: "var colors = {}; colors.RED = 2; colors.YELLOW = 3; colors.BLUE = 4 + 5;",
+            errors: [
+                { message: "No magic number: 4"},
+                { message: "No magic number: 5"}
+            ]
+        },
+        {
+            code: "function getSecondsInMinute() {return 60;}",
+            errors: [
+                { message: "No magic number: 60"}
+            ]
+        },
+        {
+            code: "var Promise = require('bluebird');var MINUTE = 60;" +
+                "var HOUR = 3600;" +
+                "const DAY = 86400;" +
+                "var configObject = {" +
+                  "key: 90," +
+                  "another: 10 * 10," +
+                  "10: 'an \"integer\" key'" +
+                "};" +
+                "function getSecondsInDay() {" +
+                 " return 24 * HOUR;" +
+                "}" +
+                "function getMillisecondsInDay() {" +
+                  "return (getSecondsInDay() *" +
+                    "(1000)" +
+                  ");" +
+                "}" +
+                "function callSetTimeoutZero(func) {" +
+                  "setTimeout(func, 0);" +
+                "}" +
+                "function invokeInTen(func) {" +
+                  "setTimeout(func, 10);" +
+                "}",
+            env: { es6: true },
+            errors: [
+                { message: "No magic number: 10"},
+                { message: "No magic number: 10"},
+                { message: "No magic number: 24"},
+                { message: "No magic number: 1000"},
+                { message: "No magic number: 10"}
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
**When does this rule warn? Please describe and show example code:**

This rule will warn when magic numbers are used in the code. For example : 

```javascript
// Valid code
var TAX_PERCENTAGE = 0.25;

var dutyFreePrice = 100,
    finalPrice = dutyFreePrice + (dutyFreePrice * TAX_PERCENTAGE);
```

```javascript
// Invalid code : Warns "No magic number: 0.25"
var dutyFreePrice = 100,
    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25); 
```

The configuration takes 3 parameters : 
* `ignore`: An array of numbers to ignore. It's set to `[0, 1, 2]` by default.
* `detectObjects`: A boolean to specify if we should detect numbers when setting object properties for example. `false` by default.
* `enforceConst`: A boolean to specify if we should check for the `const` keyword in variable declaration of numbers. `false` by default.

**Is this rule preventing an error or is it stylistic?**

It's more of a best practice / stylistic rule. Avoiding 'magic numbers' is good for understanding the code and refactoring it.

**Why is this rule a candidate for inclusion instead of creating a custom rule?**

I think it's a good candidate for inclusion because its application is really broad. "Magic numbers" and their usage is not something specific to my team, but concerns every developers (it even has it's own [wikipedia article](https://en.wikipedia.org/wiki/Magic_number_(programming)) :) ).

**Are you willing to create the rule yourself?**

Yes :). Or to be more precise, I used @danielstjules's library, [buddy.js](https://github.com/danielstjules/buddy.js), as the basis for this rule (code and specifications). I liked what buddy.js did, but I didn't want to use yet another tool for checking for magic numbers.
I will make it a plugin if your think it's not worth integrating it in core of course.

Cheers