### PR TITLE
Add WebExtensions globals.

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -83,6 +83,9 @@ module.exports = {
     embertest: {
         globals: globals.embertest
     },
+    webextensions: {
+        globals: globals.webextensions
+    },
     es6: {
         ecmaFeatures: {
             arrowFunctions: true,

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -114,6 +114,7 @@ An environment defines global variables that are predefined. The available envir
 * `nashorn` - Java 8 Nashorn global variables.
 * `serviceworker` - Service Worker global variables.
 * `embertest` - Ember test helper globals.
+* `webextensions` - WebExtensions globals.
 * `es6` - enable all ECMAScript 6 features except for modules.
 
 These environments are not mutually exclusive, so you can define more than one at a time.

--- a/tests/fixtures/configurations/env-webextensions.json
+++ b/tests/fixtures/configurations/env-webextensions.json
@@ -1,0 +1,8 @@
+{
+  "env": {
+    "webextensions": true
+  },
+  "rules": {
+    "no-undef": 2
+  }
+}

--- a/tests/fixtures/globals-webextensions.js
+++ b/tests/fixtures/globals-webextensions.js
@@ -1,0 +1,3 @@
+chrome.browserAction.setBadgeText({text: 'ᕕ( ᐛ)ᕗ'});
+opr.sidebarAction.setTitle({title: 'ᕕ( ᐛ)ᕗ'});
+browser.tabs.hide();

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -176,6 +176,18 @@ describe("cli", function() {
         });
     });
 
+    describe("when given a config with environment set to WebExtensions", function() {
+        it("should execute without any errors", function() {
+            var configPath = getFixturePath("configurations", "env-webextensions.json");
+            var filePath = getFixturePath("globals-webextensions.js");
+            var code = "--config " + configPath + " " + filePath;
+
+            var exit = cli.execute(code);
+
+            assert.equal(exit, 0);
+        });
+    });
+
     describe("when given a config that is a sharable config", function() {
         it("should execute without any errors", function() {
             var stubbedConfig = proxyquire("../../lib/config", {


### PR DESCRIPTION
As per [Chrome’s documentation](https://developer.chrome.com/extensions/api_index), [Opera’s documentation](https://dev.opera.com/extensions/index.html), and [Firefox’s documentation](https://wiki.mozilla.org/WebExtensions), and the [globals project](https://github.com/sindresorhus/globals/pull/55).