### PR TITLE
Fix: `no-unused-vars` had been missing some parameters

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -62,7 +62,7 @@ module.exports = function(context) {
             var node = definition.node;
             if (node.type === "VariableDeclarator") {
                 node = node.parent;
-            } else if (definition.type === "Parameter" && node.type === "FunctionDeclaration") {
+            } else if (definition.type === "Parameter") {
                 return false;
             }
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -223,7 +223,7 @@ ruleTester.run("no-unused-vars", rule, {
             errors: [
                 {line: 1, column: 14, message: "\"数\" is defined but never used" }
             ]
-        }
+        },
         // surrogate pair.
         // TODO: https://github.com/eslint/espree/issues/181
         // {
@@ -233,5 +233,37 @@ ruleTester.run("no-unused-vars", rule, {
         //         {line: 1, column: 16, message: "\"𠮷\" is defined but never used" }
         //     ]
         // }
+
+        // https://github.com/eslint/eslint/issues/4047
+        {
+            code: "export default function(a) {}",
+            ecmaFeatures: {modules: true},
+            errors: [{message: "\"a\" is defined but never used"}]
+        },
+        {
+            code: "export default function(a, b) { console.log(a); }",
+            ecmaFeatures: {modules: true},
+            errors: [{message: "\"b\" is defined but never used"}]
+        },
+        {
+            code: "export default (function(a) {});",
+            ecmaFeatures: {modules: true},
+            errors: [{message: "\"a\" is defined but never used"}]
+        },
+        {
+            code: "export default (function(a, b) { console.log(a); });",
+            ecmaFeatures: {modules: true},
+            errors: [{message: "\"b\" is defined but never used"}]
+        },
+        {
+            code: "export default (a) => {};",
+            ecmaFeatures: {modules: true, arrowFunctions: true},
+            errors: [{message: "\"a\" is defined but never used"}]
+        },
+        {
+            code: "export default (a, b) => { console.log(a); };",
+            ecmaFeatures: {modules: true, arrowFunctions: true},
+            errors: [{message: "\"b\" is defined but never used"}]
+        }
     ]
 });


### PR DESCRIPTION
Fixes #4047.

If function expressions or arrow function expressions were exported,
these parameters had been not reported by `no-unused-vars`.