### PR TITLE
Update: Make radix accept a "as-needed" option (fixes #4048)

### DIFF
--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -11,6 +11,11 @@
 
 module.exports = function(context) {
 
+    var MODE_ALWAYS = "always",
+        MODE_AS_NEEDED = "as-needed";
+
+    var mode = context.options[0] || MODE_ALWAYS;
+
     return {
         "CallExpression": function(node) {
 
@@ -25,17 +30,37 @@ module.exports = function(context) {
                 return;
             }
 
-            if (node.arguments.length < 2) {
-                context.report(node, "Missing radix parameter.");
+            if (node.arguments.length === 0) {
+                context.report({
+                    node: node,
+                    message: "No parameters passed."
+                });
+            } else if (node.arguments.length < 2 && mode === MODE_ALWAYS) {
+                context.report({
+                    node: node,
+                    message: "Missing radix parameter."
+                });
+            } else if (node.arguments.length > 1 && mode === MODE_AS_NEEDED &&
+                (node.arguments[1] && node.arguments[1].type === "Literal" &&
+                    node.arguments[1].value === 10)
+            ) {
+                context.report({
+                    node: node,
+                    message: "Redundant radix parameter."
+                });
             } else {
 
                 radix = node.arguments[1];
 
                 // don't allow non-numeric literals or undefined
-                if ((radix.type === "Literal" && typeof radix.value !== "number") ||
-                    (radix.type === "Identifier" && radix.name === "undefined")
+                if (radix &&
+                    ((radix.type === "Literal" && typeof radix.value !== "number") ||
+                    (radix.type === "Identifier" && radix.name === "undefined"))
                 ) {
-                    context.report(node, "Invalid radix parameter.");
+                    context.report({
+                        node: node,
+                        message: "Invalid radix parameter."
+                    });
                 }
             }
 
@@ -44,4 +69,9 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "enum": ["always", "as-needed"]
+    }
+];
+

--- a/tests/lib/rules/radix.js
+++ b/tests/lib/rules/radix.js
@@ -19,14 +19,38 @@ ruleTester.run("radix", rule, {
         "parseInt(\"10\", 10);",
         "parseInt(\"10\", foo);",
         "Number.parseInt(\"10\", foo);",
-        "Number.parseInt(\"10\", foo);"
+        "Number.parseInt(\"10\", foo);",
+        {
+            code: "parseInt(\"10\", 10);",
+            options: ["always"]
+        },
+        {
+            code: "parseInt(\"10\");",
+            options: ["as-needed"]
+        },
+        {
+            code: "parseInt(\"10\", 8);",
+            options: ["as-needed"]
+        },
+        {
+            code: "parseInt(\"10\", foo);",
+            options: ["as-needed"]
+        }
     ],
 
     invalid: [
         {
             code: "parseInt();",
+            options: ["as-needed"],
             errors: [{
-                message: "Missing radix parameter.",
+                message: "No parameters passed.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "parseInt();",
+            errors: [{
+                message: "No parameters passed.",
                 type: "CallExpression"
             }]
         },
@@ -75,7 +99,15 @@ ruleTester.run("radix", rule, {
         {
             code: "Number.parseInt();",
             errors: [{
-                message: "Missing radix parameter.",
+                message: "No parameters passed.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "Number.parseInt();",
+            options: ["as-needed"],
+            errors: [{
+                message: "No parameters passed.",
                 type: "CallExpression"
             }]
         },
@@ -83,6 +115,14 @@ ruleTester.run("radix", rule, {
             code: "Number.parseInt(\"10\");",
             errors: [{
                 message: "Missing radix parameter.",
+                type: "CallExpression"
+            }]
+        },
+        {
+            code: "parseInt(\"10\", 10);",
+            options: ["as-needed"],
+            errors: [{
+                message: "Redundant radix parameter.",
                 type: "CallExpression"
             }]
         }


### PR DESCRIPTION
This makes the radix rule disallow using the second parameter to parseInt
when it's 10. Other values are allowed.

BTW, I'm not sure if `"never"` is a good name as it suggests radix is disallowed in all cases but here we only disallow the exact `10` value (in the future we might want to also include variables statically-determinably equal to 10 but that's another story). Perhaps `"no10"` would be a better name? Or `"disallow10"`, `"forbid10"`?