### PR TITLE
Improve comma-dangle documentation

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -15,10 +15,12 @@ On the other hand, trailing commas simplify adding and removing items to objects
 
 This rule enforces consistent use of trailing commas in object and array literals.
 
-This rule takes one argument. If it is `"always"` then it warns whenever a missing comma is detected.
-If `"always-multiline"` then it warns if there is a missing trailing comma on arrays or objects that
-span multiple lines, and warns if there is a trailing comma present on single line arrays or objects.
-If `"never"` then it warns whenever an trailing comma is detected.
+This rule takes one argument, which can be one of the following options:
+
+- `"always"` - warn whenever a missing comma is detected.
+- `"always-multiline"` - warn if there is a missing trailing comma on arrays or objects that span multiple lines, and warns if there is a trailing comma present on single line arrays or objects.
+- `"never"` - warn whenever a trailing comma is detected.
+
 The default value of this option is `"never"`.
 
 The following patterns are considered problems when configured `"never"`:


### PR DESCRIPTION
Fix a minor misspelling (an -> a). Also, reading paragraphs is pretty hard in order to figure out options, so I refactored the options to be on a bullet list.