### PR TITLE
Fix: message templates fail when no parameters are passed (fixes #4080)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -829,14 +829,16 @@ module.exports = (function() {
             return;
         }
 
-        message = message.replace(/\{\{\s*(.+?)\s*\}\}/g, function(fullMatch, term) {
-            if (term in opts) {
-                return opts[term];
-            }
+        if (opts) {
+            message = message.replace(/\{\{\s*(.+?)\s*\}\}/g, function(fullMatch, term) {
+                if (term in opts) {
+                    return opts[term];
+                }
 
-            // Preserve old behavior: If parameter name not provided, don't replace it.
-            return fullMatch;
-        });
+                // Preserve old behavior: If parameter name not provided, don't replace it.
+                return fullMatch;
+            });
+        }
 
         var problem = {
             ruleId: ruleId,

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -106,7 +106,8 @@ module.exports = function(context) {
                             context.report({
                                 node: token,
                                 loc: token.loc.start,
-                                message: "Multiple spaces found before '" + token.value + "'.",
+                                message: "Multiple spaces found before '{{value}}'.",
+                                data: { value: token.value },
                                 fix: createFix(previousToken, token)
                             });
                         }

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -788,6 +788,22 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
+        it("should not crash if no template parameters are passed", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    "Literal": function(node) {
+                        context.report(node, "message {{code}}");
+                    }
+                };
+            });
+
+            config.rules["test-rule"] = 1;
+
+            var messages = eslint.verify("0", config);
+            assert.equal(messages[0].message, "message {{code}}");
+        });
+
         it("should allow template parameter with non-identifier characters", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {


### PR DESCRIPTION
Fixed both core and no-multi-spaces rule.