### PR TITLE
Fix: `prefer-arrow-callback` had been wrong at arguments

### DIFF
--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -20,6 +20,41 @@ function isFunctionName(variable) {
 }
 
 /**
+ * Checks whether or not a given MetaProperty node equals to a given value.
+ * @param {ASTNode} node - A MetaProperty node to check.
+ * @param {string} metaName - The name of `MetaProperty.meta`.
+ * @param {string} propertyName - The name of `MetaProperty.property`.
+ * @returns {boolean} `true` if the node is the specific value.
+ */
+function checkMetaProperty(node, metaName, propertyName) {
+    // TODO: Remove this if block after https://github.com/eslint/espree/issues/206 was fixed.
+    if (typeof node.meta === "string") {
+        return node.meta === metaName && node.property === propertyName;
+    }
+    return node.meta.name === metaName && node.property.name === propertyName;
+}
+
+/**
+ * Gets the variable object of `arguments` which is defined implicitly.
+ * @param {escope.Scope} scope - A scope to get.
+ * @returns {escope.Variable} The found variable object.
+ */
+function getVariableOfArguments(scope) {
+    var variables = scope.variables;
+    for (var i = 0; i < variables.length; ++i) {
+        var variable = variables[i];
+        if (variable.name === "arguments") {
+            // If there was a parameter which is named "arguments", the implicit "arguments" is not defined.
+            // So does fast return with null.
+            return (variable.identifiers.length === 0) ? variable : null;
+        }
+    }
+
+    /* istanbul ignore next */
+    return null;
+}
+
+/**
  * Checkes whether or not a given node is a callback.
  * @param {ASTNode} node - A node to check.
  * @returns {object}
@@ -81,42 +116,62 @@ function getCallbackInfo(node) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    // {Array<boolean>}
-    // This stack stores flags that function scopes have one or more ThisExpressions or not.
+    // {Array<{this: boolean, super: boolean, meta: boolean}>}
+    // - this - A flag which shows there are one or more ThisExpression.
+    // - super - A flag which shows there are one or more Super.
+    // - meta - A flag which shows there are one or more MethProperty.
     var stack = [];
 
     /**
-     * Pushes new function scope with `false` flag.
-     * That `false` is meaning the scope does not have ThisExpression.
+     * Pushes new function scope with all `false` flags.
      * @returns {void}
      */
     function enterScope() {
-        stack.push(false);
+        stack.push({this: false, super: false, meta: false});
     }
 
     /**
      * Pops a function scope from the stack.
-     * @returns {boolean} `true` if the function scope has one or more ThisExpressions.
+     * @returns {{this: boolean, super: boolean, meta: boolean}} The information of the last scope.
      */
     function exitScope() {
         return stack.pop();
     }
 
     return {
+        // Reset internal state.
         Program: function() {
             stack = [];
         },
 
+        // If there are below, it cannot replace with arrow functions merely.
         ThisExpression: function() {
-            stack[stack.length - 1] = true;
+            var info = stack[stack.length - 1];
+            if (info) {
+                info.this = true;
+            }
+        },
+        Super: function() {
+            var info = stack[stack.length - 1];
+            if (info) {
+                info.super = true;
+            }
+        },
+        MetaProperty: function(node) {
+            var info = stack[stack.length - 1];
+            if (info && checkMetaProperty(node, "new", "target")) {
+                info.meta = true;
+            }
         },
 
+        // To skip nested scopes.
         FunctionDeclaration: enterScope,
         "FunctionDeclaration:exit": exitScope,
 
+        // Main.
         FunctionExpression: enterScope,
         "FunctionExpression:exit": function(node) {
-            var hasThisKeyword = exitScope();
+            var scopeInfo = exitScope();
 
             // Skip generators.
             if (node.generator) {
@@ -129,9 +184,19 @@ module.exports = function(context) {
                 return;
             }
 
-            // Reports if it's a callback.
-            var info = getCallbackInfo(node);
-            if (info.isCallback && (!hasThisKeyword || info.isLexicalThis)) {
+            // Skip if it's using arguments.
+            var variable = getVariableOfArguments(context.getScope());
+            if (variable && variable.references.length > 0) {
+                return;
+            }
+
+            // Reports if it's a callback which can replace with arrows.
+            var callbackInfo = getCallbackInfo(node);
+            if (callbackInfo.isCallback &&
+                (!scopeInfo.this || callbackInfo.isLexicalThis) &&
+                !scopeInfo.super &&
+                !scopeInfo.meta
+            ) {
                 context.report(node, "Unexpected function expression.");
             }
         }

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -34,7 +34,13 @@ ruleTester.run("prefer-arrow-callback", rule, {
         {code: "foo(a => { (function() {}); });", ecmaFeatures: {arrowFunctions: true}},
         {code: "var foo = function foo() {};"},
         {code: "(function foo() {})();"},
-        {code: "foo(function bar() { bar; });"}
+        {code: "foo(function bar() { bar; });"},
+        {code: "foo(function bar() { arguments; });"},
+        {code: "foo(function bar() { arguments; }.bind(this));"},
+        {code: "foo(function bar() { super.a; });", ecmaFeatures: {classes: true}},
+        {code: "foo(function bar() { super.a; }.bind(this));", ecmaFeatures: {classes: true}},
+        {code: "foo(function bar() { new.target; });", ecmaFeatures: {newTarget: true}},
+        {code: "foo(function bar() { new.target; }.bind(this));", ecmaFeatures: {newTarget: true}}
     ],
     invalid: [
         {code: "foo(function() {});", errors: errors},
@@ -44,6 +50,7 @@ ruleTester.run("prefer-arrow-callback", rule, {
         {code: "foo(function() { this; }.bind(this));", errors: errors},
         {code: "foo(function() { (() => this); }.bind(this));", ecmaFeatures: {arrowFunctions: true}, errors: errors},
         {code: "foo(function bar(a) { a; });", errors: errors},
-        {code: "foo(function(a) { a; });", errors: errors}
+        {code: "foo(function(a) { a; });", errors: errors},
+        {code: "foo(function(arguments) { arguments; });", errors: errors}
     ]
 });


### PR DESCRIPTION
Fixes #4095.

The rule should not warn function expressions if these are use of implicit `arguments`, `super`, or `new.target`.