### PR TITLE
Update: added exceptions for objects and arrays in `lines-around-comment` rule (fixes #2965)

### DIFF
--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -33,7 +33,7 @@ var y = 10;
 
 ### Options
 
-This rule has 6 options:
+This rule has 10 options:
 
 1. `beforeBlockComment` (enabled by default)
 2. `afterBlockComment`
@@ -41,6 +41,10 @@ This rule has 6 options:
 4. `afterLineComment`
 5. `allowBlockStart`
 6. `allowBlockEnd`
+7. `allowObjectStart`
+8. `allowObjectEnd`
+9. `allowArrayStart`
+10. `allowArrayEnd`
 
 Any combination of these rules may be applied at the same time.
 
@@ -195,6 +199,186 @@ function foo(){
 }
 ```
 
+#### `allowObjectStart` option
+
+When this option is set to `true`, it allows the comment to be present at the start of any object-like statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
+
+With both `beforeLineComment` and `allowObjectStart` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "beforeLineComment": true, "allowObjectStart": true }]*/
+
+var foo = {
+    // what a great and wonderful day
+    day: "great"
+};
+
+const {
+    // what a great and wonderful day
+    foo: someDay
+} = {foo: "great"};
+
+const {
+    // what a great and wonderful day
+    day
+} = {day: "great"};
+```
+
+With both `beforeBlockComment` and `allowObjectStart` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "beforeBlockComment": true, "allowObjectStart": true }]*/
+
+var foo = {
+    /* what a great and wonderful day */
+    day: "great"
+};
+
+const {
+    /* what a great and wonderful day */
+    foo: someDay
+} = {foo: "great"};
+
+const {
+    /* what a great and wonderful day */
+    day
+} = {day: "great"};
+```
+
+#### `allowObjectEnd` option
+
+When this option is set to `true`, it allows the comment to be present at the end of any object-like statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
+
+With both `afterLineComment` and `allowObjectEnd` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "afterLineComment": true, "allowObjectEnd": true }]*/
+
+var foo = {
+    day: "great"
+    // what a great and wonderful day
+};
+
+const {
+    foo: someDay
+    // what a great and wonderful day
+} = {foo: "great"};
+
+const {
+    day
+    // what a great and wonderful day
+} = {day: "great"};
+```
+
+With both `afterBlockComment` and `allowObjectEnd` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "afterBlockComment": true, "allowObjectEnd": true }]*/
+
+var foo = {
+    day: "great"
+
+    /* what a great and wonderful day */
+};
+
+const {
+    foo: someDay
+
+    /* what a great and wonderful day */
+} = {foo: "great"};
+
+const {
+    day
+
+    /* what a great and wonderful day */
+} = {day: "great"};
+```
+
+#### `allowArrayStart` option
+
+When this option is set to `true`, it allows the comment to be present at the start of any array-like statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
+
+With both `beforeLineComment` and `allowArrayStart` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "beforeLineComment": true, "allowArrayStart": true }]*/
+
+var day = [
+    // what a great and wonderful day
+    "great",
+    "wonderful"
+];
+
+const [
+    // what a great and wonderful day
+    someDay
+] = ["great", "not great"];
+```
+
+With both `beforeBlockComment` and `allowArrayStart` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "beforeBlockComment": true, "allowArrayStart": true }]*/
+
+var day = [
+    /* what a great and wonderful day */
+    "great",
+    "wonderful"
+];
+
+const [
+    /* what a great and wonderful day */
+    someDay
+] = ["great", "not great"];
+```
+
+#### `allowArrayEnd` option
+
+When this option is set to `true`, it allows the comment to be present at the end of any array-like statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
+
+With both `afterLineComment` and `allowArrayEnd` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "afterLineComment": true, "allowArrayEnd": true }]*/
+
+var day = [
+    "great",
+    "wonderful"
+    // what a great and wonderful day
+];
+
+const [
+    someDay
+    // what a great and wonderful day
+] = ["great", "not great"];
+```
+
+With both `afterBlockComment` and `allowArrayEnd` set to `true` the following code
+would not warn:
+
+```js
+/*eslint lines-around-comment: [2, { "afterBlockComment": true, "allowArrayEnd": true }]*/
+
+var day = [
+    "great",
+    "wonderful"
+
+    /* what a great and wonderful day */
+];
+
+const [
+    someDay
+
+    /* what a great and wonderful day */
+] = ["great", "not great"];
+```
 
 #### Inline comments
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -88,11 +88,23 @@ module.exports = function(context) {
     }
 
     /**
-     * Returns whether or not comments are at the block start or not.
+     * Returns whether or not comments are inside a node type or not.
      * @param {ASTNode} node The Comment node.
-     * @returns {boolean} True if the comment is at block start.
+     * @param {ASTNode} parent The Comment parent node.
+     * @param {string} nodeType The parent type to check against.
+     * @returns {boolean} True if the comment is inside nodeType.
      */
-    function isCommentAtBlockStart(node) {
+    function isCommentInsideNodeType(node, parent, nodeType) {
+        return parent.type === nodeType || (parent.body && parent.body.type === nodeType);
+    }
+
+    /**
+     * Returns whether or not comments are at the parent start or not.
+     * @param {ASTNode} node The Comment node.
+     * @param {string} nodeType The parent type to check against.
+     * @returns {boolean} True if the comment is at parent start.
+     */
+    function isCommentAtParentStart(node, nodeType) {
         var ancestors = context.getAncestors();
         var parent;
 
@@ -100,8 +112,35 @@ module.exports = function(context) {
             parent = ancestors.pop();
         }
 
-        return parent && (parent.type === "ClassBody" || parent.type === "BlockStatement" || (parent.body && parent.body.type === "BlockStatement")) &&
+        return parent && isCommentInsideNodeType(node, parent, nodeType) &&
                 node.loc.start.line - parent.loc.start.line === 1;
+    }
+
+    /**
+     * Returns whether or not comments are at the parent end or not.
+     * @param {ASTNode} node The Comment node.
+     * @param {string} nodeType The parent type to check against.
+     * @returns {boolean} True if the comment is at parent end.
+     */
+    function isCommentAtParentEnd(node, nodeType) {
+        var ancestors = context.getAncestors();
+        var parent;
+
+        if (ancestors.length) {
+            parent = ancestors.pop();
+        }
+
+        return parent && isCommentInsideNodeType(node, parent, nodeType) &&
+                parent.loc.end.line - node.loc.end.line === 1;
+    }
+
+    /**
+     * Returns whether or not comments are at the block start or not.
+     * @param {ASTNode} node The Comment node.
+     * @returns {boolean} True if the comment is at block start.
+     */
+    function isCommentAtBlockStart(node) {
+        return isCommentAtParentStart(node, "ClassBody") || isCommentAtParentStart(node, "BlockStatement");
     }
 
     /**
@@ -110,15 +149,43 @@ module.exports = function(context) {
      * @returns {boolean} True if the comment is at block end.
      */
     function isCommentAtBlockEnd(node) {
-        var ancestors = context.getAncestors();
-        var parent;
+        return isCommentAtParentEnd(node, "ClassBody") || isCommentAtParentEnd(node, "BlockStatement");
+    }
 
-        if (ancestors.length) {
-            parent = ancestors.pop();
-        }
+    /**
+     * Returns whether or not comments are at the object start or not.
+     * @param {ASTNode} node The Comment node.
+     * @returns {boolean} True if the comment is at object start.
+     */
+    function isCommentAtObjectStart(node) {
+        return isCommentAtParentStart(node, "ObjectExpression") || isCommentAtParentStart(node, "ObjectPattern");
+    }
 
-        return parent && (parent.type === "ClassBody" || parent.type === "BlockStatement" || (parent.body && parent.body.type === "BlockStatement")) &&
-                parent.loc.end.line - node.loc.end.line === 1;
+    /**
+     * Returns whether or not comments are at the object end or not.
+     * @param {ASTNode} node The Comment node.
+     * @returns {boolean} True if the comment is at object end.
+     */
+    function isCommentAtObjectEnd(node) {
+        return isCommentAtParentEnd(node, "ObjectExpression") || isCommentAtParentEnd(node, "ObjectPattern");
+    }
+
+    /**
+     * Returns whether or not comments are at the array start or not.
+     * @param {ASTNode} node The Comment node.
+     * @returns {boolean} True if the comment is at array start.
+     */
+    function isCommentAtArrayStart(node) {
+        return isCommentAtParentStart(node, "ArrayExpression") || isCommentAtParentStart(node, "ArrayPattern");
+    }
+
+    /**
+     * Returns whether or not comments are at the array end or not.
+     * @param {ASTNode} node The Comment node.
+     * @returns {boolean} True if the comment is at array end.
+     */
+    function isCommentAtArrayEnd(node) {
+        return isCommentAtParentEnd(node, "ArrayExpression") || isCommentAtParentEnd(node, "ArrayPattern");
     }
 
     /**
@@ -146,7 +213,14 @@ module.exports = function(context) {
             commentIsNotAlone = codeAroundComment(node);
 
         var blockStartAllowed = options.allowBlockStart && isCommentAtBlockStart(node),
-            blockEndAllowed = options.allowBlockEnd && isCommentAtBlockEnd(node);
+            blockEndAllowed = options.allowBlockEnd && isCommentAtBlockEnd(node),
+            objectStartAllowed = options.allowObjectStart && isCommentAtObjectStart(node),
+            objectEndAllowed = options.allowObjectEnd && isCommentAtObjectEnd(node),
+            arrayStartAllowed = options.allowArrayStart && isCommentAtArrayStart(node),
+            arrayEndAllowed = options.allowArrayEnd && isCommentAtArrayEnd(node);
+
+        var exceptionStartAllowed = blockStartAllowed || objectStartAllowed || arrayStartAllowed;
+        var exceptionEndAllowed = blockEndAllowed || objectEndAllowed || arrayEndAllowed;
 
         // ignore top of the file and bottom of the file
         if (prevLineNum < 1) {
@@ -162,12 +236,12 @@ module.exports = function(context) {
         }
 
         // check for newline before
-        if (!blockStartAllowed && before && !contains(prevLineNum, commentAndEmptyLines)) {
+        if (!exceptionStartAllowed && before && !contains(prevLineNum, commentAndEmptyLines)) {
             context.report(node, "Expected line before comment.");
         }
 
         // check for newline after
-        if (!blockEndAllowed && after && !contains(nextLineNum, commentAndEmptyLines)) {
+        if (!exceptionEndAllowed && after && !contains(nextLineNum, commentAndEmptyLines)) {
             context.report(node, "Expected line after comment.");
         }
 
@@ -220,6 +294,18 @@ module.exports.schema = [
                 "type": "boolean"
             },
             "allowBlockEnd": {
+                "type": "boolean"
+            },
+            "allowObjectStart": {
+                "type": "boolean"
+            },
+            "allowObjectEnd": {
+                "type": "boolean"
+            },
+            "allowArrayStart": {
+                "type": "boolean"
+            },
+            "allowArrayEnd": {
                 "type": "boolean"
             }
         },

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -317,8 +317,353 @@ ruleTester.run("lines-around-comment", rule, {
                 allowBlockEnd: true
             }],
             ecmaFeatures: {classes: true}
-        }
+        },
 
+        // check for object start comments
+        {
+            code:
+            "var a,\n\n" +
+            "// line\n" +
+            "b;",
+            options: [{
+                beforeLineComment: true,
+                allowObjectStart: true
+            }]
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  // line at object start\n" +
+            "  g: 1\n" +
+            "};",
+            options: [{
+                beforeLineComment: true,
+                allowObjectStart: true
+            }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    // hi\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                beforeLineComment: true,
+                allowObjectStart: true
+            }]
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  /* block comment at object start*/\n" +
+            "  g: 1\n" +
+            "};",
+            options: [{
+                beforeBlockComment: true,
+                allowObjectStart: true
+            }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    /**\n" +
+            "    * hi\n" +
+            "    */\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                beforeLineComment: true,
+                allowObjectStart: true
+            }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  // line at object start\n" +
+            "  g: a\n" +
+            "} = {};",
+            options: [{
+                beforeLineComment: true,
+                allowObjectStart: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const {\n" +
+            "  // line at object start\n" +
+            "  g\n" +
+            "} = {};",
+            options: [{
+                beforeLineComment: true,
+                allowObjectStart: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const {\n" +
+            "  /* block comment at object-like start*/\n" +
+            "  g: a\n" +
+            "} = {};",
+            options: [{
+                beforeBlockComment: true,
+                allowObjectStart: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const {\n" +
+            "  /* block comment at object-like start*/\n" +
+            "  g\n" +
+            "} = {};",
+            options: [{
+                beforeBlockComment: true,
+                allowObjectStart: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+
+        // check for object end comments
+        {
+            code:
+            "var a,\n" +
+            "// line\n\n" +
+            "b;",
+            options: [{
+                afterLineComment: true,
+                allowObjectEnd: true
+            }]
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  g: 1\n" +
+            "  // line at object end\n" +
+            "};",
+            options: [{
+                afterLineComment: true,
+                allowObjectEnd: true
+            }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "    // hi\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                afterLineComment: true,
+                allowObjectEnd: true
+            }]
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  g: 1\n" +
+            "  \n" +
+            "  /* block comment at object end*/\n" +
+            "};",
+            options: [{
+                afterBlockComment: true,
+                allowObjectEnd: true
+            }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "    \n" +
+            "    /**\n" +
+            "    * hi\n" +
+            "    */\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                afterBlockComment: true,
+                allowObjectEnd: true
+            }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  g: a\n" +
+            "  // line at object end\n" +
+            "} = {};",
+            options: [{
+                afterLineComment: true,
+                allowObjectEnd: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const {\n" +
+            "  g\n" +
+            "  // line at object end\n" +
+            "} = {};",
+            options: [{
+                afterLineComment: true,
+                allowObjectEnd: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const {\n" +
+            "  g: a\n" +
+            "  \n" +
+            "  /* block comment at object-like end*/\n" +
+            "} = {};",
+            options: [{
+                afterBlockComment: true,
+                allowObjectEnd: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const {\n" +
+            "  g\n" +
+            "  \n" +
+            "  /* block comment at object-like end*/\n" +
+            "} = {};",
+            options: [{
+                afterBlockComment: true,
+                allowObjectEnd: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+
+        // check for array start comments
+        {
+            code:
+            "var a,\n\n" +
+            "// line\n" +
+            "b;",
+            options: [{
+                beforeLineComment: true,
+                allowArrayStart: true
+            }]
+        },
+        {
+            code:
+            "var arr = [\n" +
+            "  // line at array start\n" +
+            "  1\n" +
+            "];",
+            options: [{
+                beforeLineComment: true,
+                allowArrayStart: true
+            }]
+        },
+        {
+            code:
+            "var arr = [\n" +
+            "  /* block comment at array start*/\n" +
+            "  1\n" +
+            "];",
+            options: [{
+                beforeBlockComment: true,
+                allowArrayStart: true
+            }]
+        },
+        {
+            code:
+            "const [\n" +
+            "  // line at array start\n" +
+            "  a\n" +
+            "] = [];",
+            options: [{
+                beforeLineComment: true,
+                allowArrayStart: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const [\n" +
+            "  /* block comment at array start*/\n" +
+            "  a\n" +
+            "] = [];",
+            options: [{
+                beforeBlockComment: true,
+                allowArrayStart: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+
+        // check for array end comments
+        {
+            code:
+            "var a,\n" +
+            "// line\n\n" +
+            "b;",
+            options: [{
+                afterLineComment: true,
+                allowArrayEnd: true
+            }]
+        },
+        {
+            code:
+            "var arr = [\n" +
+            "  1\n" +
+            "  // line at array end\n" +
+            "];",
+            options: [{
+                afterLineComment: true,
+                allowArrayEnd: true
+            }]
+        },
+        {
+            code:
+            "var arr = [\n" +
+            "  1\n" +
+            "  \n" +
+            "  /* block comment at array end*/\n" +
+            "];",
+            options: [{
+                afterBlockComment: true,
+                allowArrayEnd: true
+            }]
+        },
+        {
+            code:
+            "const [\n" +
+            "  a\n" +
+            "  // line at array end\n" +
+            "] = [];",
+            options: [{
+                afterLineComment: true,
+                allowArrayEnd: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        },
+        {
+            code:
+            "const [\n" +
+            "  a\n" +
+            "  \n" +
+            "  /* block comment at array end*/\n" +
+            "] = [];",
+            options: [{
+                afterBlockComment: true,
+                allowArrayEnd: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true}
+        }
     ],
 
     invalid: [
@@ -414,6 +759,312 @@ ruleTester.run("lines-around-comment", rule, {
                 allowBlockEnd: true
             }],
             errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+
+        // object start comments
+        {
+            code:
+            "var obj = {\n" +
+            "  // line at object start\n" +
+            "  g: 1\n" +
+            "};",
+            options: [{
+                beforeLineComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    // hi\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                beforeLineComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Line", line: 3 }]
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  /* block comment at object start*/\n" +
+            "  g: 1\n" +
+            "};",
+            options: [{
+                beforeBlockComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Block", line: 2 }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    /**\n" +
+            "    * hi\n" +
+            "    */\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                beforeLineComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Block", line: 3 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  // line at object start\n" +
+            "  g: a\n" +
+            "} = {};",
+            options: [{
+                beforeLineComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  // line at object start\n" +
+            "  g\n" +
+            "} = {};",
+            options: [{
+                beforeLineComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  /* block comment at object-like start*/\n" +
+            "  g: a\n" +
+            "} = {};",
+            options: [{
+                beforeBlockComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: beforeMessage, type: "Block", line: 2 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  /* block comment at object-like start*/\n" +
+            "  g\n" +
+            "} = {};",
+            options: [{
+                beforeBlockComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: beforeMessage, type: "Block", line: 2 }]
+        },
+
+        // object end comments
+        {
+            code:
+            "var obj = {\n" +
+            "  g: 1\n" +
+            "  // line at object end\n" +
+            "};",
+            options: [{
+                afterLineComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Line", line: 3 }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "    // hi\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                afterLineComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Line", line: 5 }]
+        },
+        {
+            code:
+            "var obj = {\n" +
+            "  g: 1\n" +
+            "  \n" +
+            "  /* block comment at object end*/\n" +
+            "};",
+            options: [{
+                afterBlockComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Block", line: 4 }]
+        },
+        {
+            code:
+            "function hi() {\n" +
+            "  return {\n" +
+            "    test: function() {\n" +
+            "    }\n" +
+            "    \n" +
+            "    /**\n" +
+            "    * hi\n" +
+            "    */\n" +
+            "  }\n" +
+            "}",
+            options: [{
+                afterBlockComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Block", line: 6 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  g: a\n" +
+            "  // line at object end\n" +
+            "} = {};",
+            options: [{
+                afterLineComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: afterMessage, type: "Line", line: 3 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  g\n" +
+            "  // line at object end\n" +
+            "} = {};",
+            options: [{
+                afterLineComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: afterMessage, type: "Line", line: 3 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  g: a\n" +
+            "  \n" +
+            "  /* block comment at object-like end*/\n" +
+            "} = {};",
+            options: [{
+                afterBlockComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: afterMessage, type: "Block", line: 4 }]
+        },
+        {
+            code:
+            "const {\n" +
+            "  g\n" +
+            "  \n" +
+            "  /* block comment at object-like end*/\n" +
+            "} = {};",
+            options: [{
+                afterBlockComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: afterMessage, type: "Block", line: 4 }]
+        },
+
+        // array start comments
+        {
+            code:
+            "var arr = [\n" +
+            "  // line at array start\n" +
+            "  1\n" +
+            "];",
+            options: [{
+                beforeLineComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code:
+            "var arr = [\n" +
+            "  /* block comment at array start*/\n" +
+            "  1\n" +
+            "];",
+            options: [{
+                beforeBlockComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Block", line: 2 }]
+        },
+        {
+            code:
+            "const [\n" +
+            "  // line at array start\n" +
+            "  a\n" +
+            "] = [];",
+            options: [{
+                beforeLineComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code:
+            "const [\n" +
+            "  /* block comment at array start*/\n" +
+            "  a\n" +
+            "] = [];",
+            options: [{
+                beforeBlockComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: beforeMessage, type: "Block", line: 2 }]
+        },
+
+        // array end comments
+        {
+            code:
+            "var arr = [\n" +
+            "  1\n" +
+            "  // line at array end\n" +
+            "];",
+            options: [{
+                afterLineComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Line", line: 3 }]
+        },
+        {
+            code:
+            "var arr = [\n" +
+            "  1\n" +
+            "  \n" +
+            "  /* block comment at array end*/\n" +
+            "];",
+            options: [{
+                afterBlockComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Block", line: 4 }]
+        },
+        {
+            code:
+            "const [\n" +
+            "  a\n" +
+            "  // line at array end\n" +
+            "] = [];",
+            options: [{
+                afterLineComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: afterMessage, type: "Line", line: 3 }]
+        },
+        {
+            code:
+            "const [\n" +
+            "  a\n" +
+            "  \n" +
+            "  /* block comment at array end*/\n" +
+            "] = [];",
+            options: [{
+                afterBlockComment: true
+            }],
+            ecmaFeatures: {blockBindings: true, destructuring: true},
+            errors: [{ message: afterMessage, type: "Block", line: 4 }]
         }
     ]
 


### PR DESCRIPTION
Added the following exceptions to the `lines-around-comment` rule:

* `allowObjectStart`
* `allowObjectEnd`
* `allowArrayStart`
* `allowArrayEnd`

See #2965

**Edit:** I updated the commit message to be less than 72 characters long, that seems to be a new requirement here. Not much I can fit in when `Update: "lines-around-comment" (fixes #2965)` already takes up 44/72 chars. :stuck_out_tongue: