### PR TITLE
Update: RuleTester allows string errors in invalid cases (fixes #4117)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -415,6 +415,18 @@ invalid: [
 ]
 ```
 
+For simpler cases where the only thing that really matters is the error message, you can also specify any `errors` as strings. You can also have some strings and some objects, if you like.
+
+```js
+invalid: [
+    {
+        code: "'single quotes'",
+        options: ["double"],
+        errors: ["Strings must use doublequote."]
+    }
+]
+```
+
 ### Write Several Tests
 
 You must have at least one valid and one invalid case for the rule tests to pass. Provide as many unit tests as possible. Your pull request will never be turned down for having too many tests submitted with it!

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Mocha test wrapper
  * @author Ilya Volodin
+ * @copyright 2015 Kevin Partington. All rights reserved.
  * @copyright 2015 Nicholas C. Zakas. All rights reserved.
  * @copyright 2014 Ilya Volodin. All rights reserved.
  * See LICENSE file in root directory for full license.
@@ -19,6 +20,7 @@
  *      ],
  *      invalid: [
  *          { code: "{code}", errors: {numErrors} },
+ *          { code: "{code}", errors: ["{errorMessage}"] },
  *          { code: "{code}", options: {options}, global: {globals}, parser: "{parser}", settings: {settings}, errors: [{ message: "{errorMessage}", type: "{errorNodeType}"}] }
  *      ]
  *  });
@@ -268,20 +270,32 @@ RuleTester.prototype = {
                     assert.ok(!("fatal" in messages[i]), "A fatal parsing error occurred: " + messages[i].message);
                     assert.equal(messages[i].ruleId, ruleName, "Error rule name should be the same as the name of the rule being tested");
 
-                    if (item.errors[i].message) {
-                        assert.equal(messages[i].message, item.errors[i].message, "Error message should be " + item.errors[i].message);
-                    }
+                    if (typeof item.errors[i] === "string") {
+                        // Just an error message.
 
-                    if (item.errors[i].type) {
-                        assert.equal(messages[i].nodeType, item.errors[i].type, "Error type should be " + item.errors[i].type);
-                    }
+                        assert.equal(messages[i].message, item.errors[i], "Error message should be " + item.errors[i]);
+                    } else if (typeof item.errors[i] === "object") {
+                        // Error object. This may have a message, node type,
+                        // line, and/or column.
 
-                    if (item.errors[i].hasOwnProperty("line")) {
-                        assert.equal(messages[i].line, item.errors[i].line, "Error line should be " + item.errors[i].line);
-                    }
+                        if (item.errors[i].message) {
+                            assert.equal(messages[i].message, item.errors[i].message, "Error message should be " + item.errors[i].message);
+                        }
 
-                    if (item.errors[i].hasOwnProperty("column")) {
-                        assert.equal(messages[i].column, item.errors[i].column, "Error column should be " + item.errors[i].column);
+                        if (item.errors[i].type) {
+                            assert.equal(messages[i].nodeType, item.errors[i].type, "Error type should be " + item.errors[i].type);
+                        }
+
+                        if (item.errors[i].hasOwnProperty("line")) {
+                            assert.equal(messages[i].line, item.errors[i].line, "Error line should be " + item.errors[i].line);
+                        }
+
+                        if (item.errors[i].hasOwnProperty("column")) {
+                            assert.equal(messages[i].column, item.errors[i].column, "Error column should be " + item.errors[i].column);
+                        }
+                    } else {
+                        // Only string or object errors are valid.
+                        assert.fail(messages[i], null, "Error should be a string or object.");
                     }
                 }
             }

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -1,6 +1,8 @@
 /**
  * @fileoverview Tests for ESLint Tester
  * @author Nicholas C. Zakas
+ * @Copyright 2015 Kevin Partington. All rights reserved.
+ * @copyright 2015 Nicholas C. Zakas. All rights reserved.
  */
 "use strict";
 
@@ -105,6 +107,62 @@ describe("RuleTester", function() {
                 ]
             });
         }, /^Should have 1 errors but had 0/);
+    });
+
+    it("should throw an error when the error message is wrong", function() {
+        assert.throws(function() {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                // Only the invalid test matters here
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar;", errors: [{ message: "Bad error message." }] }
+                ]
+            });
+        }, /^Error message should be /);
+    });
+
+    it("should throw an error when the error is neither an object nor a string", function() {
+        assert.throws(function() {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                // Only the invalid test matters here
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar;", errors: [42] }
+                ]
+            });
+        }, /^Error should be a string or object/);
+    });
+
+    it("should throw an error when the error is a string and it does not match error message", function() {
+        assert.throws(function() {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                // Only the invalid test matters here
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar;", errors: ["Bad error message."] }
+                ]
+            });
+        }, /^Error message should be /);
+    });
+
+    it("should not throw an error when the error is a string and it matches error message", function() {
+        assert.doesNotThrow(function() {
+            ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+                // Only the invalid test matters here
+                valid: [
+                    "bar = baz;"
+                ],
+                invalid: [
+                    { code: "var foo = bar;", errors: ["Bad var."] }
+                ]
+            });
+        });
     });
 
     it("should throw an error when the expected output doesn't match", function() {


### PR DESCRIPTION
RuleTester now allows string errors for "invalid" test cases. Also added some test cases to prevent non-object, non-string errors and to ensure incorrect error messages result in assertion failures.

Diff looks a little weird in the `lib/testers/rule-tester.js` file. All I'm really doing is wrapping the existing assertions in an `if`/`else if`.

Also added some documentation. Hope it looks okay.

Fixes #4117.