### PR TITLE
Update: RuleTester come to check AST was not modified

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -78,6 +78,34 @@ var RuleTesterParameters = [
 
 var validateSchema = validate(metaSchema, { verbose: true });
 
+var hasOwnProperty = Function.call.bind(Object.hasOwnProperty);
+
+/**
+ * Clones a given value deeply.
+ * Note: This ignores `parent` property.
+ *
+ * @param {any} x - A value to clone.
+ * @returns {any} A cloned value.
+ */
+function cloneDeeplyExcludesParent(x) {
+    if (typeof x === "object" && x !== null) {
+        if (Array.isArray(x)) {
+            return x.map(cloneDeeplyExcludesParent);
+        }
+
+        var retv = {};
+        for (var key in x) {
+            if (key !== "parent" && hasOwnProperty(x, key)) {
+                retv[key] = cloneDeeplyExcludesParent(x[key]);
+            }
+        }
+
+        return retv;
+    }
+
+    return x;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -178,7 +206,7 @@ RuleTester.prototype = {
          */
         function runRuleForItem(ruleName, item) {
             var config = clone(testerConfig),
-                code, filename, schema;
+                code, filename, schema, beforeAST, afterAST;
 
             if (typeof item === "string") {
                 code = item;
@@ -223,7 +251,21 @@ RuleTester.prototype = {
 
             validator.validate(config, "rule-tester");
 
-            return eslint.verify(code, config, filename);
+            // To cache AST.
+            eslint.reset();
+            eslint.on("Program", function(node) {
+                beforeAST = cloneDeeplyExcludesParent(node);
+
+                eslint.on("Program:exit", function(node) {
+                    afterAST = cloneDeeplyExcludesParent(node);
+                });
+            });
+
+            return {
+                messages: eslint.verify(code, config, filename, true),
+                beforeAST: beforeAST,
+                afterAST: afterAST
+            };
         }
 
         /**
@@ -235,10 +277,17 @@ RuleTester.prototype = {
          * @private
          */
         function testValidTemplate(ruleName, item) {
-            var messages = runRuleForItem(ruleName, item);
+            var result = runRuleForItem(ruleName, item);
+            var messages = result.messages;
 
             assert.equal(messages.length, 0, util.format("Should have no errors but had %d: %s",
                         messages.length, util.inspect(messages)));
+
+            assert.deepEqual(
+                result.beforeAST,
+                result.afterAST,
+                "Rule should not modify AST."
+            );
         }
 
         /**
@@ -250,7 +299,8 @@ RuleTester.prototype = {
          * @private
          */
         function testInvalidTemplate(ruleName, item) {
-            var messages = runRuleForItem(ruleName, item);
+            var result = runRuleForItem(ruleName, item);
+            var messages = result.messages;
 
             if (typeof item.errors === "number") {
                 assert.equal(messages.length, item.errors, util.format("Should have %d errors but had %d: %s",
@@ -261,10 +311,9 @@ RuleTester.prototype = {
                     item.errors.length, messages.length, util.inspect(messages)));
 
                 if (item.hasOwnProperty("output")) {
-                    var result = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
-                    assert.equal(result.output, item.output, "Output is incorrect.");
+                    var fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+                    assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }
-
 
                 for (var i = 0, l = item.errors.length; i < l; i++) {
                     assert.ok(!("fatal" in messages[i]), "A fatal parsing error occurred: " + messages[i].message);
@@ -299,6 +348,12 @@ RuleTester.prototype = {
                     }
                 }
             }
+
+            assert.deepEqual(
+                result.beforeAST,
+                result.afterAST,
+                "Rule should not modify AST."
+            );
         }
 
         // this creates a mocha test suite and pipes all supplied info

--- a/tests/fixtures/testers/rule-tester/modify-ast-at-first.js
+++ b/tests/fixtures/testers/rule-tester/modify-ast-at-first.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Rule which modifies AST.
+ * @author Toru Nagashima
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    return {
+        "Program": function(node) {
+            node.body.push({
+                "type": "Identifier",
+                "name": "modified",
+                "range": [0, 8],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 8
+                    }
+                }
+            });
+        },
+
+        "Identifier": function(node) {
+            if (node.name === "bar") {
+                context.report({message: "error", node: node});
+            }
+        }
+    };
+};

--- a/tests/fixtures/testers/rule-tester/modify-ast-at-last.js
+++ b/tests/fixtures/testers/rule-tester/modify-ast-at-last.js
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Rule which modifies AST.
+ * @author Toru Nagashima
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    return {
+        "Program:exit": function(node) {
+            node.body.push({
+                "type": "Identifier",
+                "name": "modified",
+                "range": [0, 8],
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 0
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 8
+                    }
+                }
+            });
+        },
+
+        "Identifier": function(node) {
+            if (node.name === "bar") {
+                context.report({message: "error", node: node});
+            }
+        }
+    };
+};

--- a/tests/fixtures/testers/rule-tester/modify-ast.js
+++ b/tests/fixtures/testers/rule-tester/modify-ast.js
@@ -1,0 +1,22 @@
+/**
+ * @fileoverview Rule which modifies AST.
+ * @author Toru Nagashima
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    return {
+        "Identifier": function(node) {
+            node.name += "!";
+
+            if (node.name === "bar!") {
+                context.report({message: "error", node: node});
+            }
+        }
+    };
+};

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -521,4 +521,60 @@ describe("RuleTester", function() {
         });
     });
 
+    it("should throw an error if AST was modified", function() {
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
+                valid: [
+                    "var foo = 0;"
+                ],
+                invalid: []
+            });
+        }, "Rule should not modify AST.");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast"), {
+                valid: [],
+                invalid: [
+                    {code: "var bar = 0;", errors: ["error"]}
+                ]
+            });
+        }, "Rule should not modify AST.");
+    });
+
+    it("should throw an error if AST was modified (at Program)", function() {
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
+                valid: [
+                    "var foo = 0;"
+                ],
+                invalid: []
+            });
+        }, "Rule should not modify AST.");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-first"), {
+                valid: [],
+                invalid: [
+                    {code: "var bar = 0;", errors: ["error"]}
+                ]
+            });
+        }, "Rule should not modify AST.");
+    });
+
+    it("should throw an error if AST was modified (at Program:exit)", function() {
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+                valid: [
+                    "var foo = 0;"
+                ],
+                invalid: []
+            });
+        }, "Rule should not modify AST.");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+                valid: [],
+                invalid: [
+                    {code: "var bar = 0;", errors: ["error"]}
+                ]
+            });
+        }, "Rule should not modify AST.");
+    });
 });


### PR DESCRIPTION
Fixes #4156

I defined `@@ast-getter-before-run` and `@@ast-getter-after-run` rules to get AST.
This is working but implementation-dependent (`for-in` loop iterates properties in the same order as added).
If this is not accepted, I will think an other way.