### PR TITLE
New: Disallow inline rule configuration option

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -31,6 +31,7 @@ The most important method on `linter` is `verify()`, which initiates linting of 
 * `options` - (optional) Additional options for this run.
     * `filename` - (optional) the filename to associate with the source code.
     * `saveState` - (optional) set to true to maintain the internal state of `linter` after linting (mostly used for testing purposes).
+    * `allowInlineConfig` - (optional) set to `false` to disable inline comments from changing eslint rules.
 
 You can call `verify()` like this:
 

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -69,7 +69,9 @@ Miscellaneous:
   --debug                    Output debugging information
   -h, --help                 Show help
   -v, --version              Outputs the version number
-  ```
+  --no-inline-config         Prevent comments from changing eslint rules -
+                             default: false
+```
 
 ### Basic configuration
 
@@ -328,6 +330,23 @@ This option outputs the current ESLint version onto the console. All other optio
 Example:
 
     eslint -v
+
+#### `--no-inline-config`
+
+This option prevents inline comments like `/*eslint-disable*/` or
+`/*global foo*/` from having any effect. This allows you to set an ESLint
+config without files modifying it. All inline config comments are ignored, e.g.:
+
+* `/*eslint-disable*/`
+* `/*eslint-enable*/`
+* `/*global*/`
+* `/*eslint*/`
+* `/*eslint-env*/`
+* `// eslint-disable-line`
+
+Example:
+
+    eslint --no-inline-config file.js
 
 ## Ignoring files from linting
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -95,7 +95,8 @@ var defaultOptions = {
         // it will always be used
         cacheLocation: "",
         cacheFile: ".eslintcache",
-        fix: false
+        fix: false,
+        allowInlineConfig: true
     },
     loadedPlugins = Object.create(null);
 
@@ -176,10 +177,11 @@ function calculateStatsPerRun(results) {
  * @param {Object} configHelper The configuration options for ESLint.
  * @param {string} filename An optional string representing the texts filename.
  * @param {boolean} fix Indicates if fixes should be processed.
+ * @param {boolean} allowInlineConfig Allow/ignore comments that change config.
  * @returns {Result} The results for linting on this text.
  * @private
  */
-function processText(text, configHelper, filename, fix) {
+function processText(text, configHelper, filename, fix, allowInlineConfig) {
 
     // clear all existing settings for a new file
     eslint.reset();
@@ -213,7 +215,10 @@ function processText(text, configHelper, filename, fix) {
         var parsedBlocks = processor.preprocess(text, filename);
         var unprocessedMessages = [];
         parsedBlocks.forEach(function(block) {
-            unprocessedMessages.push(eslint.verify(block, config, filename));
+            unprocessedMessages.push(eslint.verify(block, config, {
+                filename: filename,
+                allowInlineConfig: allowInlineConfig
+            }));
         });
 
         // TODO(nzakas): Figure out how fixes might work for processors
@@ -222,7 +227,10 @@ function processText(text, configHelper, filename, fix) {
 
     } else {
 
-        messages = eslint.verify(text, config, filename);
+        messages = eslint.verify(text, config, {
+            filename: filename,
+            allowInlineConfig: allowInlineConfig
+        });
 
         if (fix) {
             debug("Generating fixed text for " + filename);
@@ -259,7 +267,7 @@ function processText(text, configHelper, filename, fix) {
 function processFile(filename, configHelper, options) {
 
     var text = fs.readFileSync(path.resolve(filename), "utf8"),
-        result = processText(text, configHelper, filename, options.fix);
+        result = processText(text, configHelper, filename, options.fix, options.allowInlineConfig);
 
     return result;
 
@@ -675,7 +683,7 @@ CLIEngine.prototype = {
         if (filename && options.ignore && exclude(filename)) {
             results.push(createIgnoreResult(filename));
         } else {
-            results.push(processText(text, configHelper, filename, options.fix));
+            results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig));
         }
 
         stats = calculateStatsPerRun(results);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -54,7 +54,8 @@ function translateOptions(cliOptions) {
         cache: cliOptions.cache,
         cacheFile: cliOptions.cacheFile,
         cacheLocation: cliOptions.cacheLocation,
-        fix: cliOptions.fix
+        fix: cliOptions.fix,
+        allowInlineConfig: cliOptions.inlineConfig
     };
 }
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -608,9 +608,11 @@ module.exports = (function() {
      * @param {Object} config An object whose keys specify the rules to use.
      * @param {(string|Object)} [filenameOrOptions] The optional filename of the file being checked.
      *      If this is not set, the filename will default to '<input>' in the rule context. If
-     *      an object, then it has "filename" and "saveState" properties.
+     *      an object, then it has "filename", "saveState", and "allowInlineConfig" properties.
      * @param {boolean} [saveState] Indicates if the state from the last run should be saved.
      *      Mostly useful for testing purposes.
+     * @param {boolean} [filenameOrOptions.allowInlineConfig] Allow/disallow inline comments' ability to change config once it is set. Defaults to true if not supplied.
+     *      Useful if you want to validate JS without comments overriding rules.
      * @returns {Object[]} The results as an array of messages or null if no messages.
      */
     api.verify = function(textOrSourceCode, config, filenameOrOptions, saveState) {
@@ -619,11 +621,13 @@ module.exports = (function() {
             shebang,
             ecmaFeatures,
             ecmaVersion,
+            allowInlineConfig,
             text = (typeof textOrSourceCode === "string") ? textOrSourceCode : null;
 
         // evaluate arguments
         if (typeof filenameOrOptions === "object") {
             currentFilename = filenameOrOptions.filename;
+            allowInlineConfig = filenameOrOptions.allowInlineConfig;
             saveState = filenameOrOptions.saveState;
         } else {
             currentFilename = filenameOrOptions;
@@ -674,7 +678,9 @@ module.exports = (function() {
         if (ast) {
 
             // parse global comments and modify config
-            config = modifyConfigsFromComments(currentFilename, ast, config, reportingConfig, messages);
+            if (allowInlineConfig !== false) {
+                config = modifyConfigsFromComments(currentFilename, ast, config, reportingConfig, messages);
+            }
 
             // enable appropriate rules
             Object.keys(config.rules).filter(function(key) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -198,6 +198,12 @@ module.exports = optionator({
             alias: "v",
             type: "Boolean",
             description: "Outputs the version number"
+        },
+        {
+            option: "inline-config",
+            type: "Boolean",
+            default: "true",
+            description: "Allow comments to change eslint config/rules"
         }
     ]
 });

--- a/tests/fixtures/disable-inline-config.js
+++ b/tests/fixtures/disable-inline-config.js
@@ -1,0 +1,1 @@
+console.log('bar'); // eslint-disable-line

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1854,4 +1854,60 @@ describe("CLIEngine", function() {
         });
 
     });
+
+    describe("when evaluating code with comments to change config when allowInlineConfig is disabled", function() {
+
+        it("should report a violation for disabling rules", function() {
+            var code = [
+                "alert('test'); // eslint-disable-line no-alert"
+            ].join("\n");
+            var config = {
+                envs: ["browser"],
+                ignore: true,
+                allowInlineConfig: false,
+                rules: {
+                    "eol-last": 0,
+                    "no-alert": 1,
+                    "no-trailing-spaces": 0,
+                    "strict": 0,
+                    "quotes": 0
+                }
+            };
+
+            var eslintCLI = new CLIEngine(config);
+
+            var report = eslintCLI.executeOnText(code);
+            var messages = report.results[0].messages;
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].ruleId, "no-alert");
+        });
+
+        it("should not report a violation by default", function() {
+            var code = [
+                "alert('test'); // eslint-disable-line no-alert"
+            ].join("\n");
+            var config = {
+                envs: ["browser"],
+                ignore: true,
+                // allowInlineConfig: true is the default
+                rules: {
+                    "eol-last": 0,
+                    "no-alert": 1,
+                    "no-trailing-spaces": 0,
+                    "strict": 0,
+                    "quotes": 0
+                }
+            };
+
+            var eslintCLI = new CLIEngine(config);
+
+            var report = eslintCLI.executeOnText(code);
+            var messages = report.results[0].messages;
+
+            assert.equal(messages.length, 0);
+        });
+
+    });
+
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -633,6 +633,73 @@ describe("cli", function() {
         });
     });
 
+    describe("when passed --no-inline-config", function() {
+
+        var sandbox = sinon.sandbox.create(),
+            localCLI;
+
+        afterEach(function() {
+            sandbox.verifyAndRestore();
+        });
+
+        it("should pass allowInlineConfig:true to CLIEngine when --no-inline-config is used", function() {
+
+            // create a fake CLIEngine to test with
+            var fakeCLIEngine = sandbox.mock().withExactArgs(sinon.match({ allowInlineConfig: false }));
+            fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
+            sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns({
+                errorCount: 1,
+                warningCount: 0,
+                results: [{
+                    filePath: "./foo.js",
+                    output: "bar",
+                    messages: [
+                        {
+                            severity: 2,
+                            message: "Fake message"
+                        }
+                    ]
+                }]
+            });
+            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(function() {
+                return "done";
+            });
+            fakeCLIEngine.outputFixes = sandbox.stub();
+
+            localCLI = proxyquire("../../lib/cli", {
+                "./cli-engine": fakeCLIEngine,
+                "./logging": log
+            });
+
+            localCLI.execute("--no-inline-config .");
+        });
+
+        it("should not error and allowInlineConfig should be true by default", function() {
+            // create a fake CLIEngine to test with
+            var fakeCLIEngine = sandbox.mock().withExactArgs(sinon.match({ allowInlineConfig: true }));
+            fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);
+            sandbox.stub(fakeCLIEngine.prototype, "executeOnFiles").returns({
+                errorCount: 0,
+                warningCount: 0,
+                results: []
+            });
+            sandbox.stub(fakeCLIEngine.prototype, "getFormatter").returns(function() {
+                return "done";
+            });
+            fakeCLIEngine.outputFixes = sandbox.stub();
+
+            localCLI = proxyquire("../../lib/cli", {
+                "./cli-engine": fakeCLIEngine,
+                "./logging": log
+            });
+
+            var exitCode = localCLI.execute(".");
+            assert.equal(exitCode, 0);
+
+        });
+
+    });
+
     // NOTE: If you are adding new tests for cli.js, duplicate the following tests
 
     describe("when passed --fix", function() {

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -264,6 +264,18 @@ describe("options", function() {
         });
     });
 
+    describe("--inline-config", function() {
+        it("should return false when passed --no-inline-config", function() {
+            var currentOptions = options.parse("--no-inline-config");
+            assert.isFalse(currentOptions.inlineConfig);
+        });
+
+        it("should return true for --inline-config when empty", function() {
+            var currentOptions = options.parse("");
+            assert.isTrue(currentOptions.inlineConfig);
+        });
+    });
+
     describe("--parser", function() {
         it("should return a string for --parser when passed", function() {
             var currentOptions = options.parse("--parser test");


### PR DESCRIPTION
Closes #3901.

This adds a `disallowInlineConfig` option, off by default, that disables
inline configuration in comments of a particular file.

This disable:

* `/*eslint-disable*/`
* `/*eslint-enable*/`
* `/*global*/`
* `/*eslint*/`
* `/*eslint-env*/`