### PR TITLE
New: Add rule no-arrow-condition (fixes #3280)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -4,6 +4,7 @@
     "rules": {
         "no-alert": 0,
         "no-array-constructor": 0,
+        "no-arrow-condition": 0,
         "no-bitwise": 0,
         "no-caller": 0,
         "no-catch-shadow": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -206,6 +206,7 @@ These rules are only relevant to ES6 environments.
 * [arrow-spacing](arrow-spacing.md) - require space before/after arrow function's arrow (fixable)
 * [constructor-super](constructor-super.md) - verify calls of `super()` in constructors
 * [generator-star-spacing](generator-star-spacing.md) - enforce spacing around the `*` in generator functions (fixable)
+* [no-arrow-condition](no-arrow-condition.md) - disallow arrow functions where a condition is expected
 * [no-class-assign](no-class-assign.md) - disallow modifying variables of class declarations
 * [no-const-assign](no-const-assign.md) - disallow modifying variables that are declared using `const`
 * [no-dupe-class-members](no-dupe-class-members.md) - disallow duplicate name in class members

--- a/docs/rules/no-arrow-condition.md
+++ b/docs/rules/no-arrow-condition.md
@@ -1,0 +1,44 @@
+# Disallow arrow functions where a condition is expected (no-arrow-condition)
+
+Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where a condition is expected. Even if the arguments of the arrow function are wrapped with parens, this rule still warns about it.
+
+Here's an example where the usage of `=>` is most likely a typo:
+
+```js
+// This is probably a typo
+if (a => 1) {}
+// And should instead be
+if (a >= 1) {}
+```
+
+There are also cases where the usage of `=>` can be ambiguous and should be rewritten to more clearly show the author's intent:
+
+```js
+// The intent is not clear
+var x = a => 1 ? 2 : 3
+// Did the author mean this
+var x = function (a) { return a >= 1 ? 2 : 3 }
+// Or this
+var x = a <= 1 ? 2 : 3
+```
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+/*eslint no-arrow-condition: 2*/
+/*eslint-env es6*/
+
+if (a => 1) {}
+while (a => 1) {}
+for (var a = 1; a => 10; a++) {}
+a => 1 ? 2 : 3
+(a => 1) ? 2 : 3
+var x = a => 1 ? 2 : 3
+var x = (a) => 1 ? 2 : 3
+```
+
+## Related Rules
+
+* [arrow-parens](arrow-parens.md)

--- a/lib/rules/no-arrow-condition.js
+++ b/lib/rules/no-arrow-condition.js
@@ -1,0 +1,88 @@
+/**
+ * @fileoverview A rule to warn against using arrow functions in conditions.
+ * @author Jxck <https://github.com/Jxck>
+ * @copyright 2015 Luke Karrys. All rights reserved.
+ * The MIT License (MIT)
+
+ * Copyright (c) 2015 Jxck
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a node is an arrow function expression.
+ * @param {ASTNode} node - node to test
+ * @returns {boolean} `true` if the node is an arrow function expression.
+ */
+function isArrowFunction(node) {
+    return node.test.type === "ArrowFunctionExpression";
+}
+
+/**
+ * Checks whether or not a node is a conditional expression.
+ * @param {ASTNode} node - node to test
+ * @returns {boolean} `true` if the node is a conditional expression.
+ */
+function isConditional(node) {
+    return node.body.type === "ConditionalExpression";
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    /**
+     * Reports if a conditional statement is an arrow function.
+     * @param {ASTNode} node - A node to check and report.
+     * @returns {void}
+     */
+    function checkCondition(node) {
+        if (isArrowFunction(node)) {
+            context.report(node, "Arrow function `=>` used inside {{statementType}} instead of comparison operator.", {statementType: node.type});
+        }
+    }
+
+    /**
+     * Reports if an arrow function contains an ambiguous conditional.
+     * @param {ASTNode} node - A node to check and report.
+     * @returns {void}
+     */
+    function checkArrowFunc(node) {
+        if (isConditional(node)) {
+            context.report(node, "Arrow function used ambiguously with a conditional expression.");
+        }
+    }
+
+    return {
+        "IfStatement": checkCondition,
+        "WhileStatement": checkCondition,
+        "ForStatement": checkCondition,
+        "ConditionalExpression": checkCondition,
+        "ArrowFunctionExpression": checkArrowFunc
+    };
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-arrow-condition.js
+++ b/tests/lib/rules/no-arrow-condition.js
@@ -1,0 +1,103 @@
+/**
+ * @fileoverview Tests for no-arrow-condition rule.
+ * @author Jxck <https://github.com/Jxck>
+ * @copyright 2015 Luke Karrys. All rights reserved.
+ * The MIT License (MIT)
+
+ * Copyright (c) 2015 Jxck
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-arrow-condition"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Extends a rule object to include support for arrow functions
+ * @param {object} obj - rule object
+ * @returns {object} object extened to include `ecmaFeatures.arrowFunctions = true`
+ */
+function addArrowFunctions(obj) {
+    obj.ecmaFeatures = { arrowFunctions: true };
+    return obj;
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-arrow-condition", rule, {
+    valid: [
+        { code: "if (a >= 1) {}" },
+        { code: "while (a >= 1) {}" },
+        { code: "for (var a = 1; a >= 10; a++) {}" },
+        { code: "a >= 1 ? 2 : 3" },
+        { code: "(a >= 1) ? 2 : 3" },
+        { code: "[1,2,3].filter(n => n > 2)" }
+    ].map(addArrowFunctions),
+    invalid: [
+        {
+            code: "if (a => 1) {}",
+            errors: [{ message: "Arrow function `=>` used inside IfStatement instead of comparison operator." }]
+        },
+        {
+            code: "if ((a) => 1) {}",
+            errors: [{ message: "Arrow function `=>` used inside IfStatement instead of comparison operator." }]
+        },
+        {
+            code: "while (a => 1) {}",
+            errors: [{ message: "Arrow function `=>` used inside WhileStatement instead of comparison operator." }]
+        },
+        {
+            code: "for (var a = 1; a => 10; a++) {}",
+            errors: [{ message: "Arrow function `=>` used inside ForStatement instead of comparison operator." }]
+        },
+        {
+            code: "(a => 1) ? 2 : 3",
+            errors: [{ message: "Arrow function `=>` used inside ConditionalExpression instead of comparison operator." }]
+        },
+        {
+            code: "var x = (a => 1) ? 2 : 3",
+            errors: [{ message: "Arrow function `=>` used inside ConditionalExpression instead of comparison operator." }]
+        },
+        {
+            code: "a => 1 ? 2 : 3",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
+        },
+        {
+            code: "var x = a => 1 ? 2 : 3",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
+        },
+        {
+            code: "var x = (a) => 1 ? 2 : 3",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
+        }
+    ].map(addArrowFunctions)
+});


### PR DESCRIPTION
This PR implements the `no-arrow-condition` rule as discussed in #3280.

I took the majority of the code from [this plugin](https://github.com/Jxck/eslint-plugin-arrow-function) which I had already modified slightly for my personal use case to add an option I'll describe below. I thought it would be easier to discuss in this PR rather than #3280 since the tests/docs do the best job of explaining what the option does.

By default this rule will warn about any case where the author uses `=>` but the intent might not be clear.

```js
/*eslint no-arrow-condition: 2*/
/*eslint-env es6*/

// All lines will produce warnings
if (a => 1) {}
while (a => 1) {}
for (var a = 1; a => 10; a++) {}
a => 1 ? 2 : 3
(a => 1) ? 2 : 3
var x = a => 1 ? 2 : 3
var x = (a) => 1 ? 2 : 3
```

I added an option `allowFunctionExpression` which when turned on, will not warn for implicit return arrow function expressions:

```js
/*eslint no-arrow-condition: [2, {"allowFunctionExpression": true}]*/
/*eslint-env es6*/

// Will not produce warnings
var x = a => 1 ? 2 : 3
var x = (a) => 1 ? 2 : 3
```

I wanted to open discussion for the option name, it's default value, and if other people agree it should be added. I added it because it matched my personal preference for writing implicit return arrow functions, but still wanting warnings for when an arrow function was used accidentally.

