### PR TITLE
Fix: no-magic-numbers: variable declarations (fixes #4192)

### DIFF
--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -63,19 +63,32 @@ module.exports = function(context) {
     return {
         "Literal": function(node) {
             var parent = node.parent,
+                value = node.value,
+                raw = node.raw,
                 okTypes = detectObjects ? [] : ["ObjectExpression", "Property", "AssignmentExpression"];
 
-            // don't warn on parseInt() or Number.parseInt() radix
-            if (node.parent.type === "CallExpression" && node === node.parent.arguments[1] &&
-                    (node.parent.callee.name === "parseInt" ||
-                    node.parent.callee.type === "MemberExpression" &&
-                    node.parent.callee.object.name === "Number" &&
-                    node.parent.callee.property.name === "parseInt")
-                ) {
+            if (!isNumber(node)) {
                 return;
             }
 
-            if (!isNumber(node) || shouldIgnoreNumber(node.value)) {
+            if (parent.type === "UnaryExpression" && parent.operator === "-") {
+                node = parent;
+                parent = node.parent;
+                value = -value;
+                raw = "-" + raw;
+            }
+
+            if (shouldIgnoreNumber(value)) {
+                return;
+            }
+
+            // don't warn on parseInt() or Number.parseInt() radix
+            if (parent.type === "CallExpression" && node === parent.arguments[1] &&
+                    (parent.callee.name === "parseInt" ||
+                    parent.callee.type === "MemberExpression" &&
+                    parent.callee.object.name === "Number" &&
+                    parent.callee.property.name === "parseInt")
+            ) {
                 return;
             }
 
@@ -89,7 +102,7 @@ module.exports = function(context) {
             } else if (okTypes.indexOf(parent.type) === -1) {
                 context.report({
                     node: node,
-                    message: "No magic number: " + node.raw
+                    message: "No magic number: " + raw
                 });
             }
         }

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -22,10 +22,13 @@ var ruleTester = new RuleTester();
 ruleTester.run("no-magic-numbers", rule, {
     valid: [
         {
-            code: "var x = parseInt(y, 10)"
+            code: "var x = parseInt(y, 10);"
         },
         {
-            code: "var x = Number.parseInt(y, 10)"
+            code: "var x = parseInt(y, -10);"
+        },
+        {
+            code: "var x = Number.parseInt(y, 10);"
         },
         {
             code: "const foo = 42;",
@@ -39,7 +42,19 @@ ruleTester.run("no-magic-numbers", rule, {
             }]
         },
         {
+            code: "var foo = -42;"
+        },
+        {
             code: "var foo = 0 + 1 + 2;"
+        },
+        {
+            code: "var foo = 0 + 1 - 2;"
+        },
+        {
+            code: "var foo = 0 + 1 - 2 + -2;",
+            options: [{
+                ignore: [0, 1, 2, -2]
+            }]
         },
         {
             code: "var foo = 0 + 1 + 2 + 3 + 4;",
@@ -67,6 +82,12 @@ ruleTester.run("no-magic-numbers", rule, {
             errors: [{
                 message: "Number constants declarations must use 'const'"
             }]
+        },
+        {
+            code: "var foo = 0 + 1 - 2 + -2;",
+            errors: [
+                { message: "No magic number: -2"}
+            ]
         },
         {
             code: "var foo = 0 + 1 + 2;",
@@ -110,6 +131,12 @@ ruleTester.run("no-magic-numbers", rule, {
             code: "function getSecondsInMinute() {return 60;}",
             errors: [
                 { message: "No magic number: 60"}
+            ]
+        },
+        {
+            code: "function getNegativeSecondsInMinute() {return -60;}",
+            errors: [
+                { message: "No magic number: -60"}
             ]
         },
         {


### PR DESCRIPTION
Currently following code is considered as error: ```var foo = -42;```
I don't think it should