### PR TITLE
Docs: Add missing single-quote

### DIFF
--- a/docs/developer-guide/shareable-configs.md
+++ b/docs/developer-guide/shareable-configs.md
@@ -108,7 +108,7 @@ myconfig
 In your `index.js` you can do something like this:
 
 ```js
-module.exports = require('./lib/ci.js);
+module.exports = require('./lib/ci.js');
 ```
 
 Now inside your package you have `/lib/defaults.js`, which contains:


### PR DESCRIPTION
Adds missing single quote to docs. Same as: https://github.com/eslint/eslint.github.io/pull/150