### PR TITLE
Fix: Support comma-first style in key-spacing (fixes #3877)

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -99,30 +99,12 @@ module.exports = function(context) {
         afterColon = +!(options.afterColon === false); // Defaults to true
 
     /**
-     * Gets the first node on the same line with the provided node.
-     * @param {ASTNode} node The node to check find from
-     * @returns {ASTNode} the first node on the given node's line
-     */
-    function getFirstNodeInLine(node) {
-        var startLine, endLine, firstToken = node;
-
-        do {
-            node = firstToken;
-            firstToken = context.getTokenBefore(node);
-            startLine = node.loc.start.line;
-            endLine = firstToken ? firstToken.loc.end.line : -1;
-        } while (startLine === endLine);
-
-        return node;
-    }
-
-    /**
      * Starting from the given a node (a property.key node here) looks forward
-     * until it finds the first node before a colon punctuator and returns it.
-     * @param {ASTNode} node The node to start looking from
-     * @returns {ASTNode} the first node before a colon punctuator
+     * until it finds the last token before a colon punctuator and returns it.
+     * @param {ASTNode} node The node to start looking from.
+     * @returns {ASTNode} The last token before a colon punctuator.
      */
-    function getFirstNodeBeforeColon(node) {
+    function getLastTokenBeforeColon(node) {
         var prevNode;
 
         while (node && (node.type !== "Punctuator" || node.value !== ":")) {
@@ -181,16 +163,15 @@ module.exports = function(context) {
      * @returns {int} Width of the key.
      */
     function getKeyWidth(property) {
-        var key, startToken, endToken;
+        var startToken, endToken;
 
         // Ignore shorthand methods and properties, as they have no colon
         if (property.method || property.shorthand) {
             return 0;
         }
 
-        key = property.key;
-        startToken = getFirstNodeInLine(key);
-        endToken = getFirstNodeBeforeColon(key);
+        startToken = context.getFirstToken(property);
+        endToken = getLastTokenBeforeColon(property.key);
 
         return endToken.range[1] - startToken.range[0];
     }

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -183,7 +183,7 @@ ruleTester.run("key-spacing", rule, {
         code: [
             "var x = {",
             "    foo: 10",
-            "    , b: 20",
+            "  , b  : 20",
             "};"
         ].join("\n"),
         options: [{ align: "colon" }]
@@ -191,7 +191,7 @@ ruleTester.run("key-spacing", rule, {
         code: [
             "var x = {",
             "    foo : 10",
-            "    , b : 20",
+            "  , b   : 20",
             "};"
         ].join("\n"),
         options: [{ align: "colon", beforeColon: true }]
@@ -284,6 +284,35 @@ ruleTester.run("key-spacing", rule, {
         ].join("\n"),
         ecmaFeatures: { objectLiteralShorthandMethods: true },
         options: [{ "align": "value" }]
+    }, {
+        code: [
+            "var obj = {",
+            "    foo : foo",
+            "  , bar : bar",
+            "  , cats: cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }]
+    }, {
+        code: [
+            "var obj = { foo : foo",
+            "          , bar : bar",
+            "          , cats: cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }]
+    }, {
+        code: [
+            "var obj = {",
+            "    foo :  foo",
+            "  , bar :  bar",
+            "  , cats : cats",
+            "};"
+        ].join("\n"),
+        options: [{
+            "align": "value",
+            "beforeColon": true
+        }]
     }],
 
     invalid: [{
@@ -484,7 +513,7 @@ ruleTester.run("key-spacing", rule, {
         code: [
             "var x = {",
             "    foo: 10",
-            "  , b  : 20",
+            "  , b   : 20",
             "};"
         ].join("\n"),
         options: [{ align: "colon" }],
@@ -580,6 +609,78 @@ ruleTester.run("key-spacing", rule, {
         options: [{ "align": "value" }],
         errors: [
             { message: "Extra space before value for key \"baz\".", line: 6, column: 13, type: "Literal" }
+        ]
+    }, {
+        code: [
+            "var obj = {",
+            "    foo: foo",
+            "  , cats: cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }],
+        errors: [
+            { message: "Missing space after key \"foo\".", line: 2, column: 5, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = {",
+            "    foo : foo",
+            "  , cats:  cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }],
+        errors: [
+            { message: "Extra space before value for key \"cats\".", line: 3, column: 12, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = { foo: foo",
+            "          , cats: cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }],
+        errors: [
+            { message: "Missing space after key \"foo\".", line: 1, column: 13, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = { foo  : foo",
+            "          , cats: cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }],
+        errors: [
+            { message: "Extra space after key \"foo\".", line: 1, column: 13, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = { foo :foo",
+            "          , cats: cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }],
+        errors: [
+            { message: "Missing space before value for key \"foo\".", line: 1, column: 18, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = { foo :  foo",
+            "          , cats: cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }],
+        errors: [
+            { message: "Extra space before value for key \"foo\".", line: 1, column: 20, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "var obj = { foo : foo",
+            "          , cats:  cats",
+            "};"
+        ].join("\n"),
+        options: [{ "align": "colon" }],
+        errors: [
+            { message: "Extra space before value for key \"cats\".", line: 2, column: 20, type: "Identifier" }
         ]
     }]
 });


### PR DESCRIPTION
:warning: **do not merge** :warning: Once #4219 is in, I'll rebase this on top of master.

Please take a look at lines 186 and 194 in the tests. These were previously testing that comma-first style was explicitly not supported. I'd like some confirmation that this is **not** a breaking change, that those tests were merely asserting a current behavior and not necessarily the intended behavior, which is what they've been changed to test.