### PR TITLE
Fix: Restore multi-lined arguments compat on `indent` (fixes #4224)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -299,6 +299,19 @@ module.exports = function(context) {
     }
 
     /**
+     * Returns the first argument that is on a new line
+     * @param {ASTNode} node a CallExpression node with arguments
+     * @returns {ASTNode} the first of its arguments that is on a new line
+     */
+    function getFirstMultilineArg(node) {
+        for (var i = 0; i < node.arguments.length; i++) {
+            if (node.arguments[i].loc.end.line > node.loc.start.line) {
+                return node.arguments[i];
+            }
+        }
+    }
+
+    /**
      * Check indent for function block content
      * @param {ASTNode} node node to examine
      * @returns {void}
@@ -338,9 +351,8 @@ module.exports = function(context) {
                 }
             } else {
                 if (isCallArgsMultiline(calleeParent) &&
-                    calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line &&
-                    !isNodeFirstInLine(calleeNode)) {
-                    indent = getNodeIndent(calleeParent);
+                    calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line) {
+                    indent = getNodeIndent(getFirstMultilineArg(calleeParent));
                 }
             }
         }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -86,6 +86,35 @@ ruleTester.run("indent", rule, {
         },
         {
             code:
+            "example(\n" +
+            "    precedingArg, function () {\n" +
+            "        console.log('example');\n" +
+            "    }\n" +
+            ");\n",
+            options: [4]
+        },
+        {
+            code:
+            "example(\n" +
+            "    precedingArg, () => {\n" +
+            "        console.log('example');\n" +
+            "    }\n" +
+            ");\n",
+            options: [4],
+            ecmaFeatures: {arrowFunctions: true}
+        },
+        {
+            code:
+            "example(arg0,\n" +
+            "    precedingArg, () => {\n" +
+            "        console.log('example');\n" +
+            "    }\n" +
+            ");\n",
+            options: [4],
+            ecmaFeatures: {arrowFunctions: true}
+        },
+        {
+            code:
             "let foo = somethingList\n" +
             "    .filter(x => {\n" +
             "        return x;\n" +


### PR DESCRIPTION
Commit 9488faf (which fixed related bugs #4165 and #4164) introduced new
errors on valid code with `indent` rule:

    example(
        precedingArg, function () {
            console.log('example');
        }
    )

    3:9  error  Expected indentation of 4 space characters but found 8

This patch rewrites the rule algorithm to both address #4165 and #4164
and fix #4224.