### PR TITLE
Update: Add `max` option to eol-last (fixes #4235)

### DIFF
--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -1,4 +1,4 @@
-# Require file to end with single newline (eol-last)
+# Require files to end with newlines (eol-last)
 
 Trailing newlines in non-empty files are a common UNIX idiom. Benefits of
 trailing newlines include the ability to concatenate or append to files as well
@@ -6,13 +6,41 @@ as output files to the terminal without interfering with shell prompts. This
 rule enforces newlines for all non-empty programs.
 
 Prior to v0.16.0 this rule also enforced that there was only a single line at
-the end of the file. If you still want this behaviour, consider enabling
-[no-multiple-empty-lines](no-multiple-empty-lines.md) and/or
+the end of the file. If you still want this behaviour, set the `max` option to 1.
+Related rules: [no-multiple-empty-lines](no-multiple-empty-lines.md) and
 [no-trailing-spaces](no-trailing-spaces.md).
 
 **Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
+
+### Options
+
+The `eol-last` rule can be tweaked with options (currently only one):
+
+* `type` - Either `unix` (LF) or `windows` (CRLF). When omitted `unix` is assumed.
+* `max` - Maximum number of tolerated newlines at the end of file. By default
+          any number of newlines is allowed.
+
+### Examples
+
+Require at least one newline:
+
+```json
+"eol-last": 2
+```
+
+Require one and exactly one newline:
+
+```json
+"eol-last": [2, {"max": 1}]
+```
+
+Require at least one newline but not more than 4:
+
+```json
+"eol-last": [2, {"max": 4}]
+```
 
 The following patterns are considered problems:
 
@@ -21,7 +49,16 @@ The following patterns are considered problems:
 
 function doSmth() {
   var foo = 2;
+} // missing newline here
+```
+
+```js
+/*eslint eol-last: [2, {"max": 1}]*/
+
+function doSmth() {
+  var foo = 2;
 }
+// two newlines here
 ```
 
 The following patterns are not considered problems:
@@ -35,6 +72,10 @@ function doSmth() {
 // spaces here
 ```
 
-### Options
+```js
+/*eslint eol-last: [2, {"max": 1}]*/
 
-This rule may take one option which is either `unix` (LF) or `windows` (CRLF). When omitted `unix` is assumed.
+function doSmth() {
+  var foo = 2;
+}
+```

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -14,19 +14,36 @@ module.exports = function(context) {
     // Public
     //--------------------------------------------------------------------------
 
+    var maxLines = -1,
+        linebreakStyle = "unix";
+
+    if (context.options.length) {
+        var opts = context.options[0];
+        maxLines = opts.max || -1;
+        linebreakStyle = opts.type || "unix";
+    }
+
+    var linebreak = linebreakStyle === "windows" ? "\r\n" : "\n";
+
     return {
 
         "Program": function checkBadEOF(node) {
             // Get the whole source code, not for node only.
             var src = context.getSource(),
-                location = {column: 1},
-                linebreakStyle = context.options[0] || "unix",
-                linebreak = linebreakStyle === "unix" ? "\n" : "\r\n";
+                location = {column: 1};
+
             if (src.length === 0) {
                 return;
             }
 
-            if (src[src.length - 1] !== "\n") {
+            var lastChar = src.length - linebreak.length,
+                numberOfNewLines = 0;
+            while (lastChar >= 0 && src.substr(lastChar, linebreak.length) === linebreak) {
+                numberOfNewLines++;
+                lastChar -= linebreak.length;
+            }
+
+            if (numberOfNewLines === 0) {
                 // file is not newline-terminated
                 location.line = src.split(/\n/g).length;
                 context.report({
@@ -37,6 +54,19 @@ module.exports = function(context) {
                         return fixer.insertTextAfterRange([0, src.length], linebreak);
                     }
                 });
+            } else if (maxLines !== -1 && numberOfNewLines > maxLines) {
+                // file is terminated with too many newlines
+                location.line = src.split(/\n/g).length;
+                context.report({
+                    node: node,
+                    loc: location,
+                    message: "Too many newlines at end of file.",
+                    fix: function(fixer) {
+                        return fixer.removeRange(
+                            [src.length - 1 + linebreak.length * (maxLines - numberOfNewLines),
+                             src.length - 1]);
+                    }
+                });
             }
         }
 
@@ -44,8 +74,15 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [
-    {
-        "enum": ["unix", "windows"]
-    }
-];
+module.exports.schema = [{
+    "type": "object",
+    "properties": {
+        "type": {
+            "enum": ["unix", "windows"]
+        },
+        "max": {
+            "type": "integer"
+        }
+    },
+    "additionalProperties": false
+}];

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -24,11 +24,18 @@ ruleTester.run("eol-last", rule, {
         "var a = 123;\n",
         "var a = 123;\n\n",
         "var a = 123;\n   \n",
-
         "\r\n",
         "var a = 123;\r\n",
         "var a = 123;\r\n\r\n",
-        "var a = 123;\r\n   \r\n"
+        "var a = 123;\r\n   \r\n",
+        {
+            code: "var a = 123;\n\n\n\n\n\n\n\n\n\n",
+            options: [{"max": 10}]
+        },
+        {
+            code: "var a = 123;\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+            options: [{"type": "windows", "max": 10}]
+        }
     ],
 
     invalid: [
@@ -44,15 +51,33 @@ ruleTester.run("eol-last", rule, {
         },
         {
             code: "var a = 123;",
-            options: ["windows"],
+            options: [{"type": "windows"}],
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
             output: "var a = 123;\r\n"
         },
         {
             code: "var a = 123;\r\n   ",
-            options: ["windows"],
+            options: [{"type": "windows"}],
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
             output: "var a = 123;\r\n   \r\n"
+        },
+        {
+            code: "var a = 123;\n\n",
+            options: [{"max": 1}],
+            errors: [{ message: "Too many newlines at end of file.", type: "Program" }],
+            output: "var a = 123;\n"
+        },
+        {
+            code: "var a = 123;\n\n\n\n\n\n\n\n\n\n",
+            options: [{"max": 5}],
+            errors: [{ message: "Too many newlines at end of file.", type: "Program" }],
+            output: "var a = 123;\n\n\n\n\n"
+        },
+        {
+            code: "var a = 123;\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n\r\n",
+            options: [{"type": "windows", "max": 5}],
+            errors: [{ message: "Too many newlines at end of file.", type: "Program" }],
+            output: "var a = 123;\r\n\r\n\r\n\r\n\r\n"
         }
     ]
 });


### PR DESCRIPTION
Currently there is no way to specify a rule for having one (and only
one) ending newline. Using the no-multiple-empty-lines trick as
currently described in eol-last documentation does not stand if one
wants to allow 2+ blank lines inside files (not at the end).

This patch adds an optional `max` option to set the maximum number of
newlines allowed at end of files. For instance, requiring one and only
one newline can be achieved using:

    "eol-last": [2, {"max": 1}]