### PR TITLE
Update docs about using gitignore

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -578,7 +578,7 @@ You can also use your `.gitignore` file:
 
     eslint --ignore-path .gitignore file.js
 
-Any file that follows the standard ignore file format can be used. Keep in mind that specifying `--ignore-path` means that any existing `.eslintignore` file will not be used.
+Any file that follows the standard ignore file format can be used. Keep in mind that specifying `--ignore-path` means that any existing `.eslintignore` file will not be used. Note that globbing rules in .eslintignore are more strict than in .gitignore. See all supported patterns in [minimatch docs](https://github.com/isaacs/minimatch)
 
 ### Ignored File Warnings
 


### PR DESCRIPTION
Hey,

I've spent some time on debugging why files ignored by my .gitignore are not ignored by eslint and found out that rules like

```
*.min.js
```

doesn't work here if file is in subfolder. Rule which works both for .gitignore and .eslintignore is

```
**/*.min.js
```

There may be more differences, so I've added link to minimatch docs instead of listing them.