### PR TITLE
Fix: `consistent-return` comes to checking the last path.

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -1005,7 +1005,7 @@ function time(cmd, runs, runNumber, results, cb) {
         results.push(actual);
         echo("Performance Run #" + runNumber + ":  %dms", actual);
         if (runs > 1) {
-            time(cmd, runs - 1, runNumber + 1, results, cb);
+            return time(cmd, runs - 1, runNumber + 1, results, cb);
         } else {
             return cb(results);
         }

--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -31,7 +31,7 @@ function doSomething(condition) {
     if (condition) {
         return true;
     } else {
-        return;      /*error Expected a return value.*/
+        return;                   /*error Expected a return value.*/
     }
 }
 
@@ -40,7 +40,14 @@ function doSomething(condition) {
     if (condition) {
         return;
     } else {
-        return true; /*error Expected no return value.*/
+        return true;              /*error Expected no return value.*/
+    }
+}
+
+function doSomething(condition) { /*error Expected to return a value at the end of this function.*/
+
+    if (condition) {
+        return true;
     }
 }
 ```

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -51,7 +51,8 @@ function writeFile(config, format, callback) {
         exec("npm i eslint-config-" + config.extends + " --save-dev", function(err) {
 
             if (err) {
-                return callback(err);
+                callback(err);
+                return;
             }
 
             // TODO: consider supporting more than 1 plugin though it's required yet.

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -435,6 +435,7 @@ function getRuleReplacementMessage(ruleId) {
         var newRules = replacements.rules[ruleId];
         return "Rule \'" + ruleId + "\' was removed and replaced by: " + newRules.join(", ");
     }
+    return null;
 }
 
 var eslintEnvPattern = /\/\*\s*eslint-env\s(.+?)\*\//g;

--- a/lib/formatters/checkstyle.js
+++ b/lib/formatters/checkstyle.js
@@ -41,7 +41,8 @@ function xmlEscape(s) {
                 return "&quot;";
             case "'":
                 return "&apos;";
-            // no default
+            default:
+                throw new Error("unreachable");
         }
     });
 }

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -49,7 +49,6 @@ module.exports = function(context) {
      * @returns {boolean} Whether or not this is part of a callback expression
      */
     function isCallbackExpression(node, parentNode) {
-
         // ensure the parent node exists and is an expression
         if (!parentNode || parentNode.type !== "ExpressionStatement") {
             return false;
@@ -66,6 +65,8 @@ module.exports = function(context) {
                 return true;
             }
         }
+
+        return false;
     }
 
     //--------------------------------------------------------------------------

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -95,7 +95,7 @@ module.exports = function(context) {
         }
 
         if (tokens.right && !options.after && tokens.right.type === "Line") {
-            return false;
+            return;
         }
 
         if (tokens.right && astUtils.isTokenOnSameLine(tokens.comma, tokens.right) &&

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -5,71 +5,108 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a given code path segment is unreachable.
+ * @param {CodePathSegment} segment - A CodePathSegment to check.
+ * @returns {boolean} `true` if the segment is unreachable.
+ */
+function isUnreachable(segment) {
+    return !segment.reachable;
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    var functions = [];
-
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
+    var funcInfo = null;
 
     /**
-     * Marks entrance into a function by pushing a new object onto the functions
-     * stack.
+     * Checks whether of not the implicit returning is consistent if the last
+     * code path segment is reachable.
+     *
+     * @param {ASTNode} node - A program/function node to check.
      * @returns {void}
-     * @private
      */
-    function enterFunction() {
-        functions.push({});
+    function checkLastSegment(node) {
+        var loc, type;
+
+        // Skip if it expected no return value or unreachable.
+        // When unreachable, all paths are returned or thrown.
+        if (!funcInfo.hasReturnValue ||
+            funcInfo.codePath.currentSegments.every(isUnreachable)
+        ) {
+            return;
+        }
+
+        // Adjust a location and a message.
+        if (node.type === "Program") {
+            // The head of program.
+            loc = {line: 1, column: 0};
+            type = "program";
+        } else if (node.type === "ArrowFunctionExpression") {
+            // `=>` token
+            loc = context.getSourceCode().getTokenBefore(node.body).loc.start;
+            type = "function";
+        } else if (
+            node.parent.type === "MethodDefinition" ||
+            (node.parent.type === "Property" && node.parent.method)
+        ) {
+            // Method name.
+            loc = node.parent.key.loc.start;
+            type = "method";
+        } else {
+            // Function name or `function` keyword.
+            loc = (node.id || node).loc.start;
+            type = "function";
+        }
+
+        // Reports.
+        context.report({
+            node: node,
+            loc: loc,
+            message: "Expected to return a value at the end of this {{type}}.",
+            data: {type: type}
+        });
     }
-
-    /**
-     * Marks exit of a function by popping off the functions stack.
-     * @returns {void}
-     * @private
-     */
-    function exitFunction() {
-        functions.pop();
-    }
-
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
 
     return {
+        // Initializes/Disposes state of each code path.
+        "onCodePathStart": function(codePath) {
+            funcInfo = {
+                upper: funcInfo,
+                codePath: codePath,
+                hasReturn: false,
+                hasReturnValue: false,
+                message: ""
+            };
+        },
+        "onCodePathEnd": function() {
+            funcInfo = funcInfo.upper;
+        },
 
-        "Program": enterFunction,
-        "FunctionDeclaration": enterFunction,
-        "FunctionExpression": enterFunction,
-        "ArrowFunctionExpression": enterFunction,
-
-        "Program:exit": exitFunction,
-        "FunctionDeclaration:exit": exitFunction,
-        "FunctionExpression:exit": exitFunction,
-        "ArrowFunctionExpression:exit": exitFunction,
-
+        // Reports a given return statement if it's inconsistent.
         "ReturnStatement": function(node) {
+            var hasReturnValue = Boolean(node.argument);
 
-            var returnInfo = functions[functions.length - 1],
-                returnTypeDefined = "type" in returnInfo;
-
-            if (returnTypeDefined) {
-
-                if (returnInfo.type !== !!node.argument) {
-                    context.report(node, "Expected " + (returnInfo.type ? "a" : "no") + " return value.");
-                }
-
-            } else {
-                returnInfo.type = !!node.argument;
+            if (!funcInfo.hasReturn) {
+                funcInfo.hasReturn = true;
+                funcInfo.hasReturnValue = hasReturnValue;
+                funcInfo.message = "Expected " + (hasReturnValue ? "a" : "no") + " return value.";
+            } else if (funcInfo.hasReturnValue !== hasReturnValue) {
+                context.report({node: node, message: funcInfo.message});
             }
+        },
 
-        }
+        // Reports a given program/function if the implicit returning is not consistent.
+        "Program:exit": checkLastSegment,
+        "FunctionDeclaration:exit": checkLastSegment,
+        "FunctionExpression:exit": checkLastSegment,
+        "ArrowFunctionExpression:exit": checkLastSegment
     };
-
 };
 
 module.exports.schema = [];

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -71,12 +71,11 @@ module.exports = function(context) {
         // assigned later in the same scope.
         if (!lookup.references.some(function(reference) {
             var write = reference.writeExpr;
-
-            if (reference.from === scope &&
-                    write && write.type === "ThisExpression" &&
-                    write.parent.operator === "=") {
-                return true;
-            }
+            return (
+                reference.from === scope &&
+                write && write.type === "ThisExpression" &&
+                write.parent.operator === "="
+            );
         })) {
             variable.defs.map(function(def) {
                 return def.node;

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -192,6 +192,7 @@ module.exports = function(context) {
                 afterColon: whitespace[2]
             };
         }
+        return null;
     }
 
     /**

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -33,7 +33,7 @@ function report(context, node, identifierName) {
 /**
  * Returns the property name of a MemberExpression.
  * @param {ASTNode} memberExpressionNode The MemberExpression node.
- * @returns {string|undefined} Returns the property name if available, undefined else.
+ * @returns {string|null} Returns the property name if available, null else.
  */
 function getPropertyName(memberExpressionNode) {
     if (memberExpressionNode.computed) {
@@ -43,13 +43,14 @@ function getPropertyName(memberExpressionNode) {
     } else {
         return memberExpressionNode.property.name;
     }
+    return null;
 }
 
 /**
  * Finds the escope reference in the given scope.
  * @param {Object} scope The scope to search.
  * @param {ASTNode} node The identifier node.
- * @returns {Reference|undefined} Returns the found reference or undefined if none were found.
+ * @returns {Reference|null} Returns the found reference or null if none were found.
  */
 function findReference(scope, node) {
     var references = scope.references.filter(function(reference) {
@@ -60,6 +61,7 @@ function findReference(scope, node) {
     if (references.length === 1) {
         return references[0];
     }
+    return null;
 }
 
 /**

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -18,35 +18,28 @@ module.exports = function(context) {
      * @private
      */
     function getRegExp(node) {
-
         if (node.value instanceof RegExp) {
             return node.value;
         } else if (typeof node.value === "string") {
 
             var parent = context.getAncestors().pop();
             if ((parent.type === "NewExpression" || parent.type === "CallExpression") &&
-            parent.callee.type === "Identifier" && parent.callee.name === "RegExp") {
-
+                parent.callee.type === "Identifier" && parent.callee.name === "RegExp"
+            ) {
                 // there could be an invalid regular expression string
                 try {
                     return new RegExp(node.value);
                 } catch (ex) {
                     return null;
                 }
-
             }
-        } else {
-            return null;
         }
 
+        return null;
     }
 
-
-
     return {
-
         "Literal": function(node) {
-
             var computedValue,
                 regex = getRegExp(node);
 

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -87,7 +87,7 @@ function isNumeric(node) {
  * used from bottom to up since it walks up the BinaryExpression trees using
  * node.parent to find the result.
  * @param {BinaryExpression} node The BinaryExpression node to be walked up on
- * @returns {ASTNode|undefined} The first non-numeric item in the BinaryExpression tree or undefined
+ * @returns {ASTNode|null} The first non-numeric item in the BinaryExpression tree or null
  */
 function getNonNumericOperand(node) {
     var left = node.left, right = node.right;
@@ -99,6 +99,8 @@ function getNonNumericOperand(node) {
     if (left.type !== "BinaryExpression" && !isNumeric(left)) {
         return left;
     }
+
+    return null;
 }
 
 /**

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -83,13 +83,13 @@ module.exports = function(context) {
 
         if ((node.type === "NewExpression" || node.prefix) && firstToken.type === "Keyword") {
             checkUnaryWordOperatorForSpaces(node, firstToken, secondToken);
-            return void 0;
+            return;
         }
 
         if (options.nonwords) {
             if (node.prefix) {
                 if (isFirstBangInBangBangExpression(node)) {
-                    return void 0;
+                    return;
                 }
                 if (firstToken.range[1] === secondToken.range[0]) {
                     context.report({

--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -61,6 +61,8 @@ module.exports = function(context) {
                 return true;
             }
         }
+
+        return false;
     }
 
     /**

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -20,9 +20,11 @@ ruleTester.run("consistent-return", rule, {
 
     valid: [
         "function foo() { return; }",
+        "function foo() { if (true) return; }",
         "function foo() { if (true) return; else return; }",
         "function foo() { if (true) return true; else return false; }",
         "f(function() { return; })",
+        "f(function() { if (true) return; })",
         "f(function() { if (true) return; else return; })",
         "f(function() { if (true) return true; else return false; })",
         "function foo() { function bar() { return true; } return; }",
@@ -95,6 +97,80 @@ ruleTester.run("consistent-return", rule, {
                 {
                     message: "Expected a return value.",
                     type: "ReturnStatement"
+                }
+            ]
+        },
+        {
+            code: "function foo() { if (a) return true; }",
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this function.",
+                    type: "FunctionDeclaration",
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "f(function foo() { if (a) return true; });",
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this function.",
+                    type: "FunctionExpression",
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: "f(function() { if (a) return true; });",
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this function.",
+                    type: "FunctionExpression",
+                    column: 3
+                }
+            ]
+        },
+        {
+            code: "f(() => { if (a) return true; });",
+            ecmaFeatures: {arrowFunctions: true},
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this function.",
+                    type: "ArrowFunctionExpression",
+                    column: 6
+                }
+            ]
+        },
+        {
+            code: "var obj = {foo() { if (a) return true; }};",
+            ecmaFeatures: {objectLiteralShorthandMethods: true},
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this method.",
+                    type: "FunctionExpression",
+                    column: 12
+                }
+            ]
+        },
+        {
+            code: "class A {foo() { if (a) return true; }};",
+            ecmaFeatures: {classes: true},
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this method.",
+                    type: "FunctionExpression",
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "if (a) return true;",
+            ecmaFeatures: {globalReturn: true},
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this program.",
+                    type: "Program",
+                    column: 1
                 }
             ]
         }


### PR DESCRIPTION
Refs #3530, Fixes #3373.
This PR includes #3559.

I applied the code path analysis to the `consistent-return` rule.
If there were one or more `ReturnStatement`s which returned a value, this rule checks whether the last code path returns a value.