### PR TITLE
Fix: `constructor-super` with the code path analysis

### DIFF
--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -7,100 +7,207 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a given node is a constructor.
+ * @param {ASTNode} node - A node to check. This node type is one of
+ *   `Program`, `FunctionDeclaration`, `FunctionExpression`, and
+ *   `ArrowFunctionExpression`.
+ * @returns {boolean} `true` if the node is a constructor.
+ */
+function isConstructorFunction(node) {
+    return (
+        node.type === "FunctionExpression" &&
+        node.parent.type === "MethodDefinition" &&
+        node.parent.kind === "constructor"
+    );
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    // {{hasExtends: boolean, scope: Scope, codePath: CodePath}[]}
+    // Information for each constructor.
+    // - upper:      Information of the upper constructor.
+    // - hasExtends: A flag which shows whether own class has a valid `extends`
+    //               part.
+    // - scope:      The scope of own class.
+    // - codePath:   The code path object of the constructor.
+    var funcInfo = null;
+
+    // {Map<string, {calledInSomePaths: boolean, calledInEveryPaths: boolean}>}
+    // Information for each code path segment.
+    // - calledInSomePaths:  A flag of be called `super()` in some code paths.
+    // - calledInEveryPaths: A flag of be called `super()` in all code paths.
+    var segInfoMap = Object.create(null);
 
     /**
-     * Searches a class node from ancestors of a node.
-     * @param {Node} node - A node to get.
-     * @returns {ClassDeclaration|ClassExpression|null} the found class node or `null`.
+     * Gets the flag which shows `super()` is called in some paths.
+     * @param {CodePathSegment} segment - A code path segment to get.
+     * @returns {boolean} The flag which shows `super()` is called in some paths
      */
-    function getClassInAncestor(node) {
-        while (node) {
-            if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
-                return node;
-            }
-            node = node.parent;
-        }
-        /* istanbul ignore next */
-        return null;
+    function isCalledInSomePath(segment) {
+        return segInfoMap[segment.id].calledInSomePaths;
     }
 
     /**
-     * Checks whether or not a node is the null literal.
-     * @param {Node} node - A node to check.
-     * @returns {boolean} whether or not a node is the null literal.
+     * Gets the flag which shows `super()` is called in all paths.
+     * @param {CodePathSegment} segment - A code path segment to get.
+     * @returns {boolean} The flag which shows `super()` is called in all paths.
      */
-    function isNullLiteral(node) {
-        return node && node.type === "Literal" && node.value === null;
+    function isCalledInEveryPath(segment) {
+        return segInfoMap[segment.id].calledInEveryPaths;
     }
-
-    /**
-     * Checks whether or not the current traversal context is on constructors.
-     * @param {{scope: Scope}} item - A checking context to check.
-     * @returns {boolean} whether or not the current traversal context is on constructors.
-     */
-    function isOnConstructor(item) {
-        return item && item.scope === context.getScope().variableScope.upper.variableScope;
-    }
-
-    // A stack for checking context.
-    var stack = [];
 
     return {
         /**
-         * Start checking.
-         * @param {MethodDefinition} node - A target node.
+         * Stacks a constructor information.
+         * @param {CodePath} codePath - A code path which was started.
+         * @param {ASTNode} node - The current node.
          * @returns {void}
          */
-        "MethodDefinition": function(node) {
-            if (node.kind !== "constructor") {
+        "onCodePathStart": function(codePath, node) {
+            if (!isConstructorFunction(node)) {
                 return;
             }
-            stack.push({
-                superCallings: [],
-                scope: context.getScope().variableScope
-            });
+
+            // Class > ClassBody > MethodDefinition > FunctionExpression
+            var classNode = node.parent.parent.parent;
+            funcInfo = {
+                upper: funcInfo,
+                hasExtends: Boolean(
+                    classNode.superClass &&
+                    !astUtils.isNullOrUndefined(classNode.superClass)
+                ),
+                scope: context.getScope(),
+                codePath: codePath
+            };
         },
 
         /**
-         * Checks the result, then reports invalid/missing `super()`.
-         * @param {MethodDefinition} node - A target node.
+         * Pops a constructor information.
+         * And reports if `super()` lacked.
+         * @param {CodePath} codePath - A code path which was ended.
+         * @param {ASTNode} node - The current node.
          * @returns {void}
          */
-        "MethodDefinition:exit": function(node) {
-            if (node.kind !== "constructor") {
-                return;
-            }
-            var result = stack.pop();
-
-            var classNode = getClassInAncestor(node);
-            /* istanbul ignore if */
-            if (!classNode) {
+        "onCodePathEnd": function(codePath, node) {
+            if (!isConstructorFunction(node)) {
                 return;
             }
 
-            if (classNode.superClass === null || isNullLiteral(classNode.superClass)) {
-                result.superCallings.forEach(function(superCalling) {
-                    context.report(superCalling, "unexpected `super()`.");
+            // Skip if own class which has a valid `extends` part.
+            var hasExtends = funcInfo.hasExtends;
+            funcInfo = funcInfo.upper;
+            if (!hasExtends) {
+                return;
+            }
+
+            // Reports if `super()` lacked.
+            var segments = codePath.returnedSegments;
+            var calledInEveryPaths = segments.every(isCalledInEveryPath);
+            var calledInSomePaths = segments.some(isCalledInSomePath);
+            if (!calledInEveryPaths) {
+                context.report({
+                    message: calledInSomePaths ?
+                        "Lacked a call of \"super()\" in some code paths." :
+                        "Expected to call \"super()\".",
+                    node: node.parent
                 });
-            } else if (result.superCallings.length === 0) {
-                context.report(node.key, "this constructor requires `super()`.");
             }
         },
 
         /**
-         * Checks the result of checking, then reports invalid/missing `super()`.
-         * @param {MethodDefinition} node - A target node.
+         * Initialize information of a given code path segment.
+         * @param {CodePathSegment} segment - A code path segment to initialize.
          * @returns {void}
          */
-        "CallExpression": function(node) {
-            var item = stack[stack.length - 1];
-            if (isOnConstructor(item) && node.callee.type === "Super") {
-                item.superCallings.push(node);
+        "onCodePathSegmentStart": function(segment) {
+            // Skip if this is not in a constructor of a class which has a valid
+            // `extends` part.
+            if (!(
+                funcInfo &&
+                funcInfo.hasExtends &&
+                funcInfo.scope === context.getScope().variableScope
+            )) {
+                return;
             }
+
+            // Initialize info.
+            var info = segInfoMap[segment.id] = {
+                calledInSomePaths: false,
+                calledInEveryPaths: false
+            };
+
+            // When there are previous segments, aggregates these.
+            var prevSegments = segment.prevSegments;
+            if (prevSegments.length > 0) {
+                info.calledInSomePaths = prevSegments.some(isCalledInSomePath);
+                info.calledInEveryPaths = prevSegments.every(isCalledInEveryPath);
+            }
+        },
+
+        /**
+         * Checks for a call of `super()`.
+         * @param {ASTNode} node - A CallExpression node to check.
+         * @returns {void}
+         */
+        "CallExpression:exit": function(node) {
+            // Skip if the node is not `super()`.
+            if (node.callee.type !== "Super") {
+                return;
+            }
+
+            // Skip if this is not in a constructor.
+            if (!(funcInfo && funcInfo.scope === context.getScope().variableScope)) {
+                return;
+            }
+
+            // Reports if needed.
+            if (funcInfo.hasExtends) {
+                // This class has a valid `extends` part.
+                // Checks duplicate `super()`;
+                var segments = funcInfo.codePath.currentSegments;
+                var duplicate = false;
+                for (var i = 0; i < segments.length; ++i) {
+                    var info = segInfoMap[segments[i].id];
+
+                    duplicate = duplicate || info.calledInSomePaths;
+                    info.calledInSomePaths = info.calledInEveryPaths = true;
+                }
+
+                if (duplicate) {
+                    context.report({
+                        message: "Unexpected duplicate \"super()\".",
+                        node: node
+                    });
+                }
+            } else {
+                // This class does not have a valid `extends` part.
+                // Disallow `super()`.
+                context.report({
+                    message: "Unexpected \"super()\".",
+                    node: node
+                });
+            }
+        },
+
+        /**
+         * Resets state.
+         * @returns {void}
+         */
+        "Program:exit": function() {
+            segInfoMap = Object.create(null);
         }
     };
 };

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -38,63 +38,134 @@ ruleTester.run("constructor-super", rule, {
 
         // ignores out of constructors.
         { code: "class A { b() { super(); } }", ecmaFeatures: {classes: true} },
-        { code: "function a() { super(); }", ecmaFeatures: {classes: true} }
+        { code: "function a() { super(); }", ecmaFeatures: {classes: true} },
+
+        // multi code path.
+        { code: "class A extends B { constructor() { a ? super() : super(); } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { if (a) super(); else super(); } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { try {} finally { super(); } } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { if (a) throw Error(); super(); } }", ecmaFeatures: {classes: true} }
     ],
     invalid: [
         // non derived classes.
         {
             code: "class A { constructor() { super(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "unexpected `super()`.", type: "CallExpression"}]
+            errors: [{ message: "Unexpected \"super()\".", type: "CallExpression"}]
         },
         {
             code: "class A extends null { constructor() { super(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "unexpected `super()`.", type: "CallExpression"}]
+            errors: [{ message: "Unexpected \"super()\".", type: "CallExpression"}]
         },
 
         // derived classes.
         {
             code: "class A extends B { constructor() { } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition"}]
         },
 
         // nested execution scope.
         {
             code: "class A extends B { constructor() { function c() { super(); } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { var c = function() { super(); } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { var c = () => super(); } }",
             ecmaFeatures: {classes: true, arrowFunctions: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier"}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition"}]
         },
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { super(); } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 21}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition", column: 21}]
         },
         {
             code: "class A extends B { constructor() { var C = class extends D { constructor() { super(); } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 21}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition", column: 21}]
         },
         {
             code: "class A extends B { constructor() { super(); class C extends D { constructor() { } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 66}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition", column: 66}]
         },
         {
             code: "class A extends B { constructor() { super(); var C = class extends D { constructor() { } } } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "this constructor requires `super()`.", type: "Identifier", column: 72}]
+            errors: [{ message: "Expected to call \"super()\".", type: "MethodDefinition", column: 72}]
+        },
+
+        // lacked in some code path.
+        {
+            code: "class A extends B { constructor() { if (a) super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { if (a); else super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { a && super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { switch (a) { case 0: super(); } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { switch (a) { case 0: break; default: super(); } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { try { super(); } catch (err) {} } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { try { a; } catch (err) { super(); } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { if (a) return; super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Lacked a call of \"super()\" in some code paths.", type: "MethodDefinition"}]
+        },
+
+        // duplicate.
+        {
+            code: "class A extends B { constructor() { super(); super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Unexpected duplicate \"super()\".", type: "CallExpression", column: 46}]
+        },
+        {
+            code: "class A extends B { constructor() { super() || super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Unexpected duplicate \"super()\".", type: "CallExpression", column: 48}]
+        },
+        {
+            code: "class A extends B { constructor() { if (a) super(); super(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Unexpected duplicate \"super()\".", type: "CallExpression", column: 53}]
+        },
+        {
+            code: "class A extends B { constructor() { switch (a) { case 0: super(); default: super(); } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "Unexpected duplicate \"super()\".", type: "CallExpression", column: 76}]
         }
     ]
 });


### PR DESCRIPTION
Refs #3530.
This PR includes #3559.

I applied the code path analysis to the `constructor-super` rule.
If a class inherited a base class, this rule comes to checking whether the constructor calls `super()` once in every code path.