### PR TITLE
Fix: `no-fallthrough` with the code path analysis

### DIFF
--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -4,93 +4,84 @@
  */
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var getLast = require("../util").getLast;
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
 
 var FALLTHROUGH_COMMENT = /falls?\s?through/i;
+
+/**
+ * Checks whether or not a given node has a fallthrough comment.
+ * @param {ASTNode} node - A SwitchCase node to get comments.
+ * @param {RuleContext} context - A rule context which stores comments.
+ * @returns {boolean} `true` if the node has a fallthrough comment.
+ */
+function hasFallthroughComment(node, context) {
+    var sourceCode = context.getSourceCode();
+    var comment = getLast(sourceCode.getComments(node).leading);
+
+    return Boolean(comment && FALLTHROUGH_COMMENT.test(comment.value));
+}
+
+/**
+ * Checks whether or not a given code path segment is reachable.
+ * @param {CodePathSegment} segment - A CodePathSegment to check.
+ * @returns {boolean} `true` if the segment is reachable.
+ */
+function isReachable(segment) {
+    return segment.reachable;
+}
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var currentCodePath = null;
 
-    var switches = [];
+    // We need to use leading comments of the next SwitchCase node because
+    // trailing comments is wrong if semicolons are omitted.
+    var fallthroughCase = null;
 
     return {
+        "onCodePathStart": function(codePath) {
+            currentCodePath = codePath;
+        },
+        "onCodePathEnd": function() {
+            currentCodePath = currentCodePath.upper;
+        },
 
         "SwitchCase": function(node) {
-
-            var consequent = node.consequent,
-                switchData = switches[switches.length - 1],
-                i,
-                comments,
-                comment;
-
-            /*
-             * Some developers wrap case bodies in blocks, so if there is just one
-             * node and it's a block statement, check inside.
-             */
-            if (consequent.length === 1 && consequent[0].type === "BlockStatement") {
-                consequent = consequent[0];
+            // Checks whether or not there is a fallthrough comment.
+            // And reports the previous fallthrough node if that does not exist.
+            if (fallthroughCase && !hasFallthroughComment(node, context)) {
+                context.report({
+                    message: "Expected a \"break\" statement before \"{{type}}\".",
+                    data: {type: node.test ? "case" : "default"},
+                    node: node
+                });
             }
-
-            // checking on previous case
-            if (!switchData.lastCaseClosed) {
-
-                // a fall through comment will be the last trailing comment of the last case
-                comments = context.getComments(switchData.lastCase).trailing;
-                comment = comments[comments.length - 1];
-
-                // unless the user doesn't like semicolons, in which case it's first leading comment of this case
-                if (!comment) {
-                    comments = context.getComments(node).leading;
-                    comment = comments[comments.length - 1];
-                }
-
-                // check for comment
-                if (!comment || !FALLTHROUGH_COMMENT.test(comment.value)) {
-                    context.report(node,
-                        "Expected a \"break\" statement before \"{{code}}\".",
-                        { code: node.test ? "case" : "default" });
-                }
-            }
-
-            // now dealing with the current case
-            switchData.lastCaseClosed = false;
-            switchData.lastCase = node;
-
-            // try to verify using statements - go backwards as a fast path for the search
-            if (consequent.length) {
-                for (i = consequent.length - 1; i >= 0; i--) {
-                    if (/(?:Break|Continue|Return|Throw)Statement/.test(consequent[i].type)) {
-                        switchData.lastCaseClosed = true;
-                        break;
-                    }
-                }
-            } else {
-                // the case statement has no statements, so it must logically fall through
-                switchData.lastCaseClosed = true;
-            }
-
-            /*
-             * Any warnings are triggered when the next SwitchCase occurs.
-             * There is no need to warn on the last SwitchCase, since it can't
-             * fall through to anything.
-             */
+            fallthroughCase = null;
         },
 
-        "SwitchStatement": function(node) {
-            switches.push({
-                node: node,
-                lastCaseClosed: true,
-                lastCase: null
-            });
-        },
-
-        "SwitchStatement:exit": function() {
-            switches.pop();
+        "SwitchCase:exit": function(node) {
+            // `reachable` meant fall through because statements preceded by
+            // `break`, `return`, or `throw` are unreachable.
+            // And allows empty cases and the last case.
+            if (currentCodePath.currentSegments.some(isReachable) &&
+                node.consequent.length > 0 &&
+                getLast(node.parent.cases) !== node
+            ) {
+                fallthroughCase = node;
+            }
         }
     };
-
 };
 
 module.exports.schema = [];

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -5,8 +5,6 @@
 
 "use strict";
 
-/* jshint node:true */
-
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
@@ -17,6 +15,11 @@ var rule = require("../../../lib/rules/no-fallthrough"),
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
+
+var errorsDefault = [{
+    message: "Expected a \"break\" statement before \"default\".",
+    type: "SwitchCase"
+}];
 
 var ruleTester = new RuleTester();
 ruleTester.run("no-fallthrough", rule, {
@@ -44,7 +47,12 @@ ruleTester.run("no-fallthrough", rule, {
         "switch(foo) { case 0: switch(bar) { case 2: break; } /* falls through */ case 1: break; }",
         "function foo() { switch(foo) { case 1: return a; a++; }}",
         "switch (foo) { case 0: a(); /* falls through */ default:  b(); /* comment */ }",
-        "switch (foo) { case 0: a(); /* falls through */ default: /* comment */ b(); }"
+        "switch (foo) { case 0: a(); /* falls through */ default: /* comment */ b(); }",
+        "switch (foo) { case 0: if (a) { break; } else { throw 0; } default: b(); }",
+        "switch (foo) { case 0: try { break; } finally {} default: b(); }",
+        "switch (foo) { case 0: try {} finally { break; } default: b(); }",
+        "switch (foo) { case 0: try { throw 0; } catch (err) { break; } default: b(); }",
+        "switch (foo) { case 0: do { throw 0; } while(a); default: b(); }"
     ],
     invalid: [
         {
@@ -68,7 +76,11 @@ ruleTester.run("no-fallthrough", rule, {
                     column: 1
                 }
             ]
-        }
-
+        },
+        {code: "switch(foo) { case 0: a(); default: b() }", errors: errorsDefault},
+        {code: "switch(foo) { case 0: if (a) { break; } default: b() }", errors: errorsDefault},
+        {code: "switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }", errors: errorsDefault},
+        {code: "switch(foo) { case 0: while (a) { break; } default: b() }", errors: errorsDefault},
+        {code: "switch(foo) { case 0: do { break; } while (a); default: b() }", errors: errorsDefault}
     ]
 });


### PR DESCRIPTION
Refs #3530, Fixes #4246.
This PR includes #3559.

I applied the code path analysis to the `no-fallthrough` rule.
This rule comes to checking correctly `return`, `throw`, `break`, and `continue` in nested blocks.