### PR TITLE
Fix: `no-this-before-super` with the code path analysis

### DIFF
--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -7,136 +7,183 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a given node is a constructor.
+ * @param {ASTNode} node - A node to check. This node type is one of
+ *   `Program`, `FunctionDeclaration`, `FunctionExpression`, and
+ *   `ArrowFunctionExpression`.
+ * @returns {boolean} `true` if the node is a constructor.
+ */
+function isConstructorFunction(node) {
+    return (
+        node.type === "FunctionExpression" &&
+        node.parent.type === "MethodDefinition" &&
+        node.parent.kind === "constructor"
+    );
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    // {{hasExtends: boolean, scope: Scope}[]}
+    // Information for each constructor.
+    // - upper:      Information of the upper constructor.
+    // - hasExtends: A flag which shows whether the owner class has a valid
+    //               `extends` part.
+    // - scope:      The scope of the owner class.
+    // - codePath:   The code path of this constructor.
+    var funcInfo = null;
+
+    // {Map<string, boolean>}
+    // Information for each code path segment.
+    // The value is a flag which shows `super()` called in all code paths.
+    var segInfoMap = Object.create(null);
 
     /**
-     * Searches a class node that a node is belonging to.
-     * @param {Node} node - A node to start searching.
-     * @returns {ClassDeclaration|ClassExpression|null} the found class node, or `null`.
+     * Gets whether or not `super()` is called in a given code path segment.
+     * @param {CodePathSegment} segment - A code path segment to get.
+     * @returns {boolean} `true` if `super()` is called.
      */
-    function getClassInAncestor(node) {
-        while (node) {
-            if (node.type === "ClassDeclaration" || node.type === "ClassExpression") {
-                return node;
-            }
-            node = node.parent;
-        }
-        /* istanbul ignore next */
-        return null;
+    function isCalled(segment) {
+        return Boolean(segInfoMap[segment.id]);
     }
 
     /**
-     * Checks whether or not a node is the null literal.
-     * @param {Node} node - A node to check.
-     * @returns {boolean} whether or not a node is the null literal.
+     * Checks whether or not this is in a constructor.
+     * @returns {boolean} `true` if this is in a constructor.
      */
-    function isNullLiteral(node) {
-        return node && node.type === "Literal" && node.value === null;
-    }
-
-    /**
-     * Checks whether or not a node is the callee of a call expression.
-     * @param {Node} node - A node to check.
-     * @returns {boolean} whether or not a node is the callee of a call expression.
-     */
-    function isCallee(node) {
-        return node && node.parent.type === "CallExpression" && node.parent.callee === node;
-    }
-
-    /**
-     * Checks whether or not the current traversal context is before `super()`.
-     * @param {object} item - A checking context.
-     * @returns {boolean} whether or not the current traversal context is before `super()`.
-     */
-    function isBeforeSuperCalling(item) {
-        return (
-            item &&
-            item.scope === context.getScope().variableScope.upper.variableScope &&
-            item.superCalled === false
+    function isInConstructor() {
+        return Boolean(
+            funcInfo &&
+            funcInfo.hasExtends &&
+            funcInfo.scope === context.getScope().variableScope
         );
     }
 
-    var stack = [];
+    /**
+     * Checks whether or not this is before `super()` is called.
+     * @returns {boolean} `true` if this is before `super()` is called.
+     */
+    function isBeforeCallOfSuper() {
+        return (
+            isInConstructor(funcInfo) &&
+            !funcInfo.codePath.currentSegments.every(isCalled)
+        );
+    }
 
     return {
         /**
-         * Start checking.
-         * @param {MethodDefinition} node - A target node.
+         * Stacks a constructor information.
+         * @param {CodePath} codePath - A code path which was started.
+         * @param {ASTNode} node - The current node.
          * @returns {void}
          */
-        "MethodDefinition": function(node) {
-            if (node.kind !== "constructor") {
+        "onCodePathStart": function(codePath, node) {
+            if (!isConstructorFunction(node)) {
                 return;
             }
-            stack.push({
-                thisOrSuperBeforeSuperCalled: [],
-                superCalled: false,
-                scope: context.getScope().variableScope
-            });
+
+            // Class > ClassBody > MethodDefinition > FunctionExpression
+            var classNode = node.parent.parent.parent;
+            funcInfo = {
+                upper: funcInfo,
+                hasExtends: Boolean(
+                    classNode.superClass &&
+                    !astUtils.isNullOrUndefined(classNode.superClass)
+                ),
+                scope: context.getScope(),
+                codePath: codePath
+            };
         },
 
         /**
-         * Treats the result of checking and reports invalid `this`/`super`.
-         * @param {MethodDefinition} node - A target node.
+         * Pops a constructor information.
+         * @param {CodePath} codePath - A code path which was ended.
+         * @param {ASTNode} node - The current node.
          * @returns {void}
          */
-        "MethodDefinition:exit": function(node) {
-            if (node.kind !== "constructor") {
-                return;
+        "onCodePathEnd": function(codePath, node) {
+            if (isConstructorFunction(node)) {
+                funcInfo = funcInfo.upper;
             }
-            var result = stack.pop();
-
-            // Skip if it has no extends or `extends null`.
-            var classNode = getClassInAncestor(node);
-            if (!classNode || !classNode.superClass || isNullLiteral(classNode.superClass)) {
-                return;
-            }
-
-            // Reports.
-            result.thisOrSuperBeforeSuperCalled.forEach(function(thisOrSuper) {
-                var type = (thisOrSuper.type === "Super" ? "super" : "this");
-                context.report(thisOrSuper, "\"{{type}}\" is not allowed before super()", {type: type});
-            });
         },
 
         /**
-         * Marks the node if is before `super()`.
-         * @param {ThisExpression} node - A target node.
+         * Initialize information of a given code path segment.
+         * @param {CodePathSegment} segment - A code path segment to initialize.
+         * @returns {void}
+         */
+        "onCodePathSegmentStart": function(segment) {
+            if (!isInConstructor(funcInfo)) {
+                return;
+            }
+
+            // Initialize info.
+            segInfoMap[segment.id] = (
+                segment.prevSegments.length > 0 &&
+                segment.prevSegments.every(isCalled)
+            );
+        },
+
+        /**
+         * Reports if this is before `super()`.
+         * @param {ASTNode} node - A target node.
          * @returns {void}
          */
         "ThisExpression": function(node) {
-            var item = stack[stack.length - 1];
-            if (isBeforeSuperCalling(item)) {
-                item.thisOrSuperBeforeSuperCalled.push(node);
+            if (isBeforeCallOfSuper()) {
+                context.report({
+                    message: "\"this\" is not allowed before \"super()\".",
+                    node: node
+                });
             }
         },
 
         /**
-         * Marks the node if is before `super()`. (exclude `super()` itself)
-         * @param {Super} node - A target node.
+         * Reports if this is before `super()`.
+         * @param {ASTNode} node - A target node.
          * @returns {void}
          */
         "Super": function(node) {
-            var item = stack[stack.length - 1];
-            if (isBeforeSuperCalling(item) && isCallee(node) === false) {
-                item.thisOrSuperBeforeSuperCalled.push(node);
+            if (!astUtils.isCallee(node) && isBeforeCallOfSuper()) {
+                context.report({
+                    message: "\"super\" is not allowed before \"super()\".",
+                    node: node
+                });
             }
         },
 
         /**
          * Marks `super()` called.
-         * To catch `super(this.a);`, marks on `CallExpression:exit`.
-         * @param {CallExpression} node - A target node.
+         * @param {ASTNode} node - A target node.
          * @returns {void}
          */
         "CallExpression:exit": function(node) {
-            var item = stack[stack.length - 1];
-            if (isBeforeSuperCalling(item) && node.callee.type === "Super") {
-                item.superCalled = true;
+            if (node.callee.type === "Super" && isBeforeCallOfSuper()) {
+                var segments = funcInfo.codePath.currentSegments;
+                for (var i = 0; i < segments.length; ++i) {
+                    segInfoMap[segments[i].id] = true;
+                }
             }
+        },
+
+        /**
+         * Resets state.
+         * @returns {void}
+         */
+        "Program:exit": function() {
+            segInfoMap = Object.create(null);
         }
     };
 };

--- a/tests/lib/rules/no-this-before-super.js
+++ b/tests/lib/rules/no-this-before-super.js
@@ -47,70 +47,92 @@ ruleTester.run("no-this-before-super", rule, {
         // ignores out of constructors.
         { code: "class A { b() { this.c = 0; } }", ecmaFeatures: {classes: true} },
         { code: "class A extends B { c() { this.d = 0; } }", ecmaFeatures: {classes: true} },
-        { code: "function a() { this.b = 0; }", ecmaFeatures: {classes: true} }
+        { code: "function a() { this.b = 0; }", ecmaFeatures: {classes: true} },
+
+        // multi code path.
+        { code: "class A extends B { constructor() { if (a) { super(); this.a(); } else { super(); this.b(); } } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { if (a) super(); else super(); this.a(); } }", ecmaFeatures: {classes: true} },
+        { code: "class A extends B { constructor() { try { super(); } finally {} this.a(); } }", ecmaFeatures: {classes: true} }
     ],
     invalid: [
         // disallows all `this`/`super` if `super()` is missing.
         {
             code: "class A extends B { constructor() { this.c = 0; } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression"}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { this.c(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression"}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super.c(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"super\" is not allowed before super()", type: "Super"}]
+            errors: [{ message: "\"super\" is not allowed before \"super()\".", type: "Super"}]
         },
 
         // disallows `this`/`super` before `super()`.
         {
             code: "class A extends B { constructor() { this.c = 0; super(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression"}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { this.c(); super(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression"}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super.c(); super(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"super\" is not allowed before super()", type: "Super"}]
+            errors: [{ message: "\"super\" is not allowed before \"super()\".", type: "Super"}]
         },
 
         // disallows `this`/`super` in arguments of `super()`.
         {
             code: "class A extends B { constructor() { super(this.c); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression"}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super(this.c()); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression"}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
         },
         {
             code: "class A extends B { constructor() { super(super.c()); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"super\" is not allowed before super()", type: "Super"}]
+            errors: [{ message: "\"super\" is not allowed before \"super()\".", type: "Super"}]
         },
 
         // even if is nested, reports correctly.
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { super(); this.e(); } } this.f(); super(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression", column: 96}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression", column: 96}]
         },
         {
             code: "class A extends B { constructor() { class C extends D { constructor() { this.e(); super(); } } super(); this.f(); } }",
             ecmaFeatures: {classes: true},
-            errors: [{ message: "\"this\" is not allowed before super()", type: "ThisExpression", column: 73}]
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression", column: 73}]
+        },
+
+        // multi code path.
+        {
+            code: "class A extends B { constructor() { if (a) super(); this.a(); } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
+        },
+        {
+            code: "class A extends B { constructor() { try { super(); } finally { this.a; } } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
+        },
+        {
+            code: "class A extends B { constructor() { try { super(); } catch (err) { } this.a; } }",
+            ecmaFeatures: {classes: true},
+            errors: [{ message: "\"this\" is not allowed before \"super()\".", type: "ThisExpression"}]
         }
     ]
 });


### PR DESCRIPTION
Refs #3530.
This PR includes #3559.

I applied the code path analysis to the `no-this-before-super` rule.
This rule comes to checking whether it never use `this` and `super` before a call of `super()` in every code path of constructors.