### PR TITLE
Update: Add `maxEOF` to no-multiple-empty-lines (fixes #4235)

### DIFF
--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -7,7 +7,7 @@ rule enforces newlines for all non-empty programs.
 
 Prior to v0.16.0 this rule also enforced that there was only a single line at
 the end of the file. If you still want this behaviour, consider enabling
-[no-multiple-empty-lines](no-multiple-empty-lines.md) and/or
+[no-multiple-empty-lines](no-multiple-empty-lines.md) with `maxEOF` and/or
 [no-trailing-spaces](no-trailing-spaces.md).
 
 **Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -9,11 +9,28 @@ This rule aims to reduce the scrolling required when reading through your code. 
 
 ### Options
 
-You can configure the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error (code is 2) with a maximum tolerated blank lines of 2:
+The second argument can be used to configure this rule:
+
+* `max` sets the maximum number of consecutive blank lines.
+* `maxEOF` can be used to set a different number for the end of file. The last
+  blank lines will then be treated differently. If omitted, the `max` option is
+  applied everywhere.
+
+For example, this sets the rule as an error (code is 2) with a maximum
+tolerated blank lines of 2 (for the whole file):
 
 ```json
 "no-multiple-empty-lines": [2, {"max": 2}]
 ```
+
+While this tolerates three consecutive blank lines within the file, but only
+one at the end:
+
+```json
+"no-multiple-empty-lines": [2, {"max": 3, "maxEOF": 1}]
+```
+
+### Examples
 
 The following patterns are considered problems:
 
@@ -26,6 +43,14 @@ var foo = 5;
                   /*error Multiple blank lines not allowed.*/
 var bar = 3;
 
+```
+
+```js
+/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 1}]*/
+
+var foo = 5;
+
+                  /*error Too many blank lines at the end of file.*/
 ```
 
 The following patterns are not considered problems:
@@ -47,6 +72,21 @@ var foo = 5;
 
 
 var bar = 3;
+```
+
+```js
+/*eslint no-multiple-empty-lines: [2, {max: 2}]*/
+
+var foo = 5;
+// extra line
+```
+
+```js
+/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 10}]*/
+
+var foo = 5;
+
+// 10 extra lines
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -13,13 +13,15 @@
 module.exports = function(context) {
 
     // Use options.max or 2 as default
-    var numLines = 2;
+    var max = 2,
+        maxEOF;
 
     // store lines that appear empty but really aren't
     var notEmpty = [];
 
     if (context.options.length) {
-        numLines = context.options[0].max;
+        max = context.options[0].max;
+        maxEOF = context.options[0].maxEOF;
     }
 
     //--------------------------------------------------------------------------
@@ -45,17 +47,28 @@ module.exports = function(context) {
                 location,
                 trimmedLines = lines.map(function(str) {
                     return str.trim();
-                });
+                }),
+                firstOfEndingBlankLines;
 
             // add the notEmpty lines in there with a placeholder
             notEmpty.forEach(function(x, i) {
                 trimmedLines[i] = x;
             });
 
-            // swallow the final newline, as some editors add it automatically
-            // and we don't want it to cause an issue
-            if (trimmedLines[trimmedLines.length - 1] === "") {
-                trimmedLines = trimmedLines.slice(0, -1);
+            if (typeof maxEOF === "undefined") {
+                // swallow the final newline, as some editors add it
+                // automatically and we don't want it to cause an issue
+                if (trimmedLines[trimmedLines.length - 1] === "") {
+                    trimmedLines = trimmedLines.slice(0, -1);
+                }
+                firstOfEndingBlankLines = trimmedLines.length;
+            } else {
+                // save the number of the first of the last blank lines
+                firstOfEndingBlankLines = trimmedLines.length;
+                while (trimmedLines[firstOfEndingBlankLines - 1] === ""
+                        && firstOfEndingBlankLines > 0) {
+                    firstOfEndingBlankLines--;
+                }
             }
 
             // Aggregate and count blank lines
@@ -67,12 +80,22 @@ module.exports = function(context) {
                 if (lastLocation === currentLocation - 1) {
                     blankCounter++;
                 } else {
-                    if (blankCounter >= numLines) {
-                        location = {
-                            line: lastLocation + 1,
-                            column: lines[lastLocation].length
-                        };
-                        context.report(node, location, "Multiple blank lines not allowed.");
+                    location = {
+                        line: lastLocation + 1,
+                        column: 1
+                    };
+                    if (lastLocation < firstOfEndingBlankLines) {
+                        // within the file, not at the end
+                        if (blankCounter >= max) {
+                            context.report(node, location,
+                                    "Multiple blank lines not allowed.");
+                        }
+                    } else {
+                        // inside the last blank lines
+                        if (blankCounter >= maxEOF) {
+                            context.report(node, location,
+                                    "Too many blank lines at the end of file.");
+                        }
                     }
 
                     // Finally, reset the blank counter
@@ -89,6 +112,9 @@ module.exports.schema = [
         "type": "object",
         "properties": {
             "max": {
+                "type": "integer"
+            },
+            "maxEOF": {
                 "type": "integer"
             }
         },

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -21,6 +21,10 @@ var ruleTester = new RuleTester(),
         messsage: "Multiple blank lines not allowed.",
         type: "Program"
     },
+    expectedErrorEOF = {
+        messsage: "Too many blank lines at the end of file.",
+        type: "Program"
+    },
     ruleArgs = [
         {
             max: 2
@@ -61,8 +65,16 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             code: "`\n\n`",
             options: [{ max: 0 }],
             ecmaFeatures: { templateStrings: true }
-        }
+        },
 
+        {
+            code: "// valid 5\nvar a = 5;\n\n\n\n",
+            options: [ { max: 0, maxEOF: 4 } ]
+        },
+        {
+            code: "// valid 5\nvar a = 5;\n\n\n\n",
+            options: [ { max: 3 } ]
+        }
     ],
 
     invalid: [
@@ -110,6 +122,26 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             code: "// invalid 7\nvar a = 5;\n\nvar b = 3;",
             errors: [ expectedError ],
             options: [ { max: 0 } ]
+        },
+        {
+            code: "// valid 5\nvar a = 5;\n\n",
+            errors: [ expectedErrorEOF ],
+            options: [ { max: 5, maxEOF: 1 } ]
+        },
+        {
+            code: "// valid 5\nvar a = 5;\n\n\n\n\n",
+            errors: [ expectedErrorEOF ],
+            options: [ { max: 0, maxEOF: 4 } ]
+        },
+        {
+            code: "// valid 5\n\n\n\n\n\n\n\n\nvar a = 5;\n\n",
+            errors: [ expectedErrorEOF ],
+            options: [ { max: 10, maxEOF: 1 } ]
+        },
+        {
+            code: "// valid 5\nvar a = 5;\n",
+            errors: [ expectedErrorEOF ],
+            options: [ { max: 2, maxEOF: 0 } ]
         }
     ]
 });


### PR DESCRIPTION
Currently there is no way to specify a rule for having one (and only
one) ending newline. Using eol-last only checks if there is at least
one newline.

This patch adds an optional `maxEOF` option to no-multiple-empty-lines
rule. When set, blank lines at the end are treated differently from
lines within the file. When `maxEOF` is omitted, the rule's original
behaviour does not change.

For instance, requiring one and only one newline at the end of file can
be achieved using:

    {
        eol-last: 2,
        no-multiple-empty-lines: [ 2, { max: 2, maxEOF: 1 } ]
    }