### PR TITLE
Add "ignore" rule to skip processing for a given operator

### DIFF
--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -56,6 +56,10 @@ module.exports = function(context) {
         var operator = operatorToken.value;
         var style = styleOverrides[operator] || globalStyle;
 
+        if ( style === "ignore" ) {
+            return;
+        }
+
         // if single line
         if (astUtils.isTokenOnSameLine(leftToken, operatorToken) &&
                 astUtils.isTokenOnSameLine(operatorToken, rightToken)) {
@@ -126,7 +130,7 @@ module.exports = function(context) {
 
 module.exports.schema = [
     {
-        "enum": ["after", "before", "none", null]
+        "enum": ["after", "before", "ignore", "none", null]
     },
     {
         "type": "object",
@@ -136,7 +140,7 @@ module.exports.schema = [
                 "properties": {
                     "anyOf": {
                         "type": "string",
-                        "enum": ["after", "before", "none"]
+                        "enum": ["after", "before", "ignore", "none"]
                     }
                 }
             }


### PR DESCRIPTION
Proposed patch for [#4249](https://github.com/eslint/eslint/issues/4294) to add an "ignore" value for the overrides to allow `eslint` to skip the rule for a particular operator.