### PR TITLE
Fix: eslint.report can be called w/o node if loc provided (fixes #4220)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -118,6 +118,8 @@ The main method you'll use is `context.report()`, which publishes a warning or e
 * `data` - (optional) placeholder data for `message`.
 * `fix` - (optional) a function that applies a fix to resolve the problem.
 
+Note that at least one of `node` or `loc` is required.
+
 The simplest example is to use just `node` and `message`:
 
 ```js

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -24,7 +24,8 @@ var estraverse = require("./util/estraverse"),
     CommentEventGenerator = require("./util/comment-event-generator"),
     EventEmitter = require("events").EventEmitter,
     validator = require("./config-validator"),
-    replacements = require("../conf/replacements.json");
+    replacements = require("../conf/replacements.json"),
+    assert = require("assert");
 
 var DEFAULT_PARSER = require("../conf/eslint.json").parser;
 
@@ -806,13 +807,19 @@ module.exports = (function() {
      * @returns {void}
      */
     api.report = function(ruleId, severity, node, location, message, opts, fix) {
+        if (node) {
+            assert.strictEqual(typeof node, "object", "Node must be an object");
+        }
 
         if (typeof location === "string") {
+            assert.ok(node, "Node must be provided when reporting error if location is not provided");
+
             fix = opts;
             opts = message;
             message = location;
             location = node.loc.start;
         }
+        // else, assume location was provided, so node may be omitted
 
         if (isDisabledByReportingConfig(reportingConfig, ruleId, location)) {
             return;
@@ -835,7 +842,7 @@ module.exports = (function() {
             message: message,
             line: location.line,
             column: location.column + 1,   // switch to 1-base instead of 0-base
-            nodeType: node.type,
+            nodeType: node && node.type,
             source: sourceCode.lines[location.line - 1] || ""
         };
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -718,6 +718,46 @@ describe("eslint", function() {
             });
         });
 
+        it("should not throw an error if node is provided and location is not", function() {
+            eslint.on("Program", function(node) {
+                eslint.report("test-rule", 2, node, "hello world");
+            });
+
+            assert.doesNotThrow(function() {
+                eslint.verify("0", config, "", true);
+            });
+        });
+
+        it("should not throw an error if location is provided and node is not", function() {
+            eslint.on("Program", function() {
+                eslint.report("test-rule", 2, null, { line: 1, column: 1}, "hello world");
+            });
+
+            assert.doesNotThrow(function() {
+                eslint.verify("0", config, "", true);
+            });
+        });
+
+        it("should throw an error if neither node nor location is provided", function() {
+            eslint.on("Program", function() {
+                eslint.report("test-rule", 2, null, "hello world");
+            });
+
+            assert.throws(function() {
+                eslint.verify("0", config, "", true);
+            }, /Node must be provided when reporting error if location is not provided$/);
+        });
+
+        it("should throw an error if node is not an object", function() {
+            eslint.on("Program", function() {
+                eslint.report("test-rule", 2, "not a node", "hello world");
+            });
+
+            assert.throws(function() {
+                eslint.verify("0", config, "", true);
+            }, /Node must be an object$/);
+        });
+
         it("should correctly parse a message with object keys as numbers", function() {
             eslint.on("Program", function(node) {
                 eslint.report("test-rule", 2, node, "my message {{name}}{{0}}", {0: "!", name: "testing"});

--- a/tests/lib/rule-context.js
+++ b/tests/lib/rule-context.js
@@ -1,0 +1,98 @@
+/**
+ * @fileoverview Tests for RuleContext object.
+ * @author Kevin Partington
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var sinon = require("sinon"),
+    leche = require("leche"),
+    realESLint = require("../../lib/eslint"),
+    RuleContext = require("../../lib/rule-context");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("RuleContext", function() {
+    var sandbox = sinon.sandbox.create();
+
+    describe("report()", function() {
+        var ruleContext, eslint;
+
+        beforeEach(function() {
+            eslint = leche.fake(realESLint);
+            ruleContext = new RuleContext("fake-rule", eslint, 2, {}, {}, {});
+        });
+
+        describe("old-style call with location", function() {
+            it("should call eslint.report() with rule ID and severity prepended", function() {
+                var node = {},
+                    location = {},
+                    message = "Message",
+                    messageOpts = {};
+
+                var mockESLint = sandbox.mock(eslint);
+
+                mockESLint.expects("report")
+                    .once()
+                    .withArgs("fake-rule", 2, node, location, message, messageOpts);
+
+                ruleContext.report(node, location, message, messageOpts);
+
+                mockESLint.verify();
+            });
+        });
+
+        describe("old-style call without location", function() {
+            it("should call eslint.report() with rule ID and severity prepended", function() {
+                var node = {},
+                    message = "Message",
+                    messageOpts = {};
+
+                var mockESLint = sandbox.mock(eslint);
+
+                mockESLint.expects("report")
+                    .once()
+                    .withArgs("fake-rule", 2, node, message, messageOpts);
+
+                ruleContext.report(node, message, messageOpts);
+
+                mockESLint.verify();
+            });
+        });
+
+        describe("new-style call with all options", function() {
+            it("should call eslint.report() with rule ID and severity prepended and all new-style options", function() {
+                var node = {},
+                    location = {},
+                    message = "Message",
+                    messageOpts = {},
+                    fixerObj = {},
+                    fix = sandbox.mock().returns(fixerObj).once();
+
+                var mockESLint = sandbox.mock(eslint);
+
+                mockESLint.expects("report")
+                    .once()
+                    .withArgs("fake-rule", 2, node, location, message, messageOpts, fixerObj);
+
+                ruleContext.report({
+                    node: node,
+                    loc: location,
+                    message: message,
+                    data: messageOpts,
+                    fix: fix
+                });
+
+                fix.verify();
+                mockESLint.verify();
+            });
+        });
+    });
+
+});


### PR DESCRIPTION
Also updated docs to note that either node or loc (or both) must be supplied. Code will now throw clearer message if neither is supplied and will not throw TypeError if node is not supplied.

Fixes #4220.

Also, is this potentially a breaking change? I ask because it used to be impossible to report without a node, so formatters could probably implicitly assume that nodeType would be present. That is no longer the case. No tests failed so I assume the standard formatters are fine, but third-party formatters may potentially be broken with this change. Unlikely, I know, but wanted to raise the issue for your consideration.

Finally, I'd like to note that there is no test file for `lib/rule-context.js`. Most of those functions are passthroughs but some are not so straightforward (e.g., `context.report` since it unfolds the object form into the positional arg form used by `eslint.report`). Should I open an issue on that?