### PR TITLE
Docs: Clarify that ASI can cause problem whether semicolons are used or not

### DIFF
--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -9,27 +9,44 @@ var website = "eslint.org";
 
 On the first line, the JavaScript engine will automatically insert a semicolon, so this is not considered a syntax error. The JavaScript engine still knows how to interpret the line and knows that the line end indicates the end of the statement.
 
-In the debate over ASI, there are generally two schools of thought. The first is that we should treat ASI as if it didn't exist and always include semicolons manually. The rationale is that it's easier to always include semicolons than to try to remember when they are or are not required, and thus decreases the possibility of introducing an error. For example, consider this code:
+In the debate over ASI, there are generally two schools of thought. The first is that we should treat ASI as if it didn't exist and always include semicolons manually. The rationale is that it's easier to always include semicolons than to try to remember when they are or are not required, and thus decreases the possibility of introducing an error.
 
-```
+However, the ASI mechanism can sometimes be tricky to people who are using semicolons. For example, consider this code:
+
+```js
 return
-{
-    name: "ESLint"
-}
-```
-
-This may look like a `return` statement that returns an object literal, however, the JavaScript engine will interpret this code as:
-
-```
-return;
 {
     name: "ESLint"
 };
 ```
 
-Effectively, an object literal is created in an unreachable part of the code. That's because a semicolon will be inserted after the `return` statement.
+This may look like a `return` statement that returns an object literal, however, the JavaScript engine will interpret this code as:
 
-On the other side of the argument are those who say ASI isn't magic, it follows a set of rules as to when semicolons are inserted and it's fairly easy to remember them. In short, as once described by Isaac Schlueter, a `\n` character always ends a statement (just like a semicolon) unless one of the following is true:
+```js
+return;
+{
+    name: "ESLint";
+}
+```
+
+Effectively, a semicolon is inserted after the `return` statement, causing the code below it (a labeled literal inside a block) to be unreachable. This rule and the [no-unreachable](no-unreachable.md) rule will protect your code from such cases.
+
+On the other side of the argument are those who says that since semicolons are inserted automatically, they are optional and do not need to be inserted manually. However, the ASI mechanism can also be tricky to people who don't use semicolons. For example, consider this code:
+
+```js
+var globalCounter = { }
+
+(function () {
+    var n = 0
+    globalCounter.increment = function () {
+        return ++n
+    }
+})()
+```
+
+In this example, a semicolon will not be inserted after the first line, causing a run-time error (because an empty object is called as if it's a function). The [no-unexpected-multiline](no-unexpected-multiline.md) rule can protect your code from such cases.
+
+Although ASI allows for more freedom over your coding style, it can also make your code behave in an unexpected way, whether you use semicolons or not. Therefore, it is best to know when ASI takes place and when it does not, and have ESLint protect your code from these potentially unexpected cases. In short, as once described by Isaac Schlueter, a `\n` character always ends a statement (just like a semicolon) unless one of the following is true:
 
 1. The statement has an unclosed paren, array literal, or object literal or ends in some other way that is not a valid way to end a statement. (For instance, ending with `.` or `,`.)
 1. The line is `--` or `++` (in which case it will decrement/increment the next token.)


### PR DESCRIPTION
In the current state of the semi rules docs, the example code for not using semicolon is mispresented as a reason to use semicolon. Here is the original example code from the docs:

```js
return
{
    name: "ESLint"
}
```

A person who always uses semicolons will expect that this will return an object, and will notice that there’s a semicolon missing. They might fix it, so that it looks like this:

```js
return
{
    name: "ESLint"
};
```

Now, it makes perfect sense to a semicolon person, but what actually happens is that a `;` will be inserted after the `return`. Now, this is not a reason to use semicolons, but a reason to use ESLint to check for missing semicolons.

<br>

The current documentation also describe the effective behavior in the wrong way:

> Effectively, an object literal is created in an unreachable part of the code.

Since the curly braces are on its own, this is actually interpreted as a code block. Inside it is a string literal `"ESLint"`, with a label before it. This pull request fixes this mistake.

<br>

Let's come back to this code.

```js
return
{
    name: "ESLint"
}
```

Now, for a person who does not use semicolon, they will see that the “return” statement is terminated by the new line (because this line is valid on its own). They will immediately see that the following code is unreachable, and fixes it like this:

```js
return {
    name: "ESLint"
}
```

As demonstrated, the code example presented in the docs is actually an example of how ASI may make a code behave in an unexpected way to a person who uses semicolons.

<br>

Now, here is the code that may cause unexpected behavior to a person who may not use semicolons, quoting from [Isaac Z. Schlueter’s blog](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding):

```js
foo()
[1,2,3].forEach(bar)
```

A more concrete example is added in this pull request.

Therefore, whether one uses semicolons or not, this is now a matter of style, because in both cases, the ASI has its caveats, and ESLint can help you avoid them all.