### PR TITLE
Update the message to include number of lines

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -88,13 +88,13 @@ module.exports = function(context) {
                         // within the file, not at the end
                         if (blankCounter >= max) {
                             context.report(node, location,
-                                    "Multiple blank lines not allowed.");
+                                    "More than " + max + " blank lines not allowed.");
                         }
                     } else {
                         // inside the last blank lines
                         if (blankCounter >= maxEOF) {
                             context.report(node, location,
-                                    "Too many blank lines at the end of file.");
+                                    "Too many blank lines at the end of file. Max of " + maxEOF + " allowed.");
                         }
                     }
 


### PR DESCRIPTION
The message returned was a bit confusing as it says "Multiple blank lines not allowed." even when multiple blank lines are allowed. Minor update to the message to include the number of blank lines allowed.