### PR TITLE
Fix: Update the message to include number of lines (fixes #4342)

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -88,13 +88,13 @@ module.exports = function(context) {
                         // within the file, not at the end
                         if (blankCounter >= max) {
                             context.report(node, location,
-                                    "Multiple blank lines not allowed.");
+                                    "More than " + max + " blank lines not allowed.");
                         }
                     } else {
                         // inside the last blank lines
                         if (blankCounter >= maxEOF) {
                             context.report(node, location,
-                                    "Too many blank lines at the end of file.");
+                                    "Too many blank lines at the end of file. Max of " + maxEOF + " allowed.");
                         }
                     }
 

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -17,19 +17,45 @@ var rule = require("../../../lib/rules/no-multiple-empty-lines"),
 //------------------------------------------------------------------------------
 
 var ruleTester = new RuleTester(),
-    expectedError = {
-        messsage: "Multiple blank lines not allowed.",
-        type: "Program"
-    },
-    expectedErrorEOF = {
-        messsage: "Too many blank lines at the end of file.",
-        type: "Program"
-    },
     ruleArgs = [
         {
             max: 2
         }
     ];
+
+/**
+ * Creates the expected error message object for the specified number of lines
+ * @param {lines} lines - The number of lines expected.
+ * @returns {object} the expected error message object
+ * @private
+ */
+function getExpectedError(lines) {
+    if (typeof lines !== "number") {
+        lines = 2;
+    }
+
+    return {
+        message: "More than " + lines + " blank lines not allowed.",
+        type: "Program"
+    };
+}
+
+/**
+ * Creates the expected error message object for the specified number of lines
+ * @param {lines} lines - The number of lines expected.
+ * @returns {object} the expected error message object
+ * @private
+ */
+function getExpectedErrorEOF(lines) {
+    if (typeof lines !== "number") {
+        lines = 0;
+    }
+
+    return {
+        message: "Too many blank lines at the end of file. Max of " + lines + " allowed.",
+        type: "Program"
+    };
+}
 
 ruleTester.run("no-multiple-empty-lines", rule, {
 
@@ -80,27 +106,27 @@ ruleTester.run("no-multiple-empty-lines", rule, {
     invalid: [
         {
             code: "// invalid 1\n\n\n\n\nvar a = 5;",
-            errors: [ expectedError ],
+            errors: [ getExpectedError() ],
             options: ruleArgs
         },
         {
             code: "// invalid 2\nvar a = 5;\n\n\n\n",
-            errors: [ expectedError ],
+            errors: [ getExpectedError() ],
             options: ruleArgs
         },
         {
             code: "// invalid 2\nvar a = 5;\n \n \n \n",
-            errors: [ expectedError ],
+            errors: [ getExpectedError() ],
             options: ruleArgs
         },
         {
             code: "// invalid 3\nvar a=5;\n\n\n\nvar b = 3;",
-            errors: [ expectedError ],
+            errors: [ getExpectedError() ],
             options: ruleArgs
         },
         {
             code: "// invalid 3\nvar a=5;\n\n\n\nvar b = 3;\n",
-            errors: [ expectedError ],
+            errors: [ getExpectedError() ],
             options: ruleArgs
         },
         {
@@ -110,37 +136,37 @@ ruleTester.run("no-multiple-empty-lines", rule, {
         },
         {
             code: "// invalid 5\nvar a = 5;\n\n\n\n\n\n\n\n\n\n\n\n\n\nb = 3;",
-            errors: [ expectedError ],
+            errors: [ getExpectedError() ],
             options: ruleArgs
         },
         {
             code: "// invalid 6\nvar a=5;\n\n\n\n\n",
-            errors: [ expectedError ],
+            errors: [ getExpectedError() ],
             options: ruleArgs
         },
         {
             code: "// invalid 7\nvar a = 5;\n\nvar b = 3;",
-            errors: [ expectedError ],
+            errors: [ getExpectedError(0) ],
             options: [ { max: 0 } ]
         },
         {
             code: "// valid 5\nvar a = 5;\n\n",
-            errors: [ expectedErrorEOF ],
+            errors: [ getExpectedErrorEOF(1) ],
             options: [ { max: 5, maxEOF: 1 } ]
         },
         {
             code: "// valid 5\nvar a = 5;\n\n\n\n\n",
-            errors: [ expectedErrorEOF ],
+            errors: [ getExpectedErrorEOF(4) ],
             options: [ { max: 0, maxEOF: 4 } ]
         },
         {
             code: "// valid 5\n\n\n\n\n\n\n\n\nvar a = 5;\n\n",
-            errors: [ expectedErrorEOF ],
+            errors: [ getExpectedErrorEOF(1) ],
             options: [ { max: 10, maxEOF: 1 } ]
         },
         {
             code: "// valid 5\nvar a = 5;\n",
-            errors: [ expectedErrorEOF ],
+            errors: [ getExpectedErrorEOF(0) ],
             options: [ { max: 2, maxEOF: 0 } ]
         }
     ]


### PR DESCRIPTION
The message returned was a bit confusing as it says "Multiple blank lines not allowed." even when multiple blank lines are allowed. Minor update to the message to include the number of blank lines allowed.