### PR TITLE
Fix: Display singular/plural version of "line" in message

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -88,7 +88,7 @@ module.exports = function(context) {
                         // within the file, not at the end
                         if (blankCounter >= max) {
                             context.report(node, location,
-                                    "More than " + max + " blank lines not allowed.");
+                                    "More than " + max + " blank " + (max === 1 ? "line" : "lines") + " not allowed.");
                         }
                     } else {
                         // inside the last blank lines

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -16,12 +16,7 @@ var rule = require("../../../lib/rules/no-multiple-empty-lines"),
 // Tests
 //------------------------------------------------------------------------------
 
-var ruleTester = new RuleTester(),
-    ruleArgs = [
-        {
-            max: 2
-        }
-    ];
+var ruleTester = new RuleTester();
 
 /**
  * Creates the expected error message object for the specified number of lines
@@ -30,12 +25,12 @@ var ruleTester = new RuleTester(),
  * @private
  */
 function getExpectedError(lines) {
-    if (typeof lines !== "number") {
-        lines = 2;
-    }
+    var message = lines === 1
+        ? "More than 1 blank line not allowed."
+        : "More than " + lines + " blank lines not allowed.";
 
     return {
-        message: "More than " + lines + " blank lines not allowed.",
+        message: message,
         type: "Program"
     };
 }
@@ -61,12 +56,20 @@ ruleTester.run("no-multiple-empty-lines", rule, {
 
     valid: [
         {
+            code: "// valid 1\nvar a = 5;\nvar b = 3;",
+            options: [ { max: 1 } ]
+        },
+        {
+            code: "// valid 1\n\nvar a = 5;\n\nvar b = 3;",
+            options: [ { max: 1 } ]
+        },
+        {
             code: "// valid 1\nvar a = 5;\n\nvar b = 3;",
-            options: ruleArgs
+            options: [ { max: 2 } ]
         },
         {
             code: "// valid 2\nvar a = 5,\n    b = 3;",
-            options: ruleArgs
+            options: [ { max: 2 } ]
         },
         {
             code: "// valid 3\nvar a = 5;\n\n\n\n\nvar b = 3;",
@@ -78,18 +81,18 @@ ruleTester.run("no-multiple-empty-lines", rule, {
         },
         {
             code: "// valid 5\nvar a = 5;\n",
-            options: [{ max: 0 } ]
+            options: [ { max: 0 } ]
         },
 
         // template strings
         {
             code: "x = `\n\n\n\nhi\n\n\n\n`",
-            options: ruleArgs,
+            options: [ { max: 2 } ],
             ecmaFeatures: { templateStrings: true }
         },
         {
             code: "`\n\n`",
-            options: [{ max: 0 }],
+            options: [ { max: 0 } ],
             ecmaFeatures: { templateStrings: true }
         },
 
@@ -105,44 +108,49 @@ ruleTester.run("no-multiple-empty-lines", rule, {
 
     invalid: [
         {
+            code: "// invalid 1\nvar a = 5;\n\n\nvar b = 3;",
+            errors: [ getExpectedError(1) ],
+            options: [ { max: 1 } ]
+        },
+        {
             code: "// invalid 1\n\n\n\n\nvar a = 5;",
-            errors: [ getExpectedError() ],
-            options: ruleArgs
+            errors: [ getExpectedError(2) ],
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 2\nvar a = 5;\n\n\n\n",
-            errors: [ getExpectedError() ],
-            options: ruleArgs
+            errors: [ getExpectedError(2) ],
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 2\nvar a = 5;\n \n \n \n",
-            errors: [ getExpectedError() ],
-            options: ruleArgs
+            errors: [ getExpectedError(2) ],
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 3\nvar a=5;\n\n\n\nvar b = 3;",
-            errors: [ getExpectedError() ],
-            options: ruleArgs
+            errors: [ getExpectedError(2) ],
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 3\nvar a=5;\n\n\n\nvar b = 3;\n",
-            errors: [ getExpectedError() ],
-            options: ruleArgs
+            errors: [ getExpectedError(2) ],
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 4\nvar a = 5;\n\n\n\nb = 3;\nvar c = 5;\n\n\n\nvar d = 3;",
             errors: 2,
-            options: ruleArgs
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 5\nvar a = 5;\n\n\n\n\n\n\n\n\n\n\n\n\n\nb = 3;",
-            errors: [ getExpectedError() ],
-            options: ruleArgs
+            errors: [ getExpectedError(2) ],
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 6\nvar a=5;\n\n\n\n\n",
-            errors: [ getExpectedError() ],
-            options: ruleArgs
+            errors: [ getExpectedError(2) ],
+            options: [ { max: 2 } ]
         },
         {
             code: "// invalid 7\nvar a = 5;\n\nvar b = 3;",


### PR DESCRIPTION
Right now, if *no-multiple-empty-lines* has a `max` value of 1, the message reads:

> "More than 1 blank line**s** not allowed."

This PR singularizes "line" when `max` is 1:

> "More than 1 blank line not allowed."