### PR TITLE
Fix: indent auto-fix is no longer fooled by spaces vs tabs (fixes #4274)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -6,6 +6,7 @@
  * @author Gyandeep Singh
  * @copyright 2015 Vitaly Puzrin. All rights reserved.
  * @copyright 2015 Gyandeep Singh. All rights reserved.
+ * @copyright 2016 Kevin Partington. All rights reserved.
  Copyright (C) 2014 by Vitaly Puzrin
 
  Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -38,6 +39,7 @@ module.exports = function(context) {
 
     var MESSAGE = "Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.";
     var DEFAULT_VARIABLE_INDENT = 1;
+    var sourceCode = context.getSourceCode();
 
     var indentType = "space";
     var indentSize = 4;
@@ -106,43 +108,51 @@ module.exports = function(context) {
          * @private
          */
         function getFixerFunction() {
-            var rangeToFix = [];
+            var replacement = "" + new Array(needed + 1).join(indentChar),  // replace with repeat in future
+                endOfPreviousToken = -1,
+                endOfLeadingComments = -1,
+                previousNewlineIndex = -1,
+                rangeToFix,
+                startOfLine,
+                referenceToken,
+                previousToken,
+                leadingComments;
 
-            if (needed > gotten) {
-                var spaces = "" + new Array(needed - gotten + 1).join(indentChar);  // replace with repeat in future
-
-                if (isLastNodeCheck === true) {
-                    rangeToFix = [
-                        node.range[1] - 1,
-                        node.range[1] - 1
-                    ];
-                } else {
-                    rangeToFix = [
-                        node.range[0],
-                        node.range[0]
-                    ];
-                }
-
-                return function(fixer) {
-                    return fixer.insertTextBeforeRange(rangeToFix, spaces);
-                };
+            if (isLastNodeCheck === true) {
+                referenceToken = sourceCode.getLastToken(node);
             } else {
-                if (isLastNodeCheck === true) {
-                    rangeToFix = [
-                        node.range[1] - (gotten - needed) - 1,
-                        node.range[1] - 1
-                    ];
-                } else {
-                    rangeToFix = [
-                        node.range[0] - (gotten - needed),
-                        node.range[0]
-                    ];
-                }
-
-                return function(fixer) {
-                    return fixer.removeRange(rangeToFix);
-                };
+                referenceToken = sourceCode.getFirstToken(node);
             }
+
+            // Three candidates for "start of line" for indent purposes.
+
+            // 1. End of leading comment.
+            leadingComments = sourceCode.getComments(node).leading;
+
+            if (leadingComments && leadingComments.length) {
+                // Use the end of the comment as the "start of line"
+                endOfLeadingComments = leadingComments[leadingComments.length - 1].range[1];
+            }
+
+            // 2. End of previous token.
+            previousToken = sourceCode.getTokenBefore(referenceToken);
+
+            if (previousToken) {
+                // Use the end of the last token as the "start of line".
+                endOfPreviousToken = previousToken.range[1];
+            }
+
+            // 3. The actual most recent newline before the start of the token.
+            previousNewlineIndex = sourceCode.text.slice(0, referenceToken.range[0]).lastIndexOf("\n") + 1;
+
+            // We will use the largest index.
+            startOfLine = Math.max(endOfLeadingComments, endOfPreviousToken, previousNewlineIndex);
+
+            rangeToFix = [startOfLine, referenceToken.range[0]];
+
+            return function(fixer) {
+                return fixer.replaceTextRange(rangeToFix, replacement);
+            };
         }
 
         if (loc) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2120,6 +2120,40 @@ ruleTester.run("indent", rule, {
                 [2, 1, 0, "IfStatement"]
             ])
         },
+        {
+            code:
+            "function a() {\n" +
+            "\tif (a) {\n" +
+            "\t\tvar x; /* multiline comment\n" +
+            "wooooo */}\n" +
+            "}",
+            output:
+            "function a() {\n" +
+            "\tif (a) {\n" +
+            "\t\tvar x; /* multiline comment\n" +
+            "wooooo */}\n" +
+            "}",
+            options: ["tab"],
+            errors: expectedErrors("tab", [
+                [4, 1, 0, "BlockStatement"]
+            ])
+        },
+        {
+            code:
+            "/* Leading\n" +
+            "comment */\tif (a) {\n" +
+            "\tvar x; /* multiline comment\n" +
+            "wooooo */}",
+            output:
+            "/* Leading\n" +
+            "comment */if (a) {\n" +
+            "\tvar x; /* multiline comment\n" +
+            "wooooo */}",
+            options: ["tab"],
+            errors: expectedErrors("tab", [
+                [4, 1, 0, "BlockStatement"]
+            ])
+        },
 
         // autofixing basically ignores block comments
         {


### PR DESCRIPTION
Initial steps toward fixing #4274 by replacing the text range of the leading indent with the new indent, rather than trying to add or remove characters since that can be fooled by spaces vs tabs. I was getting a bit confused with all of the ranges being passed around, so I decided to switch to tokens as an intermediary-- hopefully this will be a little easier to follow. Added a couple of new test cases related to the problems I had seen with old auto-fix, and those tests and all current tests pass with this implementation.

**This is a work in progress**. Please do not merge yet.

Next steps will be determined after project collaborators/reviewers answer the following questions:

1. Is this an okay approach, in general?
1. Ideas for test cases to add? (In theory I could basically triple all of the existing test cases to create new ones that involve tab-to-space and space-to-tab transforms, but that might be overkill.)

Fixes #4274 (once this is improved with extra test cases).