### PR TITLE
Fix: Autofix quotes produces invalid javascript (fixes #4380)

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -11,13 +11,31 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var astUtils = require("../ast-utils"),
-    toSingleQuotes = require("to-single-quotes"),
-    toDoubleQuotes = require("to-double-quotes");
+var astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
+
+/**
+ * Converts string quoted with oldQuote to a string quoted with newQuote.
+ * @param {String} str The string to transform.
+ * @param {String} newQuote The new quote character.
+ * @param {String} oldQuote The old quote character.
+ * @returns {String} Converted string.
+ * @private
+ */
+function convertQuotes(str, newQuote, oldQuote) {
+    return newQuote + str.slice(1, -1).replace(/\\.|["']/g, function(match) {
+        if (match.length === 2 && match[1] === oldQuote) {
+            return match[1]; // unescape
+        }
+        if (match === newQuote) {
+            return "\\" + match; // escape
+        }
+        return match;
+    }) + newQuote;
+}
 
 var QUOTE_SETTINGS = {
     "double": {
@@ -25,7 +43,7 @@ var QUOTE_SETTINGS = {
         alternateQuote: "'",
         description: "doublequote",
         convert: function(str) {
-            return toDoubleQuotes(str);
+            return convertQuotes(str, this.quote, this.alternateQuote);
         }
     },
     "single": {
@@ -33,7 +51,7 @@ var QUOTE_SETTINGS = {
         alternateQuote: "\"",
         description: "singlequote",
         convert: function(str) {
-            return toSingleQuotes(str);
+            return convertQuotes(str, this.quote, this.alternateQuote);
         }
     },
     "backtick": {
@@ -41,7 +59,16 @@ var QUOTE_SETTINGS = {
         alternateQuote: "\"",
         description: "backtick",
         convert: function(str) {
-            return str.replace(/`/g, "\`").replace(/^(?:\\*)["']|(?:\\*)["']$/g, "`");
+            var quote = "`";
+            return quote + str.slice(1, -1).replace(/\\.|`|\${/g, function(match) {
+                if (match.length === 2 && /["']/.test(match[1])) {
+                    return match[1]; // unescape
+                }
+                if (match === quote || match[0] === "$") {
+                    return "\\" + match; // escape
+                }
+                return match;
+            }) + quote;
         }
     }
 };

--- a/package.json
+++ b/package.json
@@ -66,8 +66,6 @@
     "shelljs": "^0.5.3",
     "strip-json-comments": "~1.0.1",
     "text-table": "~0.2.0",
-    "to-double-quotes": "^2.0.0",
-    "to-single-quotes": "^2.0.0",
     "user-home": "^2.0.0",
     "xml-escape": "~1.0.0"
   },

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -94,8 +94,20 @@ ruleTester.run("quotes", rule, {
             errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
         },
         {
+            code: "var foo = '\\\\';",
+            output: "var foo = \"\\\\\";",
+            options: ["double", "avoid-escape"],
+            errors: [{ message: "Strings must use doublequote.", type: "Literal" }]
+        },
+        {
             code: "var foo = 'bar';",
             output: "var foo = `bar`;",
+            options: ["backtick"],
+            errors: [{ message: "Strings must use backtick.", type: "Literal" }]
+        },
+        {
+            code: "var foo = 'b${x}a$r';",
+            output: "var foo = `b\\${x}a$r`;",
             options: ["backtick"],
             errors: [{ message: "Strings must use backtick.", type: "Literal" }]
         },


### PR DESCRIPTION
Note: This removes dependency on to-single-quotes and to-double-quotes packages, because they use a heuristic to detect matching quote pairs in arbitrary strings, which is much harder to test and verify than simple convertQuotes function bellow