### PR TITLE
Update indent.md

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -46,7 +46,7 @@ Level of indentation denotes the multiple of the indent specified. Example:
 * Indent of tabs with SwitchCase set to 2 will indent `SwitchCase` with 2 tabs with respect to switch.
 
 
-2 space indentation with enabled switch cases validation
+2 space indentation with enabled switch cases indentation
 
 ```json
  "indent": [2, 2, {"SwitchCase": 1}]


### PR DESCRIPTION
Corrected that the example enables case indentation, not verification.  It is verified even without the SwitchCase option.