### PR TITLE
Replace link to deprecated rule with newer rule

### DIFF
--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -146,5 +146,5 @@ If you do not want to enforce semicolon usage (or omission) in any particular wa
 ## Related Rules
 
 * [no-extra-semi](no-extra-semi.md)
-* [no-space-before-semi](no-space-before-semi.md)
 * [no-unexpected-multiline](no-unexpected-multiline.md)
+* [semi-spacing](semi-spacing.md)


### PR DESCRIPTION
no-space-before-semi is deprecated and replaced with semi-spacing, so link to that instead.