### PR TITLE
Fix: eqeqeq autofix avoids clashes with space-infix-ops (fixes #4423)

### DIFF
--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -13,7 +13,11 @@
 
 module.exports = function(context) {
 
-    var sourceCode = context.getSourceCode();
+    var sourceCode = context.getSourceCode(),
+        replacements = {
+            "==": "===",
+            "!=": "!=="
+        };
 
     /**
      * Checks if an expression is a typeof expression
@@ -89,7 +93,7 @@ module.exports = function(context) {
                 message: "Expected '{{op}}=' and instead saw '{{op}}'.",
                 data: { op: node.operator },
                 fix: function(fixer) {
-                    return fixer.insertTextAfter(sourceCode.getTokenAfter(node.left), "=");
+                    return fixer.replaceText(sourceCode.getTokenAfter(node.left), replacements[node.operator]);
                 }
             });
 


### PR DESCRIPTION
Fixes #4423.

This provides an alternative fix for #4321 and will allow for a less risk-averse alternative to the change performed in #4329.

See #4373 for more info.