### PR TITLE
Revert "Update: Allow empty arrow body (fixes #4411)"

### DIFF
--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -2,6 +2,17 @@
 
 Arrow functions can omit braces when there is a single statement in the body. This rule enforces the consistent use of braces in arrow functions.
 
+Additionally, this rule specifically warns against a possible developer error when the intention is to return an empty object literal but creates an empty block instead, returning undefined.
+
+```js
+/*eslint-env es6*/
+// Bad
+var foo = () => {};
+
+// Good
+var foo = () => ({});
+```
+
 ## Rule Details
 
 This rule can enforce the use of braces around arrow function body.
@@ -50,6 +61,8 @@ When the rule is set to `"as-needed"` the following patterns are considered prob
 let foo = () => {
     return 0;
 };
+
+let foo = () => {};
 ```
 
 The following patterns are not considered problems:
@@ -64,7 +77,6 @@ let foo = (retv, name) => {
     return retv;
 };
 let foo = () => { bar(); };
-let foo = () => {};
 let foo = () => { /* do nothing */ };
 let foo = () => {
     // do nothing.

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -24,16 +24,29 @@ module.exports = function(context) {
         if (arrowBody.type === "BlockStatement") {
             var blockBody = arrowBody.body;
 
-            if (blockBody.length !== 1) {
+            if (blockBody.length > 1) {
                 return;
             }
 
-            if (asNeeded && blockBody[0].type === "ReturnStatement") {
+            if (blockBody.length === 0) {
+                var hasComments = context.getComments(arrowBody).trailing.length > 0;
+                if (hasComments) {
+                    return;
+                }
+
                 context.report({
                     node: node,
                     loc: arrowBody.loc.start,
-                    message: "Unexpected block statement surrounding arrow body."
+                    message: "Unexpected empty block in arrow body."
                 });
+            } else {
+                if (asNeeded && blockBody[0].type === "ReturnStatement") {
+                    context.report({
+                        node: node,
+                        loc: arrowBody.loc.start,
+                        message: "Unexpected block statement surrounding arrow body."
+                    });
+                }
             }
         } else {
             if (always) {

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -20,7 +20,6 @@ var rule = require("../../../lib/rules/arrow-body-style"),
 var ruleTester = new RuleTester();
 ruleTester.run("arrow-body-style", rule, {
     valid: [
-        { code: "var foo = () => {};", ecmaFeatures: { arrowFunctions: true } },
         { code: "var foo = () => 0;", ecmaFeatures: { arrowFunctions: true } },
         { code: "var addToB = (a) => { b =  b + a };", ecmaFeatures: { arrowFunctions: true } },
         { code: "var foo = () => { /* do nothing */ };", ecmaFeatures: { arrowFunctions: true } },
@@ -34,6 +33,13 @@ ruleTester.run("arrow-body-style", rule, {
         { code: "var foo = () => { return bar(); };", ecmaFeatures: { arrowFunctions: true }, options: ["always"] }
     ],
     invalid: [
+        {
+            code: "var foo = () => {};",
+            ecmaFeatures: { arrowFunctions: true },
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected empty block in arrow body." }
+            ]
+        },
         {
             code: "var foo = () => 0;",
             ecmaFeatures: { arrowFunctions: true },


### PR DESCRIPTION
Reverts eslint/eslint#4420 because it's a breaking change.