### PR TITLE
Fix: Improves performance (refs #3530)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -129,5 +129,26 @@ module.exports = {
      * @param {ASTNode} A node to get.
      * @returns {ASTNode|null} The trailing statement's node.
      */
-    getTrailingStatement: esutils.ast.trailingStatement
+    getTrailingStatement: esutils.ast.trailingStatement,
+
+    /**
+     * Finds the variable by a given name in a given scope and its upper scopes.
+     *
+     * @param {escope.Scope} initScope - A scope to start find.
+     * @param {string} name - A variable name to find.
+     * @returns {escope.Variable|null} A found variable or `null`.
+     */
+    getVariableByName: function(initScope, name) {
+        var scope = initScope;
+        while (scope) {
+            var variable = scope.set.get(name);
+            if (variable) {
+                return variable;
+            }
+
+            scope = scope.upper;
+        }
+
+        return null;
+    }
 };

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -113,25 +113,6 @@ function parseListConfig(string) {
 }
 
 /**
- * @param {Scope} scope The scope object to check.
- * @param {string} name The name of the variable to look up.
- * @returns {Variable} The variable object if found or null if not.
- */
-function getVariable(scope, name) {
-    var variable = null;
-    scope.variables.some(function(v) {
-        if (v.name === name) {
-            variable = v;
-            return true;
-        } else {
-            return false;
-        }
-
-    });
-    return variable;
-}
-
-/**
  * Ensures that variables representing built-in properties of the Global Object,
  * and any globals declared by special block comments, are present in the global
  * scope.
@@ -162,29 +143,31 @@ function addDeclaredGlobals(program, globalScope, config) {
     assign(explicitGlobals, config.astGlobals);
 
     Object.keys(declaredGlobals).forEach(function(name) {
-        var variable = getVariable(globalScope, name);
+        var variable = globalScope.set.get(name);
         if (!variable) {
             variable = new escope.Variable(name, globalScope);
             variable.eslintExplicitGlobal = false;
             globalScope.variables.push(variable);
+            globalScope.set.set(name, variable);
         }
         variable.writeable = declaredGlobals[name];
     });
 
     Object.keys(explicitGlobals).forEach(function(name) {
-        var variable = getVariable(globalScope, name);
+        var variable = globalScope.set.get(name);
         if (!variable) {
             variable = new escope.Variable(name, globalScope);
             variable.eslintExplicitGlobal = true;
             variable.eslintExplicitGlobalComment = explicitGlobals[name].comment;
             globalScope.variables.push(variable);
+            globalScope.set.set(name, variable);
         }
         variable.writeable = explicitGlobals[name].value;
     });
 
     // mark all exported variables as such
     Object.keys(exportedGlobals).forEach(function(name) {
-        var variable = getVariable(globalScope, name);
+        var variable = globalScope.set.get(name);
         if (variable) {
             variable.eslintUsed = true;
         }
@@ -891,8 +874,14 @@ module.exports = (function() {
 
     // copy over methods
     Object.keys(externalMethods).forEach(function(methodName) {
-        api[methodName] = function() {
-            return sourceCode ? sourceCode[externalMethods[methodName]].apply(sourceCode, arguments) : null;
+        var exMethodName = externalMethods[methodName];
+
+        // All functions expected to have less arguments than 5.
+        api[methodName] = function(a, b, c, d, e) {
+            if (sourceCode) {
+                return sourceCode[exMethodName](a, b, c, d, e);
+            }
+            return null;
         };
     });
 

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -72,42 +72,29 @@ var PASSTHROUGHS = [
  * @param {object} ecmaFeatures The ecmaFeatures settings passed from the config file.
  */
 function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) {
+    // public.
+    this.id = ruleId;
+    this.options = options;
+    this.settings = settings;
+    this.ecmaFeatures = ecmaFeatures;
+
+    // private.
+    this.eslint = eslint;
+    this.severity = severity;
+
+    Object.freeze(this);
+}
+
+RuleContext.prototype = {
+    constructor: RuleContext,
 
     /**
-     * The read-only ID of the rule.
+     * Passthrough to eslint.getSourceCode().
+     * @returns {SourceCode} The SourceCode object for the code.
      */
-    Object.defineProperty(this, "id", {
-        value: ruleId
-    });
-
-    /**
-     * The read-only options of the rule
-     */
-    Object.defineProperty(this, "options", {
-        value: options
-    });
-
-    /**
-     * The read-only settings shared between all rules
-     */
-    Object.defineProperty(this, "settings", {
-        value: settings
-    });
-
-    /**
-     * The read-only ecmaFeatures shared across all rules
-     */
-    Object.defineProperty(this, "ecmaFeatures", {
-        value: Object.create(ecmaFeatures)
-    });
-    Object.freeze(this.ecmaFeatures);
-
-    // copy over passthrough methods
-    PASSTHROUGHS.forEach(function(name) {
-        this[name] = function() {
-            return eslint[name].apply(eslint, arguments);
-        };
-    }, this);
+    getSourceCode: function() {
+        return this.eslint.getSourceCode();
+    },
 
     /**
      * Passthrough to eslint.report() that automatically assigns the rule ID and severity.
@@ -119,8 +106,7 @@ function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) 
      *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    this.report = function(nodeOrDescriptor, location, message, opts) {
-
+    report: function(nodeOrDescriptor, location, message, opts) {
         var descriptor,
             fix = null;
 
@@ -133,31 +119,37 @@ function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) 
                 fix = descriptor.fix(new RuleFixer());
             }
 
-            eslint.report(
-                ruleId, severity, descriptor.node,
+            this.eslint.report(
+                this.id,
+                this.severity,
+                descriptor.node,
                 descriptor.loc || descriptor.node.loc.start,
-                descriptor.message, descriptor.data, fix
+                descriptor.message,
+                descriptor.data,
+                fix
             );
 
             return;
         }
 
         // old style call
-        eslint.report(ruleId, severity, nodeOrDescriptor, location, message, opts);
-    };
-
-    /**
-     * Passthrough to eslint.getSourceCode().
-     * @returns {SourceCode} The SourceCode object for the code.
-     */
-    this.getSourceCode = function() {
-        return eslint.getSourceCode();
-    };
-
-}
-
-RuleContext.prototype = {
-    constructor: RuleContext
+        this.eslint.report(
+            this.id,
+            this.severity,
+            nodeOrDescriptor,
+            location,
+            message,
+            opts
+        );
+    }
 };
+
+// copy over passthrough methods
+PASSTHROUGHS.forEach(function(name) {
+    // All functions expected to have less arguments than 5.
+    this[name] = function(a, b, c, d, e) {
+        return this.eslint[name](a, b, c, d, e);
+    };
+}, RuleContext.prototype);
 
 module.exports = RuleContext;

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -53,39 +53,35 @@ module.exports = function(context) {
      */
     function ensureWasAssigned() {
         var scope = context.getScope();
+        var variable = scope.set.get(alias);
+        if (!variable) {
+            return;
+        }
 
-        scope.variables.some(function(variable) {
-            var lookup;
+        if (variable.defs.some(function(def) {
+            return def.node.type === "VariableDeclarator" &&
+                def.node.init !== null;
+        })) {
+            return;
+        }
 
-            if (variable.name === alias) {
-                if (variable.defs.some(function(def) {
-                    return def.node.type === "VariableDeclarator" &&
-                        def.node.init !== null;
-                })) {
-                    return true;
-                }
+        var lookup = (variable.references.length === 0 && scope.type === "global") ? scope : variable;
 
-                lookup = scope.type === "global" ? scope : variable;
+        // The alias has been declared and not assigned: check it was
+        // assigned later in the same scope.
+        if (!lookup.references.some(function(reference) {
+            var write = reference.writeExpr;
 
-                // The alias has been declared and not assigned: check it was
-                // assigned later in the same scope.
-                if (!lookup.references.some(function(reference) {
-                    var write = reference.writeExpr;
-
-                    if (reference.from === scope &&
-                            write && write.type === "ThisExpression" &&
-                            write.parent.operator === "=") {
-                        return true;
-                    }
-                })) {
-                    variable.defs.map(function(def) {
-                        return def.node;
-                    }).forEach(reportBadAssignment);
-                }
-
+            if (reference.from === scope &&
+                    write && write.type === "ThisExpression" &&
+                    write.parent.operator === "=") {
                 return true;
             }
-        });
+        })) {
+            variable.defs.map(function(def) {
+                return def.node;
+            }).forEach(reportBadAssignment);
+        }
     }
 
     return {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -75,6 +75,11 @@ module.exports = function(context) {
         }
     }
 
+    var indentPattern = {
+        normal: indentType === "space" ? /^ +/ : /^\t+/,
+        excludeCommas: indentType === "space" ? /^[ ,]+/ : /^[\t,]+/
+    };
+
     var caseIndentStore = {};
 
     /**
@@ -168,17 +173,9 @@ module.exports = function(context) {
     function getNodeIndent(node, byLastLine, excludeCommas) {
         var token = byLastLine ? context.getLastToken(node) : context.getFirstToken(node);
         var src = context.getSource(token, token.loc.start.column);
-
-        var skip = excludeCommas ? "," : "";
-
-        var regExp;
-        if (indentType === "space") {
-            regExp = new RegExp("^[ " + skip + "]+");
-        } else {
-            regExp = new RegExp("^[\t" + skip + "]+");
-        }
-
+        var regExp = excludeCommas ? indentPattern.excludeCommas : indentPattern.normal;
         var indent = regExp.exec(src);
+
         return indent ? indent[0].length : 0;
     }
 

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -7,6 +7,16 @@
  */
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assign = require("object-assign");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
 /**
  * Return an array with with any line numbers that are empty.
  * @param {Array} lines An array of each line of the file.
@@ -57,7 +67,7 @@ function contains(val, array) {
 
 module.exports = function(context) {
 
-    var options = context.options[0] || {};
+    var options = context.options[0] ? assign({}, context.options[0]) : {};
     options.beforeLineComment = options.beforeLineComment || false;
     options.afterLineComment = options.afterLineComment || false;
     options.beforeBlockComment = typeof options.beforeBlockComment !== "undefined" ? options.beforeBlockComment : true;

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -7,6 +7,16 @@
 
 "use strict";
 
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assign = require("object-assign");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
 var CAPS_ALLOWED = [
     "Array",
     "Boolean",
@@ -67,7 +77,7 @@ function calculateCapIsNewExceptions(config) {
 
 module.exports = function(context) {
 
-    var config = context.options[0] || {};
+    var config = context.options[0] ? assign({}, context.options[0]) : {};
     config.newIsCap = config.newIsCap !== false;
     config.capIsNew = config.capIsNew !== false;
     var skipProperties = config.properties === false;

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -69,9 +69,8 @@ function findReference(scope, node) {
  * @returns {boolean} Whether or not the name is shadowed globally.
  */
 function isGloballyShadowed(globalScope, identifierName) {
-    return globalScope.variables.some(function(variable) {
-        return variable.name === identifierName && variable.defs.length > 0;
-    });
+    var variable = globalScope.set.get(identifierName);
+    return Boolean(variable && variable.defs.length > 0);
 }
 
 /**

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -22,19 +28,7 @@ module.exports = function(context) {
      * @returns {boolean} True is its been shadowed
      */
     function paramIsShadowing(scope, name) {
-        var found = scope.variables.some(function(variable) {
-            return variable.name === name;
-        });
-
-        if (found) {
-            return true;
-        }
-
-        if (scope.upper) {
-            return paramIsShadowing(scope.upper, name);
-        }
-
-        return false;
+        return astUtils.getVariableByName(scope, name) !== null;
     }
 
     //--------------------------------------------------------------------------

--- a/lib/rules/no-label-var.js
+++ b/lib/rules/no-label-var.js
@@ -6,6 +6,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -18,32 +24,12 @@ module.exports = function(context) {
     /**
      * Check if the identifier is present inside current scope
      * @param {object} scope current scope
-     * @param {ASTNode} identifier To evaluate
+     * @param {string} name To evaluate
      * @returns {boolean} True if its present
      * @private
      */
-    function findIdentifier(scope, identifier) {
-        var found = false;
-
-        scope.variables.forEach(function(variable) {
-            if (variable.name === identifier) {
-                found = true;
-            }
-        });
-
-        scope.references.forEach(function(reference) {
-            if (reference.identifier.name === identifier) {
-                found = true;
-            }
-        });
-
-        // If we have not found the identifier in this scope, check the parent
-        // scope.
-        if (scope.upper && !found) {
-            return findIdentifier(scope.upper, identifier);
-        }
-
-        return found;
+    function findIdentifier(scope, name) {
+        return astUtils.getVariableByName(scope, name) !== null;
     }
 
     //--------------------------------------------------------------------------

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -7,6 +7,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -100,69 +106,36 @@ module.exports = function(context) {
     }
 
     /**
-     * Checks if a variable is contained in the list of given scope variables.
-     * @param {Object} variable The variable to check.
-     * @param {Array} scopeVars The scope variables to look for.
-     * @returns {boolean} Whether or not the variable is contains in the list of scope variables.
-     */
-    function isContainedInScopeVars(variable, scopeVars) {
-        return scopeVars.some(function(scopeVar) {
-            return (
-                (scopeVar.identifiers.length > 0 || (options.builtinGlobals && "writeable" in scopeVar)) &&
-                variable.name === scopeVar.name &&
-                !isDuplicatedClassNameVariable(scopeVar) &&
-                !isOnInitializer(variable, scopeVar) &&
-                !(options.hoist !== "all" && isInTdz(variable, scopeVar))
-            );
-        });
-    }
-
-    /**
-     * Checks if the given variables are shadowed in the given scope.
-     * @param {Array} variables The variables to look for
-     * @param {Object} scope The scope to be checked.
-     * @returns {Array} Variables which are not declared in the given scope.
-     */
-    function checkShadowsInScope(variables, scope) {
-
-        var passedVars = [];
-
-        variables.forEach(function(variable) {
-            // "arguments" is a special case that has no identifiers (#1759)
-            if (variable.identifiers.length > 0 && isContainedInScopeVars(variable, scope.variables)) {
-                context.report(
-                    variable.identifiers[0],
-                    "\"{{name}}\" is already declared in the upper scope.",
-                    {name: variable.name});
-            } else {
-                passedVars.push(variable);
-            }
-        });
-
-        return passedVars;
-    }
-
-    /**
      * Checks the current context for shadowed variables.
      * @param {Scope} scope - Fixme
      * @returns {void}
      */
     function checkForShadows(scope) {
-        var variables = scope.variables.filter(function(variable) {
-            return (
-                // Skip "arguments".
-                variable.identifiers.length > 0 &&
-                // Skip variables of a class name in the class scope of ClassDeclaration.
-                !isDuplicatedClassNameVariable(variable) &&
-                !isAllowed(variable)
-            );
-        });
+        var variables = scope.variables;
+        for (var i = 0; i < variables.length; ++i) {
+            var variable = variables[i];
 
-        // iterate through the array of variables and find duplicates with the upper scope
-        var upper = scope.upper;
-        while (upper && variables.length) {
-            variables = checkShadowsInScope(variables, upper);
-            upper = upper.upper;
+            // Skips "arguments" or variables of a class name in the class scope of ClassDeclaration.
+            if (variable.identifiers.length === 0 ||
+                isDuplicatedClassNameVariable(variable) ||
+                isAllowed(variable)
+            ) {
+                continue;
+            }
+
+            // Gets shadowed variable.
+            var shadowed = astUtils.getVariableByName(scope.upper, variable.name);
+            if (shadowed &&
+                (shadowed.identifiers.length > 0 || (options.builtinGlobals && "writeable" in shadowed)) &&
+                !isOnInitializer(variable, shadowed) &&
+                !(options.hoist !== "all" && isInTdz(variable, shadowed))
+            ) {
+                context.report({
+                    node: variable.identifiers[0],
+                    message: "\"{{name}}\" is already declared in the upper scope.",
+                    data: variable
+                });
+            }
         }
     }
 

--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -21,26 +21,26 @@ module.exports = function(context) {
      */
     function detectOpenSpaces(node) {
         var lastCalleeToken = sourceCode.getLastToken(node.callee),
-            tokens = sourceCode.getTokens(node),
-            i = tokens.indexOf(lastCalleeToken),
-            l = tokens.length;
+            prevToken = lastCalleeToken,
+            parenToken = sourceCode.getTokenAfter(lastCalleeToken);
 
-        while (i < l && tokens[i].value !== "(") {
-            ++i;
-        }
-
-        if (i >= l) {
+        if (sourceCode.getLastToken(node).value !== ")") {
             return;
         }
 
+        while (parenToken.value !== "(") {
+            prevToken = parenToken;
+            parenToken = sourceCode.getTokenAfter(parenToken);
+        }
+
         // look for a space between the callee and the open paren
-        if (sourceCode.isSpaceBetweenTokens(tokens[i - 1], tokens[i])) {
+        if (sourceCode.isSpaceBetweenTokens(prevToken, parenToken)) {
             context.report({
                 node: node,
                 loc: lastCalleeToken.loc.start,
                 message: "Unexpected space between function name and paren.",
                 fix: function(fixer) {
-                    return fixer.removeRange([tokens[i - 1].range[1], tokens[i].range[0]]);
+                    return fixer.removeRange([prevToken.range[1], parenToken.range[0]]);
                 }
             });
         }

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -10,11 +10,13 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-// none!
+var astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+var hasOwnProperty = Object.prototype.hasOwnProperty;
 
 /**
  * Check if a variable is an implicit declaration
@@ -35,18 +37,13 @@ function isImplicitGlobal(variable) {
  * @returns {Variable} The variable, or null if ref refers to an undeclared variable.
  */
 function getDeclaredGlobalVariable(scope, ref) {
-    var declaredGlobal = null;
-    scope.variables.some(function(variable) {
-        if (variable.name === ref.identifier.name) {
-            // If it's an implicit global, it must have a `writeable` field (indicating it was declared)
-            if (!isImplicitGlobal(variable) || {}.hasOwnProperty.call(variable, "writeable")) {
-                declaredGlobal = variable;
-                return true;
-            }
-        }
-        return false;
-    });
-    return declaredGlobal;
+    var variable = astUtils.getVariableByName(scope, ref.identifier.name);
+
+    // If it's an implicit global, it must have a `writeable` field (indicating it was declared)
+    if (variable && (!isImplicitGlobal(variable) || hasOwnProperty.call(variable, "writeable"))) {
+        return variable;
+    }
+    return null;
 }
 
 /**

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -7,6 +7,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Constants
 //------------------------------------------------------------------------------
 
@@ -17,26 +23,6 @@ var NO_FUNC = "nofunc";
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    /**
-     * Finds variable declarations in a given scope.
-     * @param {string} name The variable name to find.
-     * @param {Scope} scope The scope to search in.
-     * @returns {Object} The variable declaration object.
-     * @private
-     */
-    function findDeclaration(name, scope) {
-        // try searching in the current scope first
-        for (var i = 0, l = scope.variables.length; i < l; i++) {
-            if (scope.variables[i].name === name) {
-                return scope.variables[i];
-            }
-        }
-        // check if there's upper scope and call recursivly till we find the variable
-        if (scope.upper) {
-            return findDeclaration(name, scope.upper);
-        }
-    }
 
     /**
      * Finds and validates all variables in a given scope.
@@ -68,7 +54,7 @@ module.exports = function(context) {
             if (reference.resolved && reference.resolved.identifiers.length > 0) {
                 checkLocationAndReport(reference, reference.resolved);
             } else {
-                var declaration = findDeclaration(reference.identifier.name, scope);
+                var declaration = astUtils.getVariableByName(scope, reference.identifier.name);
                 // if there're no identifiers, this is a global environment variable
                 if (declaration && declaration.identifiers.length !== 0) {
                     checkLocationAndReport(reference, declaration);

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -6,7 +6,8 @@
 
 "use strict";
 
-var astUtils = require("../ast-utils");
+var assign = require("object-assign"),
+    astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -17,7 +18,7 @@ module.exports = function(context) {
     var usedDefaultGlobal = !context.options[0];
     var globalStyle = context.options[0] || "after";
     var options = context.options[1] || {};
-    var styleOverrides = options.overrides || {};
+    var styleOverrides = options.overrides ? assign({}, options.overrides) : {};
 
     if (usedDefaultGlobal && !styleOverrides["?"]) {
         styleOverrides["?"] = "before";

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -37,7 +37,7 @@ module.exports = function(context) {
             return true;
         }
 
-        parent = context.getAncestors().pop();
+        parent = node.parent;
         return parent.type === "MethodDefinition" ||
             (parent.type === "Property" &&
                 (
@@ -55,7 +55,6 @@ module.exports = function(context) {
      */
     function validateSpacingBeforeParentheses(node) {
         var isNamed = isNamedFunction(node),
-            tokens,
             leftToken,
             rightToken,
             location;
@@ -64,31 +63,11 @@ module.exports = function(context) {
             return;
         }
 
-        tokens = context.getTokens(node);
-
-        if (node.generator) {
-            if (node.id) {
-                leftToken = tokens[2];
-                rightToken = tokens[3];
-            } else {
-                // Object methods are named but don't have an id
-                leftToken = context.getTokenBefore(node);
-                rightToken = tokens[0];
-            }
-        } else if (isNamed) {
-            if (node.id) {
-                leftToken = tokens[1];
-                rightToken = tokens[2];
-            } else {
-                // Object methods are named but don't have an id
-                leftToken = context.getTokenBefore(node);
-                rightToken = tokens[0];
-            }
-        } else {
-            leftToken = tokens[0];
-            rightToken = tokens[1];
+        rightToken = sourceCode.getFirstToken(node);
+        while (rightToken.value !== "(") {
+            rightToken = sourceCode.getTokenAfter(rightToken);
         }
-
+        leftToken = context.getTokenBefore(rightToken);
         location = leftToken.loc.end;
 
         if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken)) {

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -41,9 +41,7 @@ function escapeAndRepeat(s) {
  * @returns {string[]} A marker list.
  */
 function parseMarkersOption(markers) {
-    if (!markers) {
-        markers = [];
-    }
+    markers = markers ? markers.slice(0) : [];
 
     // `*` is a marker for JSDoc comments.
     if (markers.indexOf("*") === -1) {

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -56,6 +56,7 @@ var assert = require("assert"),
     validator = require("../config-validator"),
     validate = require("is-my-json-valid"),
     eslint = require("../eslint"),
+    rules = require("../rules"),
     metaSchema = require("../../conf/json-schema-schema.json"),
     SourceCodeFixer = require("../util/source-code-fixer");
 
@@ -104,6 +105,27 @@ function cloneDeeplyExcludesParent(x) {
     }
 
     return x;
+}
+
+/**
+ * Freezes a given value deeply.
+ *
+ * @param {any} x - A value to freeze.
+ * @returns {void}
+ */
+function freezeDeeply(x) {
+    if (typeof x === "object" && x !== null) {
+        if (Array.isArray(x)) {
+            x.forEach(freezeDeeply);
+        } else {
+            for (var key in x) {
+                if (key !== "parent" && hasOwnProperty(x, key)) {
+                    freezeDeeply(x[key]);
+                }
+            }
+        }
+        Object.freeze(x);
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -251,7 +273,8 @@ RuleTester.prototype = {
 
             validator.validate(config, "rule-tester");
 
-            // To cache AST.
+            // Setup AST getters.
+            // To check whether or not AST was not modified in verify.
             eslint.reset();
             eslint.on("Program", function(node) {
                 beforeAST = cloneDeeplyExcludesParent(node);
@@ -261,11 +284,29 @@ RuleTester.prototype = {
                 });
             });
 
-            return {
-                messages: eslint.verify(code, config, filename, true),
-                beforeAST: beforeAST,
-                afterAST: afterAST
-            };
+            // Freezes rule-context properties.
+            var originalGet = rules.get;
+            try {
+                rules.get = function(ruleId) {
+                    var rule = originalGet(ruleId);
+                    return function(context) {
+                        Object.freeze(context);
+                        freezeDeeply(context.options);
+                        freezeDeeply(context.settings);
+                        freezeDeeply(context.ecmaFeatures);
+
+                        return rule(context);
+                    };
+                };
+
+                return {
+                    messages: eslint.verify(code, config, filename, true),
+                    beforeAST: beforeAST,
+                    afterAST: afterAST
+                };
+            } finally {
+                rules.get = originalGet;
+            }
         }
 
         /**


### PR DESCRIPTION
This was separated from #3559 

- `RuleContext` method definitions are moved to outside of the constructor. `RuleContext` object is created many times, so that constructor should be as simple as possible. (`lib/rule-context.js`)
- Construction of a regular expression object which depends on rule's options is moved to outside of `getNodeIndent` function. The function is called many times and to create dynamic regular expression object is slow. (`lib/rules/indent.js`)
- Avoid calling `Function#apply` as possible. (`lib/eslint.js` and `lib/rule-context.js`)
- Avoid calling `SourceCode#getTokens`. A CPU Profiler said that function is slow a bit. (`lib/rules/no-spaced-func.js` and `lib/rules/space-before-function-paren.js`)

**Before** (`npm run perf` for multiple files)

```
CPU Speed is 3392 with multiplier 7500000
Performance Run #1:  3882.190459ms
Performance Run #2:  3767.144016ms
Performance Run #3:  3813.567308ms
Performance Run #4:  3784.897383ms
Performance Run #5:  3768.8099039999997ms
Performance budget exceeded: 3784.897383ms (limit: 2211.0849056603774ms)


Load performance Run #1:  252.483815ms
Load performance Run #2:  251.585219ms
Load performance Run #3:  248.925052ms
Load performance Run #4:  252.786566ms
Load performance Run #5:  253.870494ms

Load Performance median :  252.483815ms
```

**After**

```
CPU Speed is 3392 with multiplier 7500000
Performance Run #1:  3075.235085ms
Performance Run #2:  3030.254616ms
Performance Run #3:  3057.690596ms
Performance Run #4:  3047.723645ms
Performance Run #5:  3016.89371ms
Performance budget exceeded: 3047.723645ms (limit: 2211.0849056603774ms)


Load performance Run #1:  254.633259ms
Load performance Run #2:  250.226913ms
Load performance Run #3:  253.68184ms
Load performance Run #4:  252.021688ms
Load performance Run #5:  251.831827ms

Load Performance median :  252.021688ms
```