### PR TITLE
Fix: `curly` warns wrong location for `else`

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -52,6 +52,22 @@ module.exports = function(context) {
     }
 
     /**
+     * Gets the `else` keyword token of a given `IfStatement` node.
+     * @param {ASTNode} node - A `IfStatement` node to get.
+     * @returns {Token} The `else` keyword token.
+     */
+    function getElseKeyword(node) {
+        var sourceCode = context.getSourceCode();
+        var token = sourceCode.getTokenAfter(node.consequent);
+
+        while (token.type !== "Keyword" || token.value !== "else") {
+            token = sourceCode.getTokenAfter(token);
+        }
+
+        return token;
+    }
+
+    /**
      * Checks a given IfStatement node requires braces of the consequent chunk.
      * This returns `true` when below:
      *
@@ -89,11 +105,15 @@ module.exports = function(context) {
      * @private
      */
     function reportExpectedBraceError(node, name, suffix) {
-        context.report(node, "Expected { after '{{name}}'{{suffix}}.",
-            {
+        context.report({
+            node: node,
+            loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
+            message: "Expected { after '{{name}}'{{suffix}}.",
+            data: {
                 name: name,
                 suffix: (suffix ? " " + suffix : "")
-            });
+            }
+        });
     }
 
     /**
@@ -105,12 +125,15 @@ module.exports = function(context) {
      * @private
      */
     function reportUnnecessaryBraceError(node, name, suffix) {
-        context.report(node, "Unnecessary { after '{{name}}'{{suffix}}.",
-            {
+        context.report({
+            node: node,
+            loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
+            message: "Unnecessary { after '{{name}}'{{suffix}}.",
+            data: {
                 name: name,
                 suffix: (suffix ? " " + suffix : "")
             }
-        );
+        });
     }
 
     /**

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -256,6 +256,30 @@ ruleTester.run("curly", rule, {
             ]
         },
         {
+            code: [
+                "if (0)",
+                "    console.log(0)",
+                "else if (1) {",
+                "    console.log(1)",
+                "    console.log(1)",
+                "} else {",
+                "    if (2)",
+                "        console.log(2)",
+                "    else",
+                "        console.log(3)",
+                "}"
+            ].join("\n"),
+            options: ["multi"],
+            errors: [
+                {
+                    message: "Unnecessary { after 'else'.",
+                    type: "IfStatement",
+                    line: 6,
+                    column: 3
+                }
+            ]
+        },
+        {
             code: "if (foo) \n baz()",
             options: ["multi-line"],
             errors: [


### PR DESCRIPTION
Fixes #4362 

This rule is reporting correct error, but that location was the head of `IfStatement` node even if about `else` block.
I fixed the location of when it's `else` block.