### PR TITLE
Update: Add JSX exceptions to no-extra-parens (fixes #4229)

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -1,6 +1,6 @@
 # Disallow Extra Parens (no-extra-parens)
 
-This rule restricts the use of parentheses to only where they are necessary. It may be restricted to report only function expressions.
+This rule restricts the use of parentheses to only where they are necessary. It may be restricted to report only function expressions. It can also be configured to allow parentheses around JSX elements.
 
 ## Rule Details
 
@@ -69,6 +69,53 @@ a = (b * c);
 typeof (a);
 ```
 
+#### JSX
+
+The second, optional configuration parameter for the rule is an exceptions object. There is one configurable exception for JSX elements, with possible values `"never"`, `"all"`, or `"multiline"`.
+
+By default, the rule will warn about parentheses around JSX elements:
+
+```jsx
+/*eslint no-extra-parens: [2, "all"]*/
+
+var app = (<App />); /*error Gratuitous parentheses around expression.*/
+```
+
+This is equivalent to explicitly setting the JSX exception to `"never"`:
+
+```jsx
+/*eslint no-extra-parens: [2, "all", { "jsx": "never" }]*/
+
+var app = (<App />); /*error Gratuitous parentheses around expression.*/
+```
+
+If those parentheses are considered acceptable, set the JSX exception to `"all"` to allow parentheses around all JSX elements:
+
+```jsx
+/*eslint no-extra-parens: [2, "all", { "jsx": "all" }]*/
+
+var app = (<App />);
+```
+
+Set the JSX exception `"multiline"` to allow parentheses only around JSX elements that span multiple lines:
+
+```jsx
+/*eslint no-extra-parens: [2, "all", { "jsx": "multiline" }]*/
+
+var app = (
+    <App>
+        Hello, world!
+    </App>
+);
+```
+
+The JSX `"multiline"` exception mode will still warn about parentheses around JSX elements that do not span more than one line:
+
+```jsx
+/*eslint no-extra-parens: [2, "all", { "jsx": "multiline" }]*/
+
+var app = (<App>Hello world</App>); /*error Gratuitous parentheses around expression.*/
+```
 
 ## Further Reading
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -7,12 +7,29 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Determines whether a node spans multiple lines.
+ * @param {ASTNode} node - The node to check.
+ * @returns {boolean} True if the node spans multiple lines.
+ * @private
+ */
+function isMultiline(node) {
+    return node.loc.end.line - node.loc.start.line > 0;
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
 
     var ALL_NODES = context.options[0] !== "functions";
+    var ALLOW_JSX = context.options[1] && context.options[1].jsx === "all";
+    var ALLOW_MULTILINE_JSX = ALLOW_JSX ||
+        (context.options[1] && context.options[1].jsx === "multiline");
 
     /**
      * Determines if this rule should be enforced for a node given the current configuration.
@@ -21,6 +38,12 @@ module.exports = function(context) {
      * @private
      */
     function ruleApplies(node) {
+        if (node.type === "JSXElement" && (ALLOW_JSX ||
+                (ALLOW_MULTILINE_JSX && isMultiline(node))
+        )) {
+            return false;
+        }
+
         return ALL_NODES || node.type === "FunctionExpression" || node.type === "ArrowFunctionExpression";
     }
 
@@ -474,8 +497,42 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [
-    {
-        "enum": ["all", "functions"]
-    }
-];
+module.exports.schema = {
+    "anyOf": [
+        {
+            "type": "array",
+            "items": [
+                {
+                    "enum": [0, 1, 2]
+                },
+                {
+                    "enum": ["functions"]
+                }
+            ],
+            "minItems": 1,
+            "maxItems": 2
+        },
+        {
+            "type": "array",
+            "items": [
+                {
+                    "enum": [0, 1, 2]
+                },
+                {
+                    "enum": ["all"]
+                },
+                {
+                    "type": "object",
+                    "properties": {
+                        "jsx": {
+                            "enum": ["never", "all", "multiline"]
+                        }
+                    },
+                    "additionalProperties": false
+                }
+            ],
+            "minItems": 1,
+            "maxItems": 3
+        }
+    ]
+};

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -195,7 +195,13 @@ ruleTester.run("no-extra-parens", rule, {
         {code: "(class{}).foo() ? bar : baz;", ecmaFeatures: {classes: true}},
         {code: "(class{}).foo.bar();", ecmaFeatures: {classes: true}},
         {code: "(class{}.foo());", ecmaFeatures: {classes: true}},
-        {code: "(class{}.foo.bar);", ecmaFeatures: {classes: true}}
+        {code: "(class{}.foo.bar);", ecmaFeatures: {classes: true}},
+
+        {code: "<foo />", ecmaFeatures: {jsx: true}},
+        {code: "<foo>\n    Hello\n</foo>", ecmaFeatures: {jsx: true}},
+        {code: "(<foo />)", options: ["all", { "jsx": "all" }], ecmaFeatures: { jsx: true }},
+        {code: "(<foo>\n    Hello\n</foo>)", options: ["all", { "jsx": "all" }], ecmaFeatures: {jsx: true}},
+        {code: "(<foo>\n    Hello\n</foo>)", options: ["all", { "jsx": "multiline" }], ecmaFeatures: {jsx: true}}
     ],
     invalid: [
         invalid("(0)", "Literal"),
@@ -291,6 +297,12 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("bar ? baz : (class{}).foo();", "ClassExpression", null, {ecmaFeatures: {classes: true}}),
         invalid("bar((class{}).foo(), 0);", "ClassExpression", null, {ecmaFeatures: {classes: true}}),
         invalid("bar[(class{}).foo()];", "ClassExpression", null, {ecmaFeatures: {classes: true}}),
-        invalid("var bar = (class{}).foo();", "ClassExpression", null, {ecmaFeatures: {classes: true}})
+        invalid("var bar = (class{}).foo();", "ClassExpression", null, {ecmaFeatures: {classes: true}}),
+
+        invalid("(<foo />)", "JSXElement", null, {ecmaFeatures: {jsx: true}}),
+        invalid("(<foo>\n    Hello\n</foo>)", "JSXElement", null, {ecmaFeatures: {jsx: true}}),
+        invalid("(<foo />)", "JSXElement", null, {ecmaFeatures: {jsx: true}, options: ["all", {"jsx": "never"}]}),
+        invalid("(<foo>\n    Hello\n</foo>)", "JSXElement", null, {ecmaFeatures: {jsx: true}, options: ["all", {"jsx": "never"}]}),
+        invalid("(<foo />)", "JSXElement", null, {ecmaFeatures: {jsx: true}, options: ["all", {"jsx": "multiline"}]})
     ]
 });


### PR DESCRIPTION
While the options themselves are unchanged from the proposal in #4229, the behavior of the schema in this PR differs slightly from that of the example in the issue thread. The proposed schema would have allowed configuring the JSX exception in conjunction with `"function"` mode, which would never check JSX elements in the first place and could lead to confusion. The schema in this PR only permits configuring the JSX exception when the rule is in `"all"` mode and actually checking JSX elements.

I observed no performance difference of this PR compared to master.