### PR TITLE
Breaking: Implement yield-star-spacing rule (fixes #4115)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -191,6 +191,7 @@
         "vars-on-top": 0,
         "wrap-iife": 0,
         "wrap-regex": 0,
+        "yield-star-spacing": 0,
         "yoda": [0, "never"]
     }
 }

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -227,6 +227,7 @@ These rules are only relevant to ES6 environments.
 * [prefer-spread](prefer-spread.md) - suggest using the spread operator instead of `.apply()`.
 * [prefer-template](prefer-template.md) - suggest using template literals instead of strings concatenation
 * [require-yield](require-yield.md) - disallow generator functions that do not have `yield`
+* [yield-star-spacing](yield-star-spacing.md) - enforce spacing around the `*` in `yield*` expressions (fixable)
 
 
 ## Removed

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -1,0 +1,86 @@
+# Enforce spacing around the `*` in `yield*` expressions (yield-star-spacing)
+
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+
+## Rule Details
+
+This rule enforces spacing around the `*` in `yield*` expressions.
+
+The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`.
+
+* `before` enforces spacing between the `yield` and the `*`.
+  If `true`, a space is required, otherwise spaces are disallowed.
+
+* `after` enforces spacing between the `*` and the argument.
+  If it is `true`, a space is required, otherwise spaces are disallowed.
+
+The default is `{"before": false, "after": true}`.
+
+```json
+"yield-star-spacing": [2, {"before": true, "after": false}]
+```
+
+The option also has a string shorthand:
+
+* `{"before": false, "after": true}` → `"after"`
+* `{"before": true, "after": false}` → `"before"`
+* `{"before": true, "after": true}` → `"both"`
+* `{"before": false, "after": false}` → `"neither"`
+
+```json
+"yield-star-spacing": [2, "after"]
+```
+
+When using `"after"` this spacing will be enforced:
+
+```js
+/*eslint yield-star-spacing: [2, "after"]*/
+/*eslint-env es6*/
+
+function *generator() {
+  yield* other();
+}
+```
+
+When using `"before"` this spacing will be enforced:
+
+```js
+/*eslint yield-star-spacing: [2, "before"]*/
+/*eslint-env es6*/
+
+function *generator() {
+  yield *other();
+}
+```
+
+When using `"both"` this spacing will be enforced:
+
+```js
+/*eslint yield-star-spacing: [2, "both"]*/
+/*eslint-env es6*/
+
+function *generator() {
+  yield * other();
+}
+```
+
+When using `"neither"` this spacing will be enforced:
+
+```js
+/*eslint yield-star-spacing: [2, "neither"]*/
+/*eslint-env es6*/
+
+function *generator() {
+  yield*other();
+}
+```
+
+To use this rule you must set the `generators` flag to `true` in the `ecmaFeatures` configuration object.
+
+## When Not To Use It
+
+If your project will not be using generators or you are not concerned with spacing consistency, you do not need this rule.
+
+## Further Reading
+
+* [Understanding ES6: Generators](https://leanpub.com/understandinges6/read/#leanpub-auto-generators)

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -148,16 +148,11 @@ module.exports = function(context) {
             var tokens = context.getFirstTokens(node, 3),
                 word = "yield";
 
-            if (!node.argument) {
+            if (!node.argument || node.delegate) {
                 return;
             }
 
-            if (node.delegate) {
-                word += "*";
-                checkUnaryWordOperatorForSpaces(node, tokens[1], tokens[2], word);
-            } else {
-                checkUnaryWordOperatorForSpaces(node, tokens[0], tokens[1], word);
-            }
+            checkUnaryWordOperatorForSpaces(node, tokens[0], tokens[1], word);
         }
     };
 

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -1,0 +1,101 @@
+/**
+ * @fileoverview Rule to check the spacing around the * in yield* expressions.
+ * @author Bryan Smith
+ * @copyright 2015 Bryan Smith. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var sourceCode = context.getSourceCode();
+
+    var mode = (function(option) {
+        if (!option || typeof option === "string") {
+            return {
+                before: { before: true, after: false },
+                after: { before: false, after: true },
+                both: { before: true, after: true },
+                neither: { before: false, after: false }
+            }[option || "after"];
+        }
+        return option;
+    }(context.options[0]));
+
+    /**
+     * Checks the spacing between two tokens before or after the star token.
+     * @param {string} side Either "before" or "after".
+     * @param {Token} leftToken `function` keyword token if side is "before", or
+     *     star token if side is "after".
+     * @param {Token} rightToken Star token if side is "before", or identifier
+     *     token if side is "after".
+     * @returns {void}
+     */
+    function checkSpacing(side, leftToken, rightToken) {
+        if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken) !== mode[side]) {
+            var after = leftToken.value === "*";
+            var spaceRequired = mode[side];
+            var node = after ? leftToken : rightToken;
+            var type = spaceRequired ? "Missing" : "Unexpected";
+            var message = type + " space " + side + " *.";
+            context.report({
+                node: node,
+                message: message,
+                fix: function(fixer) {
+                    if (spaceRequired) {
+                        if (after) {
+                            return fixer.insertTextAfter(node, " ");
+                        }
+                        return fixer.insertTextBefore(node, " ");
+                    }
+                    return fixer.removeRange([leftToken.range[1], rightToken.range[0]]);
+                }
+            });
+        }
+    }
+
+    /**
+     * Enforces the spacing around the star if node is a yield* expression.
+     * @param {ASTNode} node A yield expression node.
+     * @returns {void}
+     */
+    function checkExpression(node) {
+        if (!node.delegate) {
+            return;
+        }
+
+        var tokens = sourceCode.getFirstTokens(node, 3);
+        var yieldToken = tokens[0];
+        var starToken = tokens[1];
+        var nextToken = tokens[2];
+
+        checkSpacing("before", yieldToken, starToken);
+        checkSpacing("after", starToken, nextToken);
+    }
+
+    return {
+        "YieldExpression": checkExpression
+    };
+
+};
+
+module.exports.schema = [
+    {
+        "oneOf": [
+            {
+                "enum": ["before", "after", "both", "neither"]
+            },
+            {
+                "type": "object",
+                "properties": {
+                    "before": {"type": "boolean"},
+                    "after": {"type": "boolean"}
+                },
+                "additionalProperties": false
+            }
+        ]
+    }
+];

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -147,6 +147,14 @@ ruleTester.run("space-unary-ops", rule, {
         {
             code: "function *foo() { (yield) * 0 }",
             ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo() { yield*0 }",
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo() { yield *0 }",
+            ecmaFeatures: { generators: true }
         }
     ],
 
@@ -361,28 +369,6 @@ ruleTester.run("space-unary-ops", rule, {
             ecmaFeatures: { generators: true },
             errors: [{
                 message: "Unary word operator \"yield\" must be followed by whitespace.",
-                type: "YieldExpression",
-                line: 1,
-                column: 19
-            }]
-        },
-        {
-            code: "function *foo() { yield*0 }",
-            output: "function *foo() { yield* 0 }",
-            ecmaFeatures: { generators: true },
-            errors: [{
-                message: "Unary word operator \"yield*\" must be followed by whitespace.",
-                type: "YieldExpression",
-                line: 1,
-                column: 19
-            }]
-        },
-        {
-            code: "function *foo() { yield *0 }",
-            output: "function *foo() { yield * 0 }",
-            ecmaFeatures: { generators: true },
-            errors: [{
-                message: "Unary word operator \"yield*\" must be followed by whitespace.",
                 type: "YieldExpression",
                 line: 1,
                 column: 19

--- a/tests/lib/rules/yield-star-spacing.js
+++ b/tests/lib/rules/yield-star-spacing.js
@@ -1,0 +1,325 @@
+/**
+ * @fileoverview Tests for yield-star-spacing rule.
+ * @author Bryan Smith
+ * @copyright 2015 Bryan Smith. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/yield-star-spacing"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("yield-star-spacing", rule, {
+
+    valid: [
+
+        // default (after)
+        {
+            code: "function *foo(){ yield foo; }",
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield* foo; }",
+            ecmaFeatures: { generators: true }
+        },
+
+        // after
+        {
+            code: "function *foo(){ yield foo; }",
+            options: ["after"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield* foo; }",
+            options: ["after"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield* foo(); }",
+            options: ["after"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield* 0 }",
+            options: ["after"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield* []; }",
+            options: ["after"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ var result = yield* foo(); }",
+            options: ["after"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ var result = yield* (foo()); }",
+            options: ["after"],
+            ecmaFeatures: { generators: true }
+        },
+
+        // before
+        {
+            code: "function *foo(){ yield foo; }",
+            options: ["before"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield *foo; }",
+            options: ["before"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield *foo(); }",
+            options: ["before"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield *0 }",
+            options: ["before"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield *[]; }",
+            options: ["before"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ var result = yield *foo(); }",
+            options: ["before"],
+            ecmaFeatures: { generators: true }
+        },
+
+        // both
+        {
+            code: "function *foo(){ yield foo; }",
+            options: ["both"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield * foo; }",
+            options: ["both"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield * foo(); }",
+            options: ["both"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield * 0 }",
+            options: ["both"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield * []; }",
+            options: ["both"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ var result = yield * foo(); }",
+            options: ["both"],
+            ecmaFeatures: { generators: true }
+        },
+
+        // neither
+        {
+            code: "function *foo(){ yield foo; }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield*foo; }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield*foo(); }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield*0 }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ yield*[]; }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true }
+        },
+        {
+            code: "function *foo(){ var result = yield*foo(); }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true }
+        }
+    ],
+
+    invalid: [
+        // default (after)
+        {
+            code: "function *foo(){ yield *foo1; }",
+            output: "function *foo(){ yield* foo1; }",
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Unexpected space before *.",
+                type: "Punctuator"
+            }, {
+                message: "Missing space after *.",
+                type: "Punctuator"
+            }]
+        },
+
+        // after
+        {
+            code: "function *foo(){ yield *foo1; }",
+            output: "function *foo(){ yield* foo1; }",
+            options: ["after"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Unexpected space before *.",
+                type: "Punctuator"
+            }, {
+                message: "Missing space after *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield * foo; }",
+            output: "function *foo(){ yield* foo; }",
+            options: ["after"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Unexpected space before *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield*foo2; }",
+            output: "function *foo(){ yield* foo2; }",
+            options: ["after"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Missing space after *.",
+                type: "Punctuator"
+            }]
+        },
+
+        // before
+        {
+            code: "function *foo(){ yield* foo; }",
+            output: "function *foo(){ yield *foo; }",
+            options: ["before"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Missing space before *.",
+                type: "Punctuator"
+            }, {
+                message: "Unexpected space after *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield * foo; }",
+            output: "function *foo(){ yield *foo; }",
+            options: ["before"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Unexpected space after *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield*foo; }",
+            output: "function *foo(){ yield *foo; }",
+            options: ["before"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Missing space before *.",
+                type: "Punctuator"
+            }]
+        },
+
+        // both
+        {
+            code: "function *foo(){ yield* foo; }",
+            output: "function *foo(){ yield * foo; }",
+            options: ["both"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Missing space before *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield *foo3; }",
+            output: "function *foo(){ yield * foo3; }",
+            options: ["both"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Missing space after *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield*foo4; }",
+            output: "function *foo(){ yield * foo4; }",
+            options: ["both"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Missing space before *.",
+                type: "Punctuator"
+            }, {
+                message: "Missing space after *.",
+                type: "Punctuator"
+            }]
+        },
+
+        // neither
+        {
+            code: "function *foo(){ yield* foo; }",
+            output: "function *foo(){ yield*foo; }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Unexpected space after *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield *foo; }",
+            output: "function *foo(){ yield*foo; }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Unexpected space before *.",
+                type: "Punctuator"
+            }]
+        },
+        {
+            code: "function *foo(){ yield * foo; }",
+            output: "function *foo(){ yield*foo; }",
+            options: ["neither"],
+            ecmaFeatures: { generators: true },
+            errors: [{
+                message: "Unexpected space before *.",
+                type: "Punctuator"
+            }, {
+                message: "Unexpected space after *.",
+                type: "Punctuator"
+            }]
+        }
+    ]
+
+});


### PR DESCRIPTION
This change removes checking of yield* operators from the space-unary-ops rule, and adds a new yield-star-spacing rule to check spacing around the * in yield* expressions.