### PR TITLE
Fix: Revert freezing context object (refs #4495)

### DIFF
--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -72,29 +72,42 @@ var PASSTHROUGHS = [
  * @param {object} ecmaFeatures The ecmaFeatures settings passed from the config file.
  */
 function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) {
-    // public.
-    this.id = ruleId;
-    this.options = options;
-    this.settings = settings;
-    this.ecmaFeatures = ecmaFeatures;
-
-    // private.
-    this.eslint = eslint;
-    this.severity = severity;
-
-    Object.freeze(this);
-}
-
-RuleContext.prototype = {
-    constructor: RuleContext,
 
     /**
-     * Passthrough to eslint.getSourceCode().
-     * @returns {SourceCode} The SourceCode object for the code.
+     * The read-only ID of the rule.
      */
-    getSourceCode: function() {
-        return this.eslint.getSourceCode();
-    },
+    Object.defineProperty(this, "id", {
+        value: ruleId
+    });
+
+    /**
+     * The read-only options of the rule
+     */
+    Object.defineProperty(this, "options", {
+        value: options
+    });
+
+    /**
+     * The read-only settings shared between all rules
+     */
+    Object.defineProperty(this, "settings", {
+        value: settings
+    });
+
+    /**
+     * The read-only ecmaFeatures shared across all rules
+     */
+    Object.defineProperty(this, "ecmaFeatures", {
+        value: Object.create(ecmaFeatures)
+    });
+    Object.freeze(this.ecmaFeatures);
+
+    // copy over passthrough methods
+    PASSTHROUGHS.forEach(function(name) {
+        this[name] = function() {
+            return eslint[name].apply(eslint, arguments);
+        };
+    }, this);
 
     /**
      * Passthrough to eslint.report() that automatically assigns the rule ID and severity.
@@ -106,7 +119,8 @@ RuleContext.prototype = {
      *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    report: function(nodeOrDescriptor, location, message, opts) {
+    this.report = function(nodeOrDescriptor, location, message, opts) {
+
         var descriptor,
             fix = null;
 
@@ -119,37 +133,31 @@ RuleContext.prototype = {
                 fix = descriptor.fix(new RuleFixer());
             }
 
-            this.eslint.report(
-                this.id,
-                this.severity,
-                descriptor.node,
+            eslint.report(
+                ruleId, severity, descriptor.node,
                 descriptor.loc || descriptor.node.loc.start,
-                descriptor.message,
-                descriptor.data,
-                fix
+                descriptor.message, descriptor.data, fix
             );
 
             return;
         }
 
         // old style call
-        this.eslint.report(
-            this.id,
-            this.severity,
-            nodeOrDescriptor,
-            location,
-            message,
-            opts
-        );
-    }
-};
-
-// copy over passthrough methods
-PASSTHROUGHS.forEach(function(name) {
-    // All functions expected to have less arguments than 5.
-    this[name] = function(a, b, c, d, e) {
-        return this.eslint[name](a, b, c, d, e);
+        eslint.report(ruleId, severity, nodeOrDescriptor, location, message, opts);
     };
-}, RuleContext.prototype);
+
+    /**
+     * Passthrough to eslint.getSourceCode().
+     * @returns {SourceCode} The SourceCode object for the code.
+     */
+    this.getSourceCode = function() {
+        return eslint.getSourceCode();
+    };
+
+}
+
+RuleContext.prototype = {
+    constructor: RuleContext
+};
 
 module.exports = RuleContext;


### PR DESCRIPTION
This reverts the perf work in `rule-context.js`. All other perf changes remain.