### PR TITLE
Fix: `no-spaced-func` had been crashed

### DIFF
--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -24,17 +24,21 @@ module.exports = function(context) {
             prevToken = lastCalleeToken,
             parenToken = sourceCode.getTokenAfter(lastCalleeToken);
 
-        if (sourceCode.getLastToken(node).value !== ")") {
-            return;
-        }
-
-        while (parenToken.value !== "(") {
+        // advances to an open parenthesis.
+        while (
+            parenToken &&
+            parenToken.range[1] < node.range[1] &&
+            parenToken.value !== "("
+        ) {
             prevToken = parenToken;
             parenToken = sourceCode.getTokenAfter(parenToken);
         }
 
         // look for a space between the callee and the open paren
-        if (sourceCode.isSpaceBetweenTokens(prevToken, parenToken)) {
+        if (parenToken &&
+            parenToken.range[1] < node.range[1] &&
+            sourceCode.isSpaceBetweenTokens(prevToken, parenToken)
+        ) {
             context.report({
                 node: node,
                 loc: lastCalleeToken.loc.start,

--- a/tests/lib/rules/no-spaced-func.js
+++ b/tests/lib/rules/no-spaced-func.js
@@ -33,7 +33,8 @@ ruleTester.run("no-spaced-func", rule, {
         "( f()() )(0)",
         "(function(){ if (foo) { bar(); } }());",
         "f(0, (1))",
-        "describe/*.only*/('foo', function () {});"
+        "describe/**/('foo', function () {});",
+        "new (foo())"
     ],
     invalid: [
         {


### PR DESCRIPTION
Fixes #4508

If the `callee` is enclosed with parentheses and arguments parentheses
are omitted, `no-spaced-func` had been crashed.