### PR TITLE
Fix: Bugfix for eqeqeq autofix (fixes #4540)

### DIFF
--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -93,7 +93,18 @@ module.exports = function(context) {
                 message: "Expected '{{op}}=' and instead saw '{{op}}'.",
                 data: { op: node.operator },
                 fix: function(fixer) {
-                    return fixer.replaceText(sourceCode.getTokenAfter(node.left), replacements[node.operator]);
+                    var tokens = sourceCode.getTokensBetween(node.left, node.right),
+                        opToken,
+                        i;
+
+                    for (i = 0; i < tokens.length; ++i) {
+                        if (tokens[i].value === node.operator) {
+                            opToken = tokens[i];
+                            break;
+                        }
+                    }
+
+                    return fixer.replaceTextRange(opToken.range, replacements[node.operator]);
                 }
             });
 

--- a/tests/lib/rules/eqeqeq.js
+++ b/tests/lib/rules/eqeqeq.js
@@ -51,6 +51,14 @@ ruleTester.run("eqeqeq", rule, {
         { code: "'hello' != 'world'", output: "'hello' !== 'world'", options: ["allow-null"], errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression"}] },
         { code: "2 == 3", output: "2 === 3", options: ["allow-null"], errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
         { code: "true == true", output: "true === true", options: ["allow-null"], errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression"}] },
-        { code: "a\n==\nb", output: "a\n===\nb", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 2 }] }
+        { code: "a\n==\nb", output: "a\n===\nb", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 2 }] },
+        { code: "(a) == b", output: "(a) === b", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 1 }] },
+        { code: "(a) != b", output: "(a) !== b", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression", line: 1 }] },
+        { code: "a == (b)", output: "a === (b)", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 1 }] },
+        { code: "a != (b)", output: "a !== (b)", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression", line: 1 }] },
+        { code: "(a) == (b)", output: "(a) === (b)", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 1 }] },
+        { code: "(a) != (b)", output: "(a) !== (b)", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression", line: 1 }] },
+        { code: "(a == b) == (c)", output: "(a === b) === (c)", errors: [{ message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 1 }, { message: "Expected '===' and instead saw '=='.", type: "BinaryExpression", line: 1 }] },
+        { code: "(a != b) != (c)", output: "(a !== b) !== (c)", errors: [{ message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression", line: 1 }, { message: "Expected '!==' and instead saw '!='.", type: "BinaryExpression", line: 1 }] }
     ]
 });


### PR DESCRIPTION
Finding range for ==/!= instead of assuming it is next token

Fixes #4540.

I'm open to feedback on whether there might be a simpler way for me to do what I'm doing. I found a way to get a good token array, but if SourceCode or token-store have other tricks I can do to make this even simpler, I would love to hear about it.