### PR TITLE
Fix: Adding options unit tests for --ignore-pattern (refs #4507)

### DIFF
--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -145,6 +145,23 @@ describe("options", function() {
         });
     });
 
+    describe("--ignore-pattern", function() {
+        it("should return a string array for .ignorePattern when passed", function() {
+            var currentOptions = options.parse("--ignore-pattern *.js");
+            assert.ok(currentOptions.ignorePattern);
+            assert.equal(currentOptions.ignorePattern.length, 1);
+            assert.equal(currentOptions.ignorePattern[0], "*.js");
+        });
+
+        it("should return a string array for multiple values", function() {
+            var currentOptions = options.parse("--ignore-pattern *.js --ignore-pattern *.ts");
+            assert.ok(currentOptions.ignorePattern);
+            assert.equal(currentOptions.ignorePattern.length, 2);
+            assert.equal(currentOptions.ignorePattern[0], "*.js");
+            assert.equal(currentOptions.ignorePattern[1], "*.ts");
+        });
+    });
+
     describe("--color", function() {
         it("should return true for .color when passed", function() {
             var currentOptions = options.parse("--color");


### PR DESCRIPTION
Refs #4507.

This won't fix the issue, but it does add a few unit tests for known working cases. I hope that any fix we or optionator will do to fix the issue will be accompanied by appropriate unit test cases similar to these ones. Kind of unfortunate that nobody caught the lack of unit tests when we made the type change, but oh well.