### PR TITLE
Introduce third option "no-paren" to space-after-keywords

### DIFF
--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -23,7 +23,8 @@ if(condition) {
 This rule will enforce consistency of spacing after the keywords `if`, `else`, `for`, `while`, `do`, `switch`, `try`, `catch`, `finally`, and `with`.
 
 This rule takes one argument. If it is `"always"` then the keywords must be followed by at least one space. If `"never"`
-then there should be no spaces following. The default is `"always"`.
+then there should be no spaces following. If `"no-parens"` then keywords must be followed by at least one space if they 
+are not followed by a parenthese. The default is `"always"`.
 
 The following patterns are considered problems:
 
@@ -57,4 +58,14 @@ if (a) {} else {}
 /*eslint space-after-keywords: [2, "never"]*/
 
 if(a) {}
+```
+
+```js
+/*eslint space-after-keywords: [2, "no-paren"]*/
+
+if(a) {}
+
+if(a) {} else {}
+
+try {} catch(e) {}
 ```

--- a/lib/rules/space-before-keywords.js
+++ b/lib/rules/space-before-keywords.js
@@ -1,214 +1,116 @@
 /**
- * @fileoverview Require or disallow spaces before keywords
- * @author Marko Raatikka
- * @copyright 2015 Marko Raatikka. All rights reserved.
- * See LICENSE file in root directory for full license.
+ * @fileoverview Rule to enforce the number of spaces after certain keywords
+ * @author Nick Fisher
+ * @copyright 2014 Nick Fisher. All rights reserved.
  */
 "use strict";
-
-var astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
-var ERROR_MSG_SPACE_EXPECTED = "Missing space before keyword \"{{keyword}}\".";
-var ERROR_MSG_NO_SPACE_EXPECTED = "Unexpected space before keyword \"{{keyword}}\".";
-
 module.exports = function(context) {
 
-    var sourceCode = context.getSourceCode();
-
-    var SPACE_REQUIRED = context.options[0] !== "never";
-
-    //--------------------------------------------------------------------------
-    // Helpers
-    //--------------------------------------------------------------------------
+    // unless the first option is `"never"`, then a space is required
+    var requiresSpaceAlways = context.options[0] === "always";
+    var requiresSpaceNever = context.options[0] === "never";
 
     /**
-     * Report the error message
-     * @param {ASTNode} node node to report
-     * @param {string} message Error message to be displayed
-     * @param {object} data Data object for the rule message
+     * Check if the separation of two adjacent tokens meets the spacing rules, and report a problem if not.
+     *
+     * @param {ASTNode} node  The node to which the potential problem belongs.
+     * @param {Token} left    The first token.
+     * @param {Token} right   The second token
      * @returns {void}
      */
-    function report(node, message, data) {
-        context.report({
-            node: node,
-            message: message,
-            data: data,
-            fix: function(fixer) {
-                if (SPACE_REQUIRED) {
-                    return fixer.insertTextBefore(node, " ");
-                } else {
-                    var tokenBefore = context.getTokenBefore(node);
-                    return fixer.removeRange([tokenBefore.range[1], node.range[0]]);
+    function checkTokens(node, left, right) {
+        if (right.type !== "Punctuator") {
+            return;
+        }
+
+        var hasSpace = left.range[1] < right.range[0],
+            value = left.value,
+            requiresSpace = requiresSpaceAlways || (!requiresSpaceNever && right.value !== "(");
+
+        if (hasSpace !== requiresSpace) {
+            context.report({
+                node: node,
+                loc: left.loc.end,
+                message: "Keyword \"{{value}}\" must {{not}}be followed by whitespace.",
+                data: {
+                    value: value,
+                    not: requiresSpace ? "" : "not "
+                },
+                fix: function(fixer) {
+                    if (requiresSpace) {
+                        return fixer.insertTextAfter(left, " ");
+                    } else {
+                        return fixer.removeRange([left.range[1], right.range[0]]);
+                    }
                 }
-            }
-        });
+            });
+        } else if (left.loc.end.line !== right.loc.start.line) {
+            context.report({
+                node: node,
+                loc: left.loc.end,
+                message: "Keyword \"{{value}}\" must not be followed by a newline.",
+                data: {
+                    value: value
+                },
+                fix: function(fixer) {
+                    var text = "";
+                    if (requiresSpace) {
+                        text = " ";
+                    }
+                    return fixer.replaceTextRange([left.range[1], right.range[0]], text);
+                }
+            });
+        }
     }
 
     /**
-     * Check if a token meets the criteria
-     *
-     * @param   {ASTNode} node    The node to check
-     * @param   {Object}  left    The left-hand side token of the node
-     * @param   {Object}  right   The right-hand side token of the node
-     * @param   {Object}  options See check()
+     * Check if the given node (`if`, `for`, `while`, etc), has the correct spacing after it.
+     * @param {ASTNode} node The node to check.
      * @returns {void}
      */
-    function checkTokens(node, left, right, options) {
-
-        if (!left) {
-            return;
-        }
-
-        if (left.type === "Keyword") {
-            return;
-        }
-
-        if (!SPACE_REQUIRED && typeof options.requireSpace === "undefined") {
-            return;
-        }
-
-        options = options || {};
-        options.allowedPrecedingChars = options.allowedPrecedingChars || [ "{" ];
-        options.requireSpace = typeof options.requireSpace === "undefined" ? SPACE_REQUIRED : options.requireSpace;
-
-        var hasSpace = sourceCode.isSpaceBetweenTokens(left, right);
-        var spaceOk = hasSpace === options.requireSpace;
-
-        if (spaceOk) {
-            return;
-        }
-
-        if (!astUtils.isTokenOnSameLine(left, right)) {
-            if (!options.requireSpace) {
-                report(node, ERROR_MSG_NO_SPACE_EXPECTED, { keyword: right.value });
-            }
-            return;
-        }
-
-        if (!options.requireSpace) {
-            report(node, ERROR_MSG_NO_SPACE_EXPECTED, { keyword: right.value });
-            return;
-        }
-
-        if (options.allowedPrecedingChars.indexOf(left.value) !== -1) {
-            return;
-        }
-
-        report(node, ERROR_MSG_SPACE_EXPECTED, { keyword: right.value });
-
+    function check(node) {
+        var tokens = context.getFirstTokens(node, 2);
+        checkTokens(node, tokens[0], tokens[1]);
     }
-
-    /**
-     * Get right and left tokens of a node and check to see if they meet the given criteria
-     *
-     * @param   {ASTNode}  node                          The node to check
-     * @param   {Object}   options                       Options to validate the node against
-     * @param   {Array}    options.allowedPrecedingChars Characters that can precede the right token
-     * @param   {Boolean}  options.requireSpace          Whether or not the right token needs to be
-     *                                                   preceded by a space
-     * @returns {void}
-     */
-    function check(node, options) {
-
-        options = options || {};
-
-        var left = context.getTokenBefore(node);
-        var right = context.getFirstToken(node);
-
-        checkTokens(node, left, right, options);
-
-    }
-
-    //--------------------------------------------------------------------------
-    // Public
-    //--------------------------------------------------------------------------
 
     return {
-
         "IfStatement": function(node) {
-            // if
             check(node);
-            // else
-            if (node.alternate) {
-                var tokens = context.getTokensBefore(node.alternate, 2);
-                if (tokens[0].value === "}") {
-                    check(tokens[1], { requireSpace: SPACE_REQUIRED });
-                }
+            // check the `else`
+            if (node.alternate && node.alternate.type !== "IfStatement") {
+                checkTokens(node.alternate, context.getTokenBefore(node.alternate), context.getFirstToken(node.alternate));
             }
         },
         "ForStatement": check,
+        "ForOfStatement": check,
         "ForInStatement": check,
         "WhileStatement": check,
         "DoWhileStatement": function(node) {
-            var whileNode = context.getTokenAfter(node.body);
-            // do
             check(node);
-            // while
-            check(whileNode, { requireSpace: SPACE_REQUIRED });
+            // check the `while`
+            var whileTokens = context.getTokensAfter(node.body, 2);
+            checkTokens(node, whileTokens[0], whileTokens[1]);
         },
-        "SwitchStatement": function(node) {
-            // switch
-            check(node);
-            // case/default
-            node.cases.forEach(function(caseNode) {
-                check(caseNode);
-            });
-        },
-        "ThrowStatement": check,
+        "SwitchStatement": check,
         "TryStatement": function(node) {
-            // try
             check(node);
-            // finally
+            // check the `finally`
             if (node.finalizer) {
-                check(context.getTokenBefore(node.finalizer), { requireSpace: SPACE_REQUIRED });
+                checkTokens(node.finalizer, context.getTokenBefore(node.finalizer), context.getFirstToken(node.finalizer));
             }
         },
-        "CatchClause": function(node) {
-            check(node, { requireSpace: SPACE_REQUIRED });
-        },
-        "WithStatement": check,
-        "VariableDeclaration": function(node) {
-            check(node, { allowedPrecedingChars: [ "(", "{" ] });
-        },
-        "ReturnStatement": check,
-        "BreakStatement": check,
-        "LabeledStatement": check,
-        "ContinueStatement": check,
-        "FunctionDeclaration": check,
-        "FunctionExpression": function(node) {
-            var left = context.getTokenBefore(node);
-            var right = context.getFirstToken(node);
-
-            // If it's a method, a getter, or a setter, the first token is not the `function` keyword.
-            if (right.type !== "Keyword") {
-                return;
-            }
-
-            checkTokens(node, left, right, { allowedPrecedingChars: [ "(", "{" ] });
-        },
-        "YieldExpression": function(node) {
-            check(node, { allowedPrecedingChars: [ "(", "{" ] });
-        },
-        "ForOfStatement": check,
-        "ClassBody": function(node) {
-
-            // Find the 'class' token
-            while (node.value !== "class") {
-                node = context.getTokenBefore(node);
-            }
-
-            check(node);
-        }
+        "CatchClause": check,
+        "WithStatement": check
     };
-
 };
 
 module.exports.schema = [
     {
-        "enum": ["always", "never"]
+        "enum": ["always", "never", "no-paren"]
     }
 ];

--- a/tests/lib/rules/space-after-keywords.js
+++ b/tests/lib/rules/space-after-keywords.js
@@ -17,6 +17,7 @@ var ruleTester = new RuleTester();
 ruleTester.run("space-after-keywords", rule, {
     valid: [
         { code: "switch (a){ default: break; }", args: [1] },
+        { code: "switch(a){ default: break; }", args: ["no-paren"] },
         { code: "if (a) {}", args: [1] },
         { code: "if (a) {} else {}", args: [1] },
         { code: "for (;;){}", args: [1] },
@@ -32,6 +33,7 @@ ruleTester.run("space-after-keywords", rule, {
         { code: "with (a) {}", args: [1]},
         { code: "if(a) {}", options: ["never"]},
         { code: "if(a){}else{}", options: ["never"]},
+        { code: "if(a){} else {}", options: ["no-paren"]},
         { code: "if(a){}else if(b){}else{}", options: ["never"]},
         { code: "if (a) {} else\nfoo();", options: ["always"]},
         { code: "if(a) {} else\nfoo();", options: ["never"]},
@@ -41,6 +43,7 @@ ruleTester.run("space-after-keywords", rule, {
         { code: "try {}catch (e) {}", args: [1]},
         { code: "try{} finally{}", options: ["never"]},
         { code: "try{} catch(e) {}", options: ["never"]},
+        { code: "try {} catch(e) {}", options: ["no-paren"]},
         { code: "(function(){})", args: [1] },
         { code: "(function(){})", args: [1] }
     ],
@@ -108,10 +111,22 @@ ruleTester.run("space-after-keywords", rule, {
             output: "if(a) {}"
         },
         {
+            code: "if (a) {}",
+            options: ["no-paren"],
+            errors: [{ message: "Keyword \"if\" must not be followed by whitespace.", type: "IfStatement" }],
+            output: "if(a) {}"
+        },
+        {
             code: "if(a){}else {}",
             options: ["never"],
             errors: [{ message: "Keyword \"else\" must not be followed by whitespace." }],
             output: "if(a){}else{}"
+        },
+        {
+            code: "if (a){}else {}",
+            options: ["no-paren"],
+            errors: [{ message: "Keyword \"if\" must not be followed by whitespace." }],
+            output: "if(a){}else {}"
         },
         {
             code: "if(a){}else if(b){}else {}",
@@ -125,7 +140,19 @@ ruleTester.run("space-after-keywords", rule, {
             output: "try {}finally {}"
         },
         {
+            code: "try{}finally {}",
+            options: ["no-paren"],
+            errors: [{ message: "Keyword \"try\" must be followed by whitespace." }],
+            output: "try {}finally {}"
+        },
+        {
             code: "try {}finally{}",
+            errors: [{ message: "Keyword \"finally\" must be followed by whitespace." }],
+            output: "try {}finally {}"
+        },
+        {
+            code: "try {}finally{}",
+            options: ["no-paren"],
             errors: [{ message: "Keyword \"finally\" must be followed by whitespace." }],
             output: "try {}finally {}"
         },


### PR DESCRIPTION
A common style for spaces after keywords is to only require them if the keyword is not followed by a parenthese. This change introduces a "no-paren" options to space-after-keywords.