### PR TITLE
Fix: Add for-of to `curly` rule (fixes #4571)

### DIFF
--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -251,9 +251,12 @@ module.exports = function(context) {
 
         "ForInStatement": function(node) {
             prepareCheck(node, node.body, "for-in").check();
+        },
+
+        "ForOfStatement": function(node) {
+            prepareCheck(node, node.body, "for-of").check();
         }
     };
-
 };
 
 module.exports.schema = {

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -26,6 +26,10 @@ ruleTester.run("curly", rule, {
         "for (;foo;) { bar() }",
         "for (var foo in bar) { console.log(foo) }",
         {
+            code: "for (var foo of bar) { console.log(foo) }",
+            ecmaFeatures: { forOf: true }
+        },
+        {
             code: "for (;foo;) bar()",
             options: ["multi"]
         },
@@ -44,6 +48,16 @@ ruleTester.run("curly", rule, {
         {
             code: "for (var foo in bar) { console.log(1); console.log(2) }",
             options: ["multi"]
+        },
+        {
+            code: "for (var foo of bar) console.log(foo)",
+            options: ["multi"],
+            ecmaFeatures: { forOf: true }
+        },
+        {
+            code: "for (var foo of bar) { console.log(1); console.log(2) }",
+            options: ["multi"],
+            ecmaFeatures: { forOf: true }
         },
         {
             code: "if (foo) bar()",
@@ -80,6 +94,16 @@ ruleTester.run("curly", rule, {
         {
             code: "for (var foo in bar) { \n console.log(1); \n console.log(2); \n }",
             options: ["multi-line"]
+        },
+        {
+            code: "for (var foo of bar) console.log(foo)",
+            options: ["multi-line"],
+            ecmaFeatures: { forOf: true }
+        },
+        {
+            code: "for (var foo of bar) { \n console.log(1); \n console.log(2); \n }",
+            options: ["multi-line"],
+            ecmaFeatures: { forOf: true }
         },
         {
             code: "if (foo) { \n bar(); \n baz(); \n }",
@@ -121,6 +145,16 @@ ruleTester.run("curly", rule, {
             code: "for (var foo in bar) { \n if (foo) console.log(1); \n else console.log(2) \n }",
             options: ["multi-or-nest"]
         },
+        {
+            code: "for (var foo of bar) \n console.log(foo)",
+            options: ["multi-or-nest"],
+            ecmaFeatures: { forOf: true }
+        },
+        {
+            code: "for (var foo of bar) { \n if (foo) console.log(1); \n else console.log(2) \n }",
+            options: ["multi-or-nest"],
+            ecmaFeatures: { forOf: true }
+        },
 
         // https://github.com/eslint/eslint/issues/3856
         {
@@ -151,7 +185,6 @@ ruleTester.run("curly", rule, {
             code: "if (true) foo(); else { bar(); baz(); }",
             options: ["multi"]
         },
-
         {
             code: "if (true) { foo(); } else { bar(); baz(); }",
             options: ["multi", "consistent"]
@@ -226,6 +259,16 @@ ruleTester.run("curly", rule, {
                 {
                     message: "Expected { after 'for-in'.",
                     type: "ForInStatement"
+                }
+            ]
+        },
+        {
+            code: "for (var foo of bar) console.log(foo)",
+            ecmaFeatures: { forOf: true },
+            errors: [
+                {
+                    message: "Expected { after 'for-of'.",
+                    type: "ForOfStatement"
                 }
             ]
         },
@@ -324,6 +367,17 @@ ruleTester.run("curly", rule, {
             ]
         },
         {
+            code: "for (var foo of bar) { console.log(foo) }",
+            options: ["multi"],
+            ecmaFeatures: { forOf: true },
+            errors: [
+                {
+                    message: "Unnecessary { after 'for-of'.",
+                    type: "ForOfStatement"
+                }
+            ]
+        },
+        {
             code: "if (foo) \n baz()",
             options: ["multi-line"],
             errors: [
@@ -403,7 +457,28 @@ ruleTester.run("curly", rule, {
                 }
             ]
         },
-
+        {
+            code: "for (var foo of bar) \n console.log(foo)",
+            options: ["multi-line"],
+            ecmaFeatures: { forOf: true },
+            errors: [
+                {
+                    message: "Expected { after 'for-of'.",
+                    type: "ForOfStatement"
+                }
+            ]
+        },
+        {
+            code: "for (var foo of bar) \n console.log(1); \n console.log(2)",
+            options: ["multi-line"],
+            ecmaFeatures: { forOf: true },
+            errors: [
+                {
+                    message: "Expected { after 'for-of'.",
+                    type: "ForOfStatement"
+                }
+            ]
+        },
         {
             code: "if (foo) \n quz = { \n bar: baz, \n qux: foo \n };",
             options: ["multi-or-nest"],
@@ -471,6 +546,28 @@ ruleTester.run("curly", rule, {
                 {
                     message: "Unnecessary { after 'for-in'.",
                     type: "ForInStatement"
+                }
+            ]
+        },
+        {
+            code: "for (var foo of bar) \n if (foo) console.log(1); \n else console.log(2);",
+            options: ["multi-or-nest"],
+            ecmaFeatures: { forOf: true },
+            errors: [
+                {
+                    message: "Expected { after 'for-of'.",
+                    type: "ForOfStatement"
+                }
+            ]
+        },
+        {
+            code: "for (var foo of bar) { if (foo) console.log(1) }",
+            options: ["multi-or-nest"],
+            ecmaFeatures: { forOf: true },
+            errors: [
+                {
+                    message: "Unnecessary { after 'for-of'.",
+                    type: "ForOfStatement"
                 }
             ]
         },


### PR DESCRIPTION
Wanted to also include for-of, having done the work to add for-in to the `curly` rule.