### PR TITLE
Docs: Add Code of Conduct (fixes #3095)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,64 @@
+# Code of Conduct
+
+Like the technical community as a whole, the various ESLint teams and communities are made up of a mixture of professionals and volunteers from all over the world, working on every aspect of the mission - including mentorship, teaching, and connecting people.
+
+Diversity is one of our huge strengths, but it can also lead to communication issues and unhappiness. To that end, we have a few ground rules that we ask people to adhere to. This code applies equally to founders, mentors and those seeking help and guidance.
+
+This isn't an exhaustive list of things that you can’t do. Rather, take it in the spirit in which it's intended - a guide to make it easier to enrich all of us and the technical communities in which we participate.
+
+* **Be friendly and patient.** We understand that we all have different levels of experience or knowledge in many diverse fields, be it technical or nontechnical in nature. We also have areas of knowledge we are eager to expand, and we want to be a community where people can not only contribute, but feel comfortable to ask questions as well and learn along the way. If someone is wrong, or says something accidentally offensive, respond with patience and try to keep it polite and civil. Remember that we all were newbies at one point.
+
+* **Be welcoming.** We strive to be a community that welcomes and supports people of all backgrounds and identities. This includes, but is not limited to, members of any race, ethnicity, culture, national origin, color, immigration status, social and economic class, educational level, sex, sexual orientation, gender identity and expression, age, size, family status, political belief, religion, and mental and physical ability.
+
+* **Be considerate.** Your work will be used by other people, and you in turn will depend on the work of others. Any decision you make will affect users and colleagues, and you should take those consequences into account when making decisions. Remember that we're a world-wide community, so you might not be communicating in someone else's primary language.
+
+* **Be respectful.** Not all of us will agree all the time, but disagreement is no excuse for poor behavior and poor manners. We might all experience some frustration now and then, but we cannot allow that frustration to turn into a personal attack. It's important to remember that a community where people feel uncomfortable or threatened is not a productive one. Members of the ESLint community should be respectful when dealing with other members as well as with people outside the ESLint community.
+
+* **Be careful in the words that you choose.** We are a community of professionals, and we conduct ourselves professionally. Be kind to others. Do not insult or put down other participants. Harassment and other exclusionary behavior aren't acceptable. This includes, but is not limited to:
+
+    * Violent threats or language directed against another person.
+    * Discriminatory jokes and language.
+    * Posting sexually explicit or violent material.
+    * Posting (or threatening to post) other people's personally identifying information ("doxing").
+    * Personal insults, especially those using racist or sexist terms.
+    * Unwelcome sexual attention.
+    * Advocating for, or encouraging, any of the above behavior.
+    * Repeated harassment of others. In general, if someone asks you to stop, then stop.
+
+* **When we disagree, try to understand why.** Disagreements, both social and technical, happen all the time and ESLint is no exception. It is important that we resolve disagreements and differing views constructively. Remember that we're different. The strength of the ESLint community comes from inclusion of people from a wide range of backgrounds. Different people have different perspectives on issues. Being unable to understand why someone holds a viewpoint doesn't mean that they're wrong. Don't forget that it is human to err and blaming each other doesn't get us anywhere. Instead, focus on helping to resolve issues and learning from mistakes.
+
+
+## Reporting Guidelines
+
+**Important:** If you believe anyone is in physical danger, please notify appropriate law enforcement first. Then report to us.
+
+If you believe someone is violating the code of conduct we ask that you report it to [eslint-conduct@googlegroups.com](mailto:eslint-conduct@googlegroups.com). This is a private mailing list only viewable by project leads and cannot be accessed publicly except to send emails. All reports will be kept confidential. In some cases we may determine that a public statement will need to be made. If that's the case, the identities of all victims and reporters will remain confidential unless those individuals instruct us otherwise.
+
+In your report please include:
+
+* Your contact info (so we can get in touch with you if we need to follow up).
+* Names (real, nicknames, or pseudonyms) of any individuals involved. If there were other witnesses besides you, please try to include them as well.
+* When and where the incident occurred. Please be as specific as possible.
+* Your account of what occurred. If there is a publicly available record (e.g. a mailing list archive or a public IRC logger) please include a link. Screenshots can be useful in the case something is edited or deleted before action is taken.
+* Any extra context you believe existed for the incident.
+* If you believe this incident is ongoing.
+* Any other information you believe we should have.
+
+### What happens after you file a report?
+
+Reports will receive urgent and immediate attention from the project leads. If the act is ongoing, any team member may act immediately to end the situation without reaching consensus. If the act involves physical danger, then any team member should act immediately to protect safety (this can include contacting law enforcement directly). Any such actions must be reported to the project leads within 24 hours.
+
+Possible responses to violation reports include:
+
+* Taking no action (if there was no violation)
+* Private reprimand over email
+* A public reprimand in the forum in which the violation occurred (mailing list, issue tracker, chatroom, etc.)
+* Requesting the violator to voluntarily take time away from the project (this may be enforced if the violator does not agree)
+* Requesting a public or private apology
+* Permanent or temporary suspension of privileges in the project (including blocking chatroom, mailing list, GitHub, issues, etc.)
+
+Once a response has been determined, the original reporter will be contacted for feedback about the response. The feedback will be considered when finalizing the response.
+
+## Credits
+
+Original text courtesy of the [Speak Up! project](http://speakup.io/coc.html) and [Django Project](https://www.djangoproject.com/conduct/), and [jQuery Code of Conduct](https://jquery.org/conduct/).


### PR DESCRIPTION
This is based largely on the jQuery Code of Conduct, which some changes made to make it more appropriate for ESLint. As we don't have the strength of a foundation behind us, we aren't able to do some things, but I think the overall message here is clear.