### PR TITLE
Breaking: Freeze context object (fixes #4495)

### DIFF
--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -72,42 +72,29 @@ var PASSTHROUGHS = [
  * @param {object} ecmaFeatures The ecmaFeatures settings passed from the config file.
  */
 function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) {
+    // public.
+    this.id = ruleId;
+    this.options = options;
+    this.settings = settings;
+    this.ecmaFeatures = ecmaFeatures;
+
+    // private.
+    this.eslint = eslint;
+    this.severity = severity;
+
+    Object.freeze(this);
+}
+
+RuleContext.prototype = {
+    constructor: RuleContext,
 
     /**
-     * The read-only ID of the rule.
+     * Passthrough to eslint.getSourceCode().
+     * @returns {SourceCode} The SourceCode object for the code.
      */
-    Object.defineProperty(this, "id", {
-        value: ruleId
-    });
-
-    /**
-     * The read-only options of the rule
-     */
-    Object.defineProperty(this, "options", {
-        value: options
-    });
-
-    /**
-     * The read-only settings shared between all rules
-     */
-    Object.defineProperty(this, "settings", {
-        value: settings
-    });
-
-    /**
-     * The read-only ecmaFeatures shared across all rules
-     */
-    Object.defineProperty(this, "ecmaFeatures", {
-        value: Object.create(ecmaFeatures)
-    });
-    Object.freeze(this.ecmaFeatures);
-
-    // copy over passthrough methods
-    PASSTHROUGHS.forEach(function(name) {
-        this[name] = function() {
-            return eslint[name].apply(eslint, arguments);
-        };
-    }, this);
+    getSourceCode: function() {
+        return this.eslint.getSourceCode();
+    },
 
     /**
      * Passthrough to eslint.report() that automatically assigns the rule ID and severity.
@@ -119,8 +106,7 @@ function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) 
      *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    this.report = function(nodeOrDescriptor, location, message, opts) {
-
+    report: function(nodeOrDescriptor, location, message, opts) {
         var descriptor,
             fix = null;
 
@@ -133,31 +119,37 @@ function RuleContext(ruleId, eslint, severity, options, settings, ecmaFeatures) 
                 fix = descriptor.fix(new RuleFixer());
             }
 
-            eslint.report(
-                ruleId, severity, descriptor.node,
+            this.eslint.report(
+                this.id,
+                this.severity,
+                descriptor.node,
                 descriptor.loc || descriptor.node.loc.start,
-                descriptor.message, descriptor.data, fix
+                descriptor.message,
+                descriptor.data,
+                fix
             );
 
             return;
         }
 
         // old style call
-        eslint.report(ruleId, severity, nodeOrDescriptor, location, message, opts);
-    };
-
-    /**
-     * Passthrough to eslint.getSourceCode().
-     * @returns {SourceCode} The SourceCode object for the code.
-     */
-    this.getSourceCode = function() {
-        return eslint.getSourceCode();
-    };
-
-}
-
-RuleContext.prototype = {
-    constructor: RuleContext
+        this.eslint.report(
+            this.id,
+            this.severity,
+            nodeOrDescriptor,
+            location,
+            message,
+            opts
+        );
+    }
 };
+
+// copy over passthrough methods
+PASSTHROUGHS.forEach(function(name) {
+    // All functions expected to have less arguments than 5.
+    this[name] = function(a, b, c, d, e) {
+        return this.eslint[name](a, b, c, d, e);
+    };
+}, RuleContext.prototype);
 
 module.exports = RuleContext;


### PR DESCRIPTION
This reverts commit bec6c9b0e2edca5f5bc99a7abc13b6f62a9a5411, which froze the context object and broke `eslint-plugin-react`. This is a performance enhancement plus security measure.