### PR TITLE
Breaking: added bower_components to default ignore (fixes #3550)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -1,4 +1,4 @@
-# Command line Interface
+# Command Line Interface
 
 To run ESLint on Node.js, you must have npm installed. If npm is not installed, follow the instructions here: https://www.npmjs.com/
 
@@ -362,3 +362,5 @@ ESLint supports `.eslintignore` files to exclude files from the linting process 
 
     node_modules/*
     **/vendor/*.js
+
+A more detailed breakdown of supported patterns and directories ESLint ignores by default can be found in [Configuring ESLint](http://eslint.org/docs/user-guide/configuring#ignoring-files-and-directories).

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -574,12 +574,12 @@ Globs are matched using [minimatch](https://github.com/isaacs/minimatch), so a n
 * Lines preceded by `!` are negated patterns that re-include a pattern that was ignored by an earlier pattern.
 * Brace expansion can refer to multiple files in a pattern. For example, `file.{js,ts,coffee}` will ignore `file.js`, `file.ts`, and `file.coffee`.
 
-In addition to any patterns in a `.eslintignore` file, ESLint always ignores files in `node_modules/**`.
+In addition to any patterns in a `.eslintignore` file, ESLint always ignores files in `node_modules/**` and `bower_components/**`.
 
-For example, placing the following `.eslintignore` file in the current working directory will ignore all of `node_modules`, any files with the extensions `.ts.js` or `.coffee.js` extension that might have been transpiled, and anything in the `build/` directory except `build/index.js`:
+For example, placing the following `.eslintignore` file in the current working directory will ignore all of `node_modules`, `bower_components`, any files with the extensions `.ts.js` or `.coffee.js` extension that might have been transpiled, and anything in the `build/` directory except `build/index.js`:
 
 ```text
-# node_modules ignored by default
+# node_modules and bower_components ignored by default
 
 # Ignore files compiled from TypeScript and CoffeeScript
 **/*.{ts,coffee}.js

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -54,7 +54,7 @@ function loadIgnoreFile(filepath) {
         }
     }
 
-    return ["node_modules/**"].concat(ignorePatterns);
+    return ["node_modules/**", "bower_components/**"].concat(ignorePatterns);
 }
 
 var ignoreFileFinder;

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -34,6 +34,7 @@ describe("IgnoredPaths", function() {
                 ignoredPaths = IgnoredPaths.load({ ignore: true });
                 assert.ok(ignoredPaths.patterns.length > 1);
                 assert.equal(ignoredPaths.patterns[0], "node_modules/**");
+                assert.equal(ignoredPaths.patterns[1], "bower_components/**");
             } finally {
                 process.chdir(cwd);
             }
@@ -126,9 +127,19 @@ describe("IgnoredPaths", function() {
             assert.ok(ignoredPaths.contains("node_modules/mocha/bin/mocha"));
         });
 
+        it("should always ignore files in bower_components", function() {
+            var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
+            assert.ok(ignoredPaths.contains("bower_components/mocha/bin/mocha"));
+        });
+
         it("should not ignore files in node_modules in a subdirectory", function() {
             var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
             assert.notOk(ignoredPaths.contains("subdir/node_modules/test.js"));
+        });
+
+        it("should not ignore files in bower_components in a subdirectory", function() {
+            var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
+            assert.notOk(ignoredPaths.contains("subdir/bower_components/test.js"));
         });
 
         it("should return false for file not matching any ignore pattern", function() {
@@ -144,7 +155,7 @@ describe("IgnoredPaths", function() {
 
         it("should ignore comments", function() {
             var ignoredPaths = IgnoredPaths.load({ ignore: true, ignorePath: filepath });
-            assert.equal(ignoredPaths.patterns.length, 2);
+            assert.equal(ignoredPaths.patterns.length, 3);
         });
 
     });


### PR DESCRIPTION
Pretty self-explanatory, extends the built-in ignore to include `bower_components/` . Docs & unit tests updated. Had to resubmit the PR as I had accidentally deleted my fork.

Original PR discussion can be found in #3552