### PR TITLE
Docs: no-extra-semi no longer refers to deprecated rule (fixes #4598)

### DIFF
--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -41,4 +41,4 @@ If you intentionally use extra semicolons then you can disable this rule.
 ## Related Rules
 
 * [semi](semi.md)
-* [no-space-before-semi](no-space-before-semi.md)
+* [semi-spacing](semi-spacing.md)


### PR DESCRIPTION
Fixes #4598.