### PR TITLE
Build: Consume no-underscore-dangle allowAfterThis option (fixes #4599)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -403,10 +403,10 @@ function CLIEngine(options) {
      * execution (e.g. file passed with no errors and no warnings
      * @type {Object}
      */
-    this._fileCache = fileEntryCache.create(cacheFile); // eslint-disable-line no-underscore-dangle
+    this._fileCache = fileEntryCache.create(cacheFile);
 
     if (!this.options.cache) {
-        this._fileCache.destroy(); // eslint-disable-line no-underscore-dangle
+        this._fileCache.destroy();
     }
 
     // load in additional rules
@@ -532,7 +532,7 @@ CLIEngine.prototype = {
         var results = [],
             processed = {},
             options = this.options,
-            fileCache = this._fileCache, // eslint-disable-line no-underscore-dangle
+            fileCache = this._fileCache,
             configHelper = new Config(options),
             stats,
             startTime,

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -5,7 +5,6 @@
  * See LICENSE file in root directory for full license.
  */
 "use strict";
-/* eslint no-underscore-dangle: 0*/
 
 //------------------------------------------------------------------------------
 // Requirements

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -62,7 +62,7 @@ rules:
     no-undef: 2
     no-undef-init: 2
     no-undefined: 2
-    no-underscore-dangle: 2
+    no-underscore-dangle: [2, {allowAfterThis: true}]
     no-unused-expressions: 2
     no-unused-vars: [2, {vars: "all", args: "after-used"}]
     no-use-before-define: 2


### PR DESCRIPTION
Just want to make sure, I want to change the eslint-config-eslint package, right? Not the conf/eslint.json (which I believe represents "Recommended" rules)? Let me know if I goofed.