### PR TITLE
Do not implicitly cache `package.json`

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -147,7 +147,7 @@ function loadJSConfigFile(filePath) {
 function loadPackageJSONConfigFile(filePath) {
     debug("Loading package.json config file: " + filePath);
     try {
-        return require(filePath).eslintConfig || null;
+        return loadJSONConfigFile(filePath).eslintConfig || null;
     } catch (e) {
         debug("Error reading package.json file: " + filePath);
         e.message = "Cannot read config file: " + filePath + "\nError: " + e.message;

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "semver": "^5.0.3",
     "shelljs-nodecli": "~0.1.0",
     "sinon": "1.17.2",
-    "through": "^2.3.6"
+    "through": "^2.3.6",
+    "tmp": "0.0.28"
   },
   "keywords": [
     "ast",

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -15,6 +15,7 @@ var assert = require("chai").assert,
     sinon = require("sinon"),
     path = require("path"),
     fs = require("fs"),
+    tmp = require("tmp"),
     yaml = require("js-yaml"),
     proxyquire = require("proxyquire"),
     environments = require("../../../conf/environments"),
@@ -45,6 +46,22 @@ function getFixturePath(filepath) {
  */
 function readJSModule(code) {
     return eval("var module = {};\n" + code);  // eslint-disable-line no-eval
+}
+
+/**
+ * Helper function to write configs to temp file.
+ * @param {object} config Config to write out to temp file.
+ * @param {string} filename Name of file to write in temp dir.
+ * @param {string} existingTmpDir Optional dir path if temp file exists.
+ * @returns {string} Full path to the temp file.
+ * @private
+ */
+function writeTempConfigFile(config, filename, existingTmpDir) {
+    var tmpFileDir = existingTmpDir || tmp.dirSync({prefix: "eslint-tests-"}).name,
+        tmpFilePath = path.join(tmpFileDir, filename),
+        tmpFileContents = JSON.stringify(config);
+    fs.writeFileSync(tmpFilePath, tmpFileContents);
+    return tmpFilePath;
 }
 
 //------------------------------------------------------------------------------
@@ -234,6 +251,32 @@ describe("ConfigFile", function() {
             });
         });
 
+        it("should load fresh information from a JSON file", function() {
+            var initialConfig = {
+                    ecmaFeatures: {},
+                    env: {},
+                    globals: {},
+                    rules: {
+                        quotes: [2, "double"]
+                    }
+                },
+                updatedConfig = {
+                    ecmaFeatures: {},
+                    env: {},
+                    globals: {},
+                    rules: {
+                        quotes: 0
+                    }
+                },
+                tmpFilename = "fresh-test.json",
+                tmpFilePath = writeTempConfigFile(initialConfig, tmpFilename),
+                config = ConfigFile.load(tmpFilePath);
+            assert.deepEqual(config, initialConfig);
+            writeTempConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
+            config = ConfigFile.load(tmpFilePath);
+            assert.deepEqual(config, updatedConfig);
+        });
+
         it("should load information from a package.json file", function() {
             var config = ConfigFile.load(getFixturePath("package-json/package.json"));
             assert.deepEqual(config, {
@@ -242,6 +285,36 @@ describe("ConfigFile", function() {
                 globals: {},
                 rules: {}
             });
+        });
+
+        it("should load fresh information from a package.json file", function() {
+            var initialConfig = {
+                    eslintConfig: {
+                        ecmaFeatures: {},
+                        env: {},
+                        globals: {},
+                        rules: {
+                            quotes: [2, "double"]
+                        }
+                    }
+                },
+                updatedConfig = {
+                    eslintConfig: {
+                        ecmaFeatures: {},
+                        env: {},
+                        globals: {},
+                        rules: {
+                            quotes: 0
+                        }
+                    }
+                },
+                tmpFilename = "package.json",
+                tmpFilePath = writeTempConfigFile(initialConfig, tmpFilename),
+                config = ConfigFile.load(tmpFilePath);
+            assert.deepEqual(config, initialConfig.eslintConfig);
+            writeTempConfigFile(updatedConfig, tmpFilename, path.dirname(tmpFilePath));
+            config = ConfigFile.load(tmpFilePath);
+            assert.deepEqual(config, updatedConfig.eslintConfig);
         });
 
         it("should load information from a YAML file", function() {


### PR DESCRIPTION
Currently eslint will load the config stored in a project's package.json using `require`.  The downside to this is that the json is cached in `require.cache`.  Thus, if eslint is executed twice in the same process, and the config has changed in the interim, it will not read the new config.  For an example of this causing a downstream bug in the wild see https://github.com/AtomLinter/linter-eslint/issues/349

Closes #4611 

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/eslint/eslint/4610)
<!-- Reviewable:end -->
