### PR TITLE
Fix: Handle forbidden LineTerminators in no-extra-parens (fixes #4229)

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -13,6 +13,7 @@
 module.exports = function(context) {
 
     var ALL_NODES = context.options[0] !== "functions";
+    var sourceCode = context.getSourceCode();
 
     /**
      * Determines if this rule should be enforced for a node given the current configuration.
@@ -73,6 +74,22 @@ module.exports = function(context) {
      */
     function hasDoubleExcessParens(node) {
         return ruleApplies(node) && isParenthesisedTwice(node);
+    }
+
+    /**
+     * Determines if a node following a [no LineTerminator here] restriction is
+     * surrounded by (potentially) invalid extra parentheses.
+     * @param {Token} token - The token preceding the [no LineTerminator here] restriction.
+     * @param {ASTNode} node - The node to be checked.
+     * @returns {boolean} True if the node is incorrectly parenthesised.
+     * @private
+     */
+    function hasExcessParensNoLineTerminator(token, node) {
+        if (token.loc.end.line === node.loc.start.line) {
+            return hasExcessParens(node);
+        }
+
+        return hasDoubleExcessParens(node);
     }
 
     /**
@@ -422,7 +439,10 @@ module.exports = function(context) {
             });
         },
         "ReturnStatement": function(node) {
-            if (node.argument && hasExcessParens(node.argument) &&
+            var returnToken = sourceCode.getFirstToken(node);
+
+            if (node.argument &&
+                    hasExcessParensNoLineTerminator(returnToken, node.argument) &&
                     // RegExp literal is allowed to have parens (#1589)
                     !(node.argument.type === "Literal" && node.argument.regex)) {
                 report(node.argument);
@@ -446,7 +466,9 @@ module.exports = function(context) {
             }
         },
         "ThrowStatement": function(node) {
-            if (hasExcessParens(node.argument)) {
+            var throwToken = sourceCode.getFirstToken(node);
+
+            if (hasExcessParensNoLineTerminator(throwToken, node.argument)) {
                 report(node.argument);
             }
         },
@@ -471,11 +493,16 @@ module.exports = function(context) {
             }
         },
         "YieldExpression": function(node) {
-            if (node.argument &&
-                    ((precedence(node.argument) >= precedence(node) &&
-                    hasExcessParens(node.argument)) ||
-                    hasDoubleExcessParens(node.argument))) {
-                report(node.argument);
+            var yieldToken;
+
+            if (node.argument) {
+                yieldToken = sourceCode.getFirstToken(node);
+
+                if ((precedence(node.argument) >= precedence(node) &&
+                        hasExcessParensNoLineTerminator(yieldToken, node.argument)) ||
+                        hasDoubleExcessParens(node.argument)) {
+                    report(node.argument);
+                }
             }
         }
     };

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -203,7 +203,41 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "function *a() { yield b, c; }", ecmaFeatures: { generators: true } },
         { code: "function *a() { yield (b, c); }", ecmaFeatures: { generators: true } },
         { code: "function *a() { yield b + c; }", ecmaFeatures: { generators: true } },
-        { code: "function *a() { (yield b) + c; }", ecmaFeatures: { generators: true } }
+        { code: "function *a() { (yield b) + c; }", ecmaFeatures: { generators: true } },
+
+        // https://github.com/eslint/eslint/issues/4229
+        [
+            "function a() {",
+            "    return (",
+            "        b",
+            "    );",
+            "}"
+        ].join("\n"),
+        {
+            code: [
+                "function a() {",
+                "    return (",
+                "        <JSX />",
+                "    );",
+                "}"
+            ].join("\n"),
+            ecmaFeatures: { jsx: true }
+        },
+        [
+            "throw (",
+            "    a",
+            ");"
+        ].join("\n"),
+        {
+            code: [
+                "function *a() {",
+                "    yield (",
+                "        b",
+                "    );",
+                "}"
+            ].join("\n"),
+            ecmaFeatures: { generators: true }
+        }
     ],
     invalid: [
         invalid("(0)", "Literal"),
@@ -305,6 +339,70 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("function *a() { yield (b); }", "Identifier", null, {ecmaFeatures: {generators: true}}),
         invalid("function *a() { (yield b), c; }", "YieldExpression", null, {ecmaFeatures: {generators: true}}),
         invalid("function *a() { yield ((b, c)); }", "SequenceExpression", null, {ecmaFeatures: {generators: true}}),
-        invalid("function *a() { yield (b + c); }", "BinaryExpression", null, {ecmaFeatures: {generators: true}})
+        invalid("function *a() { yield (b + c); }", "BinaryExpression", null, {ecmaFeatures: {generators: true}}),
+
+        // https://github.com/eslint/eslint/issues/4229
+        invalid([
+            "function a() {",
+            "    return (b);",
+            "}"
+        ].join("\n"), "Identifier"),
+        invalid([
+            "function a() {",
+            "    return",
+            "    (b);",
+            "}"
+        ].join("\n"), "Identifier"),
+        invalid([
+            "function a() {",
+            "    return ((",
+            "       b",
+            "    ));",
+            "}"
+        ].join("\n"), "Identifier"),
+        invalid([
+            "function a() {",
+            "    return (<JSX />);",
+            "}"
+        ].join("\n"), "JSXElement", null, {ecmaFeatures: {jsx: true}}),
+        invalid([
+            "function a() {",
+            "    return",
+            "    (<JSX />);",
+            "}"
+        ].join("\n"), "JSXElement", null, {ecmaFeatures: {jsx: true}}),
+        invalid([
+            "function a() {",
+            "    return ((",
+            "       <JSX />",
+            "    ));",
+            "}"
+        ].join("\n"), "JSXElement", null, {ecmaFeatures: {jsx: true}}),
+        invalid([
+            "throw (a);"
+        ].join("\n"), "Identifier"),
+        invalid([
+            "throw ((",
+            "   a",
+            "));"
+        ].join("\n"), "Identifier"),
+        invalid([
+            "function *a() {",
+            "    yield (b);",
+            "}"
+        ].join("\n"), "Identifier", null, {ecmaFeatures: {generators: true}}),
+        invalid([
+            "function *a() {",
+            "    yield",
+            "    (b);",
+            "}"
+        ].join("\n"), "Identifier", null, {ecmaFeatures: {generators: true}}),
+        invalid([
+            "function *a() {",
+            "    yield ((",
+            "       b",
+            "    ));",
+            "}"
+        ].join("\n"), "Identifier", null, {ecmaFeatures: {generators: true}})
     ]
 });


### PR DESCRIPTION
Previously, this rule would warn about excess parentheses even when they were syntactically significant and removing them would alter the meaning of a program. There are three applicable productions in the grammar with the restriction `[no LineTerminator here]`:

```
ReturnStatement[Yield]:
  return [no LineTerminator here] Expression;
  return [no LineTerminator here] Expression[In, ?Yield];

ThrowStatement[Yield]:
  throw [no LineTerminator here] Expression[In, ?Yield];

YieldExpression[In]:
  yield [no LineTerminator here] * AssignmentExpression[?In, Yield]
  yield [no LineTerminator here] AssignmentExpression[?In, Yield]
```

If the expression following a `return`, `throw`, or `yield` is on a new line, it must be wrapped in parentheses, and this rule should not warn. It should, however, still check for double parentheses, since the second set would be unnecessary.

Thanks to @michaelficarra for pasting the relevant portions of the spec.