### PR TITLE
Breaking: Remove ES6 global variables from builtins (fixes #4085)

### DIFF
--- a/conf/environments.js
+++ b/conf/environments.js
@@ -16,7 +16,7 @@ var globals = require("globals");
 //------------------------------------------------------------------------------
 
 module.exports = {
-    builtin: globals.builtin,
+    builtin: globals.es5,
     browser: {
         globals: globals.browser
     },
@@ -87,6 +87,7 @@ module.exports = {
         globals: globals.webextensions
     },
     es6: {
+        globals: globals.es6,
         ecmaFeatures: {
             arrowFunctions: true,
             blockBindings: true,

--- a/docs/user-guide/migrating-to-2.0.0.md
+++ b/docs/user-guide/migrating-to-2.0.0.md
@@ -47,3 +47,20 @@ module.exports = {
 };
 ```
 
+## Built-In Global Variables
+
+Prior to 2.0.0, new global variables that were standardized as part of ES6 such as `Promise`, `Map`, `Set`, and `Symbol` were included in the built-in global environment. This could lead to potential issues when, for example, `no-undef` permitted use of the `Promise` constructor even in ES5 code where promises are unavailable. In 2.0.0, the built-in environment only includes the standard ES5 global variables, and the new ES6 global variables have been moved to the `es6` environment.
+
+**To address:** If you are writing ES6 code, enable the `es6` environment if you have not already done so:
+
+```js
+// In your .eslintrc
+{
+    env: {
+        es6: true
+    }
+}
+
+// Or in a configuration comment
+/*eslint-env es6*/
+```

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "esutils": "^2.0.2",
     "file-entry-cache": "^1.1.1",
     "glob": "^5.0.14",
-    "globals": "^8.11.0",
+    "globals": "^8.14.0",
     "handlebars": "^4.0.0",
     "inquirer": "^0.11.0",
     "is-my-json-valid": "^2.10.0",

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -186,7 +186,7 @@ describe("ConfigFile", function() {
                 extends: "../package-json/package.json",
                 ecmaFeatures: environments.es6.ecmaFeatures,
                 env: { es6: true },
-                globals: {},
+                globals: environments.es6.globals,
                 rules: {
                     eqeqeq: 2
                 }
@@ -239,7 +239,7 @@ describe("ConfigFile", function() {
             assert.deepEqual(config, {
                 ecmaFeatures: environments.es6.ecmaFeatures,
                 env: { es6: true },
-                globals: {},
+                globals: environments.es6.globals,
                 rules: {}
             });
         });
@@ -270,7 +270,7 @@ describe("ConfigFile", function() {
                 extends: "../package-json/package.json",
                 ecmaFeatures: environments.es6.ecmaFeatures,
                 env: { es6: true },
-                globals: {},
+                globals: environments.es6.globals,
                 rules: { booya: 2 }
             });
         });

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -97,7 +97,7 @@ describe("ConfigOps", function() {
                     es6: true
                 },
                 ecmaFeatures: environments.es6.ecmaFeatures,
-                globals: {},
+                globals: environments.es6.globals,
                 rules: {}
             });
         });

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1409,6 +1409,34 @@ describe("eslint", function() {
             });
             eslint.verify(code, config, filename, true);
         });
+
+        it("ES6 global variables should not be available by default", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope();
+
+                assert.equal(getVariable(scope, "Promise"), null);
+                assert.equal(getVariable(scope, "Symbol"), null);
+                assert.equal(getVariable(scope, "WeakMap"), null);
+            });
+            eslint.verify(code, config, filename, true);
+        });
+
+        it("ES6 global variables should be available in the es6 environment", function() {
+            var config = { rules: {} };
+
+            eslint.reset();
+            eslint.on("Program", function() {
+                var scope = eslint.getScope();
+
+                assert.notEqual(getVariable(scope, "Promise"), null);
+                assert.notEqual(getVariable(scope, "Symbol"), null);
+                assert.notEqual(getVariable(scope, "WeakMap"), null);
+            });
+            eslint.verify(code, config, filename, true);
+        });
     });
 
     describe("when evaluating empty code", function() {
@@ -2201,6 +2229,26 @@ describe("eslint", function() {
         });
     });
 
+    describe("when evaluating code without comments to environment", function() {
+        it("should report a violation when using typed array", function() {
+            var code = "var array = new Uint8Array();";
+
+            var config = { rules: { "no-undef": 1} };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 1);
+        });
+
+        it("should report a violation when using Promise", function() {
+            var code = "new Promise();";
+
+            var config = { rules: { "no-undef": 1} };
+
+            var messages = eslint.verify(code, config, filename);
+            assert.equal(messages.length, 1);
+        });
+    });
+
     describe("when evaluating code with comments to environment", function() {
         it("should not support legacy config", function() {
             var code = "/*jshint mocha:true */ describe();";
@@ -2214,10 +2262,10 @@ describe("eslint", function() {
             assert.equal(messages[0].line, 1);
         });
 
-        it("should not report a violation when using typed array", function() {
-            var code = "var array = new Uint8Array();";
+        it("should not report a violation", function() {
+            var code = "/*eslint-env es6 */ new Promise();";
 
-            var config = { rules: { "no-undef": 1} };
+            var config = { rules: { "no-undef": 1 } };
 
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 0);


### PR DESCRIPTION
This upgrades to `globals@8.14.0`, which has separate `es5` and `es6` environments. Only ES5 global variables are considered builtin now, and ES6 global variables are supplied as part of the `es6` environment.