### PR TITLE
Breaking: Treat package.json like the rest of configs (fixes #4451)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -378,7 +378,7 @@ There are two ways to use configuration files. The first is to save the file whe
 
     eslint -c myconfig.json myfiletotest.js
 
-The second way to use configuration files is via `.eslintrc` and `package.json` files. ESLint will automatically look for them in the directory of the file to be linted, and in successive parent directories all the way up to the root directory of the filesystem. This option is useful when you want different configurations for different parts of a project or when you want others to be able to use ESLint directly without needing to remember to pass in the configuration file.
+The second way to use configuration files is via `.eslintrc.*` and `package.json` files. ESLint will automatically look for them in the directory of the file to be linted, and in successive parent directories all the way up to the root directory of the filesystem. This option is useful when you want different configurations for different parts of a project or when you want others to be able to use ESLint directly without needing to remember to pass in the configuration file.
 
 In each case, the settings in the configuration file override default settings.
 
@@ -389,21 +389,22 @@ ESLint supports configuration files in several formats:
 * **JavaScript** - use `.eslintrc.js` and export an object containing your configuration.
 * **YAML** - use `.eslintrc.yaml` or `.eslintrc.yml` to define the configuration structure.
 * **JSON** - use `.eslintrc.json` to define the configuration structure. ESLint's JSON files also allow JavaScript-style comments.
-* **package.json** - create an `eslintConfig` property in your `package.json` file and define your configuration there.
 * **Deprecated** - use `.eslintrc`, which can be either JSON or YAML.
+* **package.json** - create an `eslintConfig` property in your `package.json` file and define your configuration there.
 
-If there are multiple `.eslintrc.*` files in the same directory, ESLint will only use one. The priority order is:
+If there are multiple configuration files in the same directory, ESLint will only use one. The priority order is:
 
 1. `.eslintrc.js`
 1. `.eslintrc.yaml`
 1. `.eslintrc.yml`
 1. `.eslintrc.json`
 1. `.eslintrc`
+1. `package.json`
 
 
 ## Configuration Cascading and Hierarchy
 
-When using `.eslintrc` and `package.json` files for configuration, you can take advantage of configuration cascading. For instance, suppose you have the following structure:
+When using `.eslintrc.*` and `package.json` files for configuration, you can take advantage of configuration cascading. For instance, suppose you have the following structure:
 
 ```text
 your-project
@@ -429,11 +430,11 @@ your-project
   └── test.js
 ```
 
-If there is an `.eslintrc` and a `package.json` file found in the same directory, both will be used, with the `.eslintrc` having the higher precendence.
+If there is an `.eslintrc` and a `package.json` file found in the same directory, `.eslintrc` will take a priority and `package.json` file will not be used.
 
 **Note:** If you have a personal configuration file in your home directory (`~/.eslintrc`), it will only be used if no other configuration files are found. Since a personal configuration would apply to everything inside of a user's directory, including third-party code, this could cause problems when running ESLint.
 
-By default, ESLint will look for configuration files in all parent folders up to the root directory. This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to unexpected results. To limit ESLint to a specific project, place `"root": true` inside the `eslintConfig` field of the `package.json` file or in the `.eslintrc` file at your project's root level.  ESLint will stop looking in parent folders once it finds a configuration with `"root": true`.
+By default, ESLint will look for configuration files in all parent folders up to the root directory. This can be useful if you want all of your projects to follow a certain convention, but can sometimes lead to unexpected results. To limit ESLint to a specific project, place `"root": true` inside the `eslintConfig` field of the `package.json` file or in the `.eslintrc.*` file at your project's root level.  ESLint will stop looking in parent folders once it finds a configuration with `"root": true`.
 
 ```js
 {
@@ -474,8 +475,7 @@ The complete configuration hierarchy, from highest precedence to lowest preceden
     1. `--env`
     1. `-c`, `--config`
 3. Project-level configuration:
-    1. `.eslintrc` file in same directory as linted file
-    1. `package.json` file in same directory as linted file
+    1. `.eslintrc.*` or `package.json` file in same directory as linted file
     1. Continue searching for `.eslintrc` and `package.json` files in ancestor directories (parent has highest precedence, then grandparent, etc.), up to and including the root directory or until a config with `"root": true` is found.
     1. In the absence of any configuration from (1) thru (3), fall back to a personal default configuration in  `~/.eslintrc`.
 

--- a/docs/user-guide/migrating-to-2.0.0.md
+++ b/docs/user-guide/migrating-to-2.0.0.md
@@ -47,6 +47,11 @@ module.exports = {
 };
 ```
 
+## Configuration cascading changes
+
+If you previously relied on the fact that ESLint will merge configurations from `.eslintrc` and `package.json` files located in the same directory you will have to choose either `.eslintrc` or `package.json` file
+and move all of your configuration into one or the other. In 2.0.0 `package.json` will be treated just like any other configuration file and will have the lowest priority.
+
 ## Built-In Global Variables
 
 Prior to 2.0.0, new global variables that were standardized as part of ES6 such as `Promise`, `Map`, `Set`, and `Symbol` were included in the built-in global environment. This could lead to potential issues when, for example, `no-undef` permitted use of the `Promise` constructor even in ES5 code where promises are unavailable. In 2.0.0, the built-in environment only includes the standard ES5 global variables, and the new ES6 global variables have been moved to the `es6` environment.

--- a/lib/config.js
+++ b/lib/config.js
@@ -26,8 +26,7 @@ var path = require("path"),
 // Constants
 //------------------------------------------------------------------------------
 
-var PACKAGE_CONFIG_FILENAME = "package.json",
-    PERSONAL_CONFIG_DIR = userHome || null;
+var PERSONAL_CONFIG_DIR = userHome || null;
 
 //------------------------------------------------------------------------------
 // Private
@@ -327,7 +326,7 @@ Config.prototype.getConfig = function(filePath) {
 Config.prototype.findLocalConfigFiles = function(directory) {
 
     if (!this.localConfigFinder) {
-        this.localConfigFinder = new FileFinder(ConfigFile.CONFIG_FILES, PACKAGE_CONFIG_FILENAME);
+        this.localConfigFinder = new FileFinder(ConfigFile.CONFIG_FILES);
     }
 
     return this.localConfigFinder.findAllInDirectoryAndParents(directory);

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -28,7 +28,8 @@ var CONFIG_FILES = [
     ".eslintrc.yaml",
     ".eslintrc.yml",
     ".eslintrc.json",
-    ".eslintrc"
+    ".eslintrc",
+    "package.json"
 ];
 
 debug = debug("eslint:config-file");

--- a/lib/file-finder.js
+++ b/lib/file-finder.js
@@ -40,11 +40,31 @@ function getDirectoryEntries(directory) {
 /**
  * FileFinder
  * @constructor
- * @param {...string} arguments The basename(s) of the file(s) to find.
+ * @param {string[]} files The basename(s) of the file(s) to find.
  */
-function FileFinder() {
-    this.fileNames = Array.prototype.slice.call(arguments);
+function FileFinder(files) {
+    this.fileNames = Array.isArray(files) ? files : [files];
     this.cache = {};
+}
+
+/**
+ * Create a hash of filenames from a directory listing
+ * @param {string[]} entries Array of directory entries.
+ * @param {string} directory Path to a current directory.
+ * @param {string[]} supportedConfigs List of support filenames.
+ * @returns {Object} Hashmap of filenames
+ */
+function normalizeDirectoryEntries(entries, directory, supportedConfigs) {
+    var fileHash = {};
+    entries.forEach(function(entry) {
+        if (supportedConfigs.indexOf(entry) >= 0) {
+            var resolvedEntry = path.resolve(directory, entry);
+            if (fs.statSync(resolvedEntry).isFile()) {
+                fileHash[entry] = resolvedEntry;
+            }
+        }
+    });
+    return fileHash;
 }
 
 /**
@@ -53,7 +73,7 @@ function FileFinder() {
  * Does not check if a matching directory entry is a file, and intentionally
  * only searches for the first file name in this.fileNames.
  * Is currently used by lib/ignored_paths.js to find an .eslintignore file.
- * @param  {string} directory The directory to start the search from.
+ * @param {string} directory The directory to start the search from.
  * @returns {string} Path of the file found, or an empty string if not found.
  */
 FileFinder.prototype.findInDirectoryOrParents = function(directory) {
@@ -62,7 +82,6 @@ FileFinder.prototype.findInDirectoryOrParents = function(directory) {
         dirs,
         filePath,
         i,
-        name,
         names,
         searched;
 
@@ -76,18 +95,18 @@ FileFinder.prototype.findInDirectoryOrParents = function(directory) {
 
     dirs = [];
     searched = 0;
-    name = this.fileNames[0];
-    names = Array.isArray(name) ? name : [name];
+    names = this.fileNames;
 
     (function() {
         while (directory !== child) {
             dirs[searched++] = directory;
-
-            for (var k = 0, found = false; k < names.length && !found; k++) {
-
-                if (getDirectoryEntries(directory).indexOf(names[k]) !== -1 && fs.statSync(path.resolve(directory, names[k])).isFile()) {
-                    filePath = path.resolve(directory, names[k]);
-                    return;
+            var filesMap = normalizeDirectoryEntries(getDirectoryEntries(directory), directory, names);
+            if (Object.keys(filesMap).length) {
+                for (var k = 0; k < names.length; k++) {
+                    if (filesMap[names[k]]) {
+                        filePath = filesMap[names[k]];
+                        return;
+                    }
                 }
             }
 
@@ -118,9 +137,7 @@ FileFinder.prototype.findAllInDirectoryAndParents = function(directory) {
     var cache = this.cache,
         child,
         dirs,
-        name,
         fileNames,
-        fileNamesCount,
         filePath,
         i,
         j,
@@ -137,33 +154,27 @@ FileFinder.prototype.findAllInDirectoryAndParents = function(directory) {
     dirs = [];
     searched = 0;
     fileNames = this.fileNames;
-    fileNamesCount = fileNames.length;
 
     do {
         dirs[searched++] = directory;
         cache[directory] = [];
 
-        for (i = 0; i < fileNamesCount; i++) {
-            name = fileNames[i];
+        var filesMap = normalizeDirectoryEntries(getDirectoryEntries(directory), directory, fileNames);
 
-            // convert to an array for easier handling
-            if (!Array.isArray(name)) {
-                name = [name];
-            }
+        if (Object.keys(filesMap).length) {
+            for (var k = 0; k < fileNames.length; k++) {
 
-            for (var k = 0, found = false; k < name.length && !found; k++) {
-
-                if (getDirectoryEntries(directory).indexOf(name[k]) !== -1 && fs.statSync(path.resolve(directory, name[k])).isFile()) {
-                    filePath = path.resolve(directory, name[k]);
-                    found = true;
+                if (filesMap[fileNames[k]]) {
+                    filePath = filesMap[fileNames[k]];
 
                     // Add the file path to the cache of each directory searched.
                     for (j = 0; j < searched; j++) {
                         cache[dirs[j]].push(filePath);
                     }
+
+                    break;
                 }
             }
-
         }
         child = directory;
 

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -124,13 +124,26 @@ describe("Config", function() {
             assert.lengthOf(actual, 0);
         });
 
-        it("should return the path when a package.json file is found", function() {
+        it("should return package.json only when no other config files are found", function() {
             var configHelper = new Config(),
-                expected = getFixturePath("broken", "package.json"),
+                expected0 = getFixturePath("packagejson", "subdir", "package.json"),
+                expected1 = getFixturePath("packagejson", ".eslintrc"),
+                actual = configHelper.findLocalConfigFiles(getFixturePath("packagejson", "subdir"));
+
+            assert.isArray(actual);
+            assert.lengthOf(actual, 2);
+            assert.equal(actual[0], expected0);
+            assert.equal(actual[1], expected1);
+        });
+
+        it("should return the only one config file even if there are multiple found", function() {
+            var configHelper = new Config(),
+                expected = getFixturePath("broken", ".eslintrc"),
 
                 // The first element of the array is the .eslintrc in the same directory.
-                actual = configHelper.findLocalConfigFiles(getFixturePath("broken"))[1];
+                actual = configHelper.findLocalConfigFiles(getFixturePath("broken"));
 
+            assert.equal(actual.length, 1);
             assert.equal(actual, expected);
         });
 

--- a/tests/lib/file-finder.js
+++ b/tests/lib/file-finder.js
@@ -183,12 +183,12 @@ describe("FileFinder", function() {
 
             it("should return multiple files when the first is missing and more than one filename is requested", function() {
                 var firstExpected = path.join(fileFinderDir, "subdir", uniqueFileName),
-                    secondExpected = path.join(fileFinderDir, "subdir", "empty2");
+                    secondExpected = path.join(fileFinderDir, uniqueFileName);
 
-                finder = new FileFinder(["notreal", uniqueFileName], "empty2");
+                finder = new FileFinder(["notreal", uniqueFileName, "empty2"]);
                 actual = finder.findAllInDirectoryAndParents(subdir);
 
-                assert.equal(actual.length, 3);
+                assert.equal(actual.length, 2);
                 assert.equal(actual[0], firstExpected);
                 assert.equal(actual[1], secondExpected);
             });


### PR DESCRIPTION
* Added `package.json` as a lowest priority configuration file
* Changed signature of `FileFinder` constructor to only take one parameter (either a string or an array of strings)
* Modified the logic for `FileFinder`. Before it would retrieve directory listing for every configuration file type, which can add up quickly for deeply nested directory without configuration files. Performance improvement is negligible on a small project, but can be noticeable on large projects with a lot of subfolders.
* Modified documentation and added a step into migration guide.