### PR TITLE
Update to use secure versions of handlebars only.

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "file-entry-cache": "^1.1.1",
     "glob": "^5.0.14",
     "globals": "^8.14.0",
-    "handlebars": "^4.0.0",
+    "handlebars": "^4.0.5",
     "inquirer": "^0.11.0",
     "is-my-json-valid": "^2.10.0",
     "is-resolvable": "^1.0.0",


### PR DESCRIPTION
NSP has a reported security vulnerability with old versions of underscore, which is used by handlebars < 4.0.5.
https://nodesecurity.io/advisories/48
This update changes eslint's minimum handlebars version up from 4.0.0 to 4.0.5.

This pull request fixes #4642