### PR TITLE
Upgrade: Handlebars to >= 4.0.5 for security reasons (fixes #4642)

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "file-entry-cache": "^1.1.1",
     "glob": "^5.0.14",
     "globals": "^8.14.0",
-    "handlebars": "^4.0.0",
+    "handlebars": "^4.0.5",
     "inquirer": "^0.11.0",
     "is-my-json-valid": "^2.10.0",
     "is-resolvable": "^1.0.0",


### PR DESCRIPTION
NSP has reported a security vulnerability with old versions of uglify-js, one of which is used by handlebars < 4.0.5.

https://nodesecurity.io/advisories/48

This update changes eslint's minimum handlebars version up from 4.0.0 to 4.0.5.