### PR TITLE
Fix: Use oneValuePerFlag for --ignore-pattern option (fixes #4507)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -73,13 +73,13 @@ Miscellaneous:
                              default: false
 ```
 
-Options that accept array values can be specified by repeating the option or with a comma-delimited list.
+Options that accept array values can be specified by repeating the option or with a comma-delimited list (other than `--ignore-pattern` which does not allow the second style).
 
 Example:
 
-    eslint --ignore-pattern a.js --ignore-pattern b.js file.js
+    eslint --ext .jsx --ext .js file.js
 
-    eslint --ignore-pattern a.js,b.js file.js
+    eslint --ext .jsx,.js file.js
 
 ### Basic configuration
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -18,8 +18,10 @@ var optionator = require("optionator");
 // exports "parse(args)", "generateHelp()", and "generateHelpForOption(optionName)"
 module.exports = optionator({
     prepend: "eslint [options] file.js [file.js] [dir]",
-    concatRepeatedArrays: true,
-    mergeRepeatedObjects: true,
+    defaults: {
+        concatRepeatedArrays: true,
+        mergeRepeatedObjects: true
+    },
     options: [
         {
             heading: "Basic configuration"
@@ -113,7 +115,10 @@ module.exports = optionator({
         {
             option: "ignore-pattern",
             type: "[String]",
-            description: "Pattern of files to ignore (in addition to those in .eslintignore)"
+            description: "Pattern of files to ignore (in addition to those in .eslintignore)",
+            concatRepeatedArrays: [true, {
+                oneValuePerFlag: true
+            }]
         },
         {
             heading: "Using stdin"

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "object-assign": "^4.0.1",
-    "optionator": "^0.6.0",
+    "optionator": "^0.7.1",
     "path-is-absolute": "^1.0.0",
     "path-is-inside": "^1.0.1",
     "shelljs": "^0.5.3",

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -160,6 +160,14 @@ describe("options", function() {
             assert.equal(currentOptions.ignorePattern[0], "*.js");
             assert.equal(currentOptions.ignorePattern[1], "*.ts");
         });
+
+        it("should return a string array of properly parsed values, when those values include commas", function() {
+            var currentOptions = options.parse("--ignore-pattern *.js --ignore-pattern foo-{bar,baz}.js");
+            assert.ok(currentOptions.ignorePattern);
+            assert.equal(currentOptions.ignorePattern.length, 2);
+            assert.equal(currentOptions.ignorePattern[0], "*.js");
+            assert.equal(currentOptions.ignorePattern[1], "foo-{bar,baz}.js");
+        });
     });
 
     describe("--color", function() {


### PR DESCRIPTION
Updates optionator from 0.6.0 to 0.7.1

Multiple ignore patterns must be specified by using the flag multiple
times, not by using a comma (since the pattern could include a comma)