### PR TITLE
Breaking: Correct links between variables and references

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -173,6 +173,21 @@ function addDeclaredGlobals(program, globalScope, config) {
             variable.eslintUsed = true;
         }
     });
+
+    // "through" contains all references that their definition cannot be found.
+    // Since we augment the global scope using configuration, we need to update references and remove the ones that were added by configuration.
+    globalScope.through = globalScope.through.filter(function(reference) {
+        var name = reference.identifier.name;
+        var variable = globalScope.set.get(name);
+        if (variable) {
+            // Links the variable and the reference.
+            // And this reference is removed from `Scope#through`.
+            reference.resolved = variable;
+            variable.references.push(reference);
+            return false;
+        }
+        return true;
+    });
 }
 
 /**

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -7,37 +7,10 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Helpers
-//------------------------------------------------------------------------------
-
-/**
- * Collects unresolved references from the global scope, then creates a map to references from its name.
- * @param {RuleContext} context - The current context.
- * @returns {object} A map object. Its key is the variable names. Its value is the references of each variable.
- */
-function collectUnresolvedReferences(context) {
-    var unresolved = Object.create(null);
-    var references = context.getScope().through;
-
-    for (var i = 0; i < references.length; ++i) {
-        var reference = references[i];
-        var name = reference.identifier.name;
-
-        if (name in unresolved === false) {
-            unresolved[name] = [];
-        }
-        unresolved[name].push(reference);
-    }
-
-    return unresolved;
-}
-
-//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var unresolvedReferences = Object.create(null);
     var stack = [];
 
     /**
@@ -80,8 +53,6 @@ module.exports = function(context) {
             return;
         }
 
-        var isGlobal = context.getScope().type === "global";
-
         // Defines a predicate to check whether or not a given reference is outside of valid scope.
         var scopeRange = stack[stack.length - 1];
 
@@ -99,23 +70,16 @@ module.exports = function(context) {
         // Gets declared variables, and checks its references.
         var variables = context.getDeclaredVariables(node);
         for (var i = 0; i < variables.length; ++i) {
-            var variable = variables[i];
-            var references = variable.references;
-
-            // Global variables are not resolved.
-            // In this case, use unresolved references.
-            if (isGlobal && variable.name in unresolvedReferences) {
-                references = unresolvedReferences[variable.name];
-            }
-
             // Reports.
-            references.filter(isOutsideOfScope).forEach(report);
+            variables[i]
+                .references
+                .filter(isOutsideOfScope)
+                .forEach(report);
         }
     }
 
     return {
         "Program": function(node) {
-            unresolvedReferences = collectUnresolvedReferences(context);
             stack = [node.range];
         },
 

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -65,11 +65,9 @@ module.exports = function(context) {
             return;
         }
 
-        var lookup = (variable.references.length === 0 && scope.type === "global") ? scope : variable;
-
         // The alias has been declared and not assigned: check it was
         // assigned later in the same scope.
-        if (!lookup.references.some(function(reference) {
+        if (!variable.references.some(function(reference) {
             var write = reference.writeExpr;
             return (
                 reference.from === scope &&

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -65,17 +65,6 @@ function findReference(scope, node) {
 }
 
 /**
- * Checks if the given identifier name is shadowed in the given global scope.
- * @param {Object} globalScope The global scope.
- * @param {string} identifierName The identifier name to check
- * @returns {boolean} Whether or not the name is shadowed globally.
- */
-function isGloballyShadowed(globalScope, identifierName) {
-    var variable = globalScope.set.get(identifierName);
-    return Boolean(variable && variable.defs.length > 0);
-}
-
-/**
  * Checks if the given identifier node is shadowed in the given scope.
  * @param {Object} scope The current scope.
  * @param {Object} globalScope The global scope.
@@ -83,16 +72,8 @@ function isGloballyShadowed(globalScope, identifierName) {
  * @returns {boolean} Whether or not the name is shadowed.
  */
 function isShadowed(scope, globalScope, node) {
-    var reference = findReference(scope, node),
-        identifierName = node.name;
-
-    if (reference) {
-        if (reference.resolved || isGloballyShadowed(globalScope, identifierName)) {
-            return true;
-        }
-    }
-
-    return false;
+    var reference = findReference(scope, node);
+    return reference && reference.resolved && reference.resolved.defs.length > 0;
 }
 
 /**

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -24,26 +24,6 @@ var candidatesOfGlobalObject = Object.freeze([
 ]);
 
 /**
- * Gets a map to check whether or not a name is the global object's.
- *
- * @param {Map<string, escope.Variable>} globals
- *      A map which contains all global variables.
- * @returns {object} A map. Keys are names of the global object.
- */
-function getGlobalObjectNames(globals) {
-    return candidatesOfGlobalObject.reduce(
-        function(retv, name) {
-            var variable = globals.get(name);
-            if (variable && variable.eslintExplicitGlobal === false) {
-                retv[name] = true;
-            }
-            return retv;
-        },
-        Object.create(null)
-    );
-}
-
-/**
  * Checks a given node is a Identifier node of the specified name.
  *
  * @param {ASTNode} node - A node to check.
@@ -168,38 +148,50 @@ module.exports = function(context) {
     }
 
     /**
-     * Reports an access of `eval` of the global object.
+     * Reports accesses of `eval` via the global object.
      *
-     * @param {ASTNode} id - An `Identifier` node of the global object.
+     * @param {escope.Scope} globalScope - The global scope.
      * @returns {void}
      */
-    function reportAccessingEvalOfGlobalObject(id) {
-        var name = id.name;
-        var node = id.parent;
-        for (;;) {
-            // To detect code like `window.window.eval`.
-            if (isMember(node, name)) {
-                node = node.parent;
+    function reportAccessingEvalViaGlobalObject(globalScope) {
+        for (var i = 0; i < candidatesOfGlobalObject.length; ++i) {
+            var name = candidatesOfGlobalObject[i];
+            var variable = astUtils.getVariableByName(globalScope, name);
+            if (!variable) {
                 continue;
             }
 
-            if (isMember(node, "eval")) {
-                report(node);
+            var references = variable.references;
+            for (var j = 0; j < references.length; ++j) {
+                var identifier = references[j].identifier;
+                var node = identifier.parent;
+
+                // To detect code like `window.window.eval`.
+                while (isMember(node, name)) {
+                    node = node.parent;
+                }
+
+                // Reports.
+                if (isMember(node, "eval")) {
+                    report(node);
+                }
             }
-            return;
         }
     }
 
     /**
      * Reports all accesses of `eval` (excludes direct calls to eval).
      *
+     * @param {escope.Scope} globalScope - The global scope.
      * @returns {void}
      */
-    function reportAccessingEval() {
-        var globalScope = context.getScope();
-        var globals = getGlobalObjectNames(globalScope.set);
-        var references = globalScope.through;
+    function reportAccessingEval(globalScope) {
+        var variable = astUtils.getVariableByName(globalScope, "eval");
+        if (!variable) {
+            return;
+        }
 
+        var references = variable.references;
         for (var i = 0; i < references.length; ++i) {
             var reference = references[i];
             var id = reference.identifier;
@@ -207,10 +199,6 @@ module.exports = function(context) {
             if (id.name === "eval" && !astUtils.isCallee(id)) {
                 // Is accessing to eval (excludes direct calls to eval)
                 report(id);
-
-            } else if (globals[id.name]) {
-                // This is the global object.
-                reportAccessingEvalOfGlobalObject(id);
             }
         }
     }
@@ -254,8 +242,11 @@ module.exports = function(context) {
         },
 
         "Program:exit": function() {
+            var globalScope = context.getScope();
+
             exitVarScope();
-            reportAccessingEval();
+            reportAccessingEval(globalScope);
+            reportAccessingEvalViaGlobalObject(globalScope);
         },
 
         "FunctionDeclaration": enterVarScope,

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -13,29 +13,6 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    var unresolved = Object.create(null);
-
-    /**
-     * Collects unresolved references from the global scope, then creates a map to references from its name.
-     * Usage of the map is explained at `checkVariable(variable)`.
-     * @returns {void}
-     */
-    function collectUnresolvedReferences() {
-        unresolved = Object.create(null);
-
-        var references = context.getScope().through;
-        for (var i = 0; i < references.length; ++i) {
-            var reference = references[i];
-            var name = reference.identifier.name;
-
-            if (name in unresolved === false) {
-                unresolved[name] = [];
-            }
-            unresolved[name].push(reference);
-        }
-    }
-
     /**
      * Reports a reference if is non initializer and writable.
      * @param {References} references - Collection of reference to check.
@@ -57,13 +34,7 @@ module.exports = function(context) {
      */
     function checkVariable(variable) {
         if (variable.defs[0].type === "FunctionName") {
-            // If the function is in global scope, its references are not resolved (by escope's design).
-            // So when references of the function are nothing, this checks in unresolved.
-            if (variable.references.length > 0) {
-                checkReference(variable.references);
-            } else if (unresolved[variable.name]) {
-                checkReference(unresolved[variable.name]);
-            }
+            checkReference(variable.references);
         }
     }
 
@@ -77,11 +48,9 @@ module.exports = function(context) {
     }
 
     return {
-        "Program": collectUnresolvedReferences,
         "FunctionDeclaration": checkForFunction,
         "FunctionExpression": checkForFunction
     };
-
 };
 
 module.exports.schema = [];

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -66,7 +66,6 @@ function getContainingLoopNode(node) {
  * @returns {boolean} Whether or not a reference refers to a variable that is block-binding in the loop.
  */
 function isBlockBindingsInLoop(loopNode, reference) {
-    // A reference to a `let`/`const` variable always has a resolved variable.
     var variable = reference.resolved;
     var definition = variable && variable.defs[0];
     var declaration = definition && definition.parent;

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -10,62 +10,50 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
     var config = context.options[0];
     var exceptions = (config && config.exceptions) || [];
 
     /**
-     * Gets the names of writeable built-in variables.
-     * @param {escope.Scope} scope - A scope to get.
-     * @returns {object} A map that its key is variable names.
-     */
-    function getBuiltinGlobals(scope) {
-        return scope.variables.reduce(function(retv, variable) {
-            if (variable.writeable === false && variable.name !== "__proto__") {
-                retv[variable.name] = true;
-            }
-            return retv;
-        }, Object.create(null));
-    }
-
-    /**
-     * Reports if a given reference's name is same as native object's.
-     * @param {object} builtins - A map that its key is a variable name.
+     * Reports write references.
      * @param {Reference} reference - A reference to check.
      * @param {int} index - The index of the reference in the references.
      * @param {Reference[]} references - The array that the reference belongs to.
      * @returns {void}
      */
-    function checkThroughReference(builtins, reference, index, references) {
+    function checkReference(reference, index, references) {
         var identifier = reference.identifier;
 
-        if (identifier &&
-            builtins[identifier.name] &&
-            exceptions.indexOf(identifier.name) === -1 &&
-            reference.init === false &&
+        if (reference.init === false &&
             reference.isWrite() &&
             // Destructuring assignments can have multiple default value,
             // so possibly there are multiple writeable references for the same identifier.
             (index === 0 || references[index - 1].identifier !== identifier)
         ) {
-            context.report(
-                identifier,
-                "{{name}} is a read-only native object.",
-                {name: identifier.name});
+            context.report({
+                node: identifier,
+                message: "{{name}} is a read-only native object.",
+                data: identifier
+            });
+        }
+    }
+
+    /**
+     * Reports write references if a given variable is readonly builtin.
+     * @param {Variable} variable - A variable to check.
+     * @returns {void}
+     */
+    function checkVariable(variable) {
+        if (variable.writeable === false && exceptions.indexOf(variable.name) === -1) {
+            variable.references.forEach(checkReference);
         }
     }
 
     return {
-        // Checks assignments of global variables.
-        // References to implicit global variables are not resolved,
-        // so those are in the `through` of the global scope.
         "Program": function() {
             var globalScope = context.getScope();
-            var builtins = getBuiltinGlobals(globalScope);
-            globalScope.through.forEach(checkThroughReference.bind(null, builtins));
+            globalScope.variables.forEach(checkVariable);
         }
     };
-
 };
 
 module.exports.schema = [

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -7,44 +7,8 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-var astUtils = require("../ast-utils");
-
-//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
-
-var hasOwnProperty = Object.prototype.hasOwnProperty;
-
-/**
- * Check if a variable is an implicit declaration
- * @param {ASTNode} variable node to evaluate
- * @returns {boolean} True if its an implicit declaration
- * @private
- */
-function isImplicitGlobal(variable) {
-    return variable.defs.every(function(def) {
-        return def.type === "ImplicitGlobalVariable";
-    });
-}
-
-/**
- * Gets the declared variable, defined in `scope`, that `ref` refers to.
- * @param {Scope} scope The scope in which to search.
- * @param {Reference} ref The reference to find in the scope.
- * @returns {Variable} The variable, or null if ref refers to an undeclared variable.
- */
-function getDeclaredGlobalVariable(scope, ref) {
-    var variable = astUtils.getVariableByName(scope, ref.identifier.name);
-
-    // If it's an implicit global, it must have a `writeable` field (indicating it was declared)
-    if (variable && (!isImplicitGlobal(variable) || hasOwnProperty.call(variable, "writeable"))) {
-        return variable;
-    }
-    return null;
-}
 
 /**
  * Checks if the given node is the argument of a typeof operator.
@@ -61,35 +25,28 @@ function hasTypeOfOperator(node) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    var NOT_DEFINED_MESSAGE = "\"{{name}}\" is not defined.";
-
     var options = context.options[0];
     var considerTypeOf = options && options.typeof === true || false;
 
     return {
-
         "Program:exit": function(/* node */) {
-
             var globalScope = context.getScope();
 
             globalScope.through.forEach(function(ref) {
-                var variable = getDeclaredGlobalVariable(globalScope, ref),
-                    name = ref.identifier.name;
+                var identifier = ref.identifier;
 
-                if (hasTypeOfOperator(ref.identifier) && !considerTypeOf) {
+                if (!considerTypeOf && hasTypeOfOperator(identifier)) {
                     return;
                 }
 
-                if (!variable) {
-                    context.report(ref.identifier, NOT_DEFINED_MESSAGE, { name: name });
-                }
+                context.report({
+                    node: identifier,
+                    message: "\"{{name}}\" is not defined.",
+                    data: identifier
+                });
             });
-
         }
-
     };
-
 };
 
 module.exports.schema = [

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -109,7 +109,7 @@ module.exports = function(context) {
      * @param {Reference[]} references - The variable references to check.
      * @returns {boolean} True if the variable is used
      */
-    function isUsedVariable(variable, references) {
+    function isUsedVariable(variable) {
         var functionNodes = variable.defs.filter(function(def) {
                 return def.type === "FunctionName";
             }).map(function(def) {
@@ -117,48 +117,19 @@ module.exports = function(context) {
             }),
             isFunctionDefinition = functionNodes.length > 0;
 
-        return references.some(function(ref) {
+        return variable.references.some(function(ref) {
             return isReadRef(ref) && !(isFunctionDefinition && isSelfReference(ref, functionNodes));
         });
     }
 
     /**
-     * Gets unresolved references.
-     * They contains var's, function's, and explicit global variable's.
-     * If `config.vars` is not "all", returns empty map.
-     * @param {Scope} scope - the global scope.
-     * @returns {object} Unresolved references. Keys of the object is its variable name. Values of the object is an array of its references.
-     * @private
-     */
-    function collectUnresolvedReferences(scope) {
-        var unresolvedRefs = Object.create(null);
-
-        if (config.vars === "all") {
-            for (var i = 0, l = scope.through.length; i < l; ++i) {
-                var ref = scope.through[i];
-                var name = ref.identifier.name;
-
-                if (isReadRef(ref)) {
-                    if (!unresolvedRefs[name]) {
-                        unresolvedRefs[name] = [];
-                    }
-                    unresolvedRefs[name].push(ref);
-                }
-            }
-        }
-
-        return unresolvedRefs;
-    }
-
-    /**
      * Gets an array of variables without read references.
      * @param {Scope} scope - an escope Scope object.
-     * @param {object} unresolvedRefs - a map of each variable name and its references.
      * @param {Variable[]} unusedVars - an array that saving result.
      * @returns {Variable[]} unused variables of the scope and descendant scopes.
      * @private
      */
-    function collectUnusedVariables(scope, unresolvedRefs, unusedVars) {
+    function collectUnusedVariables(scope, unusedVars) {
         var variables = scope.variables;
         var childScopes = scope.childScopes;
         var i, l;
@@ -218,16 +189,14 @@ module.exports = function(context) {
                     }
                 }
 
-                // On global, variables without let/const/class are unresolved.
-                var references = (scope.type === "global" ? unresolvedRefs[variable.name] : null) || variable.references;
-                if (!isUsedVariable(variable, references) && !isExported(variable)) {
+                if (!isUsedVariable(variable) && !isExported(variable)) {
                     unusedVars.push(variable);
                 }
             }
         }
 
         for (i = 0, l = childScopes.length; i < l; ++i) {
-            collectUnusedVariables(childScopes[i], unresolvedRefs, unusedVars);
+            collectUnusedVariables(childScopes[i], unusedVars);
         }
 
         return unusedVars;
@@ -283,19 +252,24 @@ module.exports = function(context) {
 
     return {
         "Program:exit": function(programNode) {
-            var globalScope = context.getScope();
-            var unresolvedRefs = collectUnresolvedReferences(globalScope);
-            var unusedVars = collectUnusedVariables(globalScope, unresolvedRefs, []);
+            var unusedVars = collectUnusedVariables(context.getScope(), []);
 
             for (var i = 0, l = unusedVars.length; i < l; ++i) {
                 var unusedVar = unusedVars[i];
 
-                if (unusedVar.eslintUsed) {
-                    continue; // explicitly exported variables
-                } else if (unusedVar.eslintExplicitGlobal) {
-                    context.report(programNode, getLocation(unusedVar), MESSAGE, unusedVar);
+                if (unusedVar.eslintExplicitGlobal) {
+                    context.report({
+                        node: programNode,
+                        loc: getLocation(unusedVar),
+                        message: MESSAGE,
+                        data: unusedVar
+                    });
                 } else if (unusedVar.defs.length > 0) {
-                    context.report(unusedVar.identifiers[0], MESSAGE, unusedVar);
+                    context.report({
+                        node: unusedVar.identifiers[0],
+                        message: MESSAGE,
+                        data: unusedVar
+                    });
                 }
             }
         }

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -7,12 +7,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-var astUtils = require("../ast-utils");
-
-//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -105,10 +99,7 @@ module.exports = function(context) {
      */
     function findVariablesInScope(scope) {
         scope.references.forEach(function(reference) {
-            var variable = (
-                reference.resolved ||
-                astUtils.getVariableByName(scope, reference.identifier.name)
-            );
+            var variable = reference.resolved;
 
             // Skips when the reference is:
             // - referring to an undefined variable.


### PR DESCRIPTION
Fixes #4615

`no-eval` and `no-native-reassign` were using `Scope#through` to find references of built-in global variables, so those needed to fix in order to follow this change. Those references become resolved, so no longer `Scope#through` contains the references.
Others, just remove redundant fallback.