### PR TITLE
New: provide parsing faculties via RuleContext (fixes #3670)

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -73,6 +73,7 @@ The `context` object contains additional functionality that is helpful for rules
 * `id` - the rule ID.
 * `options` - an array of rule options.
 * `settings` - the `settings` from configuration.
+* `parserName` - the `parser` from configuration.
 
 Additionally, the `context` object has the following methods:
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -728,7 +728,7 @@ module.exports = (function() {
                 try {
                     rule = ruleCreator(new RuleContext(
                         key, api, severity, options,
-                        config.settings, config.parserOptions
+                        config.settings, config.parserOptions, config.parser
                     ));
 
                     // add all the node types as listeners

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -70,13 +70,15 @@ var PASSTHROUGHS = [
  * @param {array} options The configuration information to be added to the rule.
  * @param {object} settings The configuration settings passed from the config file.
  * @param {object} parserOptions The parserOptions settings passed from the config file.
+ * @param {object} parserName The parser setting passed from the config file.
  */
-function RuleContext(ruleId, eslint, severity, options, settings, parserOptions) {
+function RuleContext(ruleId, eslint, severity, options, settings, parserOptions, parserName) {
     // public.
     this.id = ruleId;
     this.options = options;
     this.settings = settings;
     this.parserOptions = parserOptions;
+    this.parserName = parserName;
 
     // private.
     this.eslint = eslint;

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1083,6 +1083,41 @@ describe("eslint", function() {
 
     });
 
+    describe("when config has parser", function() {
+
+        // custom parser unsupported in browser, only test in Node
+        if (typeof window === "undefined") {
+            it("should pass parser as parserName to all rules when provided on config", function() {
+
+                var alternateParser = "esprima-fb";
+
+                eslint.reset();
+                eslint.defineRule("test-rule", sandbox.mock().withArgs(
+                    sinon.match({parserName: alternateParser})
+                ).returns({}));
+
+                var config = { rules: { "test-rule": 2 }, parser: alternateParser };
+
+                eslint.verify("0", config, filename);
+            });
+        }
+
+        it("should pass parser as parserName to all rules when default parser is used", function() {
+
+            var DEFAULT_PARSER = eslint.defaults().parser;
+
+            eslint.reset();
+            eslint.defineRule("test-rule", sandbox.mock().withArgs(
+                sinon.match({parserName: DEFAULT_PARSER})
+            ).returns({}));
+
+            var config = { rules: { "test-rule": 2 } };
+
+            eslint.verify("0", config, filename);
+        });
+
+    });
+
 
     describe("when passing in configuration values for rules", function() {
         var code = "var answer = 6 * 7";

--- a/tests/lib/rule-context.js
+++ b/tests/lib/rule-context.js
@@ -26,7 +26,7 @@ describe("RuleContext", function() {
 
         beforeEach(function() {
             eslint = leche.fake(realESLint);
-            ruleContext = new RuleContext("fake-rule", eslint, 2, {}, {}, {});
+            ruleContext = new RuleContext("fake-rule", eslint, 2, {}, {}, {}, "espree");
         });
 
         describe("old-style call with location", function() {


### PR DESCRIPTION
Wanted to get something in code to discuss around #3670.

One notable diversion from discussion: used `parserName` on `RuleContext` directly vs. mutating the exported `parser` object to add `parser.name`.

I believe this satisfies my use case. Wanted to get it in the queue for 2.0.

Tasks:
- [x] sign CLA 😎
- [x] gain consensus on implementation
- [x] update documentation
- [x] confirm tests are valid