### PR TITLE
Add a commentLength option to the max-len rule

### DIFF
--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -38,26 +38,36 @@ var foo = {
 
 ### Options
 
-The `max-len` rule has two required options:
+The `max-len` rule supports the following options:
 
-* The total number of characters allowed on each line of code. This character count includes indentation.
-* The character count to use whenever a tab character is encountered.
+`code`: The total number of characters allowed on each line of code. This character count includes indentation. Defaults to 80.
 
-For example, to specify a maximum line length of 80 characters with each tab counting as 4 characters, use the following configuration:
+`comments`: The total number of characters allowed on a line of comments (e.g. no code on the line). If not specified, `code` is used for comment lines.
+
+`tabWidth`: The character count to use whenever a tab character is encountered. Defaults to 4.
+
+`ignoreComments`: Ignores all trailing comments and comments on their own line. For example, `function foo(/*string*/ bar) { /* ... */ }` isn't collapsed.
+
+`ignoreTrailingComments`: Only ignores comments that are trailing source.
+
+`commentLength`: Specifies an alternate max length that applies only to full length comments.
+
+`ignoreUrls`: Ignores lines that contain a URL.
+
+`ignorePattern`: Ignores lines matching a regular express, such as `^\\s*var\\s.+=\\s*require\\s*\\(`. Be aware that regular expressions can only match a single line and need to be doubly escaped when written in YAML or JSON.
+
+Optionally, you may specify `code` and `tabWidth` as integers before the options object:
 
 ```json
-"max-len": [2, 80, 4]
+"max-len": [2, 80, 4, {ignoreUrls: true}]
 ```
 
-There are additional optional arguments to ignore comments, lines with URLs, or lines matching a regular expression.
+is equivalent to
 
 ```json
-"max-len": [2, 80, 4, {"ignoreComments": true, "ignoreUrls": true, "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\("}]
+"max-len": [2, {code: 80, tabWidth: 4, ignoreUrls: true}]
 ```
 
-The `ignoreComments` option only ignores trailing comments and comments on their own line. For example, `function foo(/*string*/ bar) { /* ... */ }` isn't collapsed.
-
-Be aware that regular expressions can only match a single line and need to be doubly escaped when written in YAML or JSON.
 
 ## Related Rules
 

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -37,12 +37,25 @@ module.exports = function(context) {
         return line.length + extraCharacterCount;
     }
 
-    var maxLength = context.options[0] || 80,
-        tabWidth = context.options[1] || 4,
-        ignoreOptions = context.options[2] || {},
-        ignorePattern = ignoreOptions.ignorePattern || null,
-        ignoreComments = ignoreOptions.ignoreComments || false,
-        ignoreUrls = ignoreOptions.ignoreUrls || false;
+    // The options object must be the last option specified…
+    var lastOption = context.options[context.options.length - 1];
+    var options = typeof lastOption === "object" ? Object.create(lastOption) : {};
+    // …but max code length…
+    if (typeof context.options[0] === "number") {
+        options.code = context.options[0];
+    }
+    // …and tabWidth can be optionally specified directly as integers.
+    if (typeof context.options[1] === "number") {
+        options.tabWidth = context.options[1];
+    }
+
+    var maxLength = options.code || 80,
+        tabWidth = options.tabWidth || 4,
+        ignorePattern = options.ignorePattern || null,
+        ignoreComments = options.ignoreComments || false,
+        ignoreTrailingComments = options.ignoreTrailingComments || options.ignoreComments || false,
+        ignoreUrls = options.ignoreUrls || false,
+        maxCommentLength = options.comments;
 
     if (ignorePattern) {
         ignorePattern = new RegExp(ignorePattern);
@@ -62,8 +75,24 @@ module.exports = function(context) {
      */
     function isTrailingComment(line, lineNumber, comment) {
         return comment &&
-            (comment.loc.start.line <= lineNumber && lineNumber <= comment.loc.end.line) &&
+            (comment.loc.start.line === lineNumber && lineNumber <= comment.loc.end.line) &&
             (comment.loc.end.line > lineNumber || comment.loc.end.column === line.length);
+    }
+
+    /**
+     * Tells if a comment encompasses the entire line.
+     * @param {string} line The source line with a trailing comment
+     * @param {number} lineNumber The one-indexed line number this is on
+     * @param {ASTNode} comment The comment to remove
+     * @returns {boolean} If the comment covers the entire line
+     */
+    function isFullLineComment(line, lineNumber, comment) {
+        var start = comment.loc.start,
+            end = comment.loc.end;
+
+        return comment &&
+            (start.line < lineNumber || (start.line === lineNumber && start.column === 0)) &&
+            (end.line > lineNumber || end.column === line.length);
     }
 
     /**
@@ -75,13 +104,8 @@ module.exports = function(context) {
      * @returns {string} Line without comment and trailing whitepace
      */
     function stripTrailingComment(line, lineNumber, comment) {
-        if (comment.loc.start.line < lineNumber) {
-            // this entire line is a comment
-            return "";
-        } else {
-            // loc.column is zero-indexed
-            return line.slice(0, comment.loc.start.column).replace(/\s+$/, "");
-        }
+        // loc.column is zero-indexed
+        return line.slice(0, comment.loc.start.column).replace(/\s+$/, "");
     }
 
     /**
@@ -94,14 +118,17 @@ module.exports = function(context) {
         // split (honors line-ending)
         var lines = context.getSourceLines(),
             // list of comments to ignore
-            comments = ignoreComments ? context.getAllComments() : [],
+            comments = ignoreComments || maxCommentLength ? context.getAllComments() : [],
             // we iterate over comments in parallel with the lines
             commentsIndex = 0;
 
         lines.forEach(function(line, i) {
             // i is zero-indexed, line numbers are one-indexed
-            var lineNumber = i + 1,
-                lineLength;
+            var lineNumber = i + 1;
+            // if we're checking comment length; we need to know whether this
+            // line is a comment
+            var lineIsComment = false;
+
             // we can short-circuit the comment checks if we're already out of comments to check
             if (commentsIndex < comments.length) {
                 // iterate over comments until we find one past the current line
@@ -110,7 +137,10 @@ module.exports = function(context) {
                 } while (comment && comment.loc.start.line <= lineNumber);
                 // and step back by one
                 comment = comments[--commentsIndex];
-                if (isTrailingComment(line, lineNumber, comment)) {
+
+                if (isFullLineComment(line, lineNumber, comment)) {
+                    lineIsComment = true;
+                } else if (ignoreTrailingComments && isTrailingComment(line, lineNumber, comment)) {
                     line = stripTrailingComment(line, lineNumber, comment);
                 }
             }
@@ -119,8 +149,16 @@ module.exports = function(context) {
                 // ignore this line
                 return;
             }
-            lineLength = computeLineLength(line, tabWidth);
-            if (lineLength > maxLength) {
+
+            var lineLength = computeLineLength(line, tabWidth);
+
+            if (lineIsComment && ignoreComments) {
+                return;
+            }
+
+            if (lineIsComment && lineLength > maxCommentLength) {
+                context.report(node, { line: lineNumber, column: 0 }, "Line " + (i + 1) + " exceeds the maximum comment line length of " + maxCommentLength + ".");
+            } else if (lineLength > maxLength) {
                 context.report(node, { line: lineNumber, column: 0 }, "Line " + (i + 1) + " exceeds the maximum line length of " + maxLength + ".");
             }
         });
@@ -137,28 +175,46 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [
-    {
-        "type": "integer",
-        "minimum": 0
-    },
-    {
-        "type": "integer",
-        "minimum": 0
-    },
-    {
-        "type": "object",
-        "properties": {
-            "ignorePattern": {
-                "type": "string"
-            },
-            "ignoreComments": {
-                "type": "boolean"
-            },
-            "ignoreUrls": {
-                "type": "boolean"
-            }
+var OPTIONS_SCHEMA = {
+    "type": "object",
+    "properties": {
+        "code": {
+            "type": "integer"
         },
-        "additionalProperties": false
-    }
+        "comments": {
+            "type": "integer"
+        },
+        "tabWidth": {
+            "type": "integer"
+        },
+        "ignorePattern": {
+            "type": "string"
+        },
+        "ignoreComments": {
+            "type": "boolean"
+        },
+        "ignoreUrls": {
+            "type": "boolean"
+        },
+        "ignoreTrailingComments": {
+            "type": "boolean"
+        }
+    },
+    "additionalProperties": false
+};
+
+var OPTIONS_OR_INTEGER_SCHEMA = {
+    "anyOf": [
+        OPTIONS_SCHEMA,
+        {
+            "type": "integer",
+            "minimum": 0
+        }
+    ]
+};
+
+module.exports.schema = [
+    OPTIONS_OR_INTEGER_SCHEMA,
+    OPTIONS_OR_INTEGER_SCHEMA,
+    OPTIONS_SCHEMA
 ];

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -66,6 +66,16 @@ ruleTester.run("max-len", rule, {
                 "   but\n" +
                 "   with a short line-length */",
             options: [10, 4, {ignoreComments: true}]
+        }, {
+            code:
+                "// I like short comments\n" +
+                "function butLongSourceLines() { weird(eh()) }",
+            options: [80, {tabWidth: 4, comments: 30}]
+        }, {
+            code:
+                "// Full line comment\n" +
+                "someCode(); // With a long trailing comment.",
+            options: [{code: 30, tabWidth: 4, comments: 20, ignoreTrailingComments: true}]
         },
         // blank line
         ""
@@ -192,6 +202,28 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     message: "Line 1 exceeds the maximum line length of 40.",
+                    type: "Program",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        }, {
+            code: "// A comment that exceeds the max comment length.",
+            options: [80, 4, {comments: 20}],
+            errors: [
+                {
+                    message: "Line 1 exceeds the maximum comment line length of 20.",
+                    type: "Program",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        }, {
+            code: "// A comment that exceeds the max comment length.",
+            options: [{code: 20}],
+            errors: [
+                {
+                    message: "Line 1 exceeds the maximum line length of 20.",
                     type: "Program",
                     line: 1,
                     column: 1


### PR DESCRIPTION
This allows for separate line length restrictions for source and comments.

For example, allowing source lines to be up to 100 characters wide, while restricting comments to 80 for readability.