### PR TITLE
Fix: max-len rule overestimates the width of some tabs (fixes #4661)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -19,23 +19,22 @@ module.exports = function(context) {
     var URL_REGEXP = /[^:/?#]:\/\/[^?#]/;
 
     /**
-     * Creates a string that is made up of repeating a given string a certain
-     * number of times. This uses exponentiation of squares to achieve significant
-     * performance gains over the more traditional implementation of such
-     * functionality.
-     * @param {string} str The string to repeat.
-     * @param {int} num The number of times to repeat the string.
-     * @returns {string} The created string.
+     * Computes the length of a line that may contain tabs. The width of each
+     * tab will be the number of spaces to the next tab stop.
+     * @param {string} line The line.
+     * @param {int} tabWidth The width of each tab stop in spaces.
+     * @returns {int} The computed line length.
      * @private
      */
-    function stringRepeat(str, num) {
-        var result = "";
-        for (num |= 0; num > 0; num >>>= 1, str += str) {
-            if (num & 1) {
-                result += str;
-            }
-        }
-        return result;
+    function computeLineLength(line, tabWidth) {
+        var extraCharacterCount = 0;
+        line.replace(/\t/g, function(match, offset) {
+            var totalOffset = offset + extraCharacterCount,
+                previousTabStopOffset = tabWidth ? totalOffset % tabWidth : 0,
+                spaceCount = tabWidth - previousTabStopOffset;
+            extraCharacterCount += spaceCount - 1;  // -1 for the replaced tab
+        });
+        return line.length + extraCharacterCount;
     }
 
     var maxLength = context.options[0] || 80,
@@ -43,8 +42,7 @@ module.exports = function(context) {
         ignoreOptions = context.options[2] || {},
         ignorePattern = ignoreOptions.ignorePattern || null,
         ignoreComments = ignoreOptions.ignoreComments || false,
-        ignoreUrls = ignoreOptions.ignoreUrls || false,
-        tabString = stringRepeat(" ", tabWidth);
+        ignoreUrls = ignoreOptions.ignoreUrls || false;
 
     if (ignorePattern) {
         ignorePattern = new RegExp(ignorePattern);
@@ -102,7 +100,8 @@ module.exports = function(context) {
 
         lines.forEach(function(line, i) {
             // i is zero-indexed, line numbers are one-indexed
-            var lineNumber = i + 1;
+            var lineNumber = i + 1,
+                lineLength;
             // we can short-circuit the comment checks if we're already out of comments to check
             if (commentsIndex < comments.length) {
                 // iterate over comments until we find one past the current line
@@ -120,8 +119,8 @@ module.exports = function(context) {
                 // ignore this line
                 return;
             }
-            // replace the tabs
-            if (line.replace(/\t/g, tabString).length > maxLength) {
+            lineLength = computeLineLength(line, tabWidth);
+            if (lineLength > maxLength) {
                 context.report(node, { line: lineNumber, column: 0 }, "Line " + (i + 1) + " exceeds the maximum line length of " + maxLength + ".");
             }
         });

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -26,6 +26,12 @@ ruleTester.run("max-len", rule, {
             code: "\t\t\tvar i = 1;\n\t\t\tvar j = 1;",
             options: [15, 1]
         }, {
+            code: "var one\t\t= 1;\nvar three\t= 3;",
+            options: [16, 4]
+        }, {
+            code: "\tvar one\t\t= 1;\n\tvar three\t= 3;",
+            options: [20, 4]
+        }, {
             code: "var i = 1;\r\nvar i = 1;\n",
             options: [10, 4]
         }, {


### PR DESCRIPTION
max-len incorrectly assumed that all tab characters would be the same width as the tab stops (`tabWidth`).

The new `computeLineLength()` determines the width of each tab to be the number of spaces to the next tab stop.

`computeLineLength()` can handle `tabWidth === 0` but it doesn't check that `tabWidth` is a positive integer. I wasn't sure if you wanted this validated, and if invalid input should throw or be silently rounded and made positive.