### PR TITLE
Fix: `no-invalid-this` allows this in static method

### DIFF
--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -74,13 +74,6 @@ var obj = {
     }
 };
 
-class Foo {
-    static foo() {
-        this.a = 0;      /*error Unexpected `this`.*/
-        baz(() => this); /*error Unexpected `this`.*/
-    }
-}
-
 foo.forEach(function() {
     this.a = 0;          /*error Unexpected `this`.*/
     baz(() => this);     /*error Unexpected `this`.*/
@@ -170,6 +163,12 @@ Foo.prototype.foo = function foo() {
 class Foo {
     foo() {
         // OK, this is in a method.
+        this.a = 0;
+        baz(() => this);
+    }
+
+    static foo() {
+        // OK, this is in a method (static methods also have valid this).
         this.a = 0;
         baz(() => this);
     }

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -345,7 +345,7 @@ module.exports = {
                 //   class A { set foo() { ... } }
                 //   class A { static foo() { ... } }
                 case "MethodDefinition":
-                    return parent.static;
+                    return false;
 
                 // e.g.
                 //   var foo = function foo() { ... }.bind(obj);

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -42,6 +42,7 @@ ruleTester.run("no-eval", rule, {
         "var obj = {foo: function() { this.eval('foo'); }}",
         "var obj = {}; obj.foo = function() { this.eval('foo'); }",
         { code: "class A { foo() { this.eval(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A { static foo() { this.eval(); } }", parserOptions: { ecmaVersion: 6 } },
 
         // Allows indirect eval
         { code: "(0, eval)('foo')", options: [{"allowIndirect": true}] },

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -202,8 +202,8 @@ var patterns = [
         code: "class A {static foo() { console.log(this); z(x => console.log(x, this)); }};",
         parserOptions: { ecmaVersion: 6 },
         errors: errors,
-        valid: [],
-        invalid: [NORMAL, USE_STRICT, MODULES]
+        valid: [NORMAL, USE_STRICT, MODULES],
+        invalid: []
     },
 
     // Constructors.


### PR DESCRIPTION
Fixes #4669

I fixed `astUtils.isDefaultThisBinding`.
`no-eval` also is using this, so I added a test to `no-eval` as well.