### PR TITLE
Fix: ensure `ConfigOps.merge` do a deep copy

### DIFF
--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -167,14 +167,10 @@ module.exports = {
             Object.keys(src).forEach(function(key) {
                 if (Array.isArray(src[key]) || Array.isArray(target[key])) {
                     dst[key] = deepmerge(target[key], src[key], key === "plugins", isRule);
-                } else if (typeof src[key] !== "object" || !src[key]) {
+                } else if (typeof src[key] !== "object" || !src[key] || key === "exported" || key === "astGlobals") {
                     dst[key] = src[key];
                 } else {
-                    if (!target[key]) {
-                        dst[key] = src[key];
-                    } else {
-                        dst[key] = deepmerge(target[key], src[key], combine, key === "rules");
-                    }
+                    dst[key] = deepmerge(target[key] || {}, src[key], combine, key === "rules");
                 }
             });
         }

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -385,6 +385,20 @@ describe("ConfigOps", function() {
             });
         });
 
+        it("should copy deeply if there is not the destination's property", function() {
+            var a = {};
+            var b = {foo: {bar: 1}};
+
+            var result = ConfigOps.merge(a, b);
+            assert(a.foo === void 0);
+            assert(b.foo.bar === 1);
+            assert(result.foo.bar === 1);
+
+            result.foo.bar = 2;
+            assert(b.foo.bar === 1);
+            assert(result.foo.bar === 2);
+        });
+
         describe("plugins", function() {
             var baseConfig;
 


### PR DESCRIPTION
Fixes #4682

```js
var result = ConfigOps.merge({}, src);
```

Even if `result` is modified, `src` should keep the original value.
`npm run perf` was around the same result between before and after.