### PR TITLE
New: Add no-confusing-arrow rule (ref #4417)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -11,6 +11,7 @@
         "no-catch-shadow": 0,
         "no-class-assign": 0,
         "no-cond-assign": 2,
+        "no-confusing-arrow": 0,
         "no-console": 2,
         "no-const-assign": 0,
         "no-constant-condition": 2,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -219,6 +219,7 @@ These rules are only relevant to ES6 environments.
 * [generator-star-spacing](generator-star-spacing.md) - enforce spacing around the `*` in generator functions (fixable)
 * [no-arrow-condition](no-arrow-condition.md) - disallow arrow functions where a condition is expected
 * [no-class-assign](no-class-assign.md) - disallow modifying variables of class declarations
+* [no-confusing-arrow](no-confusing-arrow.md) - disallow arrow functions where they could be confused with comparisons
 * [no-const-assign](no-const-assign.md) - disallow modifying variables that are declared using `const`
 * [no-dupe-class-members](no-dupe-class-members.md) - disallow duplicate name in class members
 * [no-this-before-super](no-this-before-super.md) - disallow use of `this`/`super` before calling `super()` in constructors.

--- a/docs/rules/no-confusing-arrow.md
+++ b/docs/rules/no-confusing-arrow.md
@@ -1,0 +1,41 @@
+# Disallow arrow functions where they could be confused with comparisons (no-confusing-arrow)
+
+Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where it could be confused with a comparison operator. Even if the arguments of the arrow function are wrapped with parens, this rule still warns about it.
+
+Here's an example where the usage of `=>` could be confusing:
+
+```js
+// The intent is not clear
+var x = a => 1 ? 2 : 3
+// Did the author mean this
+var x = function (a) { return a >= 1 ? 2 : 3 }
+// Or this
+var x = a <= 1 ? 2 : 3
+```
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+/*eslint no-confusing-arrow: 2*/
+/*eslint-env es6*/
+
+var x = a => 1 ? 2 : 3
+var x = (a) => 1 ? 2 : 3
+```
+
+The following patterns are not considered warnings:
+
+```js
+/*eslint no-confusing-arrow: 2*/
+/*eslint-env es6*/
+
+var x = a => { return 1 ? 2 : 3; }
+var x = (a) => { return 1 ? 2 : 3; }
+```
+
+## Related Rules
+
+* [no-constant-condition](no-constant-condition.md)
+* [arrow-parens](arrow-parens.md)

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -1,0 +1,65 @@
+/**
+ * @fileoverview A rule to warn against using arrow functions when they could be
+ * confused with comparisions
+ * @author Jxck <https://github.com/Jxck>
+ * @copyright 2015 Luke Karrys. All rights reserved.
+ * The MIT License (MIT)
+
+ * Copyright (c) 2015 Jxck
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether or not a node is a conditional expression.
+ * @param {ASTNode} node - node to test
+ * @returns {boolean} `true` if the node is a conditional expression.
+ */
+function isConditional(node) {
+    return node.body && node.body.type === "ConditionalExpression";
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    /**
+     * Reports if an arrow function contains an ambiguous conditional.
+     * @param {ASTNode} node - A node to check and report.
+     * @returns {void}
+     */
+    function checkArrowFunc(node) {
+        if (isConditional(node)) {
+            context.report(node, "Arrow function used ambiguously with a conditional expression.");
+        }
+    }
+
+    return {
+        "ArrowFunctionExpression": checkArrowFunc
+    };
+};
+
+module.exports.schema = [];

--- a/tests/lib/rules/no-confusing-arrow.js
+++ b/tests/lib/rules/no-confusing-arrow.js
@@ -1,0 +1,76 @@
+/**
+ * @fileoverview Tests for no-confusing-arrow rule.
+ * @author Jxck <https://github.com/Jxck>
+ * @copyright 2015 Luke Karrys. All rights reserved.
+ * The MIT License (MIT)
+
+ * Copyright (c) 2015 Jxck
+
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-confusing-arrow"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Extends a rule object to include support for arrow functions
+ * @param {object} obj - rule object
+ * @returns {object} object extend to include ES6 features
+ */
+function addArrowFunctions(obj) {
+    obj.parserOptions = { ecmaVersion: 6 };
+    return obj;
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-confusing-arrow", rule, {
+    valid: [
+        { code: "a => { return 1 ? 2 : 3; }" },
+        { code: "var x = a => { return 1 ? 2 : 3; }" },
+        { code: "var x = (a) => { return 1 ? 2 : 3; }" }
+    ].map(addArrowFunctions),
+    invalid: [
+        {
+            code: "a => 1 ? 2 : 3",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
+        },
+        {
+            code: "var x = a => 1 ? 2 : 3",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
+        },
+        {
+            code: "var x = (a) => 1 ? 2 : 3",
+            errors: [{ message: "Arrow function used ambiguously with a conditional expression." }]
+        }
+    ].map(addArrowFunctions)
+});


### PR DESCRIPTION
This PR implements `no-confusing-arrow`. This rule implements the part of `no-arrow-condition` that isn't currently covered by `no-constant-condition`.

I'll submit another PR deprecating `no-arrow-condition` which will then close #4417.