### PR TITLE
Breaking: deprecate `no-arrow-condition` rule (fixes #4417)

### DIFF
--- a/conf/replacements.json
+++ b/conf/replacements.json
@@ -2,6 +2,7 @@
     "rules": {
         "generator-star": ["generator-star-spacing"],
         "global-strict": ["strict"],
+        "no-arrow-condition": ["no-confusing-arrow", "no-constant-condition"],
         "no-comma-dangle": ["comma-dangle"],
         "no-empty-class": ["no-empty-character-class"],
         "no-extra-strict": ["strict"],

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -217,7 +217,6 @@ These rules are only relevant to ES6 environments.
 * [arrow-spacing](arrow-spacing.md) - require space before/after arrow function's arrow (fixable)
 * [constructor-super](constructor-super.md) - verify calls of `super()` in constructors
 * [generator-star-spacing](generator-star-spacing.md) - enforce spacing around the `*` in generator functions (fixable)
-* [no-arrow-condition](no-arrow-condition.md) - disallow arrow functions where a condition is expected
 * [no-class-assign](no-class-assign.md) - disallow modifying variables of class declarations
 * [no-const-assign](no-const-assign.md) - disallow modifying variables that are declared using `const`
 * [no-dupe-class-members](no-dupe-class-members.md) - disallow duplicate name in class members
@@ -240,6 +239,7 @@ These rules existed in a previous version of ESLint but have since been replaced
 
 * [generator-star](generator-star.md) - enforce the position of the `*` in generator functions (replaced by [generator-star-spacing](generator-star-spacing.md))
 * [global-strict](global-strict.md) - require or disallow the `"use strict"` pragma in the global scope (replaced by [strict](strict.md))
+* [no-arrow-condition](no-arrow-condition.md) - disallow arrow functions where a condition is expected (replaced by [no-confusing-arrow](no-confusing-arrow.md) and [no-constant-condition](no-constant-condition.md))
 * [no-comma-dangle](no-comma-dangle.md) - disallow trailing commas in object literals (replaced by [comma-dangle](comma-dangle.md))
 * [no-empty-class](no-empty-class.md) - disallow the use of empty character classes in regular expressions (replaced by [no-empty-character-class](no-empty-character-class.md))
 * [no-extra-strict](no-extra-strict.md) - disallow unnecessary use of `"use strict";` when already in strict mode (replaced by [strict](strict.md))

--- a/docs/rules/no-arrow-condition.md
+++ b/docs/rules/no-arrow-condition.md
@@ -1,5 +1,7 @@
 # Disallow arrow functions where a condition is expected (no-arrow-condition)
 
+**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by a combination of [no-confusing-arrow](no-confusing-arrow.md) and [no-constant-condition](no-constant-condition.md) rules.
+
 Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where a condition is expected. Even if the arguments of the arrow function are wrapped with parens, this rule still warns about it.
 
 Here's an example where the usage of `=>` is most likely a typo:
@@ -42,3 +44,5 @@ var x = (a) => 1 ? 2 : 3
 ## Related Rules
 
 * [arrow-parens](arrow-parens.md)
+* [no-confusing-arrow](no-confusing-arrow.md)
+* [no-constant-condition](no-constant-condition.md)

--- a/docs/user-guide/migrating-to-2.0.0.md
+++ b/docs/user-guide/migrating-to-2.0.0.md
@@ -47,6 +47,14 @@ module.exports = {
 };
 ```
 
+## Removed Rules
+
+The following rules have been deprecated with new rules created to take their place. The following is a list of the removed rules and their replacements:
+
+* [no-arrow-condition](http://eslint.org/docs/rules/no-arrow-condition) is replaced by a combination of [no-confusing-arrow](http://eslint.org/docs/rules/no-confusing-arrow) and [no-arrow-condition](http://eslint.org/docs/rules/no-arrow-condition). Turn on both of these rules to get the same functionality as `no-arrow-condition`.
+
+**To address:** You'll need to update your rule configurations to use the new rules. ESLint v2.0.0 will also warn you when you're using a rule that has been removed and will suggest the replacement rules. Hopefully, this will result in few surprises during the upgrade process.
+
 ## Configuration Cascading Changes
 
 Prior to 2.0.0, if a directory contained both an `.eslintrc` file and a `package.json` file with ESLint configuration information, the settings from the two files would be merged together. In 2.0.0, only the settings from the `.eslintrc.*` file are used and the ones in `package.json` are ignored when both are present. Otherwise, `package.json` can still be used with ESLint configuration, but only if no other `.eslintrc.*` files are present.


### PR DESCRIPTION
This PR deprecates the `no-arrow-condition` rule in favor of `no-confusing-arrow` (#4687) and [`no-constant-condition`](http://eslint.org/docs/rules/no-constant-condition.html).