### PR TITLE
Fixed bug where disabling an environment didn't work if the parent co…

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -56,7 +56,7 @@ function isObject(item) {
  * @returns {Object} the parsed config object (empty object if there was a parse error)
  * @private
  */
-function loadConfig(configToLoad) {
+function loadConfig(configToLoad, previousConfig) {
     var config = {},
         filePath = "";
 
@@ -70,7 +70,7 @@ function loadConfig(configToLoad) {
             }
         } else {
             filePath = configToLoad;
-            config = ConfigFile.load(filePath);
+            config = ConfigFile.load(filePath, previousConfig);
         }
 
     }
@@ -133,7 +133,7 @@ function getPersonalConfig() {
 
         if (filename) {
             debug("Using personal config");
-            config = loadConfig(filename);
+            config = loadConfig(filename, {});
         }
     }
 
@@ -173,8 +173,8 @@ function getLocalConfig(thisConfig, directory) {
         }
 
         debug("Loading " + localConfigFile);
-        localConfig = loadConfig(localConfigFile);
-
+        localConfig = loadConfig(localConfigFile, config);
+        
         // Don't consider a local config file found if the config is null
         if (!localConfig) {
             continue;
@@ -214,7 +214,7 @@ function Config(options) {
     this.cache = {};
     this.parser = options.parser;
 
-    this.baseConfig = options.baseConfig ? loadConfig(options.baseConfig) : { rules: {} };
+    this.baseConfig = options.baseConfig ? loadConfig(options.baseConfig, {}) : { rules: {} };
 
     this.useEslintrc = (options.useEslintrc !== false);
 
@@ -236,7 +236,7 @@ function Config(options) {
     if (useConfig) {
         debug("Using command line config " + useConfig);
         if (isResolvable(useConfig) || isResolvable("eslint-config-" + useConfig) || useConfig.charAt(0) === "@") {
-            this.useSpecificConfig = loadConfig(useConfig);
+            this.useSpecificConfig = loadConfig(useConfig, {});
         } else {
             this.useSpecificConfig = loadConfig(path.resolve(this.options.cwd, useConfig));
         }

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -324,7 +324,7 @@ function applyExtends(config, filePath) {
 
         try {
             debug("Loading " + parentPath);
-            return ConfigOps.merge(load(parentPath), previousValue);
+            return ConfigOps.merge(load(parentPath, {}), previousValue);
         } catch (e) {
             // If the file referenced by `extends` failed to load, add the path to the
             // configuration file that referenced it to the error message so the user is
@@ -377,10 +377,11 @@ function resolve(filePath) {
  * Loads a configuration file from the given file path.
  * @param {string} filePath The filename or package name to load the configuration
  *      information from.
+ * @param {Object} previousConfig The previous config object.
  * @returns {Object} The configuration information.
  * @private
  */
-function load(filePath) {
+function load(filePath, previousConfig) {
 
     var resolvedPath = resolve(filePath),
         config = loadConfigFile(resolvedPath);
@@ -398,7 +399,7 @@ function load(filePath) {
 
         if (config.env) {
             // Merge in environment-specific globals and parserOptions.
-            config = ConfigOps.applyEnvironments(config);
+            config = ConfigOps.applyEnvironments(config, previousConfig);
         }
 
     }

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -78,10 +78,22 @@ module.exports = {
     /**
      * Given a config with environment settings, applies the globals and
      * ecmaFeatures to the configuration and returns the result.
+     * If the previous config disabled an environment, then this will leave it disabled (and remove it from this config's list.
      * @param {Object} config The configuration information.
+     * @param {Object} previousConfig The previous configuration information.
      * @returns {Object} The updated configuration information.
      */
-    applyEnvironments: function(config) {
+    applyEnvironments: function(config, previousConfig) {
+        if (previousConfig.env) {
+            // Check if a previous config had disabled an environment; if so, don't re-enable it.
+            Object.keys(previousConfig.env).forEach(function(envName) {
+                if (previousConfig.env[envName] === false && config.env && config.env[envName] === true) {
+                    debug('Removing env "' + envName + '" from config since it was disabled in a previous one.');
+                    delete config.env[envName];
+                }
+            });
+        }
+
         if (config.env && typeof config.env === "object") {
             debug("Apply environment settings to config");
             return this.merge(this.createEnvironmentConfig(config.env), config);


### PR DESCRIPTION
…nfig file enabled it.

This works for subfolder/parent-folder eslintrc files.  Previously, even if the child folder had "env: { node: false }", once it got to the parent folder's config file it would see "env: { node: true }" and add all the globals anyway.

This changes many of the methods to take a previousConfig, so that env settings can cascade.