### PR TITLE
Fix: Remove path analysis from debug log (fixes #4631)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -20,7 +20,7 @@ var exitCode = 0,
 
 // must do this initialization *before* other requires in order to work
 if (debug) {
-    require("debug").enable("eslint:*");
+    require("debug").enable("eslint:*,-eslint:code-path");
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
I didn't remove any of the logging, I just changed `debug` command to not include `code-path` logs. This way, people can still get path analysis logs by running `DEBUG=eslint:*`