### PR TITLE
New: Enhanced local plugin resolution. (fixes #3458)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -23,6 +23,7 @@ var fs = require("fs"),
     assign = require("object-assign"),
     debug = require("debug"),
     shell = require("shelljs"),
+    resolve = require("resolve"),
 
     rules = require("./rules"),
     eslint = require("./eslint"),
@@ -118,12 +119,17 @@ function loadPlugins(pluginNames) {
             var pluginNamespace = util.getNamespace(pluginName),
                 pluginNameWithoutNamespace = util.removeNameSpace(pluginName),
                 pluginNameWithoutPrefix = util.removePluginPrefix(pluginNameWithoutNamespace),
+                pluginModuleName = pluginNamespace + util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix,
                 plugin;
 
             if (!loadedPlugins[pluginNameWithoutPrefix]) {
                 debug("Load plugin " + pluginNameWithoutPrefix);
 
-                plugin = require(pluginNamespace + util.PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+                plugin = require(resolve.sync(pluginModuleName, {
+                    basedir: path.dirname(module.parent.parent.filename),
+                    moduleDirectory: [ "node_modules" ]
+                }));
+
                 // if this plugin has rules, import them
                 if (plugin.rules) {
                     rules.import(plugin.rules, pluginNameWithoutPrefix);

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "optionator": "^0.7.1",
     "path-is-absolute": "^1.0.0",
     "path-is-inside": "^1.0.1",
+    "resolve": "^1.1.6",
     "shelljs": "^0.5.3",
     "strip-json-comments": "~1.0.1",
     "text-table": "~0.2.0",

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -41,6 +41,11 @@ describe("CLIEngine", function() {
         examplePreprocessorName = "eslint-plugin-processor",
         fixtureDir;
 
+    requireStubs.resolve = {
+        sync: function(s) {
+            return s;
+        }
+    };
     requireStubs[examplePluginName] = examplePlugin;
     requireStubs[examplePluginNameWithNamespace] = examplePlugin;
     requireStubs[examplePreprocessorName] = require("../fixtures/processors/custom-processor");

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -615,9 +615,15 @@ describe("cli", function() {
                 examplePlugin = { rules: { "cli-example-rule": require(getFixturePath("rules", "custom-rule.js")) } },
                 exampleRuleConfig = "'example/cli-example-rule: 2'";
 
+            requireStubs.resolve = {
+                sync: function(s) {
+                    return s;
+                }
+            };
             requireStubs["./logging"] = log;
             requireStubs[examplePluginName] = examplePlugin;
             requireStubs[examplePluginName]["@global"] = true;
+            requireStubs["./cli-engine"] = proxyquire("../../lib/cli-engine", requireStubs);
 
             cli = proxyquire("../../lib/cli", requireStubs);
             var exit = cli.execute("--plugin " + examplePluginName + " --rule " + exampleRuleConfig + " " + filePath);


### PR DESCRIPTION
When writing presets sometimes it is desirable to include plugins as dependencies, since the preset may be explicitly for that dependency and that means one less thing users need to include and it offers an easy way to pin versions of a plugin with your preset. Unfortunately, the default `eslint` behavior is incapable of loading these local-style plugins for a couple of reasons:

 * `require` only resolves things relative to local eslint installation,
 * absolute paths are not supported,
 * developers don't want any code in `preset` definition files.

So with all those caveats in mind, the behavior has been altered to simply start the preset resolution process at the _caller_'s module (i.e. the preset) instead of the _callee_'s module (i.e. `eslint`).

This fixes https://github.com/eslint/eslint/issues/3458.