### PR TITLE
Update: add allow-x options for bitwise

### DIFF
--- a/lib/rules/no-bitwise.js
+++ b/lib/rules/no-bitwise.js
@@ -10,12 +10,28 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var options = context.options;
 
-    var BITWISE_OPERATORS = [
-        "^", "|", "&", "<<", ">>", ">>>",
-        "^=", "|=", "&=", "<<=", ">>=", ">>>=",
-        "~"
-    ];
+    // Remove the allow from each allowed option and force lowercase.
+    var allowed = (options[0] || "").split(",").map(function map(exception) {
+        return exception.replace("allow-", "").toLowerCase();
+    });
+
+    var BITWISE_OPERATORS = {
+        "^": "xor",
+        "|": "or",
+        "&": "and",
+        "<<": "leftshift",
+        ">>": "rightshift",
+        ">>>": "zerofill-rightshift",
+        "^=": "xor-assign",
+        "|=": "or-assign",
+        "&=": "and-assign",
+        "<<=": "leftshift-assign",
+        ">>=": "rightshift-assign",
+        ">>>=": "zerofill-rightshift-assign",
+        "~": "not"
+    };
 
     /**
      * Reports an unexpected use of a bitwise operator.
@@ -32,16 +48,27 @@ module.exports = function(context) {
      * @returns {boolean} Whether or not the node has a bitwise operator.
      */
     function hasBitwiseOperator(node) {
-        return BITWISE_OPERATORS.indexOf(node.operator) !== -1;
+        return Object.keys(BITWISE_OPERATORS).indexOf(node.operator) !== -1;
+    }
+
+    /**
+     * Checks if exceptions were provided, e.g. `allow-not, allow-or`.
+     * @param   {ASTNode} node The node to check.
+     * @returns {boolean} Whether or not the node has a bitwise operator.
+     */
+    function allowedOperator(node) {
+        return allowed.some(function some(exception) {
+            return exception === BITWISE_OPERATORS[node.operator];
+        });
     }
 
     /**
      * Report if the given node contains a bitwise operator.
-     * @param {ASTNode} node The node to check.
+     * @param   {ASTNode} node The node to check.
      * @returns {void}
      */
     function checkNodeForBitwiseOperator(node) {
-        if (hasBitwiseOperator(node)) {
+        if (hasBitwiseOperator(node) && !allowedOperator(node)) {
             report(node);
         }
     }

--- a/tests/lib/rules/no-bitwise.js
+++ b/tests/lib/rules/no-bitwise.js
@@ -21,7 +21,10 @@ ruleTester.run("no-bitwise", rule, {
     valid: [
         "a + b",
         "!a",
-        "a += b"
+        "a += b",
+        { code: "~[1, 2, 3].indexOf(1)", options: ["allow-not"] },
+        { code: "~1<<2 === -8", options: ["allow-not,allow-leftshift"] },
+        { code: "~1<<2 === -8", options: ["allow-NOT,allow-leftShift"] }
     ],
     invalid: [
         { code: "a ^ b", errors: [{ message: "Unexpected use of '^'.", type: "BinaryExpression"}] },


### PR DESCRIPTION
Mostly useful for allowing the NOT operator for code like `~[1, 2, 3].indexOf(1)`, which is something where using bitwise operators makes sense. I know there are no docs attached, but mainly was wondering if these kinds of features get accepted. 

Usage would be along the line of `no-bitwise: [2, "allow-not"]`