### PR TITLE
Upgrade: beefy to ^2.0.0, fixes installation errors (fixes #4760)

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "xml-escape": "~1.0.0"
   },
   "devDependencies": {
-    "beefy": "^1.0.0",
+    "beefy": "^2.0.0",
     "brfs": "0.0.9",
     "browserify": "^12.0.1",
     "chai": "^3.4.0",


### PR DESCRIPTION
This fixes the installation errors noted in #4760. The errors were being thrown by `chokidar@0.8.1`, which is a dependency of an older version of `beefy`. Updated `beefy` to `^2.0.0` and installed without errors. Also tested that `npm run profile` still runs correctly (and in fact is no longer throws a 404 for the favicon!).