### PR TITLE
Update: Autofix arrow-paren "always" rule (fixes #4766)

### DIFF
--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -45,6 +45,8 @@ The rule can also be configured to discourage the use of parens when they are no
 a => {}
 ```
 
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line **when using the "always" option**.
+
 ### Options
 
 The rule takes one option, a string, which could be either "always" or "as-needed". The default is "always".

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -35,7 +35,13 @@ module.exports = function(context) {
 
             // (x) => x
             if (after.value !== ")") {
-                context.report(node, message);
+                context.report({
+                    node: node,
+                    message: message,
+                    fix: function(fixer) {
+                        return fixer.replaceText(token, "(" + token.value + ")");
+                    }
+                });
             }
         }
     }

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -44,6 +44,7 @@ var type = "ArrowFunctionExpression";
 var invalid = [
     {
         code: "a => {}",
+        output: "(a) => {}",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -54,6 +55,7 @@ var invalid = [
     },
     {
         code: "a => a",
+        output: "(a) => a",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -64,6 +66,7 @@ var invalid = [
     },
     {
         code: "a => {\n}",
+        output: "(a) => {\n}",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -74,6 +77,7 @@ var invalid = [
     },
     {
         code: "a.then(foo => {});",
+        output: "a.then((foo) => {});",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -84,6 +88,7 @@ var invalid = [
     },
     {
         code: "a.then(foo => a);",
+        output: "a.then((foo) => a);",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -94,6 +99,7 @@ var invalid = [
     },
     {
         code: "a(foo => { if (true) {}; });",
+        output: "a((foo) => { if (true) {}; });",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,


### PR DESCRIPTION
Implement auto fix functionality for arrow-paren rule **when using "always" option**

While this does violate the best practice of only changing one character in a fix, I was not able to contrive a situation where it overlaps with another fix.  Caveat: I may not be familiar with every rule fix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/eslint/eslint/4767)
<!-- Reviewable:end -->
