### PR TITLE
Docs: fix typos, suggests

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -365,7 +365,7 @@ ruleTester.run("no-with", rule, {
 });
 ```
 
-Be sure to replace the value of `"block-scoped-var"` with your rule's ID. There are plenty of examples in the `tests/lib/rules/` directory.
+Be sure to replace the value of `"no-with"` with your rule's ID. There are plenty of examples in the `tests/lib/rules/` directory.
 
 ### Valid Code
 
@@ -395,7 +395,7 @@ The `options` property must be an array of options. This gets passed through to 
 
 ### Invalid Code
 
-Each invalid case must be an object containing the code to test and at least the message that is produced by the rule. The `errors` key specifies an array of objects, each containing a message (your rule may trigger multiple messages for the same code). You should also specify the type of AST node you expect to receive back using the `type` key. The AST node should represent the actual spot in the code where there is a problem. For example:
+Each invalid case must be an object containing the code to test and at least one message that is produced by the rule. The `errors` key specifies an array of objects, each containing a message (your rule may trigger multiple messages for the same code). You should also specify the type of AST node you expect to receive back using the `type` key. The AST node should represent the actual spot in the code where there is a problem. For example:
 
 ```js
 invalid: [

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -1,4 +1,4 @@
-# Disallow return in else (no-else-return)
+# Disallow return before else (no-else-return)
 
 If an `if` block contains a `return` statement, the `else` block becomes unnecessary. Its contents can be placed outside of the block.
 

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -2,7 +2,7 @@
 
 ## Rule Details
 
-This error is raised to highlight a potential error. Commonly, when a developer intends to write
+This rule is raised to highlight a potential error. Commonly, when a developer intends to write
 
 ```js
 if(!(a in b)) {

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -87,7 +87,7 @@ var foo = (1 + 2) * 3;
 
 An object literal may be used as a third array item to specify exceptions, with the key `"exceptions"` and an array as the value. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing, then any "exception" will *disallow* spacing. Conversely, if `"never"` is set to disallow spacing, then any "exception" will *enforce* spacing.
 
-The following exceptions are available: `["{}", "[]", "()", "empty"`].
+The following exceptions are available: `["{}", "[]", "()", "empty"]`.
 
 For example, given `"space-in-parens": [2, "always", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
 


### PR DESCRIPTION
the reason of the change in docs/rules/no-else-return.md: 
both rule/index.md (no-else-return - disallow else after a return in an if)  and  this whole file describe  'return before else' not 'return in esle'