### PR TITLE
Docs: Add license header to Working with Rules guide

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -7,6 +7,7 @@ Each ESLint rule has two files: a source file in the `lib/rules` directory and a
  * @fileoverview Rule to flag use of an empty block statement
  * @author Nicholas C. Zakas
  * @copyright 2014 Nicholas C. Zakas. All rights reserved.
+ * See LICENSE in root directory for full license.
  */
 "use strict";
 
@@ -336,6 +337,7 @@ The basic pattern for a rule unit test file is:
  * @fileoverview Tests for no-with rule.
  * @author Nicholas C. Zakas
  * @copyright 2015 Nicholas C. Zakas. All rights reserved.
+ * See LICENSE in root directory for full license.
  */
 
 "use strict";


### PR DESCRIPTION
I'd seen this mentioned in code review recently, so I decided to track down one possible cause.

This doesn't add it to JS files on the assumption that we'll do it like we've done previously and add the header as we go, but I can add it to them too if we want.