### PR TITLE
Update: optionally allow bitwise operators (fixes #4742)

### DIFF
--- a/docs/rules/no-bitwise.md
+++ b/docs/rules/no-bitwise.md
@@ -57,3 +57,11 @@ var x = y < z;
 
 x += y;
 ```
+
+This rule takes one argument, an object with the `allow` property. This allows the listed bitwise operators to be used as exceptions to the rule. For example:
+
+```js
+/*eslint no-bitwise: [2, { allow: ["~"] }] */
+
+~[1,2,3].indexOf(1) === -1;
+```

--- a/lib/rules/no-bitwise.js
+++ b/lib/rules/no-bitwise.js
@@ -5,17 +5,22 @@
 
 "use strict";
 
+//
+// Set of bitwise operators.
+//
+var BITWISE_OPERATORS = [
+    "^", "|", "&", "<<", ">>", ">>>",
+    "^=", "|=", "&=", "<<=", ">>=", ">>>=",
+    "~"
+];
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    var BITWISE_OPERATORS = [
-        "^", "|", "&", "<<", ">>", ">>>",
-        "^=", "|=", "&=", "<<=", ">>=", ">>>=",
-        "~"
-    ];
+    var options = context.options[0] || {};
+    var allowed = options.allow || [];
 
     /**
      * Reports an unexpected use of a bitwise operator.
@@ -36,12 +41,21 @@ module.exports = function(context) {
     }
 
     /**
+     * Checks if exceptions were provided, e.g. `{ allow: ['~', '|'] }`.
+     * @param   {ASTNode} node The node to check.
+     * @returns {boolean} Whether or not the node has a bitwise operator.
+     */
+    function allowedOperator(node) {
+        return allowed.indexOf(node.operator) !== -1;
+    }
+
+    /**
      * Report if the given node contains a bitwise operator.
-     * @param {ASTNode} node The node to check.
+     * @param   {ASTNode} node The node to check.
      * @returns {void}
      */
     function checkNodeForBitwiseOperator(node) {
-        if (hasBitwiseOperator(node)) {
+        if (hasBitwiseOperator(node) && !allowedOperator(node)) {
             report(node);
         }
     }
@@ -54,4 +68,18 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "allow": {
+                "type": "array",
+                "items": {
+                    "enum": BITWISE_OPERATORS
+                },
+                "uniqueItems": true
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/no-bitwise.js
+++ b/tests/lib/rules/no-bitwise.js
@@ -21,7 +21,10 @@ ruleTester.run("no-bitwise", rule, {
     valid: [
         "a + b",
         "!a",
-        "a += b"
+        "a += b",
+        { code: "~[1, 2, 3].indexOf(1)", options: [{ allow: ["~"] }]},
+        { code: "~1<<2 === -8", options: [{ allow: ["~", "<<"] }]},
+        { code: "~1<<2 === -8", options: [{ allow: ["~", "<<"] }]}
     ],
     invalid: [
         { code: "a ^ b", errors: [{ message: "Unexpected use of '^'.", type: "BinaryExpression"}] },


### PR DESCRIPTION
Mostly useful for allowing the NOT operator for code like ~[1, 2, 3].indexOf(1), which is something where using bitwise operators makes sense. I know there are no docs attached, but mainly was wondering if these kinds of features get accepted.

Usage would be along the line of `no-bitwise: [2, { allow: [ '~' ] }]`

edit: clean new PR from #4738
edit: related to #4742