### PR TITLE
Breaking: merges keyword spacing rules

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -153,6 +153,7 @@
         "init-declarations": 0,
         "jsx-quotes": [0, "prefer-double"],
         "key-spacing": [0, { "beforeColon": false, "afterColon": true }],
+        "keyword-spacing": 0,
         "lines-around-comment": 0,
         "max-depth": [0, 4],
         "max-len": [0, 80, 4],

--- a/conf/replacements.json
+++ b/conf/replacements.json
@@ -10,8 +10,11 @@
         "no-space-before-semi": ["semi-spacing"],
         "no-wrap-func": ["no-extra-parens"],
         "space-after-function-name": ["space-before-function-paren"],
+        "space-after-keywords": ["keyword-spacing"],
         "space-before-function-parentheses": ["space-before-function-paren"],
+        "space-before-keywords": ["keyword-spacing"],
         "space-in-brackets": ["object-curly-spacing", "array-bracket-spacing", "computed-property-spacing"],
+        "space-return-throw-case": ["keyword-spacing"],
         "space-unary-word-ops": ["space-unary-ops"],
         "spaced-line-comment": ["spaced-comment"]
     }

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -160,6 +160,7 @@ These rules are purely matters of style and are quite subjective.
 * [indent](indent.md) - specify tab or space width for your code (fixable)
 * [jsx-quotes](jsx-quotes.md) - specify whether double or single quotes should be used in JSX attributes
 * [key-spacing](key-spacing.md) - enforce spacing between keys and values in object literal properties
+* [keyword-spacing](keyword-spacing.md) - enforce spacing before and after keywords (fixable)
 * [linebreak-style](linebreak-style.md) - disallow mixed 'LF' and 'CRLF' as linebreaks
 * [lines-around-comment](lines-around-comment.md) - enforce empty lines around comments
 * [max-depth](max-depth.md) - specify the maximum depth that blocks can be nested
@@ -199,13 +200,10 @@ These rules are purely matters of style and are quite subjective.
 * [semi-spacing](semi-spacing.md) - enforce spacing before and after semicolons (fixable)
 * [semi](semi.md) - require or disallow use of semicolons instead of ASI (fixable)
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block
-* [space-after-keywords](space-after-keywords.md) - require a space after certain keywords (fixable)
 * [space-before-blocks](space-before-blocks.md) - require or disallow a space before blocks (fixable)
 * [space-before-function-paren](space-before-function-paren.md) - require or disallow a space before function opening parenthesis (fixable)
-* [space-before-keywords](space-before-keywords.md) - require a space before certain keywords (fixable)
 * [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses
 * [space-infix-ops](space-infix-ops.md) - require spaces around operators (fixable)
-* [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case` (fixable)
 * [space-unary-ops](space-unary-ops.md) - require or disallow spaces before/after unary operators (fixable)
 * [spaced-comment](spaced-comment.md) - require or disallow a space immediately following the `//` or `/*` in a comment
 * [wrap-regex](wrap-regex.md) - require regex literals to be wrapped in parentheses
@@ -251,7 +249,10 @@ These rules existed in a previous version of ESLint but have since been replaced
 * [no-space-before-semi](no-space-before-semi.md) - disallow space before semicolon (replaced by [semi-spacing](semi-spacing.md))
 * [no-wrap-func](no-wrap-func.md) - disallow wrapping of non-IIFE statements in parens (replaced by [no-extra-parens](no-extra-parens.md))
 * [space-after-function-name](space-after-function-name.md) - require a space after function names (replaced by [space-before-function-paren](space-before-function-paren.md))
+* [space-after-keywords](space-after-keywords.md) - require a space after certain keywords (fixable) (replaced by [keyword-spacing](keyword-spacing.md))
 * [space-before-function-parentheses](space-before-function-parentheses.md) - require or disallow space before function parentheses (replaced by [space-before-function-paren](space-before-function-paren.md))
+* [space-before-keywords](space-before-keywords.md) - require a space before certain keywords (fixable) (replaced by [keyword-spacing](keyword-spacing.md))
 * [space-in-brackets](space-in-brackets.md) - require or disallow spaces inside brackets (replaced by [object-curly-spacing](object-curly-spacing.md) and [array-bracket-spacing](array-bracket-spacing.md))
+* [space-return-throw-case](space-return-throw-case.md) - require a space after `return`, `throw`, and `case` (fixable) (replaced by [keyword-spacing](keyword-spacing.md))
 * [space-unary-word-ops](space-unary-word-ops.md) - require or disallow spaces before/after unary operators (replaced by [space-unary-ops](space-unary-ops.md))
 * [spaced-line-comment](spaced-line-comment.md) - require or disallow a space immediately following the `//` in a line comment (replaced by [spaced-comment](spaced-comment.md))

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -1,0 +1,321 @@
+# Enforce spacing before and after keywords (keyword-spacing)
+
+Keywords are syntax elements of JavaScript, such as `function` and `if`.
+These identifiers have special meaning to the language and so often appear in a different color in code editors.
+As an important part of the language, style guides often refer to the spacing that should be used around keywords.
+For example, you might have a style guide that says keywords should be always surrounded by spaces, which would mean `if-else` statements must look like this:
+
+```js
+if (foo) {
+    // ...
+} else {
+    // ...
+}
+```
+
+Of course, you could also have a style guide that disallows spaces around keywords.
+
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+
+## Rule Details
+
+This rule will enforce consistency of spacing around keywords and keyword-like tokens: `as` (in module declarations), `break`, `case`, `catch`, `class`, `const`, `continue`, `debugger`, `default`, `delete`, `do`, `else`, `export`, `extends`, `finally`, `for`, `from` (in module declarations), `function`, `get` (of getters), `if`, `import`, `in`, `instanceof`, `let`, `new`, `of` (in for-of statements), `return`, `set` (of setters), `static`, `super`, `switch`, `this`, `throw`, `try`, `typeof`, `var`, `void`, `while`, `with`, and `yield`.
+
+The following patterns are considered problems:
+
+```js
+/*eslint keyword-spacing: 2*/
+/*eslint-env es6*/
+
+if(foo){              /*error Expected space(s) after "if".*/
+    //...
+}else if (bar) {      /*error Expected space(s) before "else".*/
+    //...
+} else{               /*error Expected space(s) after "else".*/
+    //...
+}
+
+try{                  /*error Expected space(s) after "try".*/
+    //...
+}catch(e) {           /*error Expected space(s) before "catch".*/
+                      /*error Expected space(s) after "catch".*/
+    //...
+}
+
+switch (a) {
+    case+1:           /*error Expected space(s) after "case".*/
+        break;
+}
+
+function foo() {
+    return[0, 1, 2];  /*error Expected space(s) after "return".*/
+}
+
+for (let[a, b]of[foo, bar, baz]) { /*error Expected space(s) after "let".*/
+                                   /*error Expected space(s) before "of".*/
+                                   /*error Expected space(s) after "of".*/
+    //...
+}
+
+let obj = {
+    get[FOO]() {      /*error Expected space(s) after "get".*/
+        //...
+    },
+    set[FOO](value) { /*error Expected space(s) after "set".*/
+        //...
+    }
+};
+
+import{foo}from"foo";     /*error Expected space(s) after "import".*/
+                          /*error Expected space(s) before "from".*/
+                          /*error Expected space(s) after "from".*/
+import*as bar from "foo"; /*error Expected space(s) after "import".*/
+                          /*error Expected space(s) before "as".*/
+```
+
+The following patterns are considered not problems:
+
+```js
+/*eslint keyword-spacing: 2*/
+/*eslint-env es6*/
+
+if (foo) {
+    //...
+} else if (bar) {
+    //...
+} else {
+    //...
+}
+
+try {
+    //...
+} catch (e) {
+    //...
+}
+
+switch (a) {
+    case +1:
+        break;
+}
+
+function foo() {
+    return [0, 1, 2];
+}
+
+for (let [a, b] of [foo, bar, baz]) {
+    //...
+}
+
+let obj = {
+    get [FOO]() {
+        //...
+    },
+    set [FOO](value) {
+        //...
+    }
+};
+
+import {foo} from "foo";
+import * as bar from "foo";
+```
+
+This rule is designed carefully to not conflict with other spacing rules.
+Basically this rule ignores usage of spacing at places that other rules are catching.
+So the following patterns are considered not problems.
+
+```js
+/*eslint keyword-spacing: 2*/
+/*eslint-env es6*/
+
+// not conflict with `array-bracket-spacing`
+let a = [this];
+let b = [function() {}];
+
+// not conflict with `arrow-spacing`
+let a = () =>this.foo;
+
+// not conflict with `block-spacing`
+{function foo() {}}
+
+// not conflict with `comma-spacing`
+let a = [100,this.foo, this.bar];
+
+// not conflict with `computed-property-spacing`
+obj[this.foo] = 0;
+
+// not conflict with `generator-star-spacing`
+function* foo() {}
+
+// not conflict with `key-spacing`
+let obj = {
+    foo:function() {}
+};
+
+// not conflict with `no-spaced-func`
+class A {
+    constructor() {
+        super();
+    }
+}
+
+// not conflict with `object-curly-spacing`
+let obj = {foo: this};
+
+// not conflict with `semi-spacing`
+let a = this;function foo() {}
+
+// not conflict with `space-before-function-paren`
+// not conflict with `space-in-parens`
+(function() {})();
+
+// not conflict with `space-infix-ops`
+if ("foo"in{foo: 0}) {}
+if (10+this.foo <=this.bar) {}
+
+// not conflict with `space-unary-ops`
+function* foo(a) {
+    return yield+a;
+}
+
+// not conflict with `yield-star-spacing`
+function* foo(a) {
+    return yield* a;
+}
+
+// not conflict with `jsx-curly-spacing`
+let a = <A foo={this.foo} bar={function(){}} />
+```
+
+
+### Options
+
+This rule has 3 options.
+
+```json
+{
+    "keyword-spacing": [2, {"before": true, "after": true, "overrides": null}]
+}
+```
+
+- `"before"` (`boolean`, default is `true`) -
+  This option specifies usage of spacing before the keywords.
+  If `true` then the keywords must be preceded by at least one space.
+  Otherwise, no spaces will be allowed before the keywords (if possible).
+- `"after"` (`boolean`, default is `true`) -
+  This option specifies usage of spacing after the keywords.
+  If `true` then the keywords must be followed by at least one space.
+  Otherwise, no spaces will be allowed after the keywords (if possible).
+- `"overrides"` (`object`, default is `null`) -
+  This option specifies overwriting usage of spacing for each keyword.
+  For Example:
+
+  ```json
+  {
+      "keyword-spacing": [2, {"overrides": {
+          "if": {"after": false},
+          "for": {"after": false},
+          "while": {"after": false}
+      }}]
+  }
+  ```
+
+  In this case, no spaces will be allowed only after `if`, `for`, and `while`.
+
+The following patterns are considered problems when configured `{"before": false, "after": false}`:
+
+```js
+/*eslint keyword-spacing: [2, {before: false, after: false}]*/
+/*eslint-env es6*/
+
+if (foo){              /*error Unexpected space(s) after "if".*/
+    //...
+} else if(bar) {       /*error Unexpected space(s) before "else".*/
+    //...
+}else {                /*error Unexpected space(s) after "else".*/
+    //...
+}
+
+try {                  /*error Unexpected space(s) after "try".*/
+    //...
+} catch (e) {          /*error Unexpected space(s) before "catch".*/
+                       /*error Unexpected space(s) after "catch".*/
+    //...
+}
+
+switch(a) {
+    case +1:           /*error Unexpected space(s) after "case".*/
+        break;
+}
+
+function foo() {
+    return [0, 1, 2];  /*error Unexpected space(s) after "return".*/
+}
+
+for (let [a, b] of [foo, bar, baz]) { /*error Unexpected space(s) after "let".*/
+                                      /*error Unexpected space(s) before "of".*/
+                                      /*error Unexpected space(s) after "of".*/
+    //...
+}
+
+let obj = {
+    get [FOO]() {      /*error Unexpected space(s) after "get".*/
+        //...
+    },
+    set [FOO](value) { /*error Unexpected space(s) after "set".*/
+        //...
+    }
+};
+
+import {foo} from "foo";   /*error Unexpected space(s) after "import".*/
+                           /*error Unexpected space(s) before "from".*/
+                           /*error Unexpected space(s) after "from".*/
+import * as bar from"foo"; /*error Unexpected space(s) after "import".*/
+                           /*error Unexpected space(s) before "as".*/
+```
+
+The following patterns are considered not problems when configured `{"before": false, "after": false}`:
+
+```js
+/*eslint keyword-spacing: [2, {before: false, after: false}]*/
+/*eslint-env es6*/
+
+if(foo) {
+    //...
+}else if(bar) {
+    //...
+}else{
+    //...
+}
+
+try{
+    //...
+}catch(e) {
+    //...
+}
+
+switch(a) {
+    case+1:
+        break;
+}
+
+function foo() {
+    return[0, 1, 2];
+}
+
+for(let[a, b]of[foo, bar, baz]) {
+    //...
+}
+
+let obj = {
+    get[FOO]() {
+        //...
+    },
+    set[FOO](value) {
+        //...
+    }
+};
+```
+
+## When Not To Use It
+
+If you don't want to enforce consistency on keyword spacing, then it's safe to disable this rule.

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -1,5 +1,7 @@
 # Require or disallow spaces following keywords (space-after-keywords)
 
+**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
+
 Some style guides will require or disallow spaces following the certain keywords.
 
 ```js

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -1,5 +1,7 @@
 # Require or disallow spaces before keywords (space-before-keywords)
 
+**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
+
 Keywords are syntax elements of JavaScript, such as `function` and `if`. These identifiers have special meaning to the language and so often appear in a different color in code editors. As an important part of the language, style guides often refer to the spacing that should be used around keywords. For example, you might have a style guide that says keywords should be always be preceded by spaces, which would mean `if-else` statements must look like this:
 
 ```js

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -1,5 +1,7 @@
 # Require spaces following `return`, `throw`, and `case` (space-return-throw-case)
 
+**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
+
 Require spaces following `return`, `throw`, and `case`.
 
 **Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.

--- a/docs/user-guide/migrating-to-2.0.0.md
+++ b/docs/user-guide/migrating-to-2.0.0.md
@@ -52,6 +52,9 @@ module.exports = {
 The following rules have been deprecated with new rules created to take their place. The following is a list of the removed rules and their replacements:
 
 * [no-arrow-condition](http://eslint.org/docs/rules/no-arrow-condition) is replaced by a combination of [no-confusing-arrow](http://eslint.org/docs/rules/no-confusing-arrow) and [no-constant-condition](http://eslint.org/docs/rules/no-constant-condition). Turn on both of these rules to get the same functionality as `no-arrow-condition`.
+* [space-after-keywords](http://eslint.org/docs/rules/space-after-keywords) is replaced by [keyword-spacing](http://eslint.org/docs/rules/keyword-spacing).
+* [space-before-keywords](http://eslint.org/docs/rules/space-before-keywords) is replaced by [keyword-spacing](http://eslint.org/docs/rules/keyword-spacing).
+* [space-return-throw-case](http://eslint.org/docs/rules/space-return-throw-case) is replaced by [keyword-spacing](http://eslint.org/docs/rules/keyword-spacing).
 
 **To address:** You'll need to update your rule configurations to use the new rules. ESLint v2.0.0 will also warn you when you're using a rule that has been removed and will suggest the replacement rules. Hopefully, this will result in few surprises during the upgrade process.
 

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -1,0 +1,490 @@
+/**
+ * @fileoverview Rule to enforce spacing before and after keywords.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils"),
+    keywords = require("../util/keywords");
+
+//------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var PREV_TOKEN = /^[\)\]\}>]$/;
+var NEXT_TOKEN = /^(?:[\(\[\{<~!]|\+\+?|--?)$/;
+var PREV_TOKEN_M = /^[\)\]\}>*]$/;
+var NEXT_TOKEN_M = /^[\{*]$/;
+var CHECK_TYPE = /^(?:JSXElement|RegularExpression|String|Template)$/;
+var KEYS = keywords.concat(["as", "await", "from", "get", "let", "of", "set", "yield"]);
+
+// check duplications.
+(function() {
+    KEYS.sort();
+    for (var i = 1; i < KEYS.length; ++i) {
+        if (KEYS[i] === KEYS[i - 1]) {
+            throw new Error("Duplication was found in the keyword list: " + KEYS[i]);
+        }
+    }
+}());
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var sourceCode = context.getSourceCode();
+
+    /**
+     * Reports a given token if there are not space(s) before the token.
+     *
+     * @param {Token} token - A token to report.
+     * @param {RegExp|undefined} pattern - Optional. A pattern of the previous
+     *      token to check.
+     * @returns {void}
+     */
+    function expectSpaceBefore(token, pattern) {
+        pattern = pattern || PREV_TOKEN;
+
+        var prevToken = sourceCode.getTokenBefore(token);
+        if (prevToken &&
+            (CHECK_TYPE.test(prevToken.type) || pattern.test(prevToken.value)) &&
+            astUtils.isTokenOnSameLine(prevToken, token) &&
+            !sourceCode.isSpaceBetweenTokens(prevToken, token)
+        ) {
+            context.report({
+                loc: token.loc.start,
+                message: "Expected space(s) before \"{{value}}\".",
+                data: token,
+                fix: function(fixer) {
+                    return fixer.insertTextBefore(token, " ");
+                }
+            });
+        }
+    }
+
+    /**
+     * Reports a given token if there are space(s) before the token.
+     *
+     * @param {Token} token - A token to report.
+     * @param {RegExp|undefined} pattern - Optional. A pattern of the previous
+     *      token to check.
+     * @returns {void}
+     */
+    function unexpectSpaceBefore(token, pattern) {
+        pattern = pattern || PREV_TOKEN;
+
+        var prevToken = sourceCode.getTokenBefore(token);
+        if (prevToken &&
+            (CHECK_TYPE.test(prevToken.type) || pattern.test(prevToken.value)) &&
+            astUtils.isTokenOnSameLine(prevToken, token) &&
+            sourceCode.isSpaceBetweenTokens(prevToken, token)
+        ) {
+            context.report({
+                loc: token.loc.start,
+                message: "Unexpected space(s) before \"{{value}}\".",
+                data: token,
+                fix: function(fixer) {
+                    return fixer.removeRange([prevToken.range[1], token.range[0]]);
+                }
+            });
+        }
+    }
+
+    /**
+     * Reports a given token if there are not space(s) after the token.
+     *
+     * @param {Token} token - A token to report.
+     * @param {RegExp|undefined} pattern - Optional. A pattern of the next
+     *      token to check.
+     * @returns {void}
+     */
+    function expectSpaceAfter(token, pattern) {
+        pattern = pattern || NEXT_TOKEN;
+
+        var nextToken = sourceCode.getTokenAfter(token);
+        if (nextToken &&
+            (CHECK_TYPE.test(nextToken.type) || pattern.test(nextToken.value)) &&
+            astUtils.isTokenOnSameLine(token, nextToken) &&
+            !sourceCode.isSpaceBetweenTokens(token, nextToken)
+        ) {
+            context.report({
+                loc: token.loc.start,
+                message: "Expected space(s) after \"{{value}}\".",
+                data: token,
+                fix: function(fixer) {
+                    return fixer.insertTextAfter(token, " ");
+                }
+            });
+        }
+    }
+
+    /**
+     * Reports a given token if there are space(s) after the token.
+     *
+     * @param {Token} token - A token to report.
+     * @param {RegExp|undefined} pattern - Optional. A pattern of the next
+     *      token to check.
+     * @returns {void}
+     */
+    function unexpectSpaceAfter(token, pattern) {
+        pattern = pattern || NEXT_TOKEN;
+
+        var nextToken = sourceCode.getTokenAfter(token);
+        if (nextToken &&
+            (CHECK_TYPE.test(nextToken.type) || pattern.test(nextToken.value)) &&
+            astUtils.isTokenOnSameLine(token, nextToken) &&
+            sourceCode.isSpaceBetweenTokens(token, nextToken)
+        ) {
+            context.report({
+                loc: token.loc.start,
+                message: "Unexpected space(s) after \"{{value}}\".",
+                data: token,
+                fix: function(fixer) {
+                    return fixer.removeRange([token.range[1], nextToken.range[0]]);
+                }
+            });
+        }
+    }
+
+    /**
+     * Parses the option object and determines check methods for each keyword.
+     *
+     * @param {object|undefined} options - The option object to parse.
+     * @returns {object} - Normalized option object.
+     *      Keys are keywords (there are for every keyword).
+     *      Values are instances of `{"before": function, "after": function}`.
+     */
+    function parseOptions(options) {
+        var before = !options || options.before !== false;
+        var after = !options || options.after !== false;
+        var defaultValue = {
+            before: before ? expectSpaceBefore : unexpectSpaceBefore,
+            after: after ? expectSpaceAfter : unexpectSpaceAfter
+        };
+        var overrides = (options && options.overrides) || {};
+        var retv = Object.create(null);
+
+        for (var i = 0; i < KEYS.length; ++i) {
+            var key = KEYS[i];
+            var override = overrides[key];
+
+            if (override) {
+                var thisBefore = ("before" in override) ? override.before : before;
+                var thisAfter = ("after" in override) ? override.after : after;
+                retv[key] = {
+                    before: thisBefore ? expectSpaceBefore : unexpectSpaceBefore,
+                    after: thisAfter ? expectSpaceAfter : unexpectSpaceAfter
+                };
+            } else {
+                retv[key] = defaultValue;
+            }
+        }
+
+        return retv;
+    }
+
+    var checkMethodMap = parseOptions(context.options[0]);
+
+    /**
+     * Reports a given token if usage of spacing followed by the token is
+     * invalid.
+     *
+     * @param {Token} token - A token to report.
+     * @param {RegExp|undefined} pattern - Optional. A pattern of the previous
+     *      token to check.
+     * @returns {void}
+     */
+    function checkSpacingBefore(token, pattern) {
+        checkMethodMap[token.value].before(token, pattern);
+    }
+
+    /**
+     * Reports a given token if usage of spacing preceded by the token is
+     * invalid.
+     *
+     * @param {Token} token - A token to report.
+     * @param {RegExp|undefined} pattern - Optional. A pattern of the next
+     *      token to check.
+     * @returns {void}
+     */
+    function checkSpacingAfter(token, pattern) {
+        checkMethodMap[token.value].after(token, pattern);
+    }
+
+    /**
+     * Reports a given token if usage of spacing around the token is invalid.
+     *
+     * @param {Token} token - A token to report.
+     * @returns {void}
+     */
+    function checkSpacingAround(token) {
+        checkSpacingBefore(token);
+        checkSpacingAfter(token);
+    }
+
+    /**
+     * Reports the first token of a given node if the first token is a keyword
+     * and usage of spacing around the token is invalid.
+     *
+     * @param {ASTNode|null} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingAroundFirstToken(node) {
+        var firstToken = node && sourceCode.getFirstToken(node);
+        if (firstToken && firstToken.type === "Keyword") {
+            checkSpacingAround(firstToken);
+        }
+    }
+
+    /**
+     * Reports the first token of a given node if the first token is a keyword
+     * and usage of spacing followed by the token is invalid.
+     *
+     * This is used for unary operators (e.g. `typeof`), `function`, and `super`.
+     * Other rules are handling usage of spacing preceded by those keywords.
+     *
+     * @param {ASTNode|null} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingBeforeFirstToken(node) {
+        var firstToken = node && sourceCode.getFirstToken(node);
+        if (firstToken && firstToken.type === "Keyword") {
+            checkSpacingBefore(firstToken);
+        }
+    }
+
+    /**
+     * Reports the previous token of a given node if the token is a keyword and
+     * usage of spacing around the token is invalid.
+     *
+     * @param {ASTNode|null} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingAroundTokenBefore(node) {
+        if (node) {
+            var token = sourceCode.getTokenBefore(node);
+            while (token.type !== "Keyword") {
+                token = sourceCode.getTokenBefore(token);
+            }
+
+            checkSpacingAround(token);
+        }
+    }
+
+    /**
+     * Reports `class` and `extends` keywords of a given node if usage of
+     * spacing around those keywords is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForClass(node) {
+        checkSpacingAroundFirstToken(node);
+        checkSpacingAroundTokenBefore(node.superClass);
+    }
+
+    /**
+     * Reports `if` and `else` keywords of a given node if usage of spacing
+     * around those keywords is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForIfStatement(node) {
+        checkSpacingAroundFirstToken(node);
+        checkSpacingAroundTokenBefore(node.alternate);
+    }
+
+    /**
+     * Reports `try`, `catch`, and `finally` keywords of a given node if usage
+     * of spacing around those keywords is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForTryStatement(node) {
+        checkSpacingAroundFirstToken(node);
+        checkSpacingAroundFirstToken(node.handler);
+        checkSpacingAroundTokenBefore(node.finalizer);
+    }
+
+    /**
+     * Reports `do` and `while` keywords of a given node if usage of spacing
+     * around those keywords is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForDoWhileStatement(node) {
+        checkSpacingAroundFirstToken(node);
+        checkSpacingAroundTokenBefore(node.test);
+    }
+
+    /**
+     * Reports `for` and `in` keywords of a given node if usage of spacing
+     * around those keywords is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForForInStatement(node) {
+        checkSpacingAroundFirstToken(node);
+        checkSpacingAroundTokenBefore(node.right);
+    }
+
+    /**
+     * Reports `for` and `of` keywords of a given node if usage of spacing
+     * around those keywords is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForForOfStatement(node) {
+        checkSpacingAroundFirstToken(node);
+
+        // `of` is not a keyword token.
+        var token = sourceCode.getTokenBefore(node.right);
+        while (token.value !== "of") {
+            token = sourceCode.getTokenBefore(token);
+        }
+        checkSpacingAround(token);
+    }
+
+    /**
+     * Reports `import`, `export`, `as`, and `from` keywords of a given node if
+     * usage of spacing around those keywords is invalid.
+     *
+     * This rule handles the `*` token in module declarations.
+     *
+     *     import*as A from "./a"; /*error Expected space(s) after "import".
+     *                               error Expected space(s) before "as".
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForModuleDeclaration(node) {
+        var firstToken = sourceCode.getFirstToken(node);
+        checkSpacingBefore(firstToken, PREV_TOKEN_M);
+        checkSpacingAfter(firstToken, NEXT_TOKEN_M);
+
+        if (node.source) {
+            var fromToken = sourceCode.getTokenBefore(node.source);
+            checkSpacingBefore(fromToken, PREV_TOKEN_M);
+            checkSpacingAfter(fromToken, NEXT_TOKEN_M);
+        }
+    }
+
+    /**
+     * Reports `as` keyword of a given node if usage of spacing around this
+     * keyword is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForImportNamespaceSpecifier(node) {
+        var asToken = sourceCode.getFirstToken(node, 1);
+        checkSpacingBefore(asToken, PREV_TOKEN_M);
+    }
+
+    /**
+     * Reports `static`, `get`, and `set` keywords of a given node if usage of
+     * spacing around those keywords is invalid.
+     *
+     * @param {ASTNode} node - A node to report.
+     * @returns {void}
+     */
+    function checkSpacingForProperty(node) {
+        if (node.static) {
+            checkSpacingAroundFirstToken(node);
+        }
+        if (node.kind === "get" || node.kind === "set") {
+            var token = sourceCode.getFirstToken(
+                node,
+                node.static ? 1 : 0
+            );
+            checkSpacingAround(token);
+        }
+    }
+
+    return {
+        // Statements
+        DebuggerStatement: checkSpacingAroundFirstToken,
+        WithStatement: checkSpacingAroundFirstToken,
+
+        // Statements - Control flow
+        BreakStatement: checkSpacingAroundFirstToken,
+        ContinueStatement: checkSpacingAroundFirstToken,
+        ReturnStatement: checkSpacingAroundFirstToken,
+        ThrowStatement: checkSpacingAroundFirstToken,
+        TryStatement: checkSpacingForTryStatement,
+
+        // Statements - Choice
+        IfStatement: checkSpacingForIfStatement,
+        SwitchStatement: checkSpacingAroundFirstToken,
+        SwitchCase: checkSpacingAroundFirstToken,
+
+        // Statements - Loops
+        DoWhileStatement: checkSpacingForDoWhileStatement,
+        ForInStatement: checkSpacingForForInStatement,
+        ForOfStatement: checkSpacingForForOfStatement,
+        ForStatement: checkSpacingAroundFirstToken,
+        WhileStatement: checkSpacingAroundFirstToken,
+
+        // Statements - Declarations
+        ClassDeclaration: checkSpacingForClass,
+        ExportNamedDeclaration: checkSpacingForModuleDeclaration,
+        ExportDefaultDeclaration: checkSpacingAroundFirstToken,
+        ExportAllDeclaration: checkSpacingForModuleDeclaration,
+        FunctionDeclaration: checkSpacingBeforeFirstToken,
+        ImportDeclaration: checkSpacingForModuleDeclaration,
+        VariableDeclaration: checkSpacingAroundFirstToken,
+
+        // Expressions
+        ClassExpression: checkSpacingForClass,
+        FunctionExpression: checkSpacingBeforeFirstToken,
+        NewExpression: checkSpacingBeforeFirstToken,
+        Super: checkSpacingBeforeFirstToken,
+        ThisExpression: checkSpacingBeforeFirstToken,
+        UnaryExpression: checkSpacingBeforeFirstToken,
+        YieldExpression: checkSpacingBeforeFirstToken,
+
+        // Others
+        ImportNamespaceSpecifier: checkSpacingForImportNamespaceSpecifier,
+        MethodDefinition: checkSpacingForProperty,
+        Property: checkSpacingForProperty
+    };
+};
+
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "before": {"type": "boolean"},
+            "after": {"type": "boolean"},
+            "overrides": {
+                "type": "object",
+                "properties": KEYS.reduce(function(retv, key) {
+                    retv[key] = {
+                        "type": "object",
+                        "properties": {
+                            "before": {"type": "boolean"},
+                            "after": {"type": "boolean"}
+                        },
+                        "additionalProperties": false
+                    };
+                    return retv;
+                }, {}),
+                "additionalProperties": false
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -19,6 +19,7 @@ rules:
     func-style: [2, "declaration"]
     guard-for-in: 2
     key-spacing: [2, { beforeColon: false, afterColon: true }]
+    keyword-spacing: 2
     new-cap: 2
     new-parens: 2
     no-alert: 2
@@ -75,11 +76,9 @@ rules:
     require-jsdoc: 2
     semi: 2
     semi-spacing: [2, {before: false, after: true}]
-    space-after-keywords: [2, "always"]
     space-before-blocks: 2
     space-before-function-paren: [2, "never"]
     space-infix-ops: 2
-    space-return-throw-case: 2
     space-unary-ops: [2, {words: true, nonwords: false}]
     spaced-comment: [2, "always", { exceptions: ["-"]}]
     strict: [2, "global"]

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -1,0 +1,2748 @@
+/**
+ * @fileoverview Tests for keyword-spacing rule.
+ * @author Toru Nagashima
+ * @copyright 2015 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/keyword-spacing"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var BOTH = {before: true, after: true};
+var NEITHER = {before: false, after: false};
+
+/**
+ * Creates an option object to test an "overrides" option.
+ *
+ * e.g.
+ *
+ *     override("as", BOTH)
+ *
+ * returns
+ *
+ *     {
+ *         before: false,
+ *         after: false,
+ *         overrides: {as: {before: true, after: true}}
+ *     }
+ *
+ * @param {string} keyword - A keyword to be overriden.
+ * @param {object} value - A value to override.
+ * @returns {object} An option object to test an "overrides" option.
+ */
+function override(keyword, value) {
+    var retv = {
+        before: value.before === false,
+        after: value.after === false,
+        overrides: {}
+    };
+    retv.overrides[keyword] = value;
+
+    return retv;
+}
+
+/**
+ * Gets an error message that expected space(s) before a specified keyword.
+ *
+ * @param {string} keyword - A keyword.
+ * @returns {string[]} An error message.
+ */
+function expectedBefore(keyword) {
+    return ["Expected space(s) before \"" + keyword + "\"."];
+}
+
+/**
+ * Gets an error message that expected space(s) after a specified keyword.
+ *
+ * @param {string} keyword - A keyword.
+ * @returns {string[]} An error message.
+ */
+function expectedAfter(keyword) {
+    return ["Expected space(s) after \"" + keyword + "\"."];
+}
+
+/**
+ * Gets error messages that expected space(s) before and after a specified
+ * keyword.
+ *
+ * @param {string} keyword - A keyword.
+ * @returns {string[]} Error messages.
+ */
+function expectedBeforeAndAfter(keyword) {
+    return [
+        "Expected space(s) before \"" + keyword + "\".",
+        "Expected space(s) after \"" + keyword + "\"."
+    ];
+}
+
+/**
+ * Gets an error message that unexpected space(s) before a specified keyword.
+ *
+ * @param {string} keyword - A keyword.
+ * @returns {string[]} An error message.
+ */
+function unexpectedBefore(keyword) {
+    return ["Unexpected space(s) before \"" + keyword + "\"."];
+}
+
+/**
+ * Gets an error message that unexpected space(s) after a specified keyword.
+ *
+ * @param {string} keyword - A keyword.
+ * @returns {string[]} An error message.
+ */
+function unexpectedAfter(keyword) {
+    return ["Unexpected space(s) after \"" + keyword + "\"."];
+}
+
+/**
+ * Gets error messages that unexpected space(s) before and after a specified
+ * keyword.
+ *
+ * @param {string} keyword - A keyword.
+ * @returns {string[]} Error messages.
+ */
+function unexpectedBeforeAndAfter(keyword) {
+    return [
+        "Unexpected space(s) before \"" + keyword + "\".",
+        "Unexpected space(s) after \"" + keyword + "\"."
+    ];
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("keyword-spacing", rule, {
+    valid: [
+        //----------------------------------------------------------------------
+        // as
+        //----------------------------------------------------------------------
+
+        {code: "import * as a from \"foo\"", parserOptions: {sourceType: "module"}},
+        {code: "import*as a from\"foo\"", options: [NEITHER], parserOptions: {sourceType: "module"}},
+        {code: "import* as a from\"foo\"", options: [override("as", BOTH)], parserOptions: {sourceType: "module"}},
+        {code: "import *as a from \"foo\"", options: [override("as", NEITHER)], parserOptions: {sourceType: "module"}},
+
+        //----------------------------------------------------------------------
+        // break
+        //----------------------------------------------------------------------
+
+        {code: "A: for (;;) { {} break A; }"},
+        {code: "A: for(;;) { {}break A; }", options: [NEITHER]},
+        {code: "A: for(;;) { {} break A; }", options: [override("break", BOTH)]},
+        {code: "A: for (;;) { {}break A; }", options: [override("break", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "for (;;) {break}"},
+        {code: "for(;;) { break }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: "for (;;) { ;break; }"},
+        {code: "for(;;) { ; break ; }", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // case
+        //----------------------------------------------------------------------
+
+        {code: "switch (a) { case 0: {} case +1: }"},
+        {code: "switch (a) { case 0: {} case (1): }"},
+        {code: "switch(a) { case 0: {}case+1: }", options: [NEITHER]},
+        {code: "switch(a) { case 0: {}case(1): }", options: [NEITHER]},
+        {code: "switch(a) { case 0: {} case +1: }", options: [override("case", BOTH)]},
+        {code: "switch (a) { case 0: {}case+1: }", options: [override("case", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "switch (a) {case 0: }"},
+        {code: "switch(a) { case 0: }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: "switch (a) { case 0: ;case 1: }"},
+        {code: "switch(a) { case 0: ; case 1: }", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // catch
+        //----------------------------------------------------------------------
+
+        {code: "try {} catch (e) {}"},
+        {code: "try{}catch(e) {}", options: [NEITHER]},
+        {code: "try{} catch (e) {}", options: [override("catch", BOTH)]},
+        {code: "try {}catch(e) {}", options: [override("catch", NEITHER)]},
+        {code: "try {}\ncatch (e) {}"},
+        {code: "try{}\ncatch(e) {}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // class
+        //----------------------------------------------------------------------
+
+        {code: "{} class Bar {}", parserOptions: {ecmaVersion: 6}},
+        {code: "(class {})", parserOptions: {ecmaVersion: 6}},
+        {code: "{}class Bar {}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "(class{})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "{} class Bar {}", options: [override("class", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "{}class Bar {}", options: [override("class", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[class {}]", parserOptions: {ecmaVersion: 6}},
+        {code: "[ class{}]", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `arrow-spacing`
+        {code: "() =>class {}", parserOptions: {ecmaVersion: 6}},
+        {code: "() => class{}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{class Bar {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "{ class Bar {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,class {})", parserOptions: {ecmaVersion: 6}},
+        {code: "(0, class{})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[class {}]", parserOptions: {ecmaVersion: 6}},
+        {code: "({[class {}]: 0})", parserOptions: {ecmaVersion: 6}},
+        {code: "a[ class{}]", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "({[ class{}]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:class {} })", parserOptions: {ecmaVersion: 6}},
+        {code: "({a: class{} })", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `semi-spacing`
+        {code: ";class Bar {};", parserOptions: {ecmaVersion: 6}},
+        {code: "; class Bar {} ;", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-in-parens`
+        {code: "(class {})", parserOptions: {ecmaVersion: 6}},
+        {code: "( class{})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =class {}", parserOptions: {ecmaVersion: 6}},
+        {code: "a = class{}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-unary-ops`
+        {code: "!class {}", parserOptions: {ecmaVersion: 6}},
+        {code: "! class{}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={class {}} />", parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ class{}} />", options: [NEITHER], parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // const
+        //----------------------------------------------------------------------
+
+        {code: "{} const [a] = b", parserOptions: {ecmaVersion: 6}},
+        {code: "{} const {a} = b", parserOptions: {ecmaVersion: 6}},
+        {code: "{}const[a] = b", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "{}const{a} = b", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "{} const [a] = b", options: [override("const", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "{} const {a} = b", options: [override("const", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "{}const[a] = b", options: [override("const", NEITHER)], parserOptions: {ecmaVersion: 6}},
+        {code: "{}const{a} = b", options: [override("const", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{const a = b}", parserOptions: {ecmaVersion: 6}},
+        {code: "{ const a = b}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `semi-spacing`
+        {code: ";const a = b;", parserOptions: {ecmaVersion: 6}},
+        {code: "; const a = b ;", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // continue
+        //----------------------------------------------------------------------
+
+        {code: "A: for (;;) { {} continue A; }"},
+        {code: "A: for(;;) { {}continue A; }", options: [NEITHER]},
+        {code: "A: for(;;) { {} continue A; }", options: [override("continue", BOTH)]},
+        {code: "A: for (;;) { {}continue A; }", options: [override("continue", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "for (;;) {continue}"},
+        {code: "for(;;) { continue }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: "for (;;) { ;continue; }"},
+        {code: "for(;;) { ; continue ; }", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // debugger
+        //----------------------------------------------------------------------
+
+        {code: "{} debugger"},
+        {code: "{}debugger", options: [NEITHER]},
+        {code: "{} debugger", options: [override("debugger", BOTH)]},
+        {code: "{}debugger", options: [override("debugger", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "{debugger}"},
+        {code: "{ debugger }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";debugger;"},
+        {code: "; debugger ;", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // default
+        //----------------------------------------------------------------------
+
+        {code: "switch (a) { case 0: {} default: }"},
+        {code: "switch(a) { case 0: {}default: }", options: [NEITHER]},
+        {code: "switch(a) { case 0: {} default: }", options: [override("default", BOTH)]},
+        {code: "switch (a) { case 0: {}default: }", options: [override("default", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "switch (a) {default:}"},
+        {code: "switch(a) { default: }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: "switch (a) { case 0: ;default: }"},
+        {code: "switch(a) { case 0: ; default: }", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // delete
+        //----------------------------------------------------------------------
+
+        {code: "{} delete foo.a"},
+        {code: "{}delete foo.a", options: [NEITHER]},
+        {code: "{} delete foo.a", options: [override("delete", BOTH)]},
+        {code: "{}delete foo.a", options: [override("delete", NEITHER)]},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[delete foo.a]"},
+        {code: "[ delete foo.a]", options: [NEITHER]},
+
+        // not conflict with `arrow-spacing`
+        {code: "(() =>delete foo.a)", parserOptions: {ecmaVersion: 6}},
+        {code: "(() => delete foo.a)", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{delete foo.a }"},
+        {code: "{ delete foo.a }", options: [NEITHER]},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,delete foo.a)"},
+        {code: "(0, delete foo.a)", options: [NEITHER]},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[delete foo.a]"},
+        {code: "({[delete foo.a]: 0})", parserOptions: {ecmaVersion: 6}},
+        {code: "a[ delete foo.a]", options: [NEITHER]},
+        {code: "({[ delete foo.a]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:delete foo.a })"},
+        {code: "({a: delete foo.a })", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";delete foo.a"},
+        {code: "; delete foo.a", options: [NEITHER]},
+
+        // not conflict with `space-in-parens`
+        {code: "(delete foo.a)"},
+        {code: "( delete foo.a)", options: [NEITHER]},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =delete foo.a"},
+        {code: "a = delete foo.a", options: [NEITHER]},
+
+        // not conflict with `space-unary-ops`
+        {code: "!delete(foo.a)"},
+        {code: "! delete (foo.a)", options: [NEITHER]},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={delete foo.a} />", parserOptions: {ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ delete foo.a} />", options: [NEITHER], parserOptions: {ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // do
+        //----------------------------------------------------------------------
+
+        {code: "{} do {} while (true)"},
+        {code: "{}do{}while(true)", options: [NEITHER]},
+        {code: "{} do {}while(true)", options: [override("do", BOTH)]},
+        {code: "{}do{} while (true)", options: [override("do", NEITHER)]},
+        {code: "{}\ndo\n{} while (true)"},
+        {code: "{}\ndo\n{}while(true)", options: [NEITHER]},
+
+        // not conflict with `block-spacing`
+        {code: "{do {} while (true)}"},
+        {code: "{ do{}while(true) }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";do; while (true)"},
+        {code: "; do ;while(true)", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // else
+        //----------------------------------------------------------------------
+
+        {code: "if (a) {} else {}"},
+        {code: "if (a) {} else if (b) {}"},
+        {code: "if (a) {} else (0)"},
+        {code: "if (a) {} else []"},
+        {code: "if (a) {} else +1"},
+        {code: "if (a) {} else \"a\""},
+        {code: "if(a){}else{}", options: [NEITHER]},
+        {code: "if(a){}else if(b) {}", options: [NEITHER]},
+        {code: "if(a) {}else(0)", options: [NEITHER]},
+        {code: "if(a) {}else[]", options: [NEITHER]},
+        {code: "if(a) {}else+1", options: [NEITHER]},
+        {code: "if(a) {}else\"a\"", options: [NEITHER]},
+        {code: "if(a) {} else {}", options: [override("else", BOTH)]},
+        {code: "if (a) {}else{}", options: [override("else", NEITHER)]},
+        {code: "if (a) {}\nelse\n{}"},
+        {code: "if(a) {}\nelse\n{}", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: "if (a);else;"},
+        {code: "if(a); else ;", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // export
+        //----------------------------------------------------------------------
+
+        {code: "{} export {a}", parserOptions: {sourceType: "module"}},
+        {code: "{} export default a", parserOptions: {sourceType: "module"}},
+        {code: "{} export * from \"a\"", parserOptions: {sourceType: "module"}},
+        {code: "{}export{a}", options: [NEITHER], parserOptions: {sourceType: "module"}},
+        {code: "{} export {a}", options: [override("export", BOTH)], parserOptions: {sourceType: "module"}},
+        {code: "{}export{a}", options: [override("export", NEITHER)], parserOptions: {sourceType: "module"}},
+
+        // not conflict with `semi-spacing`
+        {code: ";export {a}", parserOptions: {sourceType: "module"}},
+        {code: "; export{a}", options: [NEITHER], parserOptions: {sourceType: "module"}},
+
+        //----------------------------------------------------------------------
+        // extends
+        //----------------------------------------------------------------------
+
+        {code: "class Bar extends [] {}", parserOptions: {ecmaVersion: 6}},
+        {code: "class Bar extends[] {}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "class Bar extends [] {}", options: [override("extends", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "class Bar extends[] {}", options: [override("extends", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // finally
+        //----------------------------------------------------------------------
+
+        {code: "try {} finally {}"},
+        {code: "try{}finally{}", options: [NEITHER]},
+        {code: "try{} finally {}", options: [override("finally", BOTH)]},
+        {code: "try {}finally{}", options: [override("finally", NEITHER)]},
+        {code: "try {}\nfinally\n{}"},
+        {code: "try{}\nfinally\n{}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // for
+        //----------------------------------------------------------------------
+
+        {code: "{} for (;;) {}"},
+        {code: "{} for (var foo in obj) {}"},
+        {code: "{} for (var foo of list) {}", parserOptions: {ecmaVersion: 6}},
+        {code: "{}for(;;) {}", options: [NEITHER]},
+        {code: "{}for(var foo in obj) {}", options: [NEITHER]},
+        {code: "{}for(var foo of list) {}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "{} for (;;) {}", options: [override("for", BOTH)]},
+        {code: "{} for (var foo in obj) {}", options: [override("for", BOTH)]},
+        {code: "{} for (var foo of list) {}", options: [override("for", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "{}for(;;) {}", options: [override("for", NEITHER)]},
+        {code: "{}for(var foo in obj) {}", options: [override("for", NEITHER)]},
+        {code: "{}for(var foo of list) {}", options: [override("for", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{for (;;) {} }"},
+        {code: "{for (var foo in obj) {} }"},
+        {code: "{for (var foo of list) {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "{ for(;;) {} }", options: [NEITHER]},
+        {code: "{ for(var foo in obj) {} }", options: [NEITHER]},
+        {code: "{ for(var foo of list) {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `semi-spacing`
+        {code: ";for (;;) {}"},
+        {code: ";for (var foo in obj) {}"},
+        {code: ";for (var foo of list) {}", parserOptions: {ecmaVersion: 6}},
+        {code: "; for(;;) {}", options: [NEITHER]},
+        {code: "; for(var foo in obj) {}", options: [NEITHER]},
+        {code: "; for(var foo of list) {}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // from
+        //----------------------------------------------------------------------
+
+        {code: "import {foo} from \"foo\"", parserOptions: {sourceType: "module"}},
+        {code: "export {foo} from \"foo\"", parserOptions: {sourceType: "module"}},
+        {code: "export * from \"foo\"", parserOptions: {sourceType: "module"}},
+        {code: "import{foo}from\"foo\"", options: [NEITHER], parserOptions: {sourceType: "module"}},
+        {code: "export{foo}from\"foo\"", options: [NEITHER], parserOptions: {sourceType: "module"}},
+        {code: "export*from\"foo\"", options: [NEITHER], parserOptions: {sourceType: "module"}},
+        {code: "import{foo} from \"foo\"", options: [override("from", BOTH)], parserOptions: {sourceType: "module"}},
+        {code: "export{foo} from \"foo\"", options: [override("from", BOTH)], parserOptions: {sourceType: "module"}},
+        {code: "export* from \"foo\"", options: [override("from", BOTH)], parserOptions: {sourceType: "module"}},
+        {code: "import {foo}from\"foo\"", options: [override("from", NEITHER)], parserOptions: {sourceType: "module"}},
+        {code: "export {foo}from\"foo\"", options: [override("from", NEITHER)], parserOptions: {sourceType: "module"}},
+        {code: "export *from\"foo\"", options: [override("from", NEITHER)], parserOptions: {sourceType: "module"}},
+
+        //----------------------------------------------------------------------
+        // function
+        //----------------------------------------------------------------------
+
+        {code: "{} function foo() {}"},
+        {code: "{}function foo() {}", options: [NEITHER]},
+        {code: "{} function foo() {}", options: [override("function", BOTH)]},
+        {code: "{}function foo() {}", options: [override("function", NEITHER)]},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[function() {}]"},
+        {code: "[ function() {}]", options: [NEITHER]},
+
+        // not conflict with `arrow-spacing`
+        {code: "(() =>function() {})", parserOptions: {ecmaVersion: 6}},
+        {code: "(() => function() {})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{function foo() {} }"},
+        {code: "{ function foo() {} }", options: [NEITHER]},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,function() {})"},
+        {code: "(0, function() {})", options: [NEITHER]},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[function() {}]"},
+        {code: "({[function() {}]: 0})", parserOptions: {ecmaVersion: 6}},
+        {code: "a[ function() {}]", options: [NEITHER]},
+        {code: "({[ function(){}]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `generator-star-spacing`
+        {code: "function* foo() {}", parserOptions: {ecmaVersion: 6}},
+        {code: "function *foo() {}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:function() {} })"},
+        {code: "({a: function() {} })", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";function foo() {};"},
+        {code: "; function foo() {} ;", options: [NEITHER]},
+
+        // not conflict with `space-before-function-paren`
+        // not conflict with `space-in-parens`
+        {code: "(function() {})"},
+        {code: "( function () {})", options: [NEITHER]},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =function() {}"},
+        {code: "a = function() {}", options: [NEITHER]},
+
+        // not conflict with `space-unary-ops`
+        {code: "!function() {}"},
+        {code: "! function() {}", options: [NEITHER]},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={function() {}} />", parserOptions: {ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ function() {}} />", options: [NEITHER], parserOptions: {ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // get
+        //----------------------------------------------------------------------
+
+        {code: "({ get [b]() {} })", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {} get [b]() {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {} static get [b]() {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "({ get[b]() {} })", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {}get[b]() {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {}static get[b]() {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "({ get [b]() {} })", options: [override("get", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {} get [b]() {} }", options: [override("get", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "({ get[b]() {} })", options: [override("get", NEITHER)], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {}get[b]() {} }", options: [override("get", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `comma-spacing`
+        {code: "({ a,get [b]() {} })", parserOptions: {ecmaVersion: 6}},
+        {code: "({ a, get[b]() {} })", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // if
+        //----------------------------------------------------------------------
+
+        {code: "{} if (a) {}"},
+        {code: "if (a) {} else if (a) {}"},
+        {code: "{}if(a) {}", options: [NEITHER]},
+        {code: "if(a) {}else if(a) {}", options: [NEITHER]},
+        {code: "{} if (a) {}", options: [override("if", BOTH)]},
+        {code: "if (a) {}else if (a) {}", options: [override("if", BOTH)]},
+        {code: "{}if(a) {}", options: [override("if", NEITHER)]},
+        {code: "if(a) {} else if(a) {}", options: [override("if", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "{if (a) {} }"},
+        {code: "{ if(a) {} }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";if (a) {}"},
+        {code: "; if(a) {}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // import
+        //----------------------------------------------------------------------
+
+        {code: "{} import {a} from \"foo\"", parserOptions: {sourceType: "module"}},
+        {code: "{} import a from \"foo\"", parserOptions: {sourceType: "module"}},
+        {code: "{} import * as a from \"a\"", parserOptions: {sourceType: "module"}},
+        {code: "{}import{a}from\"foo\"", options: [NEITHER], parserOptions: {sourceType: "module"}},
+        {code: "{}import*as a from\"foo\"", options: [NEITHER], parserOptions: {sourceType: "module"}},
+        {code: "{} import {a}from\"foo\"", options: [override("import", BOTH)], parserOptions: {sourceType: "module"}},
+        {code: "{} import *as a from\"foo\"", options: [override("import", BOTH)], parserOptions: {sourceType: "module"}},
+        {code: "{}import{a} from \"foo\"", options: [override("import", NEITHER)], parserOptions: {sourceType: "module"}},
+        {code: "{}import* as a from \"foo\"", options: [override("import", NEITHER)], parserOptions: {sourceType: "module"}},
+
+        // not conflict with `semi-spacing`
+        {code: ";import {a} from \"foo\"", parserOptions: {sourceType: "module"}},
+        {code: "; import{a}from\"foo\"", options: [NEITHER], parserOptions: {sourceType: "module"}},
+
+        //----------------------------------------------------------------------
+        // in
+        //----------------------------------------------------------------------
+
+        {code: "for ([foo] in {foo: 0}) {}", parserOptions: {ecmaVersion: 6}},
+        {code: "for([foo]in{foo: 0}) {}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "for([foo] in {foo: 0}) {}", options: [override("in", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "for ([foo]in{foo: 0}) {}", options: [override("in", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-infix-ops`
+        {code: "if (\"foo\"in{foo: 0}) {}"},
+        {code: "if(\"foo\" in {foo: 0}) {}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // instanceof
+        //----------------------------------------------------------------------
+
+        // not conflict with `space-infix-ops`
+        {code: "if (\"foo\"instanceof{foo: 0}) {}"},
+        {code: "if(\"foo\" instanceof {foo: 0}) {}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // let
+        //----------------------------------------------------------------------
+
+        {code: "{} let [a] = b", parserOptions: {ecmaVersion: 6}},
+        {code: "{}let[a] = b", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "{} let [a] = b", options: [override("let", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "{}let[a] = b", options: [override("let", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{let [a] = b }", parserOptions: {ecmaVersion: 6}},
+        {code: "{ let[a] = b }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `semi-spacing`
+        {code: ";let [a] = b", parserOptions: {ecmaVersion: 6}},
+        {code: "; let[a] = b", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // new
+        //----------------------------------------------------------------------
+
+        {code: "{} new foo()"},
+        {code: "{}new foo()", options: [NEITHER]},
+        {code: "{} new foo()", options: [override("new", BOTH)]},
+        {code: "{}new foo()", options: [override("new", NEITHER)]},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[new foo()]"},
+        {code: "[ new foo()]", options: [NEITHER]},
+
+        // not conflict with `arrow-spacing`
+        {code: "(() =>new foo())", parserOptions: {ecmaVersion: 6}},
+        {code: "(() => new foo())", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{new foo() }"},
+        {code: "{ new foo() }", options: [NEITHER]},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,new foo())"},
+        {code: "(0, new foo())", options: [NEITHER]},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[new foo()]"},
+        {code: "({[new foo()]: 0})", parserOptions: {ecmaVersion: 6}},
+        {code: "a[ new foo()]", options: [NEITHER]},
+        {code: "({[ new foo()]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:new foo() })"},
+        {code: "({a: new foo() })", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";new foo()"},
+        {code: "; new foo()", options: [NEITHER]},
+
+        // not conflict with `space-in-parens`
+        {code: "(new foo())"},
+        {code: "( new foo())", options: [NEITHER]},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =new foo()"},
+        {code: "a = new foo()", options: [NEITHER]},
+
+        // not conflict with `space-unary-ops`
+        {code: "!new(foo)()"},
+        {code: "! new (foo)()", options: [NEITHER]},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={new foo()} />", parserOptions: {ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ new foo()} />", options: [NEITHER], parserOptions: {ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // of
+        //----------------------------------------------------------------------
+
+        {code: "for ([foo] of {foo: 0}) {}", parserOptions: {ecmaVersion: 6}},
+        {code: "for([foo]of{foo: 0}) {}", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "for([foo] of {foo: 0}) {}", options: [override("of", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "for ([foo]of{foo: 0}) {}", options: [override("of", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // return
+        //----------------------------------------------------------------------
+
+        {code: "function foo() { {} return +a }"},
+        {code: "function foo() { {}return+a }", options: [NEITHER]},
+        {code: "function foo() { {} return +a }", options: [override("return", BOTH)]},
+        {code: "function foo() { {}return+a }", options: [override("return", NEITHER)]},
+        {code: "function foo() {\nreturn\n}"},
+        {code: "function foo() {\nreturn\n}", options: [NEITHER]},
+
+        // not conflict with `block-spacing`
+        {code: "function foo() {return}"},
+        {code: "function foo() { return }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: "function foo() { ;return; }"},
+        {code: "function foo() { ; return ; }", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // set
+        //----------------------------------------------------------------------
+
+        {code: "({ set [b](value) {} })", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {} set [b](value) {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {} static set [b](value) {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "({ set[b](value) {} })", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {}set[b](value) {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "({ set [b](value) {} })", options: [override("set", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {} set [b](value) {} }", options: [override("set", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "({ set[b](value) {} })", options: [override("set", NEITHER)], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {}set[b](value) {} }", options: [override("set", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `comma-spacing`
+        {code: "({ a,set [b](value) {} })", parserOptions: {ecmaVersion: 6}},
+        {code: "({ a, set[b](value) {} })", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // static
+        //----------------------------------------------------------------------
+
+        {code: "class A { a() {} static [b]() {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {}static[b]() {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {} static [b]() {} }", options: [override("static", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() {}static[b]() {} }", options: [override("static", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `generator-star-spacing`
+        {code: "class A { static* [a]() {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { static *[a]() {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `semi-spacing`
+        {code: "class A { ;static a() {} }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { ; static a() {} }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        //----------------------------------------------------------------------
+        // super
+        //----------------------------------------------------------------------
+
+        {code: "class A { a() { {} super[b]; } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { {}super[b]; } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { {} super[b]; } }", options: [override("super", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { {}super[b]; } }", options: [override("super", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "class A { a() { [super]; } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { [ super ]; } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `arrow-spacing`
+        {code: "class A { a() { () =>super; } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { () => super; } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "class A { a() {super} }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { super } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `comma-spacing`
+        {code: "class A { a() { (0,super) } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { (0, super) } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `computed-property-spacing`
+        {code: "class A { a() { ({[super]: 0}) } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { ({[ super ]: 0}) } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "class A { a() { ({a:super }) } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { ({a: super }) } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `no-spaced-func`
+        {code: "class A { constructor() { super(); } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { constructor() { super (); } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `semi-spacing`
+        {code: "class A { a() { ;super; } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { ; super ; } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-in-parens`
+        {code: "class A { a() { (super) } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { ( super ) } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-infix-ops`
+        {code: "class A { a() { b =super } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { b = super } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-unary-ops`
+        {code: "class A { a() { !super } }", parserOptions: {ecmaVersion: 6}},
+        {code: "class A { a() { ! super } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "class A { a() { <Foo onClick={super} /> } }", parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}},
+        {code: "class A { a() { <Foo onClick={ super } /> } }", options: [NEITHER], parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // switch
+        //----------------------------------------------------------------------
+
+        {code: "{} switch (a) {}"},
+        {code: "{}switch(a) {}", options: [NEITHER]},
+        {code: "{} switch (a) {}", options: [override("switch", BOTH)]},
+        {code: "{}switch(a) {}", options: [override("switch", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "{switch (a) {} }"},
+        {code: "{ switch(a) {} }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";switch (a) {}"},
+        {code: "; switch(a) {}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // this
+        //----------------------------------------------------------------------
+
+        {code: "{} this[a]"},
+        {code: "{}this[a]", options: [NEITHER]},
+        {code: "{} this[a]", options: [override("this", BOTH)]},
+        {code: "{}this[a]", options: [override("this", NEITHER)]},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[this]"},
+        {code: "[ this ]", options: [NEITHER]},
+
+        // not conflict with `arrow-spacing`
+        {code: "(() =>this)", parserOptions: {ecmaVersion: 6}},
+        {code: "(() => this)", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{this}"},
+        {code: "{ this }", options: [NEITHER]},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,this)"},
+        {code: "(0, this)", options: [NEITHER]},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[this]"},
+        {code: "({[this]: 0})", parserOptions: {ecmaVersion: 6}},
+        {code: "a[ this ]", options: [NEITHER]},
+        {code: "({[ this ]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:this })"},
+        {code: "({a: this })", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";this"},
+        {code: "; this", options: [NEITHER]},
+
+        // not conflict with `space-in-parens`
+        {code: "(this)"},
+        {code: "( this )", options: [NEITHER]},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =this"},
+        {code: "a = this", options: [NEITHER]},
+
+        // not conflict with `space-unary-ops`
+        {code: "!this"},
+        {code: "! this", options: [NEITHER]},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={this} />", parserOptions: {ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ this } />", options: [NEITHER], parserOptions: {ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // throw
+        //----------------------------------------------------------------------
+
+        {code: "function foo() { {} throw +a }"},
+        {code: "function foo() { {}throw+a }", options: [NEITHER]},
+        {code: "function foo() { {} throw +a }", options: [override("throw", BOTH)]},
+        {code: "function foo() { {}throw+a }", options: [override("throw", NEITHER)]},
+        {code: "function foo() {\nthrow a\n}"},
+        {code: "function foo() {\nthrow a\n}", options: [NEITHER]},
+
+        // not conflict with `block-spacing`
+        {code: "function foo() {throw a }"},
+        {code: "function foo() { throw a }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: "function foo() { ;throw a }"},
+        {code: "function foo() { ; throw a }", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // try
+        //----------------------------------------------------------------------
+
+        {code: "{} try {} finally {}"},
+        {code: "{}try{}finally{}", options: [NEITHER]},
+        {code: "{} try {}finally{}", options: [override("try", BOTH)]},
+        {code: "{}try{} finally {}", options: [override("try", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "{try {} finally {}}"},
+        {code: "{ try{}finally{}}", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";try {} finally {}"},
+        {code: "; try{}finally{}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // typeof
+        //----------------------------------------------------------------------
+
+        {code: "{} typeof foo"},
+        {code: "{}typeof foo", options: [NEITHER]},
+        {code: "{} typeof foo", options: [override("typeof", BOTH)]},
+        {code: "{}typeof foo", options: [override("typeof", NEITHER)]},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[typeof foo]"},
+        {code: "[ typeof foo]", options: [NEITHER]},
+
+        // not conflict with `arrow-spacing`
+        {code: "(() =>typeof foo)", parserOptions: {ecmaVersion: 6}},
+        {code: "(() => typeof foo)", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{typeof foo }"},
+        {code: "{ typeof foo }", options: [NEITHER]},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,typeof foo)"},
+        {code: "(0, typeof foo)", options: [NEITHER]},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[typeof foo]"},
+        {code: "({[typeof foo]: 0})", parserOptions: {ecmaVersion: 6}},
+        {code: "a[ typeof foo]", options: [NEITHER]},
+        {code: "({[ typeof foo]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:typeof foo })"},
+        {code: "({a: typeof foo })", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";typeof foo"},
+        {code: "; typeof foo", options: [NEITHER]},
+
+        // not conflict with `space-in-parens`
+        {code: "(typeof foo)"},
+        {code: "( typeof foo)", options: [NEITHER]},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =typeof foo"},
+        {code: "a = typeof foo", options: [NEITHER]},
+
+        // not conflict with `space-unary-ops`
+        {code: "!typeof+foo"},
+        {code: "! typeof +foo", options: [NEITHER]},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={typeof foo} />", parserOptions: {ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ typeof foo} />", options: [NEITHER], parserOptions: {ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // var
+        //----------------------------------------------------------------------
+
+        {code: "{} var [a] = b", parserOptions: {ecmaVersion: 6}},
+        {code: "{}var[a] = b", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "{} var [a] = b", options: [override("var", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "{}var[a] = b", options: [override("var", NEITHER)], parserOptions: {ecmaVersion: 6}},
+        {code: "for (var foo in [1, 2, 3]) {}"},
+
+        // not conflict with `block-spacing`
+        {code: "{var a = b }"},
+        {code: "{ var a = b }", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";var a = b"},
+        {code: "; var a = b", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // void
+        //----------------------------------------------------------------------
+
+        {code: "{} void foo"},
+        {code: "{}void foo", options: [NEITHER]},
+        {code: "{} void foo", options: [override("void", BOTH)]},
+        {code: "{}void foo", options: [override("void", NEITHER)]},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[void foo]"},
+        {code: "[ void foo]", options: [NEITHER]},
+
+        // not conflict with `arrow-spacing`
+        {code: "(() =>void foo)", parserOptions: {ecmaVersion: 6}},
+        {code: "(() => void foo)", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "{void foo }"},
+        {code: "{ void foo }", options: [NEITHER]},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,void foo)"},
+        {code: "(0, void foo)", options: [NEITHER]},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[void foo]"},
+        {code: "({[void foo]: 0})", parserOptions: {ecmaVersion: 6}},
+        {code: "a[ void foo]", options: [NEITHER]},
+        {code: "({[ void foo]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:void foo })"},
+        {code: "({a: void foo })", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";void foo"},
+        {code: "; void foo", options: [NEITHER]},
+
+        // not conflict with `space-in-parens`
+        {code: "(void foo)"},
+        {code: "( void foo)", options: [NEITHER]},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =void foo"},
+        {code: "a = void foo", options: [NEITHER]},
+
+        // not conflict with `space-unary-ops`
+        {code: "!void+foo"},
+        {code: "! void +foo", options: [NEITHER]},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={void foo} />", parserOptions: {ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ void foo} />", options: [NEITHER], parserOptions: {ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // while
+        //----------------------------------------------------------------------
+
+        {code: "{} while (a) {}"},
+        {code: "do {} while (a)"},
+        {code: "{}while(a) {}", options: [NEITHER]},
+        {code: "do{}while(a)", options: [NEITHER]},
+        {code: "{} while (a) {}", options: [override("while", BOTH)]},
+        {code: "do{} while (a)", options: [override("while", BOTH)]},
+        {code: "{}while(a) {}", options: [override("while", NEITHER)]},
+        {code: "do {}while(a)", options: [override("while", NEITHER)]},
+        {code: "do {}\nwhile (a)"},
+        {code: "do{}\nwhile(a)", options: [NEITHER]},
+
+        // not conflict with `block-spacing`
+        {code: "{while (a) {}}"},
+        {code: "{ while(a) {}}", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";while (a);"},
+        {code: "do;while (a);"},
+        {code: "; while(a) ;", options: [NEITHER]},
+        {code: "do ; while(a) ;", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // with
+        //----------------------------------------------------------------------
+
+        {code: "{} with (obj) {}"},
+        {code: "{}with(obj) {}", options: [NEITHER]},
+        {code: "{} with (obj) {}", options: [override("with", BOTH)]},
+        {code: "{}with(obj) {}", options: [override("with", NEITHER)]},
+
+        // not conflict with `block-spacing`
+        {code: "{with (obj) {}}"},
+        {code: "{ with(obj) {}}", options: [NEITHER]},
+
+        // not conflict with `semi-spacing`
+        {code: ";with (obj) {}"},
+        {code: "; with(obj) {}", options: [NEITHER]},
+
+        //----------------------------------------------------------------------
+        // yield
+        //----------------------------------------------------------------------
+
+        {code: "function* foo() { {} yield foo }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { {}yield foo }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { {} yield foo }", options: [override("yield", BOTH)], parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { {}yield foo }", options: [override("yield", NEITHER)], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "function* foo() { [yield] }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { [ yield ] }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `arrow-spacing`
+        {code: "function* foo() { (() =>yield foo) }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { (() => yield foo) }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `block-spacing`
+        {code: "function* foo() {yield}", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { yield }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `comma-spacing`
+        {code: "function* foo() { (0,yield foo) }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { (0, yield foo) }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `computed-property-spacing`
+        {code: "function* foo() { a[yield] }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { ({[yield]: 0}) }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { a[ yield ] }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { ({[ yield ]: 0}) }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `key-spacing`
+        {code: "function* foo() { ({a:yield foo }) }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { ({a: yield foo }) }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `semi-spacing`
+        {code: "function* foo() { ;yield; }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { ; yield ; }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-in-parens`
+        {code: "function* foo() { (yield) }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { ( yield ) }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-infix-ops`
+        {code: "function* foo() { a =yield foo }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { a = yield foo }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `space-unary-ops`
+        {code: "function* foo() { yield+foo }", parserOptions: {ecmaVersion: 6}},
+        {code: "function* foo() { yield +foo }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "function* foo() { <Foo onClick={yield} /> }", parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}},
+        {code: "function* foo() { <Foo onClick={ yield } /> }", options: [NEITHER], parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}}
+    ],
+    invalid: [
+        //----------------------------------------------------------------------
+        // as
+        //----------------------------------------------------------------------
+
+        {
+            code: "import *as a from \"foo\"",
+            output: "import * as a from \"foo\"",
+            errors: expectedBefore("as"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "import* as a from\"foo\"",
+            output: "import*as a from\"foo\"",
+            errors: unexpectedBefore("as"),
+            options: [NEITHER],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "import*as a from\"foo\"",
+            output: "import* as a from\"foo\"",
+            errors: expectedBefore("as"),
+            options: [override("as", BOTH)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "import * as a from \"foo\"",
+            output: "import *as a from \"foo\"",
+            errors: unexpectedBefore("as"),
+            options: [override("as", NEITHER)],
+            parserOptions: {sourceType: "module"}
+        },
+
+        //----------------------------------------------------------------------
+        // break
+        //----------------------------------------------------------------------
+
+        {
+            code: "A: for (;;) { {}break A; }",
+            output: "A: for (;;) { {} break A; }",
+            errors: expectedBefore("break")
+        },
+        {
+            code: "A: for(;;) { {} break A; }",
+            output: "A: for(;;) { {}break A; }",
+            errors: unexpectedBefore("break"),
+            options: [NEITHER]
+        },
+        {
+            code: "A: for(;;) { {}break A; }",
+            output: "A: for(;;) { {} break A; }",
+            errors: expectedBefore("break"),
+            options: [override("break", BOTH)]
+        },
+        {
+            code: "A: for (;;) { {} break A; }",
+            output: "A: for (;;) { {}break A; }",
+            errors: unexpectedBefore("break"),
+            options: [override("break", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // case
+        //----------------------------------------------------------------------
+
+        {
+            code: "switch (a) { case 0: {}case+1: }",
+            output: "switch (a) { case 0: {} case +1: }",
+            errors: expectedBeforeAndAfter("case")
+        },
+        {
+            code: "switch (a) { case 0: {}case(1): }",
+            output: "switch (a) { case 0: {} case (1): }",
+            errors: expectedBeforeAndAfter("case")
+        },
+        {
+            code: "switch(a) { case 0: {} case +1: }",
+            output: "switch(a) { case 0: {}case+1: }",
+            errors: unexpectedBeforeAndAfter("case"),
+            options: [NEITHER]
+        },
+        {
+            code: "switch(a) { case 0: {} case (1): }",
+            output: "switch(a) { case 0: {}case(1): }",
+            errors: unexpectedBeforeAndAfter("case"),
+            options: [NEITHER]
+        },
+        {
+            code: "switch(a) { case 0: {}case+1: }",
+            output: "switch(a) { case 0: {} case +1: }",
+            errors: expectedBeforeAndAfter("case"),
+            options: [override("case", BOTH)]
+        },
+        {
+            code: "switch (a) { case 0: {} case +1: }",
+            output: "switch (a) { case 0: {}case+1: }",
+            errors: unexpectedBeforeAndAfter("case"),
+            options: [override("case", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // catch
+        //----------------------------------------------------------------------
+
+        {
+            code: "try {}catch(e) {}",
+            output: "try {} catch (e) {}",
+            errors: expectedBeforeAndAfter("catch")
+        },
+        {
+            code: "try{} catch (e) {}",
+            output: "try{}catch(e) {}",
+            errors: unexpectedBeforeAndAfter("catch"),
+            options: [NEITHER]
+        },
+        {
+            code: "try{}catch(e) {}",
+            output: "try{} catch (e) {}",
+            errors: expectedBeforeAndAfter("catch"),
+            options: [override("catch", BOTH)]
+        },
+        {
+            code: "try {} catch (e) {}",
+            output: "try {}catch(e) {}",
+            errors: unexpectedBeforeAndAfter("catch"),
+            options: [override("catch", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // class
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}class Bar {}",
+            output: "{} class Bar {}",
+            errors: expectedBefore("class"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "(class{})",
+            output: "(class {})",
+            errors: expectedAfter("class"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} class Bar {}",
+            output: "{}class Bar {}",
+            errors: unexpectedBefore("class"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "(class {})",
+            output: "(class{})",
+            errors: unexpectedAfter("class"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{}class Bar {}",
+            output: "{} class Bar {}",
+            errors: expectedBefore("class"),
+            options: [override("class", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} class Bar {}",
+            output: "{}class Bar {}",
+            errors: unexpectedBefore("class"),
+            options: [override("class", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // const
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}const[a] = b",
+            output: "{} const [a] = b",
+            errors: expectedBeforeAndAfter("const"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{}const{a} = b",
+            output: "{} const {a} = b",
+            errors: expectedBeforeAndAfter("const"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} const [a] = b",
+            output: "{}const[a] = b",
+            errors: unexpectedBeforeAndAfter("const"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} const {a} = b",
+            output: "{}const{a} = b",
+            errors: unexpectedBeforeAndAfter("const"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{}const[a] = b",
+            output: "{} const [a] = b",
+            errors: expectedBeforeAndAfter("const"),
+            options: [override("const", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{}const{a} = b",
+            output: "{} const {a} = b",
+            errors: expectedBeforeAndAfter("const"),
+            options: [override("const", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} const [a] = b",
+            output: "{}const[a] = b",
+            errors: unexpectedBeforeAndAfter("const"),
+            options: [override("const", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} const {a} = b",
+            output: "{}const{a} = b",
+            errors: unexpectedBeforeAndAfter("const"),
+            options: [override("const", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // continue
+        //----------------------------------------------------------------------
+
+        {
+            code: "A: for (;;) { {}continue A; }",
+            output: "A: for (;;) { {} continue A; }",
+            errors: expectedBefore("continue")
+        },
+        {
+            code: "A: for(;;) { {} continue A; }",
+            output: "A: for(;;) { {}continue A; }",
+            errors: unexpectedBefore("continue"),
+            options: [NEITHER]
+        },
+        {
+            code: "A: for(;;) { {}continue A; }",
+            output: "A: for(;;) { {} continue A; }",
+            errors: expectedBefore("continue"),
+            options: [override("continue", BOTH)]
+        },
+        {
+            code: "A: for (;;) { {} continue A; }",
+            output: "A: for (;;) { {}continue A; }",
+            errors: unexpectedBefore("continue"),
+            options: [override("continue", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // debugger
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}debugger",
+            output: "{} debugger",
+            errors: expectedBefore("debugger")
+        },
+        {
+            code: "{} debugger",
+            output: "{}debugger",
+            errors: unexpectedBefore("debugger"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}debugger",
+            output: "{} debugger",
+            errors: expectedBefore("debugger"),
+            options: [override("debugger", BOTH)]
+        },
+        {
+            code: "{} debugger",
+            output: "{}debugger",
+            errors: unexpectedBefore("debugger"),
+            options: [override("debugger", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // default
+        //----------------------------------------------------------------------
+
+        {
+            code: "switch (a) { case 0: {}default: }",
+            output: "switch (a) { case 0: {} default: }",
+            errors: expectedBefore("default")
+        },
+        {
+            code: "switch(a) { case 0: {} default: }",
+            output: "switch(a) { case 0: {}default: }",
+            errors: unexpectedBefore("default"),
+            options: [NEITHER]
+        },
+        {
+            code: "switch(a) { case 0: {}default: }",
+            output: "switch(a) { case 0: {} default: }",
+            errors: expectedBefore("default"),
+            options: [override("default", BOTH)]
+        },
+        {
+            code: "switch (a) { case 0: {} default: }",
+            output: "switch (a) { case 0: {}default: }",
+            errors: unexpectedBefore("default"),
+            options: [override("default", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // delete
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}delete foo.a",
+            output: "{} delete foo.a",
+            errors: expectedBefore("delete")
+        },
+        {
+            code: "{} delete foo.a",
+            output: "{}delete foo.a",
+            errors: unexpectedBefore("delete"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}delete foo.a",
+            output: "{} delete foo.a",
+            errors: expectedBefore("delete"),
+            options: [override("delete", BOTH)]
+        },
+        {
+            code: "{} delete foo.a",
+            output: "{}delete foo.a",
+            errors: unexpectedBefore("delete"),
+            options: [override("delete", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // do
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}do{} while (true)",
+            output: "{} do {} while (true)",
+            errors: expectedBeforeAndAfter("do")
+        },
+        {
+            code: "{} do {}while(true)",
+            output: "{}do{}while(true)",
+            errors: unexpectedBeforeAndAfter("do"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}do{}while(true)",
+            output: "{} do {}while(true)",
+            errors: expectedBeforeAndAfter("do"),
+            options: [override("do", BOTH)]
+        },
+        {
+            code: "{} do {} while (true)",
+            output: "{}do{} while (true)",
+            errors: unexpectedBeforeAndAfter("do"),
+            options: [override("do", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // else
+        //----------------------------------------------------------------------
+
+        {
+            code: "if (a) {}else{}",
+            output: "if (a) {} else {}",
+            errors: expectedBeforeAndAfter("else")
+        },
+        {
+            code: "if (a) {}else if (b) {}",
+            output: "if (a) {} else if (b) {}",
+            errors: expectedBefore("else")
+        },
+        {
+            code: "if (a) {}else(0)",
+            output: "if (a) {} else (0)",
+            errors: expectedBeforeAndAfter("else")
+        },
+        {
+            code: "if (a) {}else[]",
+            output: "if (a) {} else []",
+            errors: expectedBeforeAndAfter("else")
+        },
+        {
+            code: "if (a) {}else+1",
+            output: "if (a) {} else +1",
+            errors: expectedBeforeAndAfter("else")
+        },
+        {
+            code: "if (a) {}else\"a\"",
+            output: "if (a) {} else \"a\"",
+            errors: expectedBeforeAndAfter("else")
+        },
+        {
+            code: "if(a){} else {}",
+            output: "if(a){}else{}",
+            errors: unexpectedBeforeAndAfter("else"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a){} else if(b) {}",
+            output: "if(a){}else if(b) {}",
+            errors: unexpectedBefore("else"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a) {} else (0)",
+            output: "if(a) {}else(0)",
+            errors: unexpectedBeforeAndAfter("else"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a) {} else []",
+            output: "if(a) {}else[]",
+            errors: unexpectedBeforeAndAfter("else"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a) {} else +1",
+            output: "if(a) {}else+1",
+            errors: unexpectedBeforeAndAfter("else"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a) {} else \"a\"",
+            output: "if(a) {}else\"a\"",
+            errors: unexpectedBeforeAndAfter("else"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a) {}else{}",
+            output: "if(a) {} else {}",
+            errors: expectedBeforeAndAfter("else"),
+            options: [override("else", BOTH)]
+        },
+        {
+            code: "if (a) {} else {}",
+            output: "if (a) {}else{}",
+            errors: unexpectedBeforeAndAfter("else"),
+            options: [override("else", NEITHER)]
+        },
+
+        {
+            code: "if (a) {}else {}",
+            output: "if (a) {} else {}",
+            errors: expectedBefore("else")
+        },
+        {
+            code: "if (a) {} else{}",
+            output: "if (a) {} else {}",
+            errors: expectedAfter("else")
+        },
+        {
+            code: "if(a) {} else{}",
+            output: "if(a) {}else{}",
+            errors: unexpectedBefore("else"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a) {}else {}",
+            output: "if(a) {}else{}",
+            errors: unexpectedAfter("else"),
+            options: [NEITHER]
+        },
+
+        //----------------------------------------------------------------------
+        // export
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}export{a}",
+            output: "{} export {a}",
+            errors: expectedBeforeAndAfter("export"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{}export default a",
+            output: "{} export default a",
+            errors: expectedBefore("export"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{}export* from \"a\"",
+            output: "{} export * from \"a\"",
+            errors: expectedBeforeAndAfter("export"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{} export {a}",
+            output: "{}export{a}",
+            errors: unexpectedBeforeAndAfter("export"),
+            options: [NEITHER],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{}export{a}",
+            output: "{} export {a}",
+            errors: expectedBeforeAndAfter("export"),
+            options: [override("export", BOTH)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{} export {a}",
+            output: "{}export{a}",
+            errors: unexpectedBeforeAndAfter("export"),
+            options: [override("export", NEITHER)],
+            parserOptions: {sourceType: "module"}
+        },
+
+        //----------------------------------------------------------------------
+        // extends
+        //----------------------------------------------------------------------
+
+        {
+            code: "class Bar extends[] {}",
+            output: "class Bar extends [] {}",
+            errors: expectedAfter("extends"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "(class extends[] {})",
+            output: "(class extends [] {})",
+            errors: expectedAfter("extends"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class Bar extends [] {}",
+            output: "class Bar extends[] {}",
+            errors: unexpectedAfter("extends"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "(class extends [] {})",
+            output: "(class extends[] {})",
+            errors: unexpectedAfter("extends"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class Bar extends[] {}",
+            output: "class Bar extends [] {}",
+            errors: expectedAfter("extends"),
+            options: [override("extends", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class Bar extends [] {}",
+            output: "class Bar extends[] {}",
+            errors: unexpectedAfter("extends"),
+            options: [override("extends", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // finally
+        //----------------------------------------------------------------------
+
+        {
+            code: "try {}finally{}",
+            output: "try {} finally {}",
+            errors: expectedBeforeAndAfter("finally")
+        },
+        {
+            code: "try{} finally {}",
+            output: "try{}finally{}",
+            errors: unexpectedBeforeAndAfter("finally"),
+            options: [NEITHER]
+        },
+        {
+            code: "try{}finally{}",
+            output: "try{} finally {}",
+            errors: expectedBeforeAndAfter("finally"),
+            options: [override("finally", BOTH)]
+        },
+        {
+            code: "try {} finally {}",
+            output: "try {}finally{}",
+            errors: unexpectedBeforeAndAfter("finally"),
+            options: [override("finally", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // for
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}for(;;) {}",
+            output: "{} for (;;) {}",
+            errors: expectedBeforeAndAfter("for")
+        },
+        {
+            code: "{}for(var foo in obj) {}",
+            output: "{} for (var foo in obj) {}",
+            errors: expectedBeforeAndAfter("for")
+        },
+        {
+            code: "{}for(var foo of list) {}",
+            output: "{} for (var foo of list) {}",
+            errors: expectedBeforeAndAfter("for"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} for (;;) {}",
+            output: "{}for(;;) {}",
+            errors: unexpectedBeforeAndAfter("for"),
+            options: [NEITHER]
+        },
+        {
+            code: "{} for (var foo in obj) {}",
+            output: "{}for(var foo in obj) {}",
+            errors: unexpectedBeforeAndAfter("for"),
+            options: [NEITHER]
+        },
+        {
+            code: "{} for (var foo of list) {}",
+            output: "{}for(var foo of list) {}",
+            errors: unexpectedBeforeAndAfter("for"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{}for(;;) {}",
+            output: "{} for (;;) {}",
+            errors: expectedBeforeAndAfter("for"),
+            options: [override("for", BOTH)]
+        },
+        {
+            code: "{}for(var foo in obj) {}",
+            output: "{} for (var foo in obj) {}",
+            errors: expectedBeforeAndAfter("for"),
+            options: [override("for", BOTH)]
+        },
+        {
+            code: "{}for(var foo of list) {}",
+            output: "{} for (var foo of list) {}",
+            errors: expectedBeforeAndAfter("for"),
+            options: [override("for", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} for (;;) {}",
+            output: "{}for(;;) {}",
+            errors: unexpectedBeforeAndAfter("for"),
+            options: [override("for", NEITHER)]
+        },
+        {
+            code: "{} for (var foo in obj) {}",
+            output: "{}for(var foo in obj) {}",
+            errors: unexpectedBeforeAndAfter("for"),
+            options: [override("for", NEITHER)]
+        },
+        {
+            code: "{} for (var foo of list) {}",
+            output: "{}for(var foo of list) {}",
+            errors: unexpectedBeforeAndAfter("for"),
+            options: [override("for", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // from
+        //----------------------------------------------------------------------
+
+        {
+            code: "import {foo}from\"foo\"",
+            output: "import {foo} from \"foo\"",
+            errors: expectedBeforeAndAfter("from"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export {foo}from\"foo\"",
+            output: "export {foo} from \"foo\"",
+            errors: expectedBeforeAndAfter("from"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export *from\"foo\"",
+            output: "export * from \"foo\"",
+            errors: expectedBeforeAndAfter("from"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "import{foo} from \"foo\"",
+            output: "import{foo}from\"foo\"",
+            errors: unexpectedBeforeAndAfter("from"),
+            options: [NEITHER],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export{foo} from \"foo\"",
+            output: "export{foo}from\"foo\"",
+            errors: unexpectedBeforeAndAfter("from"),
+            options: [NEITHER],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export* from \"foo\"",
+            output: "export*from\"foo\"",
+            errors: unexpectedBeforeAndAfter("from"),
+            options: [NEITHER],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "import{foo}from\"foo\"",
+            output: "import{foo} from \"foo\"",
+            errors: expectedBeforeAndAfter("from"),
+            options: [override("from", BOTH)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export{foo}from\"foo\"",
+            output: "export{foo} from \"foo\"",
+            errors: expectedBeforeAndAfter("from"),
+            options: [override("from", BOTH)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export*from\"foo\"",
+            output: "export* from \"foo\"",
+            errors: expectedBeforeAndAfter("from"),
+            options: [override("from", BOTH)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "import {foo} from \"foo\"",
+            output: "import {foo}from\"foo\"",
+            errors: unexpectedBeforeAndAfter("from"),
+            options: [override("from", NEITHER)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export {foo} from \"foo\"",
+            output: "export {foo}from\"foo\"",
+            errors: unexpectedBeforeAndAfter("from"),
+            options: [override("from", NEITHER)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "export * from \"foo\"",
+            output: "export *from\"foo\"",
+            errors: unexpectedBeforeAndAfter("from"),
+            options: [override("from", NEITHER)],
+            parserOptions: {sourceType: "module"}
+        },
+
+        //----------------------------------------------------------------------
+        // function
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}function foo() {}",
+            output: "{} function foo() {}",
+            errors: expectedBefore("function")
+        },
+        {
+            code: "{} function foo() {}",
+            output: "{}function foo() {}",
+            errors: unexpectedBefore("function"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}function foo() {}",
+            output: "{} function foo() {}",
+            errors: expectedBefore("function"),
+            options: [override("function", BOTH)]
+        },
+        {
+            code: "{} function foo() {}",
+            output: "{}function foo() {}",
+            errors: unexpectedBefore("function"),
+            options: [override("function", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // get
+        //----------------------------------------------------------------------
+
+        {
+            code: "({ get[b]() {} })",
+            output: "({ get [b]() {} })",
+            errors: expectedAfter("get"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {}get[b]() {} }",
+            output: "class A { a() {} get [b]() {} }",
+            errors: expectedBeforeAndAfter("get"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} static get[b]() {} }",
+            output: "class A { a() {} static get [b]() {} }",
+            errors: expectedAfter("get"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "({ get [b]() {} })",
+            output: "({ get[b]() {} })",
+            errors: unexpectedAfter("get"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} get [b]() {} }",
+            output: "class A { a() {}get[b]() {} }",
+            errors: unexpectedBeforeAndAfter("get"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {}static get [b]() {} }",
+            output: "class A { a() {}static get[b]() {} }",
+            errors: unexpectedAfter("get"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "({ get[b]() {} })",
+            output: "({ get [b]() {} })",
+            errors: expectedAfter("get"),
+            options: [override("get", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {}get[b]() {} }",
+            output: "class A { a() {} get [b]() {} }",
+            errors: expectedBeforeAndAfter("get"),
+            options: [override("get", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "({ get [b]() {} })",
+            output: "({ get[b]() {} })",
+            errors: unexpectedAfter("get"),
+            options: [override("get", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} get [b]() {} }",
+            output: "class A { a() {}get[b]() {} }",
+            errors: unexpectedBeforeAndAfter("get"),
+            options: [override("get", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // if
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}if(a) {}",
+            output: "{} if (a) {}",
+            errors: expectedBeforeAndAfter("if")
+        },
+        {
+            code: "if (a) {} else if(b) {}",
+            output: "if (a) {} else if (b) {}",
+            errors: expectedAfter("if")
+        },
+        {
+            code: "{} if (a) {}",
+            output: "{}if(a) {}",
+            errors: unexpectedBeforeAndAfter("if"),
+            options: [NEITHER]
+        },
+        {
+            code: "if(a) {}else if (b) {}",
+            output: "if(a) {}else if(b) {}",
+            errors: unexpectedAfter("if"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}if(a) {}",
+            output: "{} if (a) {}",
+            errors: expectedBeforeAndAfter("if"),
+            options: [override("if", BOTH)]
+        },
+        {
+            code: "if (a) {}else if(b) {}",
+            output: "if (a) {}else if (b) {}",
+            errors: expectedAfter("if"),
+            options: [override("if", BOTH)]
+        },
+        {
+            code: "{} if (a) {}",
+            output: "{}if(a) {}",
+            errors: unexpectedBeforeAndAfter("if"),
+            options: [override("if", NEITHER)]
+        },
+        {
+            code: "if(a) {} else if (b) {}",
+            output: "if(a) {} else if(b) {}",
+            errors: unexpectedAfter("if"),
+            options: [override("if", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // import
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}import{a} from \"foo\"",
+            output: "{} import {a} from \"foo\"",
+            errors: expectedBeforeAndAfter("import"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{}import a from \"foo\"",
+            output: "{} import a from \"foo\"",
+            errors: expectedBefore("import"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{}import* as a from \"a\"",
+            output: "{} import * as a from \"a\"",
+            errors: expectedBeforeAndAfter("import"),
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{} import {a}from\"foo\"",
+            output: "{}import{a}from\"foo\"",
+            errors: unexpectedBeforeAndAfter("import"),
+            options: [NEITHER],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{} import *as a from\"foo\"",
+            output: "{}import*as a from\"foo\"",
+            errors: unexpectedBeforeAndAfter("import"),
+            options: [NEITHER],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{}import{a}from\"foo\"",
+            output: "{} import {a}from\"foo\"",
+            errors: expectedBeforeAndAfter("import"),
+            options: [override("import", BOTH)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{}import*as a from\"foo\"",
+            output: "{} import *as a from\"foo\"",
+            errors: expectedBeforeAndAfter("import"),
+            options: [override("import", BOTH)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{} import {a} from \"foo\"",
+            output: "{}import{a} from \"foo\"",
+            errors: unexpectedBeforeAndAfter("import"),
+            options: [override("import", NEITHER)],
+            parserOptions: {sourceType: "module"}
+        },
+        {
+            code: "{} import * as a from \"foo\"",
+            output: "{}import* as a from \"foo\"",
+            errors: unexpectedBeforeAndAfter("import"),
+            options: [override("import", NEITHER)],
+            parserOptions: {sourceType: "module"}
+        },
+
+        //----------------------------------------------------------------------
+        // in
+        //----------------------------------------------------------------------
+
+        {
+            code: "for ([foo]in{foo: 0}) {}",
+            output: "for ([foo] in {foo: 0}) {}",
+            errors: expectedBeforeAndAfter("in"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "for([foo] in {foo: 0}) {}",
+            output: "for([foo]in{foo: 0}) {}",
+            errors: unexpectedBeforeAndAfter("in"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "for([foo]in{foo: 0}) {}",
+            output: "for([foo] in {foo: 0}) {}",
+            errors: expectedBeforeAndAfter("in"),
+            options: [override("in", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "for ([foo] in {foo: 0}) {}",
+            output: "for ([foo]in{foo: 0}) {}",
+            errors: unexpectedBeforeAndAfter("in"),
+            options: [override("in", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // instanceof
+        //----------------------------------------------------------------------
+
+        // ignores
+
+        //----------------------------------------------------------------------
+        // let
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}let[a] = b",
+            output: "{} let [a] = b",
+            errors: expectedBeforeAndAfter("let"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} let [a] = b",
+            output: "{}let[a] = b",
+            errors: unexpectedBeforeAndAfter("let"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{}let[a] = b",
+            output: "{} let [a] = b",
+            errors: expectedBeforeAndAfter("let"),
+            options: [override("let", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} let [a] = b",
+            output: "{}let[a] = b",
+            errors: unexpectedBeforeAndAfter("let"),
+            options: [override("let", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // new
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}new foo()",
+            output: "{} new foo()",
+            errors: expectedBefore("new")
+        },
+        {
+            code: "{} new foo()",
+            output: "{}new foo()",
+            errors: unexpectedBefore("new"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}new foo()",
+            output: "{} new foo()",
+            errors: expectedBefore("new"),
+            options: [override("new", BOTH)]
+        },
+        {
+            code: "{} new foo()",
+            output: "{}new foo()",
+            errors: unexpectedBefore("new"),
+            options: [override("new", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // of
+        //----------------------------------------------------------------------
+
+        {
+            code: "for ([foo]of{foo: 0}) {}",
+            output: "for ([foo] of {foo: 0}) {}",
+            errors: expectedBeforeAndAfter("of"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "for([foo] of {foo: 0}) {}",
+            output: "for([foo]of{foo: 0}) {}",
+            errors: unexpectedBeforeAndAfter("of"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "for([foo]of{foo: 0}) {}",
+            output: "for([foo] of {foo: 0}) {}",
+            errors: expectedBeforeAndAfter("of"),
+            options: [override("of", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "for ([foo] of {foo: 0}) {}",
+            output: "for ([foo]of{foo: 0}) {}",
+            errors: unexpectedBeforeAndAfter("of"),
+            options: [override("of", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // return
+        //----------------------------------------------------------------------
+
+        {
+            code: "function foo() { {}return+a }",
+            output: "function foo() { {} return +a }",
+            errors: expectedBeforeAndAfter("return")
+        },
+        {
+            code: "function foo() { {} return +a }",
+            output: "function foo() { {}return+a }",
+            errors: unexpectedBeforeAndAfter("return"),
+            options: [NEITHER]
+        },
+        {
+            code: "function foo() { {}return+a }",
+            output: "function foo() { {} return +a }",
+            errors: expectedBeforeAndAfter("return"),
+            options: [override("return", BOTH)]
+        },
+        {
+            code: "function foo() { {} return +a }",
+            output: "function foo() { {}return+a }",
+            errors: unexpectedBeforeAndAfter("return"),
+            options: [override("return", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // set
+        //----------------------------------------------------------------------
+
+        {
+            code: "({ set[b](value) {} })",
+            output: "({ set [b](value) {} })",
+            errors: expectedAfter("set"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {}set[b](value) {} }",
+            output: "class A { a() {} set [b](value) {} }",
+            errors: expectedBeforeAndAfter("set"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} static set[b](value) {} }",
+            output: "class A { a() {} static set [b](value) {} }",
+            errors: expectedAfter("set"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "({ set [b](value) {} })",
+            output: "({ set[b](value) {} })",
+            errors: unexpectedAfter("set"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} set [b](value) {} }",
+            output: "class A { a() {}set[b](value) {} }",
+            errors: unexpectedBeforeAndAfter("set"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "({ set[b](value) {} })",
+            output: "({ set [b](value) {} })",
+            errors: expectedAfter("set"),
+            options: [override("set", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {}set[b](value) {} }",
+            output: "class A { a() {} set [b](value) {} }",
+            errors: expectedBeforeAndAfter("set"),
+            options: [override("set", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "({ set [b](value) {} })",
+            output: "({ set[b](value) {} })",
+            errors: unexpectedAfter("set"),
+            options: [override("set", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} set [b](value) {} }",
+            output: "class A { a() {}set[b](value) {} }",
+            errors: unexpectedBeforeAndAfter("set"),
+            options: [override("set", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // static
+        //----------------------------------------------------------------------
+
+        {
+            code: "class A { a() {}static[b]() {} }",
+            output: "class A { a() {} static [b]() {} }",
+            errors: expectedBeforeAndAfter("static"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {}static get [b]() {} }",
+            output: "class A { a() {} static get [b]() {} }",
+            errors: expectedBefore("static"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} static [b]() {} }",
+            output: "class A { a() {}static[b]() {} }",
+            errors: unexpectedBeforeAndAfter("static"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} static get[b]() {} }",
+            output: "class A { a() {}static get[b]() {} }",
+            errors: unexpectedBefore("static"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {}static[b]() {} }",
+            output: "class A { a() {} static [b]() {} }",
+            errors: expectedBeforeAndAfter("static"),
+            options: [override("static", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() {} static [b]() {} }",
+            output: "class A { a() {}static[b]() {} }",
+            errors: unexpectedBeforeAndAfter("static"),
+            options: [override("static", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // super
+        //----------------------------------------------------------------------
+
+        {
+            code: "class A { a() { {}super[b]; } }",
+            output: "class A { a() { {} super[b]; } }",
+            errors: expectedBefore("super"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() { {} super[b]; } }",
+            output: "class A { a() { {}super[b]; } }",
+            errors: unexpectedBefore("super"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() { {}super[b]; } }",
+            output: "class A { a() { {} super[b]; } }",
+            errors: expectedBefore("super"),
+            options: [override("super", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class A { a() { {} super[b]; } }",
+            output: "class A { a() { {}super[b]; } }",
+            errors: unexpectedBefore("super"),
+            options: [override("super", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // switch
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}switch(a) {}",
+            output: "{} switch (a) {}",
+            errors: expectedBeforeAndAfter("switch")
+        },
+        {
+            code: "{} switch (a) {}",
+            output: "{}switch(a) {}",
+            errors: unexpectedBeforeAndAfter("switch"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}switch(a) {}",
+            output: "{} switch (a) {}",
+            errors: expectedBeforeAndAfter("switch"),
+            options: [override("switch", BOTH)]
+        },
+        {
+            code: "{} switch (a) {}",
+            output: "{}switch(a) {}",
+            errors: unexpectedBeforeAndAfter("switch"),
+            options: [override("switch", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // this
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}this[a]",
+            output: "{} this[a]",
+            errors: expectedBefore("this")
+        },
+        {
+            code: "{} this[a]",
+            output: "{}this[a]",
+            errors: unexpectedBefore("this"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}this[a]",
+            output: "{} this[a]",
+            errors: expectedBefore("this"),
+            options: [override("this", BOTH)]
+        },
+        {
+            code: "{} this[a]",
+            output: "{}this[a]",
+            errors: unexpectedBefore("this"),
+            options: [override("this", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // throw
+        //----------------------------------------------------------------------
+
+        {
+            code: "function foo() { {}throw+a }",
+            output: "function foo() { {} throw +a }",
+            errors: expectedBeforeAndAfter("throw")
+        },
+        {
+            code: "function foo() { {} throw +a }",
+            output: "function foo() { {}throw+a }",
+            errors: unexpectedBeforeAndAfter("throw"),
+            options: [NEITHER]
+        },
+        {
+            code: "function foo() { {}throw+a }",
+            output: "function foo() { {} throw +a }",
+            errors: expectedBeforeAndAfter("throw"),
+            options: [override("throw", BOTH)]
+        },
+        {
+            code: "function foo() { {} throw +a }",
+            output: "function foo() { {}throw+a }",
+            errors: unexpectedBeforeAndAfter("throw"),
+            options: [override("throw", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // try
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}try{} finally {}",
+            output: "{} try {} finally {}",
+            errors: expectedBeforeAndAfter("try")
+        },
+        {
+            code: "{} try {}finally{}",
+            output: "{}try{}finally{}",
+            errors: unexpectedBeforeAndAfter("try"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}try{}finally{}",
+            output: "{} try {}finally{}",
+            errors: expectedBeforeAndAfter("try"),
+            options: [override("try", BOTH)]
+        },
+        {
+            code: "{} try {} finally {}",
+            output: "{}try{} finally {}",
+            errors: unexpectedBeforeAndAfter("try"),
+            options: [override("try", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // typeof
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}typeof foo",
+            output: "{} typeof foo",
+            errors: expectedBefore("typeof")
+        },
+        {
+            code: "{} typeof foo",
+            output: "{}typeof foo",
+            errors: unexpectedBefore("typeof"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}typeof foo",
+            output: "{} typeof foo",
+            errors: expectedBefore("typeof"),
+            options: [override("typeof", BOTH)]
+        },
+        {
+            code: "{} typeof foo",
+            output: "{}typeof foo",
+            errors: unexpectedBefore("typeof"),
+            options: [override("typeof", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // var
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}var[a] = b",
+            output: "{} var [a] = b",
+            errors: expectedBeforeAndAfter("var"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} var [a] = b",
+            output: "{}var[a] = b",
+            errors: unexpectedBeforeAndAfter("var"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{}var[a] = b",
+            output: "{} var [a] = b",
+            errors: expectedBeforeAndAfter("var"),
+            options: [override("var", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "{} var [a] = b",
+            output: "{}var[a] = b",
+            errors: unexpectedBeforeAndAfter("var"),
+            options: [override("var", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        },
+
+        //----------------------------------------------------------------------
+        // void
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}void foo",
+            output: "{} void foo",
+            errors: expectedBefore("void")
+        },
+        {
+            code: "{} void foo",
+            output: "{}void foo",
+            errors: unexpectedBefore("void"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}void foo",
+            output: "{} void foo",
+            errors: expectedBefore("void"),
+            options: [override("void", BOTH)]
+        },
+        {
+            code: "{} void foo",
+            output: "{}void foo",
+            errors: unexpectedBefore("void"),
+            options: [override("void", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // while
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}while(a) {}",
+            output: "{} while (a) {}",
+            errors: expectedBeforeAndAfter("while")
+        },
+        {
+            code: "do {}while(a)",
+            output: "do {} while (a)",
+            errors: expectedBeforeAndAfter("while")
+        },
+        {
+            code: "{} while (a) {}",
+            output: "{}while(a) {}",
+            errors: unexpectedBeforeAndAfter("while"),
+            options: [NEITHER]
+        },
+        {
+            code: "do{} while (a)",
+            output: "do{}while(a)",
+            errors: unexpectedBeforeAndAfter("while"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}while(a) {}",
+            output: "{} while (a) {}",
+            errors: expectedBeforeAndAfter("while"),
+            options: [override("while", BOTH)]
+        },
+        {
+            code: "do{}while(a)",
+            output: "do{} while (a)",
+            errors: expectedBeforeAndAfter("while"),
+            options: [override("while", BOTH)]
+        },
+        {
+            code: "{} while (a) {}",
+            output: "{}while(a) {}",
+            errors: unexpectedBeforeAndAfter("while"),
+            options: [override("while", NEITHER)]
+        },
+        {
+            code: "do {} while (a)",
+            output: "do {}while(a)",
+            errors: unexpectedBeforeAndAfter("while"),
+            options: [override("while", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // with
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}with(obj) {}",
+            output: "{} with (obj) {}",
+            errors: expectedBeforeAndAfter("with")
+        },
+        {
+            code: "{} with (obj) {}",
+            output: "{}with(obj) {}",
+            errors: unexpectedBeforeAndAfter("with"),
+            options: [NEITHER]
+        },
+        {
+            code: "{}with(obj) {}",
+            output: "{} with (obj) {}",
+            errors: expectedBeforeAndAfter("with"),
+            options: [override("with", BOTH)]
+        },
+        {
+            code: "{} with (obj) {}",
+            output: "{}with(obj) {}",
+            errors: unexpectedBeforeAndAfter("with"),
+            options: [override("with", NEITHER)]
+        },
+
+        //----------------------------------------------------------------------
+        // yield
+        //----------------------------------------------------------------------
+
+        {
+            code: "function* foo() { {}yield foo }",
+            output: "function* foo() { {} yield foo }",
+            errors: expectedBefore("yield"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "function* foo() { {} yield foo }",
+            output: "function* foo() { {}yield foo }",
+            errors: unexpectedBefore("yield"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "function* foo() { {}yield foo }",
+            output: "function* foo() { {} yield foo }",
+            errors: expectedBefore("yield"),
+            options: [override("yield", BOTH)],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "function* foo() { {} yield foo }",
+            output: "function* foo() { {}yield foo }",
+            errors: unexpectedBefore("yield"),
+            options: [override("yield", NEITHER)],
+            parserOptions: {ecmaVersion: 6}
+        }
+    ]
+});


### PR DESCRIPTION
refs #1338, fixes #3869, fixes #3878, fixes #4006, fixes #4585.

This PR creates a new rule `keyword-spacing`, merged from `space-after-keywords`, `space-before-keywords`, and `space-return-throw-case`.
And `space-after-keywords`, `space-before-keywords`, and `space-return-throw-case` rules get deprecated.