### PR TITLE
New: 'ignoreArrayIndexes' config for 'no-magic-numbers' (fixes #4370)

### DIFF
--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -19,13 +19,13 @@ The following pattern is considered a problem:
 /*eslint no-magic-numbers: 2*/
 
 var dutyFreePrice = 100,
-    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25);    /*error No magic number: 0.25*/
+    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25); /*error No magic number: 0.25*/
 
 
 /*eslint no-magic-numbers: 2*/
 
 var data = ['foo', 'bar', 'baz'];
-var thirdValue = data[3];   /*error No magic number: 3*/
+var thirdValue = data[3]; /*error No magic number: 3*/
 ```
 
 The following pattern is considered okay:
@@ -48,7 +48,7 @@ If provided, it must be an `Array`.
 
 ### ignoreArrayIndexes
 
-a boolean to specify if number literals used as array indexes are not magic numbers. `false` by default.
+A boolean to specify if numbers used as array indexes are considered okay. `false` by default.
 
 The following pattern is considered okay:
 ```js

--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -19,7 +19,13 @@ The following pattern is considered a problem:
 /*eslint no-magic-numbers: 2*/
 
 var dutyFreePrice = 100,
-    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25); /*error No magic number: 0.25*/
+    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25);    /*error No magic number: 0.25*/
+
+
+/*eslint no-magic-numbers: 2*/
+
+var data = ['foo', 'bar', 'baz'];
+var thirdValue = data[3];   /*error No magic number: 3*/
 ```
 
 The following pattern is considered okay:
@@ -39,6 +45,18 @@ var dutyFreePrice = 100,
 
 An array of numbers to ignore. It's set to `[]` by default.
 If provided, it must be an `Array`.
+
+### ignoreArrayIndexes
+
+a boolean to specify if number literals used as array indexes are not magic numbers. `false` by default.
+
+The following pattern is considered okay:
+```js
+/*eslint no-magic-numbers: 2, { ignoreArrayIndexes: true }*/
+
+var data = ['foo', 'bar', 'baz'];
+var thirdValue = data[3];
+```
 
 ### enforceConst
 

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -37,9 +37,10 @@
 
 module.exports = function(context) {
     var config = context.options[0] || {},
-        ignore = config.ignore || [],
         detectObjects = !!config.detectObjects,
-        enforceConst = !!config.enforceConst;
+        enforceConst = !!config.enforceConst,
+        ignore = config.ignore || [],
+        ignoreArrayIndexes = !!config.ignoreArrayIndexes;
 
     /**
      * Returns whether the node is number literal
@@ -59,6 +60,28 @@ module.exports = function(context) {
         return ignore.indexOf(num) !== -1;
     }
 
+    /**
+     * Returns whether the number should be ignored when used as a radix within parseInt() or Number.parseInt()
+     * @param {ASTNode} parent
+     * * @param {ASTNode} node
+     * @returns {boolean} true if the number should be ignored
+     */
+    function shouldIgnoreParseInt(parent, node) {
+        return parent.type === "CallExpression" && node === parent.arguments[1] &&
+            (parent.callee.name === "parseInt" ||
+            parent.callee.type === "MemberExpression" &&
+            parent.callee.object.name === "Number" &&
+            parent.callee.property.name === "parseInt");
+    }
+
+    /**
+     * Returns whether the number should be ignored when used as an array index with enabled 'ignoreArrayIndexes' option.
+     * @param {ASTNode} parent
+     * @returns {boolean} true if the number should be ignored
+     */
+    function shouldIgnoreArrayIndexes(parent) {
+        return parent.type === "MemberExpression" && ignoreArrayIndexes
+    }
 
     return {
         "Literal": function(node) {
@@ -71,6 +94,7 @@ module.exports = function(context) {
                 return;
             }
 
+            // For negative magic numbers: update the value and parent node
             if (parent.type === "UnaryExpression" && parent.operator === "-") {
                 node = parent;
                 parent = node.parent;
@@ -78,17 +102,9 @@ module.exports = function(context) {
                 raw = "-" + raw;
             }
 
-            if (shouldIgnoreNumber(value)) {
-                return;
-            }
-
-            // don't warn on parseInt() or Number.parseInt() radix
-            if (parent.type === "CallExpression" && node === parent.arguments[1] &&
-                    (parent.callee.name === "parseInt" ||
-                    parent.callee.type === "MemberExpression" &&
-                    parent.callee.object.name === "Number" &&
-                    parent.callee.property.name === "parseInt")
-            ) {
+            if (shouldIgnoreNumber(value) ||
+                shouldIgnoreParseInt(parent, node) ||
+                shouldIgnoreArrayIndexes(parent)) {
                 return;
             }
 
@@ -124,6 +140,9 @@ module.exports.schema = [{
                 "type": "number"
             },
             "uniqueItems": true
+        },
+        "ignoreArrayIndexes": {
+            "type": "boolean"
         }
     },
     "additionalProperties": false

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -67,6 +67,12 @@ ruleTester.run("no-magic-numbers", rule, {
             options: [{
                 ignore: [0, 1]
             }]
+        },
+        {
+            code: "var data = ['foo', 'bar', 'baz']; var third = data[3];",
+            options: [{
+                ignoreArrayIndexes: true
+            }]
         }
     ],
     invalid: [
@@ -180,6 +186,13 @@ ruleTester.run("no-magic-numbers", rule, {
                 { message: "No magic number: 0", line: 19},
                 { message: "No magic number: 10", line: 22}
             ]
+        },
+        {
+            code: "var data = ['foo', 'bar', 'baz']; var third = data[3];",
+            options: [{}],
+            errors: [{
+                message: "No magic number: 3", line: 1
+            }]
         }
     ]
 });


### PR DESCRIPTION
Adds a new config options 'ignoreArrayIndexes' for the no-magic-numbers rule. (#4370)

No breaking changes. 

Further improvements and code clean-up discussions via #4616.