### PR TITLE
New: 'sort-imports' rule (refs #3143)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -185,6 +185,7 @@
         "semi": 0,
         "semi-spacing": 0,
         "sort-vars": 0,
+        "sort-imports": 0,
         "space-after-keywords": 0,
         "space-before-keywords": 0,
         "space-before-blocks": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -200,6 +200,7 @@ These rules are purely matters of style and are quite subjective.
 * [semi-spacing](semi-spacing.md) - enforce spacing before and after semicolons (fixable)
 * [semi](semi.md) - require or disallow use of semicolons instead of ASI (fixable)
 * [sort-vars](sort-vars.md) - sort variables within the same declaration block
+* [sort-imports](sort-imports.md) - sort import declarations within module
 * [space-before-blocks](space-before-blocks.md) - require or disallow a space before blocks (fixable)
 * [space-before-function-paren](space-before-function-paren.md) - require or disallow a space before function opening parenthesis (fixable)
 * [space-in-parens](space-in-parens.md) - require or disallow spaces inside parentheses

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -1,0 +1,201 @@
+# Import Sorting (sort-imports)
+
+The import statement is used to import members (functions, objects or primitives) that have been exported from an external module. Using a specific member syntax:
+
+```js
+// single - Import single member.
+import myMember from "my-module.js";
+
+// multiple - Import multiple members.
+import {foo, bar} from "my-module.js";
+
+// all - Import all members, where myModule contains all the exported bindings.
+import * as myModule from "my-module.js";
+```
+
+The import statement can also import a module without exported bindings. Used when the module does not export anything, but runs it own code or changes the global context object.
+
+```js
+// none - Import module without exported bindings.
+import "my-module.js"
+```
+
+When declaring multiple imports, a sorted list of import declarations make it easier for developers to read the code and find necessary imports later. This rule is purely a matter of style.
+
+
+## Rule Details
+
+This rule checks all import declarations and verifies that all imports are first sorted by the used member syntax and then alphabetically by the first member or alias name.
+
+The sort order of import declarations based on the member syntax can be configured via the `memberSyntaxSortOrder` option.
+The default member syntax sort order is:
+
+- `none` - import module without exported bindings.
+- `all` - import all members provided by exported bindings.
+- `multiple` - import multiple members.
+- `single` - import single member.
+
+The following example shows correct sorted import declarations:
+
+```js
+/*eslint sort-imports: 2*/
+import 'module-without-export.js';
+import * as foo from 'foo.js';
+import * as bar from 'bar.js';
+import {alpha, beta} from 'alpha.js';
+import {delta, gamma} from 'delta.js';
+import a from 'baz.js';
+import b from 'qux.js';
+```
+
+The following patterns are considered problems:
+
+```js
+/*eslint sort-imports: 2*/
+import b from 'foo.js';
+import a from 'bar.js'; /*error Imports should be sorted alphabetically.*/
+
+/*eslint sort-imports: 2*/
+import a from 'foo.js';
+import A from 'bar.js'; /*error Imports should be sorted alphabetically.*/
+
+/*eslint sort-imports: 2*/
+import {b, c} from 'foo.js';
+import {a, b} from 'bar.js'; /*error Imports should be sorted alphabetically.*/
+
+/*eslint sort-imports: 2*/
+import a from 'foo.js';
+import {b, c} from 'bar.js'; /*error Imports should be sorted by their member syntax. Use 'multiple' before 'single' member syntax.*/
+
+/*eslint sort-imports: 2*/
+import a from 'foo.js';
+import * as b from 'bar.js'; /*error Imports should be sorted by their member syntax. Use 'all' before 'single' member syntax. */
+
+/*eslint sort-imports: 2*/
+import {b, a, c} from 'foo.js' /*error Members of an import declaration should be sorted alphabetically.*/
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint sort-imports: 2*/
+import a from 'foo.js';
+import b from 'bar.js';
+import c from 'baz.js';
+
+/*eslint sort-imports: 2*/
+import 'foo.js'
+import * from 'bar.js';
+import {a, b} from 'baz.js';
+import c from 'qux.js';
+
+/*eslint sort-imports: 2*/
+import {a, b, c} from 'foo.js'
+```
+
+
+### Options
+
+This rule accepts an object with its properties as
+
+- `ignoreCase` (default: `false`)
+- `ignoreMemberSort` (default: `false`)
+- `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`)
+
+Default option settings are
+
+```json
+{
+    "sort-imports": [2, {
+        "ignoreCase": false,
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+    }]
+}
+```
+
+#### ignoreCase
+
+When `true` the rule ignores the case-sensitivity of the imports local name.
+
+The following patterns are considered problems:
+
+```js
+/*eslint sort-imports: [2, { "ignoreCase": true }]*/
+
+import B from 'foo.js';
+import a from 'bar.js';
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint sort-imports: [2, { "ignoreCase": true }]*/
+
+import a from 'foo.js';
+import B from 'bar.js';
+import c from 'baz.js';
+```
+
+Default is `false`.
+
+#### ignoreMemberSort
+
+Ignores the member sorting within a `multiple` member import declaration.
+
+The following patterns are considered problems:
+
+```js
+/*eslint sort-imports: 2*/
+import {b, a, c} from 'foo.js' /*error Members of an import declaration should be sorted alphabetically.*/
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint sort-imports: [2, { "ignoreMemberSort": true }]*/
+import {b, a, c} from 'foo.js'
+```
+
+Default is `false`.
+
+#### memberSyntaxSortOrder
+
+The member syntax sort order can be configured with this option. There are four different styles and the default member syntax sort order is:
+
+- `none` - import module without exported bindings.
+- `all` - import all members provided by exported bindings.
+- `multiple` - import multiple members.
+- `single` - import single member.
+
+Use this option if you want a different sort order. Every style must be defined in the sort order (There shall be four items in the array).
+
+The following patterns are considered problems:
+
+```js
+/*eslint sort-imports: 2*/
+import a from 'foo.js';
+import * as b from 'bar.js'; /*error Imports should be sorted by their member syntax. Use 'all' before 'single' member syntax. */
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint sort-imports: [2, { "memberSyntaxSortOrder": ['single', 'all', 'multiple', 'none'] }]*/
+
+import a from 'foo.js';
+import * as b from 'bar.js';
+
+/*eslint sort-imports: [2, { "memberSyntaxSortOrder": ['all', 'single', 'multiple', 'none'] }]*/
+
+import * as foo from 'foo.js';
+import z from 'zoo.js';
+import {a, b} from 'foo.js';
+
+```
+
+Default is `["none", "all", "multiple", "single"]`.
+
+## When not to use
+
+This rule is a formatting preference and not following it won't negatively affect the quality of your code. If you alphabetizing imports isn't a part of your coding standards, then you can leave this rule disabled.

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -1,0 +1,156 @@
+/**
+ * @fileoverview Rule to require sorting of import declarations
+ * @author Christian Schuller
+ * @copyright 2015 Christian Schuller. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var configuration = context.options[0] || {},
+        ignoreCase = configuration.ignoreCase || false,
+        ignoreMemberSort = configuration.ignoreMemberSort || false,
+        memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"],
+        previousDeclaration = null;
+
+    /**
+     * Gets the used member syntax style.
+     *
+     * import "my-module.js" --> none
+     * import * as myModule from "my-module.js" --> all
+     * import {myMember} from "my-module.js" --> single
+     * import {foo, bar} from  "my-module.js" --> multiple
+     *
+     * @param {ASTNode} node - the ImportDeclaration node.
+     * @returns {string} used member parameter style, ["all", "multiple", "single"]
+     */
+    function usedMemberSyntax(node) {
+        if (node.specifiers.length === 0) {
+            return "none";
+        } else if (node.specifiers[0].type === "ImportNamespaceSpecifier") {
+            return "all";
+        } else if (node.specifiers.length === 1) {
+            return "single";
+        } else {
+            return "multiple";
+        }
+    }
+
+    /**
+     * Gets the group by member parameter index for given declaration.
+     * @param {ASTNode} node - the ImportDeclaration node.
+     * @returns {number} the declaration group by member index.
+     */
+    function getMemberParameterGroupIndex(node) {
+        return memberSyntaxSortOrder.indexOf(usedMemberSyntax(node));
+    }
+
+    /**
+     * Gets the local name of the first imported module.
+     * @param {ASTNode} node - the ImportDeclaration node.
+     * @returns {?string} the local name of the first imported module.
+     */
+    function getFirstLocalMemberName(node) {
+        if (node.specifiers[0]) {
+            return node.specifiers[0].local.name;
+        } else {
+            return null;
+        }
+    }
+
+    return {
+        "ImportDeclaration": function(node) {
+            if (previousDeclaration) {
+                var currentLocalMemberName = getFirstLocalMemberName(node),
+                    currentMemberSyntaxGroupIndex = getMemberParameterGroupIndex(node),
+                    previousLocalMemberName = getFirstLocalMemberName(previousDeclaration),
+                    previousMemberSyntaxGroupIndex = getMemberParameterGroupIndex(previousDeclaration);
+
+                if (ignoreCase) {
+                    previousLocalMemberName = previousLocalMemberName.toLowerCase();
+                    currentLocalMemberName = currentLocalMemberName.toLowerCase();
+                }
+
+                // When the current declaration uses a different member syntax,
+                // then check if the ordering is correct.
+                // Otherwise, make a default string compare (like rule sort-vars to be consistent) of the first used local member name.
+                if (currentMemberSyntaxGroupIndex !== previousMemberSyntaxGroupIndex) {
+                    if (currentMemberSyntaxGroupIndex < previousMemberSyntaxGroupIndex) {
+                        context.report({
+                            node: node,
+                            message: "Expected '{{syntaxA}}' syntax before '{{syntaxB}}' syntax.",
+                            data: {
+                                syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
+                                syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex]
+                            }
+                        });
+                    }
+                } else {
+                    if (currentLocalMemberName < previousLocalMemberName) {
+                        context.report({
+                            node: node,
+                            message: "Imports should be sorted alphabetically."
+                        });
+                    }
+                }
+            }
+
+            // Multiple members of an import declaration should also be sorted alphabetically.
+            if (!ignoreMemberSort && node.specifiers.length > 1) {
+                node.specifiers.reduce(function(previousSpecifier, currentSpecifier) {
+                    var currentSpecifierName = currentSpecifier.local.name,
+                        previousSpecifierName = previousSpecifier.local.name;
+
+                    if (ignoreCase) {
+                        currentSpecifierName = currentSpecifierName.toLowerCase();
+                        previousSpecifierName = previousSpecifierName.toLowerCase();
+                    }
+
+                    if (currentSpecifierName < previousSpecifierName) {
+                        context.report({
+                            node: currentSpecifier,
+                            message: "Member '{{memberName}}' of the import declaration should be sorted alphabetically.",
+                            data: {
+                                memberName: currentSpecifier.local.name
+                            }
+                        });
+                    }
+
+                    return currentSpecifier;
+                }, node.specifiers[0]);
+            }
+
+            previousDeclaration = node;
+        }
+    };
+};
+
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "ignoreCase": {
+                "type": "boolean"
+            },
+            "memberSyntaxSortOrder": {
+                "type": "array",
+                "items": {
+                    "enum": ["none", "all", "multiple", "single"]
+                },
+                "uniqueItems": true,
+                "minItems": 4,
+                "maxItems": 4
+            },
+            "ignoreMemberSort": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -1,0 +1,247 @@
+/**
+ * @fileoverview Tests for sort-imports rule.
+ * @author Christian Schuller
+ * @copyright 2015 Christian Schuller. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/sort-imports"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester(),
+    parserOptions = {
+        ecmaVersion: 6,
+        sourceType: "module"
+    },
+    expectedError = {
+        message: "Imports should be sorted alphabetically.",
+        type: "ImportDeclaration"
+    },
+    ignoreCaseArgs = [{ignoreCase: true}];
+
+ruleTester.run("sort-imports", rule, {
+    valid: [
+        {
+            code:
+                "import a from 'foo.js';\n" +
+                "import b from 'bar.js';\n" +
+                "import c from 'baz.js';\n",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import * as B from 'foo.js';\n" +
+                "import A from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import * as B from 'foo.js';\n" +
+                "import {a, b} from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import {b, c} from 'bar.js';\n" +
+                "import A from 'foo.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import A from 'bar.js';\n" +
+                "import {b, c} from 'foo.js';",
+            parserOptions: parserOptions,
+            options: [{
+                memberSyntaxSortOrder: [ "single", "multiple", "none", "all" ]
+            }]
+        },
+        {
+            code:
+                "import {a, b} from 'bar.js';\n" +
+                "import {b, c} from 'foo.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import A from 'foo.js';\n" +
+                "import B from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import A from 'foo.js';\n" +
+                "import a from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import a, * as b from 'foo.js';\n" +
+                "import b from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import 'foo.js';\n" +
+                " import a from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import B from 'foo.js';\n" +
+                "import a from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import a from 'foo.js';\n" +
+                "import B from 'bar.js';",
+            parserOptions: parserOptions,
+            options: ignoreCaseArgs
+        },
+        {
+            code: "import {a, b, c, d} from 'foo.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code: "import {b, A, C, d} from 'foo.js';",
+            parserOptions: parserOptions,
+            options: [{
+                ignoreMemberSort: true
+            }]
+        },
+        {
+            code: "import {B, a, C, d} from 'foo.js';",
+            parserOptions: parserOptions,
+            options: [{
+                ignoreMemberSort: true
+            }]
+        },
+        {
+            code: "import {a, B, c, D} from 'foo.js';",
+            parserOptions: parserOptions,
+            options: ignoreCaseArgs
+        },
+        {
+            code: "import a, * as b from 'foo.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import * as a from 'foo.js';\n" +
+                "\n" +
+                "import b from 'bar.js';",
+            parserOptions: parserOptions
+        },
+        {
+            code:
+                "import * as bar from 'bar.js';\n" +
+                "import * as foo from 'foo.js';",
+            parserOptions: parserOptions
+        }
+    ],
+    invalid: [
+        {
+            code:
+                "import a from 'foo.js';\n" +
+                "import A from 'bar.js';",
+            parserOptions: parserOptions,
+            errors: [expectedError]
+        },
+        {
+            code:
+                "import b from 'foo.js';\n" +
+                "import a from 'bar.js';",
+            parserOptions: parserOptions,
+            errors: [expectedError]
+        },
+        {
+            code:
+                "import {b, c} from 'foo.js';\n" +
+                "import {a, b} from 'bar.js';",
+            parserOptions: parserOptions,
+            errors: [expectedError]
+        },
+        {
+            code:
+                "import * as foo from 'foo.js';\n" +
+                "import * as bar from 'bar.js';",
+            parserOptions: parserOptions,
+            errors: [expectedError]
+        },
+        {
+            code:
+                "import a from 'foo.js';\n" +
+                "import {b, c} from 'bar.js';",
+            parserOptions: parserOptions,
+            errors: [{
+                message: "Expected 'multiple' syntax before 'single' syntax.",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code:
+                "import a from 'foo.js';\n" +
+                "import * as b from 'bar.js';",
+            parserOptions: parserOptions,
+            errors: [{
+                message: "Expected 'all' syntax before 'single' syntax.",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code:
+                "import a from 'foo.js';\n" +
+                "import 'bar.js';",
+            parserOptions: parserOptions,
+            errors: [{
+                message: "Expected 'none' syntax before 'single' syntax.",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code:
+                "import b from 'bar.js';\n" +
+                "import * as a from 'foo.js';",
+            parserOptions: parserOptions,
+            options: [{
+                memberSyntaxSortOrder: [ "all", "single", "multiple", "none" ]
+            }],
+            errors: [{
+                message: "Expected 'all' syntax before 'single' syntax.",
+                type: "ImportDeclaration"
+            }]
+        },
+        {
+            code: "import {b, a, d, c} from 'foo.js';",
+            parserOptions: parserOptions,
+            errors: [{
+                message: "Member 'a' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }, {
+                message: "Member 'c' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }]
+        },
+        {
+            code: "import {a, B, c, D} from 'foo.js';",
+            parserOptions: parserOptions,
+            errors: [{
+                message: "Member 'B' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }, {
+                message: "Member 'D' of the import declaration should be sorted alphabetically.",
+                type: "ImportSpecifier"
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
New 'sort-imports' rule that checks the sorting for 

- member syntax group
- member name
- multiple member names within one import declaration.

To be consistent with the `sort-vars` rule, the rule

- uses the same sorting (default JavaScript string compare).
- supports `ignoreCase` config option. 

No auto fix implemented. We can discuss this, I think it is a little bit tricky with this grouping stuff.

This is my first rule implementation, so please review the code carefully, I am happy for every review comment.
 