### PR TITLE
Fix: Change max-warnings type to Int (fixes #4660)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -55,7 +55,7 @@ Using stdin:
 
 Handling warnings:
   --quiet                    Report errors only - default: false
-  --max-warnings Number      Number of warnings to trigger nonzero exit code -
+  --max-warnings Int         Number of warnings to trigger nonzero exit code -
                              default: -1
 
 Output:

--- a/lib/options.js
+++ b/lib/options.js
@@ -145,7 +145,7 @@ module.exports = optionator({
         },
         {
             option: "max-warnings",
-            type: "Number",
+            type: "Int",
             default: "-1",
             description: "Number of warnings to trigger nonzero exit code"
         },

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "object-assign": "^4.0.1",
-    "optionator": "^0.7.1",
+    "optionator": "^0.8.0",
     "path-is-absolute": "^1.0.0",
     "path-is-inside": "^1.0.1",
     "shelljs": "^0.5.3",

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -266,6 +266,12 @@ describe("options", function() {
             var currentOptions = options.parse("");
             assert.equal(currentOptions.maxWarnings, -1);
         });
+
+        it("should throw an error when supplied with a non-integer", function() {
+            assert.throws(function() {
+                options.parse("--max-warnings 10.2");
+            }, /Invalid value for option 'max-warnings' - expected type Int/);
+        });
     });
 
     describe("--init", function() {


### PR DESCRIPTION
Updated Optionator to version 0.8.0
Changed the type of the --max-warnings flag from 'Number' to 'Int'
An error will now be displayed if a non-integer value is supplied