### PR TITLE
Update: Add "ignore" override for operator-linebreak (fixes #4294)

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -185,6 +185,26 @@ The rule allows you to have even finer-grained control over individual operators
 
 This would override the global setting for that specific operator.
 
+#### `"ignore"` override
+
+This option is only supported using overrides and ignores line breaks on either side of the operator.
+
+While using this setting, the following patterns are not considered problems:
+
+```js
+/*eslint operator-linebreak: [2, "after", { "overrides": { "?": "ignore", ":": "ignore"} }]*/
+
+answer = everything ?
+  42
+  : foo;
+
+answer = everything
+  ?
+  42
+  :
+  foo;
+```
+
 ## When Not To Use It
 
 If your project will not be using a common operator line break style, turn this rule off.

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -55,7 +55,8 @@ module.exports = function(context) {
 
         var rightToken = context.getTokenAfter(operatorToken);
         var operator = operatorToken.value;
-        var style = styleOverrides[operator] || globalStyle;
+        var operatorStyleOverride = styleOverrides[operator];
+        var style = operatorStyleOverride || globalStyle;
 
         // if single line
         if (astUtils.isTokenOnSameLine(leftToken, operatorToken) &&
@@ -63,7 +64,7 @@ module.exports = function(context) {
 
             return;
 
-        } else if (!astUtils.isTokenOnSameLine(leftToken, operatorToken) &&
+        } else if (operatorStyleOverride !== "ignore" && !astUtils.isTokenOnSameLine(leftToken, operatorToken) &&
                 !astUtils.isTokenOnSameLine(operatorToken, rightToken)) {
 
             // lone operator
@@ -137,7 +138,7 @@ module.exports.schema = [
                 "properties": {
                     "anyOf": {
                         "type": "string",
-                        "enum": ["after", "before", "none"]
+                        "enum": ["after", "before", "none", "ignore"]
                     }
                 }
             }

--- a/tests/lib/rules/operator-linebreak.js
+++ b/tests/lib/rules/operator-linebreak.js
@@ -61,7 +61,9 @@ ruleTester.run("operator-linebreak", rule, {
         {code: "var a;", options: ["none"]},
         {code: "\n1 + 1", options: ["none"]},
         {code: "1 + 1\n", options: ["none"]},
-        {code: "answer = everything ? 42 : foo;", options: ["none"]}
+        {code: "answer = everything ? 42 : foo;", options: ["none"]},
+        {code: "answer = everything \n?\n 42 : foo;", options: [null, { overrides: {"?": "ignore"}}]},
+        {code: "answer = everything ? 42 \n:\n foo;", options: [null, { overrides: {":": "ignore"}}]}
     ],
 
     invalid: [
@@ -362,7 +364,22 @@ ruleTester.run("operator-linebreak", rule, {
                 column: 2
             }]
         },
-
+        {
+            code: "answer = everything\n?\n42\n:\nfoo;",
+            options: ["none"],
+            errors: [{
+                message: util.format(BAD_LN_BRK_MSG, "?"),
+                type: "ConditionalExpression",
+                line: 2,
+                column: 2
+            },
+            {
+                message: util.format(BAD_LN_BRK_MSG, ":"),
+                type: "ConditionalExpression",
+                line: 4,
+                column: 2
+            }]
+        },
         {
             code: "foo +=\n42;\nbar -=\n12\n+ 5;",
             options: ["after", { overrides: {"+=": "none", "+": "before" }}],
@@ -371,6 +388,16 @@ ruleTester.run("operator-linebreak", rule, {
                 type: "AssignmentExpression",
                 line: 1,
                 column: 7
+            }]
+        },
+        {
+            code: "answer = everything\n?\n42\n:\nfoo;",
+            options: ["after", { overrides: {"?": "ignore", ":": "before" }}],
+            errors: [{
+                message: util.format(BAD_LN_BRK_MSG, ":"),
+                type: "ConditionalExpression",
+                line: 4,
+                column: 2
             }]
         }
     ]


### PR DESCRIPTION
To support "ignore" in overrides for specific operator/s.