### PR TITLE
Updating optionator dep to 0.8.1 (fixes #4851)

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "minimatch": "^3.0.0",
     "mkdirp": "^0.5.0",
     "object-assign": "^4.0.1",
-    "optionator": "^0.8.0",
+    "optionator": "^0.8.1",
     "path-is-absolute": "^1.0.0",
     "path-is-inside": "^1.0.1",
     "shelljs": "^0.5.3",


### PR DESCRIPTION
Fixes npm install warning for deprecated version of lodash