### PR TITLE
Fix: do not require a @return tag for @interface (fixes #4860)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -92,6 +92,7 @@ module.exports = function(context) {
             functionData = fns.pop(),
             hasReturns = false,
             hasConstructor = false,
+            isInterface = false,
             isOverride = false,
             params = Object.create(null),
             jsdoc;
@@ -166,6 +167,10 @@ module.exports = function(context) {
                         isOverride = true;
                         break;
 
+                    case "interface":
+                        isInterface = true;
+                        break;
+
                     // no default
                 }
 
@@ -177,7 +182,7 @@ module.exports = function(context) {
             });
 
             // check for functions missing @returns
-            if (!isOverride && !hasReturns && !hasConstructor && node.parent.kind !== "get" && !isTypeClass(node)) {
+            if (!isOverride && !hasReturns && !hasConstructor && !isInterface && node.parent.kind !== "get" && !isTypeClass(node)) {
                 if (requireReturn || functionData.returnPresent) {
                     context.report(jsdocNode, "Missing JSDoc @" + (prefer.returns || "returns") + " for function.");
                 }

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -126,6 +126,15 @@ ruleTester.run("valid-jsdoc", rule, {
             code: "/** Foo \n@return Foo\n */\nfunction foo(){}",
             options: [{ requireReturnType: false }]
         },
+        {
+            code:
+                "/**\n" +
+                " * A thing interface. \n" +
+                " * @interface\n" +
+                " */\n" +
+                "function Thing() {}",
+            options: [{ requireReturn: true }]
+        },
 
         // classes
         {


### PR DESCRIPTION
This makes it so the code below passes the `valid-jsdoc` rule:

```js
/* eslint valid-jsdoc: 2 */

/**
 * Creates a new thing.
 * @interface
 */
function Thing() {}
```

Fixes #4860.