### PR TITLE
Fix: Set proper exit code for Node > 0.10 (fixes #4691)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -60,10 +60,16 @@ if (useStdIn) {
     exitCode = cli.execute(process.argv);
 }
 
-/*
- * Wait for the stdout buffer to drain.
- * See https://github.com/eslint/eslint/issues/317
- */
-process.on("exit", function() {
-    process.exit(exitCode);
-});
+// https://github.com/eslint/eslint/issues/4691
+// In Node.js >= 0.12, you can use a cleaner way
+if ("exitCode" in process) {
+    process.exitCode = exitCode;
+} else {
+    /*
+     * Wait for the stdout buffer to drain.
+     * See https://github.com/eslint/eslint/issues/317
+     */
+    process.on("exit", function() {
+        process.exit(exitCode);
+    });
+}


### PR DESCRIPTION
Tested manually and seems to be working.