### PR TITLE
Add support for type expressions with @this

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "chalk": "^1.0.0",
     "concat-stream": "^1.4.6",
     "debug": "^2.1.1",
-    "doctrine": "^0.7.1",
+    "doctrine": "^1.1.0",
     "es6-map": "^0.1.3",
     "escape-string-regexp": "^1.0.2",
     "escope": "^3.3.0",

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -203,6 +203,26 @@ ruleTester.run("valid-jsdoc", rule, {
             parserOptions: {
                 ecmaVersion: 6
             }
+        },
+
+
+        {
+            code:
+                "/**\n" +
+                " * Use of this with a 'namepath'.\n" +
+                " * @this some.name\n" +
+                " */\n" +
+                "function foo() {}",
+            options: [{requireReturn: false}]
+        },
+        {
+            code:
+                "/**\n" +
+                " * Use of this with a type expression.\n" +
+                " * @this {some.name}\n" +
+                " */\n" +
+                "function foo() {}",
+            options: [{requireReturn: false}]
         }
     ],
 
@@ -561,6 +581,32 @@ ruleTester.run("valid-jsdoc", rule, {
             parserOptions: {
                 ecmaVersion: 6
             }
+        },
+        {
+            code:
+                "/**\n" +
+                " * Use of this with an invalid type expression\n" +
+                " * @this {not.a.valid.type.expression\n" +
+                " */\n" +
+                "function foo() {}",
+            options: [{requireReturn: false}],
+            errors: [{
+                message: "JSDoc type missing brace.",
+                type: "Block"
+            }]
+        },
+        {
+            code:
+                "/**\n" +
+                " * Use of this with a type that is not a member expression\n" +
+                " * @this {Array<string>}\n" +
+                " */\n" +
+                "function foo() {}",
+            options: [{requireReturn: false}],
+            errors: [{
+                message: "JSDoc syntax error.",
+                type: "Block"
+            }]
         }
     ]
 });


### PR DESCRIPTION
This adds support for type expressions (only member expressions) with `@this`.  For example:

```js
/**
 * @this {some.name}
 */
function foo() {
  // expects to be called with some.name as this
}
```

Previously, only "name paths" were supported.  The type expression support comes with `doctrine@1.1.0`.  Here is the complete list of changes that comes with this upgrade: https://github.com/eslint/doctrine/compare/v0.7.1...v1.1.0
