### PR TITLE
Fix: gray text was invisible on Solarized Dark theme (fixes #4886)

### DIFF
--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -62,7 +62,7 @@ module.exports = function(results) {
                     message.column || 0,
                     messageType,
                     message.message.replace(/\.$/, ""),
-                    chalk.gray(message.ruleId || "")
+                    chalk.dim(message.ruleId || "")
                 ];
             }),
             {
@@ -73,7 +73,7 @@ module.exports = function(results) {
             }
         ).split("\n").map(function(el) {
             return el.replace(/(\d+)\s+(\d+)/, function(m, p1, p2) {
-                return chalk.gray(p1 + ":" + p2);
+                return chalk.dim(p1 + ":" + p2);
             });
         }).join("\n") + "\n\n";
     });


### PR DESCRIPTION
There is a long-standing solarized bug [1] where gray text is invisible
on the dark theme.
Since solarized is a popular theme, follow Chalk's advice [2] and use 'dim' rather than 'gray'.

Works well for me on Solarized Light, Solarized Dark and the default Ubuntu theme but am unable to try it on iTerm.

[1] https://github.com/altercation/solarized/issues/220
[2] https://github.com/chalk/chalk/issues/40