### PR TITLE
Docs: Fix missing footnote

### DIFF
--- a/packages/eslint-config-eslint/README.md
+++ b/packages/eslint-config-eslint/README.md
@@ -32,3 +32,4 @@ In your `.eslintrc` file, add:
 Join our [Mailing List](https://groups.google.com/group/eslint) or [Chatroom](https://gitter.im/eslint/eslint)
 
 [npm-image]: https://img.shields.io/npm/v/eslint.svg?style=flat-square
+[npm-url]: https://www.npmjs.com/package/eslint-config-eslint


### PR DESCRIPTION
Hello

This markdown uses a missing footnote `npm-url` and the badge is rendered in a broken way in github UI. This change fixes it.

Thanks,