### PR TITLE
Breaking: `space-before-blocks` ignores after keywords

### DIFF
--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -11,7 +11,8 @@ Having an inconsistent style distracts the reader from seeing the important part
 
 This rule will enforce consistency of spacing before blocks. It is only applied on blocks that don’t begin on a new line.
 
-This rule ignores spacing which is between `=>` and a block. The spacing is handled by the `arrow-spacing` rule.
+* This rule ignores spacing which is between `=>` and a block. The spacing is handled by the `arrow-spacing` rule.
+* This rule ignores spacing which is between a keyword and a block. The spacing is handled by the `keyword-spacing` rule.
 
 This rule takes one argument. If it is `"always"` then blocks must always have at least one preceding space. If `"never"`
 then all blocks should never have any preceding space. If different spacing is desired for function
@@ -31,12 +32,6 @@ The following patterns are considered problems:
 
 if (a){           /*error Missing space before opening brace.*/
     b();
-}
-
-if (a) {
-    b();
-} else{           /*error Missing space before opening brace.*/
-    c();
 }
 
 function a(){}    /*error Missing space before opening brace.*/
@@ -60,6 +55,13 @@ The following patterns are not considered problems:
 if (a) {
     b();
 }
+
+if (a) {
+    b();
+} else{ /*no error. this is checked by `keyword-spacing` rule.*/
+    c();
+}
+
 
 function a() {}
 
@@ -209,6 +211,6 @@ You can turn this rule off if you are not concerned with the consistency of spac
 
 ## Related Rules
 
-* [space-after-keywords](space-after-keywords.md)
+* [keyword-spacing](keyword-spacing.md)
 * [arrow-spacing](arrow-spacing.md)
 * [brace-style](brace-style.md)

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -30,13 +30,14 @@ module.exports = function(context) {
     }
 
     /**
-     * Checks whether or not a given token is an arrow operator (=>).
+     * Checks whether or not a given token is an arrow operator (=>) or a keyword
+     * in order to avoid to conflict with `arrow-spacing` and `keyword-spacing`.
      *
      * @param {Token} token - A token to check.
      * @returns {boolean} `true` if the token is an arrow operator.
      */
-    function isArrow(token) {
-        return token.type === "Punctuator" && token.value === "=>";
+    function isConflicted(token) {
+        return (token.type === "Punctuator" && token.value === "=>") || token.type === "Keyword";
     }
 
     /**
@@ -50,7 +51,7 @@ module.exports = function(context) {
             parent,
             requireSpace;
 
-        if (precedingToken && !isArrow(precedingToken) && astUtils.isTokenOnSameLine(precedingToken, node)) {
+        if (precedingToken && !isConflicted(precedingToken) && astUtils.isTokenOnSameLine(precedingToken, node)) {
             hasSpace = sourceCode.isSpaceBetweenTokens(precedingToken, node);
             parent = context.getAncestors().pop();
             if (parent.type === "FunctionExpression" || parent.type === "FunctionDeclaration") {

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -135,7 +135,13 @@ ruleTester.run("space-before-blocks", rule, {
 
         // https://github.com/eslint/eslint/issues/3769
         {code: "()=>{};", options: ["always"], parserOptions: { ecmaVersion: 6 }},
-        {code: "() => {};", options: ["never"], parserOptions: { ecmaVersion: 6 }}
+        {code: "() => {};", options: ["never"], parserOptions: { ecmaVersion: 6 }},
+
+        // https://github.com/eslint/eslint/issues/1338
+        {code: "if(a) {}else{}"},
+        {code: "if(a){}else {}", options: neverArgs},
+        {code: "try {}catch(a){}", options: functionsOnlyArgs},
+        {code: "export default class{}", options: classesOnlyArgs, parserOptions: { sourceType: "module" }}
     ],
     invalid: [
         {
@@ -172,17 +178,6 @@ ruleTester.run("space-before-blocks", rule, {
             options: neverArgs,
             errors: [ expectedNoSpacingError ],
             output: "if(a){}"
-        },
-        {
-            code: "if(a) {}else{}",
-            errors: [ expectedSpacingError ],
-            output: "if(a) {}else {}"
-        },
-        {
-            code: "if(a){}else {}",
-            options: neverArgs,
-            errors: [ expectedNoSpacingError ],
-            output: "if(a){}else{}"
         },
         {
             code: "function a(){}",
@@ -261,20 +256,14 @@ ruleTester.run("space-before-blocks", rule, {
         },
         {
             code: "try{}catch(a){}",
-            errors: [ expectedSpacingError, expectedSpacingError ],
-            output: "try {}catch(a) {}"
+            errors: [ expectedSpacingError ],
+            output: "try{}catch(a) {}"
         },
         {
             code: "try {}catch(a) {}",
             options: neverArgs,
-            errors: [ expectedNoSpacingError, expectedNoSpacingError ],
-            output: "try{}catch(a){}"
-        },
-        {
-            code: "try {}catch(a){}",
-            options: functionsOnlyArgs,
             errors: [ expectedNoSpacingError ],
-            output: "try{}catch(a){}"
+            output: "try {}catch(a){}"
         },
         {
             code: "try {} catch(a){}",
@@ -398,13 +387,6 @@ ruleTester.run("space-before-blocks", rule, {
             parserOptions: { sourceType: "module" },
             errors: [ expectedNoSpacingError ],
             output: "export function a(){}"
-        },
-        {
-            code: "export default class{}",
-            options: classesOnlyArgs,
-            parserOptions: { sourceType: "module" },
-            errors: [ expectedSpacingError ],
-            output: "export default class {}"
         },
         {
             code: "class test{}",


### PR DESCRIPTION
Fixes #1338.

No longer `space-before-blocks` rule catches spacing preceded by a keyword in order to avoid to conflict with `keyword-spacing` rule.

I moved some tests to valid from invalid.