### PR TITLE
Fix: remove duplicate of eslint-config-eslint

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "inquirer": "^0.11.0",
     "is-my-json-valid": "^2.10.0",
     "is-resolvable": "^1.0.0",
-    "js-yaml": "3.4.5",
+    "js-yaml": "^3.5.1",
     "json-stable-stringify": "^1.0.0",
     "lodash.clonedeep": "^3.0.1",
     "lodash.merge": "^3.3.2",

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -88,10 +88,7 @@ rules:
 
     # Previously on by default in node environment
     no-catch-shadow: 0
-    no-console: 0
     no-mixed-requires: 2
     no-new-require: 2
     no-path-concat: 2
-    no-process-exit: 2
-    global-strict: [0, "always"]
     handle-callback-err: [2, "err"]

--- a/packages/eslint-config-eslint/package.json
+++ b/packages/eslint-config-eslint/package.json
@@ -20,7 +20,7 @@
   "homepage": "http://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "js-yaml": "^3.4.3"
+    "js-yaml": "^3.5.1"
   },
   "keywords": [
     "eslintconfig",


### PR DESCRIPTION
Fixes #4909.

And pins `js-yaml` as the same version as eslint.