### PR TITLE
Correct JSDoc for function expression on object property

### DIFF
--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -233,7 +233,7 @@ SourceCode.prototype = {
             case "FunctionExpression":
 
                 if (parent.type !== "CallExpression" && parent.type !== "NewExpression") {
-                    while (parent && !parent.leadingComments && !/Function/.test(parent.type) && parent.type !== "MethodDefinition") {
+                    while (parent && !parent.leadingComments && !/Function/.test(parent.type) && parent.type !== "MethodDefinition" && parent.type !== "Property") {
                         parent = parent.parent;
                     }
 

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -40,6 +40,33 @@ ruleTester.run("valid-jsdoc", rule, {
         "/**\n* Description\n* @inheritdoc */\nfunction foo(arg1, arg2){ return ''; }",
         "/**\n* Description\n* @inheritDoc */\nfunction foo(arg1, arg2){ return ''; }",
         {
+            code:
+                "/**\n" +
+                "* Create a new thing.\n" +
+                "*/\n" +
+                "var thing = new Thing({\n" +
+                "  foo: function() {\n" +
+                "    return 'bar';\n" +
+                "  }\n" +
+                "});\n",
+            options: [{requireReturn: false}]
+        },
+        {
+            code:
+                "/**\n" +
+                "* Create a new thing.\n" +
+                "*/\n" +
+                "var thing = new Thing({\n" +
+                "  /**\n" +
+                "   * @return {string} A string.\n" +
+                "   */\n" +
+                "  foo: function() {\n" +
+                "    return 'bar';\n" +
+                "  }\n" +
+                "});\n",
+            options: [{requireReturn: false}]
+        },
+        {
             code: "/**\n* Description\n* @return {void} */\nfunction foo(){}",
             options: [{}]
         },
@@ -231,6 +258,25 @@ ruleTester.run("valid-jsdoc", rule, {
             code: "/** @@foo */\nfunction foo(){}",
             errors: [{
                 message: "JSDoc syntax error.",
+                type: "Block"
+            }]
+        },
+        {
+            code:
+                "/**\n" +
+                "* Create a new thing.\n" +
+                "*/\n" +
+                "var thing = new Thing({\n" +
+                "  /**\n" +
+                "   * Missing return tag.\n" +
+                "   */\n" +
+                "  foo: function() {\n" +
+                "    return 'bar';\n" +
+                "  }\n" +
+                "});\n",
+            options: [{requireReturn: false}],
+            errors: [{
+                message: "Missing JSDoc @returns for function.",
                 type: "Block"
             }]
         },


### PR DESCRIPTION
Without this change, a function expression as an object property could be assigned the wrong comment block.

```
/**
 * This documents the assignment to `foo`, not the function expression for `bam`.
 */
var foo = new Bar({
  bam: function() {
    return 'baz';
  }
});
```

Fixes #4900.