### PR TITLE
Make jsx-quotes fixable

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -158,7 +158,7 @@ These rules are purely matters of style and are quite subjective.
 * [id-length](id-length.md) - this option enforces minimum and maximum identifier lengths (variable names, property names etc.)
 * [id-match](id-match.md) - require identifiers to match the provided regular expression
 * [indent](indent.md) - specify tab or space width for your code (fixable)
-* [jsx-quotes](jsx-quotes.md) - specify whether double or single quotes should be used in JSX attributes
+* [jsx-quotes](jsx-quotes.md) - specify whether double or single quotes should be used in JSX attributes (fixable)
 * [key-spacing](key-spacing.md) - enforce spacing between keys and values in object literal properties
 * [keyword-spacing](keyword-spacing.md) - enforce spacing before and after keywords (fixable)
 * [linebreak-style](linebreak-style.md) - disallow mixed 'LF' and 'CRLF' as linebreaks

--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -15,6 +15,8 @@ If you want to have e.g. a double quote within a JSX attribute value, you have t
 <a b='"' />
 ```
 
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+
 ## Rule Details
 
 This rule takes one argument.

--- a/lib/rules/jsx-quotes.js
+++ b/lib/rules/jsx-quotes.js
@@ -19,11 +19,17 @@ var astUtils = require("../ast-utils");
 var QUOTE_SETTINGS = {
     "prefer-double": {
         quote: "\"",
-        description: "singlequote"
+        description: "singlequote",
+        convert: function(str) {
+            return str.replace(/'/g, "\"");
+        }
     },
     "prefer-single": {
         quote: "'",
-        description: "doublequote"
+        description: "doublequote",
+        convert: function(str) {
+            return str.replace(/"/g, "'");
+        }
     }
 };
 
@@ -50,7 +56,13 @@ module.exports = function(context) {
             var attributeValue = node.value;
 
             if (attributeValue && astUtils.isStringLiteral(attributeValue) && !usesExpectedQuotes(attributeValue)) {
-                context.report(attributeValue, "Unexpected usage of {{description}}.", setting);
+                context.report({
+                    node: attributeValue,
+                    message: "Unexpected usage of " + setting.description + ".",
+                    fix: function(fixer) {
+                        return fixer.replaceText(attributeValue, setting.convert(attributeValue.raw));
+                    }
+                });
             }
         }
     };

--- a/tests/lib/rules/jsx-quotes.js
+++ b/tests/lib/rules/jsx-quotes.js
@@ -25,6 +25,11 @@ ruleTester.run("jsx-quotes", rule, {
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
         },
         {
+            code: "<foo bar=\"'\" />",
+            options: [ "prefer-single" ],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
+        },
+        {
             code: "<foo bar='baz' />",
             options: [ "prefer-single" ],
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
@@ -54,6 +59,24 @@ ruleTester.run("jsx-quotes", rule, {
         {
             code: "<foo bar />",
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "<foo bar='&quot;' />",
+            options: [ "prefer-single" ],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "<foo bar=\"&quot;\" />",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "<foo bar='&#39;' />",
+            options: [ "prefer-single" ],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
+        },
+        {
+            code: "<foo bar=\"&#39;\" />",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } }
         }
     ],
     invalid: [
@@ -62,7 +85,8 @@ ruleTester.run("jsx-quotes", rule, {
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
             errors: [
                 { message: "Unexpected usage of singlequote.", line: 1, column: 10, type: "Literal" }
-            ]
+            ],
+            output: "<foo bar=\"baz\" />"
         },
         {
             code: "<foo bar=\"baz\" />",
@@ -70,7 +94,25 @@ ruleTester.run("jsx-quotes", rule, {
             parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
             errors: [
                 { message: "Unexpected usage of doublequote.", line: 1, column: 10, type: "Literal" }
-            ]
+            ],
+            output: "<foo bar='baz' />"
+        },
+        {
+            code: "<foo bar=\"&quot;\" />",
+            options: [ "prefer-single" ],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+            errors: [
+                { message: "Unexpected usage of doublequote.", line: 1, column: 10, type: "Literal" }
+            ],
+            output: "<foo bar='&quot;' />"
+        },
+        {
+            code: "<foo bar=\'&#39;\' />",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { jsx: true } },
+            errors: [
+                { message: "Unexpected usage of singlequote.", line: 1, column: 10, type: "Literal" }
+            ],
+            output: "<foo bar=\"&#39;\" />"
         }
     ]
 });


### PR DESCRIPTION
This is another take to #4377 after #4374 was left undone.

As discussed [here](https://github.com/eslint/eslint/pull/4374#discussion_r49568098) It looks like this rule can only fail in a simple case, that is: external quotes are wrong, and no literal quotes appear inside:

"..." → prefer-single → fail
'...' → prefer-double → fail

I couldn't find any counterexample to this, given the JSX grammar.
If any literal quote appears inside, it will make the rule pass even if the external quotes are not the preferred ones.

The proposed fix for a failing rule is then:

- `str.replace(/"/g, "'")` (for prefer-single)
- `str.replace(/'/g, "\"")` (for prefer-double)

Escaped quotes (e.g. `"&quot;"` and `'&#39;'`) don't add anything to this, since they are left as they are, and the JSX compiler will escape them correctly.