### PR TITLE
Fix: Supports Unicode BOM (fixes #4878)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -16,6 +16,18 @@ var code = new SourceCode("var foo = bar;", ast);
 
 The `SourceCode` constructor throws an error if the AST is missing any of the required information.
 
+The `SourceCode` constructor strips Unicode BOM.
+Please note the AST also should be parsed from stripped text.
+
+```js
+var SourceCode = require("eslint").SourceCode;
+
+var code = new SourceCode("\uFEFFvar foo = bar;", ast);
+
+assert(code.hasBOM === true);
+assert(code.text === "var foo = bar;");
+```
+
 ### splitLines()
 
 This is a static function on `SourceCode` that is used to split the source code text into an array of lines.
@@ -84,7 +96,6 @@ The `verify()` method returns an array of objects containing information about t
 ```js
 {
     fatal: false,
-    severity: 2,
     ruleId: "semi",
     severity: 2,
     line: 1,

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -243,7 +243,8 @@ Once you have an instance of `SourceCode`, you can use the methods on it to work
 
 There are also some properties you can access:
 
-* `text` - the full text of the code being linted.
+* `hasBOM` - the flag to indicate whether or not the source code has Unicode BOM.
+* `text` - the full text of the code being linted. Unicode BOM has been stripped from this text.
 * `ast` - the `Program` node of the AST for the code being linted.
 * `lines` - an array of lines, split according to the specification's definition of line breaks.
 

--- a/docs/user-guide/migrating-to-2.0.0.md
+++ b/docs/user-guide/migrating-to-2.0.0.md
@@ -264,3 +264,27 @@ ESLint 2.0.0 removes these conflicting defaults, and so you may begin seeing lin
 
 [`no-multiple-empty-lines`]: ../rules/no-multiple-empty-lines
 [`func-style`]: ../rules/func-style
+
+
+## SourceCode constructor (Node API) changes
+
+`SourceCode` constructor got to handle Unicode BOM.
+If the first argument `text` has BOM, `SourceCode` constructor sets `true` to `this.hasBOM` and strips BOM from the text.
+
+```js
+var SourceCode = require("eslint").SourceCode;
+
+var code = new SourceCode("\uFEFFvar foo = bar;", ast);
+
+assert(code.hasBOM === true);
+assert(code.text === "var foo = bar;");
+```
+
+So the second argument `ast` also should be parsed from stripped text.
+
+**To address:** If you are using `SourceCode` constructor in your code, please parse the source code after it stripped BOM:
+
+```js
+var ast = yourParser.parse(text.replace(/^\uFEFF/, ""), options);
+var sourceCode = new SourceCode(text, ast);
+```

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -482,6 +482,22 @@ function findEslintEnv(text) {
     return retv;
 }
 
+/**
+ * Strips Unicode BOM from a given text.
+ *
+ * @param {string} text - A text to strip.
+ * @returns {string} The stripped text.
+ */
+function stripUnicodeBOM(text) {
+    // Check Unicode BOM.
+    // In JavaScript, string data is stored as UTF-16, so BOM is 0xFEFF.
+    // http://www.ecma-international.org/ecma-262/6.0/#sec-unicode-format-control-characters
+    if (text.charCodeAt(0) === 0xFEFF) {
+        return text.slice(1);
+    }
+    return text;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -673,17 +689,19 @@ module.exports = (function() {
 
         // only do this for text
         if (text !== null) {
-
             // there's no input, just exit here
             if (text.trim().length === 0) {
                 sourceCode = new SourceCode(text, blankScriptAST);
                 return messages;
             }
 
-            ast = parse(text.replace(/^#!([^\r\n]+)/, function(match, captured) {
-                shebang = captured;
-                return "//" + captured;
-            }), config);
+            ast = parse(
+                stripUnicodeBOM(text).replace(/^#!([^\r\n]+)/, function(match, captured) {
+                    shebang = captured;
+                    return "//" + captured;
+                }),
+                config
+            );
 
             if (ast) {
                 sourceCode = new SourceCode(text, ast);

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -16,6 +16,8 @@ var debug = require("debug")("eslint:text-fixer");
 // Helpers
 //------------------------------------------------------------------------------
 
+var BOM = "\uFEFF";
+
 /**
  * Compares items in a messages array by line and column.
  * @param {Message} a The first message.
@@ -69,7 +71,8 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
     var remainingMessages = [],
         fixes = [],
         text = sourceCode.text,
-        lastFixPos = text.length + 1;
+        lastFixPos = text.length + 1,
+        prefix = (sourceCode.hasBOM ? BOM : "");
 
     messages.forEach(function(problem) {
         if (problem.hasOwnProperty("fix")) {
@@ -96,10 +99,24 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
 
         fixes.forEach(function(problem) {
             var fix = problem.fix;
+            var start = fix.range[0];
+            var end = fix.range[1];
+            var insertionText = fix.text;
 
-            if (fix.range[1] < lastFixPos) {
-                chars.splice(fix.range[0], fix.range[1] - fix.range[0], fix.text);
-                lastFixPos = fix.range[0];
+            if (end < lastFixPos) {
+                if (start < 0) {
+                    // Remove BOM.
+                    prefix = "";
+                    start = 0;
+                }
+                if (start === 0 && insertionText[0] === BOM) {
+                    // Set BOM.
+                    prefix = BOM;
+                    insertionText = insertionText.slice(1);
+                }
+
+                chars.splice(start, end - start, insertionText);
+                lastFixPos = start;
             } else {
                 remainingMessages.push(problem);
             }
@@ -108,14 +125,14 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         return {
             fixed: true,
             messages: remainingMessages.sort(compareMessagesByLocation),
-            output: chars.join("")
+            output: prefix + chars.join("")
         };
     } else {
         debug("No fixes to apply");
         return {
             fixed: false,
             messages: messages,
-            output: text
+            output: prefix + text
         };
     }
 };

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -87,19 +87,25 @@ function looksLikeExport(astNode) {
 
 /**
  * Represents parsed source code.
- * @param {string} text The source code text.
- * @param {ASTNode} ast The Program node of the AST representing the code.
+ * @param {string} text - The source code text.
+ * @param {ASTNode} ast - The Program node of the AST representing the code. This AST should be created from the text that BOM was stripped.
  * @constructor
  */
 function SourceCode(text, ast) {
-
     validate(ast);
 
     /**
+     * The flag to indicate that the source code has Unicode BOM.
+     * @type boolean
+     */
+    this.hasBOM = (text.charCodeAt(0) === 0xFEFF);
+
+    /**
      * The original text source code.
+     * BOM was stripped from this text.
      * @type string
      */
-    this.text = text;
+    this.text = (this.hasBOM ? text.slice(1) : text);
 
     /**
      * The parsed AST for the source code.
@@ -112,7 +118,7 @@ function SourceCode(text, ast) {
      * This is done to avoid each rule needing to do so separately.
      * @type string[]
      */
-    this.lines = SourceCode.splitLines(text);
+    this.lines = SourceCode.splitLines(this.text);
 
     this.tokensAndComments = ast.tokens.concat(ast.comments).sort(function(left, right) {
         return left.range[0] - right.range[0];

--- a/tests/fixtures/utf8-bom.js
+++ b/tests/fixtures/utf8-bom.js
@@ -1,0 +1,3 @@
+﻿"use strict";
+
+console.log("This file has [0xEF, 0xBB, 0xBF] as BOM.");

--- a/tests/lib/rules/no-irregular-whitespace.js
+++ b/tests/lib/rules/no-irregular-whitespace.js
@@ -71,7 +71,10 @@ ruleTester.run("no-irregular-whitespace", rule, {
         "'\\\u2029';", // multiline string
         "'\u202F';",
         "'\u205f';",
-        "'\u3000';"
+        "'\u3000';",
+
+        // Unicode BOM.
+        "\uFEFFconsole.log('hello BOM');"
     ],
 
     invalid: [

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -86,6 +86,34 @@ var INSERT_AT_END = {
     },
     NO_FIX = {
         message: "nofix"
+    },
+    INSERT_BOM = {
+        message: "insert-bom",
+        fix: {
+            range: [0, 0],
+            text: "\uFEFF"
+        }
+    },
+    INSERT_BOM_WITH_TEXT = {
+        message: "insert-bom",
+        fix: {
+            range: [0, 0],
+            text: "\uFEFF// start\n"
+        }
+    },
+    REMOVE_BOM = {
+        message: "remove-bom",
+        fix: {
+            range: [-1, 0],
+            text: ""
+        }
+    },
+    REPLACE_BOM_WITH_TEXT = {
+        message: "remove-bom",
+        fix: {
+            range: [-1, 0],
+            text: "// start\n"
+        }
     };
 
 //------------------------------------------------------------------------------
@@ -94,13 +122,13 @@ var INSERT_AT_END = {
 
 describe("SourceCodeFixer", function() {
 
-    var sourceCode;
+    describe("applyFixes() with no BOM", function() {
 
-    beforeEach(function() {
-        sourceCode = new SourceCode(TEST_CODE, TEST_AST);
-    });
+        var sourceCode;
 
-    describe("applyFixes()", function() {
+        beforeEach(function() {
+            sourceCode = new SourceCode(TEST_CODE, TEST_AST);
+        });
 
         describe("Text Insertion", function() {
 
@@ -238,6 +266,221 @@ describe("SourceCodeFixer", function() {
                 assert.equal(result.messages.length, 1);
                 assert.equal(result.messages[0].message, "nofix");
                 assert.isFalse(result.fixed);
+            });
+
+        });
+
+        describe("BOM manipulations", function() {
+
+            it("should insert BOM with an insertion of '\uFEFF' at 0", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM_WITH_TEXT ]);
+                assert.equal(result.output, "\uFEFF// start\n" + TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should remove BOM with a negative range", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_BOM ]);
+                assert.equal(result.output, TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should replace BOM with a negative range and 'foobar'", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_BOM_WITH_TEXT ]);
+                assert.equal(result.output, "// start\n" + TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+        });
+
+    });
+
+    // This section is almost same as "with no BOM".
+    // Just `result.output` has BOM.
+    describe("applyFixes() with BOM", function() {
+
+        var sourceCode;
+
+        beforeEach(function() {
+            sourceCode = new SourceCode("\uFEFF" + TEST_CODE, TEST_AST);
+        });
+
+        describe("Text Insertion", function() {
+
+            it("should insert text at the end of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_END ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE + INSERT_AT_END.fix.text);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should insert text at the beginning of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_START ]);
+                assert.equal(result.output, "\uFEFF" + INSERT_AT_START.fix.text + TEST_CODE);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should insert text in the middle of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("6 *", INSERT_IN_MIDDLE.fix.text + "6 *"));
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should insert text at the beginning, middle, and end of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END ]);
+                assert.equal(result.output, "\uFEFF" + INSERT_AT_START.fix.text + TEST_CODE.replace("6 *", INSERT_IN_MIDDLE.fix.text + "6 *") + INSERT_AT_END.fix.text);
+                assert.equal(result.messages.length, 0);
+            });
+
+        });
+
+        describe("Text Replacement", function() {
+
+            it("should replace text at the end of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_VAR ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("var", "let"));
+                assert.isTrue(result.fixed);
+            });
+
+            it("should replace text at the beginning of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "foo"));
+                assert.isTrue(result.fixed);
+            });
+
+            it("should replace text in the middle of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_NUM ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("6", "5"));
+                assert.isTrue(result.fixed);
+            });
+
+            it("should replace text at the beginning and end of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID, REPLACE_VAR, REPLACE_NUM ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFFlet foo = 5 * 7;");
+                assert.isTrue(result.fixed);
+            });
+
+        });
+
+        describe("Text Removal", function() {
+
+            it("should remove text at the start of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("var ", ""));
+                assert.isTrue(result.fixed);
+            });
+
+            it("should remove text in the middle of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "a"));
+                assert.isTrue(result.fixed);
+            });
+
+            it("should remove text towards the end of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_END ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace(" * 7", ""));
+                assert.isTrue(result.fixed);
+            });
+
+            it("should remove text at the beginning, middle, and end of the code", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_END, REMOVE_START, REMOVE_MIDDLE ]);
+                assert.equal(result.messages.length, 0);
+                assert.equal(result.output, "\uFEFFa = 6;");
+                assert.isTrue(result.fixed);
+            });
+        });
+
+        describe("Combination", function() {
+
+            it("should replace text at the beginning, remove text in the middle, and insert text at the end", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_END, REMOVE_END, REPLACE_VAR ]);
+                assert.equal(result.output, "\uFEFFlet answer = 6;// end");
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should only apply one fix when ranges overlap", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "a"));
+                assert.equal(result.messages.length, 1);
+                assert.equal(result.messages[0].message, "foo");
+                assert.isTrue(result.fixed);
+            });
+
+            it("should apply one fix when the end of one range is the same as the start of a previous range overlap", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START, REPLACE_ID ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "foo"));
+                assert.equal(result.messages.length, 1);
+                assert.equal(result.messages[0].message, "removestart");
+                assert.isTrue(result.fixed);
+            });
+
+            it("should only apply one fix when ranges overlap and one message has no fix", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID, NO_FIX ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "a"));
+                assert.equal(result.messages.length, 2);
+                assert.equal(result.messages[0].message, "nofix");
+                assert.equal(result.messages[1].message, "foo");
+                assert.isTrue(result.fixed);
+            });
+
+        });
+
+        describe("No Fixes", function() {
+
+            it("should only apply one fix when ranges overlap and one message has no fix", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ NO_FIX ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE);
+                assert.equal(result.messages.length, 1);
+                assert.equal(result.messages[0].message, "nofix");
+                assert.isFalse(result.fixed);
+            });
+
+        });
+
+        describe("BOM manipulations", function() {
+
+            it("should insert BOM with an insertion of '\uFEFF' at 0", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM ]);
+                assert.equal(result.output, "\uFEFF" + TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM_WITH_TEXT ]);
+                assert.equal(result.output, "\uFEFF// start\n" + TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should remove BOM with a negative range", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_BOM ]);
+                assert.equal(result.output, TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
+            });
+
+            it("should replace BOM with a negative range and 'foobar'", function() {
+                var result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_BOM_WITH_TEXT ]);
+                assert.equal(result.output, "// start\n" + TEST_CODE);
+                assert.isTrue(result.fixed);
+                assert.equal(result.messages.length, 0);
             });
 
         });


### PR DESCRIPTION
Fixes #4878.

- `eslint.verify()` API came to strip BOM before parsing.
- `hasBOM` property was added into `SourceCode` object.
- `SourceCodeFixer.applyFixes()` came to insert BOM to the head of output if `sourceCode.hasBOM` is `true`.

> This diff becomes more readable if you add `?w=1`.