### PR TITLE
Update: Add describe around rule tester blocks (fixes #4907)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -401,15 +401,19 @@ RuleTester.prototype = {
         // this creates a mocha test suite and pipes all supplied info
         // through one of the templates above.
         RuleTester.describe(ruleName, function() {
-            test.valid.forEach(function(valid) {
-                RuleTester.it(valid.code || valid, function() {
-                    testValidTemplate(ruleName, valid);
+            RuleTester.describe("valid", function() {
+                test.valid.forEach(function(valid) {
+                    RuleTester.it(valid.code || valid, function() {
+                        testValidTemplate(ruleName, valid);
+                    });
                 });
             });
 
-            test.invalid.forEach(function(invalid) {
-                RuleTester.it(invalid.code, function() {
-                    testInvalidTemplate(ruleName, invalid);
+            RuleTester.describe("invalid", function() {
+                test.invalid.forEach(function(invalid) {
+                    RuleTester.it(invalid.code, function() {
+                        testInvalidTemplate(ruleName, invalid);
+                    });
                 });
             });
         });


### PR DESCRIPTION
This is how it looks now:
```
$ mocha tests/lib/rules/no-console.js
  no-console
    valid
      √ Console.info(foo) (39ms)
    invalid
      √ console.log(foo)
      √ console.error(foo)
      √ console.info(foo)

  4 passing (56ms)
```