### PR TITLE
Update: Rules should get `sourceType` from Program node (fixes #4960)

### DIFF
--- a/docs/user-guide/migrating-to-2.0.0.md
+++ b/docs/user-guide/migrating-to-2.0.0.md
@@ -177,7 +177,7 @@ If you were using `ecmaFeatures.modules` to enable ES6 module support like this:
 Additionally, if you are using `context.ecmaFeatures` inside of your rules, then you'll need to update your code in the following ways:
 
 1. If you're using an ES6 feature flag such as `context.ecmaFeatures.blockBindings`, rewrite to check for `context.parserOptions.ecmaVersion > 5`.
-1. If you're using `context.ecmaFeatures.modules`, rewrite to check for `context.parserOptions.sourceType === "module"`.
+1. If you're using `context.ecmaFeatures.modules`, rewrite to check that the `sourceType` property of the Program node is `"module"`.
 1. If you're using a non-ES6 feature flag such as `context.ecmaFeatures.jsx`, rewrite to check for `context.parserOptions.ecmaFeatures.jsx`.
 
 If you're not using `ecmaFeatures` in your configuration, then no change is needed.

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -226,11 +226,10 @@ module.exports = function(context) {
 
         "Program": function(node) {
             var scope = context.getScope(),
-                parserOptions = context.parserOptions,
-                features = parserOptions.ecmaFeatures || {},
+                features = context.parserOptions.ecmaFeatures || {},
                 strict =
                     scope.isStrict ||
-                    parserOptions.sourceType === "module" ||
+                    node.sourceType === "module" ||
                     (features.globalReturn && scope.childScopes[0].isStrict);
 
             funcInfo = {

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -73,15 +73,14 @@ module.exports = function(context) {
         // Modules is always strict mode.
         "Program": function(node) {
             var scope = context.getScope(),
-                parserOptions = context.parserOptions,
-                features = parserOptions.ecmaFeatures || {};
+                features = context.parserOptions.ecmaFeatures || {};
 
             stack.push({
                 init: true,
                 node: node,
                 valid: !(
                     scope.isStrict ||
-                    parserOptions.sourceType === "module" ||
+                    node.sourceType === "module" ||
                     (features.globalReturn && scope.childScopes[0].isStrict)
                 )
             });

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -43,16 +43,17 @@ module.exports = function(context) {
 
     /**
      * Find variables in the current scope.
+     * @param {ASTNode} node - The Program node.
      * @returns {void}
      * @private
      */
-    function checkForGlobal() {
+    function checkForGlobal(node) {
         var scope = context.getScope(),
             parserOptions = context.parserOptions,
             ecmaFeatures = parserOptions.ecmaFeatures || {};
 
         // Nodejs env or modules has a special scope.
-        if (ecmaFeatures.globalReturn || context.parserOptions.sourceType === "module") {
+        if (ecmaFeatures.globalReturn || node.sourceType === "module") {
             findVariablesInScope(scope.childScopes[0]);
         } else {
             findVariablesInScope(scope);

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -185,14 +185,14 @@ module.exports = function(context) {
     }
 
     var ruleDefinition = {
-        "Program:exit": function() {
+        "Program:exit": function(node) {
             var scope = context.getScope(),
                 ecmaFeatures = context.parserOptions.ecmaFeatures || {};
 
             findVariablesInScope(scope);
 
             // both Node.js and Modules have an extra scope
-            if (ecmaFeatures.globalReturn || context.parserOptions.sourceType === "module") {
+            if (ecmaFeatures.globalReturn || node.sourceType === "module") {
                 findVariablesInScope(scope.childScopes[0]);
             }
         }

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -39,6 +39,7 @@ ruleTester.run("no-eval", rule, {
         { code: "function foo() { var eval = 'foo'; global[eval]('foo') }", env: {"node": true} },
         "this.noeval('foo');",
         "function foo() { 'use strict'; this.eval('foo'); }",
+        { code: "function foo() { this.eval('foo'); }", parserOptions: { sourceType: "module" } },
         "var obj = {foo: function() { this.eval('foo'); }}",
         "var obj = {}; obj.foo = function() { this.eval('foo'); }",
         { code: "class A { foo() { this.eval(); } }", parserOptions: { ecmaVersion: 6 } },


### PR DESCRIPTION
- Update rules:
  - no-eval (and add a 'module' test similar to the 'strict mode' test)
  - no-invalid-this
  - no-redeclare
  - no-use-before-define
- Update 'migrating-to-2.0.0.md'

NB: The 'strict' rule was updated in #4948.