### PR TITLE
Update: Report unexpected tagged template (fixes #4210)

### DIFF
--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -25,6 +25,13 @@ var foo = bar
 
 var hello = 'world'
 [1, 2, 3].forEach(addNumber); /*error Unexpected newline between object and [ of property access.*/
+
+let x = function() {}         /*error Unexpected newline between template tag and template literal.*/
+`hello`
+
+let x = function() {}
+x                             /*error Unexpected newline between template tag and template literal.*/
+`hello`
 ```
 
 The following patterns are not considered problems:
@@ -43,6 +50,12 @@ var hello = 'world';
 
 var hello = 'world'
 void [1, 2, 3].forEach(addNumber);
+
+let x = function() {};
+`hello`
+
+let tag = function() {}
+tag `hello`
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -12,6 +12,7 @@ module.exports = function(context) {
 
     var FUNCTION_MESSAGE = "Unexpected newline between function and ( of function call.";
     var PROPERTY_MESSAGE = "Unexpected newline between object and [ of property access.";
+    var TAGGED_TEMPLATE_MESSAGE = "Unexpected newline between template tag and template literal.";
 
     /**
      * Check to see if there is a newline between the node and the following open bracket
@@ -43,6 +44,13 @@ module.exports = function(context) {
                 return;
             }
             checkForBreakAfter(node.object, PROPERTY_MESSAGE);
+        },
+
+        "TaggedTemplateExpression": function(node) {
+            if (node.tag.loc.end.line === node.quasi.loc.start.line) {
+                return;
+            }
+            context.report(node, node.loc.start, TAGGED_TEMPLATE_MESSAGE);
         },
 
         "CallExpression": function(node) {

--- a/tests/lib/rules/no-unexpected-multiline.js
+++ b/tests/lib/rules/no-unexpected-multiline.js
@@ -24,7 +24,23 @@ ruleTester.run("no-unexpected-multiline", rule, {
         "var a = b\nvoid [1, 2, 3].forEach(console.log)",
         "\"abc\\\n(123)\"",
         "var a = (\n(123)\n)",
-        "f(\n(x)\n)"
+        "f(\n(x)\n)",
+        {
+            code: "let x = function() {};\n   `hello`",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let x = function() {}\nx `hello`",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "String.raw `Hi\n${2+3}!`;",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "x\n.y\nz `Valid Test Case`",
+            parserOptions: { ecmaVersion: 6 }
+        }
     ],
     invalid: [
         {
@@ -62,6 +78,27 @@ ruleTester.run("no-unexpected-multiline", rule, {
             line: 2,
             column: 3,
             errors: [{ message: "Unexpected newline between object and [ of property access." }]
+        },
+        {
+            code: "let x = function() {}\n `hello`",
+            parserOptions: { ecmaVersion: 6 },
+            line: 1,
+            column: 9,
+            errors: [{ message: "Unexpected newline between template tag and template literal." }]
+        },
+        {
+            code: "let x = function() {}\nx\n`hello`",
+            parserOptions: { ecmaVersion: 6 },
+            line: 2,
+            column: 1,
+            errors: [{ message: "Unexpected newline between template tag and template literal." }]
+        },
+        {
+            code: "x\n.y\nz\n`Invalid Test Case`",
+            parserOptions: { ecmaVersion: 6 },
+            line: 3,
+            column: 1,
+            errors: [{ message: "Unexpected newline between template tag and template literal." }]
         }
     ]
 });


### PR DESCRIPTION
Checks and reports function expression being treated as tagged template accidently.