### PR TITLE
Use comment block for function expression in a call expression

### DIFF
--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -238,6 +238,8 @@ SourceCode.prototype = {
                     }
 
                     return parent && (parent.type !== "FunctionDeclaration") ? findJSDocComment(parent.leadingComments, parent.loc.start.line) : null;
+                } else if (node.leadingComments) {
+                    return findJSDocComment(node.leadingComments, node.loc.start.line);
                 }
 
             // falls through

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -41,6 +41,20 @@ ruleTester.run("valid-jsdoc", rule, {
         "/**\n* Description\n* @inheritDoc */\nfunction foo(arg1, arg2){ return ''; }",
         {
             code:
+                "call(\n" +
+                "  /**\n" +
+                "   * Doc for a function expression in a call expression.\n" +
+                "   * @param {string} argName This is the param description.\n" +
+                "   * @return {string} This is the return description.\n" +
+                "   */\n" +
+                "  function(argName) {\n" +
+                "    return 'the return';\n" +
+                "  }\n" +
+                ");\n",
+            options: [{requireReturn: false}]
+        },
+        {
+            code:
                 "/**\n" +
                 "* Create a new thing.\n" +
                 "*/\n" +
@@ -329,6 +343,24 @@ ruleTester.run("valid-jsdoc", rule, {
     ],
 
     invalid: [
+        {
+            code:
+                "call(\n" +
+                "  /**\n" +
+                "   * Doc for a function expression in a call expression.\n" +
+                "   * @param {string} bogusName This is the param description.\n" +
+                "   * @return {string} This is the return description.\n" +
+                "   */\n" +
+                "  function(argName) {\n" +
+                "    return 'the return';\n" +
+                "  }\n" +
+                ");\n",
+            options: [{requireReturn: false}],
+            errors: [{
+                message: "Expected JSDoc for 'argName' but found 'bogusName'.",
+                type: "Block"
+            }]
+        },
         {
             code: "/** @@foo */\nfunction foo(){}",
             errors: [{

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -207,6 +207,36 @@ describe("SourceCode", function() {
 
         });
 
+        it("should get JSDoc comment for FunctionExpression in a CallExpression", function() {
+            var code = [
+                "call(",
+                "  /** Documentation. */",
+                "  function(argName) {",
+                "    return 'the return';",
+                "  }",
+                ");"
+            ].join("\n");
+
+            /**
+             * Check jsdoc presence
+             * @param {ASTNode} node not to check
+             * @returns {void}
+             * @private
+             */
+            function assertJSDoc(node) {
+                var sourceCode = eslint.getSourceCode();
+                var jsdoc = sourceCode.getJSDocComment(node);
+                assert.equal(jsdoc.type, "Block");
+                assert.equal(jsdoc.value, "* Documentation. ");
+            }
+
+            var spy = sandbox.spy(assertJSDoc);
+
+            eslint.on("FunctionExpression", spy);
+            eslint.verify(code, {rules: {}}, filename, true);
+            assert.isTrue(spy.calledOnce, "Event handler should be called.");
+        });
+
         it("should get JSDoc comment for node when the node is a FunctionDeclaration", function() {
 
             var code = [


### PR DESCRIPTION
Without this change, comment blocks for function expressions in call expressions are not validated.

Fixes #4964.