### PR TITLE
New: allow-multiline option on comma-dangle

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -19,6 +19,7 @@ This rule takes one argument, which can be one of the following options:
 
 - `"always"` - warn whenever a missing comma is detected.
 - `"always-multiline"` - warn if there is a missing trailing comma on arrays or objects that span multiple lines, and warns if there is a trailing comma present on single line arrays or objects.
+- `"allow-multiline"` - warn whenever a trailing comma is detected on single line nodes.
 - `"never"` - warn whenever a trailing comma is detected.
 
 The default value of this option is `"never"`.
@@ -147,6 +148,62 @@ var arr = [
 foo({
   bar: "baz",
   qux: "quux",
+});
+```
+
+The following patterns are considered problems when configured `"allow-multiline"`:
+
+```js
+/*eslint comma-dangle: [1, "allow-multiline"]*/
+
+var foo = { bar: "baz", qux: "quux", }; /*error Unexpected trailing comma.*/
+
+var arr = [1,2,];                       /*error Unexpected trailing comma.*/
+
+var arr = [1,
+    2,];                                /*error Unexpected trailing comma.*/
+
+```
+
+The following patterns are not considered problems when configured `"allow-multiline"`:
+
+```js
+/*eslint comma-dangle: [2, "allow-multiline"]*/
+
+var foo = {
+    bar: "baz",
+    qux: "quux",
+};
+
+var foo = {
+    bar: "baz",
+    qux: "quux"
+};
+
+var foo = {bar: "baz", qux: "quux"};
+var arr = [1,2];
+
+var arr = [1,
+    2];
+
+var arr = [
+    1,
+    2,
+];
+
+var arr = [
+    1,
+    2
+];
+
+foo({
+  bar: "baz",
+  qux: "quux",
+});
+
+foo({
+  bar: "baz",
+  qux: "quux"
 });
 ```
 

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -187,12 +187,30 @@ module.exports = function(context) {
         }
     }
 
+    /**
+     * Only if a given node is not multiline, reports the last element of a given node
+     * when it does not have a trailing comma.
+     * Otherwise, reports a trailing comma if it exists.
+     *
+     * @param {ASTNode} node - A node to check. Its type is one of
+     *   ObjectExpression, ObjectPattern, ArrayExpression, ArrayPattern,
+     *   ImportDeclaration, and ExportNamedDeclaration.
+     * @returns {void}
+     */
+    function allowTrailingCommaIfMultiline(node) {
+        if (!isMultiline(node)) {
+            forbidTrailingComma(node);
+        }
+    }
+
     // Chooses a checking function.
     var checkForTrailingComma;
     if (mode === "always") {
         checkForTrailingComma = forceTrailingComma;
     } else if (mode === "always-multiline") {
         checkForTrailingComma = forceTrailingCommaIfMultiline;
+    } else if (mode === "allow-multiline") {
+        checkForTrailingComma = allowTrailingCommaIfMultiline;
     } else {
         checkForTrailingComma = forbidTrailingComma;
     }
@@ -209,6 +227,6 @@ module.exports = function(context) {
 
 module.exports.schema = [
     {
-        "enum": ["always", "always-multiline", "never"]
+        "enum": ["always", "always-multiline", "allow-multiline", "never"]
     }
 ];

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -38,6 +38,8 @@ ruleTester.run("comma-dangle", rule, {
         { code: "var foo = [ 'baz' ]", options: ["never"] },
         { code: "var { a, b } = foo;", options: ["never"], parserOptions: { ecmaVersion: 6 } },
         { code: "var [ a, b ] = foo;", options: ["never"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var { a,\n b, \n} = foo;", options: ["allow-multiline"], parserOptions: { ecmaVersion: 6 } },
+        { code: "var [ a,\n b, \n] = foo;", options: ["allow-multiline"], parserOptions: { ecmaVersion: 6 } },
 
         { code: "[(1),]", options: [ "always" ] },
         { code: "var x = { foo: (1),};", options: [ "always" ] },
@@ -55,14 +57,23 @@ ruleTester.run("comma-dangle", rule, {
         { code: "[\n]", options: [ "always" ] },
 
         { code: "var foo = { bar: 'baz' }", options: [ "always-multiline" ] },
+        { code: "var foo = { bar: 'baz' }", options: [ "allow-multiline" ] },
         { code: "var foo = {\nbar: 'baz',\n}", options: [ "always-multiline" ] },
+        { code: "var foo = {\nbar: 'baz',\n}", options: [ "allow-multiline" ] },
         { code: "var foo = [ 'baz' ]", options: [ "always-multiline" ] },
+        { code: "var foo = [ 'baz' ]", options: [ "allow-multiline" ] },
         { code: "var foo = [\n'baz',\n]", options: [ "always-multiline" ] },
+        { code: "var foo = [\n'baz',\n]", options: [ "allow-multiline" ] },
         { code: "var foo = { bar:\n\n'bar' }", options: [ "always-multiline" ] },
+        { code: "var foo = { bar:\n\n'bar' }", options: [ "allow-multiline" ] },
         { code: "var foo = {a: 1, b: 2, c: 3, d: 4}", options: [ "always-multiline" ]},
+        { code: "var foo = {a: 1, b: 2, c: 3, d: 4}", options: [ "allow-multiline" ]},
         { code: "var foo = {a: 1, b: 2,\n c: 3, d: 4}", options: [ "always-multiline" ]},
+        { code: "var foo = {a: 1, b: 2,\n c: 3, d: 4}", options: [ "allow-multiline" ]},
         { code: "var foo = {x: {\nfoo: 'bar',\n}}", options: [ "always-multiline" ]},
+        { code: "var foo = {x: {\nfoo: 'bar',\n}}", options: [ "allow-multiline" ]},
         { code: "var foo = new Map([\n[key, {\na: 1,\nb: 2,\nc: 3,\n}],\n])", options: [ "always-multiline" ]},
+        { code: "var foo = new Map([\n[key, {\na: 1,\nb: 2,\nc: 3,\n}],\n])", options: [ "allow-multiline" ]},
         { code: "[,,]", options: [ "always" ] },
         { code: "[\n,\n,\n]", options: [ "always" ] },
         { code: "[,]", options: [ "always" ] },
@@ -85,6 +96,11 @@ ruleTester.run("comma-dangle", rule, {
             code: "var [\n    a,\n    ...rest\n] = [];",
             parserOptions: { ecmaVersion: 6 },
             options: ["always-multiline"]
+        },
+        {
+            code: "var [\n    a,\n    ...rest\n] = [];",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["allow-multiline"]
         },
         {
             code: "[a, ...rest] = [];",
@@ -159,9 +175,19 @@ ruleTester.run("comma-dangle", rule, {
             options: ["always-multiline"]
         },
         {
+            code: "import {foo} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"]
+        },
+        {
             code: "export {foo} from 'foo';",
             parserOptions: { sourceType: "module" },
             options: ["always-multiline"]
+        },
+        {
+            code: "export {foo} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"]
         },
         {
             code: "import {\n  foo,\n} from 'foo';",
@@ -169,14 +195,29 @@ ruleTester.run("comma-dangle", rule, {
             options: ["always-multiline"]
         },
         {
+            code: "import {\n  foo,\n} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"]
+        },
+        {
             code: "export {\n  foo,\n} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["always-multiline"]
+        },
+        {
+            code: "export {\n  foo,\n} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"]
+        },
+        {
+            code: "import {foo} from \n'foo';",
             parserOptions: { sourceType: "module" },
             options: ["always-multiline"]
         },
         {
             code: "import {foo} from \n'foo';",
             parserOptions: { sourceType: "module" },
-            options: ["always-multiline"]
+            options: ["allow-multiline"]
         }
     ],
     invalid: [
@@ -272,6 +313,18 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+            code: "var foo = { bar: 'baz', }",
+            options: [ "allow-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 23
+                }
+            ]
+        },
+        {
             code: "var foo = {\nbar: 'baz',\n}",
             options: [ "never" ],
             errors: [
@@ -286,6 +339,18 @@ ruleTester.run("comma-dangle", rule, {
         {
             code: "foo({ bar: 'baz', qux: 'quux', });",
             options: [ "never" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 30
+                }
+            ]
+        },
+        {
+            code: "foo({ bar: 'baz', qux: 'quux', });",
+            options: [ "allow-multiline" ],
             errors: [
                 {
                     message: "Unexpected trailing comma.",
@@ -406,6 +471,18 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+            code: "var foo = { bar: 'baz', }",
+            options: [ "allow-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 23
+                }
+            ]
+        },
+        {
             code: "foo({\nbar: 'baz',\nqux: 'quux'\n});",
             options: [ "always-multiline" ],
             errors: [
@@ -420,6 +497,18 @@ ruleTester.run("comma-dangle", rule, {
         {
             code: "foo({ bar: 'baz', qux: 'quux', });",
             options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 30
+                }
+            ]
+        },
+        {
+            code: "foo({ bar: 'baz', qux: 'quux', });",
+            options: [ "allow-multiline" ],
             errors: [
                 {
                     message: "Unexpected trailing comma.",
@@ -454,6 +543,18 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+            code: "var foo = ['baz',]",
+            options: [ "allow-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Literal",
+                    line: 1,
+                    column: 17
+                }
+            ]
+        },
+        {
             code: "var foo = {x: {\nfoo: 'bar',\n},}",
             options: [ "always-multiline" ],
             errors: [
@@ -468,6 +569,18 @@ ruleTester.run("comma-dangle", rule, {
         {
             code: "var foo = {a: 1, b: 2,\nc: 3, d: 4,}",
             options: [ "always-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 2,
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "var foo = {a: 1, b: 2,\nc: 3, d: 4,}",
+            options: [ "allow-multiline" ],
             errors: [
                 {
                     message: "Unexpected trailing comma.",
@@ -503,8 +616,34 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+            code: "var { a, b, } = foo;",
+            options: [ "allow-multiline" ],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 11
+                }
+            ]
+        },
+        {
             code: "var [ a, b, ] = foo;",
             options: [ "never" ],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Identifier",
+                    line: 1,
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "var [ a, b, ] = foo;",
+            options: [ "allow-multiline" ],
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -528,8 +667,32 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+            code: "[(1),]",
+            options: [ "allow-multiline" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Literal",
+                    line: 1,
+                    column: 5
+                }
+            ]
+        },
+        {
             code: "var x = { foo: (1),};",
             options: [ "never" ],
+            errors: [
+                {
+                    message: "Unexpected trailing comma.",
+                    type: "Property",
+                    line: 1,
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "var x = { foo: (1),};",
+            options: [ "allow-multiline" ],
             errors: [
                 {
                     message: "Unexpected trailing comma.",
@@ -566,9 +729,21 @@ ruleTester.run("comma-dangle", rule, {
             errors: [{message: "Unexpected trailing comma.", type: "ImportSpecifier"}]
         },
         {
+            code: "import {foo,} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"],
+            errors: [{message: "Unexpected trailing comma.", type: "ImportSpecifier"}]
+        },
+        {
             code: "import foo, {abc,} from 'foo';",
             parserOptions: { sourceType: "module" },
             options: ["never"],
+            errors: [{message: "Unexpected trailing comma.", type: "ImportSpecifier"}]
+        },
+        {
+            code: "import foo, {abc,} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"],
             errors: [{message: "Unexpected trailing comma.", type: "ImportSpecifier"}]
         },
         {
@@ -578,15 +753,33 @@ ruleTester.run("comma-dangle", rule, {
             errors: [{message: "Unexpected trailing comma.", type: "ExportSpecifier"}]
         },
         {
+            code: "export {foo,} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"],
+            errors: [{message: "Unexpected trailing comma.", type: "ExportSpecifier"}]
+        },
+        {
             code: "import {foo,} from 'foo';",
             parserOptions: { sourceType: "module" },
             options: ["always-multiline"],
             errors: [{message: "Unexpected trailing comma.", type: "ImportSpecifier"}]
         },
         {
+            code: "import {foo,} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"],
+            errors: [{message: "Unexpected trailing comma.", type: "ImportSpecifier"}]
+        },
+        {
             code: "export {foo,} from 'foo';",
             parserOptions: { sourceType: "module" },
             options: ["always-multiline"],
+            errors: [{message: "Unexpected trailing comma.", type: "ExportSpecifier"}]
+        },
+        {
+            code: "export {foo,} from 'foo';",
+            parserOptions: { sourceType: "module" },
+            options: ["allow-multiline"],
             errors: [{message: "Unexpected trailing comma.", type: "ExportSpecifier"}]
         },
         {


### PR DESCRIPTION
I like using the dangle comma on multiline arrays and objects but I don't like the linter warn me if I don't use it or any of my coworkers don't use it.

In other words I would love an option to make the dangle comma optional on multiline nodes. So this is what this PR is about.

This would allow also to adopt this option on `standard` as mentioned here https://github.com/feross/standard/issues/240