### PR TITLE
Fix: multiple message in TAP formatter (fixes #4975)

### DIFF
--- a/lib/formatters/tap.js
+++ b/lib/formatters/tap.js
@@ -66,7 +66,10 @@ module.exports = function(results) {
                 // The first error will be logged as message key
                 // This is to adhere to TAP 13 loosely defined specification of having a message key
                 if ("message" in diagnostics) {
-                    diagnostics.messages = [diagnostic];
+                    if (typeof diagnostics.messages === "undefined") {
+                        diagnostics.messages = [];
+                    }
+                    diagnostics.messages.push(diagnostic);
                 } else {
                     diagnostics = diagnostic;
                 }

--- a/tests/lib/formatters/tap.js
+++ b/tests/lib/formatters/tap.js
@@ -91,6 +91,12 @@ describe("formatter:tap", function() {
                 line: 6,
                 column: 11,
                 ruleId: "bar"
+            }, {
+                message: "Unexpected baz.",
+                severity: 1,
+                line: 7,
+                column: 12,
+                ruleId: "baz"
             }]
         }];
 
@@ -104,6 +110,9 @@ describe("formatter:tap", function() {
             assert.include(result, "Unexpected bar.");
             assert.include(result, "line: 6");
             assert.include(result, "column: 11");
+            assert.include(result, "Unexpected baz.");
+            assert.include(result, "line: 7");
+            assert.include(result, "column: 12");
         });
     });
 


### PR DESCRIPTION
The current implementation display only one message.