### PR TITLE
Update: valid-jsdoc to not require `@return` in constructors (fixes #4976)

### DIFF
--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -120,6 +120,17 @@ function foo(num1, num2) { }
 function foo(a) {
     return a;
 }
+
+// @returns is not required for a constructor
+class Foo {
+    /**
+    *
+    * @param {int} num1 The first number.
+    */
+    constructor(num1) {
+        this.num1 = num1;
+    }
+}
 ```
 
 ### Options

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -274,7 +274,9 @@ module.exports = function(context) {
             });
 
             // check for functions missing @returns
-            if (!isOverride && !hasReturns && !hasConstructor && !isInterface && node.parent.kind !== "get" && !isTypeClass(node)) {
+            if (!isOverride && !hasReturns && !hasConstructor && !isInterface &&
+                node.parent.kind !== "get" && node.parent.kind !== "constructor" &&
+                node.parent.kind !== "set" && !isTypeClass(node)) {
                 if (requireReturn || functionData.returnPresent) {
                     context.report(jsdocNode, "Missing JSDoc @" + (prefer.returns || "returns") + " for function.");
                 }

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -131,6 +131,7 @@ ruleTester.run("valid-jsdoc", rule, {
             options: [{requireReturnDescription: false}]
         },
         "var obj = {\n /**\n * Getter\n * @type {string}\n */\n get location() {\n return this._location;\n }\n }",
+        "var obj = {\n /**\n * Setter\n * @param {string} value The location\n */\n set location(value) {\n this._location = value;\n }\n }",
         {
             code: "/**\n * Description for A.\n */\n class A {\n /**\n * Description for constructor.\n * @param {object[]} xs - xs\n */\n constructor(xs) {\n /**\n * Description for this.xs;\n * @type {object[]}\n */\n this.xs = xs.filter(x => x != null);\n }\n}",
             options: [{requireReturn: false}],
@@ -192,27 +193,26 @@ ruleTester.run("valid-jsdoc", rule, {
                 "        this.a = xs;" +
                 "    }\n" +
                 "}",
-            options: [{requireReturn: false}],
+            options: [{requireReturn: true}],
             parserOptions: {
                 ecmaVersion: 6
             }
         },
         {
             code:
-                "/**\n" +
-                " * Description for A.\n" +
-                " */\n" +
-                "class A {\n" +
-                "    /**\n" +
-                "     * Description for constructor.\n" +
-                "     * @param {object[]} xs - xs\n" +
-                "     * @returns {void}\n" +
-                "     */\n" +
-                "    constructor(xs) {\n" +
-                "        this.a = xs;" +
-                "    }\n" +
-                "}",
-            options: [{requireReturn: true}],
+            "/**\n" +
+            " * Description for A.\n" +
+            " */\n" +
+            "class A {\n" +
+            "    /**\n" +
+            "     * Description for method.\n" +
+            "     * @param {object[]} xs - xs\n" +
+            "     */\n" +
+            "    print(xs) {\n" +
+            "        this.a = xs;" +
+            "    }\n" +
+            "}",
+            options: [{requireReturn: false}],
             parserOptions: {
                 ecmaVersion: 6
             }
@@ -506,10 +506,10 @@ ruleTester.run("valid-jsdoc", rule, {
             "var A = \n" +
             "  class {\n" +
             "    /**\n" +
-            "     * Description for constructor.\n" +
+            "     * Description for method.\n" +
             "     * @param {object[]} xs - xs\n" +
             "     */\n" +
-            "    constructor(xs) {\n" +
+            "    print(xs) {\n" +
             "        this.a = xs;" +
             "    }\n" +
             "};",
@@ -730,7 +730,7 @@ ruleTester.run("valid-jsdoc", rule, {
                 "     * Description for constructor.\n" +
                 "     * @param {object[]} xs - xs\n" +
                 "     */\n" +
-                "    constructor(xs) {\n" +
+                "    print(xs) {\n" +
                 "        this.a = xs;" +
                 "    }\n" +
                 "};",


### PR DESCRIPTION
This just adds one additional check to see if a JSDoc comment is for a class constructor to avoid showing an error if the constructor lacks the `@return` tag.