### PR TITLE
Fix: `no-dupe-class-members` false positive (fixes #4981)

### DIFF
--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -36,6 +36,22 @@ module.exports = function(context) {
         return stateMap[key][isStatic ? "static" : "nonStatic"];
     }
 
+    /**
+     * Gets the name text of a given node.
+     *
+     * @param {ASTNode} node - A node to get the name.
+     * @returns {string} The name text of the node.
+     */
+    function getName(node) {
+        switch (node.type) {
+            case "Identifier": return node.name;
+            case "Literal": return String(node.value);
+
+            /* istanbul ignore next: syntax error */
+            default: return "";
+        }
+    }
+
     return {
         // Initializes the stack of state of member declarations.
         "Program": function() {
@@ -58,7 +74,7 @@ module.exports = function(context) {
                 return;
             }
 
-            var name = node.key.name;
+            var name = getName(node.key);
             var state = getState(name, node.static);
             var isDuplicate = false;
             if (node.kind === "get") {

--- a/tests/lib/rules/no-dupe-class-members.js
+++ b/tests/lib/rules/no-dupe-class-members.js
@@ -25,7 +25,11 @@ ruleTester.run("no-dupe-class-members", rule, {
         {code: "class A { get foo() {} set foo(value) {} }", parserOptions: { ecmaVersion: 6 }},
         {code: "class A { static foo() {} get foo() {} set foo(value) {} }", parserOptions: { ecmaVersion: 6 }},
         {code: "class A { foo() { } } class B { foo() { } }", parserOptions: { ecmaVersion: 6 }},
-        {code: "class A { [foo]() {} foo() {} }", parserOptions: { ecmaVersion: 6 }}
+        {code: "class A { [foo]() {} foo() {} }", parserOptions: { ecmaVersion: 6 }},
+        {code: "class A { 'foo'() {} 'bar'() {} baz() {} }", parserOptions: { ecmaVersion: 6 }},
+        {code: "class A { *'foo'() {} *'bar'() {} *baz() {} }", parserOptions: { ecmaVersion: 6 }},
+        {code: "class A { get 'foo'() {} get 'bar'() {} get baz() {} }", parserOptions: { ecmaVersion: 6 }},
+        {code: "class A { 1() {} 2() {} }", parserOptions: { ecmaVersion: 6 }}
     ],
     invalid: [
         {
@@ -40,6 +44,20 @@ ruleTester.run("no-dupe-class-members", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {type: "MethodDefinition", line: 1, column: 21, message: "Duplicate name 'foo'."}
+            ]
+        },
+        {
+            code: "class A { 'foo'() {} 'foo'() {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {type: "MethodDefinition", line: 1, column: 22, message: "Duplicate name 'foo'."}
+            ]
+        },
+        {
+            code: "class A { 10() {} 1e1() {} }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {type: "MethodDefinition", line: 1, column: 19, message: "Duplicate name '10'."}
             ]
         },
         {


### PR DESCRIPTION
Fixes #4981

method names can be IdentifierName, StringLiteral, and NumericLiteral: http://tc39.github.io/ecma262/#prod-LiteralPropertyName

In estree, StringLiteral and NumericLiteral are expressed by Literal node.