### PR TITLE
Fix: `getNodeByRangeIndex` performance issue (fixes #4989)

### DIFF
--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -256,11 +256,13 @@ SourceCode.prototype = {
      */
     getNodeByRangeIndex: function(index) {
         var result = null;
+        var resultParent = null;
 
         estraverse.traverse(this.ast, {
             enter: function(node, parent) {
                 if (node.range[0] <= index && index < node.range[1]) {
-                    result = assign({ parent: parent }, node);
+                    result = node;
+                    resultParent = parent;
                 } else {
                     this.skip();
                 }
@@ -272,7 +274,7 @@ SourceCode.prototype = {
             }
         });
 
-        return result;
+        return result ? assign({parent: resultParent}, result) : null;
     },
 
     /**


### PR DESCRIPTION
fixes #4989

It's hard to create tests for this, but we can confirm this on coverage.

Before: https://coveralls.io/builds/4758352/source?filename=lib%2Futil%2Fsource-code.js#L270
After: https://coveralls.io/builds/4760985/source?filename=lib%2Futil%2Fsource-code.js#L272