### PR TITLE
New: Added "table" formatter (fixes #4037)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -351,13 +351,14 @@ var isIgnored = cli.isPathIgnored("foo/bar.js");
 
 Retrieves a formatter, which you can then use to format a report object. The argument is either the name of a built-in formatter:
 
-* "[stylish](../user-guide/formatters#stylish)" (the default)
 * "[checkstyle](../user-guide/formatters#checkstyle)"
 * "[compact](../user-guide/formatters#compact)"
 * "[html](../user-guide/formatters#html)"
 * "[jslint-xml](../user-guide/formatters#jslint-xml)"
 * "[json](../user-guide/formatters#json)"
 * "[junit](../user-guide/formatters#junit)"
+* "[stylish](./user-guide/formatters#stylish)" (the default)
+* "[table](../user-guide/formatters#table)"
 * "[tap](../user-guide/formatters#tap)"
 * "[unix](../user-guide/formatters#unix)"
 

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -276,13 +276,14 @@ When specified, the given format is output into the provided file name.
 
 This option specifies the output format for the console. Possible formats are:
 
-* [stylish](formatters/#stylish) (the default)
 * [checkstyle](formatters/#checkstyle)
 * [compact](formatters/#compact)
 * [html](formatters/#html)
 * [jslint-xml](formatters/#jslint-xml)
 * [json](formatters/#json)
 * [junit](formatters/#junit)
+* [stylish](formatters/#stylish) (the default)
+* [table](formatters/#table)
 * [tap](formatters/#tap)
 * [unix](formatters/#unix)
 * [visualstudio](formatters/#visualstudio)

--- a/lib/formatters/table.js
+++ b/lib/formatters/table.js
@@ -1,0 +1,159 @@
+/**
+ * @fileoverview "table reporter.
+ * @author Gajus Kuizinas <gajus@gajus.com>
+ * @copyright 2016 Gajus Kuizinas <gajus@gajus.com>. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var chalk,
+    table,
+    pluralize;
+
+chalk = require("chalk");
+table = require("table").default;
+pluralize = require("pluralize");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Draws text table.
+ * @param {Array<Object>} messages Error messages relating to a specific file.
+ * @returns {string} A text table.
+ */
+function drawTable(messages) {
+    var rows;
+
+    rows = [];
+
+    if (messages.length === 0) {
+        return "";
+    }
+
+    rows.push([
+        chalk.bold("Line"),
+        chalk.bold("Column"),
+        chalk.bold("Type"),
+        chalk.bold("Message"),
+        chalk.bold("Rule ID")
+    ]);
+
+    messages.forEach(function(message) {
+        var messageType;
+
+        if (message.fatal || message.severity === 2) {
+            messageType = chalk.red("error");
+        } else {
+            messageType = chalk.yellow("warning");
+        }
+
+        rows.push([
+            message.line || 0,
+            message.column || 0,
+            messageType,
+            message.message,
+            message.ruleId || ""
+        ]);
+    });
+
+    return table(rows, {
+        columns: {
+            0: {
+                width: 8,
+                wrapWord: true
+            },
+            1: {
+                width: 8,
+                wrapWord: true
+            },
+            2: {
+                width: 8,
+                wrapWord: true
+            },
+            3: {
+                paddingRight: 5,
+                width: 50,
+                wrapWord: true
+            },
+            4: {
+                width: 20,
+                wrapWord: true
+            }
+        },
+        drawHorizontalLine: function(index) {
+            return index === 1;
+        }
+    });
+}
+
+/**
+ * Draws a report (multiple tables).
+ * @param {Array} results Report results for every file.
+ * @returns {string} A column of text tables.
+ */
+function drawReport(results) {
+    var files;
+
+    files = results.map(function(result) {
+        if (!result.messages.length) {
+            return "";
+        }
+
+        return "\n" + result.filePath + "\n\n" + drawTable(result.messages);
+    });
+
+    files = files.filter(function(content) {
+        return content.trim();
+    });
+
+    return files.join("");
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = function(report) {
+    var result,
+        errorCount,
+        warningCount;
+
+    result = "";
+    errorCount = 0;
+    warningCount = 0;
+
+    report.forEach(function(fileReport) {
+        errorCount += fileReport.errorCount;
+        warningCount += fileReport.warningCount;
+    });
+
+    if (errorCount || warningCount) {
+        result = drawReport(report);
+    }
+
+    result += "\n" + table([
+        [
+            chalk.red(pluralize("Error", errorCount, true))
+        ],
+        [
+            chalk.yellow(pluralize("Warning", warningCount, true))
+        ]
+    ], {
+        columns: {
+            0: {
+                width: 110,
+                wrapWord: true
+            }
+        },
+        drawHorizontalLine: function() {
+            return true;
+        }
+    });
+
+    return result;
+};

--- a/package.json
+++ b/package.json
@@ -67,8 +67,10 @@
     "path-is-inside": "^1.0.1",
     "resolve": "^1.1.6",
     "progress": "^1.1.8",
+    "pluralize": "^1.2.1",
     "shelljs": "^0.5.3",
     "strip-json-comments": "~1.0.1",
+    "table": "^3.7.8",
     "text-table": "~0.2.0",
     "user-home": "^2.0.0",
     "xml-escape": "~1.0.0"

--- a/tests/lib/formatters/table.js
+++ b/tests/lib/formatters/table.js
@@ -1,0 +1,359 @@
+/**
+ * @fileoverview Tests for "table" reporter.
+ * @author Gajus Kuizinas <gajus@gajus.com>
+ * @copyright 2016 Gajus Kuizinas <gajus@gajus.com>. All rights reserved.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert,
+    formatter;
+
+assert = require("chai").assert;
+formatter = require("../../../lib/formatters/table");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("formatter:table", function() {
+    describe("when passed no messages", function() {
+        var code;
+
+        code = [
+            {
+                filePath: "foo.js",
+                messages: [],
+                errorCount: 0,
+                warningCount: 0
+            }
+        ];
+
+        it("should return a table of error and warning count with no messages", function() {
+            var expectedOutput,
+                result;
+
+            expectedOutput = [
+                "",
+                "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
+                "║ 0 Errors                                                                                                       ║",
+                "╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢",
+                "║ 0 Warnings                                                                                                     ║",
+                "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝",
+                ""
+            ];
+
+            expectedOutput = expectedOutput.join("\n");
+
+            result = formatter(code);
+
+            assert.equal(result, expectedOutput);
+        });
+    });
+
+    describe("when passed a single message", function() {
+        it("should return a string in the correct format for errors", function() {
+            var expectedOutput,
+                code,
+                result;
+
+            code = [
+                {
+                    filePath: "foo.js",
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 5,
+                            column: 10,
+                            ruleId: "foo"
+                        }
+                    ],
+                    errorCount: 1,
+                    warningCount: 0
+                }
+            ];
+
+            expectedOutput = [
+                "",
+                "foo.js",
+                "",
+                "║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║",
+                "╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢",
+                "║ 5        │ 10       │ error    │ Unexpected foo.                                        │ foo                  ║",
+                "",
+                "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
+                "║ 1 Error                                                                                                        ║",
+                "╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢",
+                "║ 0 Warnings                                                                                                     ║",
+                "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝",
+                ""
+            ];
+
+            expectedOutput = expectedOutput.join("\n");
+
+            result = formatter(code);
+
+            assert.equal(result, expectedOutput);
+        });
+
+        it("should return a string in the correct format for warnings", function() {
+            var expectedOutput,
+                code,
+                result;
+
+            code = [
+                {
+                    filePath: "foo.js",
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 1,
+                            line: 5,
+                            column: 10,
+                            ruleId: "foo"
+                        }
+                    ],
+                    errorCount: 0,
+                    warningCount: 1
+                }
+            ];
+
+            expectedOutput = [
+                "",
+                "foo.js",
+                "",
+                "║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║",
+                "╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢",
+                "║ 5        │ 10       │ warning  │ Unexpected foo.                                        │ foo                  ║",
+                "",
+                "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
+                "║ 0 Errors                                                                                                       ║",
+                "╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢",
+                "║ 1 Warning                                                                                                      ║",
+                "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝",
+                ""
+            ];
+
+            expectedOutput = expectedOutput.join("\n");
+
+            result = formatter(code);
+            assert.equal(result, expectedOutput);
+        });
+    });
+
+    describe("when passed a fatal error message", function() {
+        it("should return a string in the correct format", function() {
+            var code,
+                expectedOutput,
+                result;
+
+            code = [
+                {
+                    filePath: "foo.js",
+                    messages: [
+                        {
+                            fatal: true,
+                            message: "Unexpected foo.",
+                            line: 5,
+                            column: 10,
+                            ruleId: "foo"
+                        }
+                    ],
+                    errorCount: 1,
+                    warningCount: 0
+                }
+            ];
+
+            expectedOutput = [
+                "",
+                "foo.js",
+                "",
+                "║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║",
+                "╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢",
+                "║ 5        │ 10       │ error    │ Unexpected foo.                                        │ foo                  ║",
+                "",
+                "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
+                "║ 1 Error                                                                                                        ║",
+                "╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢",
+                "║ 0 Warnings                                                                                                     ║",
+                "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝",
+                ""
+            ];
+
+            expectedOutput = expectedOutput.join("\n");
+
+            result = formatter(code);
+
+            assert.equal(result, expectedOutput);
+        });
+    });
+
+    describe("when passed multiple messages", function() {
+        it("should return a string with multiple entries", function() {
+            var code,
+                expectedOutput,
+                result;
+
+            code = [
+                {
+                    filePath: "foo.js",
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 5,
+                            column: 10,
+                            ruleId: "foo"
+                        },
+                        {
+                            message: "Unexpected bar.",
+                            severity: 1,
+                            line: 6,
+                            column: 11,
+                            ruleId: "bar"
+                        }
+                    ],
+                    errorCount: 1,
+                    warningCount: 1
+                }
+            ];
+
+            expectedOutput = [
+                "",
+                "foo.js",
+                "",
+                "║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║",
+                "╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢",
+                "║ 5        │ 10       │ error    │ Unexpected foo.                                        │ foo                  ║",
+                "║ 6        │ 11       │ warning  │ Unexpected bar.                                        │ bar                  ║",
+                "",
+                "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
+                "║ 1 Error                                                                                                        ║",
+                "╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢",
+                "║ 1 Warning                                                                                                      ║",
+                "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝",
+                ""
+            ];
+
+            expectedOutput = expectedOutput.join("\n");
+
+            result = formatter(code);
+
+            assert.equal(result, expectedOutput);
+        });
+    });
+
+    describe("when passed multiple files with 1 message each", function() {
+        it("should return a string with multiple entries", function() {
+            var code,
+                expectedOutput,
+                result;
+
+            code = [
+                {
+                    filePath: "foo.js",
+                    messages: [
+                        {
+                            message: "Unexpected foo.",
+                            severity: 2,
+                            line: 5,
+                            column: 10,
+                            ruleId: "foo"
+                        }
+                    ],
+                    errorCount: 1,
+                    warningCount: 0
+                }, {
+                    filePath: "bar.js",
+                    messages: [
+                        {
+                            message: "Unexpected bar.",
+                            severity: 1,
+                            line: 6,
+                            column: 11,
+                            ruleId: "bar"
+                        }
+                    ],
+                    errorCount: 0,
+                    warningCount: 1
+                }
+            ];
+
+            expectedOutput = [
+                "",
+                "foo.js",
+                "",
+                "║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║",
+                "╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢",
+                "║ 5        │ 10       │ error    │ Unexpected foo.                                        │ foo                  ║",
+                "",
+                "bar.js",
+                "",
+                "║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║",
+                "╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢",
+                "║ 6        │ 11       │ warning  │ Unexpected bar.                                        │ bar                  ║",
+                "",
+                "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
+                "║ 1 Error                                                                                                        ║",
+                "╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢",
+                "║ 1 Warning                                                                                                      ║",
+                "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝",
+                ""
+            ];
+
+            expectedOutput = expectedOutput.join("\n");
+
+            result = formatter(code);
+
+            assert.equal(result, expectedOutput);
+        });
+    });
+
+    describe("when passed one file not found message", function() {
+        it("should return a string without line and column (0, 0)", function() {
+            var code,
+                expectedOutput,
+                result;
+
+            code = [
+                {
+                    filePath: "foo.js",
+                    messages: [
+                        {
+                            fatal: true,
+                            message: "Couldn't find foo.js."
+                        }
+                    ],
+                    errorCount: 1,
+                    warningCount: 0
+                }
+            ];
+
+            expectedOutput = [
+                "",
+                "foo.js",
+                "",
+                "║ Line     │ Column   │ Type     │ Message                                                │ Rule ID              ║",
+                "╟──────────┼──────────┼──────────┼────────────────────────────────────────────────────────┼──────────────────────╢",
+                "║ 0        │ 0        │ error    │ Couldn't find foo.js.                                  │                      ║",
+                "",
+                "╔════════════════════════════════════════════════════════════════════════════════════════════════════════════════╗",
+                "║ 1 Error                                                                                                        ║",
+                "╟────────────────────────────────────────────────────────────────────────────────────────────────────────────────╢",
+                "║ 0 Warnings                                                                                                     ║",
+                "╚════════════════════════════════════════════════════════════════════════════════════════════════════════════════╝",
+                ""
+            ];
+
+            expectedOutput = expectedOutput.join("\n");
+
+            result = formatter(code);
+
+            assert.equal(result, expectedOutput);
+        });
+    });
+});


### PR DESCRIPTION
New formatter uses "table" package to format ESlint output in a ANSI/ASCII table.