### PR TITLE
Docs: Fix description of exported comment

### DIFF
--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -60,7 +60,7 @@ myFunc(function foo() {
 
 ### Exporting Variables
 
-In environments outside of CommonJS or ECMAScript modules, you may use `var` to create a global variable that may be used by other scripts. You can use the `/* exported variableName */` comment block to indicate that this variable is being exported and therefore should not be considered unused. Note that `/* exported */` has no effect when used with the `node` or `commonjs` environments or when `ecmaFeatures.modules` is true.
+In environments outside of CommonJS or ECMAScript modules, you may use `var` to create a global variable that may be used by other scripts. You can use the `/* exported variableName */` comment block to indicate that this variable is being exported and therefore should not be considered unused. Note that `/* exported */` has no effect when used with the `node` or `commonjs` environments or when `ecmaFeatures.modules` or `ecmaFeatures.globalReturn` are true.
 
 ### Options
 


### PR DESCRIPTION
Small fix: exported comment has no effect when `ecmaFeatures.globalReturn` is `true` (see [here](https://github.com/eslint/eslint/blob/v1.10.3/lib/eslint.js#L953) in the code).