### PR TITLE
Fix: `prefer-const` false positive in a loop condition (fixes #5024)

### DIFF
--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -10,6 +10,10 @@
 // Helpers
 //------------------------------------------------------------------------------
 
+var LOOP_TYPES = /^(?:While|DoWhile|For|ForIn|ForOf)Statement$/;
+var FOR_IN_OF_TYPES = /^For(?:In|Of)Statement$/;
+var SENTINEL_TYPES = /(?:Declaration|Statement)$/;
+
 /**
  * Gets a write reference from a given variable if the variable is modified only
  * once.
@@ -34,6 +38,50 @@ function getWriteReferenceIfOnce(variable) {
     }
 
     return retv;
+}
+
+/**
+ * Checks whether or not a given reference is in a loop condition or a
+ * for-loop's updater.
+ *
+ * @param {escope.Reference} reference - A reference to check.
+ * @returns {boolean} `true` if the reference is in a loop condition or a
+ *      for-loop's updater.
+ */
+function isInLoopHead(reference) {
+    var node = reference.identifier;
+    var parent = node.parent;
+    var assignment = false;
+
+    while (parent) {
+        if (LOOP_TYPES.test(parent.type)) {
+            return true;
+        }
+
+        // VariableDeclaration can be at ForInStatement.left
+        // This is catching the code like `for (const {b = ++a} of foo()) { ... }`
+        if (assignment &&
+            parent.type === "VariableDeclaration" &&
+            FOR_IN_OF_TYPES.test(parent.parent.type) &&
+            parent.parent.left === parent
+        ) {
+            return true;
+        }
+        if (parent.type === "AssignmentPattern") {
+            assignment = true;
+        }
+
+        // If a declaration or a statement was found before a loop,
+        // it's not in the head of a loop.
+        if (SENTINEL_TYPES.test(parent.type)) {
+            break;
+        }
+
+        node = parent;
+        parent = parent.parent;
+    }
+
+    return false;
 }
 
 /**
@@ -89,7 +137,7 @@ module.exports = function(context) {
             }
 
             var writer = getWriteReferenceIfOnce(variable);
-            if (writer && references.every(isInScope(writer.from))) {
+            if (writer && !isInLoopHead(writer) && references.every(isInScope(writer.from))) {
                 context.report({
                     node: identifier,
                     message: "'{{name}}' is never modified, use 'const' instead.",

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -36,7 +36,13 @@ ruleTester.run("prefer-const", rule, {
         { code: "(function() { for (let i = 0, end = 10; i < end; ++i) {} })();", parserOptions: { ecmaVersion: 6 } },
         { code: "(function() { for (let i in [1,2,3]) { i = 0; } })();", parserOptions: { ecmaVersion: 6 } },
         { code: "(function() { for (let x of [1,2,3]) { x = 0; } })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "(function(x = 0) { })();", parserOptions: { ecmaVersion: 6 } }
+        { code: "(function(x = 0) { })();", parserOptions: { ecmaVersion: 6 } },
+        { code: "let a; while (a = foo());", parserOptions: { ecmaVersion: 6 } },
+        { code: "let a; do {} while (a = foo());", parserOptions: { ecmaVersion: 6 } },
+        { code: "let a; for (; a = foo(); );", parserOptions: { ecmaVersion: 6 } },
+        { code: "let a; for (;; ++a);", parserOptions: { ecmaVersion: 6 } },
+        { code: "let a; for (const {b = ++a} in foo());", parserOptions: { ecmaVersion: 6 } },
+        { code: "let a; for (const {b = ++a} of foo());", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         {


### PR DESCRIPTION
Fixes #5024

If the singular `WriteReference` of a variable is being in a condition of a loop, this rule came to skip the variable.