### PR TITLE
Remove blank lines at beginning of files

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -14,7 +14,8 @@ module.exports = function(context) {
 
     // Use options.max or 2 as default
     var max = 2,
-        maxEOF;
+        maxEOF,
+        maxBOF;
 
     // store lines that appear empty but really aren't
     var notEmpty = [];
@@ -22,6 +23,7 @@ module.exports = function(context) {
     if (context.options.length) {
         max = context.options[0].max;
         maxEOF = context.options[0].maxEOF;
+        maxBOF = context.options[0].maxBOF;
     }
 
     //--------------------------------------------------------------------------
@@ -45,10 +47,17 @@ module.exports = function(context) {
                 lastLocation,
                 blankCounter = 0,
                 location,
-                trimmedLines = lines.map(function(str) {
-                    return str.trim();
-                }),
-                firstOfEndingBlankLines;
+                firstOfEndingBlankLines,
+                firstNonBlankLine = -1,
+                trimmedLines = [];
+
+            lines.forEach(function(str, i) {
+                var trimmed = str.trim();
+                if ((firstNonBlankLine === -1) && (trimmed !== ''))
+                    firstNonBlankLine = i;
+
+                trimmedLines.push(trimmed);
+            }),
 
             // add the notEmpty lines in there with a placeholder
             notEmpty.forEach(function(x, i) {
@@ -72,6 +81,11 @@ module.exports = function(context) {
             }
 
             // Aggregate and count blank lines
+            if (firstNonBlankLine > maxBOF) {
+                context.report(node, 0,
+                        "Too many blank lines at the beginning of the file. Max of " + maxBOF + " allowed.");
+            }
+
             lastLocation = currentLocation;
             currentLocation = trimmedLines.indexOf("", currentLocation + 1);
             while (currentLocation !== -1) {
@@ -116,6 +130,10 @@ module.exports.schema = [
                 "minimum": 0
             },
             "maxEOF": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "maxBOF": {
                 "type": "integer",
                 "minimum": 0
             }


### PR DESCRIPTION
Update no-multiple-empty-lines rule to also warn about blank lines at the beginning of a file.  For issue #5045.