### PR TITLE
Update: Remove blank lines at beginning of files (fixes #5045)

### DIFF
--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -14,7 +14,9 @@ The second argument can be used to configure this rule:
 * `max` sets the maximum number of consecutive blank lines.
 * `maxEOF` can be used to set a different number for the end of file. The last
   blank lines will then be treated differently. If omitted, the `max` option is
-  applied everywhere.
+  applied at the end of the file.
+* `maxBOF` can be used to set a different number for the beginning of the file.
+  If omitted, the 'max' option is applied at the beginning of the file.
 
 For example, this sets the rule as an error (code is 2) with a maximum
 tolerated blank lines of 2 (for the whole file):
@@ -30,15 +32,22 @@ one at the end:
 "no-multiple-empty-lines": [2, {"max": 3, "maxEOF": 1}]
 ```
 
+And this tolerates three consecutive blank lines within the file, but none at
+the beginning:
+
+```json
+"no-multiple-empty-lines": [2, {"max": 3, "maxBOF": 0}]
+```
+
+
 ### Examples
 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2}]*/
+/*eslint no-multiple-empty-lines: [2, {max: 1}]*/
 
 var foo = 5;
-
 
                   /*error Multiple blank lines not allowed.*/
 var bar = 3;
@@ -51,6 +60,12 @@ var bar = 3;
 var foo = 5;
 
                   /*error Too many blank lines at the end of file.*/
+```
+
+```js
+/*eslint no-multiple-empty-lines: [2, {max: 999, maxBOF: 0}]*/
+                  /*error Too many blank lines at the beginning of file.*/
+var foo = 5;
 ```
 
 The following patterns are not considered problems:
@@ -82,10 +97,16 @@ var foo = 5;
 ```
 
 ```js
+/*eslint no-multiple-empty-lines: [2, {max: 2, maxBOF: 1}]*/
+// extra line
+var foo = 5;
+// extra line
+```
+
+```js
 /*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 10}]*/
 
 var foo = 5;
-
 // 10 extra lines
 ```
 

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -14,7 +14,8 @@ module.exports = function(context) {
 
     // Use options.max or 2 as default
     var max = 2,
-        maxEOF;
+        maxEOF,
+        maxBOF;
 
     // store lines that appear empty but really aren't
     var notEmpty = [];
@@ -22,6 +23,7 @@ module.exports = function(context) {
     if (context.options.length) {
         max = context.options[0].max;
         maxEOF = context.options[0].maxEOF;
+        maxBOF = context.options[0].maxBOF;
     }
 
     //--------------------------------------------------------------------------
@@ -45,10 +47,18 @@ module.exports = function(context) {
                 lastLocation,
                 blankCounter = 0,
                 location,
-                trimmedLines = lines.map(function(str) {
-                    return str.trim();
-                }),
-                firstOfEndingBlankLines;
+                firstOfEndingBlankLines,
+                firstNonBlankLine = -1,
+                trimmedLines = [];
+
+            lines.forEach(function(str, i) {
+                var trimmed = str.trim();
+                if ((firstNonBlankLine === -1) && (trimmed !== "")) {
+                    firstNonBlankLine = i;
+                }
+
+                trimmedLines.push(trimmed);
+            });
 
             // add the notEmpty lines in there with a placeholder
             notEmpty.forEach(function(x, i) {
@@ -72,6 +82,11 @@ module.exports = function(context) {
             }
 
             // Aggregate and count blank lines
+            if (firstNonBlankLine > maxBOF) {
+                context.report(node, 0,
+                        "Too many blank lines at the beginning of file. Max of " + maxBOF + " allowed.");
+            }
+
             lastLocation = currentLocation;
             currentLocation = trimmedLines.indexOf("", currentLocation + 1);
             while (currentLocation !== -1) {
@@ -116,6 +131,10 @@ module.exports.schema = [
                 "minimum": 0
             },
             "maxEOF": {
+                "type": "integer",
+                "minimum": 0
+            },
+            "maxBOF": {
                 "type": "integer",
                 "minimum": 0
             }

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -52,6 +52,24 @@ function getExpectedErrorEOF(lines) {
     };
 }
 
+/**
+ * Creates the expected error message object for the specified number of lines
+ * @param {lines} lines - The number of lines expected.
+ * @returns {object} the expected error message object
+ * @private
+ */
+function getExpectedErrorBOF(lines) {
+    if (typeof lines !== "number") {
+        lines = 0;
+    }
+
+    return {
+        message: "Too many blank lines at the beginning of file. Max of " + lines + " allowed.",
+        type: "Program"
+    };
+}
+
+
 ruleTester.run("no-multiple-empty-lines", rule, {
 
     valid: [
@@ -91,26 +109,35 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             code: "// valid 9\nvar a = 1;\n\n",
             options: [{ "max": 2, "maxEOF": 1 }]
         },
+        {
+            code: "// valid 10\nvar a = 5;\n",
+            options: [ { max: 0, maxBOF: 0 } ]
+        },
+        {
+            code: "\n// valid 11\nvar a = 1;\n",
+            options: [{ "max": 2, "maxBOF": 1 }]
+        },
 
         // template strings
         {
-            code: "// valid 10\nx = `\n\n\n\nhi\n\n\n\n`",
+            code: "// valid 12\nx = `\n\n\n\nhi\n\n\n\n`",
             options: [ { max: 2 } ],
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "// valid 11\n`\n\n`",
+            code: "// valid 13\n`\n\n`",
             options: [ { max: 0 } ],
             parserOptions: { ecmaVersion: 6 }
         },
-
         {
-            code: "// valid 12\nvar a = 5;\n\n\n\n\n",
-            options: [ { max: 0, maxEOF: 4 } ]
+            code: "// valid 14\nvar a = 5;`\n\n\n\n\n`",
+            options: [ { max: 0, maxEOF: 0 } ],
+            parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "// valid 13\nvar a = 5;\n\n\n\n",
-            options: [ { max: 3 } ]
+            code: "`\n\n\n\n\n`\n// valid 15\nvar a = 5;",
+            options: [ { max: 0, maxBOF: 0 } ],
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
 
@@ -184,6 +211,34 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             code: "// invalid 14\nvar a = 5;\n\n",
             errors: [ getExpectedErrorEOF(0) ],
             options: [ { max: 2, maxEOF: 0 } ]
+        },
+        {
+            code: "\n\n// invalid 15\nvar a = 5;\n",
+            errors: [ getExpectedErrorBOF(1) ],
+            options: [ { max: 5, maxBOF: 1 } ]
+        },
+        {
+            code: "\n\n\n\n\n// invalid 16\nvar a = 5;\n",
+            errors: [ getExpectedErrorBOF(4),
+                      getExpectedError(0) ],
+            options: [ { max: 0, maxBOF: 4 } ]
+        },
+        {
+            code: "\n\n// invalid 17\n\n\n\n\n\n\n\n\nvar a = 5;\n",
+            errors: [ getExpectedErrorBOF(1) ],
+            options: [ { max: 10, maxBOF: 1 } ]
+        },
+        {
+            code: "\n// invalid 18\nvar a = 5;\n",
+            errors: [ getExpectedErrorBOF(0) ],
+            options: [ { max: 2, maxBOF: 0 } ]
+        },
+        {
+            code: "\n\n\n// invalid 19\nvar a = 5;\n\n",
+            errors: [ getExpectedErrorBOF(0),
+                      getExpectedError(2),
+                      getExpectedErrorEOF(0) ],
+            options: [ { max: 2, maxBOF: 0, maxEOF: 0 } ]
         }
     ]
 });


### PR DESCRIPTION
Update no-multiple-empty-lines rule to also warn about blank lines at the beginning of a file. (For issue #5045)