### PR TITLE
Update: Add extra aliases to consistent-this rule (fixes #4492 #5039)

### DIFF
--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -23,6 +23,12 @@ This rule designates a variable as the chosen alias for `this`. It then enforces
 
 This rule takes one option, a string, which is the designated `this` variable. The default is `that`.
 
+Additionally, you may configure extra aliases for cases where there are more than one supported alias for `this`.
+
+```js
+{ "consistent-this": [ 2, "self",  "vm" ] } ] }
+```
+
 #### Usage
 
 You can set the rule configuration like this:

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -11,15 +11,22 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    var alias = context.options[0] || "that";
+    var aliases = [];
+
+    if (context.options.length === 0) {
+        aliases.push("that");
+    } else {
+        aliases = context.options;
+    }
 
     /**
      * Reports that a variable declarator or assignment expression is assigning
      * a non-'this' value to the specified alias.
      * @param {ASTNode} node - The assigning node.
+     * @param {string} alias - the name of the alias that was incorrectly used.
      * @returns {void}
      */
-    function reportBadAssignment(node) {
+    function reportBadAssignment(node, alias) {
         context.report(node,
             "Designated alias '{{alias}}' is not assigned to 'this'.",
             { alias: alias });
@@ -36,9 +43,9 @@ module.exports = function(context) {
     function checkAssignment(node, name, value) {
         var isThis = value.type === "ThisExpression";
 
-        if (name === alias) {
+        if (aliases.indexOf(name) !== -1) {
             if (!isThis || node.operator && node.operator !== "=") {
-                reportBadAssignment(node);
+                reportBadAssignment(node, name);
             }
         } else if (isThis) {
             context.report(node,
@@ -49,18 +56,21 @@ module.exports = function(context) {
     /**
      * Ensures that a variable declaration of the alias in a program or function
      * is assigned to the correct value.
+     * @param {string} alias alias the check the assignment of.
+     * @param {object} scope scope of the current code we are checking.
+     * @private
      * @returns {void}
      */
-    function ensureWasAssigned() {
-        var scope = context.getScope();
+    function checkWasAssigned(alias, scope) {
         var variable = scope.set.get(alias);
+
         if (!variable) {
             return;
         }
 
         if (variable.defs.some(function(def) {
             return def.node.type === "VariableDeclarator" &&
-                def.node.init !== null;
+            def.node.init !== null;
         })) {
             return;
         }
@@ -77,8 +87,22 @@ module.exports = function(context) {
         })) {
             variable.defs.map(function(def) {
                 return def.node;
-            }).forEach(reportBadAssignment);
+            }).forEach(function(node) {
+                reportBadAssignment(node, alias);
+            });
         }
+    }
+
+    /**
+     * Check each alias to ensure that is was assinged to the correct value.
+     * @returns {void}
+     */
+    function ensureWasAssigned() {
+        var scope = context.getScope();
+
+        aliases.forEach(function(alias) {
+            checkWasAssigned(alias, scope);
+        });
     }
 
     return {
@@ -105,8 +129,11 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [
-    {
-        "type": "string"
-    }
-];
+module.exports.schema = {
+    "type": "array",
+    "items": {
+        "type": "string",
+        "minLength": 1
+    },
+    "uniqueItems": true
+};

--- a/tests/lib/rules/consistent-this.js
+++ b/tests/lib/rules/consistent-this.js
@@ -48,6 +48,7 @@ ruleTester.run("consistent-this", rule, {
         { code: "var foo, self; foo = 42; self = this", options: ["self"] },
         { code: "self = 42", options: ["that"] },
         { code: "var foo = {}; foo.bar = this", options: ["self"] },
+        { code: "var self = this; var vm = this;", options: ["self", "vm" ] },
         destructuringTest("var {foo, bar} = this"),
         destructuringTest("({foo, bar} = this)"),
         destructuringTest("var [foo, bar] = this"),


### PR DESCRIPTION
Added option to the rule `consistent-this` for adding extra allowed aliases for certain cases where it is acceptable to have more than 1 single name for assignments of `this`.

https://github.com/eslint/eslint/issues/4492
https://github.com/eslint/eslint/issues/5039