### PR TITLE
Fix: reduced `no-loop-func` false positive (fixes #5044)

### DIFF
--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -77,9 +77,16 @@ for (var i=10; i; i--) {
 }
 
 for (let i=10; i; i--) {
-    var a = function() { return i; }; // OK, all references are referring to block scoped variable in the loop.
+    var a = function() { return i; }; // OK, all references are referring to block scoped variables in the loop.
     a();
 }
+
+var foo = 100;
+for (let i=10; i; i--) {
+    var a = function() { return foo; }; // OK, all references are referring to never modified variables.
+    a();
+}
+//... no modifications of foo after this loop ...
 ```
 
 ## Further Reading

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -17,7 +17,8 @@
  * `Scope.through` contains references of nested functions.
  *
  * @param {ASTNode} node - An AST node to get.
- * @returns {ASTNode|null} The containing loop node of the specified node, or `null`.
+ * @returns {ASTNode|null} The containing loop node of the specified node, or
+ *      `null`.
  */
 function getContainingLoopNode(node) {
     var parent = node.parent;
@@ -60,25 +61,86 @@ function getContainingLoopNode(node) {
 }
 
 /**
- * Checks whether or not a reference refers to a variable that is block-binding in the loop.
+ * Gets the containing loop node of a given node.
+ * If the loop was nested, this returns the most outer loop.
+ *
+ * @param {ASTNode} node - A node to get. This is a loop node.
+ * @param {ASTNode|null} excludedNode - A node that the result node should not
+ *      include.
+ * @returns {ASTNode} The most outer loop node.
+ */
+function getTopLoopNode(node, excludedNode) {
+    var retv = null;
+    var border = excludedNode ? excludedNode.range[1] : 0;
+
+    while (node && node.range[0] >= border) {
+        retv = node;
+        node = getContainingLoopNode(node);
+    }
+
+    return retv;
+}
+
+/**
+ * Checks whether a given reference which refers to an upper scope's variable is
+ * safe or not.
+ *
+ * @param {ASTNode} funcNode - A target function node.
  * @param {ASTNode} loopNode - A containing loop node.
  * @param {escope.Reference} reference - A reference to check.
- * @returns {boolean} Whether or not a reference refers to a variable that is block-binding in the loop.
+ * @returns {boolean} `true` if the reference is safe or not.
  */
-function isBlockBindingsInLoop(loopNode, reference) {
+function isSafe(funcNode, loopNode, reference) {
     var variable = reference.resolved;
     var definition = variable && variable.defs[0];
     var declaration = definition && definition.parent;
+    var kind = (declaration && declaration.type === "VariableDeclaration")
+        ? declaration.kind
+        : "";
 
-    return (
-        // Checks whether this is `let`/`const`.
-        declaration &&
-        declaration.type === "VariableDeclaration" &&
-        (declaration.kind === "let" || declaration.kind === "const") &&
-        // Checks whether this is in the loop.
+    // Variables which are declared by `const` is safe.
+    if (kind === "const") {
+        return true;
+    }
+
+    // Variables which are declared by `let` in the loop is safe.
+    // It's a different instance from the next loop step's.
+    if (kind === "let" &&
         declaration.range[0] > loopNode.range[0] &&
         declaration.range[1] < loopNode.range[1]
-    );
+    ) {
+        return true;
+    }
+
+    // WriteReferences which exist after this border are unsafe because those
+    // can modify the variable.
+    var border = getTopLoopNode(
+        loopNode,
+        (kind === "let") ? declaration : null
+    ).range[0];
+
+    /**
+     * Checks whether a given reference is safe or not.
+     * The reference is every reference of the upper scope's variable we are
+     * looking now.
+     *
+     * It's safeafe if the reference matches one of the following condition.
+     * - is readonly.
+     * - doesn't exist inside a local function and after the border.
+     *
+     * @param {escope.Reference} upperRef - A reference to check.
+     * @returns {boolean} `true` if the reference is safe.
+     */
+    function isSafeReference(upperRef) {
+        var id = upperRef.identifier;
+        return (
+            !upperRef.isWrite() ||
+            variable.scope.variableScope === upperRef.from.variableScope &&
+            id.range[0] < border
+        );
+    }
+
+    return Boolean(variable) && variable.references.every(isSafeReference);
 }
 
 //------------------------------------------------------------------------------
@@ -87,10 +149,10 @@ function isBlockBindingsInLoop(loopNode, reference) {
 
 module.exports = function(context) {
     /**
-     * Reports such functions:
+     * Reports functions which match the following condition:
      *
-     * - has an ancestor node which is a loop.
-     * - has a reference that refers to a variable that is block-binding in the loop.
+     * - has a loop node in ancestors.
+     * - has any references which refers to an unsafe variable.
      *
      * @param {ASTNode} node The AST node to check.
      * @returns {boolean} Whether or not the node is within a loop.
@@ -102,7 +164,9 @@ module.exports = function(context) {
         }
 
         var references = context.getScope().through;
-        if (references.length > 0 && !references.every(isBlockBindingsInLoop.bind(null, loopNode))) {
+        if (references.length > 0 &&
+            !references.every(isSafe.bind(null, node, loopNode))
+        ) {
             context.report(node, "Don't make functions within a loop");
         }
     }

--- a/tests/lib/rules/no-loop-func.js
+++ b/tests/lib/rules/no-loop-func.js
@@ -43,14 +43,13 @@ ruleTester.run("no-loop-func", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
 
-        // refers to only variables that declared with `let`/`const` keyword in the loop.
-        // these are rebound on each loop step.
+        // functions which are using unmodified variables are OK.
         {
             code: "for (let i=0; i<l; i++) { (function() { i; }) }",
             parserOptions: { ecmaVersion: 6 }
         },
         {
-            code: "for (let i in {}) { (function() { i; }) }",
+            code: "for (let i in {}) { i = 7; (function() { i; }) }",
             parserOptions: { ecmaVersion: 6 }
         },
         {
@@ -59,6 +58,55 @@ ruleTester.run("no-loop-func", rule, {
         },
         {
             code: "for (let i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let a = 0; for (let i=0; i<l; i++) { (function() { a; }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let a = 0; for (let i in {}) { (function() { a; }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let a = 0; for (let i of {}) { (function() { a; }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let a = 0; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let a = 0; for (let i in {}) { function foo() { (function() { a; }); } }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "let a = 0; for (let i of {}) { (() => { (function() { a; }); }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a = 0; for (let i=0; i<l; i++) { (function() { a; }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a = 0; for (let i in {}) { (function() { a; }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var a = 0; for (let i of {}) { (function() { a; }); }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "let result = {};",
+                "for (const score in scores) {",
+                "  const letters = scores[score];",
+                "  letters.split('').forEach(letter => {",
+                "    result[letter] = score;",
+                "  });",
+                "}",
+                "result.__default = 6;"
+            ].join("\n"),
             parserOptions: { ecmaVersion: 6 }
         }
     ],
@@ -106,35 +154,34 @@ ruleTester.run("no-loop-func", rule, {
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
 
-        // refers to variables that declared with `let`/`const` keyword on outside of the loop.
-        // these are not rebound on each loop step.
+        // Warns functions which are using modified variables.
         {
-            code: "let a; for (let i=0; i<l; i++) { (function() { a; }); }",
+            code: "let a; for (let i=0; i<l; i++) { a = 1; (function() { a; });}",
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "let a; for (let i in {}) { (function() { a; }); }",
+            code: "let a; for (let i in {}) { (function() { a; }); a = 1; }",
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "let a; for (let i of {}) { (function() { a; }); }",
+            code: "let a; for (let i of {}) { (function() { a; }); } a = 1; ",
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "let a; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); }",
+            code: "let a; for (let i=0; i<l; i++) { (function() { (function() { a; }); }); a = 1; }",
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         },
         {
-            code: "let a; for (let i in {}) { function foo() { (function() { a; }); } }",
+            code: "let a; for (let i in {}) { a = 1; function foo() { (function() { a; }); } }",
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, type: "FunctionDeclaration" } ]
         },
         {
-            code: "let a; for (let i of {}) { (() => { (function() { a; }); }); }",
+            code: "let a; for (let i of {}) { (() => { (function() { a; }); }); } a = 1;",
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, type: "ArrowFunctionExpression" } ]
         },
@@ -142,6 +189,41 @@ ruleTester.run("no-loop-func", rule, {
             code: "for (var i = 0; i < 10; ++i) { for (let x in xs.filter(x => x != i)) {  } }",
             parserOptions: { ecmaVersion: 6 },
             errors: [ { message: expectedErrorMessage, type: "ArrowFunctionExpression" } ]
+        },
+        {
+            code: "for (let x of xs) { let a; for (let y of ys) { a = 1; (function() { a; }); } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "for (var x of xs) { for (let y of ys) { (function() { x; }); } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "for (var x of xs) { (function() { x; }); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "var a; for (let x of xs) { a = 1; (function() { a; }); }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "var a; for (let x of xs) { (function() { a; }); a = 1; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "let a; function foo() { a = 10; } for (let x of xs) { (function() { a; }); } foo();",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
+        },
+        {
+            code: "let a; function foo() { a = 10; for (let x of xs) { (function() { a; }); } } foo();",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [ { message: expectedErrorMessage, type: "FunctionExpression" } ]
         }
     ]
 });


### PR DESCRIPTION
Fixes #5044.

This PR adds a check of references which refer to upper variables from functions in a loop. The `no-loop-func` rule comes to warn the function only if there are unsafe reference. The unsafe reference is a reference that the referred variable can be modified after the function.