### PR TITLE
Docs: Replace joyent org with nodejs

### DIFF
--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -44,7 +44,7 @@ import crypto from 'crypto';
 
 ### Examples
 
-To restrict the use of all Node.js core imports (via https://github.com/joyent/node/tree/master/lib):
+To restrict the use of all Node.js core imports (via https://github.com/nodejs/node/tree/master/lib):
 
 ```json
     "no-restricted-imports": [2,

--- a/docs/rules/no-restricted-modules.md
+++ b/docs/rules/no-restricted-modules.md
@@ -42,7 +42,7 @@ var crypto = require('crypto');
 
 ### Examples
 
-To restrict the use of all Node.js core modules (via https://github.com/joyent/node/tree/master/lib):
+To restrict the use of all Node.js core modules (via https://github.com/nodejs/node/tree/master/lib):
 
 ```json
     "no-restricted-modules": [2,


### PR DESCRIPTION
Replace joyent github org with nodejs in some links in docs.