### PR TITLE
New: `no-self-assign` rule (fixes #4729)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -85,6 +85,7 @@
         "no-restricted-syntax": 0,
         "no-return-assign": 0,
         "no-script-url": 0,
+        "no-self-assign": 0,
         "no-self-compare": 0,
         "no-sequences": 0,
         "no-shadow": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -88,6 +88,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-redeclare](no-redeclare.md) - disallow declaring the same variable more than once (recommended)
 * [no-return-assign](no-return-assign.md) - disallow use of assignment in `return` statement
 * [no-script-url](no-script-url.md) - disallow use of `javascript:` urls.
+* [no-self-assign](no-self-assign.md) - disallow assignments where both sides are exactly the same
 * [no-self-compare](no-self-compare.md) - disallow comparisons where both sides are exactly the same
 * [no-sequences](no-sequences.md) - disallow use of the comma operator
 * [no-throw-literal](no-throw-literal.md) - restrict what can be thrown as an exception

--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -1,0 +1,47 @@
+# Disallow Self Assignment (no-self-assign)
+
+Self assignments have no effect, so probably those are an error due to incomplete refactoring.
+Those indicate that what you should do is still remaining.
+
+```js
+foo = foo;
+[bar, baz] = [bar, qiz];
+```
+
+## Rule Details
+
+This rule is aimed at eliminating self assignments.
+
+The following patterns are considered problems:
+
+```js
+/*eslint no-self-assign: 2*/
+
+foo = foo;              /*error 'foo' is assigned to itself.*/
+
+[a, b] = [a, b];        /*error 'a' is assigned to itself.*/
+                        /*error 'b' is assigned to itself.*/
+
+[a, ...b] = [x, ...b];  /*error 'b' is assigned to itself.*/
+
+({a, b} = {a, x});      /*error 'a' is assigned to itself.*/
+```
+
+The following patterns are considered not problems:
+
+```js
+/*eslint no-self-assign: 2*/
+
+foo = bar;
+[a, b] = [b, a];
+
+// This pattern is warned by the `no-use-before-define` rule.
+let foo = foo;
+
+// The default values have an effect.
+[foo = 1] = [foo];
+```
+
+## When Not To Use It
+
+If you don't want to notify about self assignments, then it's safe to disable this rule.

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -1,0 +1,118 @@
+/**
+ * @fileoverview Rule to disallow assignments where both sides are exactly the same
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Traverses 2 Pattern nodes in parallel, then reports self-assignments.
+ *
+ * @param {ASTNode|null} left - A left node to traverse. This is a Pattern or
+ *      a Property.
+ * @param {ASTNode|null} right - A right node to traverse. This is a Pattern or
+ *      a Property.
+ * @param {function} report - A callback function to report.
+ * @returns {void}
+ */
+function eachSelfAssignment(left, right, report) {
+    var i, j;
+
+    if (!left || !right) {
+        // do nothing
+    } else if (
+        left.type === "Identifier" &&
+        right.type === "Identifier" &&
+        left.name === right.name
+    ) {
+        report(right);
+    } else if (
+        left.type === "ArrayPattern" &&
+        right.type === "ArrayExpression"
+    ) {
+        var end = Math.min(left.elements.length, right.elements.length);
+        for (i = 0; i < end; ++i) {
+            var rightElement = right.elements[i];
+
+            eachSelfAssignment(left.elements[i], rightElement, report);
+
+            // After a spread element, those indices are unknown.
+            if (rightElement && rightElement.type === "SpreadElement") {
+                break;
+            }
+        }
+    } else if (
+        left.type === "RestElement" &&
+        right.type === "SpreadElement"
+    ) {
+        eachSelfAssignment(left.argument, right.argument, report);
+    } else if (
+        left.type === "ObjectPattern" &&
+        right.type === "ObjectExpression" &&
+        right.properties.length >= 1
+    ) {
+        // Gets the index of the last spread property.
+        // It's possible to overwrite properties followed by it.
+        var startJ = 0;
+        for (i = right.properties.length - 1; i >= 0; --i) {
+            if (right.properties[i].type === "ExperimentalSpreadProperty") {
+                startJ = i + 1;
+                break;
+            }
+        }
+
+        for (i = 0; i < left.properties.length; ++i) {
+            for (j = startJ; j < right.properties.length; ++j) {
+                eachSelfAssignment(
+                    left.properties[i],
+                    right.properties[j],
+                    report
+                );
+            }
+        }
+    } else if (
+        left.type === "Property" &&
+        right.type === "Property" &&
+        !left.computed &&
+        !right.computed &&
+        right.kind === "init" &&
+        !right.method &&
+        left.key.name === right.key.name
+    ) {
+        eachSelfAssignment(left.value, right.value, report);
+    }
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    /**
+     * Reports a given node as self assignments.
+     *
+     * @param {ASTNode} node - A node to report. This is an Identifier node.
+     * @returns {void}
+     */
+    function report(node) {
+        context.report({
+            node: node,
+            message: "'{{name}}' is assigned to itself.",
+            data: node
+        });
+    }
+
+    return {
+        "AssignmentExpression": function(node) {
+            eachSelfAssignment(node.left, node.right, report);
+        }
+    };
+};
+
+module.exports.schema = [];

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -56,6 +56,7 @@ rules:
     no-redeclare: 2
     no-return-assign: 2
     no-script-url: 2
+    no-self-assign: 2
     no-sequences: 2
     no-shadow: 2
     no-shadow-restricted-names: 2

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -1,0 +1,61 @@
+/**
+ * @fileoverview Tests for no-self-assign rule.
+ * @author Toru Nagashima
+ * @copyright 2065 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-self-assign"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-self-assign", rule, {
+    valid: [
+        "var a = a",
+        "a = b",
+        "a = +a",
+        "a = [a]",
+        {code: "let a = a", parserOptions: {ecmaVersion: 6}},
+        {code: "const a = a", parserOptions: {ecmaVersion: 6}},
+        {code: "[a] = a", parserOptions: {ecmaVersion: 6}},
+        {code: "[a = 1] = [a]", parserOptions: {ecmaVersion: 6}},
+        {code: "[a, b] = [b, a]", parserOptions: {ecmaVersion: 6}},
+        {code: "[a,, b] = [, b, a]", parserOptions: {ecmaVersion: 6}},
+        {code: "[x, a] = [...x, a]", parserOptions: {ecmaVersion: 6}},
+        {code: "[a, b] = {a, b}", parserOptions: {ecmaVersion: 6}},
+        {code: "({a} = a)", parserOptions: {ecmaVersion: 6}},
+        {code: "({a = 1} = {a})", parserOptions: {ecmaVersion: 6}},
+        {code: "({a: b} = {a})", parserOptions: {ecmaVersion: 6}},
+        {code: "({a} = {a: b})", parserOptions: {ecmaVersion: 6}},
+        {code: "({a} = {a() {}})", parserOptions: {ecmaVersion: 6}},
+        {code: "({a} = {[a]: a})", parserOptions: {ecmaVersion: 6}}
+        // TODO: https://github.com/eslint/espree/issues/247
+        // {code: "({a, ...b} = {a, ...b})", parserOptions: {ecmaVersion: 6, ecmaFeatures: {experimentalObjectRestSpread: true}}},
+    ],
+    invalid: [
+        {code: "a = a", errors: ["'a' is assigned to itself."]},
+        {code: "[a] = [a]", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself."]},
+        {code: "[a, b] = [a, b]", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself.", "'b' is assigned to itself."]},
+        {code: "[a, b] = [a, c]", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself."]},
+        {code: "[a, b] = [, b]", parserOptions: {ecmaVersion: 6}, errors: ["'b' is assigned to itself."]},
+        {code: "[a, ...b] = [a, ...b]", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself.", "'b' is assigned to itself."]},
+        {code: "[[a], {b}] = [[a], {b}]", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself.", "'b' is assigned to itself."]},
+        {code: "({a} = {a})", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself."]},
+        {code: "({a: b} = {a: b})", parserOptions: {ecmaVersion: 6}, errors: ["'b' is assigned to itself."]},
+        {code: "({a, b} = {a, b})", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself.", "'b' is assigned to itself."]},
+        {code: "({a, b} = {b, a})", parserOptions: {ecmaVersion: 6}, errors: ["'b' is assigned to itself.", "'a' is assigned to itself."]},
+        {code: "({a, b} = {c, a})", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself."]},
+        {code: "({a: {b}, c: [d]} = {a: {b}, c: [d]})", parserOptions: {ecmaVersion: 6}, errors: ["'b' is assigned to itself.", "'d' is assigned to itself."]},
+        {code: "({a, b} = {a, ...x, b})", parserOptions: {ecmaVersion: 6, ecmaFeatures: {experimentalObjectRestSpread: true}}, errors: ["'b' is assigned to itself."]}
+    ]
+});


### PR DESCRIPTION
fixes #4729.

I add this rule into `eslint-config-eslint/default.yml` to eat own dog food.

This also may be good one for `eslint:recommended`. If accepted, I can include this in #5103.