### PR TITLE
Docs: Replace ecmaFeatures setting with link to config page

### DIFF
--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -30,14 +30,7 @@ this.RegExp('[')
 
 ## New ECMAScript 6 Flags
 
-ECMAScript 6 adds the "u" ([unicode](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode)) and "y" ([sticky](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky)) flags. You can enable these to be recognized as valid by adding the following to your `.eslintrc` file:
-
-```json
-"ecmaFeatures": {
-  "regexYFlag": true,
-  "regexUFlag": true
-}
-```
+ECMAScript 6 adds the "u" ([unicode](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode)) and "y" ([sticky](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky)) flags. You can enable these to be recognized as valid by setting the ECMAScript version to 6 in your [ESLint configuration](../user-guide/configuring).
 
 ## Further Reading
 


### PR DESCRIPTION
Since it seems that it's no longer possible to configure individual ES6 features, the example config from the rule docs has been replaced with the link to the config page that explains how to set the ecmaVersion setting.