### PR TITLE
Fix: Allow same-line comments in padded-blocks (fixes #5055)

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -17,20 +17,6 @@ module.exports = function(context) {
         NEVER_MESSAGE = "Block must not be padded by blank lines.";
 
     /**
-     * Retrieves an array of all comments defined inside the given node.
-     * @param {ASTNode} node The AST node.
-     * @returns {ASTNode[]} An array of comment nodes.
-     */
-    function getCommentsInNode(node) {
-        var allComments = context.getAllComments();
-
-        return allComments.filter(function(comment) {
-            return node.range[0] < comment.range[0] &&
-                node.range[1] > comment.range[1];
-        });
-    }
-
-    /**
      * Checks if the location of a node or token is before the location of another node or token
      * @param {ASTNode|Token} a The node or token to check if its location is before b.
      * @param {ASTNode|Token} b The node or token which will be compared with a.
@@ -50,8 +36,15 @@ module.exports = function(context) {
             first = node.body[0],
             firstLine = first.loc.start.line,
             expectedFirstLine = blockStart + 2,
-            comments = getCommentsInNode(node),
-            firstComment = comments[0];
+            leadingComments = (node.body[0].leadingComments || []).slice(),
+            firstComment;
+
+        while (leadingComments.length > 0 &&
+                leadingComments[0].loc.start.line <= node.loc.start.line) {
+            leadingComments.shift();
+        }
+
+        firstComment = leadingComments[0];
 
         if (firstComment && isLocatedBefore(firstComment, first)) {
             firstLine = firstComment.loc.start.line;
@@ -71,8 +64,15 @@ module.exports = function(context) {
             lastToken = context.getLastToken(last),
             lastLine = lastToken.loc.end.line,
             expectedLastLine = blockEnd - 2,
-            comments = getCommentsInNode(node),
-            lastComment = comments[comments.length - 1];
+            trailingComments = (node.body[node.body.length - 1].trailingComments || []).slice(),
+            lastComment;
+
+        while (trailingComments.length > 0 &&
+                trailingComments[trailingComments.length - 1].loc.end.line >= node.loc.end.line) {
+            trailingComments.pop();
+        }
+
+        lastComment = trailingComments[trailingComments.length - 1];
 
         if (lastComment && isLocatedBefore(lastToken, lastComment)) {
             lastLine = lastComment.loc.end.line;

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -30,6 +30,8 @@ ruleTester.run("padded-blocks", rule, {
         {code: "{\n\na();\n//comment\n\n}" },
         {code: "{\n\na()\n//comment\n\n}" },
         {code: "{\n\na = 1\n\n}" },
+        {code: "{//comment\n\na();\n\n}" },
+        {code: "{\n\na();\n\n/* comment */ }" },
         {code: "{\na();\n}", options: ["never"]},
         {code: "{\na();}", options: ["never"]},
         {code: "{a();\n}", options: ["never"]},


### PR DESCRIPTION
This allows comments that occur on the same line as the opening or closing brace.

By refactoring the `getCommentsInNode` method as part of this change, I was able to throw in a slight (~6%) performance bump. Before:

```
Single File:
  CPU Speed is 2200 with multiplier 13000000
  Performance Run #1:  4078.844035ms
  Performance Run #2:  4145.123632ms
  Performance Run #3:  4228.349988ms
  Performance Run #4:  4022.783567ms
  Performance Run #5:  4196.384683ms

  Performance budget ok:  4145.123632ms (limit: 5909.090909090909ms)


Multi Files (450 files):
  CPU Speed is 2200 with multiplier 39000000
  Performance Run #1:  10260.395154ms
  Performance Run #2:  10054.932538ms
  Performance Run #3:  9980.401873ms
  Performance Run #4:  10205.057365ms
  Performance Run #5:  10123.912088ms

  Performance budget ok:  10123.912088ms (limit: 17727.272727272728ms)
```

After:

```
Single File:
  CPU Speed is 2200 with multiplier 13000000
  Performance Run #1:  3957.185828ms
  Performance Run #2:  3982.306874ms
  Performance Run #3:  3888.848636ms
  Performance Run #4:  3814.4996730000003ms
  Performance Run #5:  3891.909929ms

  Performance budget ok:  3891.909929ms (limit: 5909.090909090909ms)


Multi Files (450 files):
  CPU Speed is 2200 with multiplier 39000000
  Performance Run #1:  10070.100405ms
  Performance Run #2:  10050.302239ms
  Performance Run #3:  10265.260417ms
  Performance Run #4:  10013.769042ms
  Performance Run #5:  10078.269855ms

  Performance budget ok:  10070.100405ms (limit: 17727.272727272728ms)
```