### PR TITLE
Fix: find ignore file only in cwd (fixes #5087)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -12,8 +12,7 @@ var fs = require("fs"),
     path = require("path"),
     debug = require("debug"),
     ignore = require("ignore"),
-    assign = require("object-assign"),
-    FileFinder = require("./file-finder");
+    assign = require("object-assign");
 
 debug = debug("eslint:ignored-paths");
 
@@ -37,20 +36,17 @@ var DEFAULT_OPTIONS = {
 // Helpers
 //------------------------------------------------------------------------------
 
-var ignoreFileFinder;
 
 /**
- * Find an ignore file in the current directory or a parent directory.
+ * Find an ignore file in the current directory.
  * @param {stirng} cwd Current working directory
  * @returns {string} Path of ignore file or an empty string.
  */
 function findIgnoreFile(cwd) {
     cwd = cwd || DEFAULT_OPTIONS.cwd;
-    if (!ignoreFileFinder) {
-        ignoreFileFinder = new FileFinder(ESLINT_IGNORE_FILENAME, cwd);
-    }
 
-    return ignoreFileFinder.findInDirectoryOrParents(cwd);
+    var ignoreFilePath = path.resolve(cwd, ESLINT_IGNORE_FILENAME);
+    return fs.existsSync(ignoreFilePath) ? ignoreFilePath : "";
 }
 
 /**
@@ -178,6 +174,8 @@ function IgnoredPaths(options) {
         }
 
         if (options.ignorePath) {
+            debug("Using specific ignore file");
+
             try {
                 fs.statSync(options.ignorePath);
                 ignorePath = options.ignorePath;
@@ -186,15 +184,20 @@ function IgnoredPaths(options) {
                 throw e;
             }
         } else {
+            debug("Looking for ignore file in " + options.cwd);
             ignorePath = findIgnoreFile(options.cwd);
+
             try {
                 fs.statSync(ignorePath);
+                debug("Loaded ignore file " + ignorePath);
             } catch (e) {
+                debug("Could not find ignore file in cwd");
                 this.options = options;
             }
         }
 
         if (ignorePath) {
+            debug("Adding " + ignorePath);
             this.baseDir = path.dirname(ignorePath);
             addIgnoreFile(this.ig.custom, ignorePath);
         }
@@ -202,7 +205,6 @@ function IgnoredPaths(options) {
     }
 
     this.options = options;
-    return this;
 
 }
 


### PR DESCRIPTION
This was a bit messy - the tests that tested for looking up to parent directories weren't really testing anything, so when I made the change, they still passed. I fixed them so they actually tested something. :)