### PR TITLE
Fix: `sort-imports` crash (fixes #5130)

### DIFF
--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -73,8 +73,8 @@ module.exports = function(context) {
                     previousMemberSyntaxGroupIndex = getMemberParameterGroupIndex(previousDeclaration);
 
                 if (ignoreCase) {
-                    previousLocalMemberName = previousLocalMemberName.toLowerCase();
-                    currentLocalMemberName = currentLocalMemberName.toLowerCase();
+                    previousLocalMemberName = previousLocalMemberName && previousLocalMemberName.toLowerCase();
+                    currentLocalMemberName = currentLocalMemberName && currentLocalMemberName.toLowerCase();
                 }
 
                 // When the current declaration uses a different member syntax,
@@ -92,7 +92,10 @@ module.exports = function(context) {
                         });
                     }
                 } else {
-                    if (currentLocalMemberName < previousLocalMemberName) {
+                    if (previousLocalMemberName &&
+                        currentLocalMemberName &&
+                        currentLocalMemberName < previousLocalMemberName
+                    ) {
                         context.report({
                             node: node,
                             message: "Imports should be sorted alphabetically."

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -147,6 +147,15 @@ ruleTester.run("sort-imports", rule, {
                 "import * as bar from 'bar.js';\n" +
                 "import * as foo from 'foo.js';",
             parserOptions: parserOptions
+        },
+
+        // https://github.com/eslint/eslint/issues/5130
+        {
+            code:
+                "import 'foo';\n" +
+                "import bar from 'bar';",
+            parserOptions: parserOptions,
+            options: ignoreCaseArgs
         }
     ],
     invalid: [


### PR DESCRIPTION
fixes #5130.

Just I added null checks since the `getFirstLocalMemberName` function can return `null`.