### PR TITLE
Update: 'implied strict mode' ecmaFeature (fixes #4832)

### DIFF
--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -35,7 +35,7 @@ There are four options for this rule:
 1. `"function"` - require `"use strict"` in function scopes only
 1. `"safe"` - require `"use strict"` globally when inside a module wrapper and in function scopes everywhere else.
 
-All strict mode directives are flagged as unnecessary if ECMAScript modules are enabled (see [Specifying Parser Options](../user-guide/configuring#specifying-parser-options)). This behaviour does not depend on the rule options, but can be silenced by disabling this rule.
+All strict mode directives are flagged as unnecessary if ECMAScript modules or implied strict mode are enabled (see [Specifying Parser Options](../user-guide/configuring#specifying-parser-options)). This behaviour does not depend on the rule options, but can be silenced by disabling this rule.
 
 ### "never"
 

--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -23,6 +23,7 @@ Parser options are set in your `.eslintrc.*` file by using the `parserOptions` p
 * `sourceType` - set to `"script"` (default) or `"module"` if your code is in ECMAScript modules.
 * `ecmaFeatures` - an object indicating which additional language features you'd like to use:
     * `globalReturn` - allow `return` statements in the global scope
+    * `impliedStrict` - enable global [strict mode](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode) (if `ecmaVersion` is 5 or greater)
     * `jsx` - enable [JSX](http://facebook.github.io/jsx/)
     * `experimentalObjectRestSpread` - enable support for the experimental [object rest/spread properties](https://github.com/sebmarkbage/ecmascript-rest-spread) (**IMPORTANT:** This is an experimental feature that may change significantly in the future. It's recommended that you do *not* write rules relying on this functionality unless you are willing to incur maintenance cost when it changes.)
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -777,6 +777,7 @@ module.exports = (function() {
             scopeManager = escope.analyze(ast, {
                 ignoreEval: true,
                 nodejsScope: ecmaFeatures.globalReturn,
+                impliedStrict: ecmaFeatures.impliedStrict,
                 ecmaVersion: ecmaVersion,
                 sourceType: currentConfig.parserOptions.sourceType || "script"
             });

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -25,6 +25,7 @@ var messages = {
     never: "Strict mode is not permitted.",
     unnecessary: "Unnecessary 'use strict' directive.",
     module: "'use strict' is unnecessary inside of modules.",
+    implied: "'use strict' is unnecessary when implied strict mode is enabled.",
     unnecessaryInClasses: "'use strict' is unnecessary inside of classes."
 };
 
@@ -62,14 +63,15 @@ function getUseStrictDirectives(statements) {
 module.exports = function(context) {
 
     var mode = context.options[0] || "safe",
+        ecmaFeatures = context.parserOptions.ecmaFeatures || {},
         scopes = [],
         classScopes = [],
         rule;
 
-    if (mode === "safe") {
-        mode = context.parserOptions.ecmaFeatures &&
-            context.parserOptions.ecmaFeatures.globalReturn ?
-            "global" : "function";
+    if (ecmaFeatures.impliedStrict) {
+        mode = "implied";
+    } else if (mode === "safe") {
+        mode = ecmaFeatures.globalReturn ? "global" : "function";
     }
 
     /**

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "doctrine": "^1.1.0",
     "es6-map": "^0.1.3",
     "escape-string-regexp": "^1.0.2",
-    "escope": "^3.3.0",
+    "escope": "^3.4.0",
     "espree": "^3.0.0",
     "estraverse": "^4.1.1",
     "estraverse-fb": "^1.3.1",

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -2736,6 +2736,40 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "Parsing error: 'return' outside of function");
         });
 
+        it("should properly parse sloppy-mode code when impliedStrict is false", function() {
+
+            var messages = eslint.verify("var private;", {}, filename);
+
+            assert.equal(messages.length, 0);
+        });
+
+        it("should not parse sloppy-mode code when impliedStrict is true", function() {
+
+            var messages = eslint.verify("var private;", {
+                parserOptions: {
+                    ecmaFeatures: {
+                        impliedStrict: true
+                    }
+                }
+            }, filename);
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].message, "Parsing error: The keyword 'private' is reserved");
+        });
+
+        it("should properly parse valid code when impliedStrict is true", function() {
+
+            var messages = eslint.verify("var foo;", {
+                parserOptions: {
+                    ecmaFeatures: {
+                        impliedStrict: true
+                    }
+                }
+            }, filename);
+
+            assert.equal(messages.length, 0);
+        });
+
         it("should properly parse JSX when passed ecmaFeatures", function() {
 
             var messages = eslint.verify("var x = <div/>;", {

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -40,6 +40,7 @@ ruleTester.run("no-eval", rule, {
         "this.noeval('foo');",
         "function foo() { 'use strict'; this.eval('foo'); }",
         { code: "function foo() { this.eval('foo'); }", parserOptions: { sourceType: "module" } },
+        { code: "function foo() { this.eval('foo'); }", parserOptions: { ecmaFeatures: { impliedStrict: true } } },
         "var obj = {foo: function() { this.eval('foo'); }}",
         "var obj = {}; obj.foo = function() { this.eval('foo'); }",
         { code: "class A { foo() { this.eval(); } }", parserOptions: { ecmaVersion: 6 } },

--- a/tests/lib/rules/no-lone-blocks.js
+++ b/tests/lib/rules/no-lone-blocks.js
@@ -27,6 +27,7 @@ ruleTester.run("no-lone-blocks", rule, {
         {code: "{ let x = 1; }", parserOptions: { ecmaVersion: 6 }},
         {code: "{ const x = 1; }", parserOptions: { ecmaVersion: 6 }},
         {code: "'use strict'; { function bar() {} }", parserOptions: { ecmaVersion: 6 }},
+        {code: "{ function bar() {} }", parserOptions: { ecmaVersion: 6, ecmaFeatures: { impliedStrict: true }}},
         {code: "{ class Bar {} }", parserOptions: { ecmaVersion: 6 }},
 
         {code: "{ {let y = 1;} let x = 1; }", parserOptions: { ecmaVersion: 6 }}

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -28,11 +28,13 @@ ruleTester.run("strict", rule, {
         { code: "var fn = x => 1;", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
         { code: "var fn = x => { return; };", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
         { code: "foo();", parserOptions: { sourceType: "module" }, options: ["never"] },
+        { code: "function foo() { return; }", parserOptions: { ecmaFeatures: { impliedStrict: true } }, options: ["never"] },
 
         // "global" mode
         { code: "// Intentionally empty", options: ["global"] },
         { code: "\"use strict\"; foo();", options: ["global"] },
         { code: "foo();", parserOptions: { sourceType: "module" }, options: ["global"] },
+        { code: "function foo() { return; }", parserOptions: { ecmaFeatures: { impliedStrict: true } }, options: ["global"] },
         { code: "'use strict'; function foo() { return; }", options: ["global"] },
         { code: "'use strict'; var foo = function() { return; };", options: ["global"] },
         { code: "'use strict'; function foo() { bar(); 'use strict'; return; }", options: ["global"] },
@@ -43,6 +45,7 @@ ruleTester.run("strict", rule, {
         // "function" mode
         { code: "function foo() { 'use strict'; return; }", options: ["function"] },
         { code: "function foo() { return; }", parserOptions: { sourceType: "module" }, options: ["function"] },
+        { code: "function foo() { return; }", parserOptions: { ecmaFeatures: { impliedStrict: true } }, options: ["function"] },
         { code: "var foo = function() { return; }", parserOptions: { sourceType: "module" }, options: ["function"] },
         { code: "var foo = function() { 'use strict'; return; }", options: ["function"] },
         { code: "function foo() { 'use strict'; return; } var bar = function() { 'use strict'; bar(); };", options: ["function"] },
@@ -69,10 +72,14 @@ ruleTester.run("strict", rule, {
         // "safe" mode corresponds to "global" if ecmaFeatures.globalReturn is true, otherwise "function"
         { code: "function foo() { 'use strict'; return; }", options: ["safe"] },
         { code: "'use strict'; function foo() { return; }", parserOptions: { ecmaFeatures: { globalReturn: true } }, options: ["safe"] },
+        { code: "function foo() { return; }", parserOptions: { sourceType: "module" }, options: ["safe"] },
+        { code: "function foo() { return; }", parserOptions: { ecmaFeatures: { impliedStrict: true } }, options: ["safe"] },
 
         // defaults to "safe" mode
         { code: "function foo() { 'use strict'; return; }" },
-        { code: "'use strict'; function foo() { return; }", parserOptions: { ecmaFeatures: { globalReturn: true } } }
+        { code: "'use strict'; function foo() { return; }", parserOptions: { ecmaFeatures: { globalReturn: true } } },
+        { code: "function foo() { return; }", parserOptions: { sourceType: "module" } },
+        { code: "function foo() { return; }", parserOptions: { ecmaFeatures: { impliedStrict: true } } }
 
     ],
     invalid: [
@@ -114,6 +121,22 @@ ruleTester.run("strict", rule, {
             options: ["never"],
             parserOptions: { sourceType: "module" },
             errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["never"],
+            parserOptions: { ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" },
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["never"],
+            parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" },
                 { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
             ]
         },
@@ -170,6 +193,22 @@ ruleTester.run("strict", rule, {
             options: ["global"],
             parserOptions: { sourceType: "module" },
             errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["global"],
+            parserOptions: { ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" },
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["global"],
+            parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" },
                 { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
             ]
         },
@@ -237,6 +276,22 @@ ruleTester.run("strict", rule, {
             options: ["function"],
             parserOptions: { sourceType: "module" },
             errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["function"],
+            parserOptions: { ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" },
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" }
+            ]
+        }, {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["function"],
+            parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" },
                 { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
             ]
         }, {
@@ -323,6 +378,24 @@ ruleTester.run("strict", rule, {
                 { message: "Use the global form of 'use strict'.", type: "ExpressionStatement" }
             ]
         },
+        {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["safe"],
+            parserOptions: { ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" },
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" }
+            ]
+        },
+        {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            options: ["safe"],
+            parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" },
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
+            ]
+        },
 
         // Default to "safe" mode
         {
@@ -342,6 +415,22 @@ ruleTester.run("strict", rule, {
             errors: [
                 { message: "Use the global form of 'use strict'.", type: "Program" },
                 { message: "Use the global form of 'use strict'.", type: "ExpressionStatement" }
+            ]
+        },
+        {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            parserOptions: { ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" },
+                { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" }
+            ]
+        },
+        {
+            code: "'use strict'; function foo() { 'use strict'; return; }",
+            parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
+            errors: [
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" },
+                { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
             ]
         }
 


### PR DESCRIPTION
- **configuring.md** Add the new parser option `ecmaFeatures.impliedStrict`.
- **lib/eslint.js** Pass `ecmaFeatures.impliedStrict` to Escope. (No change was required to pass it to the parser.)
- **tests/lib/eslint.js** Test that a parsing error is thrown when parsing sloppy code in implied strict mode. 
- **strict.md** Mention that implied strict mode overrides the 'strict' rule options.
- **lib/rules/strict.js**
  - Implied strict mode overrides the 'strict' rule options (but is itself overridden if `sourceType` is 'module').
  - New message for each strict-mode directive in implied strict mode:
    *'use strict' is unnecessary when implied strict mode is enabled.*
- **tests/lib/rules/*.js**
  - **strict** Test that implied strict mode overrides the 'strict' rule options (but is itself overridden if `sourceType` is 'module').
  - **no-eval**, **no-invalid-this**, **no-lone-blocks**
    - These rules depend on Escope. Duplicate the tests for strict-mode directives with ones for implied strict mode.
    - **no-invalid-this** Import `lodash.clonedeep` instead of `object-assign` now that the tests mutate `pattern.parserOptions.ecmaFeatures`. @gajus, this is a merge conflict with #5015.
- **package.json** Upgrade Escope to the fateful `^3.4.0`, which supports the `impliedStrict` option.

I am hopeful that upgrading Escope to 3.4 will not cause a repeat of yesterday's chaos. I looked through the deluge of +1s from babel-eslint users and they were all using ESLint v1. The patched versions of babel-eslint also have a good head start on this PR.

Thank you, @nzakas and @michaelficarra, for your help with this feature.