### PR TITLE
Fix: Handle singular case in rule-tester error message

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -358,12 +358,12 @@ RuleTester.prototype = {
 
 
             if (typeof item.errors === "number") {
-                assert.equal(messages.length, item.errors, util.format("Should have %d errors but had %d: %s",
-                    item.errors, messages.length, util.inspect(messages)));
+                assert.equal(messages.length, item.errors, util.format("Should have %d error%s but had %d: %s",
+                    item.errors, item.errors === 1 ? "" : "s", messages.length, util.inspect(messages)));
             } else {
                 assert.equal(messages.length, item.errors.length,
-                    util.format("Should have %d errors but had %d: %s",
-                    item.errors.length, messages.length, util.inspect(messages)));
+                    util.format("Should have %d error%s but had %d: %s",
+                    item.errors.length, item.errors.length === 1 ? "" : "s", messages.length, util.inspect(messages)));
 
                 for (var i = 0, l = item.errors.length; i < l; i++) {
                     assert.ok(!("fatal" in messages[i]), "A fatal parsing error occurred: " + messages[i].message);

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -106,7 +106,7 @@ describe("RuleTester", function() {
                     { code: "Eval(foo)", errors: [{ message: "eval sucks.", type: "CallExpression"}] }
                 ]
             });
-        }, /Should have 1 errors but had 0/);
+        }, /Should have 1 error but had 0/);
     });
 
     it("should throw an error when the error message is wrong", function() {


### PR DESCRIPTION
Just a simple grammar fix in rule-tester messages: "Should have 1 errors but had 0" -> "Should have 1 error but had 0"