### PR TITLE
New: add fixer for `comma-dangle` rule.

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -162,10 +162,14 @@ module.exports = function(context) {
         }
 
         if (trailingToken.value !== ",") {
-            context.report(
-                lastItem,
-                lastItem.loc.end,
-                MISSING_MESSAGE);
+            context.report({
+                node: lastItem,
+                loc: lastItem.loc.end,
+                message: MISSING_MESSAGE,
+                fix: function(fixer) {
+                    return fixer.insertTextAfter(lastItem, ",");
+                }
+            });
         }
     }
 


### PR DESCRIPTION
This seemed like a good case for adding a fixer, since it's very simple to fix. I tested it across a very large React project (that had hundreds of missing dangling commas) and it seems to work fine.