### PR TITLE
New: Add a --print-config flag (fixes #5099)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -71,6 +71,7 @@ Miscellaneous:
   -v, --version              Outputs the version number
   --no-inline-config         Prevent comments from changing eslint rules -
                              default: false
+  --print-config             Print the configuration to be used
 ```
 
 Options that accept array values can be specified by repeating the option or with a comma-delimited list (other than `--ignore-pattern` which does not allow the second style).
@@ -356,6 +357,14 @@ config without files modifying it. All inline config comments are ignored, e.g.:
 Example:
 
     eslint --no-inline-config file.js
+
+#### `--print-config`
+
+This option outputs the configuration to be used for the file passed. When present, no linting is performed and only config-related options are valid.
+
+Example:
+
+    eslint --print-config file.js
 
 ## Ignoring files from linting
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -158,6 +158,22 @@ var cli = {
             }
 
             engine = new CLIEngine(translateOptions(currentOptions));
+            if (currentOptions.printConfig) {
+                if (files.length !== 1) {
+                    log.error("The --print-config option requires a " +
+                        "single file as positional argument.");
+                    return 1;
+                }
+
+                if (text) {
+                    log.error("The --print-config option is not available for piped-in code.");
+                    return 1;
+                }
+
+                var fileConfig = engine.getConfigForFile(files[0]);
+                log.info(JSON.stringify(fileConfig, null, "  "));
+                return 0;
+            }
 
             report = text ? engine.executeOnText(text, currentOptions.stdinFilename) : engine.executeOnFiles(files);
             if (currentOptions.fix) {

--- a/lib/options.js
+++ b/lib/options.js
@@ -209,6 +209,11 @@ module.exports = optionator({
             type: "Boolean",
             default: "true",
             description: "Allow comments to change eslint config/rules"
+        },
+        {
+            option: "print-config",
+            type: "Boolean",
+            description: "Print the configuration to be used"
         }
     ]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -842,4 +842,34 @@ describe("cli", function() {
 
     });
 
+    describe("when passing --print-config", function() {
+        it("should print out the configuration", function() {
+            var filePath = getFixturePath("files");
+
+            var exitCode = cli.execute("--print-config " + filePath);
+
+            assert.isTrue(log.info.calledOnce);
+            assert.equal(exitCode, 0);
+        });
+
+        it("should require a single positional file argument", function() {
+            var filePath1 = getFixturePath("files", "bar.js");
+            var filePath2 = getFixturePath("files", "foo.js");
+
+            var exitCode = cli.execute("--print-config " + filePath1 + " " + filePath2);
+
+            assert.isTrue(log.info.notCalled);
+            assert.isTrue(log.error.calledOnce);
+            assert.equal(exitCode, 1);
+        });
+
+        it("should error out when executing on text", function() {
+            var exitCode = cli.execute("--print-config", "foo = bar;");
+
+            assert.isTrue(log.info.notCalled);
+            assert.isTrue(log.error.calledOnce);
+            assert.equal(exitCode, 1);
+        });
+    });
+
 });

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -318,4 +318,11 @@ describe("options", function() {
             assert.equal(currentOptions.parser, "espree");
         });
     });
+
+    describe("--print-config", function() {
+        it("should return true when passed --print-config", function() {
+            var currentOptions = options.parse("--print-config");
+            assert.isTrue(currentOptions.printConfig);
+        });
+    });
 });


### PR DESCRIPTION
Hey!

As stated in the issue #5099, I did start to work on a version of the `--print-config` flag that would allow filtering the output (ie: `$ eslint --print-config env,rules some-file.js`) and everything worked well except that I couldn't figure out how to output the whole config when no value were passed to the flag. I've been playing around with different configurations for `optionator`, such as setting the type to `Boolean | [String]` but no luck so far.

In any case I've deleted the extra code for now as @nzakas requested for a dump of the whole config only.


PS: no idea on how to write more meaningful tests for that one!