### PR TITLE
Docs: Correct obvious inconsistencies in rules h2 elements

### DIFF
--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -63,6 +63,6 @@ function foo() {return true;}
 if (foo) {bar = 0;}
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about spacing style inside of blocks, you can safely disable this rule.

--- a/docs/rules/complexity.md
+++ b/docs/rules/complexity.md
@@ -48,7 +48,7 @@ function a(x) {
 }
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you can't determine an appropriate complexity limit for your code, then it's best to disable this rule.
 

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -54,6 +54,6 @@ class A extends B {
 }
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about invalid/missing `super()` callings in constructors, you can safely disable this rule.

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -88,7 +88,7 @@ Examples for valid configurations:
     // ...
     ```
 
-## When Not To Use This Rule
+## When Not To Use It
 
 There are cases where it may be safe for your application to ignore errors, however only ignore errors if you are
 confident that some other form of monitoring will help you catch the problem.

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -88,6 +88,6 @@ class A {
 }
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about modifying variables of class declarations, you can safely disable this rule.

--- a/docs/rules/no-const-assign.md
+++ b/docs/rules/no-const-assign.md
@@ -63,6 +63,6 @@ for (const a of [1, 2, 3]) { // `a` is re-defined (not modified) on each loop st
 }
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about modifying variables that are declared using `const` keyword, you can safely disable this rule.

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -63,7 +63,7 @@ class Foo {
 }
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 This rule should not be used in ES3/5 environments.
 

--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -25,7 +25,7 @@ console.log(boundGetName());      // "ESLint"
 
 In this code, the reference to `this` has been removed but `bind()` is still used. In this case, the `bind()` is unnecessary overhead (and a performance hit) and can be safely removed.
 
-## Rule details
+## Rule Details
 
 This rule is aimed at avoiding the unnecessary use of `bind()` and as such will warn whenever an immediately-invoked function expression (IIFE) is using `bind()` and doesn't have an appropriate `this` value. This rule won't flag usage of `bind()` that includes function argument binding.
 

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -144,6 +144,6 @@ var b = !!foo;
 var c = ~foo.indexOf(".");
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about shorter notations for the type conversion, you can safely disable this rule.

--- a/docs/rules/no-implicit-globals.md
+++ b/docs/rules/no-implicit-globals.md
@@ -41,7 +41,7 @@ var foo = 1;
 function bar() {}
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you want to be able to declare variables and functions in the global scope you can safely disable this rule. Or if you are always using module scoped files, this rule will never apply.
 

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -10,7 +10,7 @@ In JavaScript, prior to ES6, standalone code blocks delimited by curly braces do
 
 In ES6, code blocks may create a new scope if a block-level binding (`let` and `const`), a class declaration or a function declaration (in strict mode) are present. A block is not considered redundant in these cases.
 
-## Rule details
+## Rule Details
 
 This rule aims to eliminate unnecessary and potentially confusing blocks at the top level of a script or within other blocks.
 

--- a/docs/rules/no-new-symbol.md
+++ b/docs/rules/no-new-symbol.md
@@ -37,7 +37,7 @@ function bar(Symbol) {
 
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 This rule should not be used in ES3/5 environments.
 

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -24,7 +24,7 @@ The following patterns are considered okay and could be used alternatively:
 var a = Object.getPrototypeOf(obj);
 ```
 
-## When not to use
+## When Not To Use It
 
 If you need to support legacy browsers, you might want to turn this rule off, since support for `getPrototypeOf` is not yet universal.
 

--- a/docs/rules/no-reserved-keys.md
+++ b/docs/rules/no-reserved-keys.md
@@ -44,7 +44,7 @@ var values = {
 };
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If your code is only going to be executed in an ECMAScript 5 or higher environment, then you can safely leave this rule off.
 

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -52,6 +52,6 @@ To restrict the use of all Node.js core imports (via https://github.com/nodejs/n
     ],
 ```
 
-### When Not to Use It
+### When Not To Use It
 
 Don't use this rule or don't include a module in the list for this rule if you want to be able to import a module in your project without an ESLint error or warning.

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -68,6 +68,6 @@ class A extends B {
 }
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about using `this`/`super` before `super()` in constructors, you can safely disable this rule.

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -168,6 +168,6 @@ This option has three settings:
     ```
 
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about unused variables or function arguments, you can safely turn this rule off.

--- a/docs/rules/no-useless-call.md
+++ b/docs/rules/no-useless-call.md
@@ -57,6 +57,6 @@ a[i++].foo.call(a[i++], 1, 2, 3); /*error unnecessary '.call()'.*/
 a[++i].foo.call(a[i], 1, 2, 3);
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about unnecessary `.call()` and `.apply()`, you can safely disable this rule.

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -66,12 +66,10 @@ These patterns would not be considered problems:
 * `terms`: optional array of terms to match. Terms are matched ignoring the case. Defaults to `["todo", "fixme", "xxx"]`.
 * `location`: optional string that configures where in your comments to check for matches. Defaults to `"start"`.
 
-## When not to use it
+## When Not To Use It
 
 * If you have a large code base that was not developed with a policy to not use such warning terms, you might get hundreds of warnings / errors which might be contra-productive if you can't fix all of them (e.g. if you don't get the time to do it) as you might overlook other warnings / errors or get used to many of them and don't pay attention on it anymore.
 * Same reason as the point above: You shouldn't configure terms that are used very often (e.g. central parts of the native language used in your comments).
-
-## Further reading
 
 ### More examples of valid configurations
 

--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -37,7 +37,7 @@ foo(function() { return this.a; });
 foo(function bar(n) { return n && n + bar(n - 1); });
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 This rule should not be used in ES3/5 environments.
 

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -57,10 +57,10 @@ var b = 3;
 console.log(b);
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 If you don't want to be notified about variables that are never modified after initial assignment, you can safely disable this rule.
 
-## Related
+## Related Rules
 
 * [no-var](no-var.md)

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -297,13 +297,13 @@ Reflect.deleteProperty(foo, 'bar');
 ```
 
 
-## When Not to Use It
+## When Not To Use It
 
 This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about places where Reflect could be used, you can safely disable this rule.
 
-## Related rules
+## Related Rules
 
 * [no-useless-call](no-useless-call.md)
 * [prefer-spread](prefer-spread.md)

--- a/docs/rules/prefer-rest-params.md
+++ b/docs/rules/prefer-rest-params.md
@@ -49,6 +49,6 @@ This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about `arguments` variables, then it's safe to disable this rule.
 
-## Related rules
+## Related Rules
 
 * [prefer-spread](prefer-spread.md)

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -64,12 +64,12 @@ a[i++].foo.apply(a[i++], args); /*error use the spread operator instead of the '
 a[++i].foo.apply(a[i], args);
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 This rule should not be used in ES3/5 environments.
 
 In ES2015 (ES6) or later, if you don't want to be notified about `Function.prototype.apply()` callings, you can safely disable this rule.
 
-## Related rules
+## Related Rules
 
 * [no-useless-call](no-useless-call.md)

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -39,7 +39,7 @@ var str = `Time: ${12 * 60 * 60}`;
 var str = "Hello, " + "World!";
 ```
 
-## When Not to Use It
+## When Not To Use It
 
 This rule should not be used in ES3/5 environments.
 

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -16,7 +16,7 @@ function sum(num1, num2) {
 
 Some style guides require JSDoc comments for all functions as a way of explaining function behavior.
 
-## Rule details
+## Rule Details
 
 This rule generates warnings for nodes that do not have JSDoc comments when they should. Supported nodes:
 
@@ -107,7 +107,7 @@ class Test{
 }
 ```
 
-## When not to use
+## When Not To Use It
 
 If you do not require JSDoc for your functions, then you can leave this rule off.
 

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -2,7 +2,7 @@
 
 This rule generates warnings for generator functions that do not have the `yield` keyword.
 
-## Rule details
+## Rule Details
 
 The following patterns are considered problems:
 

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -196,6 +196,6 @@ import {a, b} from 'foo.js';
 
 Default is `["none", "all", "multiple", "single"]`.
 
-## When not to use
+## When Not To Use It
 
 This rule is a formatting preference and not following it won't negatively affect the quality of your code. If you alphabetizing imports isn't a part of your coding standards, then you can leave this rule disabled.

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -70,6 +70,6 @@ var a, A;
 var a, B, c;
 ```
 
-## When not to use
+## When Not To Use It
 
 This rule is a formatting preference and not following it won't negatively affect the quality of your code. If you alphabetizing variables isn't a part of your coding standards, then you can leave this rule off.

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -34,6 +34,6 @@ if (isNaN(NaN)) {
 }
 ```
 
-## Further reading
+## Further Reading
 
 * [Use the isNaN function to compare with NaN](http://jslinterrors.com/use-the-isnan-function-to-compare-with-nan/)


### PR DESCRIPTION
Baby step to avoid merge conflicts at an especially busy time.
Affects only 7 anchors (see below).

- Replaced “Rule details” (4 occurrences) with “Rule Details” (215 occurrences)
  - no-extra-bind.md
  - no-lone-blocks.md
  - require-jsdoc.md
  - require-yield.md

- Replace “When Not to Use It” (19 occurrences) with “When Not To Use It” (110 occurrences)
  - block-spacing.md
  - complexity.md
  - constructor-super.md
  - no-class-assign.md
  - no-const-assign.md
  - no-dupe-class-members.md
  - no-implicit-coercion.md
  - no-implicit-globals.md
  - no-new-symbol.md
  - no-reserved-keys.md
  - no-restricted-imports.md
  - no-this-before-super.md
  - no-unused-vars.md
  - no-useless-call.md
  - prefer-arrow-callback.md
  - prefer-const.md
  - prefer-reflect.md
  - prefer-spread.md
  - prefer-template.md

- Replace “When not to use it” (1 occurrence) with “When Not To Use It” (110 occurrences)
  - no-warning-comments.md

- Replace “When not to use” (4 occurrences CHANGED ANCHORS) with “When Not To Use It” (110 occurrences)
  - no-proto.md
  - require-jsdoc.md
  - sort-imports.md
  - sort-vars.md

- Replace “When Not To Use This Rule” (1 occurrence CHANGED ANCHOR) with “When Not To Use It” (110 occurrences)
  - handle-callback-error.md

- Replace “Related rules” (3 occurrences) with “Related Rules” (63 occurrences)
  - prefer-reflect.md
  - prefer-rest-params.md
  - prefer-spread.md

- Replace “Related” (1 occurrence CHANGED ANCHOR) with “Related Rules” (63 occurrences)
  - prefer-const.md

- Replaced “Further reading” (2 occurrences) with “Further Reading” (62 occurrences)
  - use-isnan.md
  - no-warning-comments.md (deleted this heading because it has no content DELETED ANCHOR)
