### PR TITLE
Fix: no-whitespace-before-property ignores whitespace inside brackets (fixes #5167)

### DIFF
--- a/docs/rules/no-whitespace-before-property.md
+++ b/docs/rules/no-whitespace-before-property.md
@@ -8,7 +8,7 @@ foo. bar .baz . quz
 
 ## Rule Details
 
-This rule alerts for whitespace around the dot or brackets before properties of objects if they are on the same line. It does not alert for whitespace when the object and property are on separate lines, as it is common to add newlines to longer chains of properties:
+This rule alerts for whitespace around the dot or before the opening bracket before properties of objects if they are on the same line. It does not alert for whitespace when the object and property are on separate lines, as it is common to add newlines to longer chains of properties:
 
 ```js
 foo
@@ -46,6 +46,8 @@ foo.bar
 
 foo[bar]
 
+foo[ bar ]
+
 foo.bar.baz
 
 foo
@@ -62,5 +64,5 @@ foo.
 
 ## When Not To Use It
 
-Turn this rule off if you do not care about allowing whitespace around dot or brackets before properties of objects if they are on the same line.
+Turn this rule off if you do not care about allowing whitespace around the dot or before the opening bracket before properties of objects if they are on the same line.
 

--- a/lib/rules/no-whitespace-before-property.js
+++ b/lib/rules/no-whitespace-before-property.js
@@ -16,28 +16,66 @@ module.exports = function(context) {
     var sourceCode = context.getSourceCode();
 
     //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Finds opening bracket token of node's computed property
+     * @param {ASTNode} node - the node to check
+     * @returns {Token} opening bracket token of node's computed property
+     * @private
+     */
+    function findOpeningBracket(node) {
+        var token = sourceCode.getTokenBefore(node.property);
+
+        while (token.value !== "[") {
+            token = sourceCode.getTokenBefore(token);
+        }
+        return token;
+    }
+
+    /**
+     * Reports whitespace before property token
+     * @param {ASTNode} node - the node to report in the event of an error
+     * @returns {void}
+     * @private
+     */
+    function reportError(node) {
+        context.report({
+            node: node,
+            message: "Unexpected whitespace before property {{propName}}.",
+            data: {
+                propName: sourceCode.getText(node.property)
+            }
+        });
+    }
+
+    //--------------------------------------------------------------------------
     // Public
     //--------------------------------------------------------------------------
 
     return {
         MemberExpression: function(node) {
-            var obj = node.object;
-            var prop = node.property;
+            var rightToken;
+            var leftToken;
 
-            if (astUtils.isTokenOnSameLine(obj, prop)) {
-                if (sourceCode.isSpaceBetweenTokens(obj, prop)) {
-                    context.report({
-                        node: node,
-                        message: "Unexpected whitespace before property '{{ propName }}'.",
-                        data: {
-                            propName: prop.name
-                        }
-                    });
-                }
+            if (!astUtils.isTokenOnSameLine(node.object, node.property)) {
+                return;
+            }
+
+            if (node.computed) {
+                rightToken = findOpeningBracket(node);
+                leftToken = sourceCode.getTokenBefore(rightToken);
+            } else {
+                rightToken = sourceCode.getFirstToken(node.property);
+                leftToken = sourceCode.getTokenBefore(rightToken, 1);
+            }
+
+            if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken)) {
+                reportError(node);
             }
         }
     };
 };
 
 module.exports.schema = [];
-

--- a/tests/lib/rules/no-whitespace-before-property.js
+++ b/tests/lib/rules/no-whitespace-before-property.js
@@ -25,21 +25,35 @@ ruleTester.run("no-whitespace-before-property", rule, {
         "foo.bar",
         "foo.bar()",
         "foo[bar]",
+        "foo['bar']",
+        "foo[0]",
+        "foo[ bar ]",
+        "foo[ 'bar' ]",
+        "foo[ 0 ]",
         "foo\n.bar",
         "foo.\nbar",
         "foo\n.bar()",
         "foo.\nbar()",
         "foo\n[bar]",
+        "foo\n['bar']",
+        "foo\n[0]",
+        "foo\n[ bar ]",
         "foo.\n bar",
         "foo\n. bar",
         "foo.\n bar()",
         "foo\n. bar()",
         "foo\n [bar]",
+        "foo\n ['bar']",
+        "foo\n [0]",
+        "foo\n [ bar ]",
         "foo.\n\tbar",
         "foo\n.\tbar",
         "foo.\n\tbar()",
         "foo\n.\tbar()",
         "foo\n\t[bar]",
+        "foo\n\t['bar']",
+        "foo\n\t[0]",
+        "foo\n\t[ bar ]",
         "foo.bar.baz",
         "foo\n.bar\n.baz",
         "foo.\nbar.\nbaz",
@@ -47,198 +61,374 @@ ruleTester.run("no-whitespace-before-property", rule, {
         "foo\n.bar()\n.baz()",
         "foo.\nbar().\nbaz()",
         "foo\n.bar\n[baz]",
+        "foo\n.bar\n['baz']",
+        "foo\n.bar\n[0]",
+        "foo\n.bar\n[ baz ]",
         "foo\n .bar\n .baz",
         "foo.\n bar.\n baz",
         "foo\n .bar()\n .baz()",
         "foo.\n bar().\n baz()",
         "foo\n .bar\n [baz]",
+        "foo\n .bar\n ['baz']",
+        "foo\n .bar\n [0]",
+        "foo\n .bar\n [ baz ]",
         "foo\n\t.bar\n\t.baz",
         "foo.\n\tbar.\n\tbaz",
         "foo\n\t.bar()\n\t.baz()",
         "foo.\n\tbar().\n\tbaz()",
-        "foo\n\t.bar\n\t[baz]"
+        "foo\n\t.bar\n\t[baz]",
+        "foo\n\t.bar\n\t['baz']",
+        "foo\n\t.bar\n\t[0]",
+        "foo\n\t.bar\n\t[ baz ]",
+        "foo['bar' + baz]",
+        "foo[ 'bar' + baz ]",
+        "(foo + bar).baz",
+        "( foo + bar ).baz",
+        "(foo ? bar : baz).qux",
+        "( foo ? bar : baz ).qux",
+        "(foo ? bar : baz)[qux]",
+        "( foo ? bar : baz )[qux]",
+        "( foo ? bar : baz )[0].qux",
+        "foo.bar[('baz')]",
+        "foo.bar[ ('baz') ]",
+        "foo[[bar]]",
+        "foo[ [ bar ] ]",
+        "foo[['bar']]",
+        "foo[ [ 'bar' ] ]",
+        "foo[(('baz'))]",
+        "foo[ (('baz'))]",
+        "foo[0][[('baz')]]",
+        "foo[bar.baz('qux')]",
+        "foo[(bar.baz() + 0) + qux]",
+        "foo['bar ' + 1 + ' baz']"
     ],
 
     invalid: [
         {
             code: "foo. bar",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo .bar",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo [bar]",
+            errors: ["Unexpected whitespace before property bar."]
+        },
+        {
+            code: "foo [0]",
+            errors: ["Unexpected whitespace before property 0."]
+        },
+        {
+            code: "foo ['bar']",
             errors: ["Unexpected whitespace before property 'bar'."]
         },
         {
             code: "foo. bar. baz",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo .bar. baz",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo [bar] [baz]",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo [bar][baz]",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo[bar] [baz]",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.bar [baz]",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo. bar[baz]",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo[bar]. baz",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+        {
+            code: "foo[ bar ] [ baz ]",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+        {
+            code: "foo [ 0 ][ baz ]",
+            errors: ["Unexpected whitespace before property 0."]
+        },
+        {
+            code: "foo[ 0 ] [ 'baz' ]",
             errors: ["Unexpected whitespace before property 'baz'."]
         },
 
         // tabs
         {
             code: "foo\t.bar",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\tbar",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t.bar()",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\tbar()",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t[bar]",
+            errors: ["Unexpected whitespace before property bar."]
+        },
+        {
+            code: "foo\t[0]",
+            errors: ["Unexpected whitespace before property 0."]
+        },
+        {
+            code: "foo\t['bar']",
             errors: ["Unexpected whitespace before property 'bar'."]
         },
         {
             code: "foo.\tbar.\tbaz",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t.bar.\tbaz",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\tbar().\tbaz()",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t.bar().\tbaz()",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t[bar]\t[baz]",
-            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property baz.", "Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t[bar][baz]",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo[bar]\t[baz]",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.bar\t[baz]",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.\tbar[baz]",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo[bar].\tbaz",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
 
         // newlines
         {
             code: "foo [bar]\n .baz",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo. bar\n .baz",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo .bar\n.baz",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\n bar. baz",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.\nbar . baz",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo. bar()\n .baz()",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo .bar()\n.baz()",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\n bar(). baz()",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.\nbar() . baz()",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo\t[bar]\n\t.baz",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\tbar\n\t.baz",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t.bar\n.baz",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\n\tbar.\tbaz",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.\nbar\t.\tbaz",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.\tbar()\n\t.baz()",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo\t.bar()\n.baz()",
-            errors: ["Unexpected whitespace before property 'bar'."]
+            errors: ["Unexpected whitespace before property bar."]
         },
         {
             code: "foo.\n\tbar().\tbaz()",
-            errors: ["Unexpected whitespace before property 'baz'."]
+            errors: ["Unexpected whitespace before property baz."]
         },
         {
             code: "foo.\nbar()\t.\tbaz()",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+
+        // parens/computed properties
+        {
+            code: "foo ['bar' + baz]",
+            errors: ["Unexpected whitespace before property 'bar' + baz."]
+        },
+        {
+            code: "(foo + bar) .baz",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+        {
+            code: "(foo + bar). baz",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+        {
+            code: "(foo + bar) [baz]",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+        {
+            code: "(foo ? bar : baz) .qux",
+            errors: ["Unexpected whitespace before property qux."]
+        },
+        {
+            code: "(foo ? bar : baz). qux",
+            errors: ["Unexpected whitespace before property qux."]
+        },
+        {
+            code: "(foo ? bar : baz) [qux]",
+            errors: ["Unexpected whitespace before property qux."]
+        },
+        {
+            code: "( foo ? bar : baz ) [0].qux",
+            errors: ["Unexpected whitespace before property 0."]
+        },
+        {
+            code: "( foo ? bar : baz )[0] .qux",
+            errors: ["Unexpected whitespace before property qux."]
+        },
+        {
+            code: "( foo ? bar : baz )[0]. qux",
+            errors: ["Unexpected whitespace before property qux."]
+        },
+        {
+            code: "( foo ? bar : baz ) [0]. qux",
+            errors: ["Unexpected whitespace before property qux.", "Unexpected whitespace before property 0."]
+        },
+        {
+            code: "foo.bar [('baz')]",
             errors: ["Unexpected whitespace before property 'baz'."]
+        },
+        {
+            code: "foo .bar[('baz')]",
+            errors: ["Unexpected whitespace before property bar."]
+        },
+        {
+            code: "foo .bar [('baz')]",
+            errors: ["Unexpected whitespace before property 'baz'.", "Unexpected whitespace before property bar."]
+        },
+        {
+            code: "foo [(('baz'))]",
+            errors: ["Unexpected whitespace before property 'baz'."]
+        },
+        {
+            code: "foo [[baz]]",
+            errors: ["Unexpected whitespace before property [baz]."]
+        },
+        {
+            code: "foo [ [ baz ] ]",
+            errors: ["Unexpected whitespace before property [ baz ]."]
+        },
+        {
+            code: "foo [['baz']]",
+            errors: ["Unexpected whitespace before property ['baz']."]
+        },
+        {
+            code: "foo [ [ 'baz' ] ]",
+            errors: ["Unexpected whitespace before property [ 'baz' ]."]
+        },
+        {
+            code: "foo[0] [[('baz')]]",
+            errors: ["Unexpected whitespace before property [('baz')]."]
+        },
+        {
+            code: "foo [0][[('baz')]]",
+            errors: ["Unexpected whitespace before property 0."]
+        },
+        {
+            code: "foo [0] [[('baz')]]",
+            errors: ["Unexpected whitespace before property [('baz')].", "Unexpected whitespace before property 0."]
+        },
+        {
+            code: "foo [bar.baz('qux')]",
+            errors: ["Unexpected whitespace before property bar.baz('qux')."]
+        },
+        {
+            code: "foo[bar .baz('qux')]",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+        {
+            code: "foo [bar . baz('qux')]",
+            errors: ["Unexpected whitespace before property bar . baz('qux').", "Unexpected whitespace before property baz."]
+        },
+        {
+            code: "foo [(bar.baz() + 0) + qux]",
+            errors: ["Unexpected whitespace before property (bar.baz() + 0) + qux."]
+        },
+        {
+            code: "foo[(bar. baz() + 0) + qux]",
+            errors: ["Unexpected whitespace before property baz."]
+        },
+        {
+            code: "foo [(bar. baz() + 0) + qux]",
+            errors: ["Unexpected whitespace before property (bar. baz() + 0) + qux.", "Unexpected whitespace before property baz."]
+        },
+        {
+            code: "foo ['bar ' + 1 + ' baz']",
+            errors: ["Unexpected whitespace before property 'bar ' + 1 + ' baz'."]
         }
     ]
 });


### PR DESCRIPTION
Rule ignores whitespace inside brackets and correctly reports property name