### PR TITLE
Fix: code path analysis and labels (fixes #5171)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -21,6 +21,7 @@ var anyFunctionPattern = /^(?:Function(?:Declaration|Expression)|ArrowFunctionEx
 var arrayOrTypedArrayPattern = /Array$/;
 var arrayMethodPattern = /^(?:every|filter|find|findIndex|forEach|map|some)$/;
 var bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/;
+var breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/;
 var thisTagPattern = /^[\s\*]*@this/m;
 
 /**
@@ -199,6 +200,37 @@ module.exports = {
             (node.type === "Literal" && typeof node.value === "string") ||
             node.type === "TemplateLiteral"
         );
+    },
+
+    /**
+     * Checks whether a given node is a breakable statement or not.
+     * The node is breakable if the node is one of the following type:
+     *
+     * - DoWhileStatement
+     * - ForInStatement
+     * - ForOfStatement
+     * - ForStatement
+     * - SwitchStatement
+     * - WhileStatement
+     *
+     * @param {ASTNode} node - A node to check.
+     * @returns {boolean} `true` if the node is breakable.
+     */
+    isBreakableStatement: function(node) {
+        return breakableTypePattern.test(node.type);
+    },
+
+    /**
+     * Gets the label if the parent node of a given node is a LabeledStatement.
+     *
+     * @param {ASTNode} node - A node to get.
+     * @returns {string|null} The label or `null`.
+     */
+    getLabel: function(node) {
+        if (node.parent.type === "LabeledStatement") {
+            return node.parent.label.name;
+        }
+        return null;
     },
 
     /**

--- a/lib/code-path-analysis/code-path-analyzer.js
+++ b/lib/code-path-analysis/code-path-analyzer.js
@@ -15,7 +15,8 @@ var assert = require("assert"),
     CodePath = require("./code-path"),
     CodePathSegment = require("./code-path-segment"),
     IdGenerator = require("./id-generator"),
-    debug = require("./debug-helpers");
+    debug = require("./debug-helpers"),
+    astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -54,22 +55,6 @@ function isForkingByTrueOrFalse(node) {
         default:
             return false;
     }
-}
-
-/**
- * Gets a label text from a given loop node.
- *
- * @param {ASTNode} node - A loop node to get. The node type is one of
- *   `WhileStatement`, `DoWhileStatement`, `ForStatement`, `ForInStatement`,
- *   and `ForOfStatement`.
- * @returns {string|null} The label text of the given node. Or `null` if there
- *   is not any label.
- */
-function getLabel(node) {
-    if (node.parent.type === "LabeledStatement") {
-        return node.parent.label.name;
-    }
-    return null;
 }
 
 /**
@@ -375,7 +360,9 @@ function processCodePathToEnter(analyzer, node) {
             break;
 
         case "SwitchStatement":
-            state.pushSwitchContext(node.cases.some(isCaseNode));
+            state.pushSwitchContext(
+                node.cases.some(isCaseNode),
+                astUtils.getLabel(node));
             break;
 
         case "TryStatement":
@@ -396,7 +383,13 @@ function processCodePathToEnter(analyzer, node) {
         case "ForStatement":
         case "ForInStatement":
         case "ForOfStatement":
-            state.pushLoopContext(node.type, getLabel(node));
+            state.pushLoopContext(node.type, astUtils.getLabel(node));
+            break;
+
+        case "LabeledStatement":
+            if (!astUtils.isBreakableStatement(node.body)) {
+                state.pushBreakContext(false, node.label.name);
+            }
             break;
 
         default:
@@ -494,6 +487,12 @@ function processCodePathToExit(analyzer, node) {
 
         case "AssignmentPattern":
             state.popForkContext();
+            break;
+
+        case "LabeledStatement":
+            if (!astUtils.isBreakableStatement(node.body)) {
+                state.popBreakContext();
+            }
             break;
 
         default:

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -12,8 +12,7 @@
 //------------------------------------------------------------------------------
 
 var CodePathSegment = require("./code-path-segment"),
-    ForkContext = require("./fork-context"),
-    getLast = require("../util").getLast;
+    ForkContext = require("./fork-context");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -75,17 +74,16 @@ function getContinueContext(state, label) {
  * @returns {LoopContext|SwitchContext} A context for a `break` statement.
  */
 function getBreakContext(state, label) {
-    if (label) {
-        return getContinueContext(state, label);
+    var context = state.breakContext;
+    while (context) {
+        if (label ? context.label === label : context.breakable) {
+            return context;
+        }
+        context = context.upper;
     }
 
-    switch (getLast(state.breakKindStack)) {
-        case "loop": return state.loopContext;
-        case "switch": return state.switchContext;
-
-        /* istanbul ignore next: foolproof (syntax error) */
-        default: return null;
-    }
+    /* istanbul ignore next: foolproof (syntax error) */
+    return null;
 }
 
 /**
@@ -230,7 +228,7 @@ function CodePathState(idGenerator, onLooped) {
     this.switchContext = null;
     this.tryContext = null;
     this.loopContext = null;
-    this.breakKindStack = [];
+    this.breakContext = null;
 
     this.currentSegments = [];
     this.initialSegment = this.forkContext.head[0];
@@ -515,20 +513,20 @@ CodePathState.prototype = {
      *
      * @param {boolean} hasCase - `true` if the switch statement has one or more
      *   case parts.
+     * @param {string|null} label - The label text.
      * @returns {void}
      */
-    pushSwitchContext: function(hasCase) {
+    pushSwitchContext: function(hasCase, label) {
         this.switchContext = {
             upper: this.switchContext,
             hasCase: hasCase,
-            brokenForkContext: ForkContext.newEmpty(this.forkContext),
             defaultSegments: null,
             defaultBodySegments: null,
             foundDefault: false,
             lastIsDefault: false,
             countForks: 0
         };
-        this.breakKindStack.push("switch");
+        this.pushBreakContext(true, label);
     },
 
     /**
@@ -544,10 +542,9 @@ CodePathState.prototype = {
     popSwitchContext: function() {
         var context = this.switchContext;
         this.switchContext = context.upper;
-        this.breakKindStack.pop();
 
         var forkContext = this.forkContext;
-        var brokenForkContext = context.brokenForkContext;
+        var brokenForkContext = this.popBreakContext().brokenForkContext;
 
         if (context.countForks === 0) {
             // When there is only one `default` chunk and there is one or more
@@ -824,6 +821,7 @@ CodePathState.prototype = {
      */
     pushLoopContext: function(type, label) {
         var forkContext = this.forkContext;
+        var breakContext = this.pushBreakContext(true, label);
 
         switch (type) {
             case "WhileStatement":
@@ -834,7 +832,7 @@ CodePathState.prototype = {
                     label: label,
                     test: void 0,
                     continueDestSegments: null,
-                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                    brokenForkContext: breakContext.brokenForkContext
                 };
                 break;
 
@@ -847,7 +845,7 @@ CodePathState.prototype = {
                     test: void 0,
                     entrySegments: null,
                     continueForkContext: ForkContext.newEmpty(forkContext),
-                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                    brokenForkContext: breakContext.brokenForkContext
                 };
                 break;
 
@@ -864,7 +862,7 @@ CodePathState.prototype = {
                     updateSegments: null,
                     endOfUpdateSegments: null,
                     continueDestSegments: null,
-                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                    brokenForkContext: breakContext.brokenForkContext
                 };
                 break;
 
@@ -878,7 +876,7 @@ CodePathState.prototype = {
                     leftSegments: null,
                     endOfLeftSegments: null,
                     continueDestSegments: null,
-                    brokenForkContext: ForkContext.newEmpty(forkContext)
+                    brokenForkContext: breakContext.brokenForkContext
                 };
                 break;
 
@@ -886,8 +884,6 @@ CodePathState.prototype = {
             default:
                 throw new Error("unknown type: \"" + type + "\"");
         }
-
-        this.breakKindStack.push("loop");
     },
 
     /**
@@ -898,9 +894,9 @@ CodePathState.prototype = {
     popLoopContext: function() {
         var context = this.loopContext;
         this.loopContext = context.upper;
-        this.breakKindStack.pop();
 
         var forkContext = this.forkContext;
+        var brokenForkContext = this.popBreakContext().brokenForkContext;
         var choiceContext;
 
         // Creates a looped path.
@@ -922,8 +918,7 @@ CodePathState.prototype = {
                     choiceContext.falseForkContext.add(forkContext.head);
                 }
                 if (context.test !== true) {
-                    context.brokenForkContext.addAll(
-                        choiceContext.falseForkContext);
+                    brokenForkContext.addAll(choiceContext.falseForkContext);
                 }
 
                 // `true` paths go to looping.
@@ -938,7 +933,7 @@ CodePathState.prototype = {
 
             case "ForInStatement":
             case "ForOfStatement":
-                context.brokenForkContext.add(forkContext.head);
+                brokenForkContext.add(forkContext.head);
                 makeLooped(
                     this,
                     forkContext.head,
@@ -951,10 +946,10 @@ CodePathState.prototype = {
         }
 
         // Go next.
-        if (context.brokenForkContext.empty) {
+        if (brokenForkContext.empty) {
             forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
         } else {
-            forkContext.replaceHead(context.brokenForkContext.makeNext(0, -1));
+            forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
         }
     },
 
@@ -1183,6 +1178,46 @@ CodePathState.prototype = {
     //--------------------------------------------------------------------------
     // Control Statements
     //--------------------------------------------------------------------------
+
+    /**
+     * Creates new context for BreakStatement.
+     *
+     * @param {boolean} breakable - The flag to indicate it can break by
+     *      an unlabeled BreakStatement.
+     * @param {string|null} label - The label of this context.
+     * @returns {object} The new context.
+     */
+    pushBreakContext: function(breakable, label) {
+        this.breakContext = {
+            upper: this.breakContext,
+            breakable: breakable,
+            label: label,
+            brokenForkContext: ForkContext.newEmpty(this.forkContext)
+        };
+        return this.breakContext;
+    },
+
+    /**
+     * Removes the top item of the break context stack.
+     *
+     * @returns {object} The removed context.
+     */
+    popBreakContext: function() {
+        var context = this.breakContext;
+        var forkContext = this.forkContext;
+        this.breakContext = context.upper;
+
+        // Process this context here for other than switches and loops.
+        if (!context.breakable) {
+            var brokenForkContext = context.brokenForkContext;
+            if (!brokenForkContext.empty) {
+                brokenForkContext.add(forkContext.head);
+                forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
+            }
+        }
+
+        return context;
+    },
 
     /**
      * Makes a path for a `break` statement.

--- a/lib/rules/no-extra-label.js
+++ b/lib/rules/no-extra-label.js
@@ -8,23 +8,10 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Helpers
+// Requirements
 //------------------------------------------------------------------------------
 
-var BREAKABLE_TYPES = /^(?:While|DoWhile|For|ForIn|ForOf|Switch)Statement$/;
-
-/**
- * Gets the label if the parent node of a given node is a LabeledStatement.
- *
- * @param {ASTNode} node - A node to get. This is one of BreakableStatement.
- * @returns {string} The label or `null`.
- */
-function getLabel(node) {
-    if (node.parent.type === "LabeledStatement") {
-        return node.parent.label.name;
-    }
-    return null;
-}
+var astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -41,7 +28,7 @@ module.exports = function(context) {
      */
     function enterBreakableStatement(node) {
         scopeInfo = {
-            label: getLabel(node),
+            label: astUtils.getLabel(node),
             breakable: true,
             upper: scopeInfo
         };
@@ -66,7 +53,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function enterLabeledStatement(node) {
-        if (!BREAKABLE_TYPES.test(node.body.type)) {
+        if (!astUtils.isBreakableStatement(node.body)) {
             scopeInfo = {
                 label: node.label.name,
                 breakable: false,
@@ -85,7 +72,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function exitLabeledStatement(node) {
-        if (!BREAKABLE_TYPES.test(node.body.type)) {
+        if (!astUtils.isBreakableStatement(node.body)) {
             scopeInfo = scopeInfo.upper;
         }
     }

--- a/tests/fixtures/code-path-analysis/block-and-break-1.js
+++ b/tests/fixtures/code-path-analysis/block-and-break-1.js
@@ -1,0 +1,30 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+s1_1->s1_4;
+s1_2->s1_5->final;
+*/
+
+A: {
+    if (a) {
+        break A;
+    }
+    foo();
+}
+
+bar();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nBlockStatement\nIfStatement\nIdentifier (a)"];
+    s1_2[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_5[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5;
+    s1_1->s1_4;
+    s1_2->s1_5->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/block-and-break-2.js
+++ b/tests/fixtures/code-path-analysis/block-and-break-2.js
@@ -1,0 +1,46 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9;
+s1_1->s1_4;
+s1_2->s1_9;
+s1_4->s1_7;
+s1_5->s1_8;
+s1_9->final;
+*/
+
+A: {
+    B: {
+        if (a) {
+            break A;
+        }
+        if (b) {
+            break B;
+        }
+        foo();
+    }
+    bar();
+}
+
+baz();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nBlockStatement\nLabeledStatement\nIdentifier (B)\nBlockStatement\nIfStatement\nIdentifier (a)"];
+    s1_2[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_4[label="IfStatement\nIdentifier (b)"];
+    s1_5[label="BlockStatement\nBreakStatement\nIdentifier (B)"];
+    s1_6[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_7[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_8[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    s1_9[label="ExpressionStatement\nCallExpression\nIdentifier (baz)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9;
+    s1_1->s1_4;
+    s1_2->s1_9;
+    s1_4->s1_7;
+    s1_5->s1_8;
+    s1_9->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/block-and-break-3.js
+++ b/tests/fixtures/code-path-analysis/block-and-break-3.js
@@ -1,0 +1,23 @@
+/*expected
+initial->s1_1->s1_2->s1_3;
+s1_1->s1_3->final;
+*/
+
+A: {
+    break A;
+}
+
+bar();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nBlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_2[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_3[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3;
+    s1_1->s1_3->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/block-and-break-4.js
+++ b/tests/fixtures/code-path-analysis/block-and-break-4.js
@@ -1,0 +1,16 @@
+/*expected
+initial->s1_1->final;
+*/
+
+A: foo();
+bar();
+
+/*DOT
+digraph {
+node[shape=box,style="rounded,filled",fillcolor=white];
+initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+s1_1[label="Program\nLabeledStatement\nIdentifier (A)\nExpressionStatement\nCallExpression\nIdentifier (foo)\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+initial->s1_1->final;
+}
+*/

--- a/tests/fixtures/code-path-analysis/while--break-nest-2.js
+++ b/tests/fixtures/code-path-analysis/while--break-nest-2.js
@@ -1,0 +1,46 @@
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_2->s1_11;
+s1_3->s1_6;
+s1_4->s1_11;
+s1_6->s1_9;
+s1_7->s1_10;
+s1_11->final;
+*/
+while (a) {
+    A: {
+        if (b) {
+            break;
+        }
+        if (c) {
+            break A;
+        }
+        foo();
+    }
+}
+
+bar();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nWhileStatement"];
+    s1_2[label="Identifier (a)"];
+    s1_3[label="BlockStatement\nLabeledStatement\nIdentifier (A)\nBlockStatement\nIfStatement\nIdentifier (b)"];
+    s1_4[label="BlockStatement\nBreakStatement"];
+    s1_5[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_6[label="IfStatement\nIdentifier (c)"];
+    s1_7[label="BlockStatement\nBreakStatement\nIdentifier (A)"];
+    s1_8[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nBlockStatement:exit"];
+    s1_9[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    s1_10[label="LabeledStatement:exit\nBlockStatement:exit"];
+    s1_11[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+    initial->s1_1->s1_2->s1_3->s1_4->s1_5->s1_6->s1_7->s1_8->s1_9->s1_10->s1_2->s1_11;
+    s1_3->s1_6;
+    s1_4->s1_11;
+    s1_6->s1_9;
+    s1_7->s1_10;
+    s1_11->final;
+}
+*/

--- a/tests/lib/rules/no-unreachable.js
+++ b/tests/lib/rules/no-unreachable.js
@@ -38,7 +38,8 @@ ruleTester.run("no-unreachable", rule, {
         "function foo() { var x = 1; while (x) { return; } x = 2; }",
         "function foo() { var x = 1; for (x in {}) { return; } x = 2; }",
         "function foo() { var x = 1; try { return; } finally { x = 2; } }",
-        "function foo() { var x = 1; for (;;) { if (x) break; } x = 2; }"
+        "function foo() { var x = 1; for (;;) { if (x) break; } x = 2; }",
+        "A: { break A; } foo()"
     ],
     invalid: [
         { code: "function foo() { return x; var x = 1; }", errors: [{ message: "Unreachable code.", type: "VariableDeclaration"}] },


### PR DESCRIPTION
Fixes #5171

Code Path Analysis comes to handle labels with other than loops and switches correctly.

Before, it has been handling `break` statements on loop contexts and switch contexts. But now, it's handling `break` statements on the independent `break` contexts stack.