### PR TITLE
Update: add `arrowFunctions` option to `no-empty` (fixes #5161)

### DIFF
--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -67,12 +67,42 @@ Since you must always have at least a `catch` or a `finally` block for any `try`
 
 ### Options
 
-`methods` set to `true` will warn for empty methods. This option is set to `false` by default.
-
 ```json
 {
-    "no-empty": [2, { "methods": true } ]
+    "no-empty": [2, {"arrowFunctions": false, "methods": false}]
 }
+```
+
+This rule has 2 options:
+
+* `arrowFunctions` (`boolean`) - If `true`, this rule will warn for empty arrow functions. This option is set to `false` by default.
+* `methods` (`boolean`) - If `true`, this rule will warn for empty methods. This option is set to `false` by default.
+
+The following pattern is considered a problem when `arrowFunctions` is set to `true`:
+
+```js
+/*eslint no-empty: [2, { arrowFunctions: true }]*/
+
+// Note: this is a block, not an empty object.
+var foo = () => {}  /*error Empty block statement.*/
+```
+
+The following pattern is not considered a problem when `arrowFunctions` is set to `true`:
+
+```js
+/*eslint no-empty: [2, { arrowFunctions: true }]*/
+
+const foo = () => {
+    console.log("this is not empty.");
+};
+
+// this is an empty object literal.
+const foo = () => ({});
+
+// there is an clear comment.
+const foo = () => {
+    // do nohting.
+};
 ```
 
 The following pattern is considered a problem when `methods` is set to `true`:

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -13,6 +13,7 @@
 module.exports = function(context) {
     var config = context.options[0] || {};
     var includeMethods = config.methods === true;
+    var includeArrowFunctions = config.arrowFunctions === true;
 
     return {
         "BlockStatement": function(node) {
@@ -24,15 +25,18 @@ module.exports = function(context) {
             }
 
             // a function is generally allowed to be empty...
-            if (parentType === "FunctionDeclaration" || parentType === "ArrowFunctionExpression") {
+            if (parentType === "FunctionDeclaration") {
                 return;
             }
-
             // ...except ES6 methods if `methods` is true
-            if (parentType === "FunctionExpression" ) {
+            if (parentType === "FunctionExpression") {
                 if (!includeMethods || (includeMethods && !node.parent.parent.method)) {
                     return;
                 }
+            }
+            // ...except arrow functions if `arrowFunctions` is true
+            if (parentType === "ArrowFunctionExpression" && !includeArrowFunctions) {
+                return;
             }
 
             // any other block is only allowed to be empty, if it contains a comment
@@ -44,7 +48,6 @@ module.exports = function(context) {
         },
 
         "SwitchStatement": function(node) {
-
             if (typeof node.cases === "undefined" || node.cases.length === 0) {
                 context.report(node, "Empty switch statement.");
             }
@@ -57,6 +60,9 @@ module.exports.schema = [
     {
         "type": "object",
         "properties": {
+            "arrowFunctions": {
+                "type": "boolean"
+            },
             "methods": {
                 "type": "boolean"
             }

--- a/tests/lib/rules/no-empty.js
+++ b/tests/lib/rules/no-empty.js
@@ -45,7 +45,13 @@ ruleTester.run("no-empty", rule, {
         // methods
         "var foo = { bar: function() {} }",
         { code: "var foo = { bar() {} }", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = { bar() { console.log('baz'); } }", parserOptions: { ecmaVersion: 6 }, options: [{ methods: true }] }
+        { code: "var foo = { bar() { console.log('baz'); } }", parserOptions: { ecmaVersion: 6 }, options: [{ methods: true }] },
+
+        // arrowFunctions
+        { code: "var foo = () => {/* empty */};", parserOptions: { ecmaVersion: 6 }, options: [{ arrowFunctions: true }] },
+        { code: "var foo = () => {\n    // empty\n};", parserOptions: { ecmaVersion: 6 }, options: [{ arrowFunctions: true }] },
+        { code: "var foo = () => bar;", parserOptions: { ecmaVersion: 6 }, options: [{ arrowFunctions: true }] },
+        { code: "var foo = () => { bar(); };", parserOptions: { ecmaVersion: 6 }, options: [{ arrowFunctions: true }] }
     ],
     invalid: [
         { code: "try {} catch (ex) {throw ex}", errors: [{ message: "Empty block statement.", type: "BlockStatement"}] },
@@ -57,6 +63,9 @@ ruleTester.run("no-empty", rule, {
         { code: "switch(foo) {}", errors: [{ message: "Empty switch statement.", type: "SwitchStatement"}] },
 
         // methods
-        { code: "var foo = { bar() {} }", parserOptions: { ecmaVersion: 6 }, options: [{ methods: true }], errors: [{ message: "Empty block statement.", type: "BlockStatement"}] }
+        { code: "var foo = { bar() {} }", parserOptions: { ecmaVersion: 6 }, options: [{ methods: true }], errors: [{ message: "Empty block statement.", type: "BlockStatement"}] },
+
+        // arrowFunctions
+        { code: "var foo = () => {};", parserOptions: { ecmaVersion: 6 }, options: [{ arrowFunctions: true }], errors: [{ message: "Empty block statement.", type: "BlockStatement"}] }
     ]
 });


### PR DESCRIPTION
Fixes #5161 
