### PR TITLE
Fix: Allow globally installed parser to be used (fixes #5186)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -421,10 +421,15 @@ function load(filePath, applyEnvironments) {
 
         // include full path of parser if present
         if (config.parser) {
-            config.parser = resolveModule.sync(config.parser, {
-                // be careful of https://github.com/substack/node-resolve/issues/78
-                basedir: path.dirname(path.resolve(filePath))
-            });
+            try {
+                config.parser = resolveModule.sync(config.parser, {
+                    // be careful of https://github.com/substack/node-resolve/issues/78
+                    basedir: path.dirname(path.resolve(filePath))
+                });
+            } catch (e) {
+                // resolveModule.sync doesn't resolve global modules
+                debug("Consider the given parser is installed globally");
+            }
         }
 
         // validate the configuration before continuing


### PR DESCRIPTION
resolveModule.sync() works as require.resolve(), but require.resolve() cannot recognize a module when it is installed globally. Therefore, resolveModule.sync('global-parser') also fails to recognize it.

This fix seems to be a monkey-patch, so there may be a more reasonable way...

Moreover, I'm not sure what tests for global parsers is like...?