### PR TITLE
Fix: Config file relative paths (fixes #5164)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -579,7 +579,9 @@ ESLint also supports extending configuration from plugins that provide configs:
 
 In this example, the `eslint-plugin-myplugin` package contains configuration named `default`.
 
-**Note:** Please note that when you are extending from the configuration bundled with plugins, you need to start with `plugin:` prefix as well as specify configuration name after the slash. You may optionally omit the `eslint-plugin-` prefix.
+**Important:** When you are extending from the configuration bundled with plugins, you need to start with `plugin:` prefix as well as specify configuration name after the slash. You may optionally omit the `eslint-plugin-` prefix.
+
+**Note:** For configuration files in your home directory, or in any path that isn't an ancestor to the location of ESLint (either globally or locally), `extends` is resolved from the path of the project using ESLint (typically the current working directory) rather than relative to the file itself.
 
 ## Comments in Configuration Files
 

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -18,6 +18,7 @@ var debug = require("debug"),
     validator = require("./config-validator"),
     Plugins = require("./plugins"),
     resolveModule = require("resolve"),
+    pathIsInside = require("path-is-inside"),
     stripComments = require("strip-json-comments"),
     stringify = require("json-stable-stringify"),
     isAbsolutePath = require("path-is-absolute");
@@ -294,6 +295,27 @@ function write(config, filePath) {
 }
 
 /**
+ * Determines the lookup path for node packages referenced in a config file.
+ * If the config
+ * @param {string} configFilePath The config file referencing the file.
+ * @returns {string} The lookup path for the file path.
+ * @private
+ */
+function getLookupPath(configFilePath) {
+
+    // calculates the path of the project including ESLint as dependency
+    var projectPath = path.resolve(__dirname, "../../../");
+    if (configFilePath && pathIsInside(configFilePath, projectPath)) {
+        // be careful of https://github.com/substack/node-resolve/issues/78
+        return path.resolve(configFilePath);
+    }
+
+    // default to ESLint project path since it's unlikely that plugins will be
+    // in this directory
+    return projectPath;
+}
+
+/**
  * Applies values from the "extends" field in a configuration file.
  * @param {Object} config The configuration information.
  * @param {string} filePath The file path from which the configuration information
@@ -386,12 +408,12 @@ function resolve(filePath, relativeTo) {
             var packagePath = filePath.substr(7, filePath.lastIndexOf("/") - 7);
             var configName = filePath.substr(filePath.lastIndexOf("/") + 1, filePath.length - filePath.lastIndexOf("/") - 1);
             filePath = resolveModule.sync(normalizePackageName(packagePath, "eslint-plugin"), {
-                basedir: relativeTo || process.cwd()
+                basedir: getLookupPath(relativeTo)
             });
             return { filePath: filePath, configName: configName };
         } else {
             filePath = resolveModule.sync(normalizePackageName(filePath, "eslint-config"), {
-                basedir: relativeTo || process.cwd()
+                basedir: getLookupPath(relativeTo)
             });
             return { filePath: filePath };
         }
@@ -422,8 +444,7 @@ function load(filePath, applyEnvironments) {
         // include full path of parser if present
         if (config.parser) {
             config.parser = resolveModule.sync(config.parser, {
-                // be careful of https://github.com/substack/node-resolve/issues/78
-                basedir: path.dirname(path.resolve(filePath))
+                basedir: getLookupPath(path.dirname(path.resolve(filePath)))
             });
         }
 
@@ -452,6 +473,7 @@ function load(filePath, applyEnvironments) {
 
 module.exports = {
 
+    getLookupPath: getLookupPath,
     load: load,
     resolve: resolve,
     write: write,


### PR DESCRIPTION
It turns out we weren't in too bad a situation. I believe this should solve most of the outstanding issues we have with parser and config locations.

@albertosantini can you try this branch and see if it works for the global install use case? (It's impossible to write a test for that.)