### PR TITLE
Docs: Simplify hierarchy of headings in rule pages

### DIFF
--- a/docs/rules/accessor-pairs.md
+++ b/docs/rules/accessor-pairs.md
@@ -32,12 +32,10 @@ This rule enforces a style where it requires to have a getter for every property
 
 By activating the option `getWithoutSet` it enforces the presence of a setter for every property which has a getter defined.
 
-### Options
+## Options
 
 `getWithoutSet` set to `true` will warn for getters without setters (Default `false`).
 `setWithoutGet` set to `true` will warn for setters without getters (Default `true`).
-
-#### Usage
 
 By default `setWithoutGet` option is always set to `true`.
 
@@ -92,7 +90,7 @@ Object.defineProperty(o, 'c', {
 
 ```
 
-#### `getWithoutSet`
+### `getWithoutSet`
 
 The following patterns are considered problems with option `getWithoutSet` set:
 

--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -22,7 +22,7 @@ spaces inside of brackets between the brackets and other tokens or enforcing spa
 separated from the adjacent value by a new line are excepted from this rule, as this is a common pattern.
   Object literals that are used as the first or last element in an array are also ignored.
 
-### Options
+## Options
 
 There are two options for this rule:
 
@@ -35,7 +35,7 @@ Depending on your coding conventions, you can choose either option by specifying
 "array-bracket-spacing": [2, "always"]
 ```
 
-#### "never"
+### "never"
 
 When `"never"` is set, the following patterns are considered problems:
 
@@ -80,7 +80,7 @@ var [x, ...y] = z;
 var [,,x,] = z;
 ```
 
-#### "always"
+### "always"
 
 When `"always"` is used, the following patterns are considered problems:
 
@@ -127,7 +127,7 @@ var [ ,,x, ] = z;
 
 Note that `"always"` has a special case where `{}` and `[]` are not considered problems.
 
-#### Exceptions
+### Exceptions
 
 An object literal may be used as a third array item to specify spacing exceptions. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing and an exception is set to `false`, it will disallow spacing for cases matching the exception. Likewise, if `"never"` is set to disallow spacing and an exception is set to `true`, it will enforce spacing for cases matching the exception.
 

--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -6,14 +6,14 @@ Arrow functions can omit braces when there is a single statement in the body. Th
 
 This rule can enforce the use of braces around arrow function body.
 
-### Options
+## Options
 
 The rule takes one option, a string, which can be:
 
 * `"always"` enforces braces around the function body
 * `"as-needed"` enforces no braces where they can be omitted (default)
 
-#### "always"
+### "always"
 
 ```json
 "arrow-body-style": [2, "always"]
@@ -39,7 +39,7 @@ let foo = (retv, name) => {
 };
 ```
 
-#### "as-needed"
+### "as-needed"
 
 When the rule is set to `"as-needed"` the following patterns are considered problems:
 

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -45,7 +45,7 @@ The rule can also be configured to discourage the use of parens when they are no
 a => {}
 ```
 
-### Options
+## Options
 
 The rule takes one option, a string, which could be either `"always"` or `"as-needed"`. The default is `"always"`.
 
@@ -53,7 +53,7 @@ You can set the option in configuration like this:
 
 "arrow-parens": [2, "always"]
 
-#### "always"
+### "always"
 
 When the rule is set to `"always"` the following patterns are considered problems:
 
@@ -83,7 +83,7 @@ a.then((foo) => {});
 a.then((foo) => { if (true) {}; });
 ```
 
-##### If Statements
+#### If Statements
 
 One benefits of this option is that it prevents the incorrect use of arrow functions in conditionals:
 
@@ -140,7 +140,7 @@ var f = (a) => b ? c: d;
 ```
 
 
-#### "as-needed"
+### "as-needed"
 
 When the rule is set to `"as-needed"` the following patterns are considered problems:
 

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -7,6 +7,9 @@ This rule is for spacing style within single line blocks.
 ## Rule Details
 
 This rule is aimed to flag usage of spacing inside of blocks.
+
+## Options
+
 This rule has a option, its value is `"always"` or `"never"`.
 
 - `"always"` (by default) enforces one or more spaces.

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -42,7 +42,7 @@ While no style is considered better than the other, most developers agree that h
 
 This rule is aimed at enforcing a particular brace style in JavaScript. As such, it warns whenever it sees a statement or declaration that does not adhere to the one true brace style.
 
-### Options
+## Options
 
 The rule takes two options:
 
@@ -55,7 +55,7 @@ You can set the style in configuration like this:
 "brace-style": [2, "stroustrup", { "allowSingleLine": true }]
 ```
 
-#### "1tbs"
+### "1tbs"
 
 This is the default setting for this rule and enforces one true brace style. While using this setting, the following patterns are considered problems:
 
@@ -131,7 +131,7 @@ if (foo) { bar(); } else { baz(); }
 try { somethingRisky(); } catch(e) { handleError(); }
 ```
 
-#### "stroustrup"
+### "stroustrup"
 
 
 This enforces Stroustrup style. While using this setting, the following patterns are considered problems:
@@ -212,7 +212,7 @@ try { somethingRisky(); }
 catch(e) { handleError(); }
 ```
 
-#### "allman"
+### "allman"
 
 
 This enforces Allman style. While using this setting, the following patterns are considered problems:

--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -49,7 +49,7 @@ function foo() {
 }
 ```
 
-### Options
+## Options
 
 The rule takes a single option, which is an array of possible callback names.
 
@@ -57,13 +57,13 @@ The rule takes a single option, which is an array of possible callback names.
 callback-return: [2, ["callback", "cb", "next"]]
 ```
 
-### Gotchas
+## Gotchas
 
 There are several cases of bad behavior that this rule will not catch and even a few cases where
 the rule will warn even though you are handling your callbacks correctly. Most of these issues arise
 in areas where it is difficult to understand the meaning of the code through static analysis.
 
-#### Passing the Callback by Reference
+### Passing the Callback by Reference
 
 Here is a case where we pass the callback to the `setTimeout` function. Our rule does not detect this pattern, but
 it is likely a mistake.
@@ -79,7 +79,7 @@ function foo(callback) {
 }
 ```
 
-#### Triggering the Callback within a Nested Function
+### Triggering the Callback within a Nested Function
 
 If you are calling the callback from within a nested function or an immediately invoked
 function expression, we won't be able to detect that you're calling the callback and so
@@ -98,7 +98,7 @@ function foo(callback) {
 }
 ```
 
-#### If/Else Statements
+### If/Else Statements
 
 Here is a case where you're doing the right thing in making sure to only `callback()` once, but because of the
 difficulty in determining what you're doing, this rule does not allow for this pattern.

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -6,7 +6,7 @@ When it comes to naming variables, styleguides generally fall into one of two ca
 
 This rule looks for any underscores (`_`) located within the source code. It ignores leading and trailing underscores and only checks those in the middle of a variable name. If ESLint decides that the variable is a constant (all uppercase), then no warning will be thrown. Otherwise, a warning will be thrown. This rule only flags definitions and assignments but not function calls.
 
-### Options
+## Options
 
 This rule accepts a single options argument with the following defaults:
 

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -14,7 +14,7 @@ var foo = 1 ,bar = 2;
 This rule aims to enforce spacing around a comma. As such, it warns whenever it sees a missing or unwanted space in commas of variable declaration, object property, function parameter, sequence and array element.
 
 
-### Options
+## Options
 
 The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`. If `before` is `true`, space is enforced before commas and if it's `false`, space is disallowed before commas. If `after` is `true`, space is enforced after commas and if it's `false`, space is disallowed after commas. The default is `{"before": false, "after": true}`.
 
@@ -24,7 +24,7 @@ The rule takes one option, an object, which has two keys `before` and `after` ha
 
 The following examples show two primary usages of this option.
 
-#### `{"before": false, "after": true}`
+### `{"before": false, "after": true}`
 
 This is the default option. It enforces spacing after commas and disallows spacing before commas.
 
@@ -57,7 +57,7 @@ function foo(a, b){}
 a, b
 ```
 
-#### `{"before": true, "after": false}`
+### `{"before": true, "after": false}`
 
 This option enforces spacing before commas and disallows spacing after commas.
 

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -10,7 +10,7 @@ In case linting is turned off, missing commas in variable declarations lead to l
 
 This rule is aimed at enforcing a particular comma style in JavaScript. As such, it warns whenever it sees a variable declaration, object property and array element that does not adhere to a particular comma style. It doesn't support cases where there are line breaks before and after comma (lone commas) with in declarations, properties and elements. It also avoids single line declaration cases.
 
-### Options
+## Options
 
 The rule takes an option, a string, which could be either `"last"` or `"first"`. The default is `"last"`.
 
@@ -20,7 +20,7 @@ You can set the style in configuration like this:
 "comma-style": [2, "first"]
 ```
 
-#### "last"
+### "last"
 
 This is the default setting for this rule. This option requires that the comma be placed after and be in the same line as the variable declaration, object property and array element.
 
@@ -74,7 +74,7 @@ function bar() {
 
 ```
 
-#### "first"
+### "first"
 
 This option requires that the comma be placed before and be in the same line as the variable declaration, object property and array element.
 
@@ -124,7 +124,7 @@ function bar() {
 
 ```
 
-#### Exceptions
+### Exceptions
 
 Exceptions of the following nodes may be passed in order to tell ESLint to ignore nodes of certain types.
 

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -25,7 +25,7 @@ This rule aims to maintain consistency around the spacing inside of computed pro
 It either requires or disallows spaces between the brackets and the values inside of them.
 Brackets that are separated from the adjacent value by a new line are exempt from this rule.
 
-### Options
+## Options
 
 There are two main options for the rule:
 
@@ -38,7 +38,7 @@ Depending on your coding conventions, you can choose either option by specifying
 "computed-property-spacing": [2, "never"]
 ```
 
-#### "never"
+### "never"
 
 When `"never"` is set, the following patterns will give a warning:
 
@@ -64,7 +64,7 @@ var x = {[b]: a}
 obj[foo[bar]]
 ```
 
-#### "always"
+### "always"
 
 When `"always"` is used, the following patterns will give a warning:
 

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -19,22 +19,18 @@ This rule designates a variable as the chosen alias for `this`. It then enforces
 * if a variable with the designated name is declared or assigned to, it *must* explicitly be assigned the current execution context, i.e. `this`
 * if `this` is explicitly assigned to a variable, the name of that variable must be the designated one
 
-### Options
+## Options
 
 This rule takes one option, a string, which is the designated `this` variable. The default is `that`.
+
+```json
+"consistent-this": [2, "that"]
+```
 
 Additionally, you may configure extra aliases for cases where there are more than one supported alias for `this`.
 
 ```js
 { "consistent-this": [ 2, "self",  "vm" ] } ] }
-```
-
-#### Usage
-
-You can set the rule configuration like this:
-
-```json
-"consistent-this": [2, "that"]
 ```
 
 The following patterns are considered problems:

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -55,9 +55,9 @@ if (foo) {
 }
 ```
 
-### Options
+## Options
 
-#### "multi"
+### "multi"
 
 By default, this rule warns whenever `if`, `else`, `for`, `while`, or `do` are used without block statements as their body. However, you can specify that block statements should be used only when there are multiple statements in the block and warn when there is only one statement in the block. To do so, configure the rule as:
 
@@ -103,7 +103,7 @@ while (true) {
 }
 ```
 
-#### "multi-line"
+### "multi-line"
 
 Alternatively, you can relax the rule to allow brace-less single-line `if`, `else if`, `else`, `for`, `while`, or `do`, while still enforcing the use of curly braces for other instances. To do so, configure the rule as:
 
@@ -155,7 +155,7 @@ while (true) {
 }
 ```
 
-#### "multi-or-nest"
+### "multi-or-nest"
 
 You can use another configuration that forces brace-less `if`, `else if`, `else`, `for`, `while`, or `do` if their body contains only one single-line statement. And forces braces in all other cases.
 
@@ -222,7 +222,7 @@ for (var i = 0; foo; i++)
     doSomething();
 ```
 
-#### "consistent"
+### "consistent"
 
 When using any of the `multi*` option, you can add an option to enforce all bodies of a `if`,
 `else if` and `else` chain to be with or without braces.

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -16,7 +16,7 @@ var b = universe
 
 This rule aims to enforce newline consistency in member expressions. This rule prevents the use of mixed newlines around the dot in a member expression.
 
-### Options
+## Options
 
 The rule takes one option, a string, which can be either `object` or `property`.
 If it is `object`, the dot in a member expression should be on the same line as the object portion.
@@ -28,7 +28,7 @@ If unset, the default behavior is `"object"`.
     "dot-location": [2, "object"]
 ```
 
-#### "object"
+### "object"
 
 This is the default option. It requires the dot to be on the same line as the object.
 
@@ -51,7 +51,7 @@ property;
 var bar = object.property;
 ```
 
-#### "property"
+### "property"
 
 This option requires the dot to be on the same line as the property.
 

--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -28,7 +28,7 @@ var x = foo.bar;
 var x = foo[bar];    // Property name is a variable, square-bracket notation required
 ```
 
-### Options
+## Options
 
 This rule accepts a single options argument with the following defaults:
 
@@ -40,7 +40,7 @@ This rule accepts a single options argument with the following defaults:
 }
 ```
 
-#### `allowKeywords`
+### `allowKeywords`
 
 Set the `allowKeywords` option to `false` (default is `true`) to follow ECMAScript version 3 compatible style, avoiding dot notation for reserved word properties.
 
@@ -57,7 +57,7 @@ var foo = { "class": "CS 101" }
 var x = foo["class"]; // Property name is a reserved word, square-bracket notation required
 ```
 
-#### `allowPattern`
+### `allowPattern`
 
 Set the `allowPattern` option to a regular expression string to allow bracket notation for property names that match a pattern (by default, no pattern is tested).
 

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -35,6 +35,6 @@ function doSmth() {
 // spaces here
 ```
 
-### Options
+## Options
 
 This rule may take one option which is either `unix` (LF) or `windows` (CRLF). When omitted `unix` is assumed.

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -27,9 +27,9 @@ if ("" == text) { }                  /*error Expected '===' and instead saw '=='
 if (obj.getStuff() != undefined) { } /*error Expected '!==' and instead saw '!='.*/
 ```
 
-### Options
+## Options
 
-#### "smart"
+### "smart"
 
 This option enforces the use of `===` and `!==` except for these cases:
 
@@ -71,7 +71,7 @@ bananas != 1        /*error Expected '!==' and instead saw '!='.*/
 value == undefined  /*error Expected '===' and instead saw '=='.*/
 ```
 
-#### "allow-null"
+### "allow-null"
 
 This option will enforce `===` and `!==` in your code with one exception - it permits comparing to `null` to check for `null` or `undefined` in a single expression.
 

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -46,9 +46,9 @@ Due to these different behaviors, it is common to have guidelines as to which st
 
 This rule is aimed at enforcing a particular type of function style throughout a JavaScript file, either declarations or expressions. You can specify which you prefer in the configuration.
 
-### Options
+## Options
 
-#### "expression"
+### "expression"
 
 This is the default configuration.  It reports an error when function declarations are used instead of function expressions.
 
@@ -62,7 +62,7 @@ An additional option object can be added with a property `"allowArrowFunctions"`
 "func-style": [2, "expression", { "allowArrowFunctions": true }]
 ```
 
-#### "declaration"
+### "declaration"
 
 This reports an error if any function expressions are used where function declarations are expected. You can specify to use expressions instead:
 
@@ -70,7 +70,7 @@ This reports an error if any function expressions are used where function declar
 "func-style": [2, "declaration"]
 ```
 
-### Examples
+## Examples
 
 The following patterns are considered problems:
 

--- a/docs/rules/global-strict.md
+++ b/docs/rules/global-strict.md
@@ -42,7 +42,7 @@ function foo() {
 }());
 ```
 
-### Options
+## Options
 
 ```json
 "global-strict": [2, "always"]

--- a/docs/rules/id-blacklist.md
+++ b/docs/rules/id-blacklist.md
@@ -20,7 +20,7 @@ It will not catch blacklisted identifiers that are:
 - object properties (so you can still use objects you do not have control over)
 
 
-### Options
+## Options
 
 This rule needs a a set of identifier names to blacklist, like so:
 

--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -116,7 +116,7 @@ export var num = 0;
 ```
 
 
-### Options
+## Options
 
 The `id-length` rule has no required options and has 4 optional ones that needs to be passed in a single options object:
 

--- a/docs/rules/id-match.md
+++ b/docs/rules/id-match.md
@@ -12,7 +12,7 @@ No more limiting yourself to camelCase, snake_case, PascalCase or oHungarianNota
 This rule compares assignments and function definitions to a provided regular expression, giving you the maximum flexibility on the matter.
 It doesn't apply to function calls, so that you can still use functions or objects you do not have control over.
 
-### Options
+## Options
 
 This rule needs a text RegExp to operate with, and accepts an options map. Its signature is as follows:
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -26,7 +26,7 @@ This rule is aimed to enforce consistent indentation style. The default style is
 
 It takes an option as the second parameter which can be `"tab"` for tab-based indentation or a positive number for space indentations.
 
-### Options
+## Options
 
 The `indent` rule has two options:
 

--- a/docs/rules/init-declarations.md
+++ b/docs/rules/init-declarations.md
@@ -26,20 +26,16 @@ bar = 2;
 
 This rule aims to bring consistency to variable initializations and declarations.
 
-### Options
+## Options
 
 The rule takes two options:
 
 1. A string which must be either `"always"` (the default), to enforce initialization at declaration, or `"never"` to disallow initialization during declaration. This rule applies to `var`, `let`, and `const` variables, however `"never"` is ignored for `const` variables, as unassigned `const`s generate a parse error.
 2. An object that further controls the behavior of this rule. Currently, the only available parameter is `ignoreForLoopInit`, which indicates if initialization at declaration is allowed in `for` loops when `"never"` is set, since it is a very typical use case.
 
-### Options
-
-This rule is configured by passing in the string `"always"` (the default)
-
 You can configure the rule as follows:
 
-(default) All variables must be initialized at declaration
+Variables must be initialized at declaration (default)
 
 ```json
 {
@@ -122,6 +118,6 @@ With `"ignoreForLoopInit"` enabled, the following pattern is not considered a pr
 for (var i = 0; i < 1; i++) {}
 ```
 
-### When Not To Use It
+## When Not To Use It
 
 When you are indifferent as to how your variables are initialized.

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -6,7 +6,7 @@ This rule enforces spacing around the colon in object literal properties. It can
 
 This rule will warn when spacing in properties does not match the specified options. In the case of long lines, it is acceptable to add a new line wherever whitespace is allowed. There are three modes:
 
-### 1. Individual
+## Options
 
 Use the `beforeColon`, `afterColon` and `mode` options to enforce having one space or zero spaces on each side, using `true` or `false`, respectively. The default is no whitespace between the key and the colon and one space between the colon and the value.
 
@@ -76,7 +76,7 @@ function foo() {
 }
 ```
 
-### 2. Vertically align values `"align": "value"`
+### `"align": "value"`
 
 Use the `align` option to enforce vertical alignment of values in an object literal. This mode still respects `beforeColon` and `afterColon` where possible, but it will pad with spaces after the colon where necessary. Groups of properties separated by blank lines are considered distinct and can have different alignment than other groups. Single line object literals will not be checked for vertical alignment, but each property will still be checked for `beforeColon` and `afterColon`.
 
@@ -121,7 +121,7 @@ var obj = {
 };
 ```
 
-### 3. Vertically align colons `"align": "colon"`
+### `"align": "colon"`
 
 The `align` option can also vertically align colons and values together. Whereas with `"value"` alignment, padding belongs right of the colon, with `"colon"` alignment, padding goes to the left of the colon. Except in the case of padding, it still respects `beforeColon` and `afterColon`. As with `"value"` alignment, groups of properties separated by blank lines are considered distinct and can have different alignment than other groups.
 
@@ -162,7 +162,7 @@ var obj = {
 };
 ```
 
-#### Fine-grained control
+### Fine-grained control
 
 You can specify these options separately for single-line and multi-line configurations by organizing the options this way:
 

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -187,7 +187,7 @@ let a = <A foo={this.foo} bar={function(){}} />
 ```
 
 
-### Options
+## Options
 
 This rule has 3 options.
 

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -58,7 +58,7 @@ function foo(params) { // \r\n
 } // \r\n
 ```
 
-### Options
+## Options
 
 This rule may take one option which is either `unix` (LF) or `windows` (CRLF). When omitted `unix` is assumed.
 

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -31,20 +31,43 @@ var x = 0;
 var y = 10;
 ```
 
-### Options
+### Inline comments
 
-This rule has 10 options:
+Inline comments are always excluded from the rule.
 
-1. `beforeBlockComment` (enabled by default)
-2. `afterBlockComment`
-3. `beforeLineComment`
-4. `afterLineComment`
-5. `allowBlockStart`
-6. `allowBlockEnd`
-7. `allowObjectStart`
-8. `allowObjectEnd`
-9. `allowArrayStart`
-10. `allowArrayEnd`
+The following would be acceptable:
+
+```js
+/*eslint lines-around-comment: 2*/
+
+var x = 0;
+var y = 10; /* the vertical position */
+```
+
+Empty lines are also not required at the beginning or end of a file.
+
+## Options
+
+This rule has 10 options.
+
+2 options for block comments:
+
+* `beforeBlockComment` (enabled by default)
+* `afterBlockComment`
+
+2 options for line comments:
+
+* `beforeLineComment`
+* `afterLineComment`
+
+6 options for exceptions:
+
+* `allowBlockStart`
+* `allowBlockEnd`
+* `allowObjectStart`
+* `allowObjectEnd`
+* `allowArrayStart`
+* `allowArrayEnd`
 
 Any combination of these rules may be applied at the same time.
 
@@ -58,7 +81,7 @@ Any combination of these rules may be applied at the same time.
 When set to `false` the option is simply ignored.
 
 
-#### Block Comments
+### Block Comments
 
 Block comments are any comment that start with `/*` and need not extend to multiple lines.
 
@@ -107,7 +130,7 @@ var night = "long";
 var day = "great"
 ```
 
-#### Line Comments
+### Line Comments
 
 Line comments are any comments that start with `//`.
 
@@ -136,9 +159,7 @@ var night = "long";
 var day = "great"
 ```
 
-### Exceptions
-
-#### `allowBlockStart` option
+### `allowBlockStart`
 
 When this option is set to `true`, it allows the comment to be present at the start of any block statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
 
@@ -168,7 +189,7 @@ function foo(){
 }
 ```
 
-#### `allowBlockEnd` option
+### `allowBlockEnd`
 
 When this option is set to `true`, it allows the comment to be present at the end of any block statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
 
@@ -199,7 +220,7 @@ function foo(){
 }
 ```
 
-#### `allowObjectStart` option
+### `allowObjectStart`
 
 When this option is set to `true`, it allows the comment to be present at the start of any object-like statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
 
@@ -247,7 +268,7 @@ const {
 } = {day: "great"};
 ```
 
-#### `allowObjectEnd` option
+### `allowObjectEnd`
 
 When this option is set to `true`, it allows the comment to be present at the end of any object-like statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
 
@@ -298,7 +319,7 @@ const {
 } = {day: "great"};
 ```
 
-#### `allowArrayStart` option
+### `allowArrayStart`
 
 When this option is set to `true`, it allows the comment to be present at the start of any array-like statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
 
@@ -338,7 +359,7 @@ const [
 ] = ["great", "not great"];
 ```
 
-#### `allowArrayEnd` option
+### `allowArrayEnd`
 
 When this option is set to `true`, it allows the comment to be present at the end of any array-like statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
 
@@ -379,21 +400,6 @@ const [
     /* what a great and wonderful day */
 ] = ["great", "not great"];
 ```
-
-#### Inline comments
-
-Inline comments are always excluded from the rule.
-
-The following would be acceptable:
-
-```js
-/*eslint lines-around-comment: 2*/
-
-var x = 0;
-var y = 10; /* the vertical position */
-```
-
-Empty lines are also not required at the beginning or end of a file.
 
 ## When Not To Use It
 

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -18,7 +18,7 @@ function foo() {
 
 This rule aims to reduce the complexity of your code by allowing you to configure the maximum depth blocks can be nested in a function. As such, it will warn when blocks are nested too deeply.
 
-### Options
+## Options
 
 The default depth above which this rule will warn is `4`.  You can configure the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error with a maximum depth of 10:
 

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -36,7 +36,7 @@ var foo = {
 };
 ```
 
-### Options
+## Options
 
 The `max-len` rule supports the following options:
 

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -18,7 +18,7 @@ foo(function () {
 
 This rule is aimed at increasing code clarity by discouraging deeply nesting callbacks. As such, it will warn when callbacks are nested deeper than the specified limit.
 
-### Options
+## Options
 
 The default max depth for this rule is 10. You can define the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error (code is 2) with a maximum depth of 3:
 

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -14,7 +14,7 @@ function foo() {
 
 This rule allows you to configure the maximum number of statements allowed in a function.  The default is 10.
 
-### Options
+## Options
 
 There is an additional optional argument to ignore top level functions.
 

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -21,7 +21,7 @@ The problem is when these developers work together in a project. This rule enfor
 
 This rule enforces a coding style where empty newlines are required or disallowed after `var`, `let`, or `const` statements to achieve a consistent coding style across the project.
 
-### Options
+## Options
 
 This rule takes one option, a string, which can be:
 

--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -35,13 +35,11 @@ This rule reports such code and encourages new lines after each call in the chai
 
 This rule checks and reports the chained calls if there are no new lines after each call or deep member access.
 
-### Options
+## Options
 
 The rule takes a single option `ignoreChainWithDepth`. The level/depth to be allowed is configurable through `ignoreChainWithDepth` option. This rule, in its default state, allows 2 levels.
 
 * `ignoreChainWithDepth` Number of depths to be allowed (Default: `2`).
-
-### Usage
 
 Following patterns are considered problems with default configuration:
 

--- a/docs/rules/no-bitwise.md
+++ b/docs/rules/no-bitwise.md
@@ -58,7 +58,7 @@ var x = y < z;
 x += y;
 ```
 
-### Options
+## Options
 
 This rule supports the following options:
 

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -15,14 +15,14 @@ There are valid reasons to use assignment operators in conditional statements. H
 
 This rule is aimed at eliminating ambiguous assignments in `for`, `if`, `while`, and `do...while` conditional statements.
 
-### Options
+## Options
 
 The rule takes one option, a string, which must contain one of the following values:
 
 * `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
 * `always`: Disallow all assignments.
 
-#### "except-parens"
+### "except-parens"
 
 This is the default option. It disallows assignments unless they are enclosed in parentheses. This option makes it possible to use common patterns, such as reassigning a value in the condition of a `while` or `do...while` loop, without causing a warning.
 
@@ -74,7 +74,7 @@ function setHeight(someNode) {
 }
 ```
 
-#### "always"
+### "always"
 
 This option disallows all assignments in conditional statement tests. All assignments are treated as problems.
 

--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -64,7 +64,7 @@ class A {
 }
 ```
 
-### Options
+## Options
 
 This rule has an option to allow indirect calls to `eval`.
 Indirect calls to `eval` are less dangerous than direct calls to `eval` because they cannot dynamically change the scope. Because of this, they also will not negatively impact performance to the degree of direct `eval`.
@@ -112,7 +112,7 @@ window.eval("var a = 0");
 global.eval("var a = 0");
 ```
 
-### Known Limitations
+## Known Limitations
 
 * This rule is warning every `eval()` even if the `eval` is not global's.
   This behavior is in order to detect calls of direct `eval`. Such as:

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -4,14 +4,12 @@ This rule restricts the use of parentheses to only where they are necessary. It 
 
 ## Rule Details
 
-### Exceptions
-
 A few cases of redundant parentheses are always allowed:
 
 * RegExp literals: `(/abc/).test(var)` is always valid.
 * IIFEs: `var x = (function () {})();`, `((function foo() {return 1;})())` are always valid.
 
-### Options
+## Options
 
 This rule takes 1 or 2 arguments. The first one is a string which must be one of the following:
 
@@ -20,7 +18,7 @@ This rule takes 1 or 2 arguments. The first one is a string which must be one of
 
 The second one is an object for more fine-grained configuration when the first option is "all".
 
-#### "all"
+### "all"
 
 The following patterns are considered problems:
 
@@ -50,7 +48,7 @@ The following patterns are not considered problems:
 (/^a$/).test(x);
 ```
 
-##### Fine-grained control
+#### Fine-grained control
 
 When setting the first option as "all", an additional option can be added to allow extra parens for assignment in conditional statements.
 
@@ -68,7 +66,7 @@ do; while ((foo = bar()))
 for (;(a = b););
 ```
 
-#### "functions"
+### "functions"
 
 The following patterns are considered problems:
 

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -29,7 +29,7 @@ foo = String(foo);
 
 This rule is aimed to flag shorter notations for the type conversion, then suggest a more self-explanatory notation.
 
-### Options
+## Options
 
 This rule has three main options and one override option to allow some coercions as required.
 
@@ -53,7 +53,7 @@ This rule has three main options and one override option to allow some coercions
 
 Note that operator `+` in `allow` list would allow `+foo` (number coercion) as well as `"" + foo` (string coercion).
 
-#### `boolean`
+### `boolean`
 
 The following patterns are considered problems:
 
@@ -77,7 +77,7 @@ var b = foo.indexOf(".") !== -1;
 var n = ~foo; // This is a just binary negating.
 ```
 
-#### `number`
+### `number`
 
 The following patterns are considered problems:
 
@@ -98,7 +98,7 @@ var b = parseFloat(foo);
 var b = parseInt(foo, 10);
 ```
 
-#### `string`
+### `string`
 
 The following patterns are considered problems:
 
@@ -118,7 +118,7 @@ The following patterns are not considered problems:
 var b = String(foo);
 ```
 
-#### Fine-grained control
+### Fine-grained control
 
 Using `allow` list, we can override and allow specific operators.
 

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -58,7 +58,7 @@ function doSomething() {
 
 This rule requires that function declarations and, optionally, variable declarations be in the root of a program or the body of a function.
 
-### Options
+## Options
 
 This rule takes a single option to specify whether it should check just function declarations or both function and variable declarations. The default is `"functions"`. Setting it to `"both"` will apply the same rules to both types of declarations.
 

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -75,7 +75,7 @@ while (true) {
 }
 ```
 
-### Options
+## Options
 
 ```json
 {

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -9,7 +9,27 @@ When this rule is enabled, all `var` statements must satisfy the following condi
 * either none or all variable declarations must be require declarations
 * all require declarations must be of the same type (optional)
 
-### Options
+This rule distinguishes between six kinds of variable declaration types:
+
+* `core`: declaration of a required [core module][1]
+* `file`: declaration of a required [file module][2]
+* `module`: declaration of a required module from the [node_modules folder][3]
+* `computed`: declaration of a required module whose type could not be determined (either because it is computed or because require was called without an argument)
+* `uninitialized`: a declaration that is not initialized
+* `other`: any other kind of declaration
+
+In this document, the first four types are summed up under the term *require declaration*.
+
+```javascript
+var fs = require('fs'),        // "core"     \
+    async = require('async'),  // "module"   |- these are "require declaration"s
+    foo = require('./foo'),    // "file"     |
+    bar = require(getName()),  // "computed" /
+    baz = 42,                  // "other"
+    bam;                       // "uninitialized"
+```
+
+## Options
 
 This rule comes with two boolean options. Both are turned off by default. You can set those in your `eslint.json`:
 
@@ -28,30 +48,6 @@ The second way to configure this rule is with boolean (This way of setting is de
 ```
 
 If enabled, violations will be reported whenever a single `var` statement contains require declarations of mixed types (see the examples below).
-
-### Nomenclature
-
-This rule distinguishes between six kinds of variable declaration types:
-
-* `core`: declaration of a required [core module][1]
-* `file`: declaration of a required [file module][2]
-* `module`: declaration of a required module from the [node_modules folder][3]
-* `computed`: declaration of a required module whose type could not be determined (either because it is computed or because require was called without an argument)
-* `uninitialized`: a declaration that is not initialized
-* `other`: any other kind of declaration
-
-In this document, the first four types are summed up under the term *require declaration*.
-
-#### Example
-
-```javascript
-var fs = require('fs'),        // "core"     \
-    async = require('async'),  // "module"   |- these are "require declaration"s
-    foo = require('./foo'),    // "file"     |
-    bar = require(getName()),  // "computed" /
-    baz = 42,                  // "other"
-    bam;                       // "uninitialized"
-```
 
 ## Examples
 

--- a/docs/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/rules/no-mixed-spaces-and-tabs.md
@@ -6,9 +6,9 @@ Most code conventions require either tabs or spaces be used for indentation. As 
 
 The `no-mixed-spaces-and-tabs` rule is aimed at flagging any lines of code that are indented with a mixture of tabs and spaces.
 
-### Options
+## Options
 
-* Smart Tabs
+### smart-tabs
 
 This option suppresses warnings about mixed tabs and spaces when the latter are used for alignment only. This technique is called [SmartTabs](http://www.emacswiki.org/emacs/SmartTabs). The option is turned off by default.
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -54,11 +54,13 @@ var arr = [1, 2];
 a ? b: c
 ```
 
-### Exceptions
+## Options
 
 Some rules, like key-spacing in one of its alignment modes, might require multiple spaces in some instances. To support this case, this rule accepts an options object with a property named `exceptions`. The `exceptions` object expects property names to be AST node types as defined by [ESTree](https://github.com/estree/estree). The easiest way to determine the node types for `exceptions` is to use the [online demo](http://eslint.org/parser).
 
 You can ignore certain parts of your code by setting node types as properties on the `exceptions` object with a value of `true`. By default, all node types are `false` except for `Property`, which is `true` by default in order to skip properties.
+
+### exceptions
 
 With this option, The following patterns are not considered problems:
 

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -7,7 +7,7 @@ Some developers prefer to have multiple blank lines removed, while others feel t
 
 This rule aims to reduce the scrolling required when reading through your code. It will warn when the maximum amount of empty lines has been exceeded.
 
-### Options
+## Options
 
 The second argument can be used to configure this rule:
 
@@ -40,7 +40,7 @@ the beginning:
 ```
 
 
-### Examples
+## Examples
 
 The following patterns are considered problems:
 

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -6,7 +6,7 @@ Assignment to variables declared as function parameters can be misleading and le
 
 This rule aims to prevent unintended behavior caused by overwriting function parameters.
 
-### Options
+## Options
 
 This rule takes one option, an object, with a property `"props"`.
 
@@ -16,10 +16,11 @@ This rule takes one option, an object, with a property `"props"`.
 }
 ```
 
-* `props` (`false` by default) - If `true` is set, this rule warns modifying of properties of parameters.
+### `props`
 
+It is `false` by default. If it is `true` is set, this rule warns modifying of properties of parameters.
 
-### The following patterns are considered problems:
+The following patterns are considered problems:
 
 ```js
 /*eslint no-param-reassign: 2*/
@@ -51,7 +52,7 @@ function foo(bar) {
 }
 ```
 
-### The following patterns are not considered problems:
+The following patterns are not considered problems:
 
 ```js
 /*eslint no-param-reassign: 2*/

--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -32,7 +32,7 @@ j
 
 This rule is aimed at flagging the use of `++` and `--`. Some believe that the use of these unary operators reduces code quality and clarity. There are some programming languages that completely exclude these operators.
 
-### Options
+## Options
 
 This rule, in its default state, does not require any arguments. If you would like to enable one or more of the following you may pass an object with the options set as follows:
 

--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -25,7 +25,7 @@ var a = 3;
 a = 10;
 ```
 
-### Options
+## Options
 
 This rule takes one option, an object, with a property `"builtinGlobals"`.
 
@@ -35,7 +35,7 @@ This rule takes one option, an object, with a property `"builtinGlobals"`.
 }
 ```
 
-#### builtinGlobals
+### builtinGlobals
 
 `false` by default.
 If this is `true`, this rule checks with built-in global variables such as `Object`, `Array`, `Number`, ...

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -12,12 +12,20 @@ Some modules provide similar or identical functionality, think `lodash` and `und
 
 This rule allows you to specify imports that you don't want to use in your application.
 
-### Options
+## Options
 
 The syntax to specify restricted modules looks like this:
 
 ```json
 "no-restricted-imports": [2, "import1", "import2"]
+```
+
+To restrict the use of all Node.js core imports (via https://github.com/nodejs/node/tree/master/lib):
+
+```json
+    "no-restricted-imports": [2,
+         "assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"
+    ],
 ```
 
 The following patterns are considered problems:
@@ -42,16 +50,6 @@ The following patterns are not considered problems:
 import crypto from 'crypto';
 ```
 
-### Examples
-
-To restrict the use of all Node.js core imports (via https://github.com/nodejs/node/tree/master/lib):
-
-```json
-    "no-restricted-imports": [2,
-         "assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"
-    ],
-```
-
-### When Not To Use It
+## When Not To Use It
 
 Don't use this rule or don't include a module in the list for this rule if you want to be able to import a module in your project without an ESLint error or warning.

--- a/docs/rules/no-restricted-modules.md
+++ b/docs/rules/no-restricted-modules.md
@@ -10,7 +10,15 @@ Blocking the `os` module can be useful if you don't want to allow any operating 
 
 This rule allows you to specify modules that you don't want to use in your application.
 
-### Options
+To restrict the use of all Node.js core modules (via https://github.com/nodejs/node/tree/master/lib):
+
+```json
+    "no-restricted-modules": [2,
+         "assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"
+    ],
+```
+
+## Options
 
 The syntax to specify restricted modules looks like this:
 
@@ -38,14 +46,4 @@ The following patterns are not considered problems:
 /*eslint no-restricted-modules: [2, "fs"]*/
 
 var crypto = require('crypto');
-```
-
-### Examples
-
-To restrict the use of all Node.js core modules (via https://github.com/nodejs/node/tree/master/lib):
-
-```json
-    "no-restricted-modules": [2,
-         "assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"
-    ],
 ```

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -8,7 +8,7 @@ Rather than creating separate rules for every language feature you want to turn 
 
 This rule is aimed at eliminating certain syntax from your JavaScript. As such, it warns whenever it sees a node type that is restricted by its options.
 
-### Options
+## Options
 
 This rule takes a list of strings where strings denote the node types:
 

--- a/docs/rules/no-return-assign.md
+++ b/docs/rules/no-return-assign.md
@@ -16,14 +16,14 @@ Because of this ambiguity, it's considered a best practice to not use assignment
 
 This rule aims to eliminate assignments from `return` statements. As such, it will warn whenever an assignment is found as part of `return`.
 
-### Options
+## Options
 
 The rule takes one option, a string, which must contain one of the following values:
 
 * `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
 * `always`: Disallow all assignments.
 
-#### "except-parens"
+### "except-parens"
 
 This is the default option.
 It disallows assignments unless they are enclosed in parentheses.
@@ -60,7 +60,7 @@ function doSomething() {
 }
 ```
 
-#### "always"
+### "always"
 
 This option disallows all assignments in `return` statements.
 All assignments are treated as problems.

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -40,7 +40,7 @@ if (true) {
 }
 ```
 
-### Options
+## Options
 
 This rule takes one option, an object, with properties `"builtinGlobals"`, `"hoist"` and `"allow"`.
 
@@ -50,7 +50,7 @@ This rule takes one option, an object, with properties `"builtinGlobals"`, `"hoi
 }
 ```
 
-#### `builtinGlobals`
+### `builtinGlobals`
 
 `false` by default.
 If this is `true`, this rule checks with built-in global variables such as `Object`, `Array`, `Number`, ...
@@ -65,7 +65,7 @@ function foo() {
 }
 ```
 
-#### `hoist`
+### `hoist`
 
 The option has three settings:
 
@@ -73,7 +73,7 @@ The option has three settings:
 * `functions` (by default) - reports shadowing before the outer functions are defined.
 * `never` - never report shadowing before the outer variables/functions are defined.
 
-##### `{ "hoist": "all" }`
+#### `{ "hoist": "all" }`
 
 With `"hoist"` set to `"all"`, both `let a` and `let b` in the `if` statement are considered problems.
 
@@ -90,7 +90,7 @@ let a = 5;
 function b() {}
 ```
 
-##### `{ "hoist": "functions" }` (default)
+#### `{ "hoist": "functions" }` (default)
 
 With `"hoist"` set to `"functions"`, `let b` is considered a warning. But `let a` in the `if` statement is not considered a warning, because it is before `let a` of the outer scope.
 
@@ -107,7 +107,7 @@ let a = 5;
 function b() {}
 ```
 
-##### `{ "hoist": "never" }`
+#### `{ "hoist": "never" }`
 
 With `"hoist"` set to `"never"`, neither `let a` nor `let b` in the `if` statement are considered problems, because they are before the declarations of the outer scope.
 
@@ -124,7 +124,7 @@ let a = 5;
 function b() {}
 ```
 
-#### `allow`
+### `allow`
 
 The option is an array of identifier names to be allowed (ie. "resolve", "reject", "done", "cb" etc.):
 

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -27,7 +27,7 @@ var foo = 0;
 var baz = 5;
 ```
 
-### Options
+## Options
 
 There is one option for this rule, `skipBlankLines`. When set to true, the rule will not flag any lines that are made up purely of whitespace. In short, if a line is zero-length after being trimmed of whitespace, then the rule will not flag that line when `skipBlankLines` is enabled.
 

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -6,7 +6,7 @@ This rule can help you locate potential ReferenceErrors resulting from misspelli
 
 ## Rule Details
 
-### Options
+## Options
 
 * `typeof` set to true will warn for variables used inside typeof check (Default false).
 
@@ -58,7 +58,7 @@ if (typeof UndefinedIdentifier === "undefined") {
 }
 ```
 
-#### `typeof`
+### `typeof`
 
 You can use this option if you want to prevent `typeof` check on a variable which has not been declared.
 

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -14,9 +14,9 @@ Whether or not you choose to allow dangling underscores in identifiers is purely
 
 This rule aims to eliminate the use of dangling underscores in identifiers.
 
-### Options
+## Options
 
-#### `allow`
+### `allow`
 
 ```json
 "no-underscore-dangle": [2, { "allow": [] }]
@@ -24,7 +24,7 @@ This rule aims to eliminate the use of dangling underscores in identifiers.
 
 Array of variable names that are permitted to be used with underscore. If provided, it must be an `Array`.
 
-#### `allowAfterThis`
+### `allowAfterThis`
 
 ```json
 "no-underscore-dangle": [2, { "allowAfterThis": true }]

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -14,14 +14,12 @@ This rule aims to eliminate unused expressions. The value of an expression shoul
 
 **Note:** Sequence expressions (those using a comma, such as `a = 1, b = 2`) are always considered unused unless their return value is assigned or a function call is made with the sequence expression value.
 
-### Options
+## Options
 
 This rule, in it's default state, does not require any arguments. If you would like to enable one or more of the following you may pass an object with the options set as follows:
 
 * `allowShortCircuit` set to `true` will allow you to use short circuit evaluations in your expressions (Default: `false`).
 * `allowTernary` set to `true` will enable you use ternary operators in your expressions similarly to short circuit evaluations (Default: `false`).
-
-### Usage
 
 By default the following patterns are considered problems:
 

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -62,7 +62,7 @@ myFunc(function foo() {
 
 In environments outside of CommonJS or ECMAScript modules, you may use `var` to create a global variable that may be used by other scripts. You can use the `/* exported variableName */` comment block to indicate that this variable is being exported and therefore should not be considered unused. Note that `/* exported */` has no effect when used with the `node` or `commonjs` environments or when `ecmaFeatures.modules` or `ecmaFeatures.globalReturn` are true.
 
-### Options
+## Options
 
 By default this rule is enabled with `all` option for variables and `after-used` for arguments.
 
@@ -74,14 +74,14 @@ By default this rule is enabled with `all` option for variables and `after-used`
 }
 ```
 
-#### `vars`
+### `vars`
 
 This option has two settings:
 
 * `all` checks all variables for usage, including those in the global scope. This is the default setting.
 * `local` checks only that locally-declared variables are used but will allow global variables to be unused.
 
-#### `args`
+### `args`
 
 This option has three settings:
 
@@ -89,7 +89,7 @@ This option has three settings:
 * `after-used` - only the last argument must be used. This allows you, for instance, to have two named parameters to a function and as long as you use the second argument, ESLint will not warn you about the first. This is the default setting.
 * `none` - do not check arguments.
 
-##### with `{ "args": "all" }`
+#### with `{ "args": "all" }`
 
 ```js
 /*eslint no-unused-vars: [2, { "args": "all" }]*/
@@ -99,7 +99,7 @@ This option has three settings:
 })();
 ```
 
-##### with `{ "args": "after-used" }`
+#### with `{ "args": "after-used" }`
 
 ```js
 /*eslint no-unused-vars: [2, { "args": "after-used" }]*/
@@ -109,7 +109,7 @@ This option has three settings:
 })();
 ```
 
-##### with `{ "args": "none" }`
+#### with `{ "args": "none" }`
 
 ```js
 /*eslint no-unused-vars: [2, { "args": "none" }]*/
@@ -119,12 +119,12 @@ This option has three settings:
 })();
 ```
 
-#### Ignore identifiers that match specific patterns
+### Ignore identifiers that match specific patterns
 
 * `varsIgnorePattern` - all variables that match this regexp pattern will not be checked.
 * `argsIgnorePattern` - all arguments that match this regexp pattern will not be checked.
 
-##### Examples
+#### Examples
 
 * Ignore all unused function arguments with a leading underscore
 

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -57,7 +57,7 @@ function g() {
 }
 ```
 
-### Options
+## Options
 
 ```json
 {

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -56,7 +56,7 @@ These patterns would not be considered problems:
 
 ```
 
-## Rule Options
+## Options
 
 ```json
 "no-warning-comments": [<enabled>, { "terms": <terms>, "location": <location> }]
@@ -66,39 +66,39 @@ These patterns would not be considered problems:
 * `terms`: optional array of terms to match. Terms are matched ignoring the case. Defaults to `["todo", "fixme", "xxx"]`.
 * `location`: optional string that configures where in your comments to check for matches. Defaults to `"start"`.
 
-## When Not To Use It
+### Examples
 
-* If you have a large code base that was not developed with a policy to not use such warning terms, you might get hundreds of warnings / errors which might be contra-productive if you can't fix all of them (e.g. if you don't get the time to do it) as you might overlook other warnings / errors or get used to many of them and don't pay attention on it anymore.
-* Same reason as the point above: You shouldn't configure terms that are used very often (e.g. central parts of the native language used in your comments).
-
-### More examples of valid configurations
-
-1. Rule configured to warn on matches and search the complete comment, not only the start of it. Note that the `term` configuration is omitted to use the defaults terms.
+* Rule configured to warn on matches and search the complete comment, not only the start of it. Note that the `term` configuration is omitted to use the defaults terms.
 
    ```json
    "no-warning-comments": [1, { "location": "anywhere" }]
    ```
 
-2. Rule configured to warn on matches of the term `bad string` at the start of comments. Note that the `location` configuration is omitted to use the default location.
+* Rule configured to warn on matches of the term `bad string` at the start of comments. Note that the `location` configuration is omitted to use the default location.
 
    ```json
    "no-warning-comments": [1, { "terms": ["bad string"] }]
    ```
 
-3. Rule configured to warn with error on matches of the default terms at the start of comments. Note that the complete configuration object (that normally holds `terms` and/or `location`) can be omitted for simplicity.
+* Rule configured to warn with error on matches of the default terms at the start of comments. Note that the complete configuration object (that normally holds `terms` and/or `location`) can be omitted for simplicity.
 
    ```json
    "no-warning-comments": [2]
    ```
 
-4. Rule configured to warn on matches of the default terms at the start of comments. Note that the complete configuration object (as already seen in the example above) and even the square brackets can be omitted for simplicity.
+* Rule configured to warn on matches of the default terms at the start of comments. Note that the complete configuration object (as already seen in the example above) and even the square brackets can be omitted for simplicity.
 
    ```json
    "no-warning-comments": 1
    ```
 
-5. Rule configured to warn on matches of the specified terms at any location in the comments. Note that you can use as many terms as you want.
+* Rule configured to warn on matches of the specified terms at any location in the comments. Note that you can use as many terms as you want.
 
    ```json
    "no-warning-comments": [1, { "terms": ["really any", "term", "can be matched"], "location": "anywhere" }]
    ```
+
+## When Not To Use It
+
+* If you have a large code base that was not developed with a policy to not use such warning terms, you might get hundreds of warnings / errors which might be contra-productive if you can't fix all of them (e.g. if you don't get the time to do it) as you might overlook other warnings / errors or get used to many of them and don't pay attention on it anymore.
+* Same reason as the point above: You shouldn't configure terms that are used very often (e.g. central parts of the native language used in your comments).

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -28,7 +28,7 @@ applies to EcmaScript 6 destructured assignment and import/export specifiers.
 It either requires or disallows spaces between those braces and the values inside of them.
 Braces that are separated from the adjacent value by a new line are exempt from this rule.
 
-### Options
+## Options
 
 There are two main options for the rule:
 
@@ -41,7 +41,7 @@ Depending on your coding conventions, you can choose either option by specifying
 "object-curly-spacing": [2, "always"]
 ```
 
-#### "never"
+### "never"
 
 When `"never"` is set, the following patterns are considered problems:
 
@@ -75,7 +75,7 @@ var {x} = y;
 import {foo} from 'bar';
 ```
 
-#### "always"
+### "always"
 
 When `"always"` is used, the following patterns are considered problems:
 
@@ -111,7 +111,7 @@ import { foo } from 'bar';
 
 Note that `{}` is always exempt from spacing requirements with this rule.
 
-#### Exceptions
+### Exceptions
 
 There are two exceptions you can apply to this rule: `objectsInObjects` and
 `arraysInObjects`. Their values can be set to either `true` or `false` as part
@@ -132,7 +132,7 @@ You can add exceptions like so:
 }]
 ```
 
-##### `objectsInObjects`
+#### `objectsInObjects`
 
 In the case of the `"always"` option, set `objectsInObjects` exception to `false` to
 enforce the following syntax (notice the `}}` at the end):
@@ -149,7 +149,7 @@ the following style (with a space between the `}` at the end:
 var obj = {"foo": {"baz": 1, "bar": 2} };
 ```
 
-##### `arraysInObjects`
+#### `arraysInObjects`
 
 In the case of the `"always"` option, set `arraysInObjects` exception to `false` to
 enforce the following syntax (notice the `]}` at the end):

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -80,15 +80,15 @@ var foo = {
 };
 ```
 
-### Options
+## Options
 
 The rule takes an option which specifies when it should be applied. It can be set to
 "always", "properties", "methods", or "never". The default is "always".
 
-1. `"always"` expects that the shorthand will be used whenever possible.
-2. `"methods"` ensures the method shorthand is used (also applies to generators).
-3. `"properties` ensures the property shorthand is used (where the key and variable name match).
-4. `"never"` ensures that no property or method shorthand is used in any object literal.
+* `"always"` expects that the shorthand will be used whenever possible.
+* `"methods"` ensures the method shorthand is used (also applies to generators).
+* `"properties` ensures the property shorthand is used (where the key and variable name match).
+* `"never"` ensures that no property or method shorthand is used in any object literal.
 
 You can set the option in configuration like this:
 

--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -20,7 +20,7 @@ This rule enforces a consistent style across the entire project.
 
 This rule enforces a consistent coding style where newlines are required or disallowed after each var declaration or just when there is a variable initialization. It ignores var declarations inside for loop conditionals.
 
-### Options
+## Options
 
 This rule takes one option, a string, which can be:
 

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -28,7 +28,7 @@ The single-declaration school of thought is based in pre-ECMAScript 6 behaviors,
 
 This rule is aimed at enforcing the use of either one variable declaration or multiple declarations per function (for `var`) or block (for `let` and `const`) scope. As such, it will warn when it encounters an unexpected number of variable declarations.
 
-### Options
+## Options
 
 There are two ways to configure this rule. The first is by using one string specified as `"always"` (the default) to enforce one variable declaration per scope or `"never"` to enforce multiple variable declarations per scope.  If you declare variables in your code with `let` and `const`, then `"always"` and `"never"` will apply to the block scope for those declarations, not the function scope.
 

--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -20,7 +20,11 @@ JavaScript provides shorthand operators that combine variable assignment and som
 
 ## Rule Details
 
-This rule enforces use of the shorthand assignment operators by requiring them where possible or prohibiting them entirely. It has two modes: `always` and `never`. The default is `always`.
+This rule enforces use of the shorthand assignment operators by requiring them where possible or prohibiting them entirely.
+
+## Options
+
+This rule has two options: `always` and `never`. The default is `always`.
 
 ### "always"
 

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -20,7 +20,7 @@ var fullHeight = borderTop
 
 The `operator-linebreak` rule is aimed at enforcing a particular operator line break style. As such, it warns whenever it sees a binary operator or assignment that does not adhere to a particular style: either placing linebreaks after or before the operators.
 
-### Options
+## Options
 
 The rule takes two options, a string, which can be `"after"`, `"before"` or `"none"` where the default is `"after"` and an object for more fine-grained configuration.
 
@@ -32,7 +32,7 @@ You can set the style in configuration like this:
 
 The default configuration is to enforce line breaks _after_ the operator except for the ternary operator `?` and `:` following that.
 
-#### "after"
+### "after"
 
 This is the default setting for this rule. This option requires the line break to be placed after the operator.
 
@@ -82,7 +82,7 @@ answer = everything ?
   foo;
 ```
 
-#### "before"
+### "before"
 
 This option requires the line break to be placed before the operator.
 
@@ -128,7 +128,7 @@ answer = everything
   : foo;
 ```
 
-#### "none"
+### "none"
 
 This option disallows line breaks on either side of the operator.
 
@@ -175,7 +175,7 @@ if (someCondition || otherCondition) {
 answer = everything ? 42 : foo;
 ```
 
-#### Fine-grained control
+### Fine-grained control
 
 The rule allows you to have even finer-grained control over individual operators by specifying an `overrides` dictionary:
 

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -34,7 +34,7 @@ This may look alright at first sight, but this code in fact throws a syntax erro
 
 This rule aims to enforce use of quotes in property names and as such will flag any properties that don't use quotes (default behavior).
 
-### Options
+## Options
 
 There are four behaviors for this rule: `"always"` (default), `"as-needed"`, `"consistent"` and `"consistent-as-needed"`. You can define these options in your configuration as:
 
@@ -44,7 +44,7 @@ There are four behaviors for this rule: `"always"` (default), `"as-needed"`, `"c
 }
 ```
 
-#### "always"
+### "always"
 
 When configured with `"always"` as the first option (the default), quoting for all properties will be enforced. Some believe that ensuring property names in object literals are always wrapped in quotes is generally a good idea, since [depending on the property name you may need to quote them anyway](https://mathiasbynens.be/notes/javascript-properties). Consider this example:
 
@@ -113,7 +113,7 @@ var object3 = {
 };
 ```
 
-#### "as-needed"
+### "as-needed"
 
 When configured with `"as-needed"` as the first option, quotes will be enforced when they are strictly required, and unnecessary quotes will cause warnings. The following patterns are considered problems:
 
@@ -219,7 +219,7 @@ var x = {
 }
 ```
 
-#### "consistent"
+### "consistent"
 
 When configured with `"consistent"`, the patterns below are considered problems. Basically `"consistent"` means all or no properties are expected to be quoted, in other words quoting style can't be mixed within an object. Please note the latter situation (no quotation at all) isn't always possible as some property names require quoting.
 
@@ -260,7 +260,7 @@ var object3 = {
 };
 ```
 
-#### "consistent-as-needed"
+### "consistent-as-needed"
 
 When configured with `"consistent-as-needed"`, the behavior is similar to `"consistent"` with one difference. Namely, properties' quoting should be consistent (as in `"consistent"`) but whenever all quotes are redundant a warning is raised. In other words if at least one property name has to be quoted (like `qux-lorem`) then all property names must be quoted, otherwise no properties can be quoted. The following patterns are considered problems:
 

--- a/docs/rules/radix.md
+++ b/docs/rules/radix.md
@@ -22,7 +22,7 @@ On the other hand, if the code is targeting only ES5-compliant environments pass
 
 This rule is aimed at preventing the unintended conversion of a string to a number of a different base than intended or at preventing the redundant `10` radix if targeting modern environments only.
 
-### Options
+## Options
 
 There are two options for this rule:
 
@@ -35,7 +35,7 @@ Depending on your coding conventions, you can choose either option by specifying
 "radix": [2, "always"]
 ```
 
-#### "always"
+### "always"
 
 The following patterns are considered problems:
 
@@ -63,7 +63,7 @@ var num = parseInt("071", 8);
 var num = parseFloat(someValue);
 ```
 
-#### "as-needed"
+### "as-needed"
 
 The following patterns are considered problems:
 

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -24,7 +24,7 @@ This rule generates warnings for nodes that do not have JSDoc comments when they
 * `ClassDeclaration`
 * `MethodDefinition`
 
-### Options
+## Options
 
 This rule accepts a `require` object with its properties as
 

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -24,7 +24,7 @@ This rule doesn't check spacing in the following cases:
 
 * The spacing around the semicolon in a for loop with an empty condition (`for(;;)`).
 
-### Options
+## Options
 
 The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`.
 If `before` is `true`, space is enforced before semicolons and if it's `false`, space is disallowed before semicolons.
@@ -37,7 +37,7 @@ The default is `{"before": false, "after": true}`.
     "semi-spacing": [2, {"before": false, "after": true}]
 ```
 
-#### `{"before": false, "after": true}`
+### `{"before": false, "after": true}`
 
 This is the default option. It enforces spacing after semicolons and disallows spacing before semicolons.
 
@@ -69,7 +69,7 @@ if (true) {;}
 ;foo();
 ```
 
-#### `{"before": true, "after": false}`
+### `{"before": true, "after": false}`
 
 This option enforces spacing before semicolons and disallows spacing after semicolons.
 

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -59,13 +59,13 @@ This rule is aimed at ensuring consistent use of semicolons. You can decide whet
 
 **Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
-### Options
+## Options
 
 The rule takes one or two options. The fists one is a string, which could be `"always"` or `"never"`. The default is `"always"`. The second one is an object for more fine-grained configuration when the first option is `"always"`.
 
 You can set the option in configuration like this:
 
-#### "always"
+### "always"
 
 By using the default option, semicolons must be used any place where they are valid.
 
@@ -97,7 +97,7 @@ object.method = function() {
 };
 ```
 
-##### Fine-grained control
+#### Fine-grained control
 
 When setting the first option as "always", an additional option can be added to omit the last semicolon in a one-line block, that is, a block in which its braces (and therefore the content of the block) are in the same line:
 
@@ -127,7 +127,7 @@ if (foo) { bar() }
 if (foo) { bar(); baz() }
 ```
 
-#### "never"
+### "never"
 
 If you want to enforce that semicolons are never used, switch the configuration to:
 

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -94,7 +94,7 @@ import {a, b, c} from 'foo.js'
 ```
 
 
-### Options
+## Options
 
 This rule accepts an object with its properties as
 
@@ -114,7 +114,7 @@ Default option settings are
 }
 ```
 
-#### `ignoreCase`
+### `ignoreCase`
 
 When `true` the rule ignores the case-sensitivity of the imports local name.
 
@@ -139,7 +139,7 @@ import c from 'baz.js';
 
 Default is `false`.
 
-#### `ignoreMemberSort`
+### `ignoreMemberSort`
 
 Ignores the member sorting within a `multiple` member import declaration.
 
@@ -159,7 +159,7 @@ import {b, a, c} from 'foo.js'
 
 Default is `false`.
 
-#### `memberSyntaxSortOrder`
+### `memberSyntaxSortOrder`
 
 The member syntax sort order can be configured with this option. There are four different styles and the default member syntax sort order is:
 

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -50,7 +50,7 @@ But this one, will only produce one:
 var c, d, a, e; /*error Variables within the same declaration block should be sorted alphabetically*/
 ```
 
-## Rule Options
+## Options
 
 ```
 "sort-vars": [<enabled>, { "ignoreCase": <boolean> }]

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -14,6 +14,8 @@ This rule will enforce consistency of spacing before blocks. It is only applied 
 * This rule ignores spacing which is between `=>` and a block. The spacing is handled by the `arrow-spacing` rule.
 * This rule ignores spacing which is between a keyword and a block. The spacing is handled by the `keyword-spacing` rule.
 
+## Options
+
 This rule takes one argument. If it is `"always"` then blocks must always have at least one preceding space. If `"never"`
 then all blocks should never have any preceding space. If different spacing is desired for function
 blocks, keyword blocks and classes, an optional configuration object can be passed as the rule argument to

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -24,6 +24,8 @@ Style guides may require a space after the `function` keyword for anonymous func
 
 This rule aims to enforce consistent spacing before function parentheses and as such, will warn whenever whitespace doesn't match the preferences specified.
 
+## Options
+
 This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`).
 
 The default configuration is `"always"`.

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -18,7 +18,7 @@ foo['bar'];
 
 This rule aims to maintain consistency around the spacing inside of square brackets, either by disallowing spaces inside of brackets between the brackets and other tokens or enforcing spaces. Brackets that are separated from the adjacent value by a new line are excepted from this rule, as this is a common pattern.  Object literals that are used as the first or last element in an array are also ignored.
 
-### Options
+## Options
 
 There are two options for this rule:
 
@@ -31,7 +31,7 @@ Depending on your coding conventions, you can choose either option by specifying
 "space-in-brackets": [2, "always"]
 ```
 
-#### "never"
+### "never"
 
 When `"never"` is set, the following patterns are considered problems:
 
@@ -95,7 +95,7 @@ var obj = {
 var obj = {};
 ```
 
-#### "always"
+### "always"
 
 When `"always"` is used, the following patterns are considered problems:
 
@@ -156,7 +156,7 @@ var obj = {
 
 Note that `"always"` has a special case where `{}` and `[]` are not considered problems.
 
-#### Exceptions
+### Exceptions
 
 An object literal may be used as a third array item to specify spacing exceptions. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing and an exception is set to `false`, it will disallow spacing for cases matching the exception. Likewise, if `"never"` is set to disallow spacing and an exception is set to `true`, it will enforce spacing for cases matching the exception.
 

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -16,7 +16,7 @@ var x = (1 + 2) * 3;
 
 This rule will enforce consistency of spacing directly inside of parentheses, by disallowing or requiring one or more spaces to the right of `(` and to the left of `)`. In either case, `()` will still be allowed.
 
-### Options
+## Options
 
 There are two options for this rule:
 
@@ -29,7 +29,7 @@ Depending on your coding conventions, you can choose either option by specifying
 "space-in-parens": [2, "always"]
 ```
 
-#### "always"
+### "always"
 
 When `"always"` is set, the following patterns are considered problems:
 
@@ -57,7 +57,7 @@ var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );
 ```
 
-#### "never"
+### "never"
 
 When `"never"` is used, the following patterns are considered problems:
 
@@ -85,7 +85,7 @@ var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());
 ```
 
-#### Exceptions
+### Exceptions
 
 An object literal may be used as a third array item to specify exceptions, with the key `"exceptions"` and an array as the value. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing, then any "exception" will *disallow* spacing. Conversely, if `"never"` is set to disallow spacing, then any "exception" will *enforce* spacing.
 

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -20,7 +20,7 @@ While this is valid JavaScript syntax, it is hard to determine what the author i
 
 This rule is aimed at ensuring there are spaces around infix operators.
 
-### Options
+## Options
 
 This rule accepts a single options argument with the following defaults:
 

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -8,7 +8,7 @@ Some styleguides require or disallow spaces before or after unary operators. Thi
 
 This rule enforces consistency regarding the spaces after `words` unary operators and after/before `nonwords` unary operators.
 
-### Options
+## Options
 
 This rule has two options: `words` and `nonwords`:
 
@@ -50,7 +50,7 @@ baz = !foo;
 qux = !!baz;
 ```
 
-### Examples
+## Examples
 
 Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are considered problems:
 

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -11,7 +11,7 @@ On the other hand, commenting out code is easier without having to put a whitesp
 This rule will enforce consistency of spacing after the start of a comment `//` or `/*`. It also provides several
 exceptions for various documentation styles.
 
-### Options
+## Options
 
 The rule takes two options. The first is a string which be either `"always"` or `"never"`. If you pass `"always"` then the `//` or `/*` must be followed by at least once whitespace. If `"never"` then there should be no whitespace following. The default is `"always"`.
 
@@ -21,7 +21,7 @@ Here is an example of how to configure the rule with this option:
 "spaced-comment": [2, "always"]
 ```
 
-#### Exceptions
+### Exceptions
 
 This rule can also take a 2nd option, an object with either of the following keys: `"exceptions"` and `"markers"`.
 
@@ -58,7 +58,7 @@ You can also define separate exceptions and markers for block and line comments:
 }]
 ```
 
-#### Examples
+## Examples
 
 The following patterns are considered problems:
 

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -26,14 +26,14 @@ Unlike scripts, ECMAScript modules are always in strict mode. Strict mode direct
 
 This rule is aimed at using strict mode directives effectively, and as such, will flag any unexpected uses or omissions of strict mode directives.
 
-### Options
+## Options
 
 There are four options for this rule:
 
-1. `"never"` - don't use `"use strict"` at all
-1. `"global"` - require `"use strict"` in the global scope
-1. `"function"` - require `"use strict"` in function scopes only
-1. `"safe"` - require `"use strict"` globally when inside a module wrapper and in function scopes everywhere else.
+* `"never"` - don't use `"use strict"` at all
+* `"global"` - require `"use strict"` in the global scope
+* `"function"` - require `"use strict"` in function scopes only
+* `"safe"` - require `"use strict"` globally when inside a module wrapper and in function scopes everywhere else.
 
 All strict mode directives are flagged as unnecessary if ECMAScript modules or implied strict mode are enabled (see [Specifying Parser Options](../user-guide/configuring#specifying-parser-options)). This behaviour does not depend on the rule options, but can be silenced by disabling this rule.
 
@@ -168,7 +168,7 @@ function foo() {
 foo();
 ```
 
-### "safe"  (default)
+### "safe" (default)
 
 Node.js and the CommonJS module system wrap modules inside a hidden function wrapper that defines each module's scope. The wrapper makes it safe to concatenate strict mode modules while maintaining their original strict mode directives. When the `node` or `commonjs` environments are enabled or `globalReturn` is enabled in `ecmaFeatures`, ESLint considers code to be inside the module wrapper, and `"safe"` mode corresponds to `"global"` mode and enforces global strict mode directives. Everywhere else, `"safe"` mode corresponds to `"function"` mode and enforces strict mode directives inside top-level functions.
 

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -13,7 +13,7 @@ let hello = `hello, ${people.name}!`;
 
 This rule aims to maintain consistency around the spacing inside of template literals.
 
-### Options
+## Options
 
 ```json
 {

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -133,9 +133,9 @@ class Foo {
 }
 ```
 
-### Options
+## Options
 
-#### `prefer`
+### `prefer`
 
 JSDoc offers a lot of tags with overlapping meaning. For example, both `@return` and `@returns` are acceptable for specifying the return value of a function. However, you may want to enforce a certain tag be used instead of others. You can specify your preferences regarding tag substitution by providing a mapping called `prefer` in the rule configuration. For example, to specify that `@returns` should be used instead of `@return`, you can use the following configuration:
 
@@ -149,7 +149,7 @@ JSDoc offers a lot of tags with overlapping meaning. For example, both `@return`
 
 With this configuration, ESLint will warn when it finds `@return` and recommend to replace it with `@returns`.
 
-#### `requireReturn`
+### `requireReturn`
 
 By default ESLint requires you to document every function with a `@return` tag regardless of whether there is anything returned by the function. If instead you want to enforce that only functions with a `return` statement are documented with a `@return` tag, set the `requireReturn` option to `false`.  When `requireReturn` is `false`, every function documented with a `@return` tag must have a `return` statement, and every function with a `return` statement must have a `@return` tag.
 
@@ -159,7 +159,7 @@ By default ESLint requires you to document every function with a `@return` tag r
 }]
 ```
 
-#### `requireParamDescription`
+### `requireParamDescription`
 
 By default ESLint requires you to specify a description for each `@param`. You can choose not to require descriptions for parameters by setting `requireParamDescription` to `false`.
 
@@ -169,7 +169,7 @@ By default ESLint requires you to specify a description for each `@param`. You c
 }]
 ```
 
-#### `requireReturnDescription`
+### `requireReturnDescription`
 
 By default ESLint requires you to specify a description for each `@return`. You can choose not to require descriptions for `@return` by setting `requireReturnDescription` to `false`.
 
@@ -179,7 +179,7 @@ By default ESLint requires you to specify a description for each `@return`. You 
 }]
 ```
 
-#### `matchDescription`
+### `matchDescription`
 
 Specify a regular expression to validate jsdoc comment block description against.
 
@@ -189,7 +189,7 @@ Specify a regular expression to validate jsdoc comment block description against
 }]
 ```
 
-#### `requireReturnType`
+### `requireReturnType`
 
 By default ESLint requires you to specify `type` for `@return` tag for every documented function.
 
@@ -199,7 +199,7 @@ By default ESLint requires you to specify `type` for `@return` tag for every doc
 }]
 ```
 
-#### preferType
+### preferType
 
 It will validate all the types from jsdoc with the options setup by the user. Inside the options, key should be what the type you want to check and the value of it should be what the expected type should be. Note that we don't check for spelling mistakes with this option.
 In the example below, it will expect the "object" to start with an uppercase and all the "string" type to start with a lowercase.

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -10,7 +10,7 @@ var x = function () { return { y: 1 };}();
 
 Since function statements cannot be immediately invoked, and function expressions can be, a common technique to create an immediately-invoked function expression is to simply wrap a function statement in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.
 
-### Options
+## Options
 
 The rule takes one option which can enforce a consistent wrapping style. The default is `outside`.
 

--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -87,7 +87,7 @@ if (-1 < str.indexOf(substr)) {
 }
 ```
 
-### Options
+## Options
 
 There are a few options to the rule:
 
@@ -100,7 +100,7 @@ There are a few options to the rule:
 
 The `onlyEquality` option is a superset of `exceptRange`, thus both options are hardly useful together.
 
-#### Range Tests
+### Range Tests
 
 "Range" comparisons test whether a variable is inside or outside the range between two literals. When configured with the `exceptRange` option, range tests are allowed when the comparison itself is wrapped directly in parentheses, such as those of an `if` or `while` condition.
 
@@ -130,7 +130,7 @@ function howLong(arr) {
 }
 ```
 
-#### Apply only to equality, but not other operators
+### Apply only to equality, but not other operators
 
 Some developers might prefer to only enforce the rule for the equality operators `==` and `===`, and not showing any warnings for any code around other operators. With `onlyEquality` option, these patterns will not be considered problems:
 


### PR DESCRIPTION
As another step toward a recommended structure for rules pages, reduce the number of depth distinctions in headings to eliminate inconsistencies in depth h2 versus h3.

Because these changes prefer less depth, they also lean toward a potential goal that each page displays a table of contents, suggested by @IanVS in https://github.com/eslint/eslint.github.io/issues/186#issuecomment-177734880

86 files changed:

- h3 from 145 occurrences in 93 files to 150 occurrences in 55 files
- h4 from 104 occurrences in 39 files to 13 occurrences in 7 files
- h5 from 12 occurrences in 6 files to 0 occurrences
- h3 + h4 + h5 from 261 occurrences in 93 files to 163 occurrences in 55 files

For comparison, no h5 and the only h4 outside rules are 27 occurrences in user-guide/command-line-interface.md

Changes to anchors:

- deleted h4 Usage
  - accessor-pairs.md
  - consistent-this.md

- deleted h3 Nomenclature
  - no-mixed-requires.md (moved content to Rule Details)

- added h2 Options in several files which I forgot to keep a list of ;)

- replaced h2 Rule Options with Options
  - no-warning-comments.md
  - sort-vars.md

The next goal is consistent punctuation of options in h3 elements.
