### PR TITLE
Breaking: new `no-empty-function` rule (fixes #5161)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -26,6 +26,7 @@
         "no-else-return": 0,
         "no-empty": 2,
         "no-empty-character-class": 2,
+        "no-empty-function": 0,
         "no-empty-pattern": 2,
         "no-eq-null": 0,
         "no-eval": 0,

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -57,6 +57,7 @@ These are rules designed to prevent you from making mistakes. They either prescr
 * [no-case-declarations](no-case-declarations.md) - disallow lexical declarations in case clauses (recommended)
 * [no-div-regex](no-div-regex.md) - disallow division operators explicitly at beginning of regular expression
 * [no-else-return](no-else-return.md) - disallow `else` after a `return` in an `if`
+* [no-empty-function](no-empty-function.md) - disallow use of empty functions
 * [no-empty-pattern](no-empty-pattern.md) - disallow use of empty destructuring patterns (recommended)
 * [no-eq-null](no-eq-null.md) - disallow comparisons to null without a type-checking operator
 * [no-eval](no-eval.md) - disallow use of `eval()`

--- a/docs/rules/no-empty-function.md
+++ b/docs/rules/no-empty-function.md
@@ -1,0 +1,297 @@
+# Disallow empty functions (no-empty-function)
+
+Empty functions can reduce readability because readers need to guess whether it's intentional or not.
+So writing a clear comment for empty functions is a good practice.
+
+```js
+function foo() {
+    // do nothing.
+}
+```
+
+Especially, the empty block of arrow functions might be confusing developers.
+It's very similar to an empty object literal.
+
+```js
+list.map(() => {});   // This is a block, would return undefined.
+list.map(() => ({})); // This is an empty object.
+```
+
+## Rule Details
+
+This rule is aimed at eliminating empty functions.
+A function will not be considered a problem if it contains a comment.
+
+The following patterns are considered problems:
+
+```js
+/*eslint no-empty-function: 2*/
+
+function foo() {}             /*error Unexpected empty function.*/
+
+var foo = function() {};      /*error Unexpected empty function.*/
+
+var foo = () => {};           /*error Unexpected empty arrow function.*/
+
+function* foo() {}            /*error Unexpected empty generator function.*/
+
+var foo = function*() {};     /*error Unexpected empty generator function.*/
+
+var obj = {
+    foo: function() {},       /*error Unexpected empty function.*/
+
+    foo: function*() {},      /*error Unexpected empty generator function.*/
+
+    foo() {},                 /*error Unexpected empty method.*/
+
+    *foo() {},                /*error Unexpected empty generator method.*/
+
+    get foo() {},             /*error Unexpected empty getter.*/
+
+    set foo(value) {}         /*error Unexpected empty setter.*/
+};
+
+class A {
+    constructor() {}          /*error Unexpected empty constructor.*/
+
+    foo() {}                  /*error Unexpected empty method.*/
+
+    *foo() {}                 /*error Unexpected empty generator method.*/
+
+    get foo() {}              /*error Unexpected empty getter.*/
+
+    set foo(value) {}         /*error Unexpected empty setter.*/
+
+    static foo() {}           /*error Unexpected empty method.*/
+
+    static *foo() {}          /*error Unexpected empty generator method.*/
+
+    static get foo() {}       /*error Unexpected empty getter.*/
+
+    static set foo(value) {}  /*error Unexpected empty setter.*/
+}
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint no-empty-function: 2*/
+
+function foo() {
+    // do nothing.
+}
+
+var foo = function() {
+    // any clear comments.
+};
+
+var foo = () => {
+    bar();
+};
+
+function* foo() {
+    // do nothing.
+}
+
+var foo = function*() {
+    // do nothing.
+};
+
+var obj = {
+    foo: function() {
+        // do nothing.
+    },
+
+    foo: function*() {
+        // do nothing.
+    },
+
+    foo() {
+        // do nothing.
+    },
+
+    *foo() {
+        // do nothing.
+    },
+
+    get foo() {
+        // do nothing.
+    },
+
+    set foo(value) {
+        // do nothing.
+    }
+};
+
+class A {
+    constructor() {
+        // do nothing.
+    }
+
+    foo() {
+        // do nothing.
+    }
+
+    *foo() {
+        // do nothing.
+    }
+
+    get foo() {
+        // do nothing.
+    }
+
+    set foo(value) {
+        // do nothing.
+    }
+
+    static foo() {
+        // do nothing.
+    }
+
+    static *foo() {
+        // do nothing.
+    }
+
+    static get foo() {
+        // do nothing.
+    }
+
+    static set foo(value) {
+        // do nothing.
+    }
+}
+```
+
+## Options
+
+```json
+{
+    "no-empty-function": [2, {"allow": []}]
+}
+```
+
+This rule has an option to allow empty of specific kind's functions.
+
+* `allow` (`string[]`) - A list of kind to allow empty functions. List items are some of the following strings. An empty array (`[]`) by default.
+    * `"functions"` - Normal functions.
+    * `"arrowFunctions"` - Arrow functions.
+    * `"generatorFunctions"` - Generator functions.
+    * `"methods"` - Class methods and method shorthands of object literals.
+    * `"generatorMethods"` - Class methods and method shorthands of object literals with generator.
+    * `"getters"` - Getters.
+    * `"setters"` - Setters.
+    * `"constructors"` - Class constructors.
+
+The following patterns are not considered problems when configured with `{"allow": ["functions"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["functions"]}]*/
+
+function foo() {}
+
+var foo = function() {};
+
+var obj = {
+    foo: function() {}
+};
+```
+
+The following patterns are not considered problems when configured with `{"allow": ["arrowFunctions"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["arrowFunctions"]}]*/
+
+var foo = () => {};
+```
+
+The following patterns are not considered problems when configured with `{"allow": ["generatorFunctions"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["generatorFunctions"]}]*/
+
+function* foo() {}
+
+var foo = function*() {};
+
+var obj = {
+    foo: function*() {}
+};
+```
+
+The following patterns are not considered problems when configured with `{"allow": ["methods"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["methods"]}]*/
+
+var obj = {
+    foo() {}
+};
+
+class A {
+    foo() {}
+    static foo() {}
+}
+```
+
+The following patterns are not considered problems when configured with `{"allow": ["generatorMethods"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["generatorMethods"]}]*/
+
+var obj = {
+    *foo() {}
+};
+
+class A {
+    *foo() {}
+    static *foo() {}
+}
+```
+
+The following patterns are not considered problems when configured with `{"allow": ["getters"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["getters"]}]*/
+
+var obj = {
+    get foo() {}
+};
+
+class A {
+    get foo() {}
+    static get foo() {}
+}
+```
+
+The following patterns are not considered problems when configured with `{"allow": ["setters"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["setters"]}]*/
+
+var obj = {
+    set foo(value) {}
+};
+
+class A {
+    set foo(value) {}
+    static set foo(value) {}
+}
+```
+
+The following patterns are not considered problems when configured with `{"allow": ["constructors"]}`:
+
+```js
+/*eslint no-empty-function: [2, {"allow": ["constructors"]}]*/
+
+class A {
+    constructor() {}
+}
+```
+
+## When Not To Use It
+
+If you don't want to be notified about empty functions, then it's safe to disable this rule.
+
+## Related Rules
+
+* [no-empty](./no-empty.md)

--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -65,38 +65,10 @@ try {
 
 Since you must always have at least a `catch` or a `finally` block for any `try`, it is common to have empty block statements when execution should continue regardless of error.
 
-### Options
-
-`methods` set to `true` will warn for empty methods. This option is set to `false` by default.
-
-```json
-{
-    "no-empty": [2, { "methods": true } ]
-}
-```
-
-The following pattern is considered a problem when `methods` is set to `true`:
-
-```js
-/*eslint no-empty: [2, { methods: true }]*/
-
-var foo = {
-    bar() {}              /*error Empty block statement.*/
-}
-```
-
-The following pattern is not considered a problem when `methods` is set to `true`:
-
-```js
-/*eslint no-empty: [2, { methods: true }]*/
-
-var foo = {
-    bar() {
-        console.log('baz');
-    }
-}
-```
-
 ## When Not To Use It
 
 If you intentionally use empty block statements then you can disable this rule.
+
+## Related Rules
+
+* [no-empty-function](./no-empty-function.md)

--- a/lib/rules/no-empty-function.js
+++ b/lib/rules/no-empty-function.js
@@ -1,0 +1,148 @@
+/**
+ * @fileoverview Rule to disallow empty functions.
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var ALLOW_OPTIONS = Object.freeze([
+    "functions",
+    "arrowFunctions",
+    "generatorFunctions",
+    "methods",
+    "generatorMethods",
+    "getters",
+    "setters",
+    "constructors"
+]);
+var SHOW_KIND = Object.freeze({
+    functions: "function",
+    arrowFunctions: "arrow function",
+    generatorFunctions: "generator function",
+    asyncFunctions: "async function",
+    methods: "method",
+    generatorMethods: "generator method",
+    asyncMethods: "async method",
+    getters: "getter",
+    setters: "setter",
+    constructors: "constructor"
+});
+
+/**
+ * Gets the kind of a given function node.
+ *
+ * @param {ASTNode} node - A function node to get. This is one of
+ *      an ArrowFunctionExpression, a FunctionDeclaration, or a
+ *      FunctionExpression.
+ * @returns {string} The kind of the function. This is one of "functions",
+ *      "arrowFunctions", "generatorFunctions", "asyncFunctions", "methods",
+ *      "generatorMethods", "asyncMethods", "getters", "setters", and
+ *      "constructors".
+ */
+function getKind(node) {
+    var parent = node.parent;
+    var kind = "";
+
+    if (node.type === "ArrowFunctionExpression") {
+        return "arrowFunctions";
+    }
+
+    // Detects main kind.
+    if (parent.type === "Property") {
+        if (parent.kind === "get") {
+            return "getters";
+        }
+        if (parent.kind === "set") {
+            return "setters";
+        }
+        kind = parent.method ? "methods" : "functions";
+
+    } else if (parent.type === "MethodDefinition") {
+        if (parent.kind === "get") {
+            return "getters";
+        }
+        if (parent.kind === "set") {
+            return "setters";
+        }
+        if (parent.kind === "constructor") {
+            return "constructors";
+        }
+        kind = "methods";
+
+    } else {
+        kind = "functions";
+    }
+
+    // Detects prefix.
+    var prefix = "";
+    if (node.generator) {
+        prefix = "generator";
+    } else if (node.async) {
+        prefix = "async";
+    } else {
+        return kind;
+    }
+    return prefix + kind[0].toUpperCase() + kind.slice(1);
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+    var options = context.options[0] || {};
+    var allowed = options.allow || [];
+
+    /**
+     * Reports a given function node if the node matches the following patterns.
+     *
+     * - Not allowed by options.
+     * - The body is empty.
+     * - The body doesn't have any comments.
+     *
+     * @param {ASTNode} node - A function node to report. This is one of
+     *      an ArrowFunctionExpression, a FunctionDeclaration, or a
+     *      FunctionExpression.
+     * @returns {void}
+     */
+    function reportIfEmpty(node) {
+        var kind = getKind(node);
+
+        if (allowed.indexOf(kind) === -1 &&
+            node.body.body.length === 0 &&
+            context.getComments(node.body).trailing.length === 0
+        ) {
+            context.report({
+                node: node,
+                loc: node.body.loc.start,
+                message: "Unexpected empty " + SHOW_KIND[kind] + "."
+            });
+        }
+    }
+
+    return {
+        ArrowFunctionExpression: reportIfEmpty,
+        FunctionDeclaration: reportIfEmpty,
+        FunctionExpression: reportIfEmpty
+    };
+};
+
+module.exports.schema = [
+    {
+        type: "object",
+        properties: {
+            allow: {
+                type: "array",
+                items: {enum: ALLOW_OPTIONS},
+                uniqueItems: true
+            }
+        },
+        additionalProperties: false
+    }
+];

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -10,29 +10,19 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
-module.exports = function(context) {
-    var config = context.options[0] || {};
-    var includeMethods = config.methods === true;
+var FUNCTION_TYPE = /^(?:ArrowFunctionExpression|Function(?:Declaration|Expression))$/;
 
+module.exports = function(context) {
     return {
         "BlockStatement": function(node) {
-            var parentType = node.parent.type;
-
             // if the body is not empty, we can just return immediately
             if (node.body.length !== 0) {
                 return;
             }
 
-            // a function is generally allowed to be empty...
-            if (parentType === "FunctionDeclaration" || parentType === "ArrowFunctionExpression") {
+            // a function is generally allowed to be empty
+            if (FUNCTION_TYPE.test(node.parent.type)) {
                 return;
-            }
-
-            // ...except ES6 methods if `methods` is true
-            if (parentType === "FunctionExpression" ) {
-                if (!includeMethods || (includeMethods && !node.parent.parent.method)) {
-                    return;
-                }
             }
 
             // any other block is only allowed to be empty, if it contains a comment
@@ -53,14 +43,4 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [
-    {
-        "type": "object",
-        "properties": {
-            "methods": {
-                "type": "boolean"
-            }
-        },
-        "additionalProperties": false
-    }
-];
+module.exports.schema = [];

--- a/tests/lib/rules/no-empty-function.js
+++ b/tests/lib/rules/no-empty-function.js
@@ -1,0 +1,236 @@
+/**
+ * @fileoverview Tests for no-empty-function rule.
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/no-empty-function"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var ALLOW_OPTIONS = Object.freeze([
+    "functions",
+    "arrowFunctions",
+    "generatorFunctions",
+    "methods",
+    "generatorMethods",
+    "getters",
+    "setters",
+    "constructors"
+]);
+
+/**
+ * Folds test items to `{valid: [], invalid: []}`.
+ * One item would be converted to 4 valid patterns and 8 invalid patterns.
+ *
+ * @param {{valid: object[], invalid: object[]}} patterns - The result.
+ * @param {{code: string, message: string, allow: string}} item - A test item.
+ * @returns {{valid: object[], invalid: object[]}} The result.
+ */
+function toValidInvalid(patterns, item) {
+    // Valid Patterns
+    patterns.valid.push(
+        {
+            code: item.code.replace("{}", "{ bar(); }"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: item.code.replace("{}", "{ /* empty */ }"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: item.code.replace("{}", "{\n    // empty\n}"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: item.code + " // allow: " + item.allow,
+            options: [{allow: [item.allow]}],
+            parserOptions: {ecmaVersion: 6}
+        }
+    );
+
+    // Invalid Patterns.
+    patterns.invalid.push({
+        code: item.code,
+        errors: [item.message],
+        parserOptions: {ecmaVersion: 6}
+    });
+    ALLOW_OPTIONS
+        .filter(function(allow) {
+            return allow !== item.allow;
+        })
+        .forEach(function(allow) {
+            // non related "allow" option has no effect.
+            patterns.invalid.push({
+                code: item.code + " // allow: " + allow,
+                errors: [item.message],
+                options: [{allow: [allow]}],
+                parserOptions: {ecmaVersion: 6}
+            });
+        });
+
+    return patterns;
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("no-empty-function", rule, [
+    {
+        code: "function foo() {}",
+        message: "Unexpected empty function.",
+        allow: "functions"
+    },
+    {
+        code: "var foo = function() {};",
+        message: "Unexpected empty function.",
+        allow: "functions"
+    },
+    {
+        code: "var obj = {foo: function() {}};",
+        message: "Unexpected empty function.",
+        allow: "functions"
+    },
+    {
+        code: "var foo = () => {};",
+        message: "Unexpected empty arrow function.",
+        allow: "arrowFunctions"
+    },
+    {
+        code: "function* foo() {}",
+        message: "Unexpected empty generator function.",
+        allow: "generatorFunctions"
+    },
+    {
+        code: "var foo = function*() {};",
+        message: "Unexpected empty generator function.",
+        allow: "generatorFunctions"
+    },
+    {
+        code: "var obj = {foo: function*() {}};",
+        message: "Unexpected empty generator function.",
+        allow: "generatorFunctions"
+    },
+    {
+        code: "var obj = {foo() {}};",
+        message: "Unexpected empty method.",
+        allow: "methods"
+    },
+    {
+        code: "class A {foo() {}}",
+        message: "Unexpected empty method.",
+        allow: "methods"
+    },
+    {
+        code: "class A {static foo() {}}",
+        message: "Unexpected empty method.",
+        allow: "methods"
+    },
+    {
+        code: "var A = class {foo() {}};",
+        message: "Unexpected empty method.",
+        allow: "methods"
+    },
+    {
+        code: "var A = class {static foo() {}};",
+        message: "Unexpected empty method.",
+        allow: "methods"
+    },
+    {
+        code: "var obj = {*foo() {}};",
+        message: "Unexpected empty generator method.",
+        allow: "generatorMethods"
+    },
+    {
+        code: "class A {*foo() {}}",
+        message: "Unexpected empty generator method.",
+        allow: "generatorMethods"
+    },
+    {
+        code: "class A {static *foo() {}}",
+        message: "Unexpected empty generator method.",
+        allow: "generatorMethods"
+    },
+    {
+        code: "var A = class {*foo() {}};",
+        message: "Unexpected empty generator method.",
+        allow: "generatorMethods"
+    },
+    {
+        code: "var A = class {static *foo() {}};",
+        message: "Unexpected empty generator method.",
+        allow: "generatorMethods"
+    },
+    {
+        code: "var obj = {get foo() {}};",
+        message: "Unexpected empty getter.",
+        allow: "getters"
+    },
+    {
+        code: "class A {get foo() {}}",
+        message: "Unexpected empty getter.",
+        allow: "getters"
+    },
+    {
+        code: "class A {static get foo() {}}",
+        message: "Unexpected empty getter.",
+        allow: "getters"
+    },
+    {
+        code: "var A = class {get foo() {}};",
+        message: "Unexpected empty getter.",
+        allow: "getters"
+    },
+    {
+        code: "var A = class {static get foo() {}};",
+        message: "Unexpected empty getter.",
+        allow: "getters"
+    },
+    {
+        code: "var obj = {set foo(value) {}};",
+        message: "Unexpected empty setter.",
+        allow: "setters"
+    },
+    {
+        code: "class A {set foo(value) {}}",
+        message: "Unexpected empty setter.",
+        allow: "setters"
+    },
+    {
+        code: "class A {static set foo(value) {}}",
+        message: "Unexpected empty setter.",
+        allow: "setters"
+    },
+    {
+        code: "var A = class {set foo(value) {}};",
+        message: "Unexpected empty setter.",
+        allow: "setters"
+    },
+    {
+        code: "var A = class {static set foo(value) {}};",
+        message: "Unexpected empty setter.",
+        allow: "setters"
+    },
+    {
+        code: "class A {constructor() {}}",
+        message: "Unexpected empty constructor.",
+        allow: "constructors"
+    },
+    {
+        code: "var A = class {constructor() {}};",
+        message: "Unexpected empty constructor.",
+        allow: "constructors"
+    }
+].reduce(toValidInvalid, {valid: [], invalid: []}));

--- a/tests/lib/rules/no-empty.js
+++ b/tests/lib/rules/no-empty.js
@@ -40,12 +40,7 @@ ruleTester.run("no-empty", rule, {
         "try { foo() } catch (ex) {/* test111 */}",
         "if (foo) { bar() } else { // nothing in me \n}",
         "if (foo) { bar() } else { /**/ \n}",
-        "if (foo) { bar() } else { // \n}",
-
-        // methods
-        "var foo = { bar: function() {} }",
-        { code: "var foo = { bar() {} }", parserOptions: { ecmaVersion: 6 } },
-        { code: "var foo = { bar() { console.log('baz'); } }", parserOptions: { ecmaVersion: 6 }, options: [{ methods: true }] }
+        "if (foo) { bar() } else { // \n}"
     ],
     invalid: [
         { code: "try {} catch (ex) {throw ex}", errors: [{ message: "Empty block statement.", type: "BlockStatement"}] },
@@ -54,9 +49,6 @@ ruleTester.run("no-empty", rule, {
         { code: "if (foo) {}", errors: [{ message: "Empty block statement.", type: "BlockStatement"}] },
         { code: "while (foo) {}", errors: [{ message: "Empty block statement.", type: "BlockStatement"}] },
         { code: "for (;foo;) {}", errors: [{ message: "Empty block statement.", type: "BlockStatement"}] },
-        { code: "switch(foo) {}", errors: [{ message: "Empty switch statement.", type: "SwitchStatement"}] },
-
-        // methods
-        { code: "var foo = { bar() {} }", parserOptions: { ecmaVersion: 6 }, options: [{ methods: true }], errors: [{ message: "Empty block statement.", type: "BlockStatement"}] }
+        { code: "switch(foo) {}", errors: [{ message: "Empty switch statement.", type: "SwitchStatement"}] }
     ]
 });


### PR DESCRIPTION
Fixes #5161

And I removed `methods` option from `no-empty` rule. It's replaced with new `no-empty-function` rule.

I has not modified the migration guide 1 to 2 because the removed option had been added in 2.0.0 pre-release.