### PR TITLE
Docs: Remove inline errors from doc examples

### DIFF
--- a/docs/rules/accessor-pairs.md
+++ b/docs/rules/accessor-pairs.md
@@ -52,14 +52,14 @@ The following patterns are considered problems by default:
 ```js
 /*eslint accessor-pairs: 2*/
 
-var o = {                       /*error Getter is not present*/
+var o = {
     set a(value) {
         this.val = value;
     }
 };
 
 var o = {d: 1};
-Object.defineProperty(o, 'c', { /*error Getter is not present*/
+Object.defineProperty(o, 'c', {
     set: function(value) {
         this.val = value;
     }
@@ -99,27 +99,27 @@ The following patterns are considered problems with option `getWithoutSet` set:
 ```js
 /*eslint accessor-pairs: [2, { getWithoutSet: true }]*/
 
-var o = {                       /*error Getter is not present*/
+var o = {
     set a(value) {
         this.val = value;
     }
 };
 
-var o = {                       /*error Setter is not present*/
+var o = {
     get a() {
         return this.val;
     }
 };
 
 var o = {d: 1};
-Object.defineProperty(o, 'c', { /*error Getter is not present*/
+Object.defineProperty(o, 'c', {
     set: function(value) {
         this.val = value;
     }
 });
 
 var o = {d: 1};
-Object.defineProperty(o, 'c', { /*error Setter is not present*/
+Object.defineProperty(o, 'c', {
     get: function() {
         return this.val;
     }

--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -43,17 +43,17 @@ When `"never"` is set, the following patterns are considered problems:
 /*eslint array-bracket-spacing: [2, "never"]*/
 /*eslint-env es6*/
 
-var arr = [ 'foo', 'bar' ];   /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var arr = ['foo', 'bar' ];                                                 /*error There should be no space before ']'*/
-var arr = [ ['foo'], 'bar'];  /*error There should be no space after '['*/
-var arr = [[ 'foo' ], 'bar']; /*error There should be no space after '['*/ /*error There should be no space before ']'*/
+var arr = [ 'foo', 'bar' ];
+var arr = ['foo', 'bar' ];
+var arr = [ ['foo'], 'bar'];
+var arr = [[ 'foo' ], 'bar'];
 var arr = ['foo',
   'bar'
 ];
-var [ x, y ] = z;             /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var [ x,y ] = z;              /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var [ x, ...y ] = z;          /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var [ ,,x, ] = z;             /*error There should be no space after '['*/ /*error There should be no space before ']'*/
+var [ x, y ] = z;
+var [ x,y ] = z;
+var [ x, ...y ] = z;
+var [ ,,x, ] = z;
 ```
 
 The following patterns are not considered problems:
@@ -88,20 +88,20 @@ When `"always"` is used, the following patterns are considered problems:
 /*eslint array-bracket-spacing: [2, "always"]*/
 /*eslint-env es6*/
 
-var arr = ['foo', 'bar'];      /*error A space is required after '['*/ /*error A space is required before ']'*/
-var arr = ['foo', 'bar' ];     /*error A space is required after '['*/
-var arr = [ ['foo'], 'bar' ];  /*error A space is required after '['*/ /*error A space is required before ']'*/
-var arr = ['foo',              /*error A space is required after '['*/
+var arr = ['foo', 'bar'];
+var arr = ['foo', 'bar' ];
+var arr = [ ['foo'], 'bar' ];
+var arr = ['foo',
   'bar'
 ];
 var arr = [
   'foo',
-  'bar'];                      /*error A space is required before ']'*/
+  'bar'];
 
-var [x, y] = z;                /*error A space is required after '['*/ /*error A space is required before ']'*/
-var [x,y] = z;                 /*error A space is required after '['*/ /*error A space is required before ']'*/
-var [x, ...y] = z;             /*error A space is required after '['*/ /*error A space is required before ']'*/
-var [,,x,] = z;                /*error A space is required after '['*/ /*error A space is required before ']'*/
+var [x, y] = z;
+var [x,y] = z;
+var [x, ...y] = z;
+var [,,x,] = z;
 ```
 
 The following patterns are not considered problems:
@@ -166,14 +166,14 @@ When `"singleValue"` is set to `false`, the following patterns are considered pr
 ```js
 /*eslint array-bracket-spacing: [2, "always", { singleValue: false }]*/
 
-var foo = [ 'foo' ];             /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var foo = [ 'foo'];              /*error There should be no space after '['*/
-var foo = ['foo' ];                                                           /*error There should be no space before ']'*/
-var foo = [ 1 ];                 /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var foo = [ 1];                  /*error There should be no space after '['*/
-var foo = [1 ];                                                               /*error There should be no space before ']'*/
-var foo = [ [ 1, 2 ] ];          /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var foo = [ { 'foo': 'bar' } ];  /*error There should be no space after '['*/ /*error There should be no space before ']'*/
+var foo = [ 'foo' ];
+var foo = [ 'foo'];
+var foo = ['foo' ];
+var foo = [ 1 ];
+var foo = [ 1];
+var foo = [1 ];
+var foo = [ [ 1, 2 ] ];
+var foo = [ { 'foo': 'bar' } ];
 ```
 
 The following patterns are not considered problems:
@@ -192,10 +192,10 @@ When `"objectsInArrays"` is set to `false`, the following patterns are considere
 ```js
 /*eslint array-bracket-spacing: [2, "always", { objectsInArrays: false }]*/
 
-var arr = [ { 'foo': 'bar' } ];   /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-var arr = [ {                     /*error There should be no space after '['*/
+var arr = [ { 'foo': 'bar' } ];
+var arr = [ {
   'foo': 'bar'
-} ]                                                                            /*error There should be no space before ']'*/
+} ]
 ```
 
 The following patterns are not considered problems:
@@ -214,8 +214,8 @@ When `"arraysInArrays"` is set to `false`, the following patterns are considered
 ```js
 /*eslint array-bracket-spacing: [2, "always", { arraysInArrays: false }]*/
 
-var arr = [ [ 1, 2 ], 2, 3, 4 ];     /*error There should be no space after '['*/
-var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ]; /*error There should be no space after '['*/ /*error There should be no space before ']'*/
+var arr = [ [ 1, 2 ], 2, 3, 4 ];
+var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -33,11 +33,11 @@ This rule finds callback functions of the following methods, then checks usage o
 The following patterns are considered problems:
 
 ```js
-var indexMap = myArray.reduce(function(memo, item, index) { /*error Expected to return a value in this function.*/
+var indexMap = myArray.reduce(function(memo, item, index) {
     memo[item] = index;
 }, {});
 
-var foo = Array.from(nodes, function(node) { /*error Expected to return a value at the end of this function.*/
+var foo = Array.from(nodes, function(node) {
     if (node.tagName === "DIV") {
         return true;
     }
@@ -47,7 +47,7 @@ var bar = foo.filter(function(x) {
     if (x) {
         return true;
     } else {
-        return;                              /*error Expected a return value.*/
+        return;
     }
 });
 ```

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -61,12 +61,12 @@ When the rule is set to `"always"` the following patterns are considered problem
 /*eslint arrow-parens: [2, "always"]*/
 /*eslint-env es6*/
 
-a => {};                     /*error Expected parentheses around arrow function argument.*/
-a => a;                      /*error Expected parentheses around arrow function argument.*/
-a => {'\n'};                 /*error Expected parentheses around arrow function argument.*/
-a.then(foo => {});           /*error Expected parentheses around arrow function argument.*/
-a.then(foo => a);            /*error Expected parentheses around arrow function argument.*/
-a(foo => { if (true) {}; }); /*error Expected parentheses around arrow function argument.*/
+a => {};
+a => a;
+a => {'\n'};
+a.then(foo => {});
+a.then(foo => a);
+a(foo => { if (true) {}; });
 ```
 
 The following patterns are not considered problems:
@@ -148,12 +148,12 @@ When the rule is set to `"as-needed"` the following patterns are considered prob
 /*eslint arrow-parens: [2, "as-needed"]*/
 /*eslint-env es6*/
 
-(a) => {};                     /*error Unexpected parentheses around single function argument*/
-(a) => a;                      /*error Unexpected parentheses around single function argument*/
-(a) => {'\n'};                 /*error Unexpected parentheses around single function argument*/
-a.then((foo) => {});           /*error Unexpected parentheses around single function argument*/
-a.then((foo) => a);            /*error Unexpected parentheses around single function argument*/
-a((foo) => { if (true) {}; }); /*error Unexpected parentheses around single function argument*/
+(a) => {};
+(a) => a;
+(a) => {'\n'};
+a.then((foo) => {});
+a.then((foo) => a);
+a((foo) => { if (true) {}; });
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -28,14 +28,14 @@ The following patterns are considered problems if `{ "before": true, "after": tr
 /*eslint arrow-spacing: 2*/
 /*eslint-env es6*/
 
-()=> {};     /*error Missing space before =>*/
-() =>{};     /*error Missing space after =>*/
-(a)=> {};    /*error Missing space before =>*/
-(a) =>{};    /*error Missing space after =>*/
-a =>a;       /*error Missing space after =>*/
-a=> a;       /*error Missing space before =>*/
-()=> {'\n'}; /*error Missing space before =>*/
-() =>{'\n'}; /*error Missing space after =>*/
+()=> {};
+() =>{};
+(a)=> {};
+(a) =>{};
+a =>a;
+a=> a;
+()=> {'\n'};
+() =>{'\n'};
 ```
 
 The following patterns are not considered problems if `{ "before": true, "after": true }`.

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -26,7 +26,7 @@ function doSomething() {
         var build = true;
     }
 
-    console.log(build); /*error 'build' used outside of binding context.*/
+    console.log(build);
 }
 ```
 
@@ -35,9 +35,9 @@ function doSomething() {
 
 function doSomething() {
     if (true) {
-        var build = true;  /*error 'build' used outside of binding context.*/
+        var build = true;
     } else {
-        var build = false; /*error 'build' used outside of binding context.*/
+        var build = false;
     }
 }
 ```
@@ -49,7 +49,7 @@ function doAnother() {
     try {
         var build = 1;
     } catch (e) {
-        var f = build; /*error 'build' used outside of binding context.*/
+        var f = build;
     }
 }
 ```

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -24,8 +24,8 @@ The following patterns are considered problems:
 
 ```js
 /*eslint block-spacing: 2*/
-function foo() {return true;} /*error Requires a space after '{'.*/ /*error Requires a space before '}'.*/
-if (foo) { bar = 0;}          /*error Requires a space before '}'.*/
+function foo() {return true;}
+if (foo) { bar = 0;}
 ```
 
 The following patterns are not considered problems:
@@ -50,8 +50,8 @@ The following patterns are considered problems:
 ```js
 /*eslint block-spacing: [2, "never"]*/
 
-function foo() { return true; } /*error Unexpected space(s) after '{'.*/ /*error Unexpected space(s) before '}'.*/
-if (foo) { bar = 0;}            /*error Unexpected space(s) after '{'.*/
+function foo() { return true; }
+if (foo) { bar = 0;}
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -61,20 +61,20 @@ This is the default setting for this rule and enforces one true brace style. Whi
 
 ```js
 /*eslint brace-style: 2*/
-function foo()       /*error Opening curly brace does not appear on the same line as controlling statement.*/
+function foo()
 {
   return true;
 }
 
-if (foo)             /*error Opening curly brace does not appear on the same line as controlling statement.*/
+if (foo)
 {
   bar();
 }
 
-try                  /*error Opening curly brace does not appear on the same line as controlling statement.*/
+try
 {
   somethingRisky();
-} catch(e)           /*error Opening curly brace does not appear on the same line as controlling statement.*/
+} catch(e)
 {
   handleError();
 }
@@ -82,7 +82,7 @@ try                  /*error Opening curly brace does not appear on the same lin
 if (foo) {
   bar();
 }
-else {              /*error Closing curly brace does not appear on the same line as the subsequent block.*/
+else {
   baz();
 }
 ```
@@ -139,27 +139,27 @@ This enforces Stroustrup style. While using this setting, the following patterns
 ```js
 /*eslint brace-style: [2, "stroustrup"]*/
 
-function foo()        /*error Opening curly brace does not appear on the same line as controlling statement.*/
+function foo()
 {
   return true;
 }
 
-if (foo)              /*error Opening curly brace does not appear on the same line as controlling statement.*/
+if (foo)
 {
   bar();
 }
 
-try                   /*error Opening curly brace does not appear on the same line as controlling statement.*/
+try
 {
   somethingRisky();
-} catch(e)            /*error Opening curly brace does not appear on the same line as controlling statement.*/ /*error Closing curly brace appears on the same line as the subsequent block.*/
+} catch(e)
 {
   handleError();
 }
 
 if (foo) {
   bar();
-} else {              /*error Closing curly brace appears on the same line as the subsequent block.*/
+} else {
   baz();
 }
 ```
@@ -220,25 +220,25 @@ This enforces Allman style. While using this setting, the following patterns are
 ```js
 /*eslint brace-style: [2, "allman"]*/
 
-function foo() {     /*error Opening curly brace appears on the same line as controlling statement.*/
+function foo() {
   return true;
 }
 
 if (foo)
 {
-  bar(); }           /*error Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.*/
+  bar(); }
 
 try
 {
   somethingRisky();
-} catch(e)           /*error Closing curly brace appears on the same line as the subsequent block.*/
+} catch(e)
 {
   handleError();
 }
 
-if (foo) {           /*error Opening curly brace appears on the same line as controlling statement.*/ /*error Opening curly brace appears on the same line as controlling statement.*/
+if (foo) {
   bar();
-} else {             /*error Closing curly brace appears on the same line as the subsequent block.*/
+} else {
   baz();
 }
 ```

--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -30,7 +30,7 @@ The following patterns are considered problems:
 
 function foo() {
     if (err) {
-        callback(err); /*error Expected return with your callback function.*/
+        callback(err);
     }
     callback();
 }
@@ -108,9 +108,9 @@ difficulty in determining what you're doing, this rule does not allow for this p
 
 function foo(callback) {
     if (err) {
-        callback(err); // this is fine, but WILL warn /*error Expected return with your callback function.*/
+        callback(err); // this is fine, but WILL warn
     } else {
-        callback();    // this is fine, but WILL warn /*error Expected return with your callback function.*/
+        callback();    // this is fine, but WILL warn
     }
 }
 ```

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -27,18 +27,18 @@ The following patterns are considered problems:
 
 ```js
 /*eslint camelcase: 2*/
-var my_favorite_color = "#112C85"; /*error Identifier 'my_favorite_color' is not in camel case.*/
+var my_favorite_color = "#112C85";
 
-function do_something() {          /*error Identifier 'do_something' is not in camel case.*/
+function do_something() {
     // ...
 }
 
-obj.do_something = function() {    /*error Identifier 'do_something' is not in camel case.*/
+obj.do_something = function() {
     // ...
 };
 
 var obj = {
-    my_pref: 1                     /*error Identifier 'my_pref' is not in camel case.*/
+    my_pref: 1
 };
 ```
 

--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -31,14 +31,14 @@ The following patterns are considered problems when configured `"never"`:
 
 var foo = {
     bar: "baz",
-    qux: "quux",   /*error Unexpected trailing comma.*/
+    qux: "quux",
 };
 
-var arr = [1,2,];  /*error Unexpected trailing comma.*/
+var arr = [1,2,];
 
 foo({
   bar: "baz",
-  qux: "quux",     /*error Unexpected trailing comma.*/
+  qux: "quux",
 });
 ```
 
@@ -67,14 +67,14 @@ The following patterns are considered problems when configured `"always"`:
 
 var foo = {
     bar: "baz",
-    qux: "quux"   /*error Missing trailing comma.*/
+    qux: "quux"
 };
 
-var arr = [1,2];  /*error Missing trailing comma.*/
+var arr = [1,2];
 
 foo({
   bar: "baz",
-  qux: "quux"     /*error Missing trailing comma.*/
+  qux: "quux"
 });
 ```
 
@@ -103,24 +103,24 @@ The following patterns are considered problems when configured `"always-multilin
 
 var foo = {
     bar: "baz",
-    qux: "quux"                         /*error Missing trailing comma.*/
+    qux: "quux"
 };
 
-var foo = { bar: "baz", qux: "quux", }; /*error Unexpected trailing comma.*/
+var foo = { bar: "baz", qux: "quux", };
 
-var arr = [1,2,];                       /*error Unexpected trailing comma.*/
+var arr = [1,2,];
 
 var arr = [1,
-    2,];                                /*error Unexpected trailing comma.*/
+    2,];
 
 var arr = [
     1,
-    2                                   /*error Missing trailing comma.*/
+    2
 ];
 
 foo({
   bar: "baz",
-  qux: "quux"                           /*error Missing trailing comma.*/
+  qux: "quux"
 });
 ```
 
@@ -156,12 +156,12 @@ The following patterns are considered problems when configured `"only-multiline"
 ```js
 /*eslint comma-dangle: [1, "only-multiline"]*/
 
-var foo = { bar: "baz", qux: "quux", }; /*error Unexpected trailing comma.*/
+var foo = { bar: "baz", qux: "quux", };
 
-var arr = [1,2,];                       /*error Unexpected trailing comma.*/
+var arr = [1,2,];
 
 var arr = [1,
-    2,];                                /*error Unexpected trailing comma.*/
+    2,];
 
 ```
 

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -33,13 +33,13 @@ The following patterns are considered problems:
 ```js
 /*eslint comma-spacing: [2, {"before": false, "after": true}]*/
 
-var foo = 1 ,bar = 2;                   /*error There should be no space before ','.*/ /*error A space is required after ','.*/
-var arr = [1 , 2];                      /*error There should be no space before ','.*/
-var obj = {"foo": "bar" ,"baz": "qur"}; /*error There should be no space before ','.*/ /*error A space is required after ','.*/
-foo(a ,b);                              /*error There should be no space before ','.*/ /*error A space is required after ','.*/
-new Foo(a ,b);                          /*error There should be no space before ','.*/ /*error A space is required after ','.*/
-function foo(a ,b){}                    /*error There should be no space before ','.*/ /*error A space is required after ','.*/
-a ,b                                    /*error There should be no space before ','.*/ /*error A space is required after ','.*/
+var foo = 1 ,bar = 2;
+var arr = [1 , 2];
+var obj = {"foo": "bar" ,"baz": "qur"};
+foo(a ,b);
+new Foo(a ,b);
+function foo(a ,b){}
+a ,b
 ```
 
 The following patterns are not considered problems:
@@ -66,12 +66,12 @@ The following patterns are considered problems:
 ```js
 /*eslint comma-spacing: [2, {"before": true, "after": false}]*/
 
-var foo = 1, bar = 2;                   /*error A space is required before ','.*/ /*error There should be no space after ','.*/
-var arr = [1 , 2];                      /*error There should be no space after ','.*/
-var obj = {"foo": "bar", "baz": "qur"}; /*error A space is required before ','.*/ /*error There should be no space after ','.*/
-new Foo(a,b);                           /*error A space is required before ','.*/
-function foo(a,b){}                     /*error A space is required before ','.*/
-a, b                                    /*error A space is required before ','.*/ /*error There should be no space after ','.*/
+var foo = 1, bar = 2;
+var arr = [1 , 2];
+var obj = {"foo": "bar", "baz": "qur"};
+new Foo(a,b);
+function foo(a,b){}
+a, b
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -30,21 +30,21 @@ While using this setting, the following patterns are considered problems:
 /*eslint comma-style: [2, "last"]*/
 
 var foo = 1
-,                        /*error Bad line breaking before and after ','.*/
+,
 bar = 2;
 
 var foo = 1
-  , bar = 2;             /*error ',' should be placed last.*/
+  , bar = 2;
 
 
 var foo = ["apples"
-           , "oranges"]; /*error ',' should be placed last.*/
+           , "oranges"];
 
 
 function bar() {
     return {
         "a": 1
-        ,"b:": 2         /*error ',' should be placed last.*/
+        ,"b:": 2
     };
 }
 
@@ -84,17 +84,17 @@ While using this setting, the following patterns are considered problems:
 /*eslint comma-style: [2, "first"]*/
 
 var foo = 1,
-    bar = 2;           /*error ',' should be placed first.*/
+    bar = 2;
 
 
 var foo = ["apples",
-           "oranges"]; /*error ',' should be placed first.*/
+           "oranges"];
 
 
 function bar() {
     return {
         "a": 1,
-        "b:": 2        /*error ',' should be placed first.*/
+        "b:": 2
     };
 }
 
@@ -142,7 +142,7 @@ The following is considered a warning:
 /*eslint comma-style: [2, "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }]*/
 
 var o = {},
-    a = []; /*error ',' should be placed first.*/
+    a = [];
 ```
 
 But the following would not be a warning:

--- a/docs/rules/complexity.md
+++ b/docs/rules/complexity.md
@@ -23,7 +23,7 @@ The following patterns are considered problems:
 ```js
 /*eslint complexity: [2, 2]*/
 
-function a(x) {               /*error Function 'a' has a complexity of 3.*/
+function a(x) {
     if (true) {
         return x;
     } else if (false) {

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -46,10 +46,10 @@ When `"never"` is set, the following patterns will give a warning:
 /*eslint computed-property-spacing: [2, "never"]*/
 /*eslint-env es6*/
 
-obj[foo ]                                                       /*error There should be no space before ']'*/
-obj[ 'foo']        /*error There should be no space after '['*/
-var x = {[ b ]: a} /*error There should be no space after '['*/ /*error There should be no space before ']'*/
-obj[foo[ bar ]]    /*error There should be no space after '['*/ /*error There should be no space before ']'*/
+obj[foo ]
+obj[ 'foo']
+var x = {[ b ]: a}
+obj[foo[ bar ]]
 ```
 
 The following patterns are considered correct:
@@ -72,13 +72,13 @@ When `"always"` is used, the following patterns will give a warning:
 /*eslint computed-property-spacing: [2, "always"]*/
 /*eslint-env es6*/
 
-obj[foo]          /*error A space is required after '['*/ /*error A space is required before ']'*/
-var x = {[b]: a}  /*error A space is required after '['*/ /*error A space is required before ']'*/
-obj[ foo]                                                 /*error A space is required before ']'*/
+obj[foo]
+var x = {[b]: a}
+obj[ foo]
 obj[ foo ]
-obj['foo' ]       /*error A space is required after '['*/
-obj[foo[ bar ]]   /*error A space is required after '['*/ /*error A space is required before ']'*/
-var x = {[ b]: a}                                         /*error A space is required before ']'*/
+obj['foo' ]
+obj[foo[ bar ]]
+var x = {[ b]: a}
 ```
 
 The following patterns are considered correct:

--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -31,7 +31,7 @@ function doSomething(condition) {
     if (condition) {
         return true;
     } else {
-        return;                   /*error Expected a return value.*/
+        return;
     }
 }
 
@@ -40,11 +40,11 @@ function doSomething(condition) {
     if (condition) {
         return;
     } else {
-        return true;              /*error Expected no return value.*/
+        return true;
     }
 }
 
-function doSomething(condition) { /*error Expected to return a value at the end of this function.*/
+function doSomething(condition) {
 
     if (condition) {
         return true;

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -42,13 +42,13 @@ The following patterns are considered problems:
 ```js
 /*eslint consistent-this: [2, "that"]*/
 
-var that = 42;   /*error Designated alias 'that' is not assigned to 'this'.*/
+var that = 42;
 
-var self = this; /*error Unexpected alias 'self' for 'this'.*/
+var self = this;
 
-that = 42;       /*error Designated alias 'that' is not assigned to 'this'.*/
+that = 42;
 
-self = this;     /*error Unexpected alias 'self' for 'this'.*/
+self = this;
 ```
 
 The following patterns are not considered problems:
@@ -85,7 +85,7 @@ But the following pattern is considered a warning:
 ```js
 /*eslint consistent-this: [2, "that"]*/
 
-var that;        /*error Designated alias 'that' is not assigned to 'this'.*/
+var that;
 function f() {
     that = this;
 }

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -18,18 +18,18 @@ The following patterns are considered problems:
 
 class A {
     constructor() {
-        super();       /*error unexpected 'super()'.*/
+        super();
     }
 }
 
 class A extends null {
     constructor() {
-        super();       /*error unexpected 'super()'.*/
+        super();
     }
 }
 
 class A extends B {
-    constructor() { }  /*error this constructor requires 'super()'.*/
+    constructor() { }
 }
 ```
 

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -25,12 +25,12 @@ The following patterns are considered problems:
 ```js
 /*eslint curly: 2*/
 
-if (foo) foo++; /*error Expected { after 'if' condition.*/
+if (foo) foo++;
 
-while (bar)     /*error Expected { after 'while' condition.*/
+while (bar)
     baz();
 
-if (foo) {      /*error Expected { after 'else'.*/
+if (foo) {
     baz();
 } else qux();
 ```
@@ -70,20 +70,20 @@ With this configuration, the rule will warn for these patterns:
 ```js
 /*eslint curly: [2, "multi"]*/
 
-if (foo) {                             /*error Unnecessary { after 'if' condition.*/
+if (foo) {
     foo++;
 }
 
-if (foo) bar();                        /*error Unnecessary { after 'else'.*/
+if (foo) bar();
 else {
     foo++;
 }
 
-while (true) {                         /*error Unnecessary { after 'while' condition.*/
+while (true) {
     doSomething();
 }
 
-for (var i=0; i < items.length; i++) { /*error Unnecessary { after 'for' condition.*/
+for (var i=0; i < items.length; i++) {
     doSomething();
 }
 ```
@@ -116,12 +116,12 @@ With this configuration, the rule will warn for these patterns:
 ```js
 /*eslint curly: [2, "multi-line"]*/
 
-if (foo)             /*error Expected { after 'if' condition.*/ /*error Expected { after 'else'.*/
+if (foo)
   doSomething();
 else
   doSomethingElse();
 
-if (foo) foo(        /*error Expected { after 'if' condition.*/
+if (foo) foo(
   bar,
   baz);
 ```
@@ -168,27 +168,27 @@ With this configuration, the rule will warn for these patterns:
 ```js
 /*eslint curly: [2, "multi-or-nest"]*/
 
-if (!foo)                   /*error Expected { after 'if' condition.*/
+if (!foo)
     foo = {
         bar: baz,
         qux: foo
     };
 
-while (true)                /*error Expected { after 'while' condition.*/
+while (true)
   if(foo)
       doSomething();
   else
       doSomethingElse();
 
-if (foo) {                  /*error Unnecessary { after 'if' condition.*/
+if (foo) {
     foo++;
 }
 
-while (true) {              /*error Unnecessary { after 'while' condition.*/
+while (true) {
     doSomething();
 }
 
-for (var i = 0; foo; i++) { /*error Unnecessary { after 'for' condition.*/
+for (var i = 0; foo; i++) {
     doSomething();
 }
 ```
@@ -239,12 +239,12 @@ With this configuration, the rule will warn for those patterns:
 if (foo) {
     bar();
     baz();
-} else                      /*error Expected { after 'else'.*/
+} else
     buz();
 
-if (foo)                    /*error Expected { after 'if' condition.*/
+if (foo)
     bar();
-else if (faa)               /*error Expected { after 'if' condition.*/
+else if (faa)
     bor();
 else {
     other();
@@ -253,11 +253,11 @@ else {
 
 if (true)
     foo();
-else {                      /*error Unnecessary { after 'else'.*/
+else {
     baz();
 }
 
-if (foo) {                  /*error Unnecessary { after 'if' condition.*/
+if (foo) {
     foo++;
 }
 ```

--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -46,7 +46,7 @@ The following pattern is considered a warning:
 ```js
 /*eslint default-case: 2*/
 
-switch (a) {       /*error Expected a default case.*/
+switch (a) {
     case 1:
         /* code */
         break;

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -38,7 +38,7 @@ The following patterns are considered problems:
 /*eslint dot-location: [2, "object"]*/
 
 var foo = object
-.property;       /*error Expected dot to be on same line as object.*/
+.property;
 ```
 
 The following patterns are not considered problems:
@@ -60,7 +60,7 @@ The following patterns are considered problems:
 ```js
 /*eslint dot-location: [2, "property"]*/
 
-var foo = object. /*error Expected dot to be on same line as property.*/
+var foo = object.
 property;
 ```
 

--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -15,7 +15,7 @@ The following patterns are considered problems:
 ```js
 /*eslint dot-notation: 2*/
 
-var x = foo["bar"]; /*error ["bar"] is better written in dot notation.*/
+var x = foo["bar"];
 ```
 
 The following patterns are not considered problems:
@@ -81,10 +81,10 @@ Example code patterns:
 /*eslint dot-notation: [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}]*/
 
 var data = {};
-data.foo_bar = 42;    /*error Identifier 'foo_bar' is not in camel case.*/
+data.foo_bar = 42;
 
 var data = {};
-data["fooBar"] = 42;  /*error ["fooBar"] is better written in dot notation.*/
+data["fooBar"] = 42;
 
 var data = {};
 data["foo_bar"] = 42; // no warning

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -20,11 +20,11 @@ The following patterns are considered problems:
 ```js
 /* eslint eqeqeq: 2 */
 
-if (x == 42) { }                     /*error Expected '===' and instead saw '=='.*/
+if (x == 42) { }
 
-if ("" == text) { }                  /*error Expected '===' and instead saw '=='.*/
+if ("" == text) { }
 
-if (obj.getStuff() != undefined) { } /*error Expected '!==' and instead saw '!='.*/
+if (obj.getStuff() != undefined) { }
 ```
 
 ### Options
@@ -61,14 +61,14 @@ The following patterns are considered problems with "smart":
 /* eslint eqeqeq: [2, "smart"] */
 
 // comparing two variables requires ===
-a == b              /*error Expected '===' and instead saw '=='.*/
+a == b
 
 // only one side is a literal
-foo == true         /*error Expected '===' and instead saw '=='.*/
-bananas != 1        /*error Expected '!==' and instead saw '!='.*/
+foo == true
+bananas != 1
 
 // comparing to undefined requires ===
-value == undefined  /*error Expected '===' and instead saw '=='.*/
+value == undefined
 ```
 
 #### "allow-null"
@@ -94,11 +94,11 @@ The following patterns are considered problems with "allow-null":
 ```js
 /* eslint eqeqeq: [2, "allow-null"] */
 
-bananas != 1              /*error Expected '!==' and instead saw '!='.*/
-typeof foo == 'undefined' /*error Expected '===' and instead saw '=='.*/
-'hello' != 'world'        /*error Expected '!==' and instead saw '!='.*/
-0 == 0                    /*error Expected '===' and instead saw '=='.*/
-foo == undefined          /*error Expected '===' and instead saw '=='.*/
+bananas != 1
+typeof foo == 'undefined'
+'hello' != 'world'
+0 == 0
+foo == undefined
 ```
 
 ## When Not To Use It

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -15,9 +15,9 @@ The following patterns are considered problems:
 ```js
 /* eslint func-names: 2*/
 
-Foo.prototype.bar = function() {}; /*error Missing function expression name.*/
+Foo.prototype.bar = function() {};
 
-(function() {                      /*error Missing function expression name.*/
+(function() {
     // ...
 }())
 ```

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -77,7 +77,7 @@ The following patterns are considered problems:
 ```js
 /*eslint func-style: [2, "declaration"]*/
 
-var foo = function() {  /*error Expected a function declaration.*/
+var foo = function() {
     // ...
 };
 ```
@@ -85,7 +85,7 @@ var foo = function() {  /*error Expected a function declaration.*/
 ```js
 /*eslint func-style: [2, "expression"]*/
 
-function foo() {  /*error Expected a function expression.*/
+function foo() {
     // ...
 }
 ```
@@ -93,7 +93,7 @@ function foo() {  /*error Expected a function expression.*/
 ```js
 /*eslint func-style: [2, "declaration"]*/
 
-var foo = () => {};  /*error Expected a function declaration.*/
+var foo = () => {};
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/global-require.md
+++ b/docs/rules/global-require.md
@@ -39,25 +39,25 @@ The following patterns are considered problems:
 
 // calling require() inside of a function is not allowed
 function readFile(filename, callback) {
-    var fs = require('fs');                                /*error Unexpected require().*/
+    var fs = require('fs');
     fs.readFile(filename, callback)
 }
 
 // conditional requires like this are also not allowed
-if (DEBUG) { require('debug'); }                           /*error Unexpected require().*/
+if (DEBUG) { require('debug'); }
 
 // a require() in a switch statement is also flagged
-switch(x) { case '1': require('1'); break; }               /*error Unexpected require().*/
+switch(x) { case '1': require('1'); break; }
 
 // you may not require() inside an arrow function body
-var getModule = (name) => require(name);                   /*error Unexpected require().*/
+var getModule = (name) => require(name);
 
 // you may not require() inside of a function body as well
-function getModule(name) { return require(name); }         /*error Unexpected require().*/
+function getModule(name) { return require(name); }
 
 // you may not require() inside of a try/catch block
 try {
-    require(unsafeModule);                                 /*error Unexpected require().*/
+    require(unsafeModule);
 } catch(e) {
     console.log(e);
 }

--- a/docs/rules/guard-for-in.md
+++ b/docs/rules/guard-for-in.md
@@ -17,7 +17,7 @@ The following patterns are considered problems:
 ```js
 /*eslint guard-for-in: 2*/
 
-for (key in foo) {    /*error The body of a for-in should be wrapped in an if statement to filter unwanted properties from the prototype.*/
+for (key in foo) {
     doSomething(key);
 }
 ```

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -20,7 +20,7 @@ The following are considered problems:
 ```js
 /*eslint handle-callback-err: 2*/
 
-function loadData (err, data) { /*error Expected error to be handled.*/
+function loadData (err, data) {
     doSomething();
 }
 

--- a/docs/rules/id-blacklist.md
+++ b/docs/rules/id-blacklist.md
@@ -37,18 +37,18 @@ For the rule in this example, the following patterns are considered problems:
 ```js
 /*eslint id-blacklist: [2, "data", "err", "e", "cb", "callback"] */
 
-var data = {...};                  /*error Identifier 'data' is blacklisted*/
+var data = {...};
 
-function callback() {              /*error Identifier 'callback' is blacklisted*/
+function callback() {
     // ...
 }
 
-element.callback = function() {    /*error Identifier 'callback' is blacklisted*/
+element.callback = function() {
     // ...
 };
 
 var itemSet = {
-    data: [...]                    /*error Identifier 'data' is blacklisted*/
+    data: [...]
 };
 ```
 

--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -19,45 +19,45 @@ The following patterns are considered problems:
 /*eslint id-length: 2*/     // default is minimum 2-chars ({ min: 2})
 /*eslint-env es6*/
 
-var x = 5;                  /*error Identifier name 'x' is too short. (< 2)*/
+var x = 5;
 
-obj.e = document.body;      /*error Identifier name 'e' is too short. (< 2)*/
+obj.e = document.body;
 
-var foo = function (e) { }; /*error Identifier name 'e' is too short. (< 2)*/
+var foo = function (e) { };
 
 try {
     dangerousStuff();
-} catch (e) {               /*error Identifier name 'e' is too short. (< 2)*/
+} catch (e) {
     // ignore as many do
 }
 
-var myObj = { a: 1 };       /*error Identifier name 'a' is too short. (< 2)*/
+var myObj = { a: 1 };
 
-(a) => { a * a };           /*error Identifier name 'a' is too short. (< 2)*/
+(a) => { a * a };
 
-function foo(x = 0) { }     /*error Identifier name 'x' is too short. (< 2)*/
+function foo(x = 0) { }
 
-class x { }                 /*error Identifier name 'x' is too short. (< 2)*/
+class x { }
 
-class Foo { x() {} }        /*error Identifier name 'x' is too short. (< 2)*/
+class Foo { x() {} }
 
-function foo(...x) { }      /*error Identifier name 'x' is too short. (< 2)*/
+function foo(...x) { }
 
-var { x} = {};              /*error Identifier name 'x' is too short. (< 2)*/
+var { x} = {};
 
-var { x: a} = {};           /*error Identifier name 'x' is too short. (< 2)*/
+var { x: a} = {};
 
-var { a: [x]} = {};         /*error Identifier name 'a' is too short. (< 2)*/
+var { a: [x]} = {};
 
-({ a: obj.x.y.z }) = {};    /*error Identifier name 'a' is too short. (< 2)*/ /*error Identifier name 'z' is too short. (< 2)*/
+({ a: obj.x.y.z }) = {};
 
-({ prop: obj.x }) = {};     /*error Identifier name 'x' is too short. (< 2)*/
+({ prop: obj.x }) = {};
 ```
 
 ```
-import x from 'y';          /*error Identifier name 'x' is too short. (< 2)*/
+import x from 'y';
 
-export var x = 0;           /*error Identifier name 'x' is too short. (< 2)*/
+export var x = 0;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/id-match.md
+++ b/docs/rules/id-match.md
@@ -34,24 +34,24 @@ For the rule in this example, which is simply camelcase, the following patterns 
 ```js
 /*eslint id-match: [2, "^[a-z]+([A-Z][a-z]+)*$", {"properties": true}]*/
 
-var my_favorite_color = "#112C85"; /*error Identifier 'my_favorite_color' does not match the pattern '^[a-z]+([A-Z][a-z]+)*$'.*/
+var my_favorite_color = "#112C85";
 
-var _myFavoriteColor  = "#112C85"; /*error Identifier '_myFavoriteColor' does not match the pattern '^[a-z]+([A-Z][a-z]+)*$'.*/
+var _myFavoriteColor  = "#112C85";
 
-var myFavoriteColor_  = "#112C85"; /*error Identifier 'myFavoriteColor_' does not match the pattern '^[a-z]+([A-Z][a-z]+)*$'.*/
+var myFavoriteColor_  = "#112C85";
 
-var MY_FAVORITE_COLOR = "#112C85"; /*error Identifier 'MY_FAVORITE_COLOR' does not match the pattern '^[a-z]+([A-Z][a-z]+)*$'.*/
+var MY_FAVORITE_COLOR = "#112C85";
 
-function do_something() {          /*error Identifier 'do_something' does not match the pattern '^[a-z]+([A-Z][a-z]+)*$'.*/
+function do_something() {
     // ...
 }
 
-obj.do_something = function() {    /*error Identifier 'do_something' does not match the pattern '^[a-z]+([A-Z][a-z]+)*$'.*/
+obj.do_something = function() {
     // ...
 };
 
 var obj = {
-    my_pref: 1                     /*error Identifier 'my_pref' does not match the pattern '^[a-z]+([A-Z][a-z]+)*$'.*/
+    my_pref: 1
 };
 ```
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -76,10 +76,10 @@ The following patterns are considered problems:
 /*eslint indent: [2, 2]*/
 
 if (a) {
-   b=c;            /*error Expected indentation of 2 space characters but found 3.*/
-function foo(d) {  /*error Expected indentation of 2 space characters but found 0.*/
-       e=f;        /*error Expected indentation of 2 space characters but found 7.*/
-}                  /*error Expected indentation of 6 space characters but found 0.*/
+   b=c;
+function foo(d) {
+       e=f;
+}
 }
 ```
 
@@ -87,9 +87,9 @@ function foo(d) {  /*error Expected indentation of 2 space characters but found 
 /*eslint indent: [2, "tab"]*/
 
 if (a) {
-     b=c;          /*error Expected indentation of 1 tab character but found 0.*/
-function foo(d) {  /*error Expected indentation of 1 tab character but found 0.*/
-           e=f;    /*error Expected indentation of 1 tab character but found 0.*/
+     b=c;
+function foo(d) {
+           e=f;
  }
 }
 ```
@@ -99,23 +99,23 @@ function foo(d) {  /*error Expected indentation of 1 tab character but found 0.*
 /*eslint-env es6*/
 
 var a,
-    b,             /*error Expected indentation of 2 space characters but found 4.*/
-    c;             /*error Expected indentation of 2 space characters but found 4.*/
+    b,
+    c;
 let a,
-    b,             /*error Expected indentation of 2 space characters but found 4.*/
-    c;             /*error Expected indentation of 2 space characters but found 4.*/
+    b,
+    c;
 const a = 1,
-    b = 2,         /*error Expected indentation of 2 space characters but found 4.*/
-    c = 3;         /*error Expected indentation of 2 space characters but found 4.*/
+    b = 2,
+    c = 3;
 ```
 
 ```js
 /*eslint indent: [2, 2, {"SwitchCase": 1}]*/
 
 switch(a){
-case "a":          /*error Expected indentation of 2 space characters but found 0.*/
+case "a":
     break;
-case "b":          /*error Expected indentation of 2 space characters but found 0.*/
+case "b":
     break;
 }
 ```

--- a/docs/rules/init-declarations.md
+++ b/docs/rules/init-declarations.md
@@ -70,8 +70,8 @@ When configured with `"always"` (the default), the following patterns are consid
 /*eslint-env es6*/
 
 function foo() {
-    var bar;     /*error Variable 'bar' should be initialized on declaration.*/
-    let baz;     /*error Variable 'baz' should be initialized on declaration.*/
+    var bar;
+    let baz;
 }
 ```
 
@@ -95,10 +95,10 @@ When configured with `"never"`, the following patterns are considered problems.
 /*eslint-env es6*/
 
 function foo() {
-    var bar = 1;   /*error Variable 'bar' should not be initialized on declaration.*/
-    let baz = 2;   /*error Variable 'baz' should not be initialized on declaration.*/
+    var bar = 1;
+    let baz = 2;
 
-    for (var i = 0; i < 1; i++) {}  /*error Variable 'i' should not be initialized on declaration.*/
+    for (var i = 0; i < 1; i++) {}
 }
 ```
 

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -47,11 +47,11 @@ The following patterns are considered problems:
 ```js
 /*eslint key-spacing: [2, {"beforeColon": false, "afterColon": false}]*/
 
-var obj = { foo: 42 };          /*error Extra space before value for key 'foo'.*/
-var bar = { baz :52 };          /*error Extra space after key 'baz'.*/
+var obj = { foo: 42 };
+var bar = { baz :52 };
 
 foo = { thisLineWouldBeTooLong:
-    soUseAnotherLine };         /*error Extra space before value for key 'thisLineWouldBeTooLong'.*/
+    soUseAnotherLine };
 ```
 
 ```js
@@ -59,8 +59,8 @@ foo = { thisLineWouldBeTooLong:
 
 function foo() {
     return {
-        foobar: 42,             /*error Missing space after key 'foobar'.*/
-        bat :"value"            /*error Missing space before value for key 'bat'.*/
+        foobar: 42,
+        bat :"value"
     };
 }
 ```
@@ -70,8 +70,8 @@ function foo() {
 
 function foo() {
     return {
-        foobar  : 42,             /*error Extra space after key 'foobar'.*/
-        bat :  "value"            /*error Extra space before value for key 'bat'.*/
+        foobar  : 42,
+        bat :  "value"
     };
 }
 ```
@@ -115,9 +115,9 @@ The following patterns are considered problems:
 /*eslint key-spacing: [2, { "align": "value" }]*/
 
 var obj = {
-    a: value,     /*error Missing space before value for key 'a'.*/
-    bcde:  42,    /*error Extra space before value for key 'bcde'.*/
-    fg :   foo()  /*error Extra space after key 'fg'.*/
+    a: value,
+    bcde:  42,
+    fg :   foo()
 };
 ```
 
@@ -156,9 +156,9 @@ The following patterns are considered problems:
 /*eslint key-spacing: [2, { "align": "colon" }]*/
 
 var obj = {
-    one:   1,  /*error Missing space after key 'one'.*/ /*error Extra space before value for key 'one'.*/
+    one:   1,
     "two": 2,
-    three:  3  /*error Extra space before value for key 'three'.*/
+    three:  3
 };
 ```
 

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -27,50 +27,44 @@ The following patterns are considered problems:
 /*eslint keyword-spacing: 2*/
 /*eslint-env es6*/
 
-if(foo){              /*error Expected space(s) after "if".*/
+if(foo){
     //...
-}else if (bar) {      /*error Expected space(s) before "else".*/
+}else if (bar) {
     //...
-} else{               /*error Expected space(s) after "else".*/
+} else{
     //...
 }
 
-try{                  /*error Expected space(s) after "try".*/
+try{
     //...
-}catch(e) {           /*error Expected space(s) before "catch".*/
-                      /*error Expected space(s) after "catch".*/
+}catch(e) {
     //...
 }
 
 switch (a) {
-    case+1:           /*error Expected space(s) after "case".*/
+    case+1:
         break;
 }
 
 function foo() {
-    return[0, 1, 2];  /*error Expected space(s) after "return".*/
+    return[0, 1, 2];
 }
 
-for (let[a, b]of[foo, bar, baz]) { /*error Expected space(s) after "let".*/
-                                   /*error Expected space(s) before "of".*/
-                                   /*error Expected space(s) after "of".*/
+for (let[a, b]of[foo, bar, baz]) {
     //...
 }
 
 let obj = {
-    get[FOO]() {      /*error Expected space(s) after "get".*/
+    get[FOO]() {
         //...
     },
-    set[FOO](value) { /*error Expected space(s) after "set".*/
+    set[FOO](value) {
         //...
     }
 };
 
-import{foo}from"foo";     /*error Expected space(s) after "import".*/
-                          /*error Expected space(s) before "from".*/
-                          /*error Expected space(s) after "from".*/
-import*as bar from "foo"; /*error Expected space(s) after "import".*/
-                          /*error Expected space(s) before "as".*/
+import{foo}from"foo";
+import*as bar from "foo";
 ```
 
 The following patterns are considered not problems:
@@ -227,50 +221,44 @@ The following patterns are considered problems when configured `{"before": false
 /*eslint keyword-spacing: [2, {before: false, after: false}]*/
 /*eslint-env es6*/
 
-if (foo){              /*error Unexpected space(s) after "if".*/
+if (foo){
     //...
-} else if(bar) {       /*error Unexpected space(s) before "else".*/
+} else if(bar) {
     //...
-}else {                /*error Unexpected space(s) after "else".*/
+}else {
     //...
 }
 
-try {                  /*error Unexpected space(s) after "try".*/
+try {
     //...
-} catch (e) {          /*error Unexpected space(s) before "catch".*/
-                       /*error Unexpected space(s) after "catch".*/
+} catch (e) {
     //...
 }
 
 switch(a) {
-    case +1:           /*error Unexpected space(s) after "case".*/
+    case +1:
         break;
 }
 
 function foo() {
-    return [0, 1, 2];  /*error Unexpected space(s) after "return".*/
+    return [0, 1, 2];
 }
 
-for (let [a, b] of [foo, bar, baz]) { /*error Unexpected space(s) after "let".*/
-                                      /*error Unexpected space(s) before "of".*/
-                                      /*error Unexpected space(s) after "of".*/
+for (let [a, b] of [foo, bar, baz]) {
     //...
 }
 
 let obj = {
-    get [FOO]() {      /*error Unexpected space(s) after "get".*/
+    get [FOO]() {
         //...
     },
-    set [FOO](value) { /*error Unexpected space(s) after "set".*/
+    set [FOO](value) {
         //...
     }
 };
 
-import {foo} from "foo";   /*error Unexpected space(s) after "import".*/
-                           /*error Unexpected space(s) before "from".*/
-                           /*error Unexpected space(s) after "from".*/
-import * as bar from"foo"; /*error Unexpected space(s) after "import".*/
-                           /*error Unexpected space(s) before "as".*/
+import {foo} from "foo";
+import * as bar from"foo";
 ```
 
 The following patterns are considered not problems when configured `{"before": false, "after": false}`:

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -17,21 +17,21 @@ The following patterns are considered problems:
 ```js
 /*eslint linebreak-style: 2*/
 
-var a = 'a', // \r\n /*error Expected linebreaks to be 'LF' but found 'CRLF'.*/
+var a = 'a', // \r\n
     b = 'b'; // \n
 ```
 
 ```js
 /*eslint linebreak-style: [2, "unix"]*/
 
-var a = 'a'; // \r\n /*error Expected linebreaks to be 'LF' but found 'CRLF'.*/
+var a = 'a'; // \r\n
 
 ```
 
 ```js
 /*eslint linebreak-style: [2, "windows"]*/
 
-var a = 'a';// \n    /*error Expected linebreaks to be 'CRLF' but found 'LF'.*/
+var a = 'a';// \n
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -81,7 +81,7 @@ This however would provide 2 warnings:
 /*eslint lines-around-comment: [2, { "beforeBlockComment": true, "afterBlockComment": true }]*/
 
 var night = "long";
-/* what a great and wonderful day */  /*error Expected line before comment.*/ /*error Expected line after comment.*/
+/* what a great and wonderful day */
 var day = "great"
 ```
 
@@ -103,7 +103,7 @@ But this would cause 1 warning:
 /*eslint lines-around-comment: [2, { "beforeBlockComment": true }]*/
 
 var night = "long";
-/* what a great and wonderful day */     /*error Expected line before comment.*/
+/* what a great and wonderful day */
 var day = "great"
 ```
 

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -34,7 +34,7 @@ The following patterns are considered problems:
 function foo() {
   for (;;) {
     if (true) {
-      if (true) { /*error Blocks are nested too deeply (3).*/
+      if (true) {
 
       }
     }

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -19,7 +19,7 @@ The following patterns are considered problems:
 ```js
 /*eslint max-len: [2, 80, 4]*/ // maximum length of 80 characters
 
-var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" }; /*error Line 3 exceeds the maximum line length of 80.*/
+var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" };
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -34,7 +34,7 @@ The following patterns are considered problems:
 foo(function () {
     bar(function () {
         baz(function() {
-            qux(function () { /*error Too many nested callbacks (4). Maximum allowed is 3.*/
+            qux(function () {
 
             });
         });

--- a/docs/rules/max-params.md
+++ b/docs/rules/max-params.md
@@ -17,7 +17,7 @@ The following patterns are considered problems:
 ```js
 /*eslint max-params: [2, 3]*/
 
-function foo (bar, baz, qux, qxx) { /*error This function has too many parameters (4). Maximum allowed is 3.*/
+function foo (bar, baz, qux, qxx) {
     doSomething();
 }
 ```

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -26,7 +26,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint max-statements: [2, 2]*/  // Maximum of 2 statements.
-function foo() { /*error This function has too many statements (3). Maximum allowed is 2.*/
+function foo() {
   var bar = 1;
   var baz = 2;
 

--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -15,8 +15,8 @@ The following patterns are considered problems:
 ```js
 /*eslint new-cap: 2*/
 
-var friend = new person(); /*error A constructor name should not start with a lowercase letter.*/
-var colleague = Person();  /*error A function with a name starting with an uppercase letter should only be used as a constructor.*/
+var friend = new person();
+var colleague = Person();
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -15,7 +15,7 @@ The following patterns are considered problems:
 ```js
 /*eslint new-parens: 2*/
 
-var person = new Person; /*error Missing '()' invoking a constructor*/
+var person = new Person;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -33,7 +33,7 @@ The following patterns are considered problems:
 ```js
 /*eslint newline-after-var: [2, "always"]*/
 
-var greet = "hello,",      /*error Expected blank line after variable declarations.*/
+var greet = "hello,",
     name = "world";
 console.log(greet, name);
 ```
@@ -42,7 +42,7 @@ console.log(greet, name);
 /*eslint newline-after-var: [2, "never"]*/
 /*eslint-env es6*/
 
-let greet = "hello,",     /*error Unexpected blank line after variable declarations.*/
+let greet = "hello,",
     name = "world";
 
 console.log(greet, name);
@@ -53,7 +53,7 @@ console.log(greet, name);
 /*eslint-env es6*/
 
 var greet = "hello,";
-const NAME = "world";      /*error Expected blank line after variable declarations.*/
+const NAME = "world";
 console.log(greet, NAME);
 ```
 
@@ -96,14 +96,14 @@ The following patterns are considered problems:
 /*eslint newline-after-var: [2, "always"]*/
 
 var greet = "hello,";
-var name = "world";             /*error Expected blank line after variable declarations.*/
+var name = "world";
 // var name = require("world");
 console.log(greet, name);
 
 
 /*eslint-disable camelcase*/
 var greet = "hello,";
-var target_name = "world";      /*error Expected blank line after variable declarations.*/
+var target_name = "world";
 /*eslint-enable camelcase*/
 console.log(greet, name);
 ```

--- a/docs/rules/no-alert.md
+++ b/docs/rules/no-alert.md
@@ -15,11 +15,11 @@ The following patterns are considered problems:
 ```js
 /*eslint no-alert: 2*/
 
-alert("here!");                          /*error Unexpected alert.*/
+alert("here!");
 
-confirm("Are you sure?");                /*error Unexpected confirm.*/
+confirm("Are you sure?");
 
-prompt("What's your name?", "John Doe"); /*error Unexpected prompt.*/
+prompt("What's your name?", "John Doe");
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-array-constructor.md
+++ b/docs/rules/no-array-constructor.md
@@ -13,13 +13,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-array-constructor: 2*/
 
-Array(0, 1, 2)     /*error The array literal notation [] is preferrable.*/
+Array(0, 1, 2)
 ```
 
 ```js
 /*eslint no-array-constructor: 2*/
 
-new Array(0, 1, 2) /*error The array literal notation [] is preferrable.*/
+new Array(0, 1, 2)
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-bitwise.md
+++ b/docs/rules/no-bitwise.md
@@ -15,31 +15,31 @@ The following patterns are considered problems:
 ```js
 /*eslint no-bitwise: 2*/
 
-var x = y | z;   /*error Unexpected use of '|'.*/
+var x = y | z;
 
-var x = y & z;   /*error Unexpected use of '&'.*/
+var x = y & z;
 
-var x = y ^ z;   /*error Unexpected use of '^'.*/
+var x = y ^ z;
 
-var x = ~ z;     /*error Unexpected use of '~'.*/
+var x = ~ z;
 
-var x = y << z;  /*error Unexpected use of '<<'.*/
+var x = y << z;
 
-var x = y >> z;  /*error Unexpected use of '>>'.*/
+var x = y >> z;
 
-var x = y >>> z; /*error Unexpected use of '>>>'.*/
+var x = y >>> z;
 
-x |= y;          /*error Unexpected use of '|='.*/
+x |= y;
 
-x &= y;          /*error Unexpected use of '&='.*/
+x &= y;
 
-x ^= y;          /*error Unexpected use of '^='.*/
+x ^= y;
 
-x <<= y;         /*error Unexpected use of '<<='.*/
+x <<= y;
 
-x >>= y;         /*error Unexpected use of '>>='.*/
+x >>= y;
 
-x >>>= y;        /*error Unexpected use of '>>>='.*/
+x >>>= y;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-caller.md
+++ b/docs/rules/no-caller.md
@@ -22,11 +22,11 @@ function foo(n) {
         return;
     }
 
-    arguments.callee(n - 1);   /*error Avoid arguments.callee.*/
+    arguments.callee(n - 1);
 }
 
 [1,2,3,4,5].map(function(n) {
-    return !(n > 1) ? 1 : arguments.callee(n - 1) * n; /*error Avoid arguments.callee.*/
+    return !(n > 1) ? 1 : arguments.callee(n - 1) * n;
 });
 ```
 

--- a/docs/rules/no-case-declarations.md
+++ b/docs/rules/no-case-declarations.md
@@ -53,16 +53,16 @@ This rule aims to prevent access to uninitialized lexical bindings as well as ac
 
 switch (foo) {
     case 1:
-        let x = 1;  /*error Unexpected lexical declaration in case block.*/
+        let x = 1;
         break;
     case 2:
-        const y = 2;  /*error Unexpected lexical declaration in case block.*/
+        const y = 2;
         break;
     case 3:
-        function f() {}  /*error Unexpected lexical declaration in case block.*/
+        function f() {}
         break;
     default:
-        class C {}  /*error Unexpected lexical declaration in case block.*/
+        class C {}
 }
 ```
 

--- a/docs/rules/no-catch-shadow.md
+++ b/docs/rules/no-catch-shadow.md
@@ -27,7 +27,7 @@ var err = "x";
 
 try {
     throw "problem";
-} catch (err) {      /*error Value of 'err' may be overwritten in IE 8 and earlier.*/
+} catch (err) {
 
 }
 
@@ -37,7 +37,7 @@ function err() {
 
 try {
     throw "problem";
-} catch (err) {      /*error Value of 'err' may be overwritten in IE 8 and earlier.*/
+} catch (err) {
 
 }
 ```

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -22,14 +22,14 @@ The following patterns are considered problems:
 /*eslint-env es6*/
 
 class A { }
-A = 0;         /*error 'A' is a class.*/
+A = 0;
 ```
 
 ```js
 /*eslint no-class-assign: 2*/
 /*eslint-env es6*/
 
-A = 0;         /*error 'A' is a class.*/
+A = 0;
 class A { }
 ```
 
@@ -39,7 +39,7 @@ class A { }
 
 class A {
     b() {
-        A = 0; /*error 'A' is a class.*/
+        A = 0;
     }
 }
 ```
@@ -50,7 +50,7 @@ class A {
 
 let A = class A {
     b() {
-        A = 0; /*error 'A' is a class.*/
+        A = 0;
         // `let A` is shadowed by the class name.
     }
 }

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -33,14 +33,14 @@ The following patterns are considered problems:
 
 // Unintentional assignment
 var x;
-if (x = 0) {         /*error Expected a conditional expression and instead saw an assignment.*/
+if (x = 0) {
     var b = 1;
 }
 
 // Practical example that is similar to an error
 function setHeight(someNode) {
     "use strict";
-    do {             /*error Expected a conditional expression and instead saw an assignment.*/
+    do {
         someNode.height = "100px";
     } while (someNode = someNode.parentNode);
 }
@@ -85,14 +85,14 @@ The following patterns are considered problems:
 
 // Unintentional assignment
 var x;
-if (x = 0) {         /*error Unexpected assignment within an 'if' statement.*/
+if (x = 0) {
     var b = 1;
 }
 
 // Practical example that is similar to an error
 function setHeight(someNode) {
     "use strict";
-    do {             /*error Unexpected assignment within a 'do...while' statement.*/
+    do {
         someNode.height = "100px";
     } while (someNode = someNode.parentNode);
 }
@@ -100,7 +100,7 @@ function setHeight(someNode) {
 // Practical example that wraps the assignment in parentheses
 function setHeight(someNode) {
     "use strict";
-    do {             /*error Unexpected assignment within a 'do...while' statement.*/
+    do {
         someNode.height = "100px";
     } while ((someNode = someNode.parentNode));
 }
@@ -108,7 +108,7 @@ function setHeight(someNode) {
 // Practical example that wraps the assignment and tests for 'null'
 function setHeight(someNode) {
     "use strict";
-    do {             /*error Unexpected assignment within a 'do...while' statement.*/
+    do {
         someNode.height = "100px";
     } while ((someNode = someNode.parentNode) !== null);
 }

--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -17,8 +17,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-console: 2*/
 
-console.log("Hello world!");              /*error Unexpected console statement.*/
-console.error("Something bad happened."); /*error Unexpected console statement.*/
+console.log("Hello world!");
+console.error("Something bad happened.");
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-const-assign.md
+++ b/docs/rules/no-const-assign.md
@@ -16,7 +16,7 @@ The following patterns are considered problems:
 /*eslint-env es6*/
 
 const a = 0;
-a = 1;       /*error 'a' is constant.*/
+a = 1;
 ```
 
 ```js
@@ -24,7 +24,7 @@ a = 1;       /*error 'a' is constant.*/
 /*eslint-env es6*/
 
 const a = 0;
-a += 1;      /*error 'a' is constant.*/
+a += 1;
 ```
 
 ```js
@@ -32,7 +32,7 @@ a += 1;      /*error 'a' is constant.*/
 /*eslint-env es6*/
 
 const a = 0;
-++a;         /*error 'a' is constant.*/
+++a;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -20,7 +20,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-constant-condition: 2*/
 
-if (true) {             /*error Unexpected constant condition.*/
+if (true) {
     doSomething();
 }
 ```
@@ -28,13 +28,13 @@ if (true) {             /*error Unexpected constant condition.*/
 ```js
 /*eslint no-constant-condition: 2*/
 
-var result = 0 ? a : b; /*error Unexpected constant condition.*/
+var result = 0 ? a : b;
 ```
 
 ```js
 /*eslint no-constant-condition: 2*/
 
-while (-2) {            /*error Unexpected constant condition.*/
+while (-2) {
     doSomething();
 }
 ```
@@ -42,7 +42,7 @@ while (-2) {            /*error Unexpected constant condition.*/
 ```js
 /*eslint no-constant-condition: 2*/
 
-for (;true;) {          /*error Unexpected constant condition.*/
+for (;true;) {
     doSomething();
 }
 ```
@@ -50,7 +50,7 @@ for (;true;) {          /*error Unexpected constant condition.*/
 ```js
 /*eslint no-constant-condition: 2*/
 
-do{                     /*error Unexpected constant condition.*/
+do{
     something();
 } while (x = -1)
 ```

--- a/docs/rules/no-continue.md
+++ b/docs/rules/no-continue.md
@@ -30,7 +30,7 @@ var sum = 0,
 
 for(i = 0; i < 10; i++) {
     if(i >= 5) {
-        continue;              /*error Unexpected use of continue statement*/
+        continue;
     }
 
     a += i;
@@ -45,7 +45,7 @@ var sum = 0,
 
 labeledLoop: for(i = 0; i < 10; i++) {
     if(i >= 5) {
-        continue labeledLoop;  /*error Unexpected use of continue statement*/
+        continue labeledLoop;
     }
 
     a += i;

--- a/docs/rules/no-control-regex.md
+++ b/docs/rules/no-control-regex.md
@@ -13,7 +13,7 @@ The following patterns are considered problems:
 /*eslint no-control-regex: 2*/
 
 var pattern1 = /\\x1f/;
-var pattern2 = new RegExp("\x1f"); /*error Unexpected control character in regular expression.*/
+var pattern2 = new RegExp("\x1f");
 ```
 
 The following patterns do not cause a warning:

--- a/docs/rules/no-delete-var.md
+++ b/docs/rules/no-delete-var.md
@@ -6,7 +6,7 @@ This rule prevents the use of `delete` operator on variables:
 /*eslint no-delete-var: 2*/
 
 var x;
-delete x;  /*error Variables should not be deleted.*/
+delete x;
 ```
 
 The delete operator will only delete the properties of objects. It cannot "delete" variables or anything else. Using them on variables might lead to unexpected behavior.

--- a/docs/rules/no-div-regex.md
+++ b/docs/rules/no-div-regex.md
@@ -15,7 +15,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-div-regex: 2*/
 
-function bar() { return /=foo/; } /*error A regular expression literal can be confused with '/='.*/
+function bar() { return /=foo/; }
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-dupe-args.md
+++ b/docs/rules/no-dupe-args.md
@@ -13,7 +13,7 @@ For example the following code will cause the rule to warn:
 ```js
 /*eslint no-dupe-args: 2*/
 
-function foo(a, b, a) {               /*error Duplicate param 'a'.*/
+function foo(a, b, a) {
     console.log("which a is it?", a);
 }
 ```

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -27,17 +27,17 @@ The following patterns are considered problems:
 
 class Foo {
   bar() { }
-  bar() { }          /*error Duplicate name 'bar'.*/
+  bar() { }
 }
 
 class Foo {
   bar() { }
-  get bar() { }      /*error Duplicate name 'bar'.*/
+  get bar() { }
 }
 
 class Foo {
   static bar() { }
-  static bar() { }   /*error Duplicate name 'bar'.*/
+  static bar() { }
 }
 ```
 

--- a/docs/rules/no-dupe-keys.md
+++ b/docs/rules/no-dupe-keys.md
@@ -20,17 +20,17 @@ The following patterns are considered problems:
 
 var foo = {
     bar: "baz",
-    bar: "qux"     /*error Duplicate key 'bar'.*/
+    bar: "qux"
 };
 
 var foo = {
     "bar": "baz",
-    bar: "qux"     /*error Duplicate key 'bar'.*/
+    bar: "qux"
 };
 
 var foo = {
     0x1: "baz",
-    1: "qux"       /*error Duplicate key '1'.*/
+    1: "qux"
 };
 ```
 

--- a/docs/rules/no-duplicate-case.md
+++ b/docs/rules/no-duplicate-case.md
@@ -35,7 +35,7 @@ var a = 1,
 switch (a) {
     case 1:
         break;
-    case 1:      /*error Duplicate case label.*/
+    case 1:
         break;
     case 2:
         break;
@@ -46,7 +46,7 @@ switch (a) {
 switch (a) {
     case "1":
         break;
-    case "1":    /*error Duplicate case label.*/
+    case "1":
         break;
     case "2":
         break;
@@ -57,7 +57,7 @@ switch (a) {
 switch (a) {
     case one:
         break;
-    case one:    /*error Duplicate case label.*/
+    case one:
         break;
     case 2:
         break;

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -24,7 +24,7 @@ The following patterns are considered problems:
 function foo() {
     if (x) {
         return y;
-    } else {            /*error Unexpected 'else' after 'return'.*/
+    } else {
         return z;
     }
 }
@@ -34,7 +34,7 @@ function foo() {
         return y;
     } else if (z) {
         return w;
-    } else {            /*error Unexpected 'else' after 'return'.*/
+    } else {
         return t;
     }
 }
@@ -42,7 +42,7 @@ function foo() {
 function foo() {
     if (x) {
         return y;
-    } else {            /*error Unexpected 'else' after 'return'.*/
+    } else {
         var t = "foo";
     }
 
@@ -54,10 +54,10 @@ function foo() {
     if (x) {
         if (y) {
             return y;
-        } else {        /*error Unexpected 'else' after 'return'.*/
+        } else {
             return x;
         }
-    } else {            /*error Unexpected 'else' after 'return'.*/
+    } else {
         return z;
     }
 }

--- a/docs/rules/no-empty-character-class.md
+++ b/docs/rules/no-empty-character-class.md
@@ -15,11 +15,11 @@ The following patterns are considered problems:
 ```js
 /*eslint no-empty-character-class: 2*/
 
-var foo = /^abc[]/;  /*error Empty class.*/
+var foo = /^abc[]/;
 
-/^abc[]/.test(foo);  /*error Empty class.*/
+/^abc[]/.test(foo);
 
-bar.match(/^abc[]/); /*error Empty class.*/
+bar.match(/^abc[]/);
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-empty-function.md
+++ b/docs/rules/no-empty-function.md
@@ -27,48 +27,48 @@ The following patterns are considered problems:
 ```js
 /*eslint no-empty-function: 2*/
 
-function foo() {}             /*error Unexpected empty function.*/
+function foo() {}
 
-var foo = function() {};      /*error Unexpected empty function.*/
+var foo = function() {};
 
-var foo = () => {};           /*error Unexpected empty arrow function.*/
+var foo = () => {};
 
-function* foo() {}            /*error Unexpected empty generator function.*/
+function* foo() {}
 
-var foo = function*() {};     /*error Unexpected empty generator function.*/
+var foo = function*() {};
 
 var obj = {
-    foo: function() {},       /*error Unexpected empty function.*/
+    foo: function() {},
 
-    foo: function*() {},      /*error Unexpected empty generator function.*/
+    foo: function*() {},
 
-    foo() {},                 /*error Unexpected empty method.*/
+    foo() {},
 
-    *foo() {},                /*error Unexpected empty generator method.*/
+    *foo() {},
 
-    get foo() {},             /*error Unexpected empty getter.*/
+    get foo() {},
 
-    set foo(value) {}         /*error Unexpected empty setter.*/
+    set foo(value) {}
 };
 
 class A {
-    constructor() {}          /*error Unexpected empty constructor.*/
+    constructor() {}
 
-    foo() {}                  /*error Unexpected empty method.*/
+    foo() {}
 
-    *foo() {}                 /*error Unexpected empty generator method.*/
+    *foo() {}
 
-    get foo() {}              /*error Unexpected empty getter.*/
+    get foo() {}
 
-    set foo(value) {}         /*error Unexpected empty setter.*/
+    set foo(value) {}
 
-    static foo() {}           /*error Unexpected empty method.*/
+    static foo() {}
 
-    static *foo() {}          /*error Unexpected empty generator method.*/
+    static *foo() {}
 
-    static get foo() {}       /*error Unexpected empty getter.*/
+    static get foo() {}
 
-    static set foo(value) {}  /*error Unexpected empty setter.*/
+    static set foo(value) {}
 }
 ```
 

--- a/docs/rules/no-empty-label.md
+++ b/docs/rules/no-empty-label.md
@@ -14,7 +14,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-empty-label: 2*/
 
-labeled:     /*error Unexpected label 'labeled'*/
+labeled:
 var x = 10;
 ```
 

--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -19,20 +19,20 @@ The following patterns are considered problems:
 ```js
 /*eslint no-empty: 2*/
 
-if (foo) {         /*error Empty block statement.*/
+if (foo) {
 }
 
-while (foo) {      /*error Empty block statement.*/
+while (foo) {
 }
 
-switch(foo) {      /*error Empty switch statement.*/
+switch(foo) {
 }
 
 try {
     doSomething();
-} catch(ex) {      /*error Empty block statement.*/
+} catch(ex) {
 
-} finally {        /*error Empty block statement.*/
+} finally {
 
 }
 ```

--- a/docs/rules/no-eq-null.md
+++ b/docs/rules/no-eq-null.md
@@ -17,11 +17,11 @@ The following patterns are considered problems:
 ```js
 /*eslint no-eq-null: 2*/
 
-if (foo == null) {     /*error Use ‘===’ to compare with ‘null’.*/
+if (foo == null) {
   bar();
 }
 
-while (qux != null) {  /*error Use ‘===’ to compare with ‘null’.*/
+while (qux != null) {
   baz();
 }
 ```

--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -19,29 +19,29 @@ The following patterns are considered problems:
 
 var obj = { x: "foo" },
     key = "x",
-    value = eval("obj." + key); /*error eval can be harmful.*/
+    value = eval("obj." + key);
 
-(0, eval)("var a = 0");         /*error eval can be harmful.*/
+(0, eval)("var a = 0");
 
-var foo = eval;                 /*error eval can be harmful.*/
+var foo = eval;
 foo("var a = 0");
 
 // This `this` is the global object.
-this.eval("var a = 0");         /*error eval can be harmful.*/
+this.eval("var a = 0");
 ```
 
 ```js
 /*eslint no-eval: 2*/
 /*eslint-env browser*/
 
-window.eval("var a = 0"); /*error eval can be harmful.*/
+window.eval("var a = 0");
 ```
 
 ```js
 /*eslint no-eval: 2*/
 /*eslint-env node*/
 
-global.eval("var a = 0"); /*error eval can be harmful.*/
+global.eval("var a = 0");
 ```
 
 The following patterns are not considered problems:
@@ -82,7 +82,7 @@ With this option the following patterns are considered problems:
 
 var obj = { x: "foo" },
     key = "x",
-    value = eval("obj." + key); /*error eval can be harmful.*/
+    value = eval("obj." + key);
 ```
 
 With this option the following patterns are not considered problems:

--- a/docs/rules/no-ex-assign.md
+++ b/docs/rules/no-ex-assign.md
@@ -25,7 +25,7 @@ The following patterns are considered problems:
 try {
     // code
 } catch (e) {
-    e = 10;   /*error Do not assign to the exception parameter.*/
+    e = 10;
 }
 ```
 

--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -37,25 +37,25 @@ The following patterns are considered problems:
 /*eslint no-extra-bind: 2*/
 /*eslint-env es6*/
 
-var x = function () {   /*error The function binding is unnecessary.*/
+var x = function () {
     foo();
 }.bind(bar);
 
-var x = (() => {        /*error The function binding is unnecessary.*/
+var x = (() => {
     foo();
 }).bind(bar);
 
-var x = (() => {        /*error The function binding is unnecessary.*/
+var x = (() => {
     this.foo();
 }).bind(bar);
 
-var x = function () {   /*error The function binding is unnecessary.*/
+var x = function () {
     (function () {
       this.foo();
     }());
 }.bind(bar);
 
-var x = function () {   /*error The function binding is unnecessary.*/
+var x = function () {
     function foo() {
       this.bar();
     }

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -25,31 +25,31 @@ The following patterns are considered problems:
 ```js
 /*eslint no-extra-boolean-cast: 2*/
 
-var foo = !!!bar;             /*error Redundant double negation.*/
+var foo = !!!bar;
 
-var foo = !!bar ? baz : bat;  /*error Redundant double negation.*/
+var foo = !!bar ? baz : bat;
 
-var foo = Boolean(!!bar);     /*error Redundant double negation.*/
+var foo = Boolean(!!bar);
 
-var foo = new Boolean(!!bar); /*error Redundant double negation.*/
+var foo = new Boolean(!!bar);
 
-if (!!foo) {                  /*error Redundant double negation.*/
+if (!!foo) {
     // ...
 }
 
-if (Boolean(foo)) {           /*error Redundant Boolean call.*/
+if (Boolean(foo)) {
     // ...
 }
 
-while (!!foo) {               /*error Redundant double negation.*/
+while (!!foo) {
     // ...
 }
 
 do {
     // ...
-} while (Boolean(foo));       /*error Redundant Boolean call.*/
+} while (Boolean(foo));
 
-for (; !!foo; ) {             /*error Redundant double negation.*/
+for (; !!foo; ) {
     // ...
 }
 ```

--- a/docs/rules/no-extra-label.md
+++ b/docs/rules/no-extra-label.md
@@ -21,16 +21,16 @@ The following patterns are considered problems:
 /*eslint no-extra-label: 2*/
 
 A: while (a) {
-    break A;      /*error This label 'A' is unnecessary.*/
+    break A;
 }
 
 B: for (let i = 0; i < 10; ++i) {
-    break B;      /*error This label 'B' is unnecessary.*/
+    break B;
 }
 
 C: switch (a) {
     case 0:
-        break C;  /*error This label 'C' is unnecessary.*/
+        break C;
 }
 ```
 

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -27,13 +27,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-extra-parens: 2*/
 
-a = (b * c); /*error Gratuitous parentheses around expression.*/
+a = (b * c);
 
-(a * b) + c; /*error Gratuitous parentheses around expression.*/
+(a * b) + c;
 
-typeof (a);  /*error Gratuitous parentheses around expression.*/
+typeof (a);
 
-(function(){} ? a() : b());  /*error Gratuitous parentheses around expression.*/
+(function(){} ? a() : b());
 ```
 
 The following patterns are not considered problems:
@@ -75,9 +75,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-extra-parens: [2, "functions"]*/
 
-((function foo() {}))();           /*error Gratuitous parentheses around expression.*/
+((function foo() {}))();
 
-var y = (function () {return 1;}); /*error Gratuitous parentheses around expression.*/
+var y = (function () {return 1;});
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -13,11 +13,11 @@ The following patterns are considered problems:
 ```js
 /*eslint no-extra-semi: 2*/
 
-var x = 5;;      /*error Unnecessary semicolon.*/
+var x = 5;;
 
 function foo() {
     // code
-};               /*error Unnecessary semicolon.*/
+};
 
 ```
 

--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -68,7 +68,7 @@ The following patterns are considered problems:
 /*eslint no-fallthrough: 2*/
 
 switch(foo) {
-    case 1:            /*error Expected a 'break' statement before 'case'.*/
+    case 1:
         doSomething();
 
     case 2:

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -19,9 +19,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-floating-decimal: 2*/
 
-var num = .5;  /*error A leading decimal point can be confused with a dot.*/
-var num = 2.;  /*error A trailing decimal point can be confused with a dot.*/
-var num = -.7; /*error A leading decimal point can be confused with a dot.*/
+var num = .5;
+var num = 2.;
+var num = -.7;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -17,10 +17,10 @@ The following patterns are considered problems:
 /*eslint no-func-assign: 2*/
 
 function foo() {}
-foo = bar;        /*error 'foo' is a function.*/
+foo = bar;
 
 function foo() {
-    foo = bar;    /*error 'foo' is a function.*/
+    foo = bar;
 }
 ```
 
@@ -29,7 +29,7 @@ Unlike the same rule in JSHint, the following pattern is also considered a warni
 ```js
 /*eslint no-func-assign: 2*/
 
-foo = bar;        /*error 'foo' is a function.*/
+foo = bar;
 function foo() {}
 ```
 

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -60,8 +60,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-implicit-coercion: 2*/
 
-var b = !!foo;             /*error use 'Boolean(foo)' instead.*/
-var b = ~foo.indexOf("."); /*error use 'foo.indexOf(".") !== -1' instead.*/
+var b = !!foo;
+var b = ~foo.indexOf(".");
 // only with `indexOf`/`lastIndexOf` method calling.
 
 ```
@@ -84,8 +84,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-implicit-coercion: 2*/
 
-var n = +foo;    /*error use 'Number(foo)' instead.*/
-var n = 1 * foo; /*error use 'Number(foo)' instead.*/
+var n = +foo;
+var n = 1 * foo;
 ```
 
 The following patterns are not considered problems:
@@ -105,9 +105,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-implicit-coercion: 2*/
 
-var n = "" + foo; /*error use 'String(foo)' instead.*/
+var n = "" + foo;
 
-foo += ""; /*error use 'foo = String(foo)' instead.*/
+foo += "";
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-implicit-globals.md
+++ b/docs/rules/no-implicit-globals.md
@@ -11,9 +11,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-implicit-globals: 2*/
 
-var foo = 1; /*error Implicit global variable.*/
+var foo = 1;
 
-function bar() {} /*error Implicit global variable.*/
+function bar() {}
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-implied-eval.md
+++ b/docs/rules/no-implied-eval.md
@@ -29,15 +29,15 @@ The following patterns are considered problems:
 ```js
 /*eslint no-implied-eval: 2*/
 
-setTimeout("alert('Hi!');", 100);    /*error Implied eval. Consider passing a function instead of a string.*/
+setTimeout("alert('Hi!');", 100);
 
-setInterval("alert('Hi!');", 100);   /*error Implied eval. Consider passing a function instead of a string.*/
+setInterval("alert('Hi!');", 100);
 
-execScript("alert('Hi!')");          /*error Implied eval. Consider passing a function instead of a string.*/
+execScript("alert('Hi!')");
 
-window.setTimeout("count = 5", 10);  /*error Implied eval. Consider passing a function instead of a string.*/
+window.setTimeout("count = 5", 10);
 
-window.setInterval("foo = bar", 10); /*error Implied eval. Consider passing a function instead of a string.*/
+window.setInterval("foo = bar", 10);
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-inline-comments.md
+++ b/docs/rules/no-inline-comments.md
@@ -16,16 +16,16 @@ The following patterns are considered problems:
 ```js
 /*eslint no-inline-comments: 2*/
 
-var a = 1; // declaring a to 1                /*error Unexpected comment inline with code.*/
+var a = 1; // declaring a to 1
 
 function getRandomNumber(){
-    return 4; // chosen by fair dice roll.    /*error Unexpected comment inline with code.*/
+    return 4; // chosen by fair dice roll.
               // guaranteed to be random.
 }
 
-/* A block comment before code */ var b = 2;  /*error Unexpected comment inline with code.*/
+/* A block comment before code */ var b = 2;
 
-var c = 3; /* A block comment after code */   /*error Unexpected comment inline with code.*/
+var c = 3; /* A block comment after code */
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -74,12 +74,12 @@ The following patterns are considered problems:
 /*eslint no-inner-declarations: 2*/
 
 if (test) {
-    function doSomething() { }        /*error Move function declaration to program root.*/
+    function doSomething() { }
 }
 
 function doSomethingElse() {
     if (test) {
-        function doAnotherThing() { } /*error Move function declaration to function body root.*/
+        function doAnotherThing() { }
     }
 }
 ```
@@ -90,12 +90,12 @@ With `"both"` option to check variable declarations, the following are considere
 /*eslint no-inner-declarations: [2, "both"]*/
 
 if (test) {
-    var foo = 42;            /*error Move variable declaration to program root.*/
+    var foo = 42;
 }
 
 function doAnotherThing() {
     if (test) {
-        var bar = 81;        /*error Move variable declaration to function body root.*/
+        var bar = 81;
     }
 }
 ```

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -9,11 +9,11 @@ The following patterns are considered problems:
 ```js
 /*eslint no-invalid-regexp: 2*/
 
-RegExp('[')      /*error Invalid regular expression: /[/: Unterminated character class*/
+RegExp('[')
 
-RegExp('.', 'z') /*error Invalid flags supplied to RegExp constructor 'z'*/
+RegExp('.', 'z')
 
-new RegExp('\\') /*error Invalid regular expression: /\/: \ at end of pattern*/
+new RegExp('\\')
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -36,47 +36,47 @@ Please note your code in ES2015 Modules/Classes is always the strict mode.
 /*eslint no-invalid-this: 2*/
 /*eslint-env es6*/
 
-this.a = 0;            /*error Unexpected 'this'.*/
-baz(() => this);       /*error Unexpected 'this'.*/
+this.a = 0;
+baz(() => this);
 
 (function() {
-    this.a = 0;        /*error Unexpected 'this'.*/
-    baz(() => this);   /*error Unexpected 'this'.*/
+    this.a = 0;
+    baz(() => this);
 })();
 
 function foo() {
-    this.a = 0;        /*error Unexpected 'this'.*/
-    baz(() => this);   /*error Unexpected 'this'.*/
+    this.a = 0;
+    baz(() => this);
 }
 
 var foo = function() {
-    this.a = 0;        /*error Unexpected 'this'.*/
-    baz(() => this);   /*error Unexpected 'this'.*/
+    this.a = 0;
+    baz(() => this);
 };
 
 foo(function() {
-    this.a = 0;        /*error Unexpected 'this'.*/
-    baz(() => this);   /*error Unexpected 'this'.*/
+    this.a = 0;
+    baz(() => this);
 });
 
 obj.foo = () => {
     // `this` of arrow functions is the outer scope's.
-    this.a = 0;        /*error Unexpected 'this'.*/
+    this.a = 0;
 };
 
 var obj = {
     aaa: function() {
         return function foo() {
             // There is in a method `aaa`, but `foo` is not a method.
-            this.a = 0;      /*error Unexpected 'this'.*/
-            baz(() => this); /*error Unexpected 'this'.*/
+            this.a = 0;
+            baz(() => this);
         };
     }
 };
 
 foo.forEach(function() {
-    this.a = 0;          /*error Unexpected 'this'.*/
-    baz(() => this);     /*error Unexpected 'this'.*/
+    this.a = 0;
+    baz(() => this);
 });
 ```
 

--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -48,28 +48,28 @@ The following examples are considered problems:
 ```js
 /*eslint no-irregular-whitespace: 2*/
 
-function thing() /*<NBSP>*/{ /*error Irregular whitespace not allowed*/
+function thing() /*<NBSP>*/{
   return 'test';
 }
 
-function thing( /*<NBSP>*/){ /*error Irregular whitespace not allowed*/
+function thing( /*<NBSP>*/){
   return 'test';
 }
 
-function thing /*<NBSP>*/(){ /*error Irregular whitespace not allowed*/
+function thing /*<NBSP>*/(){
   return 'test';
 }
 
-function thing᠎/*<MVS>*/(){   /*error Irregular whitespace not allowed*/
+function thing᠎/*<MVS>*/(){
   return 'test';
 }
 
 function thing() {
-  return 'test'; /*<ENSP>*/  /*error Irregular whitespace not allowed*/
+  return 'test'; /*<ENSP>*/
 }
 
 function thing() {
-  return 'test'; /*<NBSP>*/  /*error Irregular whitespace not allowed*/
+  return 'test'; /*<NBSP>*/
 }
 ```
 

--- a/docs/rules/no-iterator.md
+++ b/docs/rules/no-iterator.md
@@ -19,13 +19,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-iterator: 2*/
 
-Foo.prototype.__iterator__ = function() { /*error Reserved name '__iterator__'.*/
+Foo.prototype.__iterator__ = function() {
     return new FooIterator(this);
 };
 
-foo.__iterator__ = function () {};        /*error Reserved name '__iterator__'.*/
+foo.__iterator__ = function () {};
 
-foo["__iterator__"] = function () {};     /*error Reserved name '__iterator__'.*/
+foo["__iterator__"] = function () {};
 
 ```
 

--- a/docs/rules/no-label-var.md
+++ b/docs/rules/no-label-var.md
@@ -11,7 +11,7 @@ The following patterns are considered problems:
 
 var x = foo;
 function bar() {
-x:               /*error Found identifier with same name as label.*/
+x:
   for (;;) {
     break x;
   }

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -25,35 +25,35 @@ The following patterns are considered problems:
 ```js
 /*eslint no-labels: 2*/
 
-label:                  /*error Unexpected labeled statement.*/
+label:
     while(true) {
         // ...
     }
 
-label:                  /*error Unexpected labeled statement.*/
+label:
     while(true) {
-        break label;    /*error Unexpected label in break statement.*/
+        break label;
     }
 
-label:                  /*error Unexpected labeled statement.*/
+label:
     while(true) {
-        continue label; /*error Unexpected label in continue statement.*/
+        continue label;
     }
 
-label:                  /*error Unexpected labeled statement.*/
+label:
     switch (a) {
     case 0:
-        break label;    /*error Unexpected label in break statement.*/
+        break label;
     }
 
-label:                  /*error Unexpected labeled statement.*/
+label:
     {
-        break label;    /*error Unexpected label in break statement.*/
+        break label;
     }
 
-label:                  /*error Unexpected labeled statement.*/
+label:
     if (a) {
-        break label;    /*error Unexpected label in break statement.*/
+        break label;
     }
 ```
 
@@ -94,14 +94,14 @@ Those options allow us to use labels only with loop or switch statements.
 The following patterns are considered problems when configured `{"allowLoop": true, "allowSwitch": true}`:
 
 ```js
-label:                /*error Unexpected labeled statement.*/
+label:
     {
-        break label;  /*error Unexpected label in break statement.*/
+        break label;
     }
 
-label:                /*error Unexpected labeled statement.*/
+label:
     if (a) {
-        break label;  /*error Unexpected label in break statement.*/
+        break label;
     }
 ```
 

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -19,22 +19,22 @@ The following patterns are considered problems:
 ```js
 /*eslint no-lone-blocks: 2*/
 
-{}                    /*error Block is redundant.*/
+{}
 
 if (foo) {
     bar();
-    {                 /*error Nested block is redundant.*/
+    {
         baz();
     }
 }
 
 function bar() {
-    {                 /*error Nested block is redundant.*/
+    {
         baz();
     }
 }
 
-{                     /*error Block is redundant.*/
+{
     function foo() {}
 }
 ```

--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -34,7 +34,7 @@ The following patterns are considered problems:
 if (condition) {
     // ...
 } else {
-    if (anotherCondition) { /*error Unexpected if as the only statement in an else block.*/
+    if (anotherCondition) {
         // ...
     }
 }
@@ -42,7 +42,7 @@ if (condition) {
 if (condition) {
     // ...
 } else {
-    if (anotherCondition) { /*error Unexpected if as the only statement in an else block.*/
+    if (anotherCondition) {
         // ...
     } else {
         // ...

--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -38,23 +38,23 @@ The following patterns are considered problems:
 /*eslint-env es6*/
 
 for (var i=10; i; i--) {
-    (function() { return i; })();     /*error Don't make functions within a loop*/
+    (function() { return i; })();
 }
 
 while(i) {
-    var a = function() { return i; }; /*error Don't make functions within a loop*/
+    var a = function() { return i; };
     a();
 }
 
 do {
-    function a() { return i; };      /*error Don't make functions within a loop*/
+    function a() { return i; };
     a();
 } while (i);
 
 let foo = 0;
 for (let i=10; i; i--) {
     // Bad, function is referencing block scoped variable in the outer scope.
-    var a = function() { return foo; }; /*error Don't make functions within a loop*/
+    var a = function() { return foo; };
     a();
 }
 ```

--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -19,13 +19,13 @@ The following pattern is considered a problem:
 /*eslint no-magic-numbers: 2*/
 
 var dutyFreePrice = 100,
-    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25); /*error No magic number: 0.25*/
+    finalPrice = dutyFreePrice + (dutyFreePrice * 0.25);
 
 
 /*eslint no-magic-numbers: 2*/
 
 var data = ['foo', 'bar', 'baz'];
-var thirdValue = data[3]; /*error No magic number: 3*/
+var thirdValue = data[3];
 ```
 
 The following pattern is considered okay:

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -81,7 +81,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-mixed-requires: 2*/
 
-var fs = require('fs'), /*error Do not mix 'require' and other declarations.*/
+var fs = require('fs'),
     i = 0;
 ```
 
@@ -91,11 +91,11 @@ The following patterns are considered problems when grouping is turned on:
 /*eslint no-mixed-requires: [2, {"grouping": true}]*/
 
 // invalid because of mixed types "core" and "file"
-var fs = require('fs'),                /*error Do not mix core, module, file and computed requires.*/
+var fs = require('fs'),
     async = require('async');
 
 // invalid because of mixed types "file" and "unknown"
-var foo = require('foo'),              /*error Do not mix core, module, file and computed requires.*/
+var foo = require('foo'),
     bar = require(getBarModuleName());
 ```
 

--- a/docs/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/rules/no-mixed-spaces-and-tabs.md
@@ -26,7 +26,7 @@ The following patterns are considered problems:
 function add(x, y) {
 // --->..return x + y;
 
-      return x + y;    /*error Mixed spaces and tabs.*/
+      return x + y;
 }
 
 function main() {
@@ -34,7 +34,7 @@ function main() {
 // --->....y = 7;
 
     var x = 5,
-        y = 7;         /*error Mixed spaces and tabs.*/
+        y = 7;
 }
 ```
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -27,15 +27,15 @@ The following patterns are considered problems:
 ```js
 /*eslint no-multi-spaces: 2*/
 
-var a =  1;            /*error Multiple spaces found before '1'.*/
+var a =  1;
 
-if(foo   === "bar") {} /*error Multiple spaces found before '==='.*/
+if(foo   === "bar") {}
 
-a <<  b                /*error Multiple spaces found before 'b'.*/
+a <<  b
 
-var arr = [1,  2];     /*error Multiple spaces found before '2'.*/
+var arr = [1,  2];
 
-a ?  b: c              /*error Multiple spaces found before 'b'.*/
+a ?  b: c
 ```
 
 The following patterns are not considered problems:
@@ -84,7 +84,7 @@ The default `Property` exception can be disabled by setting it to `false`, so th
 /* eslint key-spacing: [2, { align: "value" }] */
 
 var obj = {
-    first:  "first",  /*error Multiple spaces found before '"first"'.*/
+    first:  "first",
     second: "second"
 };
 ```

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -16,9 +16,7 @@ This rule is aimed at preventing the use of multiline strings.
 The following generates a warning:
 
 ```js
-/*eslint no-multi-str: 2*/
-
-/*error Multiline support is limited to browsers supporting ES5 only.*/ var x = "Line 1 \
+/*eslint no-multi-str: 2*/ var x = "Line 1 \
          Line 2";
 ```
 

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -48,8 +48,6 @@ The following patterns are considered problems:
 /*eslint no-multiple-empty-lines: [2, {max: 1}]*/
 
 var foo = 5;
-
-                  /*error Multiple blank lines not allowed.*/
 var bar = 3;
 
 ```
@@ -58,13 +56,10 @@ var bar = 3;
 /*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 1}]*/
 
 var foo = 5;
-
-                  /*error Too many blank lines at the end of file.*/
 ```
 
 ```js
 /*eslint no-multiple-empty-lines: [2, {max: 999, maxBOF: 0}]*/
-                  /*error Too many blank lines at the beginning of file.*/
 var foo = 5;
 ```
 

--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -15,7 +15,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-native-reassign: 2*/
 
-String = new Object(); /*error String is a read-only native object.*/
+String = new Object();
 ```
 
 ## Options

--- a/docs/rules/no-negated-condition.md
+++ b/docs/rules/no-negated-condition.md
@@ -33,26 +33,26 @@ The following patterns are considered warnings:
 ```js
 /*eslint no-negated-condition: 2*/
 
-if (!a) {               /*error Unexpected negated condition.*/
+if (!a) {
     doSomething();
 } else {
     doSomethingElse();
 }
 
-if (a != b) {           /*error Unexpected negated condition.*/
+if (a != b) {
     doSomething();
 } else {
     doSomethingElse();
 }
 
-if (a !== b) {          /*error Unexpected negated condition.*/
+if (a !== b) {
     doSomething();
 } else {
     doSomethingElse();
 }
 
 
-!a ? b : c              /*error Unexpected negated condition.*/
+!a ? b : c
 
 ```
 

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -31,7 +31,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-negated-in-lhs: 2*/
 
-if(!a in b) {       /*error The 'in' expression's left operand is negated*/
+if(!a in b) {
     // do something
 }
 ```

--- a/docs/rules/no-nested-ternary.md
+++ b/docs/rules/no-nested-ternary.md
@@ -15,9 +15,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-nested-ternary: 2*/
 
-var thing = foo ? bar : baz === qux ? quxx : foobar; /*error Do not nest ternary expressions*/
+var thing = foo ? bar : baz === qux ? quxx : foobar;
 
-foo ? baz === qux ? quxx() : foobar() : bar();       /*error Do not nest ternary expressions*/
+foo ? baz === qux ? quxx() : foobar() : bar();
 ```
 
 The following patterns are considered okay and could be used alternatively:

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -15,8 +15,8 @@ This error is raised to highlight the use of a bad practice. By passing a string
 ```js
 /*eslint no-new-func: 2*/
 
-var x = new Function("a", "b", "return a + b"); /*error The Function constructor is eval.*/
-var x = Function("a", "b", "return a + b");     /*error The Function constructor is eval.*/
+var x = new Function("a", "b", "return a + b");
+var x = Function("a", "b", "return a + b");
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-new-object.md
+++ b/docs/rules/no-new-object.md
@@ -25,9 +25,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-new-object: 2*/
 
-var myObject = new Object(); /*error The object literal notation {} is preferrable.*/
+var myObject = new Object();
 
-var myObject = new Object;   /*error The object literal notation {} is preferrable.*/
+var myObject = new Object;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-new-require.md
+++ b/docs/rules/no-new-require.md
@@ -29,7 +29,7 @@ The following pattern is considered a warning:
 ```js
 /*eslint no-new-require: 2*/
 
-var appHeader = new require('app-header'); /*error Unexpected use of new with require.*/
+var appHeader = new require('app-header');
 ```
 
 The following pattern is not a warning:

--- a/docs/rules/no-new-symbol.md
+++ b/docs/rules/no-new-symbol.md
@@ -18,7 +18,7 @@ The following patterns are considered problems:
 /*eslint no-new-symbol: 2*/
 /*eslint-env es6*/
 
-var foo = new Symbol('foo');                    /*error `Symbol` cannot be called as a constructor. */
+var foo = new Symbol('foo');
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-new-wrappers.md
+++ b/docs/rules/no-new-wrappers.md
@@ -44,13 +44,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-new-wrappers: 2*/
 
-var stringObject = new String("Hello world"); /*error Do not use String as a constructor.*/
-var numberObject = new Number(33);            /*error Do not use Number as a constructor.*/
-var booleanObject = new Boolean(false);       /*error Do not use Boolean as a constructor.*/
+var stringObject = new String("Hello world");
+var numberObject = new Number(33);
+var booleanObject = new Boolean(false);
 
-var stringObject = new String;                /*error Do not use String as a constructor.*/
-var numberObject = new Number;                /*error Do not use Number as a constructor.*/
-var booleanObject = new Boolean;              /*error Do not use Boolean as a constructor.*/
+var stringObject = new String;
+var numberObject = new Number;
+var booleanObject = new Boolean;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-new.md
+++ b/docs/rules/no-new.md
@@ -23,7 +23,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-new: 2*/
 
-new Thing(); /*error Do not use 'new' for side effects.*/
+new Thing();
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -15,8 +15,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-obj-calls: 2*/
 
-var x = Math(); /*error 'Math' is not a function.*/
-var y = JSON(); /*error 'JSON' is not a function.*/
+var x = Math();
+var y = JSON();
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -15,7 +15,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-octal-escape: 2*/
 
-var foo = "Copyright \251"; /*error Don't use octal: '\251'. Use '\u....' instead.*/
+var foo = "Copyright \251";
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -19,8 +19,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-octal: 2*/
 
-var num = 071;       /*error Octal literals should not be used.*/
-var result = 5 + 07; /*error Octal literals should not be used.*/
+var num = 071;
+var result = 5 + 07;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -25,11 +25,11 @@ This rule takes one option, an object, with a property `"props"`.
 /*eslint no-param-reassign: 2*/
 
 function foo(bar) {
-    bar = 13;       /*error Assignment to function parameter 'bar'.*/
+    bar = 13;
 }
 
 function foo(bar) {
-    bar++;          /*error Assignment to function parameter 'bar'.*/
+    bar++;
 }
 ```
 
@@ -39,15 +39,15 @@ When `{"props": true}`:
 /*eslint no-param-reassign: [2, { "props": true }]*/
 
 function foo(bar) {
-    bar.prop = "value"; /*error Assignment to function parameter 'bar'.*/
+    bar.prop = "value";
 }
 
 function foo(bar) {
-    delete bar.aaa;     /*error Assignment to function parameter 'bar'.*/
+    delete bar.aaa;
 }
 
 function foo(bar) {
-    bar.aaa++;          /*error Assignment to function parameter 'bar'.*/
+    bar.aaa++;
 }
 ```
 

--- a/docs/rules/no-path-concat.md
+++ b/docs/rules/no-path-concat.md
@@ -31,9 +31,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-path-concat: 2*/
 
-var fullPath = __dirname + "/foo.js";  /*error Use path.join() or path.resolve() instead of + to create paths.*/
+var fullPath = __dirname + "/foo.js";
 
-var fullPath = __filename + "/foo.js"; /*error Use path.join() or path.resolve() instead of + to create paths.*/
+var fullPath = __filename + "/foo.js";
 
 ```
 

--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -44,12 +44,12 @@ The following patterns are considered problems:
 /*eslint no-plusplus: 2*/
 
 var foo = 0;
-foo++;                          /*error Unary operator '++' used.*/
+foo++;
 
 var bar = 42;
-bar--;                          /*error Unary operator '--' used.*/
+bar--;
 
-for (i = 0; i < l; i++) {       /*error Unary operator '++' used.*/
+for (i = 0; i < l; i++) {
     return;
 }
 ```

--- a/docs/rules/no-process-env.md
+++ b/docs/rules/no-process-env.md
@@ -12,7 +12,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-process-env: 2*/
 
-if(process.env.NODE_ENV === "development") { /*error Unexpected use of process.env.*/
+if(process.env.NODE_ENV === "development") {
     //...
 }
 ```

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -28,8 +28,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-process-exit: 2*/
 
-process.exit(1); /*error Don't use process.exit(); throw an error instead.*/
-process.exit(0); /*error Don't use process.exit(); throw an error instead.*/
+process.exit(1);
+process.exit(0);
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -11,9 +11,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-proto: 2*/
 
-var a = obj.__proto__;    /*error The '__proto__' property is deprecated.*/
+var a = obj.__proto__;
 
-var a = obj["__proto__"]; /*error The '__proto__' property is deprecated.*/
+var a = obj["__proto__"];
 ```
 
 The following patterns are considered okay and could be used alternatively:

--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -12,7 +12,7 @@ The following patterns are considered problems:
 /*eslint no-redeclare: 2*/
 
 var a = 3;
-var a = 10; /*error 'a' is already defined*/
+var a = 10;
 ```
 
 The following patterns are not considered problems:
@@ -45,7 +45,7 @@ When `{"builtinGlobals": true}`, the following patterns are considered problems:
 ```js
 /*eslint no-redeclare: [2, { "builtinGlobals": true }]*/
 
-var Object = 0; /*error 'Object' is already defined*/
+var Object = 0;
 ```
 
 When `{"builtinGlobals": true}` and under `browser` environment, the following patterns are considered problems:
@@ -54,7 +54,7 @@ When `{"builtinGlobals": true}` and under `browser` environment, the following p
 /*eslint-env browser*/
 /*eslint no-redeclare: [2, { "builtinGlobals": true }]*/
 
-var top = 0; /*error 'top' is already defined*/
+var top = 0;
 ```
 
 * Note: The `browser` environment has many built-in global variables, `top` is one of them.

--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -23,7 +23,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-regex-spaces: 2*/
 
-var re = /foo   bar/; /*error Spaces are hard to count. Use {3}.*/
+var re = /foo   bar/;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -25,13 +25,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-restricted-imports: [2, "fs"]*/
 
-import fs from 'fs'; /*error 'fs' import is restricted from being used.*/
+import fs from 'fs';
 ```
 
 ```js
 /*eslint no-restricted-imports: [2, "cluster"]*/
 
-import cluster from ' cluster '; /*error 'cluster' import is restricted from being used.*/
+import cluster from ' cluster ';
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-restricted-modules.md
+++ b/docs/rules/no-restricted-modules.md
@@ -23,13 +23,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-restricted-modules: [2, "fs"]*/
 
-var fs = require('fs'); /*error 'fs' module is restricted from being used.*/
+var fs = require('fs');
 ```
 
 ```js
 /*eslint no-restricted-modules: [2, "cluster"]*/
 
-var fs = require(' cluster '); /*error 'cluster' module is restricted from being used.*/
+var fs = require(' cluster ');
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -25,11 +25,11 @@ The following patterns are considered problems:
 ```js
 /* eslint no-restricted-syntax: [2, "FunctionExpression", "WithStatement"] */
 
-with (me) {                       /*error Using 'WithStatement' is not allowed.*/
+with (me) {
     dontMess();
 }
 
-var doSomething = function () {}; /*error Using 'FunctionExpression' is not allowed.*/
+var doSomething = function () {};
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-return-assign.md
+++ b/docs/rules/no-return-assign.md
@@ -34,11 +34,11 @@ The following patterns are considered problems:
 /*eslint no-return-assign: 2*/
 
 function doSomething() {
-    return foo = bar + 2; /*error Return statement should not contain assignment.*/
+    return foo = bar + 2;
 }
 
 function doSomething() {
-    return foo += 2;      /*error Return statement should not contain assignment.*/
+    return foo += 2;
 }
 ```
 
@@ -71,15 +71,15 @@ The following patterns are considered problems:
 /*eslint no-return-assign: [2, "always"]*/
 
 function doSomething() {
-    return foo = bar + 2;   /*error Return statement should not contain assignment.*/
+    return foo = bar + 2;
 }
 
 function doSomething() {
-    return foo += 2;        /*error Return statement should not contain assignment.*/
+    return foo += 2;
 }
 
 function doSomething() {
-    return (foo = bar + 2); /*error Return statement should not contain assignment.*/
+    return (foo = bar + 2);
 }
 ```
 

--- a/docs/rules/no-script-url.md
+++ b/docs/rules/no-script-url.md
@@ -9,7 +9,7 @@ The following patterns are considered problems:
 ```js
 /*eslint no-script-url: 2*/
 
-location.href = "javascript:void(0)"; /*error Script URL is a form of eval.*/
+location.href = "javascript:void(0)";
 ```
 
 ## Compatibility

--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -17,14 +17,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-self-assign: 2*/
 
-foo = foo;              /*error 'foo' is assigned to itself.*/
+foo = foo;
 
-[a, b] = [a, b];        /*error 'a' is assigned to itself.*/
-                        /*error 'b' is assigned to itself.*/
+[a, b] = [a, b];
 
-[a, ...b] = [x, ...b];  /*error 'b' is assigned to itself.*/
+[a, ...b] = [x, ...b];
 
-({a, b} = {a, x});      /*error 'a' is assigned to itself.*/
+({a, b} = {a, x});
 ```
 
 The following patterns are considered not problems:

--- a/docs/rules/no-self-compare.md
+++ b/docs/rules/no-self-compare.md
@@ -12,7 +12,7 @@ This error is raised to highlight a potentially confusing and potentially pointl
 /*eslint no-self-compare: 2*/
 
 var x = 10;
-if (x === x) { /*error Comparing to itself is potentially pointless.*/
+if (x === x) {
     x = 20;
 }
 ```

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -24,19 +24,19 @@ The following patterns are considered problems:
 ```js
 /*eslint no-sequences: 2*/
 
-foo = doSomething, val;              /*error Unexpected use of comma operator.*/
+foo = doSomething, val;
 
-do {} while (doSomething(), !!test); /*error Unexpected use of comma operator.*/
+do {} while (doSomething(), !!test);
 
-for (; doSomething(), !!test; );     /*error Unexpected use of comma operator.*/
+for (; doSomething(), !!test; );
 
-if (doSomething(), !!test);          /*error Unexpected use of comma operator.*/
+if (doSomething(), !!test);
 
-switch (val = foo(), val) {}         /*error Unexpected use of comma operator.*/
+switch (val = foo(), val) {}
 
-while (val = foo(), val < 42);       /*error Unexpected use of comma operator.*/
+while (val = foo(), val < 42);
 
-with (doSomething(), val) {}         /*error Unexpected use of comma operator.*/
+with (doSomething(), val) {}
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-shadow-restricted-names.md
+++ b/docs/rules/no-shadow-restricted-names.md
@@ -15,13 +15,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-shadow-restricted-names: 2*/
 
-function NaN(){}       /*error Shadowing of global property 'NaN'.*/
+function NaN(){}
 
-!function(Infinity){}; /*error Shadowing of global property 'Infinity'.*/
+!function(Infinity){};
 
-var undefined;         /*error Shadowing of global property 'undefined'.*/
+var undefined;
 
-try {} catch(eval){}   /*error Shadowing of global property 'eval'.*/
+try {} catch(eval){}
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -23,20 +23,20 @@ The following patterns are considered problems:
 
 var a = 3;
 function b() {
-    var a = 10;       /*error 'a' is already declared in the upper scope.*/
+    var a = 10;
 }
 
 var b = function () {
-    var a = 10;       /*error 'a' is already declared in the upper scope.*/
+    var a = 10;
 }
 
-function b(a) {       /*error 'a' is already declared in the upper scope.*/
+function b(a) {
     a = 10;
 }
 b(a);
 
 if (true) {
-    let a = 5;        /*error 'a' is already declared in the upper scope.*/
+    let a = 5;
 }
 ```
 
@@ -61,7 +61,7 @@ When `{"builtinGlobals": true}`, the following patterns are considered problems:
 /*eslint no-shadow: [2, { "builtinGlobals": true }]*/
 
 function foo() {
-    var Object = 0; /*error 'Object' is already declared in the upper scope.*/
+    var Object = 0;
 }
 ```
 
@@ -82,8 +82,8 @@ With `"hoist"` set to `"all"`, both `let a` and `let b` in the `if` statement ar
 /*eslint-env es6*/
 
 if (true) {
-    let a = 3;    /*error 'a' is already declared in the upper scope.*/
-    let b = 6;    /*error 'b' is already declared in the upper scope.*/
+    let a = 3;
+    let b = 6;
 }
 
 let a = 5;
@@ -100,7 +100,7 @@ With `"hoist"` set to `"functions"`, `let b` is considered a warning. But `let a
 
 if (true) {
     let a = 3;
-    let b = 6;    /*error 'b' is already declared in the upper scope.*/
+    let b = 6;
 }
 
 let a = 5;

--- a/docs/rules/no-spaced-func.md
+++ b/docs/rules/no-spaced-func.md
@@ -17,9 +17,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-spaced-func: 2*/
 
-fn () /*error Unexpected space between function name and paren.*/
+fn ()
 
-fn    /*error Unexpected space between function name and paren.*/
+fn
 ()
 ```
 

--- a/docs/rules/no-sparse-arrays.md
+++ b/docs/rules/no-sparse-arrays.md
@@ -25,8 +25,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-sparse-arrays: 2*/
 
-var items = [,];                 /*error Unexpected comma in middle of array.*/
-var colors = [ "red",, "blue" ]; /*error Unexpected comma in middle of array.*/
+var items = [,];
+var colors = [ "red",, "blue" ];
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -11,9 +11,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-sync: 2*/
 
-fs.existsSync(somePath);                             /*error Unexpected sync method: 'existsSync'.*/
+fs.existsSync(somePath);
 
-var contents = fs.readFileSync(somePath).toString(); /*error Unexpected sync method: 'readFileSync'.*/
+var contents = fs.readFileSync(somePath).toString();
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-ternary.md
+++ b/docs/rules/no-ternary.md
@@ -15,12 +15,12 @@ The following patterns are considered problems:
 ```js
 /*eslint no-ternary: 2*/
 
-var foo = isBar ? baz : qux; /*error Ternary operator used.*/
+var foo = isBar ? baz : qux;
 
-foo ? bar() : baz();         /*error Ternary operator used.*/
+foo ? bar() : baz();
 
 function quux() {
-  return foo ? bar : baz;    /*error Ternary operator used.*/
+  return foo ? bar : baz;
 }
 ```
 

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -16,28 +16,28 @@ The following patterns are considered problems:
 
 class A extends B {
     constructor() {
-        this.a = 0;        /*error 'this' is not allowed before 'super()'*/
+        this.a = 0;
         super();
     }
 }
 
 class A extends B {
     constructor() {
-        this.foo();        /*error 'this' is not allowed before 'super()'*/
+        this.foo();
         super();
     }
 }
 
 class A extends B {
     constructor() {
-        super.foo();       /*error 'super' is not allowed before 'super()'*/
+        super.foo();
         super();
     }
 }
 
 class A extends B {
     constructor() {
-        super(this.foo()); /*error 'this' is not allowed before 'super()'*/
+        super(this.foo());
     }
 }
 ```

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -15,20 +15,20 @@ The following patterns are considered problems:
 /*eslint no-throw-literal: 2*/
 /*eslint-env es6*/
 
-throw "error";         /*error Expected an object to be thrown.*/
+throw "error";
 
-throw 0;               /*error Expected an object to be thrown.*/
+throw 0;
 
-throw undefined;       /*error Do not throw undefined.*/
+throw undefined;
 
-throw null;            /*error Expected an object to be thrown.*/
+throw null;
 
 var err = new Error();
-throw "an " + err;     /*error Expected an object to be thrown.*/
+throw "an " + err;
 // err is recast to a string literal
 
 var err = new Error();
-throw `${err}`         /*error Expected an object to be thrown.*/
+throw `${err}`
 
 ```
 

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -13,8 +13,8 @@ The following patterns are considered problems:
 
 // spaces, tabs and unicode whitespaces
 // are not allowed at the end of lines
-var foo = 0;//•••••  /*error Trailing spaces not allowed.*/
-var baz = 5;//••     /*error Trailing spaces not allowed.*/
+var foo = 0;//•••••
+var baz = 5;//••
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -27,8 +27,8 @@ The following patterns are considered problems:
 /*eslint no-undef-init: 2*/
 /*eslint-env es6*/
 
-var foo = undefined; /*error It's not necessary to initialize 'foo' to undefined.*/
-let bar = undefined; /*error It's not necessary to initialize 'bar' to undefined.*/
+var foo = undefined;
+let bar = undefined;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -15,8 +15,8 @@ The following code causes 2 warnings, as the globals `someFunction` and `b` have
 ```js
 /*eslint no-undef: 2*/
 
-var a = someFunction();  /*error 'someFunction' is not defined.*/
-b = 10;                  /*error 'b' is not defined.*/
+var a = someFunction();
+b = 10;
 ```
 
 In this code, no warnings are generated, since the global variables have been properly declared in a `/*global */` block.
@@ -36,7 +36,7 @@ By default, variables declared in `/*global */` are considered read-only. Assign
 /*eslint no-undef: 2*/
 
 
-b = 10;                  /*error "b" is read only.*/
+b = 10;
 ```
 
 Use the `variable:true` syntax to indicate that a variable can be assigned to.
@@ -67,7 +67,7 @@ The following patterns are considered problems with option `typeof` set:
 ```js
 /* eslint no-undef: [2, { typeof: true }] */
 
-if(typeof a === "string"){}      /* error 'a' is not defined. */
+if(typeof a === "string"){}
 ```
 
 The following patterns are not considered problems with option `typeof` set:

--- a/docs/rules/no-undefined.md
+++ b/docs/rules/no-undefined.md
@@ -41,15 +41,15 @@ The following patterns are considered problems:
 ```js
 /*eslint no-undefined: 2*/
 
-var foo = undefined;      /*error Unexpected use of undefined.*/
+var foo = undefined;
 
-var undefined = "foo";    /*error Unexpected use of undefined.*/
+var undefined = "foo";
 
-if (foo === undefined) {  /*error Unexpected use of undefined.*/
+if (foo === undefined) {
     // ...
 }
 
-function foo(undefined) { /*error Unexpected use of undefined.*/
+function foo(undefined) {
     // ...
 }
 ```

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -37,9 +37,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-underscore-dangle: 2*/
 
-var foo_;           /*error Unexpected dangling '_' in 'foo_'.*/
-var __proto__ = {}; /*error Unexpected dangling '_' in '__proto__'.*/
-foo._bar();         /*error Unexpected dangling '_' in '_bar'.*/
+var foo_;
+var __proto__ = {};
+foo._bar();
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -21,16 +21,16 @@ The following patterns are considered problems:
 /*eslint no-unexpected-multiline: 2*/
 
 var foo = bar
-(1 || 2).baz();               /*error Unexpected newline between function and ( of function call.*/
+(1 || 2).baz();
 
 var hello = 'world'
-[1, 2, 3].forEach(addNumber); /*error Unexpected newline between object and [ of property access.*/
+[1, 2, 3].forEach(addNumber);
 
-let x = function() {}         /*error Unexpected newline between template tag and template literal.*/
+let x = function() {}
 `hello`
 
 let x = function() {}
-x                             /*error Unexpected newline between template tag and template literal.*/
+x
 `hello`
 ```
 

--- a/docs/rules/no-unmodified-loop-condition.md
+++ b/docs/rules/no-unmodified-loop-condition.md
@@ -29,17 +29,16 @@ If a reference is inside of a dynamic expression (e.g. `CallExpression`,
 The following patterns are considered problems:
 
 ```js
-while (node) {                           /*error 'node' is not modified in this loop.*/
+while (node) {
     doSomething(node);
 }
 node = other.
 
-for (var j = 0; j < items.length; ++i) { /*error 'j' is not modified in this loop.*/
+for (var j = 0; j < items.length; ++i) {
     doSomething(items[j]);
 }
 
-while (node !== root) {                  /*error 'node' is not modified in this loop.*/
-                                         /*error 'root' is not modified in this loop.*/
+while (node !== root) {
     doSomething(node);
 }
 ```

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -42,9 +42,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-unneeded-ternary: 2*/
 
-var a = x === 2 ? true : false; /*error Unnecessary use of boolean literals in conditional expression*/
+var a = x === 2 ? true : false;
 
-var a = x ? true : false;       /*error Unnecessary use of boolean literals in conditional expression*/
+var a = x ? true : false;
 ```
 
 The following pattern is considered a warning when `defaultAssignment` is `false`:

--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -21,21 +21,21 @@ The following are considered problems:
 
 function foo() {
     return true;
-    console.log("done");      /*error Unreachable code.*/
+    console.log("done");
 }
 
 function bar() {
     throw new Error("Oops!");
-    console.log("done");      /*error Unreachable code.*/
+    console.log("done");
 }
 
 while(value) {
     break;
-    console.log("done");      /*error Unreachable code.*/
+    console.log("done");
 }
 
 throw new Error("Oops!");
-console.log("done");          /*error Unreachable code.*/
+console.log("done");
 
 function baz() {
     if (Math.random() < 0.5) {
@@ -43,11 +43,11 @@ function baz() {
     } else {
         throw new Error();
     }
-    console.log("done");      /*error Unreachable code.*/
+    console.log("done");
 }
 
 for (;;) {}
-console.log("done");          /*error Unreachable code.*/
+console.log("done");
 ```
 
 The following patterns are not considered problems (due to JavaScript function and variable hoisting):

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -28,19 +28,19 @@ By default the following patterns are considered problems:
 ```js
 /*eslint no-unused-expressions: 2*/
 
-0         /*error Expected an assignment or function call and instead saw an expression.*/
+0
 
-if(0) 0   /*error Expected an assignment or function call and instead saw an expression.*/
+if(0) 0
 
-{0}       /*error Expected an assignment or function call and instead saw an expression.*/
+{0}
 
-f(0), {}  /*error Expected an assignment or function call and instead saw an expression.*/
+f(0), {}
 
-a && b()  /*error Expected an assignment or function call and instead saw an expression.*/
+a && b()
 
-a, b()    /*error Expected an assignment or function call and instead saw an expression.*/
+a, b()
 
-c = a, b; /*error Expected an assignment or function call and instead saw an expression.*/
+c = a, b;
 ```
 
 The following patterns are not considered problems by default:
@@ -94,9 +94,9 @@ The above options still will not allow expressions that have code paths without 
 ```js
 /*eslint no-unused-expressions: [2, { allowShortCircuit: true, allowTernary: true }]*/
 
-a || b         /*error Expected an assignment or function call and instead saw an expression.*/
+a || b
 
-a ? b : 0      /*error Expected an assignment or function call and instead saw an expression.*/
+a ? b : 0
 
-a ? b : c()    /*error Expected an assignment or function call and instead saw an expression.*/
+a ? b : c()
 ```

--- a/docs/rules/no-unused-labels.md
+++ b/docs/rules/no-unused-labels.md
@@ -24,13 +24,13 @@ The following patterns are considered problems:
 ```js
 /*eslint no-unused-labels: 2*/
 
-A: var foo = 0;  /*error 'A:' is defined but never used.*/
+A: var foo = 0;
 
-B: {             /*error 'B:' is defined but never used.*/
+B: {
     foo();
 }
 
-C:               /*error 'C:' is defined but never used.*/
+C:
 for (let i = 0; i < 10; ++i) {
     foo();
 }

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -18,23 +18,23 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-unused-vars: 2*/
-/*global some_unsed_var */   /*error 'some_unsed_var' is defined but never used*/
+/*global some_unsed_var */
 
 //It checks variables you have defined as global
 some_unsed_var = 42;
 
-var x;                       /*error 'x' is defined but never used*/
+var x;
 
-var y = 10;                  /*error 'y' is defined but never used*/
+var y = 10;
 y = 5;
 
 // By default, unused arguments cause warnings.
-(function(foo) {             /*error 'foo' is defined but never used*/
+(function(foo) {
     return 5;
 })();
 
 // Unused recursive functions also cause warnings.
-function fact(n) {           /*error 'fact' is defined but never used*/
+function fact(n) {
     if (n < 2) return 1;
     return n * fact(n - 1);
 }
@@ -94,7 +94,7 @@ This option has three settings:
 ```js
 /*eslint no-unused-vars: [2, { "args": "all" }]*/
 
-(function(foo, bar, baz) { /*error 'foo' is defined but never used*/ /*error 'baz' is defined but never used*/
+(function(foo, bar, baz) {
     return bar;
 })();
 ```
@@ -104,7 +104,7 @@ This option has three settings:
 ```js
 /*eslint no-unused-vars: [2, { "args": "after-used" }]*/
 
-(function(foo, bar, baz) { /*error 'baz' is defined but never used*/
+(function(foo, bar, baz) {
     return bar;
 })();
 ```

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -14,20 +14,20 @@ The following patterns are considered problems:
 /*eslint no-use-before-define: 2*/
 /*eslint-env es6*/
 
-alert(a);       /*error 'a' was used before it was defined*/
+alert(a);
 var a = 10;
 
-f();            /*error 'f' was used before it was defined*/
+f();
 function f() {}
 
 function g() {
-    return b;  /*error 'b' was used before it was defined*/
+    return b;
 }
 var b = 1;
 
 // With blockBindings: true
 {
-    alert(c);  /*error 'c' was used before it was defined*/
+    alert(c);
     let c = 1;
 }
 ```
@@ -108,7 +108,7 @@ The following patterns are considered problems when `"classes": false` is specif
 ```js
 /*eslint no-use-before-define: [2, {classes: false}]*/
 
-new A();  /*error 'A' was used before it was defined*/
+new A();
 class A {
 }
 ```

--- a/docs/rules/no-useless-call.md
+++ b/docs/rules/no-useless-call.md
@@ -13,14 +13,14 @@ The following patterns are considered problems:
 /*eslint no-useless-call: 2*/
 
 // These are same as `foo(1, 2, 3);`
-foo.call(undefined, 1, 2, 3);     /*error unnecessary '.call()'.*/
-foo.apply(undefined, [1, 2, 3]);  /*error unnecessary '.apply()'.*/
-foo.call(null, 1, 2, 3);          /*error unnecessary '.call()'.*/
-foo.apply(null, [1, 2, 3]);       /*error unnecessary '.apply()'.*/
+foo.call(undefined, 1, 2, 3);
+foo.apply(undefined, [1, 2, 3]);
+foo.call(null, 1, 2, 3);
+foo.apply(null, [1, 2, 3]);
 
 // These are same as `obj.foo(1, 2, 3);`
-obj.foo.call(obj, 1, 2, 3);       /*error unnecessary '.call()'.*/
-obj.foo.apply(obj, [1, 2, 3]);    /*error unnecessary '.apply()'.*/
+obj.foo.call(obj, 1, 2, 3);
+obj.foo.apply(obj, [1, 2, 3]);
 ```
 
 The following patterns are not considered problems:
@@ -51,7 +51,7 @@ So if the code about `thisArg` is a dynamic expression, this rule cannot judge c
 /*eslint no-useless-call: 2*/
 
 // This is warned.
-a[i++].foo.call(a[i++], 1, 2, 3); /*error unnecessary '.call()'.*/
+a[i++].foo.call(a[i++], 1, 2, 3);
 
 // This is not warned.
 a[++i].foo.call(a[i], 1, 2, 3);

--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -23,11 +23,11 @@ The following patterns are considered problems:
 /*eslint-env es6*/
 
 // these are the same as "10"
-var a = `some` + `string`; /*error Unexpected string concatenation of literals.*/
-var a = '1' + '0';         /*error Unexpected string concatenation of literals.*/
-var a = '1' + `0`;         /*error Unexpected string concatenation of literals.*/
-var a = `1` + '0';         /*error Unexpected string concatenation of literals.*/
-var a = `1` + `0`;         /*error Unexpected string concatenation of literals.*/
+var a = `some` + `string`;
+var a = '1' + '0';
+var a = '1' + `0`;
+var a = `1` + '0';
+var a = `1` + `0`;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -26,8 +26,8 @@ The following patterns are considered problems:
 ```js
 /*eslint no-var: 2*/
 
-var x = "y";     /*error Unexpected var, use let or const instead.*/
-var CONFIG = {}; /*error Unexpected var, use let or const instead.*/
+var x = "y";
+var CONFIG = {};
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -53,9 +53,9 @@ The following patterns are considered problems:
 ```js
 /*eslint no-void: 2*/
 
-void foo              /*error Expected 'undefined' and instead saw 'void'.*/
+void foo
 
-var foo = void bar(); /*error Expected 'undefined' and instead saw 'void'.*/
+var foo = void bar();
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -30,10 +30,10 @@ The following patterns are considered problems:
 ```
 /*eslint no-warning-comments: [2, { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
 
-// TODO: this                          /*error Unexpected 'todo' comment.*/
-// todo: this too                      /*error Unexpected 'todo' comment.*/
-// Even this: TODO                     /*error Unexpected 'todo' comment.*/
-/*                                     /*error Unexpected 'todo' comment.*/ /*error Unexpected 'fixme' comment.*/ /*Unexpected 'any other term' comment.*/ /*
+// TODO: this
+// todo: this too
+// Even this: TODO
+/* /*
  * The same goes for this TODO comment
  * Or a fixme
  * as well as any other term

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -10,7 +10,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint no-with: 2*/
-with (foo) { /*error Unexpected use of 'with' statement.*/
+with (foo) {
     // ...
 }
 ```

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -48,12 +48,12 @@ When `"never"` is set, the following patterns are considered problems:
 ```
 /*eslint object-curly-spacing: [2, "never"]*/
 
-var obj = { 'foo': 'bar' };            /*error There should be no space after '{'*/ /*error There should be no space before '}'*/
-var obj = {'foo': 'bar' };                                                          /*error There should be no space before '}'*/
-var obj = { baz: {'foo': 'qux'}, bar}; /*error There should be no space after '{'*/
-var obj = {baz: { 'foo': 'qux'}, bar}; /*error There should be no space after '{'*/
-var {x } = y;                                                                       /*error There should be no space before '}'*/
-import { foo } from 'bar';             /*error There should be no space after '{'*/ /*error There should be no space before '}'*/
+var obj = { 'foo': 'bar' };
+var obj = {'foo': 'bar' };
+var obj = { baz: {'foo': 'qux'}, bar};
+var obj = {baz: { 'foo': 'qux'}, bar};
+var {x } = y;
+import { foo } from 'bar';
 ```
 
 The following patterns are not considered problems:
@@ -82,16 +82,16 @@ When `"always"` is used, the following patterns are considered problems:
 ```
 /*eslint object-curly-spacing: [2, "always"]*/
 
-var obj = {'foo': 'bar'};               /*error A space is required after '{'*/ /*error A space is required before '}'*/
-var obj = {'foo': 'bar' };              /*error A space is required after '{'*/
-var obj = { baz: {'foo': 'qux'}, bar};  /*error A space is required after '{'*/ /*error A space is required before '}'*/
-var obj = {baz: { 'foo': 'qux' }, bar}; /*error A space is required after '{'*/ /*error A space is required before '}'*/
-var obj = {'foo': 'bar'                 /*error A space is required after '{'*/
+var obj = {'foo': 'bar'};
+var obj = {'foo': 'bar' };
+var obj = { baz: {'foo': 'qux'}, bar};
+var obj = {baz: { 'foo': 'qux' }, bar};
+var obj = {'foo': 'bar'
 };
 var obj = {
-  'foo':'bar'};                                                                 /*error A space is required before '}'*/
-var {x} = y;                            /*error A space is required after '{'*/ /*error A space is required before '}'*/
-import {foo } from 'bar';               /*error A space is required after '{'*/
+  'foo':'bar'};
+var {x} = y;
+import {foo } from 'bar';
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -49,9 +49,9 @@ Each of the following properties would warn:
 /*eslint-env es6*/
 
 var foo = {
-    x: function() {},   /*error Expected method shorthand.*/
-    y: function *() {}, /*error Expected method shorthand.*/
-    z: z                /*error Expected property shorthand.*/
+    x: function() {},
+    y: function *() {},
+    z: z
 };
 ```
 

--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -33,11 +33,11 @@ The following patterns are considered problems when set to `"always"`:
 /*eslint one-var-declaration-per-line: [2, "always"]*/
 /*eslint-env es6*/
 
-var a, b;               /*error Expected variable declaration to be on a new line. */
+var a, b;
 
-let a, b = 0;           /*error Expected variable declaration to be on a new line. */
+let a, b = 0;
 
-const a = 0, b = 0;     /*error Expected variable declaration to be on a new line. */
+const a = 0, b = 0;
 ```
 
 The following patterns are not considered problems when set to `"always"`:
@@ -59,10 +59,10 @@ The following patterns are considered problems when set to `"initializations"`:
 /*eslint one-var-declaration-per-line: [2, "initializations"]*/
 /*eslint-env es6*/
 
-var a, b, c = 0;        /*error Expected variable declaration to be on a new line. */
+var a, b, c = 0;
 
 let a,
-    b = 0, c;           /*error Expected variable declaration to be on a new line. */
+    b = 0, c;
 ```
 
 The following patterns are not considered problems when set to `"initializations"`:

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -86,23 +86,23 @@ When configured with `"always"` as the first option (the default), the following
 
 function foo() {
     var bar;
-    var baz;     /*error Combine this with the previous 'var' statement.*/
+    var baz;
     let qux;
-    let norf;    /*error Combine this with the previous 'let' statement.*/
+    let norf;
 }
 
 function foo(){
     const bar = false;
-    const baz = true;  /*error Combine this with the previous 'const' statement.*/
+    const baz = true;
     let qux;
-    let norf;          /*error Combine this with the previous 'let' statement.*/
+    let norf;
 }
 
 function foo() {
     var bar;
 
     if (baz) {
-        var qux = true; /*error Combine this with the previous 'var' statement.*/
+        var qux = true;
     }
 }
 ```
@@ -152,14 +152,14 @@ When configured with `"never"` as the first option, the following patterns are c
 /*eslint-env es6*/
 
 function foo() {
-    var bar,          /*error Split 'var' declarations into multiple statements.*/
+    var bar,
         baz;
-    const bar = true, /*error Split 'const' declarations into multiple statements.*/
+    const bar = true,
         baz = false;
 }
 
 function foo() {
-    var bar,          /*error Split 'var' declarations into multiple statements.*/
+    var bar,
         qux;
 
     if (baz) {
@@ -168,7 +168,7 @@ function foo() {
 }
 
 function foo(){
-    let bar = true,   /*error Split 'let' declarations into multiple statements.*/
+    let bar = true,
         baz = false;
 }
 ```

--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -47,10 +47,10 @@ The following patterns are considered problems and should be replaced by their s
 ```js
 /*eslint operator-assignment: [2, "always"]*/
 
-x = x + y;        /*error Assignment can be replaced with operator assignment.*/
-x = y * x;        /*error Assignment can be replaced with operator assignment.*/
-x[0] = x[0] / y;  /*error Assignment can be replaced with operator assignment.*/
-x.y = x.y << z;   /*error Assignment can be replaced with operator assignment.*/
+x = x + y;
+x = y * x;
+x[0] = x[0] / y;
+x.y = x.y << z;
 ```
 
 ### "never"
@@ -73,8 +73,8 @@ The following patterns are considered problems and should be written out fully w
 ```js
 /*eslint operator-assignment: [2, "never"]*/
 
-x *= y;               /*error Unexpected operator assignment shorthand.*/
-x ^= (y + z) / foo(); /*error Unexpected operator assignment shorthand.*/
+x *= y;
+x ^= (y + z) / foo();
 ```
 
 ## When Not To Use It

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -42,22 +42,22 @@ While using this setting, the following patterns are considered problems:
 /*eslint operator-linebreak: [2, "after"]*/
 
 foo = 1
-+                        /*error Bad line breaking before and after '+'.*/
++
 2;
 
 foo = 1
-    + 2;                 /*error '+' should be placed at the end of the line.*/
+    + 2;
 
 foo
-    = 5;                 /*error '=' should be placed at the end of the line.*/
+    = 5;
 
 if (someCondition
-    || otherCondition) { /*error '||' should be placed at the end of the line.*/
+    || otherCondition) {
 }
 
 answer = everything
-  ? 42                   /*error '?' should be placed at the end of the line.*/
-  : foo;                 /*error ':' should be placed at the end of the line.*/
+  ? 42
+  : foo;
 ```
 
 The following patterns are not considered problems:
@@ -91,18 +91,18 @@ While using this setting, the following patterns are considered problems:
 ```js
 /*eslint operator-linebreak: [2, "before"]*/
 
-foo = 1 +              /*error '+' should be placed at the beginning of the line.*/
+foo = 1 +
       2;
 
-foo =                  /*error '=' should be placed at the beginning of the line.*/
+foo =
     5;
 
-if (someCondition ||   /*error '||' should be placed at the beginning of the line.*/
+if (someCondition ||
     otherCondition) {
 }
 
-answer = everything ? /*error '?' should be placed at the beginning of the line.*/
-  42 :                /*error ':' should be placed at the beginning of the line.*/
+answer = everything ?
+  42 :
   foo;
 ```
 
@@ -137,26 +137,26 @@ While using this setting, the following patterns are considered problems:
 ```js
 /*eslint operator-linebreak: [2, "none"]*/
 
-foo = 1 +                /*error There should be no line break before or after '+'*/
+foo = 1 +
       2;
 
 foo = 1
-    + 2;                 /*error There should be no line break before or after '+'*/
+    + 2;
 
-if (someCondition ||     /*error There should be no line break before or after '||'*/
+if (someCondition ||
     otherCondition) {
 }
 
 if (someCondition
-    || otherCondition) { /*error There should be no line break before or after '||'*/
+    || otherCondition) {
 }
 
 answer = everything
-  ? 42                   /*error There should be no line break before or after '?'*/
-  : foo;                 /*error There should be no line break before or after ':'*/
+  ? 42
+  : foo;
 
-answer = everything ?    /*error There should be no line break before or after '?'*/
-  42 :                   /*error There should be no line break before or after ':'*/
+answer = everything ?
+  42 :
   foo;
 ```
 

--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -26,28 +26,28 @@ The following patterns are considered problems when set to `"always"`:
 ```js
 /*eslint padded-blocks: [2, "always"]*/
 
-if (a) {         /*error Block must be padded by blank lines.*/
+if (a) {
     b();
-}                /*error Block must be padded by blank lines.*/
+}
 
-if (a) { b(); }  /*error Block must be padded by blank lines.*/
+if (a) { b(); }
 
 if (a)
-{                /*error Block must be padded by blank lines.*/
+{
     b();
-}                /*error Block must be padded by blank lines.*/
+}
 
 if (a) {
 
     b();
-}                /*error Block must be padded by blank lines.*/
+}
 
-if (a) {         /*error Block must be padded by blank lines.*/
+if (a) {
     b();
 
 }
 
-if (a) {         /*error Block must be padded by blank lines.*/
+if (a) {
     // comment
     b();
 
@@ -85,20 +85,20 @@ The following patterns are considered problems when set to `"never"`:
 ```js
 /*eslint padded-blocks: [2, "never"]*/
 
-if (a) {  /*error Block must not be padded by blank lines.*/
+if (a) {
 
     b();
 
-}        /*error Block must not be padded by blank lines.*/
+}
 
 if (a)
-{        /*error Block must not be padded by blank lines.*/
+{
 
     b();
 
-}        /*error Block must not be padded by blank lines.*/
+}
 
-if (a) { /*error Block must not be padded by blank lines.*/
+if (a) {
 
     b();
 }
@@ -106,7 +106,7 @@ if (a) { /*error Block must not be padded by blank lines.*/
 if (a) {
     b();
 
-}        /*error Block must not be padded by blank lines.*/
+}
 ```
 
 The following patterns are not considered problems when set to `"never"`:

--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -14,8 +14,8 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-arrow-callback: 2*/
 
-foo(function(a) { return a; });                /*error Unexpected function expression.*/
-foo(function() { return this.a; }.bind(this)); /*error Unexpected function expression.*/
+foo(function(a) { return a; });
+foo(function() { return this.a; }.bind(this));
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -14,16 +14,16 @@ The following patterns are considered problems:
 /*eslint prefer-const: 2*/
 /*eslint-env es6*/
 
-let a = 3;               /*error 'a' is never modified, use 'const' instead.*/
+let a = 3;
 console.log(a);
 
 // `i` is re-defined (not modified) on each loop step.
-for (let i in [1,2,3]) {  /*error 'i' is never modified, use 'const' instead.*/
+for (let i in [1,2,3]) {
     console.log(i);
 }
 
 // `a` is re-defined (not modified) on each loop step.
-for (let a of [1,2,3]) { /*error 'a' is never modified, use 'const' instead.*/
+for (let a of [1,2,3]) {
     console.log(a);
 }
 ```

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -36,15 +36,15 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-foo.apply(undefined, args); /*error Avoid using Function.prototype.apply, instead use Reflect.apply*/
-foo.apply(null, args);      /*error Avoid using Function.prototype.apply, instead use Reflect.apply*/
-obj.foo.apply(obj, args);   /*error Avoid using Function.prototype.apply, instead use Reflect.apply*/
-obj.foo.apply(other, args); /*error Avoid using Function.prototype.apply, instead use Reflect.apply*/
+foo.apply(undefined, args);
+foo.apply(null, args);
+obj.foo.apply(obj, args);
+obj.foo.apply(other, args);
 
-foo.call(undefined, arg);   /*error Avoid using Function.prototype.call, instead use Reflect.apply*/
-foo.call(null, arg);        /*error Avoid using Function.prototype.call, instead use Reflect.apply*/
-obj.foo.call(obj, arg);     /*error Avoid using Function.prototype.call, instead use Reflect.apply*/
-obj.foo.call(other, arg);   /*error Avoid using Function.prototype.call, instead use Reflect.apply*/
+foo.call(undefined, arg);
+foo.call(null, arg);
+obj.foo.call(obj, arg);
+obj.foo.call(other, arg);
 ```
 
 The following patterns are not considered problems:
@@ -95,7 +95,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-Object.defineProperty({}, 'foo', {value: 1}) /*error Avoid using Object.defineProperty, instead use Reflect.defineProperty*/
+Object.defineProperty({}, 'foo', {value: 1})
 ```
 
 The following patterns are not considered problems:
@@ -120,7 +120,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-Object.getOwnPropertyDescriptor({}, 'foo') /*error Avoid using Object.getOwnPropertyDescriptor, instead use Reflect.getOwnPropertyDescriptor*/
+Object.getOwnPropertyDescriptor({}, 'foo')
 ```
 
 The following patterns are not considered problems:
@@ -147,7 +147,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-Object.getPrototypeOf({}, 'foo') /*error Avoid using Object.getPrototypeOf, instead use Reflect.getPrototypeOf*/
+Object.getPrototypeOf({}, 'foo')
 ```
 
 The following patterns are not considered problems:
@@ -172,7 +172,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-Object.setPrototypeOf({}, Object.prototype) /*error Avoid using Object.setPrototypeOf, instead use Reflect.setPrototypeOf*/
+Object.setPrototypeOf({}, Object.prototype)
 ```
 
 The following patterns are not considered problems:
@@ -199,7 +199,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-Object.isExtensible({}) /*error Avoid using Object.isExtensible, instead use Reflect.isExtensible*/
+Object.isExtensible({})
 ```
 
 The following patterns are not considered problems:
@@ -224,7 +224,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-Object.getOwnPropertyNames({}) /*error Avoid using Object.getOwnPropertyNames, instead use Reflect.getOwnPropertyNames*/
+Object.getOwnPropertyNames({})
 ```
 
 The following patterns are not considered problems:
@@ -249,7 +249,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-Object.preventExtensions({}) /*error Avoid using Object.preventExtensions, instead use Reflect.preventExtensions*/
+Object.preventExtensions({})
 ```
 
 The following patterns are not considered problems:
@@ -274,7 +274,7 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-reflect: 2*/
 
-delete foo.bar; /*error Avoid using the delete keyword, instead use Reflect.deleteProperty*/
+delete foo.bar;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/prefer-rest-params.md
+++ b/docs/rules/prefer-rest-params.md
@@ -13,11 +13,11 @@ The following patterns are considered problems:
 
 ```js
 function foo() {
-    console.log(arguments);                 /*error Use the rest parameters instead of 'arguments'. */
+    console.log(arguments);
 }
 
 function foo(action) {
-    var args = [].slice.call(arguments, 1); /*error Use the rest parameters instead of 'arguments'. */
+    var args = [].slice.call(arguments, 1);
     action.apply(null, args);
 }
 ```

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -25,11 +25,11 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-spread: 2*/
 
-foo.apply(undefined, args); /*error use the spread operator instead of the '.apply()'.*/
+foo.apply(undefined, args);
 
-foo.apply(null, args);      /*error use the spread operator instead of the '.apply()'.*/
+foo.apply(null, args);
 
-obj.foo.apply(obj, args);   /*error use the spread operator instead of the '.apply()'.*/
+obj.foo.apply(obj, args);
 ```
 
 The following patterns are not considered problems:
@@ -58,7 +58,7 @@ So if the `this` argument is computed in a dynamic expression, this rule cannot 
 /*eslint prefer-spread: 2*/
 
 // This warns.
-a[i++].foo.apply(a[i++], args); /*error use the spread operator instead of the '.apply()'.*/
+a[i++].foo.apply(a[i++], args);
 
 // This does not warn.
 a[++i].foo.apply(a[i], args);

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -21,8 +21,8 @@ The following patterns are considered problems:
 ```js
 /*eslint prefer-template: 2*/
 
-var str = "Hello, " + name + "!";           /*error Unexpected string concatenation.*/
-var str = "Time: " + (12 * 60 * 60 * 1000); /*error Unexpected string concatenation.*/
+var str = "Hello, " + name + "!";
+var str = "Time: " + (12 * 60 * 60 * 1000);
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -82,8 +82,8 @@ When configured with `"always"` as the first option (the default), quoting for a
 /*eslint quote-props: [2, "always"]*/
 
 var object = {
-    foo: "bar",         /*error Unquoted property 'foo' found.*/
-    baz: 42,            /*error Unquoted property 'baz' found.*/
+    foo: "bar",
+    baz: 42,
     "qux-lorem": true
 };
 ```
@@ -121,10 +121,10 @@ When configured with `"as-needed"` as the first option, quotes will be enforced 
 /*eslint quote-props: [2, "as-needed"]*/
 
 var object = {
-    "a": 0,    /*error Unnecessarily quoted property 'a' found.*/
-    "0": 0,    /*error Unnecessarily quoted property '0' found.*/
-    "true": 0, /*error Unnecessarily quoted property 'true' found.*/
-    "null": 0  /*error Unnecessarily quoted property 'null' found.*/
+    "a": 0,
+    "0": 0,
+    "true": 0,
+    "null": 0
 };
 ```
 
@@ -169,8 +169,8 @@ When `keywords` is set to `true`, the following patterns become problems:
 /*eslint quote-props: [2, "as-needed", { "keywords": true }]*/
 
 var x = {
-    while: 1,       /*error Unquoted reserved word 'while' used as key.*/
-    volatile: "foo" /*error Unquoted reserved word 'volatile' used as key.*/
+    while: 1,
+    volatile: "foo"
 };
 ```
 
@@ -207,7 +207,7 @@ When `numbers` is set to `true`, the following patterns become problems:
 /*eslint quote-props: [2, "as-needed", { "numbers": true }]*/
 
 var x = {
-    100: 1 /*error Unquoted number literal '100' used as key.*/
+    100: 1
 }
 ```
 
@@ -226,13 +226,13 @@ When configured with `"consistent"`, the patterns below are considered problems.
 ```js
 /*eslint quote-props: [2, "consistent"]*/
 
-var object1 = {        /*error Inconsistently quoted property 'baz' found.*/ /*error Inconsistently quoted property 'qux-lorem' found.*/
+var object1 = {
     foo: "bar",
     "baz": 42,
     "qux-lorem": true
 };
 
-var object2 = {        /*error Inconsistently quoted property 'baz' found.*/
+var object2 = {
     'foo': 'bar',
     baz: 42
 };
@@ -267,13 +267,13 @@ When configured with `"consistent-as-needed"`, the behavior is similar to `"cons
 ```js
 /*eslint quote-props: [2, "consistent-as-needed"]*/
 
-var object1 = {         /*error Inconsistently quoted property 'baz' found.*/ /*error Inconsistently quoted property 'qux-lorem' found.*/
+var object1 = {
     foo: "bar",
     "baz": 42,
     "qux-lorem": true
 };
 
-var object2 = {         /*error Properties shouldn't be quoted as all quotes are redundant.*/
+var object2 = {
     'foo': 'bar',
     'baz': 42
 };
@@ -309,7 +309,7 @@ When `keywords` is set to `true`, the following patterns are considered problems
 ```js
 /*eslint quote-props: [2, "consistent-as-needed", { "keywords": true }]*/
 
-var x = {           /*error Properties should be quoted as 'while' is a reserved word.*/ /*error Properties should be quoted as 'volatile' is a reserved word.*/
+var x = {
     while: 1,
     volatile: "foo"
 };

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -39,44 +39,44 @@ The following patterns are considered problems:
 ```js
 /*eslint quotes: [2, "double"]*/
 
-var single = 'single';                                 /*error Strings must use doublequote.*/
-var unescaped = 'a string containing "double" quotes'; /*error Strings must use doublequote.*/
+var single = 'single';
+var unescaped = 'a string containing "double" quotes';
 ```
 
 ```js
 /*eslint quotes: [2, "single"]*/
 
-var double = "double";                                 /*error Strings must use singlequote.*/
-var unescaped = "a string containing 'single' quotes"; /*error Strings must use singlequote.*/
+var double = "double";
+var unescaped = "a string containing 'single' quotes";
 ```
 
 ```js
 /*eslint quotes: [2, "double", "avoid-escape"]*/
 
-var single = 'single'; /*error Strings must use doublequote.*/
-var single = `single`; /*error Strings must use doublequote.*/
+var single = 'single';
+var single = `single`;
 ```
 
 ```js
 /*eslint quotes: [2, "single", "avoid-escape"]*/
 
-var double = "double"; /*error Strings must use singlequote.*/
-var double = `double`; /*error Strings must use singlequote.*/
+var double = "double";
+var double = `double`;
 ```
 
 ```js
 /*eslint quotes: [2, "backtick"]*/
 
-var single = 'single';                             /*error Strings must use backtick.*/
-var double = "double";                             /*error Strings must use backtick.*/
-var unescaped = 'a string containing `backticks`'; /*error Strings must use backtick.*/
+var single = 'single';
+var double = "double";
+var unescaped = 'a string containing `backticks`';
 ```
 
 ```js
 /*eslint quotes: [2, "backtick", "avoid-escape"]*/
 
-var single = 'single'; /*error Strings must use backtick.*/
-var double = "double"; /*error Strings must use backtick.*/
+var single = 'single';
+var double = "double";
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/radix.md
+++ b/docs/rules/radix.md
@@ -42,13 +42,13 @@ The following patterns are considered problems:
 ```js
 /*eslint radix: 2*/
 
-var num = parseInt("071");        /*error Missing radix parameter.*/
+var num = parseInt("071");
 
-var num = parseInt(someValue);    /*error Missing radix parameter.*/
+var num = parseInt(someValue);
 
-var num = parseInt("071", "abc"); /*error Invalid radix parameter.*/
+var num = parseInt("071", "abc");
 
-var num = parseInt();             /*error Missing parameters.*/
+var num = parseInt();
 ```
 
 The following patterns are not considered problems:
@@ -70,11 +70,11 @@ The following patterns are considered problems:
 ```js
 /*eslint radix: [2. "as-needed"] */
 
-var num = parseInt("071", 10);    /*error Redundant radix parameter.*/
+var num = parseInt("071", 10);
 
-var num = parseInt("071", "abc"); /*error Invalid radix parameter.*/
+var num = parseInt("071", "abc");
 
-var num = parseInt();             /*error Missing parameters.*/
+var num = parseInt();
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -57,12 +57,12 @@ The following patterns are considered problems:
     }
 }]*/
 
-function foo() {       /*error Missing JSDoc comment.*/
+function foo() {
     return 10;
 }
 
-class Test{            /*error Missing JSDoc comment.*/
-    getDate(){}        /*error Missing JSDoc comment.*/
+class Test{
+    getDate(){}
 }
 ```
 

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -10,7 +10,7 @@ The following patterns are considered problems:
 /*eslint require-yield: 2*/
 /*eslint-env es6*/
 
-function* foo() { /*error This generator function does not have 'yield'.*/
+function* foo() {
   return 10;
 }
 ```

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -46,12 +46,12 @@ The following patterns are considered problems:
 ```js
 /*eslint semi-spacing: 2*/
 
-var foo ;                      /*error Unexpected whitespace before semicolon.*/
-var foo;var bar;               /*error Missing whitespace after semicolon.*/
-throw new Error("error") ;     /*error Unexpected whitespace before semicolon.*/
-while (a) { break ; }          /*error Unexpected whitespace before semicolon.*/
-for (i = 0 ; i < 10 ; i++) {}  /*error Unexpected whitespace before semicolon.*/
-for (i = 0;i < 10;i++) {}      /*error Missing whitespace after semicolon.*/
+var foo ;
+var foo;var bar;
+throw new Error("error") ;
+while (a) { break ; }
+for (i = 0 ; i < 10 ; i++) {}
+for (i = 0;i < 10;i++) {}
 ```
 
 The following patterns are not considered problems:
@@ -78,12 +78,12 @@ The following patterns are considered problems:
 ```js
 /*eslint semi-spacing: [2, { "before": true, "after": false }]*/
 
-var foo;                    /*error Missing whitespace before semicolon.*/
-var foo ; var bar;          /*error Missing whitespace before semicolon.*/ /*error Unexpected whitespace after semicolon.*/
-throw new Error("error");   /*error Missing whitespace before semicolon.*/
-while (a) { break; }        /*error Missing whitespace before semicolon.*/ /*error Unexpected whitespace after semicolon.*/
-for (i = 0;i < 10;i++) {}   /*error Missing whitespace before semicolon.*/
-for (i = 0; i < 10; i++) {} /*error Missing whitespace before semicolon.*/ /*error Unexpected whitespace after semicolon.*/
+var foo;
+var foo ; var bar;
+throw new Error("error");
+while (a) { break; }
+for (i = 0;i < 10;i++) {}
+for (i = 0; i < 10; i++) {}
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -78,11 +78,11 @@ The following patterns are considered problems:
 ```js
 /*eslint semi: 2*/
 
-var name = "ESLint"          /*error Missing semicolon.*/
+var name = "ESLint"
 
 object.method = function() {
     // ...
-}                            /*error Missing semicolon.*/
+}
 ```
 
 The following patterns are not considered problems:
@@ -111,10 +111,10 @@ The following patterns are considered problems:
 /*eslint semi: [2, "always", { "omitLastInOneLineBlock": true}] */
 
 if (foo) {
-    bar()                   /*error Missing semicolon.*/
+    bar()
 }
 
-if (foo) { bar(); }         /*error Extra semicolon.*/
+if (foo) { bar(); }
 ```
 
 The following patterns are not considered problems:
@@ -140,11 +140,11 @@ Then, the following patterns are considered problems:
 ```js
 /*eslint semi: [2, "never"]*/
 
-var name = "ESLint";         /*error Extra semicolon.*/
+var name = "ESLint";
 
 object.method = function() {
     // ...
-};                           /*error Extra semicolon.*/
+};
 ```
 
 And the following patterns are not considered problems:

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -53,26 +53,26 @@ The following patterns are considered problems:
 ```js
 /*eslint sort-imports: 2*/
 import b from 'foo.js';
-import a from 'bar.js'; /*error Imports should be sorted alphabetically.*/
+import a from 'bar.js';
 
 /*eslint sort-imports: 2*/
 import a from 'foo.js';
-import A from 'bar.js'; /*error Imports should be sorted alphabetically.*/
+import A from 'bar.js';
 
 /*eslint sort-imports: 2*/
 import {b, c} from 'foo.js';
-import {a, b} from 'bar.js'; /*error Imports should be sorted alphabetically.*/
+import {a, b} from 'bar.js';
 
 /*eslint sort-imports: 2*/
 import a from 'foo.js';
-import {b, c} from 'bar.js'; /*error Imports should be sorted by their member syntax. Use 'multiple' before 'single' member syntax.*/
+import {b, c} from 'bar.js';
 
 /*eslint sort-imports: 2*/
 import a from 'foo.js';
-import * as b from 'bar.js'; /*error Imports should be sorted by their member syntax. Use 'all' before 'single' member syntax. */
+import * as b from 'bar.js';
 
 /*eslint sort-imports: 2*/
-import {b, a, c} from 'foo.js' /*error Members of an import declaration should be sorted alphabetically.*/
+import {b, a, c} from 'foo.js'
 ```
 
 The following patterns are not considered problems:
@@ -147,7 +147,7 @@ The following patterns are considered problems:
 
 ```js
 /*eslint sort-imports: 2*/
-import {b, a, c} from 'foo.js' /*error Members of an import declaration should be sorted alphabetically.*/
+import {b, a, c} from 'foo.js'
 ```
 
 The following patterns are not considered problems:
@@ -175,7 +175,7 @@ The following patterns are considered problems:
 ```js
 /*eslint sort-imports: 2*/
 import a from 'foo.js';
-import * as b from 'bar.js'; /*error Imports should be sorted by their member syntax. Use 'all' before 'single' member syntax. */
+import * as b from 'bar.js';
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -12,11 +12,11 @@ The following patterns are considered problems:
 ```js
 /*eslint sort-vars: 2*/
 
-var b, a;    /*error Variables within the same declaration block should be sorted alphabetically*/
+var b, a;
 
-var a, B, c; /*error Variables within the same declaration block should be sorted alphabetically*/
+var a, B, c;
 
-var a, A;    /*error Variables within the same declaration block should be sorted alphabetically*/
+var a, A;
 ```
 
 The following patterns are not considered problems:
@@ -39,7 +39,7 @@ Alphabetical list is maintained starting from the first variable and excluding a
 ```js
 /*eslint sort-vars: 2*/
 
-var c, d, a, b; /*error Variables within the same declaration block should be sorted alphabetically*/
+var c, d, a, b;
 ```
 
 But this one, will only produce one:
@@ -47,7 +47,7 @@ But this one, will only produce one:
 ```js
 /*eslint sort-vars: 2*/
 
-var c, d, a, e; /*error Variables within the same declaration block should be sorted alphabetically*/
+var c, d, a, e;
 ```
 
 ## Rule Options

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -32,17 +32,17 @@ The following patterns are considered problems:
 ```js
 /*eslint space-after-keywords: 2*/
 
-if(a) {}         /*error Keyword 'if' must be followed by whitespace.*/
+if(a) {}
 
-if (a) {} else{} /*error Keyword 'else' must be followed by whitespace.*/
+if (a) {} else{}
 
-do{} while (a);  /*error Keyword 'do' must be followed by whitespace.*/
+do{} while (a);
 ```
 
 ```js
 /*eslint space-after-keywords: [2, "never"]*/
 
-if (a) {}        /*error Keyword 'if' must not be followed by whitespace.*/
+if (a) {}
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -30,20 +30,20 @@ The following patterns are considered problems:
 ```js
 /*eslint space-before-blocks: 2*/
 
-if (a){           /*error Missing space before opening brace.*/
+if (a){
     b();
 }
 
-function a(){}    /*error Missing space before opening brace.*/
+function a(){}
 
-for (;;){         /*error Missing space before opening brace.*/
+for (;;){
     b();
 }
 
-try {} catch(a){} /*error Missing space before opening brace.*/
+try {} catch(a){}
 
-class Foo{          /*error Missing space before opening brace.*/
-  constructor(){}   /*error Missing space before opening brace.*/
+class Foo{
+  constructor(){}
 }
 ```
 
@@ -79,17 +79,17 @@ The following patterns are considered problems:
 ```js
 /*eslint space-before-blocks: [2, "never"]*/
 
-if (a) {           /*error Unexpected space before opening brace.*/
+if (a) {
     b();
 }
 
-function a() {}    /*error Unexpected space before opening brace.*/
+function a() {}
 
-for (;;) {         /*error Unexpected space before opening brace.*/
+for (;;) {
     b();
 }
 
-try {} catch(a) {} /*error Unexpected space before opening brace.*/
+try {} catch(a) {}
 ```
 
 The following patterns are not considered problems:
@@ -120,12 +120,12 @@ The following patterns are considered problems when configured `{ "functions": "
 /*eslint space-before-blocks: [2, { "functions": "never", "keywords": "always", classes: "never" }]*/
 /*eslint-env es6*/
 
-function a() {}    /*error Unexpected space before opening brace.*/
+function a() {}
 
-try {} catch(a){}  /*error Missing space before opening brace.*/
+try {} catch(a){}
 
 class Foo{
-  constructor() {} /*error Unexpected space before opening brace.*/
+  constructor() {}
 }
 ```
 
@@ -144,7 +144,7 @@ describe(function(){
   // ...
 });
 
-class Foo {         /*error Unexpected space before opening brace.*/
+class Foo {
   constructor(){}
 }
 ```
@@ -155,12 +155,12 @@ The following patterns are considered problems when configured `{ "functions": "
 /*eslint space-before-blocks: [2, { "functions": "always", "keywords": "never", classes: "never" }]*/
 /*eslint-env es6*/
 
-function a(){}      /*error Missing space before opening brace.*/
+function a(){}
 
-try {} catch(a) {}  /*error Unexpected space before opening brace.*/
+try {} catch(a) {}
 
-class Foo {         /*error Unexpected space before opening brace.*/
-  constructor(){}   /*error Missing space before opening brace.*/
+class Foo {
+  constructor(){}
 }
 ```
 
@@ -188,7 +188,7 @@ The following patterns are considered problems when configured `{ "functions": "
 /*eslint space-before-blocks: [2, { "functions": "never", "keywords": "never", classes: "always" }]*/
 /*eslint-env es6*/
 
-class Foo{         /*error Unexpected space before opening brace.*/
+class Foo{
   constructor(){}
 }
 ```

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -36,26 +36,26 @@ The following patterns are considered problems:
 /*eslint space-before-function-paren: 2*/
 /*eslint-env es6*/
 
-function foo() {           /*error Missing space before function parentheses.*/
+function foo() {
     // ...
 }
 
-var bar = function() {     /*error Missing space before function parentheses.*/
+var bar = function() {
     // ...
 };
 
-var bar = function foo() { /*error Missing space before function parentheses.*/
+var bar = function foo() {
     // ...
 };
 
 class Foo {
-    constructor() {        /*error Missing space before function parentheses.*/
+    constructor() {
         // ...
     }
 }
 
 var foo = {
-    bar() {                /*error Missing space before function parentheses.*/
+    bar() {
         // ...
     }
 };
@@ -100,26 +100,26 @@ The following patterns are considered problems:
 /*eslint space-before-function-paren: [2, "never"]*/
 /*eslint-env es6*/
 
-function foo () {           /*error Unexpected space before function parentheses.*/
+function foo () {
     // ...
 }
 
-var bar = function () {     /*error Unexpected space before function parentheses.*/
+var bar = function () {
     // ...
 };
 
-var bar = function foo () { /*error Unexpected space before function parentheses.*/
+var bar = function foo () {
     // ...
 };
 
 class Foo {
-    constructor () {        /*error Unexpected space before function parentheses.*/
+    constructor () {
         // ...
     }
 }
 
 var foo = {
-    bar () {                /*error Unexpected space before function parentheses.*/
+    bar () {
         // ...
     }
 };
@@ -164,22 +164,22 @@ The following patterns are considered problems:
 /*eslint space-before-function-paren: [2, { "anonymous": "always", "named": "never" }]*/
 /*eslint-env es6*/
 
-function foo () {      /*error Unexpected space before function parentheses.*/
+function foo () {
     // ...
 }
 
-var bar = function() { /*error Missing space before function parentheses.*/
+var bar = function() {
     // ...
 };
 
 class Foo {
-    constructor () {   /*error Unexpected space before function parentheses.*/
+    constructor () {
         // ...
     }
 }
 
 var foo = {
-    bar () {           /*error Unexpected space before function parentheses.*/
+    bar () {
         // ...
     }
 };
@@ -220,22 +220,22 @@ The following patterns are considered problems:
 /*eslint space-before-function-paren: [2, { "anonymous": "never", "named": "always" }]*/
 /*eslint-env es6*/
 
-function foo() {        /*error Missing space before function parentheses.*/
+function foo() {
     // ...
 }
 
-var bar = function () { /*error Unexpected space before function parentheses.*/
+var bar = function () {
     // ...
 };
 
 class Foo {
-    constructor() {     /*error Missing space before function parentheses.*/
+    constructor() {
         // ...
     }
 }
 
 var foo = {
-    bar() {             /*error Missing space before function parentheses.*/
+    bar() {
         // ...
     }
 };

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -37,16 +37,16 @@ The following patterns are considered errors when configured `"never"`:
 
 if (foo) {
     // ...
-} else {}         /*error Unexpected space before keyword 'else'.*/
+} else {}
 
 do {
 
 }
-while (foo)       /*error Unexpected space before keyword 'while'.*/
+while (foo)
 
-try {} finally {} /*error Unexpected space before keyword 'finally'.*/
+try {} finally {}
 
-try {} catch(e) {} /*error Unexpected space before keyword 'catch'.*/
+try {} catch(e) {}
 ```
 
 The following patterns are not considered errors when configured `"never"`:
@@ -73,14 +73,14 @@ The following patterns are considered errors when configured `"always"`:
 
 if (foo) {
     // ...
-}else {}                           /*error Missing space before keyword 'else'.*/
+}else {}
 
-const foo = 'bar';let baz = 'qux'; /*error Missing space before keyword 'let'.*/
+const foo = 'bar';let baz = 'qux';
 
-var foo =function bar () {}        /*error Missing space before keyword 'function'.*/
+var foo =function bar () {}
 
 function bar() {
-    if (foo) {return; }            /*error Missing space before keyword 'return'.*/
+    if (foo) {return; }
 }
 ```
 

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -36,12 +36,12 @@ When `"always"` is set, the following patterns are considered problems:
 ```js
 /*eslint space-in-parens: [2, "always"]*/
 
-foo( 'bar'); /*error There must be a space inside this paren.*/
-foo('bar' ); /*error There must be a space inside this paren.*/
-foo('bar');  /*error There must be a space inside this paren.*/
+foo( 'bar');
+foo('bar' );
+foo('bar');
 
-var foo = (1 + 2) * 3;             /*error There must be a space inside this paren.*/
-(function () { return 'bar'; }()); /*error There must be a space inside this paren.*/
+var foo = (1 + 2) * 3;
+(function () { return 'bar'; }());
 ```
 
 The following patterns are not considered problems:
@@ -64,12 +64,12 @@ When `"never"` is used, the following patterns are considered problems:
 ```js
 /*eslint space-in-parens: [2, "never"]*/
 
-foo( 'bar');  /*error There should be no spaces inside this paren.*/
-foo('bar' );  /*error There should be no spaces inside this paren.*/
-foo( 'bar' ); /*error There should be no spaces inside this paren.*/
+foo( 'bar');
+foo('bar' );
+foo( 'bar' );
 
-var foo = ( 1 + 2 ) * 3;             /*error There should be no spaces inside this paren.*/
-( function () { return 'bar'; }() ); /*error There should be no spaces inside this paren.*/
+var foo = ( 1 + 2 ) * 3;
+( function () { return 'bar'; }() );
 ```
 
 The following patterns are not considered problems:
@@ -96,8 +96,8 @@ For example, given `"space-in-parens": [2, "always", { "exceptions": ["{}"] }]`,
 ```js
 /*eslint space-in-parens: [2, "always", { "exceptions": ["{}"] }]*/
 
-foo( {bar: 'baz'} );    /*error There should be no spaces inside this paren.*/
-foo( 1, {bar: 'baz'} ); /*error There should be no spaces inside this paren.*/
+foo( {bar: 'baz'} );
+foo( 1, {bar: 'baz'} );
 ```
 
 The following patterns are not considered problems:
@@ -114,8 +114,8 @@ Or, given `"space-in-parens": [2, "never", { "exceptions": ["{}"] }]`, the follo
 ```js
 /*eslint space-in-parens: [2, "never", { "exceptions": ["{}"] }]*/
 
-foo({bar: 'baz'});    /*error There must be a space inside this paren.*/
-foo(1, {bar: 'baz'}); /*error There must be a space inside this paren.*/
+foo({bar: 'baz'});
+foo(1, {bar: 'baz'});
 ```
 
 The following patterns are not considered problems:
@@ -132,8 +132,8 @@ Given `"space-in-parens": [2, "always", { "exceptions": ["[]"] }]`, the followin
 ```js
 /*eslint space-in-parens: [2, "always", { "exceptions": ["[]"] }]*/
 
-foo( [bar, baz] );    /*error There should be no spaces inside this paren.*/
-foo( [bar, baz], 1 ); /*error There should be no spaces inside this paren.*/
+foo( [bar, baz] );
+foo( [bar, baz], 1 );
 ```
 
 The following patterns are not considered problems:
@@ -150,8 +150,8 @@ Or, given `"space-in-parens": [2, "never", { "exceptions": ["[]"] }]`, the follo
 ```js
 /*eslint space-in-parens: [2, "never", { "exceptions": ["[]"] }]*/
 
-foo([bar, baz]);    /*error There must be a space inside this paren.*/
-foo([bar, baz], 1); /*error There must be a space inside this paren.*/
+foo([bar, baz]);
+foo([bar, baz], 1);
 ```
 
 The following patterns are not considered problems:
@@ -168,8 +168,8 @@ Given `"space-in-parens": [2, "always", { "exceptions": ["()"] }]`, the followin
 ```js
 /*eslint space-in-parens: [2, "always", { "exceptions": ["()"] }]*/
 
-foo( ( 1 + 2 ) );    /*error There should be no spaces inside this paren.*/
-foo( ( 1 + 2 ), 1 ); /*error There should be no spaces inside this paren.*/
+foo( ( 1 + 2 ) );
+foo( ( 1 + 2 ), 1 );
 ```
 
 The following patterns are not considered problems:
@@ -186,8 +186,8 @@ Or, given `"space-in-parens": [2, "never", { "exceptions": ["()"] }]`, the follo
 ```js
 /*eslint space-in-parens: [2, "never", { "exceptions": ["()"] }]*/
 
-foo((1 + 2));    /*error There must be a space inside this paren.*/
-foo((1 + 2), 1); /*error There must be a space inside this paren.*/
+foo((1 + 2));
+foo((1 + 2), 1);
 ```
 
 The following patterns are not considered problems:
@@ -206,7 +206,7 @@ For example, given `"space-in-parens": [2, "always", { "exceptions": ["empty"] }
 ```js
 /*eslint space-in-parens: [2, "always", { "exceptions": ["empty"] }]*/
 
-foo( ); /*error There should be no spaces inside this paren.*/
+foo( );
 ```
 
 The following patterns are not considered problems:
@@ -222,7 +222,7 @@ Or, given `"space-in-parens": [2, "never", { "exceptions": ["empty"] }]`, the fo
 ```js
 /*eslint space-in-parens: [2, "never", { "exceptions": ["empty"] }]*/
 
-foo(); /*error There must be a space inside this paren.*/
+foo();
 ```
 
 The following patterns are not considered problems:
@@ -238,9 +238,9 @@ You can include multiple entries in the `"exceptions"` array. For example, given
 ```js
 /*eslint space-in-parens: [2, "always", { "exceptions": ["{}", "[]"] }]*/
 
-bar( {bar:'baz'} );          /*error There should be no spaces inside this paren.*/
-baz( 1, [1,2] );             /*error There should be no spaces inside this paren.*/
-foo( {bar: 'baz'}, [1, 2] ); /*error There should be no spaces inside this paren.*/
+bar( {bar:'baz'} );
+baz( 1, [1,2] );
+foo( {bar: 'baz'}, [1, 2] );
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -42,19 +42,19 @@ The following patterns are considered problems:
 /*eslint space-infix-ops: 2*/
 /*eslint-env es6*/
 
-a+b                   /*error Infix operators must be spaced.*/
+a+b
 
-a+ b                  /*error Infix operators must be spaced.*/
+a+ b
 
-a +b                  /*error Infix operators must be spaced.*/
+a +b
 
-a?b:c                 /*error Infix operators must be spaced.*/
+a?b:c
 
-const a={b:1};        /*error Infix operators must be spaced.*/
+const a={b:1};
 
-var {a=0}=bar;        /*error Infix operators must be spaced.*/
+var {a=0}=bar;
 
-function foo(a=0) { } /*error Infix operators must be spaced.*/
+function foo(a=0) { }
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -13,11 +13,11 @@ The following patterns are considered problems:
 ```js
 /*eslint space-return-throw-case: 2*/
 
-throw{a:0}                   /*error Keyword 'throw' must be followed by whitespace.*/
+throw{a:0}
 
-function f(){ return-a; }    /*error Keyword 'return' must be followed by whitespace.*/
+function f(){ return-a; }
 
-switch(a){ case'a': break; } /*error Keyword 'case' must be followed by whitespace.*/
+switch(a){ case'a': break; }
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -58,25 +58,25 @@ Given the default values `words`: `true`, `nonwords`: `false`, the following pat
 /*eslint space-unary-ops: 2*/
 /*eslint-env es6*/
 
-typeof!foo;        /*error Unary word operator 'typeof' must be followed by whitespace.*/
+typeof!foo;
 
-void{foo:0};       /*error Unary word operator 'void' must be followed by whitespace.*/
+void{foo:0};
 
-new[foo][0];       /*error Unary word operator 'new' must be followed by whitespace.*/
+new[foo][0];
 
-delete(foo.bar);   /*error Unary word operator 'delete' must be followed by whitespace.*/
+delete(foo.bar);
 
 function *foo() {
-    yield(0)       /*error Unary word operator 'yield' must be followed by whitespace.*/
+    yield(0)
 }
 
-++ foo;            /*error Unexpected space after unary operator '++'.*/
+++ foo;
 
-foo --;            /*error Unexpected space before unary operator '--'.*/
+foo --;
 
-- foo;             /*error Unexpected space after unary operator '-'.*/
+- foo;
 
-+ "3";             /*error Unexpected space after unary operator '+'.*/
++ "3";
 ```
 
 Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are not considered problems:

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -65,57 +65,57 @@ The following patterns are considered problems:
 ```js
 /*eslint spaced-comment: [2, "never"]*/
 
-// This is a comment with a whitespace at the beginning      /*error Unexpected space or tab after '//' in comment.*/
+// This is a comment with a whitespace at the beginning
 
-/* This is a comment with a whitespace at the beginning */   /*error Unexpected space or tab after '/*' in comment.*/
+/* This is a comment with a whitespace at the beginning */
 
-/* \nThis is a comment with a whitespace at the beginning */ /*error Unexpected space or tab after '/*' in comment.*/
+/* \nThis is a comment with a whitespace at the beginning */
 ```
 
 ```js
-/*eslint spaced-comment: [2, "always"]*/                     /*error Expected space or tab after '/*' in comment.*/
+/*eslint spaced-comment: [2, "always"]*/
 
-//This is a comment with no whitespace at the beginning      /*error Expected space or tab after '//' in comment.*/
+//This is a comment with no whitespace at the beginning
 
-/*This is a comment with no whitespace at the beginning */   /*error Expected space or tab after '/*' in comment.*/
+/*This is a comment with no whitespace at the beginning */
 ```
 
 ```js
 /* eslint spaced-comment: [2, "always", { "block": { "exceptions": ["-"] } }] */
 
-//--------------    /*error Expected space or tab after '//' in comment.*/
+//--------------
 // Comment block
-//--------------    /*error Expected space or tab after '//' in comment.*/
+//--------------
 ```
 
 ```js
 /* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
 
-//------++++++++    /*error Expected exception block, space or tab after '//' in comment.*/
+//------++++++++
 // Comment block
-//------++++++++    /*error Expected exception block, space or tab after '//' in comment.*/
+//------++++++++
 ```
 
 ```js
 /* eslint spaced-comment: [2, "always", { "markers": ["/"] }] */
 
-///This is a comment with a marker but without whitespace  /*error Expected space or tab after '///' in comment.*/
+///This is a comment with a marker but without whitespace
 ```
 
 ```js
 /* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
 
-/*------++++++++*/     /*error Expected exception block, space or tab after '/*' in comment.*/
+/*------++++++++*/
 /* Comment block */
-/*------++++++++*/     /*error Expected exception block, space or tab after '/*' in comment.*/
+/*------++++++++*/
 ```
 
 ```js
 /* eslint spaced-comment: [2, "always", { "line": { "exceptions": ["-+"] } }] */
 
-/*-+-+-+-+-+-+-+*/     /*error Expected space or tab after '/*' in comment.*/
+/*-+-+-+-+-+-+-+*/
 // Comment block
-/*-+-+-+-+-+-+-+*/     /*error Expected space or tab after '/*' in comment.*/
+/*-+-+-+-+-+-+-+*/
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -46,15 +46,15 @@ The following patterns are considered problems:
 ```js
 /*eslint strict: [2, "never"]*/
 
-"use strict";          /*error Strict mode is not permitted.*/
+"use strict";
 
 function foo() {
-    "use strict";      /*error Strict mode is not permitted.*/
+    "use strict";
     return;
 }
 
 var bar = function() {
-    "use strict";      /*error Strict mode is not permitted.*/
+    "use strict";
     return;
 };
 
@@ -89,14 +89,14 @@ The following patterns are considered problems:
 /*eslint strict: [2, "global"]*/
 
 "use strict";
-"use strict";           /*error Multiple 'use strict' directives.*/
+"use strict";
 
 function foo() {
-    "use strict";       /*error Use the global form of 'use strict'.*/
+    "use strict";
 
     return function() {
-        "use strict";   /*error Use the global form of 'use strict'.*/
-        "use strict";   /*error Use the global form of 'use strict'.*/
+        "use strict";
+        "use strict";
 
         return;
     };
@@ -130,14 +130,14 @@ The following patterns are considered problems:
 ```
 /*eslint strict: [2, "function"]*/
 
-"use strict";           /*error Use the function form of 'use strict'.*/
+"use strict";
 
-function foo() {        /*error Use the function form of 'use strict'.*/
+function foo() {
     // Missing strict mode directive
 
     return function() {
         "use strict";   // Unnecessary; parent should contain a strict mode directive
-        "use strict";   /*error Multiple 'use strict' directives.*/
+        "use strict";
 
         return;
     };

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -31,11 +31,10 @@ The following patterns are considered problems when configured `"never"`:
 ```js
 /*eslint template-curly-spacing: 2*/
 
-`hello, ${ people.name}!`;  /*error Unexpected space(s) after '${'.*/
-`hello, ${people.name }!`;  /*error Unexpected space(s) before '}'.*/
+`hello, ${ people.name}!`;
+`hello, ${people.name }!`;
 
-`hello, ${ people.name }!`; /*error Unexpected space(s) after '${'.*/
-                            /*error Unexpected space(s) before '}'.*/
+`hello, ${ people.name }!`;
 ```
 
 The following patterns are considered problems when configured `"always"`:
@@ -43,11 +42,10 @@ The following patterns are considered problems when configured `"always"`:
 ```js
 /*eslint template-curly-spacing: [2, "always"]*/
 
-`hello, ${ people.name}!`;  /*error Expected space(s) before '}'.*/
-`hello, ${people.name }!`;  /*error Expected space(s) after '${'.*/
+`hello, ${ people.name}!`;
+`hello, ${people.name }!`;
 
-`hello, ${people.name}!`;   /*error Expected space(s) after '${'.*/
-                            /*error Expected space(s) before '}'.*/
+`hello, ${people.name}!`;
 ```
 
 The following patterns are not considered problems when configured `"never"`:

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -11,11 +11,11 @@ The following patterns are considered problems:
 ```js
 /*eslint use-isnan: 2*/
 
-if (foo == NaN) { /*error Use the isNaN function to compare with NaN.*/
+if (foo == NaN) {
     // ...
 }
 
-if (foo != NaN) { /*error Use the isNaN function to compare with NaN.*/
+if (foo != NaN) {
     // ...
 }
 ```

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -11,10 +11,10 @@ The following patterns are considered problems:
 ```js
 /*eslint valid-typeof: 2*/
 
-typeof foo === "strnig"   /*error Invalid typeof comparison value*/
-typeof foo == "undefimed" /*error Invalid typeof comparison value*/
-typeof bar != "nunber"    /*error Invalid typeof comparison value*/
-typeof bar !== "fucntion" /*error Invalid typeof comparison value*/
+typeof foo === "strnig"
+typeof foo == "undefimed"
+typeof bar != "nunber"
+typeof bar !== "fucntion"
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/vars-on-top.md
+++ b/docs/rules/vars-on-top.md
@@ -22,17 +22,17 @@ function doSomething() {
     if (true) {
         first = true;
     }
-    var second;                 /*error All 'var' declarations must be at the top of the function scope.*/
+    var second;
 }
 
 // Variable declaration in for initializer:
 function doSomething() {
-    for (var i=0; i<10; i++) {} /*error All 'var' declarations must be at the top of the function scope.*/
+    for (var i=0; i<10; i++) {}
 }
 
 // Variables after other statements:
 f();
-var a;                          /*error All 'var' declarations must be at the top of the function scope.*/
+var a;
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -37,19 +37,19 @@ The following patterns are considered problems:
 ```js
 /*eslint wrap-iife: 2*/
 
-var x = function () { return { y: 1 };}(); /*error Wrap an immediate function invocation in parentheses.*/
+var x = function () { return { y: 1 };}();
 ```
 
 ```js
 /*eslint wrap-iife: [2, "outside"]*/
 
-var x = (function () { return { y: 1 };})(); /*error Move the invocation into the parens that contain the function.*/
+var x = (function () { return { y: 1 };})();
 ```
 
 ```js
 /*eslint wrap-iife: [2, "inside"]*/
 
-var x = (function () { return { y: 1 };}()); /*error Wrap only the function expression in parens.*/
+var x = (function () { return { y: 1 };}());
 ```
 
 The following patterns are not considered problems:

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -18,7 +18,7 @@ The following patterns are considered problems:
 /*eslint wrap-regex: 2*/
 
 function a() {
-    return /foo/.test("bar"); /*error Wrap the regexp literal in parens to disambiguate the slash.*/
+    return /foo/.test("bar");
 }
 ```
 

--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -31,23 +31,23 @@ The following patterns are considered problems:
 ```js
 /*eslint yoda: 2*/
 
-if ("red" === color) {          /*error Expected literal to be on the right side of ===.*/
+if ("red" === color) {
     // ...
 }
 
-if (true == flag) {             /*error Expected literal to be on the right side of ==.*/
+if (true == flag) {
     // ...
 }
 
-if (5 > count) {                /*error Expected literal to be on the right side of >.*/
+if (5 > count) {
     // ...
 }
 
-if (-1 < str.indexOf(substr)) { /*error Expected literal to be on the right side of <.*/
+if (-1 < str.indexOf(substr)) {
     // ...
 }
 
-if (0 <= x && x < 1) {          /*error Expected literal to be on the right side of <=.*/
+if (0 <= x && x < 1) {
     // ...
 }
 ```
@@ -55,7 +55,7 @@ if (0 <= x && x < 1) {          /*error Expected literal to be on the right side
 ```js
 /*eslint yoda: [2, "always"]*/
 
-if (color == "blue") { /*error Expected literal to be on the left side of ==.*/
+if (color == "blue") {
     // ...
 }
 ```


### PR DESCRIPTION
Fixes #4104.

Used `\s+/\*\s*error\s+.+\*/` regex on all `.md` files and replaced all matches with an empty string.