### PR TITLE
consistent-this doc typo fix + version compatibility

### DIFF
--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -27,10 +27,10 @@ This rule takes one option, a string, which is the designated `this` variable. T
 "consistent-this": [2, "that"]
 ```
 
-Additionally, you may configure extra aliases for cases where there are more than one supported alias for `this`.
+Additionally, since the 2.0.0 version, you may configure extra aliases for cases where there are more than one supported alias for `this`.
 
 ```js
-{ "consistent-this": [ 2, "self",  "vm" ] } ] }
+{ "consistent-this": [ 2, "self",  "vm" ] }
 ```
 
 The following patterns are considered problems:


### PR DESCRIPTION
I found out that having several values for consistent this only work with the new eslint major version. Additionally it fixes a typo.