### PR TITLE
Fix: `indent` on variable declaration with separate array (fixes #5237)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -429,13 +429,11 @@ module.exports = function(context) {
             nodeIndent = getNodeIndent(effectiveParent);
             if (parentVarNode && parentVarNode.loc.start.line !== node.loc.start.line) {
                 if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
-                    if (options.VariableDeclarator[parentVarNode.parent.kind] === 0 && (parent.type === "ObjectExpression" || parent.type === "ArrayExpression")) {
-                        nodeIndent = nodeIndent + indentSize;
-                    } else {
+                    if (parentVarNode.loc.start.line === effectiveParent.loc.start.line) {
                         nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]);
+                    } else if (parent.type === "ObjectExpression" || parent.type === "ArrayExpression") {
+                        nodeIndent = nodeIndent + indentSize;
                     }
-                } else if (parent.loc.start.line !== node.loc.start.line && parentVarNode === parentVarNode.parent.declarations[0]) {
-                    nodeIndent = nodeIndent + indentSize;
                 }
             } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && effectiveParent.type !== "MemberExpression" && effectiveParent.type !== "ExpressionStatement" && effectiveParent.type !== "AssignmentExpression" && effectiveParent.type !== "Property") {
                 nodeIndent = nodeIndent + indentSize;

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -50,7 +50,6 @@ function expectedErrors(indentType, errors) {
 
 var ruleTester = new RuleTester();
 ruleTester.run("indent", rule, {
-
     valid: [
         {
             code:
@@ -1042,6 +1041,19 @@ ruleTester.run("indent", rule, {
             "    }\n" +
             "];\n",
             options: [4, {"VariableDeclarator": 0, "SwitchCase": 1}]
+        },
+        {
+            code:
+            "const func = function (opts) {\n" +
+            "    return Promise.resolve()\n" +
+            "    .then(() => {\n" +
+            "        [\n" +
+            "            'ONE', 'TWO'\n" +
+            "        ].forEach(command => { doSomething(); });\n" +
+            "    });\n" +
+            "};",
+            parserOptions: { ecmaVersion: 6 },
+            options: [4, {"SwitchCase": 1}]
         }
     ],
     invalid: [


### PR DESCRIPTION
Indent was behaving incorrectly when there's an array on a separate deep
inside a variable declaration with an expression node wrapping it as the
parent.