### PR TITLE
Fix: Load extend modules from global node_modules

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -414,7 +414,7 @@ function resolve(filePath, relativeTo) {
         } else {
             var additionalPaths = [];
 
-            if(process.env['NODE_PATH']) {
+            if (process.env.NODE_PATH) {
                 additionalPaths.push(process.env.NODE_PATH);
             }
 

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -412,8 +412,15 @@ function resolve(filePath, relativeTo) {
             });
             return { filePath: filePath, configName: configName };
         } else {
+            var additionalPaths = [];
+
+            if(process.env['NODE_PATH']) {
+                additionalPaths.push(process.env.NODE_PATH);
+            }
+
             filePath = resolveModule.sync(normalizePackageName(filePath, "eslint-config"), {
-                basedir: getLookupPath(relativeTo)
+                basedir: getLookupPath(relativeTo),
+                paths: additionalPaths
             });
             return { filePath: filePath };
         }


### PR DESCRIPTION
`extends: '@scope/myrules'` was not attempting to load
`@scope/eslint-config-myrules` module that in installed/linked in the global
`node_modules`.

This patch pass the `$NODE_PATH` environment variable (if exsists) to
`resolve.sync` as an additional lookup path.