### PR TITLE
Docs: Add rule config above each example in jsx-quotes

### DIFF
--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -28,12 +28,16 @@ The default is `"prefer-double"`.
 The following patterns are considered problems when set to `"prefer-double"`:
 
 ```xml
+/*eslint jsx-quotes: [2, "prefer-double"]*/
+
 <a b='c' />
 ```
 
 The following patterns are not considered problems when set to `"prefer-double"`:
 
 ```xml
+/*eslint jsx-quotes: [2, "prefer-double"]*/
+
 <a b="c" />
 <a b='"' />
 ```
@@ -41,12 +45,16 @@ The following patterns are not considered problems when set to `"prefer-double"`
 The following patterns are considered problems when set to `"prefer-single"`:
 
 ```xml
+/*eslint jsx-quotes: [2, "prefer-single"]*/
+
 <a b="c" />
 ```
 
 The following patterns are not considered problems when set to `"prefer-single"`:
 
 ```xml
+/*eslint jsx-quotes: [2, "prefer-single"]*/
+
 <a b='c' />
 <a b="'" />
 ```


### PR DESCRIPTION
Most other rule doc pages define the rule config above each example, so I did the same for the jsx-quotes doc page.

I don't know if it's going to be an issue, but the rule needs to be configred with "parserOptions.ecmaFeatures.jsx = true" for it to work. I think this can't be set on a file basis, so it can't be included in the examples. But maybe it should be mentioned in a paragraph before the examples?