### PR TITLE
Docs: Fix rule config above examples for require-jsdoc

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -52,8 +52,8 @@ The following patterns are considered problems:
 /*eslint "require-jsdoc": [2, {
     "require": {
         "FunctionDeclaration": true,
-        "MethodDefinition": false,
-        "ClassDeclaration": false
+        "MethodDefinition": true,
+        "ClassDeclaration": true
     }
 }]*/
 
@@ -72,8 +72,8 @@ The following patterns are not considered problems:
 /*eslint "require-jsdoc": [2, {
     "require": {
         "FunctionDeclaration": true,
-        "MethodDefinition": false,
-        "ClassDeclaration": false
+        "MethodDefinition": true,
+        "ClassDeclaration": true
     }
 }]*/
 


### PR DESCRIPTION
`MethodDefinition` and `ClassDeclaration` options must be set to true for the examples to be correct in require-jsdoc rule doc page.