### PR TITLE
Fix: Load extend modules from global node_modules (fixes #5255)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -396,10 +396,11 @@ function normalizePackageName(name, prefix) {
  * or package name.
  * @param {string} filePath The filepath to resolve.
  * @param {string} [relativeTo] The path to resolve relative to.
+ * @param {Array} [additionalPaths] List of additional paths to lookup modules.
  * @returns {Object} A path that can be used directly to load the configuration.
  * @private
  */
-function resolve(filePath, relativeTo) {
+function resolve(filePath, relativeTo, additionalPaths) {
 
     if (isFilePath(filePath)) {
         return { filePath: path.resolve(relativeTo || "", filePath) };
@@ -408,12 +409,14 @@ function resolve(filePath, relativeTo) {
             var packagePath = filePath.substr(7, filePath.lastIndexOf("/") - 7);
             var configName = filePath.substr(filePath.lastIndexOf("/") + 1, filePath.length - filePath.lastIndexOf("/") - 1);
             filePath = resolveModule.sync(normalizePackageName(packagePath, "eslint-plugin"), {
-                basedir: getLookupPath(relativeTo)
+                basedir: getLookupPath(relativeTo),
+                paths: additionalPaths || []
             });
             return { filePath: filePath, configName: configName };
         } else {
             filePath = resolveModule.sync(normalizePackageName(filePath, "eslint-config"), {
-                basedir: getLookupPath(relativeTo)
+                basedir: getLookupPath(relativeTo),
+                paths: additionalPaths || []
             });
             return { filePath: filePath };
         }
@@ -431,7 +434,7 @@ function resolve(filePath, relativeTo) {
  */
 function load(filePath, applyEnvironments) {
 
-    var resolvedPath = resolve(filePath),
+    var resolvedPath = resolve(filePath, null, [ process.env.NODE_PATH || null ]),
         config = loadConfigFile(resolvedPath);
 
     if (config) {

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -94,6 +94,17 @@ function getRelativeModulePath(moduleName) {
     return path.resolve("./node_modules", moduleName, "index.js");
 }
 
+/**
+ * Creates a module path to the global node_modules directory.
+ * @param {string} moduleName The full module name.
+ * @param {string} nodePath The full path to global node_modules directory.
+ * @returns {string} A full path for the global module.
+ * @private
+ */
+function getGlobalModulePath(moduleName, nodePath) {
+    return path.resolve(nodePath, moduleName, "index.js");
+}
+
 
 //------------------------------------------------------------------------------
 // Tests
@@ -651,6 +662,30 @@ describe("ConfigFile", function() {
                     target = expected;
 
                     var result = StubbedConfigFile.resolve(input, relativeTo);
+                    assert.equal(result.filePath, expected);
+                });
+            });
+
+        });
+
+        describe("From global node_modules", function() {
+
+            var nodePath = "/usr/lib/node_modules/";
+
+            leche.withData([
+                [ "eslint-config-foo", getGlobalModulePath("eslint-config-foo", nodePath), null, [ nodePath ]],
+                [ "foo", getGlobalModulePath("eslint-config-foo", nodePath), null, [ nodePath ]],
+                [ "eslint-configfoo", getGlobalModulePath("eslint-config-eslint-configfoo", nodePath), null, [ nodePath ]],
+                [ "@foo/eslint-config", getGlobalModulePath("@foo/eslint-config", nodePath), null, [ nodePath ]],
+                [ "@foo/bar", getGlobalModulePath("@foo/eslint-config-bar", nodePath), null, [ nodePath ]],
+                [ "plugin:@foo/bar/baz", getGlobalModulePath("@foo/eslint-plugin-bar", nodePath), null, [ nodePath ]]
+            ], function(input, expected, relativeTo, additionalPaths) {
+                it("should return " + expected + " when passed " + input, function() {
+
+                    // used to stub out resolve.sync
+                    target = expected;
+
+                    var result = StubbedConfigFile.resolve(input, relativeTo, additionalPaths);
                     assert.equal(result.filePath, expected);
                 });
             });


### PR DESCRIPTION
`extends: '@scope/myrules'` was not attempting to load
`@scope/eslint-config-myrules` module that installed/linked in the global
`node_modules`.

This patch introduces a 3rd parameter to `resolve` function which used to pass
the `$NODE_PATH` environment variable (if exists) to `resolve.sync` as an
additional lookup path.