### PR TITLE
Fix: Popular style init handles missing package.json keys (refs #5243)

### DIFF
--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -73,10 +73,10 @@ function check(packages, opt) {
         throw new Error("Could not find a package.json file");
     }
     var fileJson = JSON.parse(fs.readFileSync(pkgJson, "utf8"));
-    if (opt.devDependencies) {
+    if (opt.devDependencies && typeof fileJson.devDependencies === "object") {
         deps = deps.concat(Object.keys(fileJson.devDependencies));
     }
-    if (opt.dependencies) {
+    if (opt.dependencies && typeof fileJson.dependencies === "object") {
         deps = deps.concat(Object.keys(fileJson.dependencies));
     }
     return packages.reduce(function(status, pkg) {

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -11,6 +11,7 @@
 //------------------------------------------------------------------------------
 
 var assert = require("chai").assert,
+    fs = require("fs"),
     shell = require("shelljs"),
     sinon = require("sinon"),
     npmUtil = require("../../../lib/util/npm-util");
@@ -48,6 +49,25 @@ describe("npmUtil", function() {
             installStatus = npmUtil.checkDevDeps(["notarealpackage"]);
             assert.isFalse(installStatus.notarealpackage);
         });
+
+        it("should handle missing devDependencies key", function() {
+            sinon.stub(fs, "existsSync", function() {
+                return true;
+            });
+            sinon.stub(fs, "readFileSync", function() {
+                return JSON.stringify({
+                    private: true,
+                    dependencies: {}
+                });
+            });
+
+            var fn = npmUtil.checkDevDeps.bind(null, ["some-package"]);
+
+            assert.doesNotThrow(fn);
+
+            fs.existsSync.restore();
+            fs.readFileSync.restore();
+        });
     });
 
     describe("checkDeps()", function() {
@@ -82,6 +102,25 @@ describe("npmUtil", function() {
             assert.throws(function() {
                 installStatus = npmUtil.checkDeps(["notarealpackage"], "/fakepath");
             }, "Could not find a package.json file");
+        });
+
+        it("should handle missing dependencies key", function() {
+            sinon.stub(fs, "existsSync", function() {
+                return true;
+            });
+            sinon.stub(fs, "readFileSync", function() {
+                return JSON.stringify({
+                    private: true,
+                    devDependencies: {}
+                });
+            });
+
+            var fn = npmUtil.checkDeps.bind(null, ["some-package"]);
+
+            assert.doesNotThrow(fn);
+
+            fs.existsSync.restore();
+            fs.readFileSync.restore();
         });
     });
 


### PR DESCRIPTION
Refs because this fixes only one bug found. There's at least one more lingering.

Given a `package.json` missing `dependencies` or `devDependencies`:

```json
{
  "name": "my-package",
  "version": "1.2.3"
}
```

`npm-util`'s `check` method would read in the `package.json` file and attempt to call `Object.keys()` on `undefined`, which throws. This handles the case where either `dependencies` or `devDependencies` are not provided.