### PR TITLE
Fix: Consolidate try/catches to top levels (fixes #5243)

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -33,10 +33,9 @@ debug = debug("eslint:config-initializer");
  * Create .eslintrc file in the current working directory
  * @param {Object} config object that contains user's answers
  * @param {string} format The file format to write to.
- * @param {function} callback function to call once the file is written.
  * @returns {void}
  */
-function writeFile(config, format, callback) {
+function writeFile(config, format) {
 
     // default is .js
     var extname = ".js";
@@ -47,15 +46,8 @@ function writeFile(config, format, callback) {
     }
 
 
-    try {
-        ConfigFile.write(config, "./.eslintrc" + extname);
-        log.info("Successfully created .eslintrc" + extname + " file in " + process.cwd());
-    } catch (e) {
-        callback(e);
-        return;
-    }
-
-    callback();
+    ConfigFile.write(config, "./.eslintrc" + extname);
+    log.info("Successfully created .eslintrc" + extname + " file in " + process.cwd());
 }
 
 /**
@@ -102,10 +94,9 @@ function installModules(config) {
  *
  * @param   {Object} answers  answers received from inquirer
  * @param   {Object} config   config object
- * @param   {Object} callback function to call with any erorrs.
  * @returns {Object}          config object with configured rules
  */
-function configureRules(answers, config, callback) {
+function configureRules(answers, config) {
     var BAR_TOTAL = 20,
         BAR_SOURCE_CODE_TOTAL = 4;
 
@@ -137,12 +128,12 @@ function configureRules(answers, config, callback) {
         });
     } catch (e) {
         log.info("\n");
-        return callback(e);
+        throw e;
     }
     fileQty = Object.keys(sourceCodes).length;
     if (fileQty === 0) {
         log.info("\n");
-        return callback(new Error("Automatic Configuration failed.  No files were able to be parsed."));
+        throw new Error("Automatic Configuration failed.  No files were able to be parsed.");
     }
 
     // Create a registry of rule configs
@@ -209,10 +200,9 @@ function configureRules(answers, config, callback) {
 /**
  * process user's answers and create config object
  * @param {Object} answers answers received from inquirer
- * @param   {Object} callback function to call with any erorrs.
  * @returns {Object} config object
  */
-function processAnswers(answers, callback) {
+function processAnswers(answers) {
     var config = {rules: {}, env: {}};
 
     if (answers.es6) {
@@ -249,7 +239,7 @@ function processAnswers(answers, callback) {
     installModules(config);
 
     if (answers.source === "auto") {
-        config = configureRules(answers, config, callback);
+        config = configureRules(answers, config);
         config = autoconfig.extendFromRecommended(config);
     }
     return config;
@@ -332,8 +322,13 @@ function promptUser(callback) {
 
         // early exit if you are using a style guide
         if (earlyAnswers.source === "guide") {
-            config = getConfigForStyleGuide(earlyAnswers.styleguide);
-            writeFile(config, earlyAnswers.format, callback);
+            try {
+                config = getConfigForStyleGuide(earlyAnswers.styleguide);
+                writeFile(config, earlyAnswers.format);
+            } catch (err) {
+                callback(err);
+                return;
+            }
             return;
         }
 
@@ -391,14 +386,19 @@ function promptUser(callback) {
 
             // early exit if you are using automatic style generation
             if (earlyAnswers.source === "auto") {
-                if (secondAnswers.jsx) {
-                    log.error("Unfortunately, autoconfig does not yet work for JSX code.\nPlease see https://github.com/eslint/eslint/issues/5007 for current status.");
+                try {
+                    if (secondAnswers.jsx) {
+                        log.error("Unfortunately, autoconfig does not yet work for JSX code.\nPlease see https://github.com/eslint/eslint/issues/5007 for current status.");
+                        return;
+                    }
+                    var combinedAnswers = lodash.assign({}, earlyAnswers, secondAnswers);
+                    config = processAnswers(combinedAnswers);
+                    installModules(config);
+                    writeFile(config, earlyAnswers.format);
+                } catch (err) {
+                    callback(err);
                     return;
                 }
-                var combinedAnswers = lodash.assign({}, earlyAnswers, secondAnswers);
-                config = processAnswers(combinedAnswers, callback);
-                installModules(config);
-                writeFile(config, earlyAnswers.format, callback);
                 return;
             }
 
@@ -439,10 +439,16 @@ function promptUser(callback) {
                     choices: ["JavaScript", "YAML", "JSON"]
                 }
             ], function(answers) {
-                var totalAnswers = lodash.assign({}, earlyAnswers, secondAnswers, answers);
-                config = processAnswers(totalAnswers);
-                installModules(config);
-                writeFile(config, answers.format, callback);
+                try {
+                    var totalAnswers = lodash.assign({}, earlyAnswers, secondAnswers, answers);
+                    config = processAnswers(totalAnswers);
+                    installModules(config);
+                    writeFile(config, answers.format);
+                } catch (err) {
+                    callback(err);
+                    return;
+                }
+                return;
             });
         });
     });

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -70,7 +70,7 @@ function check(packages, opt) {
     var deps = [];
     var pkgJson = (opt) ? findPackageJson(opt.startDir) : findPackageJson();
     if (!pkgJson) {
-        throw new Error("Could not find a package.json file");
+        throw new Error("Could not find a package.json file. Run 'npm init' to create one.");
     }
     var fileJson = JSON.parse(fs.readFileSync(pkgJson, "utf8"));
     if (opt.devDependencies && typeof fileJson.devDependencies === "object") {

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -243,29 +243,26 @@ describe("configInitializer", function() {
                 assert.notProperty(config.rules, "no-console");
             });
 
-            it("should callback with error message on fatal parsing error", function() {
+            it("should throw on fatal parsing error", function() {
                 var filename = getFixturePath("parse-error");
-                var spy = sinon.spy();
                 sinon.stub(autoconfig, "extendFromRecommended");
                 answers.patterns = filename;
                 process.chdir(fixtureDir);
-                config = init.processAnswers(answers, spy);
+                assert.throws(function() {
+                    config = init.processAnswers(answers);
+                }, "Parsing error: Unexpected token ;");
                 process.chdir(originalDir);
-                assert(spy.called);
-                assert.include(spy.firstCall.args[0].message, filename);
-                assert.include(spy.firstCall.args[0].message, "Parsing error: Unexpected token ;");
                 autoconfig.extendFromRecommended.restore();
             });
 
-            it("should callback with error message if no files are matched from patterns", function() {
-                var spy = sinon.spy();
+            it("should throw if no files are matched from patterns", function() {
                 sinon.stub(autoconfig, "extendFromRecommended");
                 answers.patterns = "not-a-real-filename";
                 process.chdir(fixtureDir);
-                config = init.processAnswers(answers, spy);
+                assert.throws(function() {
+                    config = init.processAnswers(answers);
+                }, "Automatic Configuration failed.  No files were able to be parsed.");
                 process.chdir(originalDir);
-                assert(spy.called);
-                assert.include(spy.firstCall.args[0].message, "Automatic Configuration failed.  No files were able to be parsed.");
                 autoconfig.extendFromRecommended.restore();
             });
         });


### PR DESCRIPTION
This also prevents needing to pass the `callback` to each function, instead letting it be handled within the `prompt` function.  Any error at any point in the processing should now be caught and displayed.