### PR TITLE
Fix: Skip computed members in `newline-per-chained-call`

### DIFF
--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -33,7 +33,7 @@ This rule reports such code and encourages new lines after each call in the chai
 
 ## Rule Details
 
-This rule checks and reports the chained calls if there are no new lines after each call or deep member access.
+This rule checks and reports the chained calls if there are no new lines after each call or deep member access. Computed property accesses such as `instance[something]` are excluded.
 
 ## Options
 

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -17,7 +17,7 @@ module.exports = function(context) {
         ignoreChainWithDepth = options.ignoreChainWithDepth || 2;
 
     /**
-     * Check and Capture State if the chained calls/memebers
+     * Check and Capture State if the chained calls/members
      * @param {ASTNode} node The node to check
      * @param {object} codeState The state of the code current code to be filled
      * @returns {void}
@@ -36,7 +36,7 @@ module.exports = function(context) {
 
             objectLineNumber = node.object.loc.end.line;
             propertyLineNumber = node.property.loc.end.line;
-            valid = propertyLineNumber > objectLineNumber;
+            valid = node.computed || propertyLineNumber > objectLineNumber;
 
             if (!valid) {
                 codeState.reports.push({
@@ -80,7 +80,7 @@ module.exports = function(context) {
         };
     }
     /**
-     * Process the said node and recuse internally
+     * Process the said node and recurse internally
      * @param {ASTNode} node The node to check
      * @returns {void}
      */

--- a/tests/lib/rules/newline-per-chained-call.js
+++ b/tests/lib/rules/newline-per-chained-call.js
@@ -28,6 +28,10 @@ ruleTester.run("newline-per-chained-call", rule, {
     }, {
         code: "var a = m1();"
     }, {
+        code: "var a = window\n.location\n.href\n.match(/(^[^#]*)/)[0];"
+    }, {
+        code: "var a = window['location']\n.href\n.match(/(^[^#]*)/)[0];"
+    }, {
         code: "var a = m1().m2.m3();",
         options: [{
             ignoreChainWithDepth: 3


### PR DESCRIPTION
Fixes #5245