### PR TITLE
Fix: `constructor-super` and `no-this-before-super` false (fixes #5261)

### DIFF
--- a/lib/code-path-analysis/code-path-segment.js
+++ b/lib/code-path-analysis/code-path-segment.js
@@ -120,7 +120,8 @@ function CodePathSegment(id, allPrevSegments, reachable) {
 
     // Internal data.
     Object.defineProperty(this, "internal", {value: {
-        used: false
+        used: false,
+        loopedPrevSegments: []
     }});
 
     /* istanbul ignore if */
@@ -129,6 +130,20 @@ function CodePathSegment(id, allPrevSegments, reachable) {
         this.internal.exitNodes = [];
     }
 }
+
+CodePathSegment.prototype = {
+    constructor: CodePathSegment,
+
+    /**
+     * Checks a given previous segment is coming from the end of a loop.
+     *
+     * @param {CodePathSegment} segment - A previous segment to check.
+     * @returns {boolean} `true` if the segment is coming from the end of a loop.
+     */
+    isLoopedPrevSegment: function(segment) {
+        return this.internal.loopedPrevSegments.indexOf(segment) !== -1;
+    }
+};
 
 /**
  * Creates the root segment.
@@ -203,6 +218,17 @@ CodePathSegment.markUsed = function(segment) {
             segment.allPrevSegments[i].allNextSegments.push(segment);
         }
     }
+};
+
+/**
+ * Marks a previous segment as looped.
+ *
+ * @param {CodePathSegment} segment - A segment.
+ * @param {CodePathSegment} prevSegment - A previous segment to mark.
+ * @returns {void}
+ */
+CodePathSegment.markPrevSegmentAsLooped = function(segment, prevSegment) {
+    segment.internal.loopedPrevSegments.push(prevSegment);
 };
 
 module.exports = CodePathSegment;

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -181,6 +181,10 @@ function makeLooped(state, fromSegments, toSegments) {
         fromSegment.allNextSegments.push(toSegment);
         toSegment.allPrevSegments.push(fromSegment);
 
+        if (toSegment.allPrevSegments.length >= 2) {
+            CodePathSegment.markPrevSegmentAsLooped(toSegment, fromSegment);
+        }
+
         state.notifyLooped(fromSegment, toSegment);
     }
 }

--- a/lib/code-path-analysis/code-path.js
+++ b/lib/code-path-analysis/code-path.js
@@ -102,6 +102,120 @@ CodePath.prototype = {
      */
     get currentSegments() {
         return this.internal.currentSegments;
+    },
+
+    /**
+     * Traverses all segments in this code path.
+     *
+     *     codePath.traverseSegments(function(segment, controller) {
+     *         // do something.
+     *     });
+     *
+     * This method enumerates segments in order from the head.
+     *
+     * The `controller` object has two methods.
+     *
+     * - `controller.skip()` - Skip the following segments in this branch.
+     * - `controller.break()` - Skip all following segments.
+     *
+     * @param {object} [options] - Omittable.
+     * @param {CodePathSegment} [options.first] - The first segment to traverse.
+     * @param {CodePathSegment} [options.last] - The last segment to traverse.
+     * @param {function} callback - A callback function.
+     * @returns {void}
+     */
+    traverseSegments: function(options, callback) {
+        if (typeof options === "function") {
+            callback = options;
+            options = null;
+        }
+
+        options = options || {};
+        var startSegment = options.first || this.internal.initialSegment;
+        var lastSegment = options.last;
+
+        var item = null;
+        var index = 0;
+        var end = 0;
+        var segment = null;
+        var visited = Object.create(null);
+        var stack = [[startSegment, 0]];
+        var skippedSegment = null;
+        var broken = false;
+        var controller = {
+            skip: function() {
+                if (stack.length <= 1) {
+                    broken = true;
+                } else {
+                    skippedSegment = stack[stack.length - 2][0];
+                }
+            },
+            break: function() {
+                broken = true;
+            }
+        };
+
+        /**
+         * Checks a given previous segment has been visited.
+         * @param {CodePathSegment} prevSegment - A previous segment to check.
+         * @returns {boolean} `true` if the segment has been visited.
+         */
+        function isVisited(prevSegment) {
+            return (
+                visited[prevSegment.id] ||
+                segment.isLoopedPrevSegment(prevSegment)
+            );
+        }
+
+        while (stack.length > 0) {
+            item = stack[stack.length - 1];
+            segment = item[0];
+            index = item[1];
+
+            if (index === 0) {
+                // Skip this has been visited already.
+                if (visited[segment.id]) {
+                    stack.pop();
+                    continue;
+                }
+                // Skip if all previous segments have not been visited.
+                if (segment !== startSegment &&
+                    segment.prevSegments.length > 0 &&
+                    !segment.prevSegments.every(isVisited)
+                ) {
+                    stack.pop();
+                    continue;
+                }
+                // Reset the flag of skipping if all branches have been skipped.
+                if (skippedSegment && segment.prevSegments.indexOf(skippedSegment) !== -1) {
+                    skippedSegment = null;
+                }
+                visited[segment.id] = true;
+
+                // Call the callback when the first time.
+                if (!skippedSegment) {
+                    callback.call(this, segment, controller); // eslint-disable-line callback-return
+                    if (segment === lastSegment) {
+                        controller.skip();
+                    }
+                    if (broken) {
+                        break;
+                    }
+                }
+            }
+
+            // Update the stack.
+            end = segment.nextSegments.length - 1;
+            if (index < end) {
+                item[1] += 1;
+                stack.push([segment.nextSegments[index], 0]);
+            } else if (index === end) {
+                item[0] = segment.nextSegments[index];
+                item[1] = 0;
+            } else {
+                stack.pop();
+            }
+        }
     }
 };
 

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -49,6 +49,7 @@ module.exports = function(context) {
     // Information for each code path segment.
     // - calledInSomePaths:  A flag of be called `super()` in some code paths.
     // - calledInEveryPaths: A flag of be called `super()` in all code paths.
+    // - validNodes:
     var segInfoMap = Object.create(null);
 
     /**
@@ -146,7 +147,8 @@ module.exports = function(context) {
             // Initialize info.
             var info = segInfoMap[segment.id] = {
                 calledInSomePaths: false,
-                calledInEveryPaths: false
+                calledInEveryPaths: false,
+                validNodes: []
             };
 
             // When there are previous segments, aggregates these.
@@ -155,6 +157,55 @@ module.exports = function(context) {
                 info.calledInSomePaths = prevSegments.some(isCalledInSomePath);
                 info.calledInEveryPaths = prevSegments.every(isCalledInEveryPath);
             }
+        },
+
+        /**
+         * Update information of the code path segment when a code path was
+         * looped.
+         * @param {CodePathSegment} fromSegment - The code path segment of the
+         *      end of a loop.
+         * @param {CodePathSegment} toSegment - A code path segment of the head
+         *      of a loop.
+         * @returns {void}
+         */
+        "onCodePathSegmentLoop": function(fromSegment, toSegment) {
+            // Skip if this is not in a constructor of a class which has a valid
+            // `extends` part.
+            if (!(
+                funcInfo &&
+                funcInfo.hasExtends &&
+                funcInfo.scope === context.getScope().variableScope
+            )) {
+                return;
+            }
+
+            // Update information inside of the loop.
+            var isRealLoop = toSegment.prevSegments.length >= 2;
+            funcInfo.codePath.traverseSegments(
+                {first: toSegment, last: fromSegment},
+                function(segment) {
+                    var info = segInfoMap[segment.id];
+
+                    // Updates flags.
+                    var prevSegments = segment.prevSegments;
+                    info.calledInSomePaths = prevSegments.some(isCalledInSomePath);
+                    info.calledInEveryPaths = prevSegments.every(isCalledInEveryPath);
+
+                    // If flags become true anew, reports the valid nodes.
+                    if (info.calledInSomePaths || isRealLoop) {
+                        var nodes = info.validNodes;
+                        info.validNodes = [];
+
+                        for (var i = 0; i < nodes.length; ++i) {
+                            var node = nodes[i];
+                            context.report({
+                                message: "Unexpected duplicate 'super()'.",
+                                node: node
+                            });
+                        }
+                    }
+                }
+            );
         },
 
         /**
@@ -191,6 +242,8 @@ module.exports = function(context) {
                         message: "Unexpected duplicate 'super()'.",
                         node: node
                     });
+                } else {
+                    info.validNodes.push(node);
                 }
             } else {
                 // This class does not have a valid `extends` part.

--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -36,7 +36,6 @@ function isConstructorFunction(node) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    // {{hasExtends: boolean, scope: Scope}[]}
     // Information for each constructor.
     // - upper:      Information of the upper constructor.
     // - hasExtends: A flag which shows whether the owner class has a valid
@@ -45,9 +44,11 @@ module.exports = function(context) {
     // - codePath:   The code path of this constructor.
     var funcInfo = null;
 
-    // {Map<string, boolean>}
     // Information for each code path segment.
-    // The value is a flag which shows `super()` called in all code paths.
+    // Each key are the ids of code path segments.
+    // Each value are an object:
+    // - superCalled:  The flag which shows `super()` called in all code paths.
+    // - invalidNodes: The array of invalid ThisExpression and Super nodes.
     var segInfoMap = Object.create(null);
 
     /**
@@ -56,14 +57,14 @@ module.exports = function(context) {
      * @returns {boolean} `true` if `super()` is called.
      */
     function isCalled(segment) {
-        return Boolean(segInfoMap[segment.id]);
+        return segInfoMap[segment.id].superCalled;
     }
 
     /**
      * Checks whether or not this is in a constructor.
      * @returns {boolean} `true` if this is in a constructor.
      */
-    function isInConstructor() {
+    function isInConstructorOfDerivedClass() {
         return Boolean(
             funcInfo &&
             funcInfo.hasExtends &&
@@ -77,14 +78,38 @@ module.exports = function(context) {
      */
     function isBeforeCallOfSuper() {
         return (
-            isInConstructor(funcInfo) &&
+            isInConstructorOfDerivedClass(funcInfo) &&
             !funcInfo.codePath.currentSegments.every(isCalled)
         );
     }
 
+    /**
+     * Sets a given node as invalid.
+     * @param {ASTNode} node - A node to set as invalid. This is one of
+     *      a ThisExpression and a Super.
+     * @returns {void}
+     */
+    function setInvalid(node) {
+        var segments = funcInfo.codePath.currentSegments;
+        for (var i = 0; i < segments.length; ++i) {
+            segInfoMap[segments[i].id].invalidNodes.push(node);
+        }
+    }
+
+    /**
+     * Sets the current segment as `super` was called.
+     * @returns {void}
+     */
+    function setSuperCalled() {
+        var segments = funcInfo.codePath.currentSegments;
+        for (var i = 0; i < segments.length; ++i) {
+            segInfoMap[segments[i].id].superCalled = true;
+        }
+    }
+
     return {
         /**
-         * Stacks a constructor information.
+         * Adds information of a constructor into the stack.
          * @param {CodePath} codePath - A code path which was started.
          * @param {ASTNode} node - The current node.
          * @returns {void}
@@ -108,15 +133,44 @@ module.exports = function(context) {
         },
 
         /**
-         * Pops a constructor information.
+         * Removes the top of stack item.
+         *
+         * And this treverses all segments of this code path then reports every
+         * invalid node.
+         *
          * @param {CodePath} codePath - A code path which was ended.
          * @param {ASTNode} node - The current node.
          * @returns {void}
          */
         "onCodePathEnd": function(codePath, node) {
-            if (isConstructorFunction(node)) {
-                funcInfo = funcInfo.upper;
+            if (!isConstructorFunction(node)) {
+                return;
             }
+            var isDerivedClass = funcInfo.hasExtends;
+            funcInfo = funcInfo.upper;
+
+            if (!isDerivedClass) {
+                return;
+            }
+            codePath.traverseSegments(function(segment, controller) {
+                var info = segInfoMap[segment.id];
+
+                for (var i = 0; i < info.invalidNodes.length; ++i) {
+                    var invalidNode = info.invalidNodes[i];
+
+                    context.report({
+                        message: "'{{kind}}' is not allowed before 'super()'.",
+                        node: invalidNode,
+                        data: {
+                            kind: invalidNode.type === "Super" ? "super" : "this"
+                        }
+                    });
+                }
+
+                if (info.superCalled) {
+                    controller.skip();
+                }
+            });
         },
 
         /**
@@ -125,14 +179,50 @@ module.exports = function(context) {
          * @returns {void}
          */
         "onCodePathSegmentStart": function(segment) {
-            if (!isInConstructor(funcInfo)) {
+            if (!isInConstructorOfDerivedClass(funcInfo)) {
                 return;
             }
 
             // Initialize info.
-            segInfoMap[segment.id] = (
-                segment.prevSegments.length > 0 &&
-                segment.prevSegments.every(isCalled)
+            segInfoMap[segment.id] = {
+                superCalled: (
+                    segment.prevSegments.length > 0 &&
+                    segment.prevSegments.every(isCalled)
+                ),
+                invalidNodes: []
+            };
+        },
+
+        /**
+         * Update information of the code path segment when a code path was
+         * looped.
+         * @param {CodePathSegment} fromSegment - The code path segment of the
+         *      end of a loop.
+         * @param {CodePathSegment} toSegment - A code path segment of the head
+         *      of a loop.
+         * @returns {void}
+         */
+        "onCodePathSegmentLoop": function(fromSegment, toSegment) {
+            if (!isInConstructorOfDerivedClass(funcInfo)) {
+                return;
+            }
+
+            // Update information inside of the loop.
+            funcInfo.codePath.traverseSegments(
+                {first: toSegment, last: fromSegment},
+                function(segment, controller) {
+                    var info = segInfoMap[segment.id];
+                    if (info.superCalled) {
+                        info.invalidNodes = [];
+                        controller.skip();
+                    } else if (
+                        segment.prevSegments.length > 0 &&
+                        segment.prevSegments.every(isCalled)
+                    ) {
+                        info.superCalled = true;
+                        info.invalidNodes = [];
+                    }
+                }
             );
         },
 
@@ -143,10 +233,7 @@ module.exports = function(context) {
          */
         "ThisExpression": function(node) {
             if (isBeforeCallOfSuper()) {
-                context.report({
-                    message: "'this' is not allowed before 'super()'.",
-                    node: node
-                });
+                setInvalid(node);
             }
         },
 
@@ -157,10 +244,7 @@ module.exports = function(context) {
          */
         "Super": function(node) {
             if (!astUtils.isCallee(node) && isBeforeCallOfSuper()) {
-                context.report({
-                    message: "'super' is not allowed before 'super()'.",
-                    node: node
-                });
+                setInvalid(node);
             }
         },
 
@@ -171,10 +255,7 @@ module.exports = function(context) {
          */
         "CallExpression:exit": function(node) {
             if (node.callee.type === "Super" && isBeforeCallOfSuper()) {
-                var segments = funcInfo.codePath.currentSegments;
-                for (var i = 0; i < segments.length; ++i) {
-                    segInfoMap[segments[i].id] = true;
-                }
+                setSuperCalled();
             }
         },
 

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -1,0 +1,300 @@
+/**
+ * @fileoverview Tests for CodePath.
+ * @author Toru Nagashima
+ * @copyright 2016 Toru Nagashima. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("assert"),
+    eslint = require("../../../lib/eslint");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the code path of a given source code.
+ *
+ * @param {string} code - A source code.
+ * @returns {CodePath[]} A list of created code paths.
+ */
+function parseCodePaths(code) {
+    var retv = [];
+
+    eslint.reset();
+    eslint.defineRule("test", function() {
+        return {
+            "onCodePathStart": function(codePath) {
+                retv.push(codePath);
+            }
+        };
+    });
+    eslint.verify(code, {rules: {test: 2}});
+
+    return retv;
+}
+
+/**
+ * Traverses a given code path then returns the order of traversing.
+ *
+ * @param {CodePath} codePath - A code path to traverse.
+ * @param {object|undefined} options - Omittable. The option object of
+ *      `codePath.traverseSegments()` method.
+ * @param {function|undefined} callback - Omittable. The callback function of
+ *      `codePath.traverseSegments()` method.
+ * @returns {string[]} The list of segment's ids in the order traversed.
+ */
+function getOrderOfTraversing(codePath, options, callback) {
+    var retv = [];
+
+    codePath.traverseSegments(options, function(segment, controller) {
+        retv.push(segment.id);
+        if (callback) {
+            callback(segment, controller);
+            return;
+        }
+    });
+
+    return retv;
+}
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("CodePathAnalyzer", function() {
+    describe(".traverseSegments()", function() {
+        describe("should traverse segments from the first to the end:", function() {
+            it("simple", function() {
+                var codePath = parseCodePaths("foo(); bar(); baz();")[0];
+                var order = getOrderOfTraversing(codePath);
+
+                assert.deepEqual(order, ["s1_1"]);
+                /*
+                digraph {
+                    node[shape=box,style="rounded,filled",fillcolor=white];
+                    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    s1_1[label="Program\nExpressionStatement\nCallExpression\nIdentifier (foo)\nExpressionStatement\nCallExpression\nIdentifier (bar)\nExpressionStatement\nCallExpression\nIdentifier (baz)"];
+                    initial->s1_1->final;
+                }
+                */
+            });
+
+            it("if", function() {
+                var codePath = parseCodePaths("if (a) foo(); else bar(); baz();")[0];
+                var order = getOrderOfTraversing(codePath);
+
+                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+                /*
+                digraph {
+                    node[shape=box,style="rounded,filled",fillcolor=white];
+                    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+                    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+                    s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (baz)"];
+                    s1_3[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                    initial->s1_1->s1_2->s1_4;
+                    s1_1->s1_3->s1_4->final;
+                }
+                */
+            });
+
+            it("switch", function() {
+                var codePath = parseCodePaths("switch (a) { case 0: foo(); break; case 1: bar(); } baz();")[0];
+                var order = getOrderOfTraversing(codePath);
+
+                assert.deepEqual(order, ["s1_1", "s1_2", "s1_4", "s1_5", "s1_6"]);
+                /*
+                digraph {
+                    node[shape=box,style="rounded,filled",fillcolor=white];
+                    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    s1_1[label="Program\nSwitchStatement\nIdentifier (a)\nSwitchCase\nLiteral (0)"];
+                    s1_2[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nBreakStatement"];
+                    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\nSwitchCase:exit"];
+                    s1_5[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                    s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (baz)"];
+                    s1_4[label="SwitchCase\nLiteral (1)"];
+                    initial->s1_1->s1_2->s1_3->s1_5->s1_6;
+                    s1_1->s1_4->s1_5;
+                    s1_2->s1_6;
+                    s1_4->s1_6->final;
+                }
+                */
+            });
+
+            it("while", function() {
+                var codePath = parseCodePaths("while (a) foo(); bar();")[0];
+                var order = getOrderOfTraversing(codePath);
+
+                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+                /*
+                digraph {
+                    node[shape=box,style="rounded,filled",fillcolor=white];
+                    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    s1_1[label="Program\nWhileStatement"];
+                    s1_2[label="Identifier (a)"];
+                    s1_3[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+                    s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                    initial->s1_1->s1_2->s1_3->s1_2->s1_4->final;
+                }
+                */
+            });
+
+            it("for", function() {
+                var codePath = parseCodePaths("for (var i = 0; i < 10; ++i) foo(i); bar();")[0];
+                var order = getOrderOfTraversing(codePath);
+
+                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4", "s1_5"]);
+                /*
+                digraph {
+                    node[shape=box,style="rounded,filled",fillcolor=white];
+                    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    s1_1[label="Program\nForStatement\nVariableDeclaration\nVariableDeclarator\nIdentifier (i)\nLiteral (0)"];
+                    s1_2[label="BinaryExpression\nIdentifier (i)\nLiteral (10)"];
+                    s1_3[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier (i)"];
+                    s1_4[label="UpdateExpression\nIdentifier (i)"];
+                    s1_5[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                    initial->s1_1->s1_2->s1_3->s1_4->s1_2->s1_5->final;
+                }
+                */
+            });
+
+            it("for-in", function() {
+                var codePath = parseCodePaths("for (var key in obj) foo(key); bar();")[0];
+                var order = getOrderOfTraversing(codePath);
+
+                assert.deepEqual(order, ["s1_1", "s1_3", "s1_2", "s1_4", "s1_5"]);
+                /*
+                digraph {
+                    node[shape=box,style="rounded,filled",fillcolor=white];
+                    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    s1_1[label="Program\nForInStatement"];
+                    s1_3[label="Identifier (obj)"];
+                    s1_2[label="VariableDeclaration\nVariableDeclarator\nIdentifier (key)"];
+                    s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (foo)\nIdentifier (key)"];
+                    s1_5[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                    initial->s1_1->s1_3->s1_2->s1_4->s1_2;
+                    s1_3->s1_5;
+                    s1_4->s1_5->final;
+                }
+                */
+            });
+
+            it("try-catch", function() {
+                var codePath = parseCodePaths("try { foo(); } catch (e) { bar(); } baz();")[0];
+                var order = getOrderOfTraversing(codePath);
+
+                assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+                /*
+                digraph {
+                    node[shape=box,style="rounded,filled",fillcolor=white];
+                    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                    s1_1[label="Program\nTryStatement\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+                    s1_2[label="CallExpression:exit\nExpressionStatement:exit\nBlockStatement:exit"];
+                    s1_3[label="CatchClause\nIdentifier (e)\nBlockStatement\nExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                    s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (baz)"];
+                    initial->s1_1->s1_2->s1_3->s1_4;
+                    s1_1->s1_3;
+                    s1_2->s1_4->final;
+                }
+                */
+            });
+        });
+
+        it("should traverse segments from `options.first` to `options.last`.", function() {
+            var codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
+            var order = getOrderOfTraversing(codePath, {
+                first: codePath.initialSegment.nextSegments[0],
+                last: codePath.initialSegment.nextSegments[0].nextSegments[1]
+            });
+
+            assert.deepEqual(order, ["s1_2", "s1_3", "s1_4"]);
+            /*
+            digraph {
+                node[shape=box,style="rounded,filled",fillcolor=white];
+                initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+                s1_2[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+                s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+                s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (out2)"];
+                s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (out1)"];
+                initial->s1_1->s1_2->s1_3->s1_4->s1_6;
+                s1_1->s1_5->s1_6;
+                s1_2->s1_4;
+                s1_6->final;
+            }
+            */
+        });
+
+        it("should stop immediately when 'controller.break()' was called.", function() {
+            var codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
+            var order = getOrderOfTraversing(codePath, null, function(segment, controller) {
+                if (segment.id === "s1_2") {
+                    controller.break();
+                }
+            });
+
+            assert.deepEqual(order, ["s1_1", "s1_2"]);
+            /*
+            digraph {
+                node[shape=box,style="rounded,filled",fillcolor=white];
+                initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+                s1_2[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+                s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+                s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (out2)"];
+                s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (out1)"];
+                initial->s1_1->s1_2->s1_3->s1_4->s1_6;
+                s1_1->s1_5->s1_6;
+                s1_2->s1_4;
+                s1_6->final;
+            }
+            */
+        });
+
+        it("should skip the current branch when 'controller.skip()' was called.", function() {
+            var codePath = parseCodePaths("if (a) { if (b) { foo(); } bar(); } else { out1(); } out2();")[0];
+            var order = getOrderOfTraversing(codePath, null, function(segment, controller) {
+                if (segment.id === "s1_2") {
+                    controller.skip();
+                }
+            });
+
+            assert.deepEqual(order, ["s1_1", "s1_2", "s1_5", "s1_6"]);
+            /*
+            digraph {
+                node[shape=box,style="rounded,filled",fillcolor=white];
+                initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+                s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+                s1_2[label="BlockStatement\nIfStatement\nIdentifier (b)"];
+                s1_3[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (foo)"];
+                s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (bar)"];
+                s1_6[label="ExpressionStatement\nCallExpression\nIdentifier (out2)"];
+                s1_5[label="BlockStatement\nExpressionStatement\nCallExpression\nIdentifier (out1)"];
+                initial->s1_1->s1_2->s1_3->s1_4->s1_6;
+                s1_1->s1_5->s1_6;
+                s1_2->s1_4;
+                s1_6->final;
+            }
+            */
+        });
+    });
+});

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -45,7 +45,10 @@ ruleTester.run("constructor-super", rule, {
         { code: "class A extends B { constructor() { if (a) super(); else super(); } }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A extends B { constructor() { try {} finally { super(); } } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { if (a) throw Error(); super(); } }", parserOptions: { ecmaVersion: 6 } }
+        { code: "class A extends B { constructor() { if (a) throw Error(); super(); } }", parserOptions: { ecmaVersion: 6 } },
+
+        // https://github.com/eslint/eslint/issues/5261
+        { code: "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         // non derived classes.
@@ -63,6 +66,11 @@ ruleTester.run("constructor-super", rule, {
         // derived classes.
         {
             code: "class A extends B { constructor() { } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends B { constructor() { for (var a of b) super.foo(); } }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
         },
@@ -166,6 +174,14 @@ ruleTester.run("constructor-super", rule, {
             code: "class A extends B { constructor() { switch (a) { case 0: super(); default: super(); } } }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected duplicate 'super()'.", type: "CallExpression", column: 76}]
+        },
+        {
+            code: "class A extends B { constructor(a) { while (a) super(); } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Lacked a call of 'super()' in some code paths.", type: "MethodDefinition"},
+                { message: "Unexpected duplicate 'super()'.", type: "CallExpression", column: 48}
+            ]
         }
     ]
 });

--- a/tests/lib/rules/no-this-before-super.js
+++ b/tests/lib/rules/no-this-before-super.js
@@ -52,7 +52,11 @@ ruleTester.run("no-this-before-super", rule, {
         // multi code path.
         { code: "class A extends B { constructor() { if (a) { super(); this.a(); } else { super(); this.b(); } } }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A extends B { constructor() { if (a) super(); else super(); this.a(); } }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends B { constructor() { try { super(); } finally {} this.a(); } }", parserOptions: { ecmaVersion: 6 } }
+        { code: "class A extends B { constructor() { try { super(); } finally {} this.a(); } }", parserOptions: { ecmaVersion: 6 } },
+
+        // https://github.com/eslint/eslint/issues/5261
+        { code: "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends B { constructor(a) { for (const b of a) { foo(b); } super(); } }", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         // disallows all `this`/`super` if `super()` is missing.


### PR DESCRIPTION
fixes #5261.

Consideration of loops in those rules has been lacking.

I added a method which traverses every segment in a code path
(`codePath.traverseSegments(options, callback)`) into CodePath
prototype. Those rules come to handle loops by using this method.

Handling loops of a code path is complex :(
I'd like to investigate more simple way in future.

Note: Other rules which are using code path (`no-fallthrough`,
`no-unreachable`, and `consistent-return`) are not related to this bug.
These are checking whether some statements are reachable or not.
Reachability is calculated correctly.