### PR TITLE
Docs: Fix incorrect `api.verify` JSDoc for `config` param

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -644,18 +644,18 @@ module.exports = (function() {
     /**
      * Configuration object for the `verify` API. A JS representation of the eslintrc files.
      * @typedef {Object} ESLintConfig
-     * @param {Object} rules The rule configuration to verify against.
-     * @param {string} [parser] Parser to use when generatig the AST.
-     * @param {Object} [parserOptions] Options for the parsed used.
-     * @param {Object} [settings] Global settings passed to each rule.
-     * @param {Object} [env] The environment to verify in.
-     * @param {Object} [globals] Available globalsto the code.
+     * @property {Object} rules The rule configuration to verify against.
+     * @property {string} [parser] Parser to use when generatig the AST.
+     * @property {Object} [parserOptions] Options for the parsed used.
+     * @property {Object} [settings] Global settings passed to each rule.
+     * @property {Object} [env] The environment to verify in.
+     * @property {Object} [globals] Available globalsto the code.
      */
 
     /**
      * Verifies the text against the rules specified by the second argument.
      * @param {string|SourceCode} textOrSourceCode The text to parse or a SourceCode object.
-     * @param {ESLintConfig} config An object whose keys specify the rules to use.
+     * @param {ESLintConfig} config An ESLintConfig instance to configure everything.
      * @param {(string|Object)} [filenameOrOptions] The optional filename of the file being checked.
      *      If this is not set, the filename will default to '<input>' in the rule context. If
      *      an object, then it has "filename", "saveState", and "allowInlineConfig" properties.


### PR DESCRIPTION
Refs #5104 (specifically https://github.com/eslint/eslint/issues/5104#issuecomment-184236204)