### PR TITLE
Docs: Update PR creation bot message

### DIFF
--- a/templates/pr-create.md.ejs
+++ b/templates/pr-create.md.ejs
@@ -1,5 +1,53 @@
-Thanks for the pull request, @<%= payload.sender.login %>! It looks like this is your first time contributing to ESLint, so please take a moment to read over our [contribution guidelines](http://eslint.org/docs/developer-guide/contributing/pull-requests).
+<%
 
-We'll also need you to sign our [CLA](http://eslint.org/cla), which is just a way for you to say that you give us permission to use your contribution.
+var FLAG_PATTERN = /^(Fix|Update|New|Breaking|Build|Docs|Upgrade):/,
+    ISSUE_REF_PATTERN = /\((fixes|refs) #\d+.*?\)$/;
 
-If you have any questions about the process, don't hesitate to ask.
+function isValidCommitFlag(log) {
+    var result = log.match(FLAG_PATTERN);
+    return !!result || log.indexOf("Revert \"") === 0;
+}
+
+function needsIssueRef(log) {
+    var result = log.match(ISSUE_REF_PATTERN);
+    return !result && log.indexOf("Docs:") !== 0;
+}
+
+var problems = [];
+
+// Check for one commit per pull request
+if (payload.commits > 1) {
+    problems.push("We require one commit per pull request. Please [squash](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits) your commits.");
+} else if (meta.commits) {
+    var log = meta.commits[0].commit.message;
+    if (!isValidCommitFlag(log)) {
+        problems.push("The commit summary needs to begin with a tag (such as `Fix:` or `Update:`). Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.")
+    }
+
+    if (log.length > 72) {
+        problems.push("The commit summary must be 72 characters or shorter. Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.");
+    }
+
+    if (needsIssueRef(log)) {
+        problems.push("Pull requests with code require an issue to be mentioned at the end of the commit summary, such as `(fixes #1234)`. Please [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) the commit summary with an issue (file a new issue if one doesn't already exist).")
+    }
+}
+
+// Check for CLA signature
+if (!meta.cla) {
+    problems.push("Please sign our [CLA](http://eslint.org/cla). This is just a way for you to say that you give us permission to use your contribution.")
+}
+
+if (problems.length) { %>
+Thanks for the pull request, @<%= payload.sender.login %>! I took a look to make sure it's ready for merging and found some changes are needed:
+
+<% problems.forEach(function(problem) { %>
+* <%- problem %>
+<% }); %>
+
+Can you please update the pull request to address these?
+
+(More information can be found in our [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests).)
+<% } else { %>
+LGTM
+<% } %>

--- a/tests/templates/pr-create.md.ejs.js
+++ b/tests/templates/pr-create.md.ejs.js
@@ -1,0 +1,181 @@
+/**
+ * @fileoverview Tests for pr-create.md.ejs
+ * @author Nicholas C. Zakas
+ * @copyright 2016 Nicholas C. Zakas. All rights reserved.
+ * MIT License. See LICENSE in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    fs = require("fs"),
+    path = require("path"),
+    ejs = require("ejs");
+
+//------------------------------------------------------------------------------
+// Data
+//------------------------------------------------------------------------------
+
+var TEMPLATE_TEXT = fs.readFileSync(path.resolve(__dirname, "../../templates/pr-create.md.ejs"), "utf8");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("pr-create.md.ejs", function() {
+
+
+    it("should greet the submitter by name", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                }
+            },
+            meta: {}
+        });
+
+        assert.ok(result.indexOf("@nzakas") > -1);
+    });
+
+    it("should mention the CLA when one isn't found", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                }
+            },
+            meta: { cla: false }
+        });
+
+        assert.ok(result.indexOf("http://eslint.org/cla") > -1);
+    });
+
+    it("should say LGTM when there are no problems with the pull request", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 1
+            },
+            meta: { cla: true }
+        });
+
+        assert.equal(result.trim(), "LGTM");
+    });
+
+    it("should mention squashing commits when more than one commit is found", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 2
+            },
+            meta: { cla: true }
+        });
+
+        assert.ok(result.indexOf("squash") > -1);
+    });
+
+    it("should mention commit message format when there's one commit and an invalid commit message is found", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 1
+            },
+            meta: {
+                cla: true,
+                commits: [
+                    {
+                        commit: {
+                            message: "Foo bar"
+                        }
+                    }
+                ]
+            }
+        });
+
+        assert.ok(result.indexOf("begin with a tag") > -1);
+        assert.ok(result.indexOf("require an issue") > -1);
+    });
+
+    it("should mention commit message length when there's a message longer than 72 characters", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 1
+            },
+            meta: {
+                cla: true,
+                commits: [
+                    {
+                        commit: {
+                            message: "Fix: abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz (fixes #124)"
+                        }
+                    }
+                ]
+            }
+        });
+
+        assert.ok(result.indexOf("72 characters") > -1);
+        assert.ok(result.indexOf("require an issue") === -1);
+    });
+
+    it("should not mention missing issue when there's one documentation commit", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 1
+            },
+            meta: {
+                cla: true,
+                commits: [
+                    {
+                        commit: {
+                            message: "Docs: Foo bar"
+                        }
+                    }
+                ]
+            }
+        });
+
+        assert.equal(result.trim(), "LGTM");
+        assert.ok(result.indexOf("require an issue") === -1);
+    });
+
+    it("should mention missing issue when there's a missing closing paren", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 1
+            },
+            meta: {
+                cla: true,
+                commits: [
+                    {
+                        commit: {
+                            message: "Fix: Foo bar (fixes #1234"
+                        }
+                    }
+                ]
+            }
+        });
+
+        assert.ok(result.indexOf("require an issue") > -1);
+    });
+
+});


### PR DESCRIPTION
This updates our pull request message to do some basic checks:

1. Commit message format (tag, issue reference, length)
1. CLA signature
1. Number of commits

If there are no problems, the comment is just "LGTM". :)

Right now, it can't check commit messages because the bot needs to do a separate request to get that information. I'll update the bot to do so once this is merged.

Also, I'll update the bot to run this on every pull request, not just on those without a CLA (as it is now).