### PR TITLE
Docs: Achieve consistent order of h2 in rule pages

### DIFF
--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -57,7 +57,7 @@ The rule takes a single option, which is an array of possible callback names.
 callback-return: [2, ["callback", "cb", "next"]]
 ```
 
-## Gotchas
+## Known Limitations
 
 There are several cases of bad behavior that this rule will not catch and even a few cases where
 the rule will warn even though you are handling your callbacks correctly. Most of these issues arise

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -62,6 +62,32 @@ An additional option object can be added with a property `"allowArrowFunctions"`
 "func-style": [2, "expression", { "allowArrowFunctions": true }]
 ```
 
+The following patterns are considered problems:
+
+```js
+/*eslint func-style: [2, "expression"]*/
+
+function foo() {
+    // ...
+}
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint func-style: [2, "expression"]*/
+
+var foo = function() {
+    // ...
+};
+```
+
+```js
+/*eslint func-style: [2, "declaration", { "allowArrowFunctions": true }]*/
+
+var foo = () => {};
+```
+
 ### "declaration"
 
 This reports an error if any function expressions are used where function declarations are expected. You can specify to use expressions instead:
@@ -69,8 +95,6 @@ This reports an error if any function expressions are used where function declar
 ```json
 "func-style": [2, "declaration"]
 ```
-
-## Examples
 
 The following patterns are considered problems:
 
@@ -80,14 +104,6 @@ The following patterns are considered problems:
 var foo = function() {
     // ...
 };
-```
-
-```js
-/*eslint func-style: [2, "expression"]*/
-
-function foo() {
-    // ...
-}
 ```
 
 ```js
@@ -109,20 +125,6 @@ function foo() {
 SomeObject.foo = function() {
     // ...
 };
-```
-
-```js
-/*eslint func-style: [2, "expression"]*/
-
-var foo = function() {
-    // ...
-};
-```
-
-```js
-/*eslint func-style: [2, "declaration", { "allowArrowFunctions": true }]*/
-
-var foo = () => {};
 ```
 
 

--- a/docs/rules/no-ex-assign.md
+++ b/docs/rules/no-ex-assign.md
@@ -41,11 +41,7 @@ try {
 }
 ```
 
-## Notes
-
-Related aside: there are some interesting caveats in IE 6-8 where the exception identifier will leak into the outer scope causing some unexpected behavior. Ben Alman has a [great article](http://weblog.bocoup.com/the-catch-with-try-catch/) that explains this behavior in detail
-
 ## Further Reading
 
 * [Do not assign to the exception parameter](http://jslinterrors.com/do-not-assign-to-the-exception-parameter/)
-* [The "catch" with try...catch -- Ben Alman](http://weblog.bocoup.com/the-catch-with-try-catch/)
+* [The "catch" with try...catch](http://weblog.bocoup.com/the-catch-with-try-catch/) by Ben Alman explains how the exception identifier can leak into the outer scope in IE 6-8

--- a/docs/rules/no-extra-label.md
+++ b/docs/rules/no-extra-label.md
@@ -71,12 +71,12 @@ C: switch (a) {
 }
 ```
 
+## When Not To Use It
+
+If you don't want to be notified about usage of labels, then it's safe to disable this rule.
+
 ## Related Rules
 
 * [no-labels](./no-labels.md)
 * [no-label-var](./no-label-var.md)
 * [no-unused-labels](./no-unused-labels.md)
-
-## When Not To Use It
-
-If you don't want to be notified about usage of labels, then it's safe to disable this rule.

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -33,13 +33,13 @@ var num = 0.5;
 var num = 2.0;
 ```
 
-## Compatibility
-
-* **JSHint**: W008
-
 ## When Not To Use It
 
 If you aren't concerned about misinterpreting floating decimal point values, then you can safely turn this rule off.
+
+## Compatibility
+
+* **JSHint**: W008
 
 ## Further Reading
 

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -28,7 +28,7 @@ new RegExp
 this.RegExp('[')
 ```
 
-## New ECMAScript 6 Flags
+## Environments
 
 ECMAScript 6 adds the "u" ([unicode](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode)) and "y" ([sticky](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky)) flags. You can enable these to be recognized as valid by setting the ECMAScript version to 6 in your [ESLint configuration](../user-guide/configuring).
 

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -27,7 +27,7 @@ And this rule allows `this` keywords in functions below:
 
 Otherwise are considered problems.
 
-### The following patterns are considered problems:
+The following patterns are considered problems:
 
 This rule warns below **only** under the strict mode.
 Please note your code in ES2015 Modules/Classes is always the strict mode.
@@ -80,7 +80,7 @@ foo.forEach(function() {
 });
 ```
 
-### The following patterns are not considered problems:
+The following patterns are not considered problems:
 
 ```js
 /*eslint no-invalid-this: 2*/

--- a/docs/rules/no-label-var.md
+++ b/docs/rules/no-label-var.md
@@ -41,12 +41,12 @@ q:
 
 If you don't want to be notified about usage of labels, then it's safe to disable this rule.
 
+## Further Reading
+
+* ['{a}' is a statement label](http://jslinterrors.com/a-is-a-statement-label/)
+
 ## Related Rules
 
 * [no-extra-label](./no-extra-label.md)
 * [no-labels](./no-labels.md)
 * [no-unused-labels](./no-unused-labels.md)
-
-## Further Reading
-
-* ['{a}' is a statement label](http://jslinterrors.com/a-is-a-statement-label/)

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -4,10 +4,10 @@ In the Node.JS community it is often customary to separate the `require`d module
 
 ## Rule Details
 
-When this rule is enabled, all `var` statements must satisfy the following conditions:
+When this rule is enabled, each `var` statement must satisfy the following conditions:
 
-* either none or all variable declarations must be require declarations
-* all require declarations must be of the same type (optional)
+* either none or all variable declarations must be require declarations (default)
+* all require declarations must be of the same type (grouping)
 
 This rule distinguishes between six kinds of variable declaration types:
 
@@ -35,21 +35,28 @@ This rule comes with two boolean options. Both are turned off by default. You ca
 
 ```json
 {
-    "no-mixed-requires": [1, {"grouping": true, "allowCall": true}]
+    "no-mixed-requires": [2, {"grouping": true, "allowCall": true}]
 }
 ```
 
-The second way to configure this rule is with boolean (This way of setting is deprecated).
+The second way to configure this rule is with boolean. This way of setting is deprecated.
 
 ```json
 {
-    "no-mixed-requires": [1, true]
+    "no-mixed-requires": [2, true]
 }
 ```
 
 If enabled, violations will be reported whenever a single `var` statement contains require declarations of mixed types (see the examples below).
 
-## Examples
+The following patterns are considered problems:
+
+```js
+/*eslint no-mixed-requires: 2*/
+
+var fs = require('fs'),
+    i = 0;
+```
 
 The following patterns are not considered problems:
 
@@ -72,14 +79,7 @@ var foo = require('foo' + VERSION),
     baz = require();
 ```
 
-The following patterns are considered problems:
-
-```js
-/*eslint no-mixed-requires: 2*/
-
-var fs = require('fs'),
-    i = 0;
-```
+### grouping
 
 The following patterns are considered problems when grouping is turned on:
 
@@ -94,6 +94,8 @@ var fs = require('fs'),
 var foo = require('foo'),
     bar = require(getBarModuleName());
 ```
+
+### allowCall
 
 The following patterns are not considered problems when `allowCall` is turned on:
 
@@ -111,14 +113,16 @@ var async = require('async'),
     eslint = require('eslint');
 ```
 
+## Known Limitations
+
+* The implementation is not aware of any local functions with the name `require` that may shadow Node's global `require`.
+
+* Internally, the list of core modules is retrieved via `require("repl")._builtinLibs`. If you use different versions of Node.JS for ESLint and your application, the list of core modules for each version may be different.
+  The above mentioned `_builtinLibs` property became available in 0.8, for earlier versions a hardcoded list of module names is used as a fallback. If your version of Node is older than 0.6 that list may be inaccurate.
+
 ## When Not To Use It
 
-Internally, the list of core modules is retrieved via `require("repl")._builtinLibs`. If you use different versions of Node.JS for ESLint and your application, the list of core modules for each version may be different.
-The above mentioned `_builtinLibs` property became available in 0.8, for earlier versions a hardcoded list of module names is used as a fallback. If your version of Node is older than 0.6 that list may be inaccurate.
-
 If you use a pattern such as [UMD][4] where the `require`d modules are not loaded in variable declarations, this rule will obviously do nothing for you.
-
-The implementation is not aware of any local functions with the name `require` that may shadow Node's global `require`.
 
 [1]: http://nodejs.org/api/modules.html#modules_core_modules
 [2]: http://nodejs.org/api/modules.html#modules_file_modules

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -18,49 +18,28 @@ The second argument can be used to configure this rule:
 * `maxBOF` can be used to set a different number for the beginning of the file.
   If omitted, the 'max' option is applied at the beginning of the file.
 
-For example, this sets the rule as an error (code is 2) with a maximum
-tolerated blank lines of 2 (for the whole file):
+### max
+
+In the following example, the first 2 is the code for an error
+and the second 2 is the maximum number of empty lines:
 
 ```json
 "no-multiple-empty-lines": [2, {"max": 2}]
 ```
 
-While this tolerates three consecutive blank lines within the file, but only
-one at the end:
-
-```json
-"no-multiple-empty-lines": [2, {"max": 3, "maxEOF": 1}]
-```
-
-And this tolerates three consecutive blank lines within the file, but none at
-the beginning:
-
-```json
-"no-multiple-empty-lines": [2, {"max": 3, "maxBOF": 0}]
-```
-
-
-## Examples
-
 The following patterns are considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 1}]*/
+/*eslint no-multiple-empty-lines: [2, {max: 2}]*/
+
 
 var foo = 5;
+
+
+
 var bar = 3;
 
-```
 
-```js
-/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 1}]*/
-
-var foo = 5;
-```
-
-```js
-/*eslint no-multiple-empty-lines: [2, {max: 999, maxBOF: 0}]*/
-var foo = 5;
 ```
 
 The following patterns are not considered problems:
@@ -68,41 +47,78 @@ The following patterns are not considered problems:
 ```js
 /*eslint no-multiple-empty-lines: [2, {max: 2}]*/
 
-var foo = 5;
-
-var bar = 3;
-```
-
-```js
-/*eslint no-multiple-empty-lines: [2, {max: 4}]*/
 
 var foo = 5;
-
-
 
 
 var bar = 3;
+
+
 ```
 
-```js
-/*eslint no-multiple-empty-lines: [2, {max: 2}]*/
+### maxEOF
 
-var foo = 5;
-// extra line
+```json
+"no-multiple-empty-lines": [2, {"max": 2, "maxEOF": 1}]
 ```
 
+The following patterns are considered problems:
+
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2, maxBOF: 1}]*/
-// extra line
+/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 1}]*/
+
+
 var foo = 5;
-// extra line
+
+
+var bar = 3;
+
+
 ```
 
+The following patterns are not considered problems:
+
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 10}]*/
+/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 1}]*/
+
 
 var foo = 5;
-// 10 extra lines
+
+
+var bar = 3;
+
+```
+
+### maxBOF
+
+```json
+"no-multiple-empty-lines": [2, {"max": 2, "maxBOF": 0}]
+```
+
+The following patterns are considered problems:
+
+```js
+/*eslint no-multiple-empty-lines: [2, {max: 2, maxBOF: 0}]*/
+
+
+var foo = 5;
+
+
+var bar = 3;
+
+
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint no-multiple-empty-lines: [2, {max: 2, maxBOF: 0}]*/
+var foo = 5;
+
+
+var bar = 3;
+
+
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -2,11 +2,11 @@
 
 Imports are an ES6/ES2015 standard for making the functionality of other modules available in your current module. In CommonJS this is implemented through the require() call which makes this ESLint rule roughly equivalent to its CommonJS counterpart `no-restricted-modules`.
 
-## Why would you want to restrict imports?
+Why would you want to restrict imports?
 
-Some imports might not make sense in a particular environment. For example, Node's `fs` module would not make sense in an environment that didn't have a file system.
+* Some imports might not make sense in a particular environment. For example, Node's `fs` module would not make sense in an environment that didn't have a file system.
 
-Some modules provide similar or identical functionality, think `lodash` and `underscore`. Your project may have standardized on a module. You want to make sure that the other alternatives are not being used as this would unnecessarily bloat the project and provide a higher maintenance cost of two dependencies when one would suffice.
+* Some modules provide similar or identical functionality, think `lodash` and `underscore`. Your project may have standardized on a module. You want to make sure that the other alternatives are not being used as this would unnecessarily bloat the project and provide a higher maintenance cost of two dependencies when one would suffice.
 
 ## Rule Details
 

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -51,7 +51,7 @@ try {
 }
 ```
 
-### Known Limitations
+## Known Limitations
 
 Due to the limits of static analysis, this rule cannot guarantee that you will only throw `Error` objects.  For instance, the following cases do not throw an `Error` object, but they will not be considered problems:
 

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -1,10 +1,10 @@
 # Disallow Undeclared Variables (no-undef)
 
-Any reference to an undeclared variable causes a warning, unless the variable is explicitly mentioned in a `/*global ...*/` comment. This rule provides compatibility with [JSHint](http://www.jshint.com)'s and [JSLint](http://www.jslint.com)'s treatment of global variables.
-
 This rule can help you locate potential ReferenceErrors resulting from misspellings of variable and parameter names, or accidental implicit globals (for example, from forgetting the `var` keyword in a `for` loop initializer).
 
 ## Rule Details
+
+Any reference to an undeclared variable causes a warning, unless the variable is explicitly mentioned in a `/*global ...*/` comment.
 
 ## Options
 
@@ -111,6 +111,10 @@ module.exports = function() {
 ## When Not To Use It
 
 If explicit declaration of global variables is not to your taste.
+
+## Compatibility
+
+This rule provides compatibility with treatment of global variables in [JSHint](http://www.jshint.com) and [JSLint](http://www.jslint.com).
 
 ## Further Reading
 

--- a/docs/rules/no-undefined.md
+++ b/docs/rules/no-undefined.md
@@ -32,7 +32,7 @@ Taking all of this into account, some style guides forbid the use of `undefined`
 * Checking if a value is `undefined` should be done with `typeof`.
 * Using the `void` operator to generate the value of `undefined` if necessary.
 
-## Examples
+## Rule Details
 
 This rule aims to eliminate the use of `undefined`, and as such, generates a warning whenever it is used.
 

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -73,11 +73,11 @@ The following pattern is not considered a warning when `defaultAssignment` is `t
 var a = x ? x : 1;
 ```
 
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with unnecessary complexity in conditional expressions.
+
 ## Related Rules
 
 * [no-ternary](no-ternary.md)
 * [no-nested-ternary](no-nested-ternary.md)
-
-## When Not To Use It
-
-You can turn this rule off if you are not concerned with unnecessary complexity in conditional expressions.

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -8,19 +8,6 @@ Some styleguides require or disallow spaces before or after unary operators. Thi
 
 This rule enforces consistency regarding the spaces after `words` unary operators and after/before `nonwords` unary operators.
 
-## Options
-
-This rule has two options: `words` and `nonwords`:
-
-* `words` - applies to unary word operators such as: `new`, `delete`, `typeof`, `void`, `yield`
-* `nonwords` - applies to unary operators such as: `-`, `+`, `--`, `++`, `!`, `!!`
-
-Default values are:
-
-```json
-"space-unary-ops": [1, { "words": true, "nonwords": false }]
-```
-
 Examples of unary `words` operators:
 
 ```js
@@ -50,13 +37,17 @@ baz = !foo;
 qux = !!baz;
 ```
 
-## Examples
+## Options
+
+This rule has two options: `words` and `nonwords`:
+
+* `words` - applies to unary word operators such as: `new`, `delete`, `typeof`, `void`, `yield`
+* `nonwords` - applies to unary operators such as: `-`, `+`, `--`, `++`, `!`, `!!`
 
 Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are considered problems:
 
 ```js
 /*eslint space-unary-ops: 2*/
-/*eslint-env es6*/
 
 typeof!foo;
 
@@ -65,10 +56,6 @@ void{foo:0};
 new[foo][0];
 
 delete(foo.bar);
-
-function *foo() {
-    yield(0)
-}
 
 ++ foo;
 
@@ -79,9 +66,16 @@ foo --;
 + "3";
 ```
 
+```js
+/*eslint space-unary-ops: 2*/
+/*eslint-env es6*/
+
+function *foo() {
+    yield(0)
+}
+```
+
 Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are not considered problems:
-
-
 
 ```js
 /*eslint space-unary-ops: 2*/
@@ -106,4 +100,13 @@ foo--;
 
 // Unary operator "+" is not followed by whitespace.
 +"3";
+```
+
+```js
+/*eslint space-unary-ops: 2*/
+/*eslint-env es6*/
+
+function *foo() {
+    yield (0)
+}
 ```

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -13,32 +13,30 @@ exceptions for various documentation styles.
 
 ## Options
 
-The rule takes two options. The first is a string which be either `"always"` or `"never"`. If you pass `"always"` then the `//` or `/*` must be followed by at least once whitespace. If `"never"` then there should be no whitespace following. The default is `"always"`.
+The rule takes two options.
 
-Here is an example of how to configure the rule with this option:
+* The first is a string which be either `"always"` or `"never"`. The default is `"always"`.
 
-```json
-"spaced-comment": [2, "always"]
-```
+    * If `"always"` then the `//` or `/*` must be followed by at least one whitespace.
 
-### Exceptions
+    * If `"never"` then there should be no whitespace following.
 
-This rule can also take a 2nd option, an object with either of the following keys: `"exceptions"` and `"markers"`.
+* This rule can also take a 2nd option, an object with either of the following keys: `"exceptions"` and `"markers"`.
 
-The `"exceptions"` value is an array of string patterns which are considered exceptions to the rule.
-Please note that exceptions are ignored if the first argument is `"never"`.
+    * The `"exceptions"` value is an array of string patterns which are considered exceptions to the rule.
+    Please note that exceptions are ignored if the first argument is `"never"`.
 
-```json
-"spaced-comment": [2, "always", { "exceptions": ["-", "+"] }]
-```
+    ```json
+    "spaced-comment": [2, "always", { "exceptions": ["-", "+"] }]
+    ```
 
-The `"markers"` value is an array of string patterns which are considered markers for docblock-style comments,
-such as an additional `/`, used to denote documentation read by doxygen, vsdoc, etc. which must have additional characters.
-The `"markers"` array will apply regardless of the value of the first argument, e.g. `"always"` or `"never"`.
+    * The `"markers"` value is an array of string patterns which are considered markers for docblock-style comments,
+    such as an additional `/`, used to denote documentation read by doxygen, vsdoc, etc. which must have additional characters.
+    The `"markers"` array will apply regardless of the value of the first argument, e.g. `"always"` or `"never"`.
 
-```json
-"spaced-comment": [2, "always", { "markers": ["/"] }]
-```
+    ```json
+    "spaced-comment": [2, "always", { "markers": ["/"] }]
+    ```
 
 The difference between a marker and an exception is that a marker only appears at the beginning of the comment whereas
 exceptions can occur anywhere in the comment string.
@@ -58,19 +56,9 @@ You can also define separate exceptions and markers for block and line comments:
 }]
 ```
 
-## Examples
+### always
 
 The following patterns are considered problems:
-
-```js
-/*eslint spaced-comment: [2, "never"]*/
-
-// This is a comment with a whitespace at the beginning
-
-/* This is a comment with a whitespace at the beginning */
-
-/* \nThis is a comment with a whitespace at the beginning */
-```
 
 ```js
 /*eslint spaced-comment: [2, "always"]*/
@@ -78,44 +66,6 @@ The following patterns are considered problems:
 //This is a comment with no whitespace at the beginning
 
 /*This is a comment with no whitespace at the beginning */
-```
-
-```js
-/* eslint spaced-comment: [2, "always", { "block": { "exceptions": ["-"] } }] */
-
-//--------------
-// Comment block
-//--------------
-```
-
-```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
-
-//------++++++++
-// Comment block
-//------++++++++
-```
-
-```js
-/* eslint spaced-comment: [2, "always", { "markers": ["/"] }] */
-
-///This is a comment with a marker but without whitespace
-```
-
-```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
-
-/*------++++++++*/
-/* Comment block */
-/*------++++++++*/
-```
-
-```js
-/* eslint spaced-comment: [2, "always", { "line": { "exceptions": ["-+"] } }] */
-
-/*-+-+-+-+-+-+-+*/
-// Comment block
-/*-+-+-+-+-+-+-+*/
 ```
 
 The following patterns are not considered problems:
@@ -137,10 +87,80 @@ This comment has a newline
 ```
 
 ```js
+/* eslint spaced-comment: [2, "always"] */
+
+/**
+* I am jsdoc
+*/
+```
+
+### never
+
+The following patterns are considered problems:
+
+```js
+/*eslint spaced-comment: [2, "never"]*/
+
+// This is a comment with a whitespace at the beginning
+
+/* This is a comment with a whitespace at the beginning */
+
+/* \nThis is a comment with a whitespace at the beginning */
+```
+
+The following patterns are not considered problems:
+
+```js
 /*eslint spaced-comment: [2, "never"]*/
 
 /*This is a comment with no whitespace at the beginning */
 ```
+
+```js
+/*eslint spaced-comment: [2, "never"]*/
+
+/**
+* I am jsdoc
+*/
+```
+
+### exceptions
+
+The following patterns are considered problems:
+
+```js
+/* eslint spaced-comment: [2, "always", { "block": { "exceptions": ["-"] } }] */
+
+//--------------
+// Comment block
+//--------------
+```
+
+```js
+/* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
+
+//------++++++++
+// Comment block
+//------++++++++
+```
+
+```js
+/* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
+
+/*------++++++++*/
+/* Comment block */
+/*------++++++++*/
+```
+
+```js
+/* eslint spaced-comment: [2, "always", { "line": { "exceptions": ["-+"] } }] */
+
+/*-+-+-+-+-+-+-+*/
+// Comment block
+/*-+-+-+-+-+-+-+*/
+```
+
+The following patterns are not considered problems:
 
 ```js
 /* eslint spaced-comment: [2, "always", { "exceptions": ["-"] }] */
@@ -156,6 +176,14 @@ This comment has a newline
 //--------------
 // Comment block
 //--------------
+```
+
+```js
+/* eslint spaced-comment: [2, "always", { "exceptions": ["*"] }] */
+
+/****************
+ * Comment block
+ ****************/
 ```
 
 ```js
@@ -178,13 +206,17 @@ This comment has a newline
 /*-+-+-+-+-+-+-+*/
 ```
 
-```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["*"] }] */
+### markers
 
-/****************
- * Comment block
- ****************/
+The following patterns are considered problems:
+
+```js
+/* eslint spaced-comment: [2, "always", { "markers": ["/"] }] */
+
+///This is a comment with a marker but without whitespace
 ```
+
+The following patterns are not considered problems:
 
 ```js
 /* eslint spaced-comment: [2, "always", { "markers": ["/"] }] */
@@ -195,7 +227,8 @@ This comment has a newline
 ```js
 /*eslint spaced-comment: [2, "never", { "markers": ["!<"] }]*/
 
-//!<This is a comment with a marker
+//!<This is a line comment with a marker
+
 /*!<this is a block comment with a marker
 subsequent lines are ignored
 */
@@ -207,18 +240,7 @@ subsequent lines are ignored
 /*global ABC*/
 ```
 
-```js
-/* eslint spaced-comment: [2, "always"] */
 
-/**
-* I am jsdoc
-*/
-```
+## Related Rules
 
-```js
-/*eslint spaced-comment: [2, "never"]*/
-
-/**
-* I am jsdoc
-*/
-```
+* [spaced-line-comment](spaced-line-comment.md)

--- a/docs/rules/vars-on-top.md
+++ b/docs/rules/vars-on-top.md
@@ -9,8 +9,6 @@ This rule forces the programmer to represent that behaviour by manually moving t
 This rule aims to keep all variable declarations in the leading series of statements.
 Allowing multiple declarations helps promote maintainability and is thus allowed.
 
-### Examples
-
 The following patterns are considered problems:
 
 ```js


### PR DESCRIPTION
Here is the current order (with frequency) of 8 headings at depth 2 in rules as a result of this pull request:

Rule Details 221
Options 91
Environments 2
Known Limitations 4
When Not To Use It 136
Compatibility 8
Further Reading 63
Related Rules 71

Recommend next step: Before we pick up the h3-grade sandpaper, let’s continue the discussion in https://github.com/eslint/eslint.github.io/issues/108 how to give the code examples some ❤️

Summary of 18 changed files:

* move Compatibility to follow When Not To Use It
  - no-floating-decimal.md

* move When Not To Use It to precede Related Rules
  - no-extra-label.md
  - no-unneeded-terniary.md

* move Further Reading to precede Related Rules
  - no-label-var.md

* replace Gotchas with Known Limitations
  - callback-return.md

* change depth of Known Limitations from h3 to h2
  - no-throw-literal.md

* replace New ECMAScript 6 Flags with Environments
  - no-invalid-regexp.md

* delete Why would you want to restrict imports?
  - no-restricted-imports.md: The question becomes an ordinary paragraph and the following 2 answer paragraphs become bullet points.

* delete Notes
  - no-ex-assign.md: Move content to relevant bullet point under Further Reading.

* delete Examples as h2 and h3
  - no-undefined.md: Replace with Rule Details (make it similar to no-octal.md)
  - func-style.md: Move content under relevant h3 options.
    Note: I left one apparent mistake uncorrected pending verification.
  - no-mixed-requires.md: Move content under relevant ADDED h3 options.
    Change value in json for options from 1 to 2.
    Moved some content from When Not To Use It to added Known Limitations.
  * no-multiple-empty-lines.md: Move content to relevant ADDED h3 options.
    Restore empty lines which were deleted recently via #5215 [I will search for any more such].
    Make examples more parallel.
  - space-unary-ops.md: Delete and move some content to Options.
    Also split the es6 code from code with default environment.
  - spaced-comment.md: Move content to relevant ADDED h3 options.
  - vars-on-top.md: Delete.

* change h3 to p The following patterns are/are not considered problems
  - no-invalid-this.md

* move some content from introduction to Rule Details and (added) Compatibility
  - no-undef.md
