### PR TITLE
Fix: no-multi-spaces conflicts with smart tabs (fixes #2077)

### DIFF
--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -70,7 +70,7 @@ module.exports = function(context) {
 
             var source = context.getSource(),
                 allComments = context.getAllComments(),
-                pattern = /[^\n\r\u2028\u2029 ] {2,}/g,  // note: repeating space
+                pattern = /[^\n\r\u2028\u2029\t ].? {2,}/g,  // note: repeating space
                 token,
                 previousToken,
                 parent;

--- a/tests/lib/rules/no-multi-spaces.js
+++ b/tests/lib/rules/no-multi-spaces.js
@@ -26,6 +26,7 @@ ruleTester.run("no-multi-spaces", rule, {
         "var arr = [1, 2];",
         "var arr = [ (1), (2) ];",
         "var obj = {'a': 1, 'b': (2)};",
+        "\t\tvar x = 5,\n\t\t    y = 2;",
         "a, b",
         "a >>> b",
         "a ^ b",
@@ -361,6 +362,22 @@ ruleTester.run("no-multi-spaces", rule, {
             errors: [{
                 message: "Multiple spaces found before '+'.",
                 type: "Punctuator"
+            }]
+        },
+        {
+            code: "\t\tvar x = 5,\n\t\t    y =  2;",
+            output: "\t\tvar x = 5,\n\t\t    y = 2;",
+            errors: [{
+                message: "Multiple spaces found before '2'.",
+                type: "Numeric"
+            }]
+        },
+        {
+            code: "var x =\t  5;",
+            output: "var x = 5;",
+            errors: [{
+                message: "Multiple spaces found before '5'.",
+                type: "Numeric"
             }]
         }
     ]


### PR DESCRIPTION
I've added `\t` to the list of negated characters to the regular expression that determines whether the multiple spaces that are being detected should be reported or not.

Thus, in case smart tabs are being used like in the following case, the rule won't throw an error anymore.

```javascript
\t\t var one = 1,
\t\t\s\s two = 2;
```

The only shortcoming of this fix that I can see is when a tab is used within an expression, and directly after the tab, multiple spaces have been added. In that case, the rule won't be able to report an error. For instance:

```javascript
var a =\t\s\s1;
```

However, seeing as that using tabs inline is not a practice anyways, I don't think that's an issue. Do let me know if you think otherwise!
