### PR TITLE
Fix: `sort-imports` warned between default and members (fixes #5305)

### DIFF
--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -106,16 +106,21 @@ module.exports = function(context) {
 
             // Multiple members of an import declaration should also be sorted alphabetically.
             if (!ignoreMemberSort && node.specifiers.length > 1) {
-                node.specifiers.reduce(function(previousSpecifier, currentSpecifier) {
-                    var currentSpecifierName = currentSpecifier.local.name,
-                        previousSpecifierName = previousSpecifier.local.name;
+                var previousSpecifier = null;
+                var previousSpecifierName = null;
 
-                    if (ignoreCase) {
-                        currentSpecifierName = currentSpecifierName.toLowerCase();
-                        previousSpecifierName = previousSpecifierName.toLowerCase();
+                for (var i = 0; i < node.specifiers.length; ++i) {
+                    var currentSpecifier = node.specifiers[i];
+                    if (currentSpecifier.type !== "ImportSpecifier") {
+                        continue;
                     }
 
-                    if (currentSpecifierName < previousSpecifierName) {
+                    var currentSpecifierName = currentSpecifier.local.name;
+                    if (ignoreCase) {
+                        currentSpecifierName = currentSpecifierName.toLowerCase();
+                    }
+
+                    if (previousSpecifier && currentSpecifierName < previousSpecifierName) {
                         context.report({
                             node: currentSpecifier,
                             message: "Member '{{memberName}}' of the import declaration should be sorted alphabetically.",
@@ -125,8 +130,9 @@ module.exports = function(context) {
                         });
                     }
 
-                    return currentSpecifier;
-                }, node.specifiers[0]);
+                    previousSpecifier = currentSpecifier;
+                    previousSpecifierName = currentSpecifierName;
+                }
             }
 
             previousDeclaration = node;

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -156,6 +156,12 @@ ruleTester.run("sort-imports", rule, {
                 "import bar from 'bar';",
             parserOptions: parserOptions,
             options: ignoreCaseArgs
+        },
+
+        // https://github.com/eslint/eslint/issues/5305
+        {
+            code: "import React, {Component} from 'react';",
+            parserOptions: parserOptions
         }
     ],
     invalid: [


### PR DESCRIPTION
fixes #5305.

When sorting members, this rule should ignore the default specifiers.