### PR TITLE
[prefer-const] Add auto fix for prefer-const

### DIFF
--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -146,6 +146,26 @@ function isInScope(writer) {
 
 module.exports = function(context) {
 
+    var sourceCode = context.getSourceCode();
+
+    /**
+     * Creates a fixer for a given declaration.
+     * @param {Object} declaration - The variable delcaration to fix.
+     * @returns {function|null} A function to fix the given declaration
+     */
+    function makeFixer(declaration) {
+        if (declaration.declarations.length === 1 &&
+            declaration.declarations[0].id.type === "Identifier" &&
+            (declaration.declarations[0].init || declaration.parent.left === declaration)
+        ) {
+            return function(fixer) {
+                return fixer.replaceText(declaration, sourceCode.getText(declaration).replace(/^let/, "const"));
+            };
+        } else {
+            return null;
+        }
+    }
+
     /**
      * Searches and reports variables that are never modified after declared.
      * @param {Scope} scope - A scope of the search domain.
@@ -193,7 +213,8 @@ module.exports = function(context) {
                 context.report({
                     node: identifier,
                     message: "'{{name}}' is never modified, use 'const' instead.",
-                    data: identifier
+                    data: identifier,
+                    fix: makeFixer(declaration)
                 });
             }
         }

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -67,66 +67,79 @@ ruleTester.run("prefer-const", rule, {
     invalid: [
         {
             code: "let x = 1; foo(x);",
+            output: "const x = 1; foo(x);",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i in [1,2,3]) { foo(i); }",
+            output: "for (const i in [1,2,3]) { foo(i); }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'i' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let x of [1,2,3]) { foo(x); }",
+            output: "for (const x of [1,2,3]) { foo(x); }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let [x = -1, y] = [1,2]; y = 0;",
+            output: "let [x = -1, y] = [1,2]; y = 0;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
+            output: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x = 1; foo(x); })();",
+            output: "(function() { const x = 1; foo(x); })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { for (let i in [1,2,3]) { foo(i); } })();",
+            output: "(function() { for (const i in [1,2,3]) { foo(i); } })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'i' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { for (let x of [1,2,3]) { foo(x); } })();",
+            output: "(function() { for (const x of [1,2,3]) { foo(x); } })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
+            output: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
+            output: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let x = 0; { let x = 1; foo(x); } x = 0;",
+            output: "let x = 0; { const x = 1; foo(x); } x = 0;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }",
+            output: "for (let i = 0; i < 10; ++i) { const x = 1; foo(x); }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i in [1,2,3]) { let x = 1; foo(x); }",
+            output: "for (const i in [1,2,3]) { const x = 1; foo(x); }",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 { message: "'i' is never modified, use 'const' instead.", type: "Identifier"},
@@ -136,31 +149,37 @@ ruleTester.run("prefer-const", rule, {
 
         {
             code: "let x; x = 0;",
+            output: "let x; x = 0;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x; x = 1; })();",
+            output: "(function() { let x; x = 1; })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let x; { x = 0; foo(x); }",
+            output: "let x; { x = 0; foo(x); }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x; { x = 0; foo(x); } })();",
+            output: "(function() { let x; { x = 0; foo(x); } })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let x; for (const a of [1,2,3]) { x = foo(); bar(x); }",
+            output: "let x; for (const a of [1,2,3]) { x = foo(); bar(x); }",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();",
+            output: "(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
         }


### PR DESCRIPTION
This adds an auto-fix to prefer-const that applies whenever there is a
single let declaration declared by ID with an init (e.g. `let x = 10;`,
`for (let x of list);` but not `let x; x=10;` or `let {x, y} = object`).