### PR TITLE
Build: Stop checking exit code in performance tests (fixes #5330)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -955,7 +955,7 @@ function createConfigForPerformanceTest() {
     content.push.apply(
         content,
         ls("lib/rules").map(function(fileName) {
-            return "    " + path.basename(fileName, ".js") + ": 2";
+            return "    " + path.basename(fileName, ".js") + ": 1";
         })
     );
 


### PR DESCRIPTION
~~This reverts commit b32ddad494c9d766aa71144dcccecd040246b040.~~ **edit**: Not anymore!

@BYK and @mysticatea can you explain the reasoning behind #5279 and #5280? We can't differentiate between a successful and unsuccessful performance test based on exit code alone - the exit code is 1 either way.