### PR TITLE
Build: Fix commit message validation (fixes #5340)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -85,7 +85,8 @@ var NODE = "node ", // intentional extra space
  * @private
  */
 function getTestFilePatterns() {
-    var testLibPath = "tests/lib/";
+    var testLibPath = "tests/lib/",
+        testTemplatesPath = "tests/templates/";
 
     return ls(testLibPath).filter(function(pathToCheck) {
         return test("-d", testLibPath + pathToCheck);
@@ -94,7 +95,7 @@ function getTestFilePatterns() {
             initialValue.push(testLibPath + currentValues + "/**/*.js");
         }
         return initialValue;
-    }, [testLibPath + "rules/**/*.js", testLibPath + "*.js"]).join(" ");
+    }, [testLibPath + "rules/**/*.js", testLibPath + "*.js", testTemplatesPath + "*.js"]).join(" ");
 }
 
 /**

--- a/templates/pr-create.md.ejs
+++ b/templates/pr-create.md.ejs
@@ -19,7 +19,9 @@ var problems = [];
 if (payload.commits > 1) {
     problems.push("We require one commit per pull request. Please [squash](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits) your commits.");
 } else if (meta.commits) {
-    var log = meta.commits[0].commit.message;
+    // get just the first line of the commit message
+    var log = meta.commits[0].commit.message.split(/\r?\n/g)[0];
+
     if (!isValidCommitFlag(log)) {
         problems.push("The commit summary needs to begin with a tag (such as `Fix:` or `Update:`). Please check out our [guide](http://eslint.org/docs/developer-guide/contributing/pull-requests#step-2-make-your-changes) for how to properly format your commit summary and [update](http://eslint.org/docs/developer-guide/contributing/pull-requests#updating-the-commit-message) it on this pull request.")
     }

--- a/tests/templates/pr-create.md.ejs.js
+++ b/tests/templates/pr-create.md.ejs.js
@@ -155,6 +155,30 @@ describe("pr-create.md.ejs", function() {
         assert.ok(result.indexOf("require an issue") === -1);
     });
 
+    it("should not mention missing issue or length check when there's one fix commit", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 1
+            },
+            meta: {
+                cla: true,
+                commits: [
+                    {
+                        commit: {
+                            message: "Fix: Foo bar (fixes #1234)\nSome really long string. abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz"
+                        }
+                    }
+                ]
+            }
+        });
+
+        assert.equal(result.trim(), "LGTM");
+        assert.ok(result.indexOf("require an issue") === -1);
+    });
+
     it("should mention missing issue when there's a missing closing paren", function() {
         var result = ejs.render(TEMPLATE_TEXT, {
             payload: {


### PR DESCRIPTION
Also makes sure the template test is run as part of `npm test`.