### PR TITLE
Update: Better error message for plugins (refs #5221)

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -29,11 +29,30 @@ if (debug) {
 
 // now we can safely include the other modules that use debug
 var concat = require("concat-stream"),
-    cli = require("../lib/cli");
+    cli = require("../lib/cli"),
+    path = require("path"),
+    fs = require("fs");
 
 //------------------------------------------------------------------------------
 // Execution
 //------------------------------------------------------------------------------
+
+process.on("uncaughtException", function(err){
+    // lazy load
+    var lodash = require("lodash");
+
+    if (typeof err.messageTemplate === "string" && err.messageTemplate.length > 0) {
+        var template = lodash.template(fs.readFileSync(path.resolve(__dirname, "../messages/" + err.messageTemplate + ".txt"), "utf-8"));
+
+        console.log("\nOops! Something went wrong! :(");
+        console.log("\n" + template(err.messageData || {}));
+    } else {
+        console.log(err.message);
+        console.log(err.stack);
+    }
+
+    process.exit(1);
+});
 
 if (useStdIn) {
     process.stdin.pipe(concat({ encoding: "string" }, function(text) {

--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -117,6 +117,10 @@ module.exports = {
             } catch (err) {
                 debug("Failed to load plugin eslint-plugin-" + pluginNameWithoutPrefix + ". Proceeding without it.");
                 err.message = "Failed to load plugin " + pluginName + ": " + err.message;
+                err.messageTemplate = "plugin-missing";
+                err.messageData = {
+                    pluginName: pluginNameWithoutPrefix
+                };
                 throw err;
             }
 

--- a/messages/plugin-missing.txt
+++ b/messages/plugin-missing.txt
@@ -1,0 +1,9 @@
+ESLint couldn't find the plugin "eslint-plugin-<%- pluginName %>". This can happen for a couple different reasons:
+
+1. If ESLint is installed globally, then make sure eslint-plugin-<%- pluginName %> is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.
+
+2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:
+
+    npm i eslint-plugin-<%- pluginName %>@latest --save-dev
+
+If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "README.md",
     "bin",
     "conf",
-    "lib"
+    "lib",
+    "messages"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
This is a super-simple attempt at what @btmills was suggesting. I'm trapping missing plugin errors and printing a nice message instead. Thoughts welcome.