### PR TITLE
Update: prefer-const; change modified to reassigned (fixes #5350)

### DIFF
--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -1,12 +1,12 @@
 # Suggest using `const` (prefer-const)
 
-If a variable is never modified, using the `const` declaration is better.
+If a variable is never reassigned, using the `const` declaration is better.
 
-`const` declaration tells readers, "this variable is never modified," reducing cognitive load and improving maintainability.
+`const` declaration tells readers, "this variable is never reassigned," reducing cognitive load and improving maintainability.
 
 ## Rule Details
 
-This rule is aimed at flagging variables that are declared using `let` keyword, but never modified after the initial assignment.
+This rule is aimed at flagging variables that are declared using `let` keyword, but never reassigned after the initial assignment.
 
 The following patterns are considered problems:
 
@@ -17,12 +17,12 @@ The following patterns are considered problems:
 let a = 3;
 console.log(a);
 
-// `i` is re-defined (not modified) on each loop step.
+// `i` is redefined (not reassigned) on each loop step.
 for (let i in [1,2,3]) {
     console.log(i);
 }
 
-// `a` is re-defined (not modified) on each loop step.
+// `a` is redefined (not reassigned) on each loop step.
 for (let a of [1,2,3]) {
     console.log(a);
 }
@@ -47,7 +47,7 @@ for (const a of [1,2,3]) {
   console.log(a);
 }
 
-// `end` is never modified, but we cannot separate the declarations without modifying the scope.
+// `end` is never reassigned, but we cannot separate the declarations without modifying the scope.
 for (let i = 0, end = 10; i < end; ++i) {
     console.log(a);
 }
@@ -59,7 +59,7 @@ console.log(b);
 
 ## When Not To Use It
 
-If you don't want to be notified about variables that are never modified after initial assignment, you can safely disable this rule.
+If you don't want to be notified about variables that are never reassigned after initial assignment, you can safely disable this rule.
 
 ## Related Rules
 

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview A rule to suggest using of const declaration for variables that are never modified after declared.
+ * @fileoverview A rule to suggest using of const declaration for variables that are never reassigned after declared.
  * @author Toru Nagashima
  * @copyright 2015 Toru Nagashima. All rights reserved.
  */
@@ -16,8 +16,8 @@ var SENTINEL_TYPES = /(?:Declaration|Statement)$/;
 var END_POSITION_TYPES = /^(?:Assignment|Update)/;
 
 /**
- * Gets a write reference from a given variable if the variable is modified only
- * once.
+ * Gets a write reference from a given variable if the variable is never
+ * reassigned.
  *
  * @param {escope.Variable} variable - A variable to get.
  * @returns {escope.Reference|null} A write reference or null.
@@ -31,7 +31,7 @@ function getWriteReferenceIfOnce(variable) {
 
         if (reference.isWrite()) {
             if (retv && !(retv.init && reference.init)) {
-                // This variable is modified two or more times.
+                // This variable is reassigned.
                 return null;
             }
             retv = reference;
@@ -147,7 +147,7 @@ function isInScope(writer) {
 module.exports = function(context) {
 
     /**
-     * Searches and reports variables that are never modified after declared.
+     * Searches and reports variables that are never reassigned after declared.
      * @param {Scope} scope - A scope of the search domain.
      * @returns {void}
      */
@@ -192,7 +192,7 @@ module.exports = function(context) {
             ) {
                 context.report({
                     node: identifier,
-                    message: "'{{name}}' is never modified, use 'const' instead.",
+                    message: "'{{name}}' is never reassigned, use 'const' instead.",
                     data: identifier
                 });
             }

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -68,101 +68,101 @@ ruleTester.run("prefer-const", rule, {
         {
             code: "let x = 1; foo(x);",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i in [1,2,3]) { foo(i); }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'i' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'i' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let x of [1,2,3]) { foo(x); }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let [x = -1, y] = [1,2]; y = 0;",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let {a: x = -1, b: y} = {a:1,b:2}; y = 0;",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x = 1; foo(x); })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { for (let i in [1,2,3]) { foo(i); } })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'i' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'i' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { for (let x of [1,2,3]) { foo(x); } })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let [x = -1, y] = [1,2]; y = 0; })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let {a: x = -1, b: y} = {a:1,b:2}; y = 0; })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let x = 0; { let x = 1; foo(x); } x = 0;",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i = 0; i < 10; ++i) { let x = 1; foo(x); }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "for (let i in [1,2,3]) { let x = 1; foo(x); }",
             parserOptions: { ecmaVersion: 6 },
             errors: [
-                { message: "'i' is never modified, use 'const' instead.", type: "Identifier"},
-                { message: "'x' is never modified, use 'const' instead.", type: "Identifier"}
+                { message: "'i' is never reassigned, use 'const' instead.", type: "Identifier"},
+                { message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}
             ]
         },
 
         {
             code: "let x; x = 0;",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x; x = 1; })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let x; { x = 0; foo(x); }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x; { x = 0; foo(x); } })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "let x; for (const a of [1,2,3]) { x = foo(); bar(x); }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         },
         {
             code: "(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "'x' is never modified, use 'const' instead.", type: "Identifier"}]
+            errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
         }
     ]
 });


### PR DESCRIPTION
As discussed in issue #5350; the prefer-const rule triggers if a let declaration is never reassigned. Update the error message, tests and documentation accordingly.
