### PR TITLE
Docs: Add missing `symbol` type into valid list

### DIFF
--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -1,6 +1,6 @@
 # Ensures that the results of typeof are compared against a valid string (valid-typeof)
 
-For a vast majority of use-cases, the only valid results of the `typeof` operator will be one of the following: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, and `"function"`. When the result of a `typeof` operation is compared against a string that is not one of these strings, it is usually a typo. This rule ensures that when the result of a `typeof` operation is compared against a string, that string is in the aforementioned set.
+For a vast majority of use-cases, the only valid results of the `typeof` operator will be one of the following: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, `"function"` and `"symbol"`. When the result of a `typeof` operation is compared against a string that is not one of these strings, it is usually a typo. This rule ensures that when the result of a `typeof` operation is compared against a string, that string is in the aforementioned set.
 
 ## Rule Details
 


### PR DESCRIPTION
* Update `valid-typeof.md`