### PR TITLE
Docs: Add Issue template (fixes #5313)

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!--
+This template is for bug reports. If you are reporting a bug, please continue on. If you are here for another reason, please see below:
+
+1. To propose a new rule: http://eslint.org/docs/developer-guide/contributing/new-rules
+2. To request a change: http://eslint.org/docs/developer-guide/contributing/changes
+3. If you have any questions, please stop by our chatroom: https://gitter.im/eslint/eslint
+
+Note that leaving sections blank will make it difficult for us to troubleshoot and we may have to close the issue.
+-->
+
+**What version of ESLint are you using?**
+
+**What configuration and parser (Espree, Babel-ESLint, etc.) are you using?**
+
+**What did you do? Please include the actual source code causing the issue.**
+
+**What did you expect to happen?**
+
+**What actually happened? Please include the actual, raw output from ESLint.**
+


### PR DESCRIPTION
First pass at an issue template in a new .github/ directory (see https://github.com/blog/2111-issue-and-pull-request-templates). Also moved CONTRIBUTING.md to new directory.

I like the idea of keeping these GitHub specific files out of the root directory of the project and in their own directory, but let me know what you think.