### PR TITLE
Update: Improve error message for rule-tester (fixes #5369)

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -350,6 +350,9 @@ RuleTester.prototype = {
          * @private
          */
         function testInvalidTemplate(ruleName, item) {
+            assert.ok(item.errors || item.errors === 0,
+                "Did not specify errors for an invalid test of " + ruleName);
+
             var result = runRuleForItem(ruleName, item);
             var messages = result.messages;
 

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -268,6 +268,19 @@ describe("RuleTester", function() {
         }, /Should have 2 errors but had 1/);
     });
 
+    it("should throw an error if invalid code does not have errors", function() {
+        assert.throws(function() {
+            ruleTester.run("no-eval", require("../../fixtures/testers/rule-tester/no-eval"), {
+                valid: [
+                    "Eval(foo)"
+                ],
+                invalid: [
+                    { code: "eval(foo)" }
+                ]
+            });
+        }, /Did not specify errors for an invalid test of no-eval/);
+    });
+
     it("should throw an error if invalid code has the wrong explicit number of errors", function() {
 
         assert.throws(function() {


### PR DESCRIPTION
Fixes #5369: Improves the error message when forgetting the `errors` field in the invalid tests when using `rule-tester`.

I added the name of the tested rule in the error message because neither the stack trace nor the rule-tester 'error logger' specifies where the error occurred.