### PR TITLE
Fix: `constructor-super` false positive after a loop (fixes #5394)

### DIFF
--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -67,6 +67,14 @@ module.exports = function(context) {
      * @returns {boolean} The flag which shows `super()` is called in all paths.
      */
     function isCalledInEveryPath(segment) {
+        // If specific segment is the looped segment of the current segment,
+        // skip the segment.
+        // If not skipped, this never becomes true after a loop.
+        if (segment.nextSegments.length === 1 &&
+            segment.nextSegments[0].isLoopedPrevSegment(segment)
+        ) {
+            return true;
+        }
         return segInfoMap[segment.id].calledInEveryPaths;
     }
 

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -51,7 +51,20 @@ ruleTester.run("constructor-super", rule, {
         { code: "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }", parserOptions: { ecmaVersion: 6 } },
 
         // https://github.com/eslint/eslint/issues/5319
-        { code: "class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }", parserOptions: { ecmaVersion: 6 } }
+        { code: "class Foo extends Object { constructor(method) { super(); this.method = method || function() {}; } }", parserOptions: { ecmaVersion: 6 } },
+
+        // https://github.com/eslint/eslint/issues/5394
+        {
+            code: [
+                "class A extends Object {",
+                "    constructor() {",
+                "        super();",
+                "        for (let i = 0; i < 0; i++);",
+                "    }",
+                "}"
+            ].join("\n"),
+            parserOptions: {ecmaVersion: 6}
+        }
     ],
     invalid: [
         // non derived classes.

--- a/tests/lib/rules/no-this-before-super.js
+++ b/tests/lib/rules/no-this-before-super.js
@@ -59,7 +59,21 @@ ruleTester.run("no-this-before-super", rule, {
         { code: "class A extends B { constructor(a) { for (const b of a) { foo(b); } super(); } }", parserOptions: { ecmaVersion: 6 } },
 
         // https://github.com/eslint/eslint/issues/5319
-        { code: "class A extends B { constructor(a) { super(); this.a = a && function(){} && this.foo; } }", parserOptions: { ecmaVersion: 6 } }
+        { code: "class A extends B { constructor(a) { super(); this.a = a && function(){} && this.foo; } }", parserOptions: { ecmaVersion: 6 } },
+
+        // https://github.com/eslint/eslint/issues/5394
+        {
+            code: [
+                "class A extends Object {",
+                "    constructor() {",
+                "        super();",
+                "        for (let i = 0; i < 0; i++);",
+                "        this;",
+                "    }",
+                "}"
+            ].join("\n"),
+            parserOptions: {ecmaVersion: 6}
+        }
     ],
     invalid: [
         // disallows all `this`/`super` if `super()` is missing.


### PR DESCRIPTION
Fixes #5394

When checking whether a call of `super()` exists in every previous code path, if there is a looped path, it went to wrong `false` value.
I made skipping looped previous paths.