### PR TITLE
Update: Exclude ES5 constructors from consistent-return (fixes #5379)

### DIFF
--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -21,6 +21,8 @@ Here, one branch of the function returns `true`, a Boolean value, while the othe
 
 This rule is aimed at ensuring all `return` statements either specify a value or don't specify a value.
 
+It excludes constructors which, when invoked with the `new` operator, return the instantiated object if another object is not explicitly returned.  This rule treats a function as a constructor if its name starts with an uppercase letter.
+
 The following patterns are considered problems:
 
 ```js
@@ -64,6 +66,14 @@ function doSomething(condition) {
     } else {
         return false;
     }
+}
+
+function Foo() {
+    if (!(this instanceof Foo)) {
+        return new Foo();
+    }
+
+    this.a = 0;
 }
 ```
 

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -187,6 +187,7 @@ module.exports = {
 
     isNullOrUndefined: isNullOrUndefined,
     isCallee: isCallee,
+    isES5Constructor: isES5Constructor,
     getUpperFunction: getUpperFunction,
     isArrayFromMethod: isArrayFromMethod,
 

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -37,7 +43,8 @@ module.exports = function(context) {
         // Skip if it expected no return value or unreachable.
         // When unreachable, all paths are returned or thrown.
         if (!funcInfo.hasReturnValue ||
-            funcInfo.codePath.currentSegments.every(isUnreachable)
+            funcInfo.codePath.currentSegments.every(isUnreachable) ||
+            astUtils.isES5Constructor(node)
         ) {
             return;
         }

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -29,6 +29,7 @@ ruleTester.run("consistent-return", rule, {
         "f(function() { if (true) return true; else return false; })",
         "function foo() { function bar() { return true; } return; }",
         "function foo() { function bar() { return; } return false; }",
+        "function Foo() { if (!(this instanceof Foo)) return new Foo(); }",
         { code: "var x = () => {  return {}; };", parserOptions: { ecmaVersion: 6 } },
         { code: "if (true) { return 1; } return 0;", parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } }
     ],


### PR DESCRIPTION
This PR makes the change requested in #5379 using the implementation outlined by @mysticatea in https://github.com/eslint/eslint/issues/5379#issuecomment-187997133 as I understood it.  If it missed the mark, please let me know and I'll update it.

It makes the exclusion of constructors unconditional, as it is for `no-invalid-this`.  If an option for conditional exclusion would be preferable, let me know what you'd prefer for name and behavior.

Note: This commit also exposes `isES5Constructor` from `ast-utils` so that it can be used by `consistent-return`.  If that is inappropriate or should be handled differently, let me know.

Thanks for considering,
Kevin