### PR TITLE
Fix: Prevent crash from swallowing console.log (fixes #5381)

### DIFF
--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -220,8 +220,15 @@ describe("configInitializer", function() {
                 origLog = console.log;
                 console.log = function() {}; // necessary to replace, because of progress bar
                 process.chdir(fixtureDir);
-                config = init.processAnswers(answers);
-                process.chdir(originalDir);
+                try {
+                    config = init.processAnswers(answers);
+                    process.chdir(originalDir);
+                } catch (err) {
+                    // if processAnswers crashes, we need to be sure to restore cwd and console.log
+                    console.log = origLog;
+                    process.chdir(originalDir);
+                    throw err;
+                }
             });
 
             beforeEach(function() {


### PR DESCRIPTION
To check this change, you can make the modification to `max-statements` as suggested by @btmills in https://github.com/eslint/eslint/issues/5381#issue-135846328, then run `npm test`.  You should see a multitude of errors, as well as the overall test status.