### PR TITLE
Fix: remove tests which have invalid syntax (fixes #5405)

### DIFF
--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -1149,9 +1149,10 @@ ruleTester.run("keyword-spacing", rule, {
         {code: "function* foo() { [yield] }", parserOptions: {ecmaVersion: 6}},
         {code: "function* foo() { [ yield ] }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
 
+        // This is invalid syntax: https://github.com/eslint/eslint/issues/5405
         // not conflict with `arrow-spacing`
-        {code: "function* foo() { (() =>yield foo) }", parserOptions: {ecmaVersion: 6}},
-        {code: "function* foo() { (() => yield foo) }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
+        // {code: "function* foo() { (() =>yield foo) }", parserOptions: {ecmaVersion: 6}},
+        // {code: "function* foo() { (() => yield foo) }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
 
         // not conflict with `block-spacing`
         {code: "function* foo() {yield}", parserOptions: {ecmaVersion: 6}},


### PR DESCRIPTION
Fixes #5405.

espree v3.1.0 came to raise a syntax error correctly at `yield` keywords inside of arrow functions.
Then `keyword-spacing` rule never conflicts with `arrow-spacing`, so I just removed those tests.