### PR TITLE
Fix: `getFormatter` throws an error when called as static (fixes #5378)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -404,7 +404,8 @@ CLIEngine.getFormatter = function(format) {
 
         // if there's a slash, then it's a file
         if (format.indexOf("/") > -1) {
-            formatterPath = path.resolve(this.options.cwd, format);
+            var cwd = this.options ? this.options.cwd : process.cwd();
+            formatterPath = path.resolve(cwd, format);
         } else {
             formatterPath = "./formatters/" + format;
         }

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1860,6 +1860,12 @@ describe("CLIEngine", function() {
             assert.isFunction(formatter);
         });
 
+        it("should return a function when called as a static function on CLIEngine and a custom formatter is requested", function() {
+            var formatter = CLIEngine.getFormatter(getFixturePath("formatters", "simple.js"));
+
+            assert.isFunction(formatter);
+        });
+
     });
 
     describe("getErrorResults()", function() {


### PR DESCRIPTION
Fallback to `process.cwd()` if `options.cwd` is unavailable, as is the case when `getFormatter` is called a static function.