### PR TITLE
Follow directory symlinks (fixes #5427)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -500,7 +500,8 @@ CLIEngine.prototype = {
         startTime = Date.now();
 
         globOptions = {
-            nodir: true
+            nodir: true,
+            follow: true
         };
 
         var cwd = options.cwd || process.cwd;

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -130,7 +130,8 @@ function listFilesToProcess(globPatterns, options) {
     });
     globOptions = {
         nodir: true,
-        ignore: ignoredPathsList
+        ignore: ignoredPathsList,
+        follow: true
     };
 
     debug("Creating list of files to process.");


### PR DESCRIPTION
While working on the gobble eslint plugin (https://github.com/julienw/gobble-eslint) I realized that eslint is not following symlinks. So here is a simple patch to enable just this.

I only needed to change the occurrence in cli-engine.js to make my use case work, but I thought it was a good idea to do it in glob-util.js as well. I don't know how to produce a good test for this, I'm open to ideas.