### PR TITLE
Docs: Replace ecmaFeatures with parserOptions in working-with-rules

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -70,7 +70,7 @@ In this code, `"Identifier:exit"` is called on the way up the AST. This capabili
 
 The `context` object contains additional functionality that is helpful for rules to do their jobs. As the name implies, the `context` object contains information that is relevant to the context of the rule. The `context` object has the following properties:
 
-* `ecmaFeatures` - the language feature flags.
+* `parserOptions` - the parser options configured for this run (more details [here](../user-guide/configuring#specifying-parser-options)).
 * `id` - the rule ID.
 * `options` - an array of rule options.
 * `settings` - the `settings` from configuration.


### PR DESCRIPTION
The section "The Context Object" in the "Working with Rules" document incorrectly lists `ecmaFeatures` as a key/value pair available on the context object. My understanding is that `parserOptions` is what is now exposed.

I have corrected the list entry and linked to the parse options section in the user guide "Configuration" document. Please let me know if I've goofed.