### PR TITLE
Docs: Distinguish examples in rules under Possible Errors part 1

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -15,16 +15,18 @@ On the other hand, trailing commas simplify adding and removing items to objects
 
 This rule enforces consistent use of trailing commas in object and array literals.
 
+## Options
+
 This rule takes one argument, which can be one of the following options:
 
+- `"never"` - warn whenever a trailing comma is detected. The default value of this option is `"never"`.
 - `"always"` - warn whenever a missing comma is detected.
 - `"always-multiline"` - warn if there is a missing trailing comma on arrays or objects that span multiple lines, and warns if there is a trailing comma present on single line arrays or objects.
 - `"only-multiline"` - warn whenever a trailing comma is detected on single line nodes.
-- `"never"` - warn whenever a trailing comma is detected.
 
-The default value of this option is `"never"`.
+### never
 
-The following patterns are considered problems when configured `"never"`:
+Examples of **incorrect** code for the default `"never"` option:
 
 ```js
 /*eslint comma-dangle: [2, "never"]*/
@@ -42,7 +44,7 @@ foo({
 });
 ```
 
-The following patterns are not considered problems when configured `"never"`:
+Examples of **correct** code for the default `"never"` option:
 
 ```js
 /*eslint comma-dangle: [2, "never"]*/
@@ -60,7 +62,9 @@ foo({
 });
 ```
 
-The following patterns are considered problems when configured `"always"`:
+### always
+
+Examples of **incorrect** code for the `"always"` option:
 
 ```js
 /*eslint comma-dangle: [2, "always"]*/
@@ -78,7 +82,7 @@ foo({
 });
 ```
 
-The following patterns are not considered problems when configured `"always"`:
+Examples of **correct** code for the `"always"` option:
 
 ```js
 /*eslint comma-dangle: [2, "always"]*/
@@ -96,10 +100,12 @@ foo({
 });
 ```
 
-The following patterns are considered problems when configured `"always-multiline"`:
+### always-multiline
+
+Examples of **incorrect** code for the `"always-multiline"` option:
 
 ```js
-/*eslint comma-dangle: [1, "always-multiline"]*/
+/*eslint comma-dangle: [2, "always-multiline"]*/
 
 var foo = {
     bar: "baz",
@@ -124,7 +130,7 @@ foo({
 });
 ```
 
-The following patterns are not considered problems when configured `"always-multiline"`:
+Examples of **correct** code for the `"always-multiline"` option:
 
 ```js
 /*eslint comma-dangle: [2, "always-multiline"]*/
@@ -151,10 +157,12 @@ foo({
 });
 ```
 
-The following patterns are considered problems when configured `"only-multiline"`:
+### only-multiline
+
+Examples of **incorrect** code for the `"only-multiline"` option:
 
 ```js
-/*eslint comma-dangle: [1, "only-multiline"]*/
+/*eslint comma-dangle: [2, "only-multiline"]*/
 
 var foo = { bar: "baz", qux: "quux", };
 
@@ -165,7 +173,7 @@ var arr = [1,
 
 ```
 
-The following patterns are not considered problems when configured `"only-multiline"`:
+Examples of **correct** code for the `"only-multiline"` option:
 
 ```js
 /*eslint comma-dangle: [2, "only-multiline"]*/

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -22,11 +22,11 @@ The rule takes one option, a string, which must contain one of the following val
 * `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
 * `always`: Disallow all assignments.
 
-### "except-parens"
+### except-parens
 
-This is the default option. It disallows assignments unless they are enclosed in parentheses. This option makes it possible to use common patterns, such as reassigning a value in the condition of a `while` or `do...while` loop, without causing a warning.
+The default `"except-parens"` option disallows assignment expressions unless they are enclosed in parentheses. It allows common patterns, such as reassigning a value in the condition of a `while` or `do...while` loop.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `"except-parens"` option:
 
 ```js
 /*eslint no-cond-assign: 2*/
@@ -46,7 +46,7 @@ function setHeight(someNode) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `"except-parens"` option:
 
 ```js
 /*eslint no-cond-assign: 2*/
@@ -74,11 +74,11 @@ function setHeight(someNode) {
 }
 ```
 
-### "always"
+### always
 
-This option disallows all assignments in conditional statement tests. All assignments are treated as problems.
+The `"always"` option disallows assignment expressions in the test of a conditional statement.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"always"` option:
 
 ```js
 /*eslint no-cond-assign: [2, "always"]*/
@@ -114,7 +114,7 @@ function setHeight(someNode) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the `"always"` option:
 
 ```js
 /*eslint no-cond-assign: [2, "always"]*/
@@ -129,3 +129,7 @@ if (x === 0) {
 ## Further Reading
 
 * [JSLint -- Unexpected assignment expression](http://jslinterrors.com/unexpected-assignment-expression/)
+
+## Related Rules
+
+* [no-extra-parens](no-extra-parens.md)

--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -12,7 +12,7 @@ console.error("That shouldn't have happened.");
 
 This rule is aimed at eliminating unwanted `console` references from your JavaScript. As such, it warns whenever it sees `console` used as an identifier in code.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-console: 2*/
@@ -21,7 +21,7 @@ console.log("Hello world!");
 console.error("Something bad happened.");
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-console: 2*/

--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -12,10 +12,12 @@ This pattern is most likely an error and should be avoided.
 
 ## Rule Details
 
-The rule is aimed at preventing the use of a constant expression in a condition.
-As such, it warns whenever it sees a constant expression inside a condition expression.
+The rule is aimed at preventing a constant expression in the test of:
 
-The following patterns are considered problems:
+* `if`, `for`, `while`, or `do...while` statement
+* `?:` ternary expression
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-constant-condition: 2*/
@@ -55,7 +57,7 @@ do{
 } while (x = -1)
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-constant-condition: 2*/

--- a/docs/rules/no-control-regex.md
+++ b/docs/rules/no-control-regex.md
@@ -7,7 +7,7 @@ Control characters are special, invisible characters in the ASCII range 0-31. Th
 This rule is aimed at ensuring all regular expressions don't use control characters.
 
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-control-regex: 2*/
@@ -16,7 +16,7 @@ var pattern1 = /\\x1f/;
 var pattern2 = new RegExp("\x1f");
 ```
 
-The following patterns do not cause a warning:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-control-regex: 2*/
@@ -33,4 +33,3 @@ If you need to use control character pattern matching, then you should turn this
 
 * [no-div-regex](no-div-regex.md)
 * [no-regex-spaces](no-regex-spaces.md)
-

--- a/docs/rules/no-dupe-args.md
+++ b/docs/rules/no-dupe-args.md
@@ -1,20 +1,29 @@
 # No duplicate arguments (no-dupe-args)
 
 In strict mode you will receive a `SyntaxError` if a function takes multiple arguments with the same name.
-Outside of strict mode duplicate arguments will mask the value of the first argument. This rule checks for duplicate
-parameter names to help prevent that mistake.
+Outside of strict mode duplicate arguments will mask the value of the first argument.
 
 ## Rule Details
 
-This rule prevents having duplicate param names.
+This rule prevents duplicate parameter names in a function.
 
-For example the following code will cause the rule to warn:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-dupe-args: 2*/
 
 function foo(a, b, a) {
     console.log("which a is it?", a);
+}
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-dupe-args: 2*/
+
+function foo(a, b, c) {
+    console.log(a, b, c);
 }
 ```
 

--- a/docs/rules/no-dupe-keys.md
+++ b/docs/rules/no-dupe-keys.md
@@ -13,7 +13,7 @@ var foo = {
 
 This rule is aimed at preventing possible errors and unexpected behavior that might arise from using duplicate keys in object literals. As such, it warns whenever it finds a duplicate key.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-dupe-keys: 2*/
@@ -34,7 +34,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-dupe-keys: 2*/

--- a/docs/rules/no-duplicate-case.md
+++ b/docs/rules/no-duplicate-case.md
@@ -1,30 +1,12 @@
 # Rule to disallow a duplicate case label (no-duplicate-case)
 
-A switch statements with duplicate case labels is normally an indication of a programmer error.
-
-In the following example the 3rd case label uses again the literal 1 that has already been used in the first case label.
-Most likely the case block was copied from above and it was forgotten to change the literal.
-
-```js
-var a = 1;
-
-switch (a) {
-    case 1:
-        break;
-    case 2:
-        break;
-    case 1:         // duplicate literal 1
-        break;
-    default:
-        break;
-}
-```
+If a switch statement has duplicate case labels, it is likely that a programmer copied a case but forgot to change the label.
 
 ## Rule Details
 
-This inspection reports any duplicated case labels on JavaScript switch statements.
+This rule is aimed at eliminating duplicate case labels in switch statements
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-duplicate-case: 2*/
@@ -35,48 +17,73 @@ var a = 1,
 switch (a) {
     case 1:
         break;
-    case 1:
-        break;
     case 2:
+        break;
+    case 1:         // duplicate case label
         break;
     default:
         break;
 }
 
 switch (a) {
-    case "1":
+    case one:
         break;
+    case 2:
+        break;
+    case one:         // duplicate case label
+        break;
+    default:
+        break;
+}
+
+switch (a) {
     case "1":
         break;
     case "2":
         break;
-    default:
-        break;
-}
-
-switch (a) {
-    case one:
-        break;
-    case one:
-        break;
-    case 2:
+    case "1":         // duplicate case label
         break;
     default:
         break;
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-duplicate-case: 2*/
 
-var a = 1;
+var a = 1,
+    one = 1;
 
 switch (a) {
     case 1:
         break;
     case 2:
+        break;
+    case 3:
+        break;
+    default:
+        break;
+}
+
+switch (a) {
+    case one:
+        break;
+    case 2:
+        break;
+    case 3:
+        break;
+    default:
+        break;
+}
+
+switch (a) {
+    case "1":
+        break;
+    case "2":
+        break;
+    case "3":
         break;
     default:
         break;

--- a/docs/rules/no-empty-character-class.md
+++ b/docs/rules/no-empty-character-class.md
@@ -10,7 +10,7 @@ var foo = /^abc[]/;
 
 This rule is aimed at highlighting possible typos and unexpected behavior in regular expressions which may arise from the use of empty character classes.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-empty-character-class: 2*/
@@ -22,7 +22,7 @@ var foo = /^abc[]/;
 bar.match(/^abc[]/);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-empty-character-class: 2*/

--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -1,20 +1,12 @@
 # Disallow Empty Block Statements (no-empty)
 
-Empty block statements usually occur due to refactoring that wasn't completed, such as:
-
-```js
-if (foo) {
-}
-```
-
-Empty block statements such as this are usually an indicator of an error, or at the very least, an indicator that some refactoring is likely needed.
+Empty block statements, while not technically errors, usually occur due to refactoring that wasn't completed. They can cause confusion when reading code.
 
 ## Rule Details
 
-This rule is aimed at eliminating empty block statements. While not technically an error, empty block statements can be a source of confusion when reading code.
-A block will not be considered a warning if it contains a comment line.
+This rule is aimed at eliminating empty block statements. A block will not be considered a warning if it contains a comment line.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-empty: 2*/
@@ -37,7 +29,7 @@ try {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-empty: 2*/
@@ -47,19 +39,19 @@ if (foo) {
 }
 
 while (foo) {
-    // test
+    /* empty */
 }
 
 try {
     doSomething();
 } catch (ex) {
-    // Do nothing
+    // continue regardless of error
 }
 
 try {
     doSomething();
 } finally {
-    // Do nothing
+    /* continue regardless of error */
 }
 ```
 

--- a/docs/rules/no-ex-assign.md
+++ b/docs/rules/no-ex-assign.md
@@ -17,7 +17,7 @@ This makes it impossible to track the error from that point on.
 
 This rule's purpose is to enforce convention. Assigning a value to the exception parameter wipes out all the valuable data contained therein and thus should be avoided. Since there is no `arguments` object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-ex-assign: 2*/
@@ -29,7 +29,7 @@ try {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-ex-assign: 2*/

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -20,7 +20,7 @@ if (foo) {
 
 This rule aims to eliminate the use of Boolean casts in an already Boolean context.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-extra-boolean-cast: 2*/
@@ -54,7 +54,7 @@ for (; !!foo; ) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-extra-boolean-cast: 2*/

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -16,11 +16,11 @@ This rule takes 1 or 2 arguments. The first one is a string which must be one of
 * `"all"` (default): it will report unnecessary parentheses around any expression.
 * `"functions"`: only function expressions will be checked for unnecessary parentheses.
 
-The second one is an object for more fine-grained configuration when the first option is "all".
+The second one is an object for more fine-grained configuration when the first option is `"all"`.
 
-### "all"
+### all
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `"all"` option:
 
 ```js
 /*eslint no-extra-parens: 2*/
@@ -34,7 +34,7 @@ typeof (a);
 (function(){} ? a() : b());
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `"all"` option:
 
 ```js
 /*eslint no-extra-parens: 2*/
@@ -48,14 +48,14 @@ The following patterns are not considered problems:
 (/^a$/).test(x);
 ```
 
-#### Fine-grained control
+### conditionalAssign
 
-When setting the first option as "all", an additional option can be added to allow extra parens for assignment in conditional statements.
+When setting the first option as `"all"`, an additional option can be added to allow extra parens for assignment in conditional statements.
 
-The following patterns are not considered problems:
+Examples of **correct** code for the `"all"` and `{ "conditionalAssign": true }` options:
 
 ```js
-/*eslint no-extra-parens: [2, "all", {"conditionalAssign": false}]*/
+/*eslint no-extra-parens: [2, "all", { "conditionalAssign": false }]*/
 
 while ((foo = bar())) {}
 
@@ -66,9 +66,9 @@ do; while ((foo = bar()))
 for (;(a = b););
 ```
 
-### "functions"
+### functions
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"functions"` option:
 
 ```js
 /*eslint no-extra-parens: [2, "functions"]*/
@@ -78,7 +78,7 @@ The following patterns are considered problems:
 var y = (function () {return 1;});
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the `"functions"` option:
 
 ```js
 /*eslint no-extra-parens: [2, "functions"]*/
@@ -102,3 +102,7 @@ typeof (a);
 ## Further Reading
 
 * [MDN: Operator Precedence](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Operator_Precedence)
+
+## Related Rules
+
+* [no-cond-assign](no-cond-assign.md)


### PR DESCRIPTION
First of two pull requests for rules under **Possible Errors**.

Here are the changes beyond example sentences:

* comma-dangle: add **Options**; move default option first in list; replace status 1 with 2
* no-cond-assign: simplify paragraphs about options; **Related Rules** no-extra-parens
* no-constant-condition rewrite rule details
* no-dupe-args: rewrite rule details; add example of correct code
* no-duplicate-case: rewrite introduction and rule details; move intro example to incorrect code and make correct code parallel; *sorry this rule wins hash-of-changes prize for this batch*
* no-empty: rewrite sentence about comment; include both line and block comments in correct code
* no-extra-parens: replace h4 Fine-grained control with h3 conditionalAssign; **Related Rules** no-cond-assign
