### PR TITLE
Fix: `no-undef` false positive at new.target (fixes #5420)

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "debug": "^2.1.1",
     "doctrine": "^1.2.0",
     "es6-map": "^0.1.3",
-    "escope": "^3.4.0",
+    "escope": "^3.5.0",
     "espree": "^3.1.1",
     "estraverse": "^4.1.1",
     "estraverse-fb": "^1.3.1",

--- a/tests/lib/rules/no-undef.js
+++ b/tests/lib/rules/no-undef.js
@@ -62,6 +62,9 @@ ruleTester.run("no-undef", rule, {
         { code: "/*global b:false*/ var b = 1;" },
         { code: "Array = 1;" },
 
+        // new.target: https://github.com/eslint/eslint/issues/5420
+        { code: "class A { constructor() { new.target; } }", parserOptions: { ecmaVersion: 6 } },
+
         // Experimental,
         {
             code: "var {bacon, ...others} = stuff; foo(others)",


### PR DESCRIPTION
fixes #5420.

I upgraded escope to 3.5.0 and added a test.