### PR TITLE
Docs: Distinguish examples in rules under Possible Errors part 2

### DIFF
--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -8,7 +8,7 @@ JavaScript will more or less let you put semicolons after any statement without 
 
 This rule is aimed at eliminating extra unnecessary semicolons. While not technically an error, extra semicolons can be a source of confusion when reading code.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-extra-semi: 2*/
@@ -21,7 +21,7 @@ function foo() {
 
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-extra-semi: 2*/

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -11,7 +11,7 @@ foo = bar;
 
 This rule is aimed at flagging probable mistakes and issues in the form of overwriting a function that was written as a FunctionDeclaration. As such it will warn when this issue is encountered.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-func-assign: 2*/
@@ -24,7 +24,7 @@ function foo() {
 }
 ```
 
-Unlike the same rule in JSHint, the following pattern is also considered a warning:
+Examples of **incorrect** code for this rule, unlike the corresponding rule in JSHint:
 
 ```js
 /*eslint no-func-assign: 2*/
@@ -33,7 +33,7 @@ foo = bar;
 function foo() {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-func-assign: 2*/

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -68,7 +68,9 @@ You can set the option in configuration like this:
 "no-inner-declarations": [2, "both"]
 ```
 
-The following patterns are considered problems:
+### functions
+
+Examples of **incorrect** code for the default `"functions"` option:
 
 ```js
 /*eslint no-inner-declarations: 2*/
@@ -84,27 +86,10 @@ function doSomethingElse() {
 }
 ```
 
-With `"both"` option to check variable declarations, the following are considered problems:
-
-```js
-/*eslint no-inner-declarations: [2, "both"]*/
-
-if (test) {
-    var foo = 42;
-}
-
-function doAnotherThing() {
-    if (test) {
-        var bar = 81;
-    }
-}
-```
-
-The following patterns are considered valid:
+Examples of **correct** code for the default `"functions"` option:
 
 ```js
 /*eslint no-inner-declarations: 2*/
-/*eslint-env es6*/
 
 function doSomething() { }
 
@@ -120,6 +105,31 @@ var fn;
 if (test) {
     fn = function fnExpression() { };
 }
+```
+
+### both
+
+Examples of **incorrect** code for the `"both"` option:
+
+```js
+/*eslint no-inner-declarations: [2, "both"]*/
+
+if (test) {
+    var foo = 42;
+}
+
+function doAnotherThing() {
+    if (test) {
+        var bar = 81;
+    }
+}
+```
+
+Examples of **correct** code for the `"both"` option:
+
+```js
+/*eslint no-inner-declarations: 2*/
+/*eslint-env es6*/
 
 var bar = 42;
 

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -4,7 +4,7 @@ This rule validates string arguments passed to the `RegExp` constructor.
 
 ## Rule Details
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-invalid-regexp: 2*/
@@ -16,7 +16,7 @@ RegExp('.', 'z')
 new RegExp('\\')
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-invalid-regexp: 2*/

--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -43,7 +43,7 @@ With this rule enabled the following characters will cause warnings outside of s
     \u205f - Medium Mathematical Space
     \u3000 - Ideographic Space
 
-The following examples are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-irregular-whitespace: 2*/
@@ -73,7 +73,7 @@ function thing() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-irregular-whitespace: 2*/
@@ -106,7 +106,7 @@ The `no-irregular-whitespace` rule has no required option and has one optional o
 For example, to specify that you want to skip checking for irregular whitespace within comments, use the following configuration:
 
 ```json
-"no-irregular-whitespace": [2, {"skipComments": true}]
+"no-irregular-whitespace": [2, { "skipComments": true }]
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -26,7 +26,7 @@ if(('' + !a) in b) {
 }
 ```
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-negated-in-lhs: 2*/
@@ -36,7 +36,7 @@ if(!a in b) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-negated-in-lhs: 2*/

--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -10,7 +10,7 @@ The [ECMAScript 5 specification](http://es5.github.io/#x15.8) makes it clear tha
 
 This rule is aimed at preventing the accidental calling of global objects as functions.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-obj-calls: 2*/
@@ -19,7 +19,7 @@ var x = Math();
 var y = JSON();
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-obj-calls: 2*/

--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -18,7 +18,7 @@ Now it is very clear that three spaces are expected to be matched.
 
 This rule aims to eliminate errors due to multiple spaces inside of a regular expression. As such, it warns whenever more than one space in a row is found inside of a regular expression literal.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-regex-spaces: 2*/
@@ -26,7 +26,7 @@ The following patterns are considered problems:
 var re = /foo   bar/;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-regex-spaces: 2*/

--- a/docs/rules/no-sparse-arrays.md
+++ b/docs/rules/no-sparse-arrays.md
@@ -20,7 +20,7 @@ The confusion around sparse arrays defined in this manner is enough that it's re
 
 This rule aims to eliminate sparse arrays that are defined by extra commas.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-sparse-arrays: 2*/
@@ -29,7 +29,7 @@ var items = [,];
 var colors = [ "red",, "blue" ];
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-sparse-arrays: 2*/

--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -4,10 +4,10 @@ Semicolons are optional in JavaScript, via a process called automatic semicolon 
 
 The rules for ASI are relatively straightforward: In short, as once described by Isaac Schlueter, a `\n` character always ends a statement (just like a semicolon) unless one of the following is true:
 
-1. The statement has an unclosed paren, array literal, or object literal or ends in some other way that is not a valid way to end a statement. (For instance, ending with `.` or `,`.)
-2. The line is `--` or `++` (in which case it will decrement/increment the next token.)
-3. It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
-4. The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other binary operator that can only be found between two tokens in a single expression.
+* The statement has an unclosed paren, array literal, or object literal or ends in some other way that is not a valid way to end a statement. (For instance, ending with `.` or `,`.)
+* The line is `--` or `++` (in which case it will decrement/increment the next token.)
+* It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
+* The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other binary operator that can only be found between two tokens in a single expression.
 
 This particular rule aims to spot scenarios where a newline looks like it is ending a statement, but is not.
 
@@ -15,7 +15,7 @@ This particular rule aims to spot scenarios where a newline looks like it is end
 
 This rule is aimed at ensuring that two unrelated consecutive lines are not accidentally interpreted as a single expression.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-unexpected-multiline: 2*/
@@ -34,7 +34,7 @@ x
 `hello`
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-unexpected-multiline: 2*/

--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -14,7 +14,7 @@ function fn() {
 
 This rule is aimed at detecting unreachable code. It produces an error when a statements exist after a `return`, `throw`, `break`, or `continue` statement.
 
-The following are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-unreachable: 2*/
@@ -50,7 +50,7 @@ for (;;) {}
 console.log("done");
 ```
 
-The following patterns are not considered problems (due to JavaScript function and variable hoisting):
+Examples of **correct** code for this rule, because of JavaScript function and variable hoisting:
 
 ```js
 /*eslint no-unreachable: 2*/

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -6,7 +6,7 @@ In JavaScript, `NaN` is a special value of the `Number` type. It's used to repre
 
 This rule is aimed at eliminating potential errors as the result of comparing against the special value `NaN`.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint use-isnan: 2*/
@@ -20,7 +20,7 @@ if (foo != NaN) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint use-isnan: 2*/

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -18,16 +18,16 @@ The JSDoc comments have a syntax all their own, and it is easy to mistakenly mis
 
 ## Rule Details
 
-This rule aims to prevent invalid and incomplete JSDoc comments. In doing so, it will warn when:
+This rule aims to prevent invalid and incomplete JSDoc comments. It will warn when any of the following is true:
 
-1. There is a JSDoc syntax error
-1. A `@param` or `@returns` is used without a type specified
-1. A `@param` or `@returns` is used without a description
-1. A comment for a function is missing `@returns`
-1. A parameter has no associated `@param` in the JSDoc comment
-1. `@param`s are out of order with named arguments
+* There is a JSDoc syntax error
+* A `@param` or `@returns` is used without a type specified
+* A `@param` or `@returns` is used without a description
+* A comment for a function is missing `@returns`
+* A parameter has no associated `@param` in the JSDoc comment
+* `@param`s are out of order with named arguments
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint valid-jsdoc: 2*/
@@ -89,7 +89,7 @@ function foo(a) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint valid-jsdoc: 2*/
@@ -135,7 +135,7 @@ class Foo {
 
 ## Options
 
-### `prefer`
+### prefer
 
 JSDoc offers a lot of tags with overlapping meaning. For example, both `@return` and `@returns` are acceptable for specifying the return value of a function. However, you may want to enforce a certain tag be used instead of others. You can specify your preferences regarding tag substitution by providing a mapping called `prefer` in the rule configuration. For example, to specify that `@returns` should be used instead of `@return`, you can use the following configuration:
 
@@ -149,7 +149,7 @@ JSDoc offers a lot of tags with overlapping meaning. For example, both `@return`
 
 With this configuration, ESLint will warn when it finds `@return` and recommend to replace it with `@returns`.
 
-### `requireReturn`
+### requireReturn
 
 By default ESLint requires you to document every function with a `@return` tag regardless of whether there is anything returned by the function. If instead you want to enforce that only functions with a `return` statement are documented with a `@return` tag, set the `requireReturn` option to `false`.  When `requireReturn` is `false`, every function documented with a `@return` tag must have a `return` statement, and every function with a `return` statement must have a `@return` tag.
 
@@ -159,7 +159,7 @@ By default ESLint requires you to document every function with a `@return` tag r
 }]
 ```
 
-### `requireParamDescription`
+### requireParamDescription
 
 By default ESLint requires you to specify a description for each `@param`. You can choose not to require descriptions for parameters by setting `requireParamDescription` to `false`.
 
@@ -169,7 +169,7 @@ By default ESLint requires you to specify a description for each `@param`. You c
 }]
 ```
 
-### `requireReturnDescription`
+### requireReturnDescription
 
 By default ESLint requires you to specify a description for each `@return`. You can choose not to require descriptions for `@return` by setting `requireReturnDescription` to `false`.
 
@@ -179,7 +179,7 @@ By default ESLint requires you to specify a description for each `@return`. You 
 }]
 ```
 
-### `matchDescription`
+### matchDescription
 
 Specify a regular expression to validate jsdoc comment block description against.
 
@@ -189,7 +189,7 @@ Specify a regular expression to validate jsdoc comment block description against
 }]
 ```
 
-### `requireReturnType`
+### requireReturnType
 
 By default ESLint requires you to specify `type` for `@return` tag for every documented function.
 
@@ -199,7 +199,7 @@ By default ESLint requires you to specify `type` for `@return` tag for every doc
 }]
 ```
 
-### `preferType`
+### preferType
 
 It will validate all the types from jsdoc with the options setup by the user. Inside the options, key should be what the type you want to check and the value of it should be what the expected type should be. Note that we don't check for spelling mistakes with this option.
 In the example below, it will expect the "object" to start with an uppercase and all the "string" type to start with a lowercase.
@@ -214,9 +214,11 @@ In the example below, it will expect the "object" to start with an uppercase and
 }]
 ```
 
-The following patterns are considered problems with option `preferType` setup as above:
+Examples of **incorrect** code for a sample of `"preferType"` options:
 
 ```js
+/*eslint valid-jsdoc: [2, { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
+
 /**
  * Adds two numbers together.
  * @param {String} param1 The first parameter.
@@ -246,9 +248,11 @@ function foo(param1) {
 }
 ```
 
-The following patterns are not considered problems with option `preferType` setup as above:
+Examples of **correct** code for a sample of `"preferType"` options:
 
 ```js
+/*eslint valid-jsdoc: [2, { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
+
 /**
  * Adds two numbers together.
  * @param {string} param1 The first parameter.

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -6,7 +6,7 @@ For a vast majority of use-cases, the only valid results of the `typeof` operato
 
 This rule aims to prevent errors from likely typos by ensuring that when the result of a `typeof` operation is compared against a string, that the string is a valid value.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint valid-typeof: 2*/
@@ -17,7 +17,7 @@ typeof bar != "nunber"
 typeof bar !== "fucntion"
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint valid-typeof: 2*/


### PR DESCRIPTION
Second of two pull requests for rules under **Possible Errors**.

What do you think about the wording of these example sentences?
* valid-jsdoc: Examples of incorrect/correct code for a sample of `"preferType"` options
* no-func-assign: Examples of incorrect code for this rule, unlike the corresponding rule in JSHint
* no-unreachable: Examples of correct code for this rule, because of JavaScript function and variable hoisting:


Here are the changes beyond example sentences:

* no-inner-declarations: split general correct code to be specific for functions and both
* no-unexpected-multiline: changed ordered to unordered list in Rule Details
* valid-jsdoc: when any of the following is true: changed ordered to unordered list in Rule Details;
  added eslint comment in code examples for preferType
