### PR TITLE
Fix: `no-unmodified-loop-condition` false positive (fixes #5445)

### DIFF
--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -30,8 +30,8 @@ var DYNAMIC_PATTERN = /^(?:Call|Member|New|TaggedTemplate|Yield)Expression$/;
 /**
  * @typedef {object} LoopConditionInfo
  * @property {escope.Reference} reference - The reference.
- * @property {ASTNode[]} groups - BinaryExpression or ConditionalExpression
- *      nodes that the reference is belonging to.
+ * @property {ASTNode} group - BinaryExpression or ConditionalExpression nodes
+ *      that the reference is belonging to.
  * @property {function} isInLoop - The predicate which checks a given reference
  *      is in this loop.
  * @property {boolean} modified - The flag that the reference is modified in
@@ -67,13 +67,13 @@ function isUnmodified(condition) {
 
 /**
  * Checks whether or not a given loop condition info does not have the modified
- * flag and does not have any groups that this condition is belonging to.
+ * flag and does not have the group this condition belongs to.
  *
  * @param {LoopConditionInfo} condition - A loop condition info to check.
  * @returns {boolean} `true` if the loop condition info is "unmodified".
  */
 function isUnmodifiedAndNotBelongToGroup(condition) {
-    return !condition.modified && condition.groups.length === 0;
+    return !(condition.modified || condition.group);
 }
 
 /**
@@ -144,7 +144,7 @@ function toLoopCondition(reference) {
         return null;
     }
 
-    var groups = [];
+    var group = null;
     var child = reference.identifier;
     var node = child.parent;
     while (node) {
@@ -153,7 +153,7 @@ function toLoopCondition(reference) {
                 // This reference is inside of a loop condition.
                 return {
                     reference: reference,
-                    groups: groups,
+                    group: group,
                     isInLoop: isInLoop[node.type].bind(null, node),
                     modified: false
                 };
@@ -163,13 +163,13 @@ function toLoopCondition(reference) {
         }
 
         // If it's inside of a group, OK if either operand is modified.
-        // So stores the group that the reference is belonging to.
+        // So stores the group this reference belongs to.
         if (GROUP_PATTERN.test(node.type)) {
             if (hasDynamicExpressions(node)) {
                 // This expression is dynamic, so don't check.
                 break;
             } else {
-                groups.push(node);
+                group = node;
             }
         }
 
@@ -251,7 +251,7 @@ module.exports = function(context) {
     }
 
     /**
-     * Registers given conditions to groups that the condition is belonging to.
+     * Registers given conditions to the group the condition belongs to.
      *
      * @param {LoopConditionInfo[]} conditions - A loop condition info to
      *      register.
@@ -261,12 +261,11 @@ module.exports = function(context) {
         for (var i = 0; i < conditions.length; ++i) {
             var condition = conditions[i];
 
-            for (var j = 0; j < condition.groups.length; ++j) {
-                var be = condition.groups[j];
-                var group = groupMap.get(be);
+            if (condition.group) {
+                var group = groupMap.get(condition.group);
                 if (!group) {
                     group = [];
-                    groupMap.set(be, group);
+                    groupMap.set(condition.group, group);
                 }
                 group.push(condition);
             }

--- a/tests/lib/rules/no-unmodified-loop-condition.js
+++ b/tests/lib/rules/no-unmodified-loop-condition.js
@@ -41,7 +41,8 @@ ruleTester.run("no-unmodified-loop-condition", rule, {
         "for (var foo = 0; foo; ++foo) { }",
         "for (var foo = 0; foo;) { ++foo }",
         "var foo = 0, bar = 0; for (bar; foo;) { ++foo }",
-        "var foo; if (foo) { }"
+        "var foo; if (foo) { }",
+        "var a = [1, 2, 3]; var len = a.length; for (var i = 0; i < len - 1; i++) {}"
     ],
     invalid: [
         {code: "var foo = 0; while (foo) { } foo = 1;", errors: ["'foo' is not modified in this loop."]},


### PR DESCRIPTION
Fixes #5445.

Previously, this rule has been checking whether every BinaryExpression was modified or not. But this way has been reporting wrong warnings in chaining binary expression (e.g. `foo + bar < baz`).
Now, this rule came to check whether the chain of BinaryExpressions was modified or not.