### PR TITLE
Build: Add additional linebreak to docs (fixes #5464)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -576,9 +576,9 @@ target.gensite = function(prereleaseVersion) {
 
             // 5. Prepend page title and layout variables at the top of rules
             if (path.dirname(filename).indexOf("rules") >= 0) {
-                text = "---\ntitle: " + (ruleName === "README" ? "List of available rules" : "Rule " + ruleName) + "\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n" + text;
+                text = "---\ntitle: " + (ruleName === "README" ? "List of available rules" : "Rule " + ruleName) + "\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n" + text;
             } else {
-                text = "---\ntitle: Documentation\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n" + text;
+                text = "---\ntitle: Documentation\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n" + text;
             }
 
             // 6. Remove .md extension for links and change README to empty string

--- a/docs/rules/.gitattributes
+++ b/docs/rules/.gitattributes
@@ -1,2 +1,0 @@
-# Avoid line-ending conversion for linebreak-style, or else example linting breaks
-linebreak-style.md -text


### PR DESCRIPTION
Also removed `.gitattributes' file, since it was preventing me from running `gensite` and we are not linting examples anymore. @IanVS correct me if I'm wrong, but it's no longer needed, right?