### PR TITLE
Docs: Distinguish examples in rules under Best Practices part 1

### DIFF
--- a/docs/rules/accessor-pairs.md
+++ b/docs/rules/accessor-pairs.md
@@ -34,18 +34,12 @@ By activating the option `getWithoutSet` it enforces the presence of a setter fo
 
 ## Options
 
-`getWithoutSet` set to `true` will warn for getters without setters (Default `false`).
-`setWithoutGet` set to `true` will warn for setters without getters (Default `true`).
+* `setWithoutGet` set to `true` will warn for setters without getters (Default `true`).
+* `getWithoutSet` set to `true` will warn for getters without setters (Default `false`).
 
-By default `setWithoutGet` option is always set to `true`.
+### setWithoutGet
 
-```json
-{
-    "accessor-pairs": [2, {"getWithoutSet": true}]
-}
-```
-
-The following patterns are considered problems by default:
+Examples of **incorrect** code for the default `{ "setWithoutGet": true }` option:
 
 ```js
 /*eslint accessor-pairs: 2*/
@@ -64,7 +58,7 @@ Object.defineProperty(o, 'c', {
 });
 ```
 
-The following patterns are not considered problems by default:
+Examples of **correct** code for the default `{ "setWithoutGet": true }` option:
 
 ```js
 /*eslint accessor-pairs: 2*/
@@ -90,12 +84,12 @@ Object.defineProperty(o, 'c', {
 
 ```
 
-### `getWithoutSet`
+### getWithoutSet
 
-The following patterns are considered problems with option `getWithoutSet` set:
+Examples of **incorrect** code for the `{ "getWithoutSet": true }` option:
 
 ```js
-/*eslint accessor-pairs: [2, { getWithoutSet: true }]*/
+/*eslint accessor-pairs: [2, { "getWithoutSet": true }]*/
 
 var o = {
     set a(value) {
@@ -124,10 +118,10 @@ Object.defineProperty(o, 'c', {
 });
 ```
 
-The following patterns are not considered problems with option `getWithoutSet` set:
+Examples of **correct** code for the `{ "getWithoutSet": true }` option:
 
 ```js
-/*eslint accessor-pairs: [2, { getWithoutSet: true }]*/
+/*eslint accessor-pairs: [2, { "getWithoutSet": true }]*/
 var o = {
     set a(value) {
         this.val = value;

--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -28,11 +28,11 @@ This rule finds callback functions of the following methods, then checks usage o
 * [`Array.prototype.sort`](http://www.ecma-international.org/ecma-262/6.0/#sec-array.prototype.sort)
 * And above of typed arrays.
 
-**Note:** this rule finds by the method name, so the object which has the method might not be an array.
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
+/*eslint array-callback-return: 2*/
+
 var indexMap = myArray.reduce(function(memo, item, index) {
     memo[item] = index;
 }, {});
@@ -52,9 +52,11 @@ var bar = foo.filter(function(x) {
 });
 ```
 
-The following patterns are considered not problems:
+Examples of **correct** code for this rule:
 
 ```js
+/*eslint array-callback-return: 2*/
+
 var indexMap = myArray.reduce(function(memo, item, index) {
     memo[item] = index;
     return memo;
@@ -69,6 +71,10 @@ var foo = Array.from(nodes, function(node) {
 
 var bar = foo.map(node => node.getAttribute("id"));
 ```
+
+## Known Limitations
+
+This rule checks callback functions of methods with the given names, *even if* the object which has the method is *not* an array.
 
 ## When Not To Use It
 

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -2,50 +2,32 @@
 
 The `block-scoped-var` rule generates warnings when variables are used outside of the block in which they were defined. This emulates C-style block scope.
 
-```js
-function doSomething() {
-    if (true) {
-        var build = true;
-    }
-
-    console.log(build);
-}
-```
-
 ## Rule Details
 
 This rule aims to reduce the usage of variables outside of their binding context and emulate traditional block scope from other languages. This is to help newcomers to the language avoid difficult bugs with variable hoisting.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint block-scoped-var: 2*/
 
-function doSomething() {
+function doIf() {
     if (true) {
         var build = true;
     }
 
     console.log(build);
 }
-```
 
-```js
-/*eslint block-scoped-var: 2*/
-
-function doSomething() {
+function doIfElse() {
     if (true) {
         var build = true;
     } else {
         var build = false;
     }
 }
-```
 
-```js
-/*eslint block-scoped-var: 2*/
-
-function doAnother() {
+function doTryCatch() {
     try {
         var build = 1;
     } catch (e) {
@@ -54,12 +36,12 @@ function doAnother() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint block-scoped-var: 2*/
 
-function doSomething() {
+function doIf() {
     var build;
 
     if (true) {
@@ -68,18 +50,25 @@ function doSomething() {
 
     console.log(build);
 }
-```
 
-```js
-/*eslint block-scoped-var: 2*/
-
-function doSomething() {
+function doIfElse() {
     var build;
 
     if (true) {
         build = true;
     } else {
         build = false;
+    }
+}
+
+function doTryCatch() {
+    var build;
+    var f;
+
+    try {
+        build = 1;
+    } catch (e) {
+        f = build;
     }
 }
 ```

--- a/docs/rules/complexity.md
+++ b/docs/rules/complexity.md
@@ -18,7 +18,7 @@ function a(x) {
 
 This rule is aimed at reducing code complexity by capping the amount of cyclomatic complexity allowed in a program. As such, it will warn when the cyclomatic complexity crosses the configured threshold (default is `20`).
 
-The following patterns are considered problems:
+Examples of **incorrect** code for a maximum of 2:
 
 ```js
 /*eslint complexity: [2, 2]*/
@@ -34,7 +34,7 @@ function a(x) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for a maximum of 2:
 
 ```js
 /*eslint complexity: [2, 2]*/
@@ -48,6 +48,8 @@ function a(x) {
 }
 ```
 
+## Options
+
 Optionally, you may specify a `maximum` object property:
 
 ```json
@@ -57,7 +59,7 @@ Optionally, you may specify a `maximum` object property:
 is equivalent to
 
 ```json
-"complexity": [2, {"maximum": 2}]
+"complexity": [2, { "maximum": 2 }]
 ```
 
 ## When Not To Use It

--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -23,7 +23,7 @@ This rule is aimed at ensuring all `return` statements either specify a value or
 
 It excludes constructors which, when invoked with the `new` operator, return the instantiated object if another object is not explicitly returned.  This rule treats a function as a constructor if its name starts with an uppercase letter.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint consistent-return: 2*/
@@ -54,7 +54,7 @@ function doSomething(condition) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint consistent-return: 2*/

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -20,7 +20,11 @@ There are, however, some who prefer to only use braces when there is more than o
 
 This rule is aimed at preventing bugs and increasing code clarity by ensuring that block statements are wrapped in curly braces. It will warn when it encounters blocks that omit curly braces.
 
-The following patterns are considered problems:
+## Options
+
+### all
+
+Examples of **incorrect** code for the default `"all"` option:
 
 ```js
 /*eslint curly: 2*/
@@ -35,7 +39,7 @@ if (foo) {
 } else qux();
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `"all"` option:
 
 ```js
 /*eslint curly: 2*/
@@ -55,17 +59,11 @@ if (foo) {
 }
 ```
 
-## Options
+### multi
 
-### "multi"
+By default, this rule warns whenever `if`, `else`, `for`, `while`, or `do` are used without block statements as their body. However, you can specify that block statements should be used only when there are multiple statements in the block and warn when there is only one statement in the block.
 
-By default, this rule warns whenever `if`, `else`, `for`, `while`, or `do` are used without block statements as their body. However, you can specify that block statements should be used only when there are multiple statements in the block and warn when there is only one statement in the block. To do so, configure the rule as:
-
-```json
-curly: [2, "multi"]
-```
-
-With this configuration, the rule will warn for these patterns:
+Examples of **incorrect** code for the `"multi"` option:
 
 ```js
 /*eslint curly: [2, "multi"]*/
@@ -88,7 +86,7 @@ for (var i=0; i < items.length; i++) {
 }
 ```
 
-It will not warn for these patterns:
+Examples of **correct** code for the `"multi"` option:
 
 ```js
 /*eslint curly: [2, "multi"]*/
@@ -103,15 +101,11 @@ while (true) {
 }
 ```
 
-### "multi-line"
+### multi-line
 
-Alternatively, you can relax the rule to allow brace-less single-line `if`, `else if`, `else`, `for`, `while`, or `do`, while still enforcing the use of curly braces for other instances. To do so, configure the rule as:
+Alternatively, you can relax the rule to allow brace-less single-line `if`, `else if`, `else`, `for`, `while`, or `do`, while still enforcing the use of curly braces for other instances.
 
-```json
-curly: [2, "multi-line"]
-```
-
-With this configuration, the rule will warn for these patterns:
+Examples of **incorrect** code for the `"multi-line"` option:
 
 ```js
 /*eslint curly: [2, "multi-line"]*/
@@ -126,7 +120,7 @@ if (foo) foo(
   baz);
 ```
 
-It will not warn for these patterns:
+Examples of **correct** code for the `"multi-line"` option:
 
 ```js
 /*eslint curly: [2, "multi-line"]*/
@@ -155,15 +149,11 @@ while (true) {
 }
 ```
 
-### "multi-or-nest"
+### multi-or-nest
 
 You can use another configuration that forces brace-less `if`, `else if`, `else`, `for`, `while`, or `do` if their body contains only one single-line statement. And forces braces in all other cases.
 
-```json
-curly: [2, "multi-or-nest"]
-```
-
-With this configuration, the rule will warn for these patterns:
+Examples of **incorrect** code for the `"multi-or-nest"` option:
 
 ```js
 /*eslint curly: [2, "multi-or-nest"]*/
@@ -193,7 +183,7 @@ for (var i = 0; foo; i++) {
 }
 ```
 
-It will not warn for these patterns:
+Examples of **correct** code for the `"multi-or-nest"` option:
 
 ```js
 /*eslint curly: [2, "multi-or-nest"]*/
@@ -222,16 +212,12 @@ for (var i = 0; foo; i++)
     doSomething();
 ```
 
-### "consistent"
+### consistent
 
-When using any of the `multi*` option, you can add an option to enforce all bodies of a `if`,
+When using any of the `multi*` options, you can add an option to enforce all bodies of a `if`,
 `else if` and `else` chain to be with or without braces.
 
-```json
-curly: [2, "multi", "consistent"]
-```
-
-With this configuration, the rule will warn for those patterns:
+Examples of **incorrect** code for the `"multi", "consistent"` options:
 
 ```js
 /*eslint curly: [2, "multi", "consistent"]*/
@@ -262,7 +248,7 @@ if (foo) {
 }
 ```
 
-It will not warn for these patterns:
+Examples of **correct** code for the `"multi", "consistent"` options:
 
 ```js
 /*eslint curly: [2, "multi", "consistent"]*/
@@ -291,12 +277,6 @@ else
 if (foo)
     foo++;
 
-```
-
-The default configuration is:
-
-```json
-curly: [2, "all"]
 ```
 
 ## When Not To Use It

--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -41,7 +41,7 @@ Once again, the intent here is to show that the developer intended for there to 
 
 This rule aims to require `default` case in `switch` statements. You may optionally include a `// no default` after the last `case` if there is no `default` case.
 
-The following pattern is considered a warning:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint default-case: 2*/
@@ -54,7 +54,7 @@ switch (a) {
 
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint default-case: 2*/

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -18,21 +18,16 @@ This rule aims to enforce newline consistency in member expressions. This rule p
 
 ## Options
 
-The rule takes one option, a string, which can be either `object` or `property`.
-If it is `object`, the dot in a member expression should be on the same line as the object portion.
-If it is `property`, the dot in a member expression should be on the same line as the property portion.
+The rule takes one option, a string:
 
-If unset, the default behavior is `"object"`.
+* If it is `"object"`, the dot in a member expression should be on the same line as the object portion. The default is `"object"`.
+* If it is `"property"`, the dot in a member expression should be on the same line as the property portion.
 
-```json
-    "dot-location": [2, "object"]
-```
+### object
 
-### "object"
+The default `"object"` option requires the dot to be on the same line as the object.
 
-This is the default option. It requires the dot to be on the same line as the object.
-
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `"object"` option:
 
 ```js
 /*eslint dot-location: [2, "object"]*/
@@ -41,7 +36,7 @@ var foo = object
 .property;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `"object"` option:
 
 ```js
 /*eslint dot-location: [2, "object"]*/
@@ -51,11 +46,11 @@ property;
 var bar = object.property;
 ```
 
-### "property"
+### property
 
-This option requires the dot to be on the same line as the property.
+The `"property"` option requires the dot to be on the same line as the property.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"property"` option:
 
 ```js
 /*eslint dot-location: [2, "property"]*/
@@ -64,7 +59,7 @@ var foo = object.
 property;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the `"property"` option:
 
 ```js
 /*eslint dot-location: [2, "property"]*/

--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -10,7 +10,7 @@ foo["bar"];
 
 This rule is aimed at maintaining code consistency and improving code readability by encouraging use of the dot notation style whenever possible. As such, it will warn when it encounters an unnecessary use of square-bracket notation.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint dot-notation: 2*/
@@ -18,7 +18,7 @@ The following patterns are considered problems:
 var x = foo["bar"];
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint dot-notation: 2*/
@@ -30,55 +30,31 @@ var x = foo[bar];    // Property name is a variable, square-bracket notation req
 
 ## Options
 
-This rule accepts a single options argument with the following defaults:
+This rule accepts a single options argument:
 
-```json
-{
-    "rules": {
-        "dot-notation": [2, {"allowKeywords": true, "allowPattern": ""}]
-    }
-}
-```
+* Set the `allowKeywords` option to `false` (default is `true`) to follow ECMAScript version 3 compatible style, avoiding dot notation for reserved word properties.
+* Set the `allowPattern` option to a regular expression string to allow bracket notation for property names that match a pattern (by default, no pattern is tested).
 
-### `allowKeywords`
+### allowKeywords
 
-Set the `allowKeywords` option to `false` (default is `true`) to follow ECMAScript version 3 compatible style, avoiding dot notation for reserved word properties.
-
-```json
-  "dot-notation": [2, {"allowKeywords": false}],
-```
-
-The following patterns are not considered problems:
+Examples of **correct** code for the `{ "allowKeywords": false }` option:
 
 ```js
-/*eslint dot-notation: [2, {"allowKeywords": false}]*/
+/*eslint dot-notation: [2, { "allowKeywords": false }]*/
 
 var foo = { "class": "CS 101" }
 var x = foo["class"]; // Property name is a reserved word, square-bracket notation required
 ```
 
-### `allowPattern`
-
-Set the `allowPattern` option to a regular expression string to allow bracket notation for property names that match a pattern (by default, no pattern is tested).
+### allowPattern
 
 For example, when preparing data to be sent to an external API, it is often required to use property names that include underscores.  If the `camelcase` rule is in effect, these [snake case](http://en.wikipedia.org/wiki/Snake_case) properties would not be allowed.  By providing an `allowPattern` to the `dot-notation` rule, these snake case properties can be accessed with bracket notation.
 
-Example configuration:
-
-```json
-{
-    "rules": {
-        "camelcase": 2
-        "dot-notation": [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}]
-    }
-}
-```
-
-Example code patterns:
+Examples of **correct** code for the sample `{ "allowPattern": "^[a-z]+(_[a-z]+)+$" }` option:
 
 ```js
 /*eslint camelcase: 2*/
-/*eslint dot-notation: [2, {"allowPattern": "^[a-z]+(_[a-z]+)+$"}]*/
+/*eslint dot-notation: [2, { "allowPattern": "^[a-z]+(_[a-z]+)+$" }]*/
 
 var data = {};
 data.foo_bar = 42;

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -15,7 +15,7 @@ If one of those occurs in an innocent-looking statement such as `a == b` the act
 
 This rule is aimed at eliminating the type-unsafe equality operators.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /* eslint eqeqeq: 2 */
@@ -29,33 +29,15 @@ if (obj.getStuff() != undefined) { }
 
 ## Options
 
-### "smart"
+### smart
 
-This option enforces the use of `===` and `!==` except for these cases:
+The `"smart"` option enforces the use of `===` and `!==` except for these cases:
 
 * Comparing two literal values
 * Evaluating the value of `typeof`
 * Comparing against `null`
 
-You can specify this option using the following configuration:
-
-```json
-"eqeqeq": [2, "smart"]
-```
-
-The following patterns are not considered problems:
-
-```js
-/* eslint eqeqeq: [2, "smart"] */
-
-typeof foo == 'undefined'
-'hello' != 'world'
-0 == 0
-true == true
-foo == null
-```
-
-The following patterns are considered problems with "smart":
+Examples of **incorrect** code for the `"smart"` option:
 
 ```js
 /* eslint eqeqeq: [2, "smart"] */
@@ -71,25 +53,23 @@ bananas != 1
 value == undefined
 ```
 
-### "allow-null"
-
-This option will enforce `===` and `!==` in your code with one exception - it permits comparing to `null` to check for `null` or `undefined` in a single expression.
-
-You can specify this option using the following configuration:
-
-```json
-"eqeqeq": [2, "allow-null"]
-```
-
-The following patterns are not considered problems:
+Examples of **correct** code for the `"smart"` option:
 
 ```js
-/* eslint eqeqeq: [2, "allow-null"] */
+/* eslint eqeqeq: [2, "smart"] */
 
+typeof foo == 'undefined'
+'hello' != 'world'
+0 == 0
+true == true
 foo == null
 ```
 
-The following patterns are considered problems with "allow-null":
+### allow-null
+
+The `"allow-null"` option will enforce `===` and `!==` in your code with one exception - it permits comparing to `null` to check for `null` or `undefined` in a single expression.
+
+Examples of **incorrect** code for the `"allow-null"` option:
 
 ```js
 /* eslint eqeqeq: [2, "allow-null"] */
@@ -99,6 +79,14 @@ typeof foo == 'undefined'
 'hello' != 'world'
 0 == 0
 foo == undefined
+```
+
+Examples of **correct** code for the `"allow-null"` option:
+
+```js
+/* eslint eqeqeq: [2, "allow-null"] */
+
+foo == null
 ```
 
 ## When Not To Use It

--- a/docs/rules/guard-for-in.md
+++ b/docs/rules/guard-for-in.md
@@ -12,7 +12,7 @@ for (key in foo) {
 
 This rule is aimed at preventing unexpected behavior that could arise from using a `for in` loop without filtering the results in the loop. As such, it will warn when `for in` loops do not filter their results with an `if` statement.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint guard-for-in: 2*/
@@ -22,7 +22,7 @@ for (key in foo) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint guard-for-in: 2*/

--- a/docs/rules/no-alert.md
+++ b/docs/rules/no-alert.md
@@ -10,7 +10,7 @@ alert("here!");
 
 This rule is aimed at catching debugging code that should be removed and popup UI elements that should be replaced with less obtrusive, custom UIs. As such, it will warn when it encounters `alert`, `prompt`, and `confirm` function calls which are not shadowed.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-alert: 2*/
@@ -22,7 +22,7 @@ confirm("Are you sure?");
 prompt("What's your name?", "John Doe");
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-alert: 2*/

--- a/docs/rules/no-caller.md
+++ b/docs/rules/no-caller.md
@@ -12,7 +12,7 @@ function foo() {
 
 This rule is aimed at discouraging the use of deprecated and sub-optimal code, but disallowing the use of `arguments.caller` and `arguments.callee`. As such, it will warn when `arguments.caller` and `arguments.callee` are used.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-caller: 2*/
@@ -30,7 +30,7 @@ function foo(n) {
 });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-caller: 2*/

--- a/docs/rules/no-case-declarations.md
+++ b/docs/rules/no-case-declarations.md
@@ -5,7 +5,19 @@ in `case`/`default` clauses. The reason is that the lexical declaration is visib
 in the entire switch block but it only gets initialized when it is assigned, which
 will only happen if the case where it is defined is reached.
 
+To ensure that the lexical declaration only applies to the current case clause
+wrap your clauses in blocks.
+
+## Rule Details
+
+This rule aims to prevent access to uninitialized lexical bindings as well as accessing hoisted functions across case clauses.
+
+Examples of **incorrect** code for this rule:
+
 ```js
+/*eslint no-case-declarations: 2*/
+/*eslint-env es6*/
+
 switch (foo) {
     case 1:
         let x = 1;
@@ -21,10 +33,12 @@ switch (foo) {
 }
 ```
 
-To ensure that the lexical declaration only applies to the current case clause
-wrap your clauses in blocks.
+Examples of **correct** code for this rule:
 
 ```js
+/*eslint no-case-declarations: 2*/
+/*eslint-env es6*/
+
 switch (foo) {
     case 1: {
         let x = 1;
@@ -41,28 +55,6 @@ switch (foo) {
     default: {
         class C {}
     }
-}
-```
-
-## Rule Details
-
-This rule aims to prevent access to uninitialized lexical bindings as well as accessing hoisted functions across case clauses.
-
-```js
-/*eslint no-case-declarations: 2*/
-
-switch (foo) {
-    case 1:
-        let x = 1;
-        break;
-    case 2:
-        const y = 2;
-        break;
-    case 3:
-        function f() {}
-        break;
-    default:
-        class C {}
 }
 ```
 

--- a/docs/rules/no-div-regex.md
+++ b/docs/rules/no-div-regex.md
@@ -10,7 +10,7 @@ function bar() { return /=foo/; }
 
 This is used to disambiguate the division operator to not confuse users.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-div-regex: 2*/
@@ -18,7 +18,7 @@ The following patterns are considered problems:
 function bar() { return /=foo/; }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-div-regex: 2*/

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -16,7 +16,7 @@ function foo() {
 
 This rule is aimed at highlighting an unnecessary block of code following an `if` containing a return statement. As such, it will warn when it encounters an `else` following a chain of `if`s, all of them containing a `return` statement.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-else-return: 2*/
@@ -63,7 +63,7 @@ function foo() {
 }
 ```
 
-The follow patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-else-return: 2*/


### PR DESCRIPTION
1 of 4 pull requests for rules under **Best Practices** Have a good week end!

This gets us to 25% of the rules. We might finish in about 4 weeks and celebrate April Rules day.

What do you think about the wording of these example sentences?
* complexity: Examples of incorrect/correct code for a maximum of 2
* dot-notation: Examples of correct code for the sample `{ "allowPattern": "^[a-z]+(_[a-z]+)+$" }` option

Here are the changes beyond example sentences:

* accessor-pairs: Options unordered list with default option first; delete json
* array-callback-return: add eslint comments to example code
* block-scoped-var: delete redundant code in introduction; rename functions to merge code fences in examples; add third function to correct code
* complexity: add Options heading
* curly: move default example under all option; delete redundant json for options
* dot-location: unordered list for options; delete json; simplify description of options
* dot-notation: under Options, replace json with unordered list whose items are sentences which were under the option headings
* eqeqeq: delete json; put examples under options in incorrect/correct order; add to list of rules with *missing* correct code; *tied for the cut-and-paste prize in this batch*
* no-case-declarations: delete redundant incorrect intro example; move correct code example from intro to Rule Details; add eslint-env comments; *tied for the cut-and-paste prize in this batch*

WHAT DO YOU THINK about potential change to array-callback-return: move Note to **Known Limitations** (which would precede When Not To Use It)

This rule checks callback functions of methods with the given names, *even if* the object which has the method is *not* an array.
