### PR TITLE
Upgrade: Add support for VisitorKeys from other parser (fixes #4640)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -532,7 +532,7 @@ module.exports = (function() {
      * as possible
      * @param {string} text The text to parse.
      * @param {Object} config The ESLint configuration object.
-     * @returns {ASTNode} The AST if successful or null if not.
+     * @returns {Object} Object containing ast and parser reference
      * @private
      */
     function parse(text, config) {
@@ -575,7 +575,7 @@ module.exports = (function() {
          * problem that ESLint identified just like any other.
          */
         try {
-            return parser.parse(text, parserOptions);
+            return { parser: parser, ast: parser.parse(text, parserOptions) };
         } catch (ex) {
 
             // If the message includes a leading line number, strip it:
@@ -671,12 +671,14 @@ module.exports = (function() {
      */
     api.verify = function(textOrSourceCode, config, filenameOrOptions, saveState) {
 
-        var ast,
+        var ast = null,
             shebang,
             ecmaFeatures,
             ecmaVersion,
             allowInlineConfig,
-            text = (typeof textOrSourceCode === "string") ? textOrSourceCode : null;
+            text = (typeof textOrSourceCode === "string") ? textOrSourceCode : null,
+            parser,
+            parserResult;
 
         // evaluate arguments
         if (typeof filenameOrOptions === "object") {
@@ -713,7 +715,7 @@ module.exports = (function() {
                 return messages;
             }
 
-            ast = parse(
+            parserResult = parse(
                 stripUnicodeBOM(text).replace(/^#!([^\r\n]+)/, function(match, captured) {
                     shebang = captured;
                     return "//" + captured;
@@ -721,7 +723,9 @@ module.exports = (function() {
                 config
             );
 
-            if (ast) {
+            if (parserResult) {
+                ast = parserResult.ast;
+                parser = parserResult.parse;
                 sourceCode = new SourceCode(text, ast);
             }
 
@@ -798,7 +802,7 @@ module.exports = (function() {
                 impliedStrict: ecmaFeatures.impliedStrict,
                 ecmaVersion: ecmaVersion,
                 sourceType: currentConfig.parserOptions.sourceType || "script",
-                childVisitorKeys: espree.VisitorKeys,
+                childVisitorKeys: parser ? parser.VisitorKeys : espree.VisitorKeys,
                 fallback: "none"
             });
             currentScopes = scopeManager.scopes;
@@ -847,7 +851,7 @@ module.exports = (function() {
                 leave: function(node) {
                     eventGenerator.leaveNode(node);
                 },
-                keys: espree.VisitorKeys
+                keys: parser ? parser.VisitorKeys : espree.VisitorKeys
             });
         }
 


### PR DESCRIPTION
I'm not sure this is the right approach. I had to modify return type from `parse` function, since that's the only place were we load 3rd party parsers.