### PR TITLE
Fix: key-spacing checks ObjectExpression is multiline (fixes #5479)

### DIFF
--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -370,7 +370,7 @@ module.exports = function(context) {
 
         return {
             "Property": function(node) {
-                verifySpacing(node, isSingleLine(node) ? singleLineOptions : multiLineOptions);
+                verifySpacing(node, isSingleLine(node.parent) ? singleLineOptions : multiLineOptions);
             }
         };
 

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -479,6 +479,25 @@ ruleTester.run("key-spacing", rule, {
                 "beforeColon": false
             }
         }]
+    }, {
+        code: [
+            "var obj = {",
+            "    foobar: 42,",
+            "    bat:    2",
+            "};"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                beforeColon: false,
+                afterColon: true,
+                mode: "strict"
+            },
+            multiLine: {
+                beforeColon: false,
+                afterColon: true,
+                mode: "minimum"
+            }
+        }]
     }],
 
     invalid: [{


### PR DESCRIPTION
Pretty simple fix in the end, just needed to ensure the whole ObjectExpression was passed to the line count checker.