### PR TITLE
New: Exception message template for uncaught rule error (refs #5221)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -27,7 +27,8 @@ var lodash = require("lodash"),
     validator = require("./config/config-validator"),
     replacements = require("../conf/replacements.json"),
     assert = require("assert"),
-    CodePathAnalyzer = require("./code-path-analysis/code-path-analyzer");
+    CodePathAnalyzer = require("./code-path-analysis/code-path-analyzer"),
+    ESLINT_VERSION = require("../package.json").version;
 
 var DEFAULT_PARSER = require("../conf/eslint.json").parser;
 
@@ -505,6 +506,52 @@ function stripUnicodeBOM(text) {
     return text;
 }
 
+/**
+ * Wraps a rule action with an exception handler.
+ *
+ * The exception handler will catch exceptions thrown by rule actions, decorate
+ * the exception with rule metadata, and rethrow the exception. This will allow
+ * us to detect the uncaught exception as a rule crash and show a user-friendly
+ * error message.
+ *
+ * @param {function} action The rule action to wrap.
+ * @param {object} metadata Metadata that are useful for bug reports.
+ * @returns {function} A function which will catch, decorate, and rethrow rule exceptions.
+ */
+function createRuleExceptionHandler(action, metadata) {
+    var ruleName = metadata.ruleName,
+        fileName = metadata.fileName,
+        parserPath = metadata.parserPath,
+        hasDefaultParser = parserPath === DEFAULT_PARSER,
+        pluginDelimiterIndex = ruleName.indexOf("/"),
+        pluginName = null,
+        eightSpaces = new Array(9).join(" ");
+
+    if (pluginDelimiterIndex > -1) {
+        pluginName = ruleName.slice(0, ruleName.indexOf("/"));
+    }
+
+    return function() {
+        try {
+            action.apply(null, arguments);
+        } catch (err) {
+            err.messageTemplate = "rule-crashed";
+            err.messageData = {
+                ruleName: ruleName,
+                pluginName: pluginName,
+                fileName: fileName,
+                parserPath: parserPath,
+                hasDefaultParser: hasDefaultParser,
+                eslintVersion: ESLINT_VERSION,
+                errorMessage: err.message,
+                stackTrace: err.stack.replace(/^\s+/gm, eightSpaces)
+            };
+
+            throw err;
+        }
+    };
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -773,9 +820,16 @@ module.exports = (function() {
 
                     // add all the node types as listeners
                     Object.keys(rule).forEach(function(nodeType) {
+                        var action = rule[nodeType],
+                            wrappedAction = createRuleExceptionHandler(action, {
+                                ruleName: key,
+                                fileName: currentFilename,
+                                parserPath: config.parser
+                            });
+
                         api.on(nodeType, timing.enabled
-                            ? timing.time(key, rule[nodeType])
-                            : rule[nodeType]
+                            ? timing.time(key, wrappedAction)
+                            : wrappedAction
                         );
                     });
                 } catch (ex) {

--- a/messages/rule-crashed.txt
+++ b/messages/rule-crashed.txt
@@ -1,0 +1,20 @@
+ESLint encountered an uncaught exception from rule "<%= ruleName %>".
+
+<% if (pluginName) { %>The rule in question comes from the plugin "eslint-plugin-<%= pluginName %>". You should open an issue on that plugin's issue tracker. Be sure to include your configuration, file source code, the installed version of the plugin, and the error message and stack trace.
+<% } else { %>This is a core rule, so this exception may indicate a bug in ESLint. Please open an issue in our issue tracker, using the following information in addition to your exact source code and configuration.
+<% } %>
+Useful information:
+
+    ESLint version: <%= eslintVersion %>
+
+    Parser: <%= parserPath %> <%= hasDefaultParser ? "(default)" : "" %>
+<% if (stackTrace) { %>
+    Exception stack trace: <%= stackTrace %>
+<% } %>
+    You can run this command to get your configuration:
+        eslint --print-config path/to/your/file.js
+
+    File name: <%= fileName %>
+    You should include the source from this file in your bug report.
+
+Be sure that your bug report also clearly calls out any unusual configuration.

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1063,7 +1063,7 @@ describe("eslint", function() {
         });
     });
 
-    describe("when config has parseOptions", function() {
+    describe("when config has parserOptions", function() {
 
         it("should pass ecmaFeatures to all rules when provided on config", function() {
 
@@ -3527,6 +3527,108 @@ describe("eslint", function() {
 
             assert(ok);
         });
+
+        it("should decorate exception if core rule has uncaught exception", function() {
+            var originalMessage = "Rule action exception";
+
+            eslint.defineRule("test-rule", function() {
+                return {
+                    "VariableDeclaration": function() {
+                        throw new Error(originalMessage);
+                    }
+                };
+            });
+
+            var code = "var x;";
+            var config = { rules: { "test-rule": 1 } };
+
+            try {
+                eslint.verify(code, config, "filename.js");
+                assert.fail();
+            } catch (err) {
+                assert.property(err, "message");
+                assert.strictEqual(err.message, originalMessage);
+                assert.strictEqual(err.messageTemplate, "rule-crashed");
+                assert.ok(err.messageData);
+                assert.strictEqual(err.messageData.errorMessage, originalMessage);
+                assert.strictEqual(err.messageData.ruleName, "test-rule");
+                assert.strictEqual(err.messageData.pluginName, null);
+                assert.strictEqual(err.messageData.fileName, "filename.js");
+                assert.strictEqual(err.messageData.parserPath, "espree");
+                assert.strictEqual(err.messageData.hasDefaultParser, true);
+                assert.property(err.messageData, "eslintVersion");
+                assert.property(err.messageData, "stackTrace");
+            }
+        });
+
+        it("should decorate exception if plugin rule has uncaught exception", function() {
+            var originalMessage = "Rule action exception";
+
+            eslint.defineRule("test-plugin/test-rule", function() {
+                return {
+                    "VariableDeclaration": function() {
+                        throw new Error(originalMessage);
+                    }
+                };
+            });
+
+            var code = "var x;";
+            var config = { rules: { "test-plugin/test-rule": 1 } };
+
+            try {
+                eslint.verify(code, config, "filename.js");
+                assert.fail();
+            } catch (err) {
+                assert.property(err, "message");
+                assert.strictEqual(err.message, originalMessage);
+                assert.strictEqual(err.messageTemplate, "rule-crashed");
+                assert.ok(err.messageData);
+                assert.strictEqual(err.messageData.errorMessage, originalMessage);
+                assert.strictEqual(err.messageData.ruleName, "test-plugin/test-rule");
+                assert.strictEqual(err.messageData.pluginName, "test-plugin");
+                assert.strictEqual(err.messageData.fileName, "filename.js");
+                assert.strictEqual(err.messageData.parserPath, "espree");
+                assert.strictEqual(err.messageData.hasDefaultParser, true);
+                assert.property(err.messageData, "eslintVersion");
+                assert.property(err.messageData, "stackTrace");
+            }
+        });
+
+        // only test in Node.js, not browser
+        if (typeof window === "undefined") {
+            it("should decorate exception if rule crashes with custom parser", function() {
+                var originalMessage = "Rule action exception";
+
+                eslint.defineRule("test-rule", function() {
+                    return {
+                        "VariableDeclaration": function() {
+                            throw new Error(originalMessage);
+                        }
+                    };
+                });
+
+                var code = "var x;";
+                var config = { rules: { "test-rule": 1 }, parser: "esprima-fb" };
+
+                try {
+                    eslint.verify(code, config, "filename.js");
+                    assert.fail();
+                } catch (err) {
+                    assert.property(err, "message");
+                    assert.strictEqual(err.message, originalMessage);
+                    assert.strictEqual(err.messageTemplate, "rule-crashed");
+                    assert.ok(err.messageData);
+                    assert.strictEqual(err.messageData.errorMessage, originalMessage);
+                    assert.strictEqual(err.messageData.ruleName, "test-rule");
+                    assert.strictEqual(err.messageData.pluginName, null);
+                    assert.strictEqual(err.messageData.fileName, "filename.js");
+                    assert.strictEqual(err.messageData.parserPath, "esprima-fb");
+                    assert.strictEqual(err.messageData.hasDefaultParser, false);
+                    assert.property(err.messageData, "eslintVersion");
+                    assert.property(err.messageData, "stackTrace");
+                }
+            });
+        }
     });
 
     // only test in Node.js, not browser


### PR DESCRIPTION
Hi folks. I'm asking for [30% feedback](http://blog.sandglaz.com/30-percent-feedback-rule/) here (meaning this PR is probably not ready to merge yet). Please take a look and let me know if this is the right direction.

Terminology:

* Rule action: That is my name for the node event handler in rules, i.e., the values returned in the rule creator function.

The highlights:

* When lib/eslint.js calls `api.on(nodeType)`, I am wrapping the rule action function in a containing function which will call the rule action with try/catch, and if an exception is thrown, it will decorate the exception with metadata representing a new message template.
* New message template contains information on how to report the bug. Probably needs some polishing and copy-editing.

Done:

- [x] Get the filename into the error message
- [x] Mention plugin version as an important piece of information for a plugin bug
- [x] Show parser name, distinguish between default and non-default parser

Do we want these for an initial PR?
- [ ] Different top-level message for default vs non-default parser?
- [ ] Report on node metadata (e.g., line and column number)?
- [ ] Crazy thought: Get the RuleContext object into the wrapper, so that we can do `context.getSourceCode().getText(node)`?

Feedback welcome!