### PR TITLE
Docs: Document linebreak-style as fixable

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -166,7 +166,7 @@ These rules are purely matters of style and are quite subjective.
 * [jsx-quotes](jsx-quotes.md) - specify whether double or single quotes should be used in JSX attributes (fixable)
 * [key-spacing](key-spacing.md) - enforce spacing between keys and values in object literal properties
 * [keyword-spacing](keyword-spacing.md) - enforce spacing before and after keywords (fixable)
-* [linebreak-style](linebreak-style.md) - disallow mixed 'LF' and 'CRLF' as linebreaks
+* [linebreak-style](linebreak-style.md) - disallow mixed 'LF' and 'CRLF' as linebreaks (fixable)
 * [lines-around-comment](lines-around-comment.md) - enforce empty lines around comments
 * [max-depth](max-depth.md) - specify the maximum depth that blocks can be nested
 * [max-len](max-len.md) - specify the maximum length of a line in your program

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -8,6 +8,8 @@ whereas Linux and Unix use a simple _line feed_ (LF). The corresponding _control
 
 Many versioning systems (like git and subversion) can automatically ensure the correct ending. However to cover all contingencies you can activate this rule.
 
+**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+
 ## Rule Details
 
 This rule aims to ensure having consistent line endings independent of operating system, VCS or editor used.


### PR DESCRIPTION
I believe autofixing was added (https://github.com/eslint/eslint/pull/3983) but never documented.