### PR TITLE
Docs: Distinguish examples in rules under Best Practices part 2

### DIFF
--- a/docs/rules/no-empty-function.md
+++ b/docs/rules/no-empty-function.md
@@ -22,10 +22,11 @@ list.map(() => ({})); // This is an empty object.
 This rule is aimed at eliminating empty functions.
 A function will not be considered a problem if it contains a comment.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-empty-function: "error"*/
+/*eslint-env es6*/
 
 function foo() {}
 
@@ -72,10 +73,11 @@ class A {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-empty-function: "error"*/
+/*eslint-env es6*/
 
 function foo() {
     // do nothing.
@@ -164,13 +166,7 @@ class A {
 
 ## Options
 
-```json
-{
-    "no-empty-function": ["error", {"allow": []}]
-}
-```
-
-This rule has an option to allow empty of specific kind's functions.
+This rule has an option to allow specific kinds of functions to be empty.
 
 * `allow` (`string[]`) - A list of kind to allow empty functions. List items are some of the following strings. An empty array (`[]`) by default.
     * `"functions"` - Normal functions.
@@ -182,10 +178,12 @@ This rule has an option to allow empty of specific kind's functions.
     * `"setters"` - Setters.
     * `"constructors"` - Class constructors.
 
-The following patterns are not considered problems when configured with `{"allow": ["functions"]}`:
+#### allow: functions
+
+Examples of **correct** code for the `{ "allow": ["functions"] }` option:
 
 ```js
-/*eslint no-empty-function: ["error", {"allow": ["functions"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["functions"] }]*/
 
 function foo() {}
 
@@ -196,18 +194,24 @@ var obj = {
 };
 ```
 
-The following patterns are not considered problems when configured with `{"allow": ["arrowFunctions"]}`:
+#### allow: arrowFunctions
+
+Examples of **correct** code for the `{ "allow": ["arrowFunctions"] }` option:
 
 ```js
-/*eslint no-empty-function: ["error", {"allow": ["arrowFunctions"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["arrowFunctions"] }]*/
+/*eslint-env es6*/
 
 var foo = () => {};
 ```
 
-The following patterns are not considered problems when configured with `{"allow": ["generatorFunctions"]}`:
+#### allow: generatorFunctions
+
+Examples of **correct** code for the `{ "allow": ["generatorFunctions"] }` option:
 
 ```js
-/*eslint no-empty-function: ["error", {"allow": ["generatorFunctions"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["generatorFunctions"] }]*/
+/*eslint-env es6*/
 
 function* foo() {}
 
@@ -218,10 +222,13 @@ var obj = {
 };
 ```
 
-The following patterns are not considered problems when configured with `{"allow": ["methods"]}`:
+#### allow: methods
+
+Examples of **correct** code for the `{ "allow": ["methods"] }` option:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["methods"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["methods"] }]*/
+/*eslint-env es6*/
 
 var obj = {
     foo() {}
@@ -233,10 +240,13 @@ class A {
 }
 ```
 
-The following patterns are not considered problems when configured with `{"allow": ["generatorMethods"]}`:
+#### allow: generatorMethods
+
+Examples of **correct** code for the `{ "allow": ["generatorMethods"] }` option:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["generatorMethods"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["generatorMethods"] }]*/
+/*eslint-env es6*/
 
 var obj = {
     *foo() {}
@@ -248,10 +258,13 @@ class A {
 }
 ```
 
-The following patterns are not considered problems when configured with `{"allow": ["getters"]}`:
+#### allow: getters
+
+Examples of **correct** code for the `{ "allow": ["getters"] }` option:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["getters"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["getters"] }]*/
+/*eslint-env es6*/
 
 var obj = {
     get foo() {}
@@ -263,10 +276,13 @@ class A {
 }
 ```
 
-The following patterns are not considered problems when configured with `{"allow": ["setters"]}`:
+#### allow: setters
+
+Examples of **correct** code for the `{ "allow": ["setters"] }` option:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["setters"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["setters"] }]*/
+/*eslint-env es6*/
 
 var obj = {
     set foo(value) {}
@@ -278,10 +294,13 @@ class A {
 }
 ```
 
-The following patterns are not considered problems when configured with `{"allow": ["constructors"]}`:
+#### allow: constructors
+
+Examples of **correct** code for the `{ "allow": ["constructors"] }` option:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["constructors"]}]*/
+/*eslint no-empty-function: ["error", { "allow": ["constructors"] }]*/
+/*eslint-env es6*/
 
 class A {
     constructor() {}

--- a/docs/rules/no-empty-pattern.md
+++ b/docs/rules/no-empty-pattern.md
@@ -2,21 +2,21 @@
 
 When using destructuring, it's possible to create a pattern that has no effect. This happens when empty curly braces are used to the right of an embedded object destructuring pattern, such as:
 
-```
+```js
 // doesn't create any variables
 var {a: {}} = foo;
 ```
 
 In this code, no new variables are created because `a` is just a location helper while the `{}` is expected to contain the variables to create, such as:
 
-```
+```js
 // creates variable b
 var {a: { b }} = foo;
 ```
 
 In many cases, the empty object pattern is a mistake where the author intended to use a default value instead, such as:
 
-```
+```js
 // creates variable a
 var {a = {}} = foo;
 ```
@@ -27,7 +27,7 @@ The difference between these two patterns is subtle, especially because the prob
 
 This rule aims to flag any empty patterns in destructured objects and arrays, and as such, will report a problem whenever one is encountered.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-empty-pattern: "error"*/
@@ -42,7 +42,7 @@ function foo({a: {}}) {}
 function foo({a: []}) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-empty-pattern: "error"*/

--- a/docs/rules/no-eq-null.md
+++ b/docs/rules/no-eq-null.md
@@ -12,7 +12,7 @@ if (foo == null) {
 
 The `no-eq-null` rule aims reduce potential bug and unwanted behavior by ensuring that comparisons to `null` only match `null`, and not also `undefined`. As such it will flag comparisons to null when using `==` and `!=`.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-eq-null: "error"*/
@@ -26,7 +26,7 @@ while (qux != null) {
 }
 ```
 
-The following patterns are considered okay:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-eq-null: "error"*/

--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -12,7 +12,7 @@ var obj = { x: "foo" },
 
 This rule is aimed at preventing potentially dangerous, unnecessary, and slow code by disallowing the use of the `eval()` function. As such, it will warn whenever the `eval()` function is used.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-eval: "error"*/
@@ -44,10 +44,11 @@ window.eval("var a = 0");
 global.eval("var a = 0");
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-eval: "error"*/
+/*eslint-env es6*/
 
 var obj = { x: "foo" },
     key = "x",

--- a/docs/rules/no-extend-native.md
+++ b/docs/rules/no-extend-native.md
@@ -24,28 +24,46 @@ A common suggestion to avoid this problem would be to wrap the inside of the `fo
 
 ## Rule Details
 
-Disallows directly modifying the prototype of builtin objects by looking for the following styles:
+Disallows directly modifying the prototype of builtin objects.
 
-* `Object.prototype.a = "a";`
-* `Object.defineProperty(Array.prototype, "times", {value: 999});`
+Examples of **incorrect** code for this rule:
 
-It *does not* check for any of the following less obvious approaches:
+```js
+/*eslint no-extend-native: 2*/
 
-* `var x = Object; x.prototype.thing = a;`
-* `eval("Array.prototype.forEach = 'muhahaha'");`
-* `with(Array) { prototype.thing = 'thing'; };`
-* `window.Function.prototype.bind = 'tight';`
+Object.prototype.a = "a";
+Object.defineProperty(Array.prototype, "times", { value: 999 });
+```
 
 ## Options
 
-This rule accepts an `exceptions` option, which can be used to specify a list of builtins for which extensions will be allowed:
+This rule accepts an `exceptions` option, which can be used to specify a list of builtins for which extensions will be allowed.
 
-```json
-{
-    "rules": {
-        "no-extend-native": ["error", {"exceptions": ["Object"]}]
-    }
-}
+### exceptions
+
+Examples of **correct** code for the sample `{ "exceptions": ["Object"] }` option:
+
+```js
+/*eslint no-extend-native: ["error", { "exceptions": ["Object"] }]*/
+
+Object.prototype.a = "a";
+```
+
+## Known Limitations
+
+This rule *does not* report any of the following less obvious approaches to modify the prototype of builtin objects:
+
+```js
+var x = Object;
+x.prototype.thing = a;
+
+eval("Array.prototype.forEach = 'muhahaha'");
+
+with(Array) {
+    prototype.thing = 'thing';
+};
+
+window.Function.prototype.bind = 'tight';
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -31,7 +31,7 @@ This rule is aimed at avoiding the unnecessary use of `bind()` and as such will 
 
 **Note:** Arrow functions can never have their `this` value set using `bind()`. This rule flags all uses of `bind()` with arrow functions as a problem
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-extra-bind: "error"*/
@@ -62,7 +62,7 @@ var x = function () {
 }.bind(baz);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-extra-bind: "error"*/

--- a/docs/rules/no-extra-label.md
+++ b/docs/rules/no-extra-label.md
@@ -15,7 +15,7 @@ Probably those labels would confuse developers because they expect labels to jum
 
 This rule is aimed at eliminating unnecessary labels.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-extra-label: "error"*/
@@ -34,7 +34,7 @@ C: switch (a) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-extra-label: "error"*/

--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -25,7 +25,7 @@ switch(foo) {
 }
 ```
 
-That works fine when you don't want a fallthrough, but what if the fallthrough is intentional, there is no way to indicate that in the language. It's considered a best practice to always indicate when a fallthrough is intentional using a comment:
+That works fine when you don't want a fallthrough, but what if the fallthrough is intentional, there is no way to indicate that in the language. It's considered a best practice to always indicate when a fallthrough is intentional using a comment which matches the `/falls?\s?through/i` regular expression:
 
 ```js
 switch(foo) {
@@ -62,7 +62,7 @@ In this example, there is no confusion as to the expected behavior. It is clear 
 
 This rule is aimed at eliminating unintentional fallthrough of one case to the other. As such, it flags and fallthrough scenarios that are not marked by a comment.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-fallthrough: "error"*/
@@ -76,7 +76,7 @@ switch(foo) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-fallthrough: "error"*/

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -14,7 +14,7 @@ Although not a syntax error, this format for numbers can make it difficult to di
 
 This rule is aimed at eliminating floating decimal points and will warn whenever a numeric value has a decimal point but is missing a number either before or after it.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-floating-decimal: "error"*/
@@ -24,13 +24,14 @@ var num = 2.;
 var num = -.7;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-floating-decimal: "error"*/
 
 var num = 0.5;
 var num = 2.0;
+var num = -0.7;
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -33,19 +33,6 @@ This rule is aimed to flag shorter notations for the type conversion, then sugge
 
 This rule has three main options and one override option to allow some coercions as required.
 
-```js
-{
-    "rules": {
-        "no-implicit-coercion": [2, {
-            "boolean": true,
-            "number": true,
-            "string": true,
-            "allow": [/* "!!", "~", "*", "+" */]
-        }]
-    }
-}
-```
-
 * `"boolean"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `boolean` type.
 * `"number"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `number` type.
 * `"string"` (`true` by default) - When this is `true`, this rule warns shorter type conversions for `string` type.
@@ -53,20 +40,19 @@ This rule has three main options and one override option to allow some coercions
 
 Note that operator `+` in `allow` list would allow `+foo` (number coercion) as well as `"" + foo` (string coercion).
 
-### `boolean`
+### boolean
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `{ "boolean": true }` option:
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
 
 var b = !!foo;
 var b = ~foo.indexOf(".");
-// only with `indexOf`/`lastIndexOf` method calling.
-
+// bitwise not is incorrect only with `indexOf`/`lastIndexOf` method calling.
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `{ "boolean": true }` option:
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
@@ -74,12 +60,12 @@ The following patterns are not considered problems:
 var b = Boolean(foo);
 var b = foo.indexOf(".") !== -1;
 
-var n = ~foo; // This is a just binary negating.
+var n = ~foo; // This is a just bitwise not.
 ```
 
-### `number`
+### number
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `{ "number": true }` option:
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
@@ -88,60 +74,46 @@ var n = +foo;
 var n = 1 * foo;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `{ "number": true }` option:
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
 
-var b = Number(foo);
-var b = parseFloat(foo);
-var b = parseInt(foo, 10);
+var n = Number(foo);
+var n = parseFloat(foo);
+var n = parseInt(foo, 10);
 ```
 
-### `string`
+### string
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `{ "string": true }` option:
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
 
-var n = "" + foo;
-
+var s = "" + foo;
 foo += "";
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `{ "string": true }` option:
 
 ```js
 /*eslint no-implicit-coercion: "error"*/
 
-var b = String(foo);
+var s = String(foo);
 ```
 
-### Fine-grained control
+### allow
 
 Using `allow` list, we can override and allow specific operators.
 
-For example, when the configuration is like this:
-
-```json
-{
-    "rules": {
-        "no-implicit-coercion": [2, {
-            "boolean": true,
-            "number": true,
-            "string": true,
-            "allow": ["!!", "~"]
-        }]
-    }
-}
-```
-
-The following patterns are not considered problems:
+Examples of **correct** code for the sample `{ "allow": ["!!", "~"] }` option:
 
 ```js
+/*eslint no-implicit-coercion: [2, { "allow": ["!!", "~"] } ]*/
+
 var b = !!foo;
-var c = ~foo.indexOf(".");
+var b = ~foo.indexOf(".");
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-implicit-globals.md
+++ b/docs/rules/no-implicit-globals.md
@@ -6,7 +6,7 @@ When working with browser scripts, developers often forget that variable and fun
 
 This rule disallows `var` and named `function` declarations at the top-level script scope. This does not apply to ES and CommonJS modules since they have a module scope.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -16,7 +16,7 @@ var foo = 1;
 function bar() {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-implicit-globals: "error"*/
@@ -33,8 +33,10 @@ window.bar = function() {};
 })();
 ```
 
+Examples of **correct** code for this rule with `"parserOptions": { "sourceType": "module" }` in the ESLint configuration:
+
 ```js
-/*eslint modules: true*/
+/*eslint no-implicit-globals: 2*/
 
 // foo and bar are local to module
 var foo = 1;

--- a/docs/rules/no-implied-eval.md
+++ b/docs/rules/no-implied-eval.md
@@ -24,7 +24,7 @@ The best practice is to always use a function for the first argument of `setTime
 
 This rule aims to eliminate implied `eval()` through the use of `setTimeout()`, `setInterval()` or `execScript()`. As such, it will warn when either function is used with a string as the first argument.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-implied-eval: "error"*/
@@ -40,7 +40,7 @@ window.setTimeout("count = 5", 10);
 window.setInterval("foo = bar", 10);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-implied-eval: "error"*/

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -27,14 +27,16 @@ And this rule allows `this` keywords in functions below:
 
 Otherwise are considered problems.
 
-The following patterns are considered problems:
+This rule applies **only** in strict mode.
+With `"parserOptions": { "sourceType": "module" }` in the ESLint configuration, your code is in strict mode even without a `"use strict"` directive.
 
-This rule warns below **only** under the strict mode.
-Please note your code in ES2015 Modules/Classes is always the strict mode.
+Examples of **incorrect** code for this rule in strict mode:
 
 ```js
 /*eslint no-invalid-this: "error"*/
 /*eslint-env es6*/
+
+"use strict";
 
 this.a = 0;
 baz(() => this);
@@ -80,11 +82,13 @@ foo.forEach(function() {
 });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule in strict mode:
 
 ```js
 /*eslint no-invalid-this: "error"*/
 /*eslint-env es6*/
+
+"use strict";
 
 function Foo() {
     // OK, this is in a legacy style constructor.

--- a/docs/rules/no-iterator.md
+++ b/docs/rules/no-iterator.md
@@ -14,7 +14,7 @@ You should use ECMAScript 6 iterators and generators instead.
 
 This rule is aimed at preventing errors that may arise from using the `__iterator__` property, which is not implemented in several browsers. As such, it will warn whenever it encounters the `__iterator__` property.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-iterator: "error"*/
@@ -29,7 +29,7 @@ foo["__iterator__"] = function () {};
 
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-iterator: "error"*/

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -20,7 +20,7 @@ While convenient in some cases, labels tend to be used only rarely and are frown
 
 This rule aims to eliminate the use of labeled statements in JavaScript. It will warn whenever a labeled statement is encountered and whenever `break` or `continue` are used with a label.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-labels: "error"*/
@@ -57,7 +57,7 @@ label:
     }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-labels: "error"*/
@@ -77,11 +77,7 @@ while (true) {
 
 ## Options
 
-```json
-{
-    "no-labels": ["error", {"allowLoop": false, "allowSwitch": false}]
-}
-```
+The options allow labels with loop or switch statements:
 
 * `"allowLoop"` (`boolean`, default is `false`) - If this option was set `true`, this rule ignores labels which are sticking to loop statements.
 * `"allowSwitch"` (`boolean`, default is `false`) - If this option was set `true`, this rule ignores labels which are sticking to switch statements.
@@ -89,29 +85,25 @@ while (true) {
 Actually labeled statements in JavaScript can be used with other than loop and switch statements.
 However, this way is ultra rare, not well-known, so this would be confusing developers.
 
-Those options allow us to use labels only with loop or switch statements.
+### allowLoop
 
-The following patterns are considered problems when configured `{"allowLoop": true, "allowSwitch": true}`:
-
-```js
-label:
-    {
-        break label;
-    }
-
-label:
-    if (a) {
-        break label;
-    }
-```
-
-The following patterns are not considered problems when configured `{"allowLoop": true, "allowSwitch": true}`:
+Examples of **correct** code for the { "allowLoop": true } option:
 
 ```js
+/*eslint no-labels: ["error", { "allowLoop": true }]*/
+
 label:
     while (true) {
         break label;
     }
+```
+
+### allowSwitch
+
+Examples of **correct** code for the { "allowSwitch": true } option:
+
+```js
+/*eslint no-labels: ["error", { "allowSwitch": true }]*/
 
 label:
     switch (a) {

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -14,7 +14,7 @@ In ES6, code blocks may create a new scope if a block-level binding (`let` and `
 
 This rule aims to eliminate unnecessary and potentially confusing blocks at the top level of a script or within other blocks.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-lone-blocks: "error"*/
@@ -44,11 +44,11 @@ function bar() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with es6 environment:
 
 ```js
-/*eslint-env es6*/
 /*eslint no-lone-blocks: "error"*/
+/*eslint-env es6*/
 
 while (foo) {
     bar();
@@ -80,11 +80,12 @@ aLabel: {
 }
 ```
 
-In strict mode, the following will not warn:
+Examples of **correct** code for this rule with es6 environment and strict mode via `"parserOptions": { "sourceType": "module" }` in the ESLint configuration or `"use strict"` directive in the code:
 
 ```js
-/*eslint-env es6*/
 /*eslint no-lone-blocks: "error"*/
+/*eslint-env es6*/
+
 "use strict";
 
 {


### PR DESCRIPTION
2 of 4 pull requests for rules under **Best Practices**

What do you think about the wording of these example sentences?
* no-implicit-globals: Examples of correct code for this rule with `"parserOptions": { "sourceType": "module" }` in the ESLint configuration:
* no-invalid-this: Examples of incorrect code for this rule in strict mode:
* no-long-blocks: Examples of correct code for this rule with es6 environment and strict mode via `"parserOptions": { "sourceType": "module" }` in the ESLint configuration or `"use strict"` directive in the code:

The 2 items below which have **Reviewers** questions deserve a careful look please.

Here are the changes beyond example sentences:
* no-empty-function: add eslint-env comments; delete json
* no-empty-pattern: add js to code fences in introduction
* no-eval: add eslint-env comment
* no-extend-native: convert first bullet list to correct code; move second bullet list to Known Limitations; delete json; add correct code to exceptions option; add to list of *missing* correct code
* no-fallthrough: add regexp for fallthrough comment to explain seemingly redundant intro examples
* no-floating-decimal: add third assignment to make correct code parallel to incorrect
* no-implicit-coercion: make variables in example code consistent with introduction; eslint comment instead of json for allow option
* no-implicit-globals: replace invalid eslint comment for second correct code
* no-invalid-this: add strict mode directive to code; move sentence about strict mode **Reviewers** is the sentence correct and clear? even for Node.js? does the strict mode directive improve the example code?
* no-labels: move sentence to beginning of Options; delete json; delete incorrect code under Options; split correct code
* no-lone-blocks: **Reviewers** why strict mode is relevant to the last correct example is beyond my Pooh Bear brain (although I verified that it is needed) so please make sure this is correct and clear!
