### PR TITLE
Docs: no-unused-expressions - add more edge unusable and usable examples

### DIFF
--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -3,20 +3,22 @@
 Unused expressions are those expressions that evaluate to a value but are never used. For example:
 
 ```js
-"Hello world";
+n + 1;
 ```
 
-This string is a valid JavaScript expression, but isn't actually used. Even though it's not a syntax error it is clearly a logic error and it has no effect on the code being executed.
+This is a valid JavaScript expression, but isn't actually used. Even though it's not a syntax error it is clearly a logic error and it has no effect on the code being executed.
 
 ## Rule Details
 
 This rule aims to eliminate unused expressions. The value of an expression should always be used, except in the case of expressions that side effect: function calls, assignments, and the `new` operator.
 
-**Note:** Sequence expressions (those using a comma, such as `a = 1, b = 2`) are always considered unused unless their return value is assigned or a function call is made with the sequence expression value.
+Note that sequence expressions (those using a comma, such as `a = 1, b = 2`) are always considered unused unless their return value is assigned or used in a condition evaluation, or a function call is made with the sequence expression value.
+
+Please also note that this rule does not apply to directives (which are in the form of literal string expressions (e.g., `"use strict";`) at the beginning of a script, module, or function).
 
 ## Options
 
-This rule, in it's default state, does not require any arguments. If you would like to enable one or more of the following you may pass an object with the options set as follows:
+This rule, in its default state, does not require any arguments. If you would like to enable one or more of the following you may pass an object with the options set as follows:
 
 * `allowShortCircuit` set to `true` will allow you to use short circuit evaluations in your expressions (Default: `false`).
 * `allowTernary` set to `true` will enable you use ternary operators in your expressions similarly to short circuit evaluations (Default: `false`).
@@ -39,6 +41,21 @@ a && b()
 a, b()
 
 c = a, b;
+
+a() && function namedFunctionInExpressionContext () {f();}
+
+(function anIncompleteIIFE () {});
+
+```
+
+Note that one or more string expression statements (with or without semi-colons) will only be considered as unused if they are not in the beginning of a script, module, or function (alone and uninterrupted by other statements). Otherwise, they will be treated as part of a "directive prologue", a section potentially usable by JavaScript engines. This includes "strict mode" directives.
+
+```js
+"use strict";
+"use asm"
+"use stricter";
+"use babel"
+"any other strings like this in the prologue";
 ```
 
 The following patterns are not considered problems by default:
@@ -46,7 +63,13 @@ The following patterns are not considered problems by default:
 ```js
 /*eslint no-unused-expressions: 2*/
 
-{}
+{} // In this context, this is a block statement, not an object literal
+
+{myLabel: someVar} // In this context, this is a block statement with a label and expression, not an object literal
+
+function namedFunctionDeclaration () {}
+
+(function aGenuineIIFE () {}());
 
 f()
 


### PR DESCRIPTION
Avoid using string as example of unusable since it could be a directive depending on context