### PR TITLE
Fix: newline-before-return: bug with comment (fixes: 5480)

### DIFF
--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -75,6 +75,23 @@ module.exports = function(context) {
         }
 
         comments.forEach(function(comment) {
+            // https://github.com/eslint/eslint/pull/5512
+            /*
+                function main() {
+                  var test = {
+                    //
+                  };
+
+                  //
+                  return 1;
+                }
+                on the code block above number of comment lines are miscalculated
+                sourceCode.getComments(node).leading method also counts comment lines inside block expression
+                if there are no other expressions between return and block
+            */
+            if (comment.loc.start.line < tokenBefore.loc.end.line) {
+                return;
+            }
             numLinesComments++;
 
             if (comment.type === "Block") {

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -53,6 +53,7 @@ ruleTester.run("newline-before-return", rule, {
         "function a() {\nfor (b in c) { return; }\n}",
         "function a() {\nfor (b in c) {\nreturn;\n}\n}",
         "function a() {\nfor (b in c) {\nd();\n\nreturn;\n}\n}",
+        "function a() {\nvar b = {\n//comment\n};\n\nreturn;\n}",
         {
             code: "function a() {\nfor (b of c) return;\n}",
             parserOptions: { ecmaVersion: 6 }


### PR DESCRIPTION
I think problem occurs because sourceCode.getComments(node).leading miscalculates, this is a quick fix.