### PR TITLE
Docs: Minor README clarifications

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -2,7 +2,7 @@
 
 Rules in ESLint are divided into several categories to help you better understand their value. All rules are disabled by default. ESLint recommends some rules to catch common problems, and you can use these recommended rules by including `extends: "eslint:recommended"` in your configuration file. The rules that will be enabled when you inherit from `eslint:recommended` are indicated below as "(recommended)". For more information on how to configure rules and use `extends`, please see the [configuration documentation](../user-guide/configuring.md).
 
-Some rules are fixable using the `--fix` command line flag. Those rules are marked as "(fixable)" below. Currently these fixes are limited only to whitespace fixes.
+Some rules are fixable using the `--fix` command line flag. Those rules are marked as "(fixable)" below. Currently these fixes are mostly limited only to whitespace fixes.
 
 ## Possible Errors
 
@@ -257,7 +257,7 @@ These rules existed in a previous version of ESLint but have since been replaced
 * [no-empty-class](no-empty-class.md) - disallow the use of empty character classes in regular expressions (replaced by [no-empty-character-class](no-empty-character-class.md))
 * [no-empty-label](no-empty-label.md) - disallow use of labels for anything other than loops and switches (replaced by [no-labels](no-labels.md))
 * [no-extra-strict](no-extra-strict.md) - disallow unnecessary use of `"use strict";` when already in strict mode (replaced by [strict](strict.md))
-* [no-reserved-keys](no-reserved-keys.md) - disallow reserved words being used as object literal keys
+* [no-reserved-keys](no-reserved-keys.md) - disallow reserved words being used as object literal keys (replaced by [quote-props](quote-props.md))
 * [no-space-before-semi](no-space-before-semi.md) - disallow space before semicolon (replaced by [semi-spacing](semi-spacing.md))
 * [no-wrap-func](no-wrap-func.md) - disallow wrapping of non-IIFE statements in parens (replaced by [no-extra-parens](no-extra-parens.md))
 * [space-after-function-name](space-after-function-name.md) - require a space after function names (replaced by [space-before-function-paren](space-before-function-paren.md))


### PR DESCRIPTION
Fixable rules are mostly limited to whitespace fixes; indicate no-reserved-keys replacement as quote-props