### PR TITLE
New: add "max-len", "max-lines" to arrow-body-style (refs: #5504)

### DIFF
--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -8,10 +8,16 @@ This rule can enforce the use of braces around arrow function body.
 
 ## Options
 
-The rule takes one option, a string, which can be:
+The rule takes two options, a string, which can be:
 
 * `"always"` enforces braces around the function body
 * `"as-needed"` enforces no braces where they can be omitted (default)
+
+and an object with values that apply when `"as-needed"` is applied:
+
+* `"max-len"` enforces braces around arrow functions of any line length exceeding a number of characters, excluding trailing or leading whitespace on each line
+* `"max-lines"` enforces braces around arrow functions exceeding a number of lines
+* `"include-args"` include arguments in whichever or both of these applied limitations
 
 ### "always"
 
@@ -68,5 +74,113 @@ let foo = () => {};
 let foo = () => { /* do nothing */ };
 let foo = () => {
     // do nothing.
+};
+```
+
+### "max-len"
+
+When the rule `"as-needed"` is applied in addition to an object with a key of `"max-len"`, the following patterns are considered problems:
+
+```js
+/*eslint arrow-body-style: [2, "as-needed", { "max-len": 30  }]*/
+/*eslint-env es6*/
+
+var foo = () => Promise.resolve(bar()).then(bar).then(bar);
+var foo = () => Promise.resolve(bar())
+    .then(bar)
+    .then(bar);
+var foo = () => {
+    return bar();
+};
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint arrow-body-style: [2, "as-needed", { "max-len": 30  }]*/
+/*eslint-env es6*/
+
+var foo = () => bar();
+var foo = () => {
+    return Promise.resolve(bar()).then(bar).then(bar);
+};
+```
+
+### "max-lines"
+
+When the rule `"as-needed"` is applied in addition to an object with a key of `"max-lines"`, the following patterns are considered problems:
+
+```js
+/*eslint arrow-body-style: [2, "as-needed", { "max-lines": 2 }]*/
+/*eslint-env es6*/
+
+var foo = () => Promise.resolve(bar())
+    .then(bar)
+    .then(bar);
+var foo = () => {
+    return bar();
+}
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint arrow-body-style: [2, "as-needed", { "max-lines": 2 }]*/
+/*eslint-env es6*/
+
+var foo = () => bar();
+var foo = () => Promise.resolve(bar()).then(bar).then(bar);
+var foo = () => {
+    return Promise.resolve(bar())
+        .then(bar)
+        .then(bar);
+};
+```
+
+### "include-args"
+
+When either `"max-len"` or `"max-lines"` are applied, `"include-args"` brings the function parameters into the code which is being checked for length requirements.
+`"include-args"` defaults to false.
+The following patterns are considered problems (for both `"max-lines"` and `"max-len"`):
+
+```js
+/*eslint arrow-body-style: [2, "as-needed", { "max-lines": 1, "max-len": 15, "include-args": true }]*/
+/*eslint-env es6*/
+
+var foo = ({
+    bar: bar,
+    baz: baz
+}) => bar + baz;
+var foo = (bar, baz) =>
+    bar(baz());
+```
+
+`"include-args"` defaults to false so that the following patterns are not considered problems:
+
+```js
+/*eslint arrow-body-style: [2, "as-needed", { "max-lines": 1, "max-len": 15 }]*/
+/*eslint-env es6*/
+
+var foo = ({
+    bar: bar,
+    baz: baz
+}) => bar + baz;
+var foo = (bar, baz) => bar(baz());
+```
+
+With `true` these patterns are also not considered problems:
+
+```js
+/*eslint arrow-body-style: [2, "as-needed", { "max-lines": 1, "max-len": 15, "include-args": true }]*/
+/*eslint-env es6*/
+
+var foo = ({
+    bar: bar,
+    baz: baz
+}) => {
+    return bar + baz;
+};
+var foo = (bar, baz) => {
+    return bar(baz());
 };
 ```

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -6,13 +6,52 @@
  */
 "use strict";
 
+var lodash = require("lodash");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    /**
+     * Computes the length of an arrow function not including
+     * leading or trailing whitespace.
+     * @param {array} lines An array of source code lines, either including or excluding function declaration
+     * @returns {int} The computed length of an arrow function
+     * @private
+     */
+    function computeBodyLength(lines) {
+        var body = lodash.reduce(lines, function(acc, line) {
+            // trim whitespace and tabs
+            return acc + line.trim().replace("\t", "");
+        }, "");
+        return body.length;
+    }
+
+    /**
+     * Returns Included lines based on if the declaration should be included
+     * in the restrictions
+     * @param {array} lines An array of source code lines
+     * @param {object} start starting line and column
+     * @param {object} end ending line and column
+     * @returns {array} lines without function declaration
+     * @private
+     */
+    function getIncludedLines(lines, start, end) {
+        // If the starting and ending lines are the same, simply return one line
+        // with sliced at the starting and ending columns
+        if (start.line === end.line) {
+            return [lines[start.line - 1].slice(start.column, end.column)];
+        }
+        var first = lines[start.line - 1].slice(start.column);
+        var last = lines[end.line - 1].slice(0, end.column);
+        var rest = lines.slice(start.line, end.line - 1);
+        return [first].concat(rest, last);
+    }
+
     var always = context.options[0] === "always";
     var asNeeded = !context.options[0] || context.options[0] === "as-needed";
+    var lengthRequirements = context.options[1] || false;
 
     /**
      * Determines whether a arrow function body needs braces
@@ -20,28 +59,81 @@ module.exports = function(context) {
      * @returns {void}
      */
     function validate(node) {
+
         var arrowBody = node.body;
-        if (arrowBody.type === "BlockStatement") {
-            var blockBody = arrowBody.body;
-
-            if (blockBody.length !== 1) {
-                return;
-            }
-
-            if (asNeeded && blockBody[0].type === "ReturnStatement") {
+        // Arrow body is or is not a block statement
+        var isBlock = arrowBody.type === "BlockStatement";
+        // Immediate return if arrow body is not a block and always is applied
+        if (!isBlock && always) {
+            context.report({
+                node: node,
+                loc: arrowBody.loc.start,
+                message: "Expected block statement surrounding arrow body."
+            });
+            return;
+        }
+        // Everything below this check applies only if asNeeded is applied
+        // and the source's body is not an empty block
+        var functionBody = arrowBody.body;
+        if (!asNeeded || (isBlock && functionBody.length !== 1)) {
+            return;
+        }
+        // If the first element of an arrow body is a return statement then it is unexpected
+        // unless length requirements justify this return
+        var functionBodyIsReturn = lodash.get(functionBody, "[0].type") === "ReturnStatement";
+        var unexpectedBlock = isBlock && functionBodyIsReturn;
+        if (unexpectedBlock && !lengthRequirements) {
+            context.report({
+                node: node,
+                loc: arrowBody.loc.start,
+                message: "Unexpected block statement surrounding arrow body."
+            });
+            return;
+        }
+        if (lengthRequirements) {
+            // Get maxLen, maxLines and includeArgs from lengthRequirements, defaulting to undefined
+            var maxLen = typeof lengthRequirements["max-len"] === "number"
+                && lengthRequirements["max-len"];
+            var maxLines = typeof lengthRequirements["max-lines"] === "number"
+                && lengthRequirements["max-lines"];
+            var includeArgs = lengthRequirements["include-args"] || false;
+            var source = context.getSourceCode();
+            // Start location of body based on if arguments should be included or not
+            var start = (includeArgs && node.params)
+                ? node.params[0].loc.start
+                // Find the arrow token itself and use the end of it as a starting point
+                : lodash.find(source.getTokens(node), { value: "=>" }).loc.end;
+            var end = (arrowBody.type === "ArrowFunctionExpression" || arrowBody.type === "FunctionExpression")
+                ? arrowBody.loc.start
+                : arrowBody.loc.end;
+            // Calculate lines from context
+            var lines = source.getLines();
+            var includedLines = getIncludedLines(lines, start, end);
+            // Determine if the body or params + body are above the provided maximums
+            var aboveMaxLen = maxLen && computeBodyLength(includedLines) > maxLen;
+            var aboveMaxLines = maxLines && includedLines.length > maxLines;
+            // Unexpected block check again, but now we know that the provided maximums
+            // are not violated and that this block is indeed unexpected
+            if (unexpectedBlock && !aboveMaxLen && !aboveMaxLines) {
                 context.report({
                     node: node,
-                    loc: arrowBody.loc.start,
+                    loc: start,
                     message: "Unexpected block statement surrounding arrow body."
                 });
-            }
-        } else {
-            if (always) {
-                context.report({
-                    node: node,
-                    loc: arrowBody.loc.start,
-                    message: "Expected block statement surrounding arrow body."
-                });
+            } else if (!unexpectedBlock) {
+                if (aboveMaxLen) {
+                    context.report({
+                        node: node,
+                        loc: start,
+                        message: "Arrow function exceeds maximum characters and requires block formatting."
+                    });
+                } else if (aboveMaxLines) {
+                    context.report({
+                        node: node,
+                        loc: start,
+                        message: "Arrow function exceeds maximum number of lines and requires block formatting."
+                    });
+                }
             }
         }
     }
@@ -54,5 +146,19 @@ module.exports = function(context) {
 module.exports.schema = [
     {
         "enum": ["always", "as-needed"]
+    },
+    {
+        "type": "object",
+        "properties": {
+            "max-len": {
+                "type": "number"
+            },
+            "max-lines": {
+                "type": "number"
+            },
+            "include-args": {
+                "type": "boolean"
+            }
+        }
     }
 ];

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -31,7 +31,35 @@ ruleTester.run("arrow-body-style", rule, {
         { code: "var foo = () => { b = a };", parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = () => { bar: 1 };", parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = () => { return 0; };", parserOptions: { ecmaVersion: 6 }, options: ["always"] },
-        { code: "var foo = () => { return bar(); };", parserOptions: { ecmaVersion: 6 }, options: ["always"] }
+        { code: "var foo = () => { return bar(); };", parserOptions: { ecmaVersion: 6 }, options: ["always"] },
+        { code: "var foo = () => bar();", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", { "max-len": 30 }] },
+        { code: "var foo = () => () => {\n    return bar();\n};", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", { "max-lines": 1 }] },
+        { code: "var foo = () => function() {\n    return bar();\n};", parserOptions: { ecmaVersion: 6 }, options: ["as-needed", { "max-lines": 1 }] },
+        {
+            code: "var foo = () => { return Promise.resolve(bar()).then(bar).then(bar); }",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-len": 30 }]
+        },
+        {
+            code: "var foo = () =>\n    Promise\n    .resolve(bar())\n    .then(bar);",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-len": 33 }]
+        },
+        {
+            code: "var foo = () =>\n    Promise\n    .resolve(bar())\n    .then(bar);",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-len": 33, "max-lines": 5 }]
+        },
+        {
+            code: "var foo = () => {\nreturn Promise.resolve(bar())\n.then(bar)\n.then(bar);\n}",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-lines": 2 }]
+        },
+        {
+            code: "var foo = ({\n\tbar: bar,\n\tbaz: baz\n}) => bar + baz",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-lines": 1 }]
+        }
     ],
     invalid: [
         {
@@ -39,7 +67,7 @@ ruleTester.run("arrow-body-style", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: ["always"],
             errors: [
-                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
+              { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
             ]
         },
         {
@@ -55,7 +83,7 @@ ruleTester.run("arrow-body-style", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
-                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+              { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
         },
         {
@@ -63,7 +91,63 @@ ruleTester.run("arrow-body-style", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
-                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+              { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => { return bar(); };",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-len": 30 }],
+            errors: [
+              { line: 1, column: 16, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => Promise.resolve(bar()).then(bar).then(bar);",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-len": 30 }],
+            errors: [
+              { line: 1, column: 16, type: "ArrowFunctionExpression", message: "Arrow function exceeds maximum characters and requires block formatting." }
+            ]
+        },
+        {
+            code: "var foo = () => Promise.resolve(bar())\n.then(bar)\n.then(bar);",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-lines": 2 }],
+            errors: [
+              { line: 1, column: 16, type: "ArrowFunctionExpression", message: "Arrow function exceeds maximum number of lines and requires block formatting." }
+            ]
+        },
+        {
+            code: "var foo = () => Promise.resolve(bar())\n.then(bar)\n.then(bar);",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-lines": 2, "max-len": 100 }],
+            errors: [
+              { line: 1, column: 16, type: "ArrowFunctionExpression", message: "Arrow function exceeds maximum number of lines and requires block formatting." }
+            ]
+        },
+        {
+            code: "var foo = (bar, baz) => bar(baz());",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-len": 15, "include-args": true }],
+            errors: [
+              { line: 1, column: 12, type: "ArrowFunctionExpression", message: "Arrow function exceeds maximum characters and requires block formatting." }
+            ]
+        },
+        {
+            code: "var foo = ({\n\tbar: bar,\n\tbaz: baz\n}) => bar + baz",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-lines": 1, "include-args": true }],
+            errors: [
+              { line: 1, column: 12, type: "ArrowFunctionExpression", message: "Arrow function exceeds maximum number of lines and requires block formatting." }
+            ]
+        },
+        {
+            code: "var foo = () =>\n    () => {\n    return bar();\n};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", { "max-lines": 1 }],
+            errors: [
+                { line: 1, column: 16, type: "ArrowFunctionExpression", message: "Arrow function exceeds maximum number of lines and requires block formatting." }
             ]
         }
     ]


### PR DESCRIPTION
Added an object with "max-len", "max-lines", and "include-args" to arrow-body-style rule so that the length of the arrow body and/or the length of the arguments could dictate requiring a block. The case for this is extremely long chains or function signatures, due to destructuring etc., which may become confusing without block notation. I have updated the readme to show failing patterns, but here are a few motivating examples:
```js
/*eslint arrow-body-style: [2, "as-needed", { "max-lines": 2 }]*/
/*eslint-env es6*/

var foo = () => Promise.resolve(bar())
    .then(bar)
    .then(bar);

/*eslint arrow-body-style: [2, "as-needed", { "max-lines": 1, "max-len": 15, "include-args": true }]*/
/*eslint-env es6*/

var foo = ({
    bar: bar,
    baz: baz
}) => bar + baz;
var foo = (bar, baz) =>
    bar(baz());
```

Thanks! and let me know if I can clarify or improve anything.