### PR TITLE
Docs: no-lone-blocks - show non-problematic (and problematic) label

### DIFF
--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -37,6 +37,11 @@ function bar() {
 {
     function foo() {}
 }
+
+{
+    aLabel: {
+    }
+}
 ```
 
 The following patterns are not considered problems:
@@ -69,6 +74,9 @@ function bar() {
 
 {
     class Foo {}
+}
+
+aLabel: {
 }
 ```
 


### PR DESCRIPTION
Had been wondering whether labels would be problematic, so wanted to show they weren't (unless included themselves within a block).