### PR TITLE
New: max-statements-per-line (fixes #5424)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -164,6 +164,7 @@
         "max-nested-callbacks": "off",
         "max-params": "off",
         "max-statements": "off",
+        "max-statements-per-line": "off",
         "new-cap": "off",
         "new-parens": "off",
         "newline-after-var": "off",

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -172,6 +172,7 @@ These rules are purely matters of style and are quite subjective.
 * [max-nested-callbacks](max-nested-callbacks.md): specify the maximum depth callbacks can be nested
 * [max-params](max-params.md): specify the number of parameters that can be used in the function declaration
 * [max-statements](max-statements.md): specify the maximum number of statement allowed in a function
+* [max-statements-per-line](max-statements-per-line.md): specify the maximum number of statements allowed per line
 * [new-cap](new-cap.md): require a capital letter for constructors
 * [new-parens](new-parens.md): disallow the omission of parentheses when invoking a constructor with no arguments
 * [newline-after-var](newline-after-var.md): require or disallow an empty newline after variable declarations

--- a/docs/rules/max-statements-per-line.md
+++ b/docs/rules/max-statements-per-line.md
@@ -1,0 +1,86 @@
+# Specify the Maximum Number of Statements Allowed per Line (max-statements-per-line)
+
+A line of code containing too many statements can be difficult to read. Code is generally read from the top down, especially when scanning, so limiting the number of statements allowed on a single line can be very beneficial for readability and maintainability.
+
+```js
+function () { var bar; if (condition) { bar = 1; } else { bar = 2; } return true; } // too many statements
+```
+
+## Rule Details
+
+This rule allows you to configure the maximum number of statements allowed per line.
+
+## Options
+
+### max
+
+The "max" object property is optional (default: 1).
+
+Examples of **incorrect** code for this rule with the default `{ "max": 1 }` option:
+
+```js
+/*eslint max-statements-per-line: ["error", { "max": 1 }]*/
+
+var bar; var baz;
+if (condition) { bar = 1; }
+for (var i = 0; i < length; ++i) { bar = 1; }
+switch (discriminant) { default: break; }
+function foo() { bar = 1; }
+var foo = function foo() { bar = 1; };
+(function foo() { bar = 1; })();
+```
+
+Examples of **correct** code for this rule with the default `{ "max": 1 }` option:
+
+```js
+/*eslint max-statements-per-line: ["error", { "max": 1 }]*/
+
+var bar, baz;
+if (condition) bar = 1;
+for (var i = 0; i < length; ++i);
+switch (discriminant) { default: }
+function foo() { }
+var foo = function foo() { };
+(function foo() { })();
+```
+
+Examples of **incorrect** code for this rule with a sample `{ "max": 2 }` option:
+
+```js
+/*eslint max-statements-per-line: ["error", { "max": 2 }]*/
+
+var bar; var baz; var qux;
+if (condition) { bar = 1; } else { baz = 2; }
+for (var i = 0; i < length; ++i) { bar = 1; baz = 2; }
+switch (discriminant) { case 'test': break; default: break; }
+function foo() { bar = 1; baz = 2; }
+var foo = function foo() { bar = 1; };
+(function foo() { bar = 1; baz = 2; })();
+```
+
+Examples of **correct** code for this rule with a sample `{ "max": 2 }` option:
+
+```js
+/*eslint max-statements-per-line: ["error", { "max": 2 }]*/
+
+var bar; var baz;
+if (condition) bar = 1; if (condition) baz = 2;
+for (var i = 0; i < length; ++i) { bar = 1; }
+switch (discriminant) { default: break; }
+function foo() { bar = 1; }
+var foo = function foo() { bar = 1; };
+(function foo() { var bar = 1; })();
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the number of statements on each line.
+
+## Related Rules
+
+* [complexity](complexity.md)
+* [max-depth](max-depth.md)
+* [max-len](max-len.md)
+* [max-nested-callbacks](max-nested-callbacks.md)
+* [max-params](max-params.md)
+* [max-statements](max-statements.md)

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Specify the maximum number of statements allowed per line.
+ * @author Kenneth Williams
+ * @copyright 2016 Kenneth Williams. All rights reserved.
+ * @copyright 2016 Michael Ficarra. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = function(context) {
+
+    var options = context.options[0] || {},
+        lastStatementLine = 0,
+        numberOfStatementsOnThisLine = 0,
+        maxStatementsPerLine = typeof options.max !== "undefined" ? options.max : 1;
+
+    //--------------------------------------------------------------------------
+    // Helpers
+    //--------------------------------------------------------------------------
+
+    /**
+     * Reports a node
+     * @param {ASTNode} node The node to report
+     * @returns {void}
+     * @private
+     */
+    function report(node) {
+        context.report(
+            node,
+            "This line has too many statements. Maximum allowed is {{max}}.",
+            { max: maxStatementsPerLine });
+    }
+
+    /**
+     * Enforce a maximum number of statements per line
+     * @param {ASTNode} nodes Array of nodes to evaluate
+     * @returns {void}
+     * @private
+     */
+    function enforceMaxStatementsPerLine(nodes) {
+        if (nodes.length < 1) {
+            return;
+        }
+
+        for (var i = 0, l = nodes.length; i < l; ++i) {
+            var currentStatement = nodes[i];
+            if (currentStatement.loc.start.line === lastStatementLine) {
+                ++numberOfStatementsOnThisLine;
+            } else {
+                numberOfStatementsOnThisLine = 1;
+                lastStatementLine = currentStatement.loc.end.line;
+            }
+            if (numberOfStatementsOnThisLine === maxStatementsPerLine + 1) {
+                report(currentStatement);
+            }
+        }
+    }
+
+    /**
+     * Check each line in the body of a node
+     * @param {ASTNode} node node to evaluate
+     * @returns {void}
+     * @private
+     */
+    function checkLinesInBody(node) {
+        enforceMaxStatementsPerLine(node.body);
+    }
+
+    /**
+     * Check each line in the consequent of a switch case
+     * @param {ASTNode} node node to evaluate
+     * @returns {void}
+     * @private
+     */
+    function checkLinesInConsequent(node) {
+        enforceMaxStatementsPerLine(node.consequent);
+    }
+
+    //--------------------------------------------------------------------------
+    // Public API
+    //--------------------------------------------------------------------------
+
+    return {
+        "Program": checkLinesInBody,
+        "BlockStatement": checkLinesInBody,
+        "SwitchCase": checkLinesInConsequent
+    };
+
+};
+
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "max": {
+                "type": "integer"
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/max-statements-per-line.js
+++ b/tests/lib/rules/max-statements-per-line.js
@@ -1,0 +1,111 @@
+/**
+ * @fileoverview Tests for max-statements-per-line rule.
+ * @author Kenneth Williams
+ * @copyright 2016 Kenneth Williams. All rights reserved.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/max-statements-per-line"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+ruleTester.run("max-statements-per-line", rule, {
+    valid: [
+        { code: "", options: [{ "max": 0 }] },
+        { code: "{ }", options: [{ "max": 1 }] },
+        { code: "var bar = 1;" },
+        { code: "var bar = 1;", options: [{ "max": 1 }] },
+        { code: "if (condition) var bar = 1;", options: [{ "max": 1 }] },
+        { code: "if (condition) { }", options: [{ "max": 1 }] },
+        { code: "if (condition) { } else { }", options: [{ "max": 1 }] },
+        { code: "if (condition) {\nvar bar = 1;\n} else {\nvar bar = 1;\n}", options: [{ "max": 1 }] },
+        { code: "for (var i = 0; i < length; ++i) { }", options: [{ "max": 1 }] },
+        { code: "for (var i = 0; i < length; ++i) {\nvar bar  = 1;\n}", options: [{ "max": 1 }] },
+        { code: "switch (discriminant) { default: }", options: [{ "max": 1 }] },
+        { code: "switch (discriminant) {\ndefault: break;\n}", options: [{ "max": 1 }] },
+        { code: "function foo() { }", options: [{ "max": 1 }] },
+        { code: "function foo() {\nif (condition) var bar = 1;\n}", options: [{ "max": 1 }] },
+        { code: "function foo() {\nif (condition) {\nvar bar = 1;\n}\n}", options: [{ "max": 1 }] },
+        { code: "(function() { })();", options: [{ "max": 1 }] },
+        { code: "(function() {\nvar bar = 1;\n})();", options: [{ "max": 1 }] },
+        { code: "var foo = function foo() { };", options: [{ "max": 1 }] },
+        { code: "var foo = function foo() {\nvar bar = 1;\n};", options: [{ "max": 1 }] },
+        { code: "var foo = { prop: () => { } };", options: [{ "max": 1 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var bar = 1; var baz = 2;", options: [{ "max": 2 }] },
+        { code: "if (condition) { var bar = 1; }", options: [{ "max": 2 }] },
+        { code: "if (condition) {\nvar bar = 1; var baz = 2;\n} else {\nvar bar = 1; var baz = 2;\n}", options: [{ "max": 2 }] },
+        { code: "for (var i = 0; i < length; ++i) { var bar = 1; }", options: [{ "max": 2 }] },
+        { code: "for (var i = 0; i < length; ++i) {\nvar bar = 1; var baz = 2;\n}", options: [{ "max": 2 }] },
+        { code: "switch (discriminant) { default: break; }", options: [{ "max": 2 }] },
+        { code: "switch (discriminant) {\ncase 'test': var bar = 1; break;\ndefault: var bar = 1; break;\n}", options: [{ "max": 2 }] },
+        { code: "function foo() { var bar = 1; }", options: [{ "max": 2 }] },
+        { code: "function foo() {\nvar bar = 1; var baz = 2;\n}", options: [{ "max": 2 }] },
+        { code: "function foo() {\nif (condition) { var bar = 1; }\n}", options: [{ "max": 2 }] },
+        { code: "function foo() {\nif (condition) {\nvar bar = 1; var baz = 2;\n}\n}", options: [{ "max": 2 }] },
+        { code: "(function() { var bar = 1; })();", options: [{ "max": 2 }] },
+        { code: "(function() {\nvar bar = 1; var baz = 2;\n})();", options: [{ "max": 2 }] },
+        { code: "var foo = function foo() { var bar = 1; };", options: [{ "max": 2 }] },
+        { code: "var foo = function foo() {\nvar bar = 1; var baz = 2;\n};", options: [{ "max": 2 }] },
+        { code: "var foo = { prop: () => { var bar = 1; } };", options: [{ "max": 2 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "var bar = 1; var baz = 2; var qux = 3;", options: [{ "max": 3 }] },
+        { code: "if (condition) { var bar = 1; var baz = 2; }", options: [{ "max": 3 }] },
+        { code: "if (condition) { var bar = 1; } else { var bar = 1; }", options: [{ "max": 3 }] },
+        { code: "switch (discriminant) { case 'test1': ; case 'test2': ; }", options: [{ "max": 3 }] },
+        { code: "let bar = bar => { ; }, baz = baz => { ; };", options: [{ "max": 3 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo({[bar => { ; }]: baz = qux => { ; }}) { }", options: [{ "max": 3 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "bar => { ; }, baz => { ; }, qux => { ; };", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "[bar => { ; }, baz => { ; }, qux => { ; }];", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "foo(bar => { ; }, baz => { ; }, qux => { ; });", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "({ bar: bar => { ; }, baz: baz => { ; }, qux: qux => { ; }});", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 } },
+        { code: "(bar => { ; }) ? (baz => { ; }) : (qux => { ; });", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 } }
+    ],
+    invalid: [
+        { code: "{ }", options: [{ "max": 0 }], errors: [{ message: "This line has too many statements. Maximum allowed is 0." }] },
+        { code: "var bar = 1;", options: [{ "max": 0 }], errors: [{ message: "This line has too many statements. Maximum allowed is 0." }] },
+        { code: "var bar = 1; var baz = 2;", errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "var bar = 1; var baz = 2;", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "if (condition) var bar = 1; if (condition) var baz = 2;", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "if (condition) { } if (condition) { }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "if (condition) { var bar = 1; } else { }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "if (condition) { } else { var bar = 1; }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "if (condition) { var bar = 1; } else { var bar = 1; }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "for (var i = 0; i < length; ++i) { var bar = 1; }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "switch (discriminant) { default: break; }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "function foo() { var bar = 1; }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "function foo() { if (condition) var bar = 1; }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "function foo() { if (condition) { var bar = 1; } }", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "(function() { var bar = 1; })();", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "var foo = function foo() { var bar = 1; };", options: [{ "max": 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "var foo = { prop: () => { var bar = 1; } };", options: [{ "max": 1 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "var bar = 1; var baz = 2; var qux = 3;", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "if (condition) { var bar = 1; var baz = 2; }", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "if (condition) { var bar = 1; } else { var bar = 1; }", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "if (condition) { var bar = 1; var baz = 2; } else { var bar = 1; var baz = 2; }", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "for (var i = 0; i < length; ++i) { var bar = 1; var baz = 2; }", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "switch (discriminant) { case 'test': break; default: break; }", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "function foo() { var bar = 1; var baz = 2; }", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "function foo() { if (condition) { var bar = 1; } }", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "(function() { var bar = 1; var baz = 2; })();", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "var foo = function foo() { var bar = 1; var baz = 2; };", options: [{ "max": 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "var foo = { prop: () => { var bar = 1; var baz = 2; } };", options: [{ "max": 2 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] },
+        { code: "var bar = 1; var baz = 2; var qux = 3; var waldo = 4;", options: [{ "max": 3 }], errors: [{ message: "This line has too many statements. Maximum allowed is 3." }] },
+        { code: "if (condition) { var bar = 1; var baz = 2; var qux = 3; }", options: [{ "max": 3 }], errors: [{ message: "This line has too many statements. Maximum allowed is 3." }] },
+        { code: "if (condition) { var bar = 1; var baz = 2; } else { var bar = 1; var baz = 2; }", options: [{ "max": 3 }], errors: [{ message: "This line has too many statements. Maximum allowed is 3." }] },
+        { code: "switch (discriminant) { case 'test': var bar = 1; break; default: var bar = 1; break; }", options: [{ "max": 3 }], errors: [{ message: "This line has too many statements. Maximum allowed is 3." }] },
+        { code: "let bar = bar => { ; }, baz = baz => { ; }, qux = qux => { ; };", options: [{ "max": 3 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 3." }] },
+        { code: "(bar => { ; }) ? (baz => { ; }) : (qux => { ; });", options: [{ "max": 3 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 3." }] },
+        { code: "bar => { ; }, baz => { ; }, qux => { ; }, quux => { ; };", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] },
+        { code: "[bar => { ; }, baz => { ; }, qux => { ; }, quux => { ; }];", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] },
+        { code: "foo(bar => { ; }, baz => { ; }, qux => { ; }, quux => { ; });", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] },
+        { code: "({ bar: bar => { ; }, baz: baz => { ; }, qux: qux => { ; }, quux: quux => { ; }});", options: [{ "max": 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] }
+    ]
+});


### PR DESCRIPTION
Added new rule (`max-statements-per-line`) to enforce a maximum number of statements per line.