### PR TITLE
New: add `--parser-options` to CLI (fixes #5495)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -31,6 +31,7 @@ Basic configuration:
   --ext [String]             Specify JavaScript file extensions - default: .js
   --global [String]          Define global variables
   --parser String            Specify the parser to be used - default: espree
+  --parser-options Object    Specify parser options
 
 Caching:
   --cache                    Only check changed files - default: false
@@ -146,6 +147,15 @@ Examples:
 #### `--parser`
 
 This option allows you to specify a parser to be used by eslint. By default, `espree` will be used.
+
+#### `--parser-options`
+
+This option allows you to specify parser options to be used by eslint.
+
+Examples:
+
+    echo '3 ** 4' | eslint --stdin --parser-options=ecmaVersion:6 # will fail with a parsing error
+    echo '3 ** 4' | eslint --stdin --parser-options=ecmaVersion:7 # succeeds, yay!
 
 ### Caching
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -51,6 +51,7 @@ function translateOptions(cliOptions) {
         rulePaths: cliOptions.rulesdir,
         useEslintrc: cliOptions.eslintrc,
         parser: cliOptions.parser,
+        parserOptions: cliOptions.parserOptions,
         cache: cliOptions.cache,
         cacheFile: cliOptions.cacheFile,
         cacheLocation: cliOptions.cacheLocation,

--- a/lib/config.js
+++ b/lib/config.js
@@ -166,6 +166,7 @@ function Config(options) {
     this.ignorePath = options.ignorePath;
     this.cache = {};
     this.parser = options.parser;
+    this.parserOptions = options.parserOptions || {};
 
     this.baseConfig = options.baseConfig ? loadConfig(options.baseConfig) : { rules: {} };
 
@@ -226,7 +227,7 @@ Config.prototype.getConfig = function(filePath) {
     }
 
     // Step 2: Create a copy of the baseConfig
-    config = ConfigOps.merge({parser: this.parser}, this.baseConfig);
+    config = ConfigOps.merge({parser: this.parser, parserOptions: this.parserOptions}, this.baseConfig);
 
     // Step 3: Merge in the user-specified configuration from .eslintrc and package.json
     config = ConfigOps.merge(config, userConfig);

--- a/lib/options.js
+++ b/lib/options.js
@@ -61,6 +61,11 @@ module.exports = optionator({
             description: "Specify the parser to be used"
         },
         {
+            option: "parser-options",
+            type: "Object",
+            description: "Specify parser options"
+        },
+        {
             heading: "Caching"
         },
         {

--- a/tests/fixtures/passing-es7.js
+++ b/tests/fixtures/passing-es7.js
@@ -1,0 +1,4 @@
+var foo = "bar";
+if (foo) {
+    foo = 3 ** 4;
+}

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -612,6 +612,36 @@ describe("cli", function() {
         });
     });
 
+    describe("when given parser options", function() {
+        it("should exit with error if parser options are invalid", function() {
+            var filePath = getFixturePath("passing.js");
+            var exit = cli.execute("--no-ignore --parser-options test111 " + filePath);
+
+            assert.equal(exit, 1);
+        });
+
+        it("should exit with no error if parser is valid", function() {
+            var filePath = getFixturePath("passing.js");
+            var exit = cli.execute("--no-ignore --parser-options=ecmaVersion:6 " + filePath);
+
+            assert.equal(exit, 0);
+        });
+
+        it("should exit with an error on ecmaVersion 7 feature in ecmaVersion 6", function() {
+            var filePath = getFixturePath("passing-es7.js");
+            var exit = cli.execute("--no-ignore --parser-options=ecmaVersion:6 " + filePath);
+
+            assert.equal(exit, 1);
+        });
+
+        it("should exit with no error on ecmaVersion 7 feature in ecmaVersion 7", function() {
+            var filePath = getFixturePath("passing-es7.js");
+            var exit = cli.execute("--no-ignore --parser-options=ecmaVersion:7 " + filePath);
+
+            assert.equal(exit, 0);
+        });
+    });
+
     describe("when given the max-warnings flag", function() {
         it("should not change exit code if warning count under threshold", function() {
             var filePath = getFixturePath("max-warnings"),


### PR DESCRIPTION
Per https://github.com/eslint/eslint/issues/5495#issuecomment-194060514

This PR adds `--parser-options` to the CLI - it should allow for setting any value that can be set in `.eslintrc`.