### PR TITLE
Docs: Distinguish examples in rules under Variables part 2

### DIFF
--- a/docs/rules/no-restricted-globals.md
+++ b/docs/rules/no-restricted-globals.md
@@ -13,13 +13,9 @@ This rule allows you to specify global variable names that you don't want to use
 
 ## Options
 
-This rule takes a list of strings where strings denote the global variable names:
+This rule takes a list of strings which are the global variable names.
 
-```json
-"no-restricted-globals": [2, "event", "fdescribe"]
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for sample `"event", "fdescribe"` global variable names:
 
 ```js
 /*global event, fdescribe*/
@@ -33,7 +29,7 @@ fdescribe("foo", function() {
 });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for a sample `"event"` global variable name:
 
 ```js
 /*global event*/

--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -46,6 +46,8 @@ const baz = undefined;
 
 There is one situation where initializing to `undefined` behaves differently than omitting the initialization, and that's when a `var` declaration occurs inside of a loop. For example:
 
+Example of **incorrect** code for this rule:
+
 ```js
 for (i = 0; i < 10; i++) {
     var x = undefined;
@@ -90,6 +92,18 @@ for (i = 0; i < 10; i++) {
 This produces a different outcome than defining `var x = undefined` in the loop, as `x` is no longer reset to `undefined` each time through the loop.
 
 If you're using such an initialization inside of a loop, then you should disable this rule.
+
+Example of **correct** code for this rule, because it is disabled on a specific line:
+
+```js
+/*eslint no-undef-init: 2*/
+
+for (i = 0; i < 10; i++) {
+    var x = undefined; // eslint-disable-line no-undef-init
+    console.log(x);
+    x = i;
+}
+```
 
 ## Related Rules
 

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -15,7 +15,7 @@ var a = someFunction();
 b = 10;
 ```
 
-Examples of **correct** code with `global` declaration for this rule:
+Examples of **correct** code for this rule with `global` declaration:
 
 ```js
 /*global someFunction b:true*/
@@ -27,7 +27,7 @@ b = 10;
 
 The `b:true` syntax in `/*global */` indicates that assignment to `b` is correct.
 
-Examples of **incorrect** code with `global` declaration for this rule:
+Examples of **incorrect** code for this rule with `global` declaration:
 
 ```js
 /*global b*/
@@ -44,7 +44,7 @@ By default, variables declared in `/*global */` are read-only, therefore assignm
 
 ### typeof
 
-Examples of **correct** code for the default option:
+Examples of **correct** code for the default `{ "typeof": false }` option:
 
 ```js
 /*eslint no-undef: 2*/
@@ -64,7 +64,7 @@ Examples of **incorrect** code for the `{ "typeof": true }` option:
 if(typeof a === "string"){}
 ```
 
-Examples of **correct** code for the `{ "typeof": true }` option:
+Examples of **correct** code for the `{ "typeof": true }` option with `global` declaration:
 
 ```js
 /*global a*/
@@ -79,9 +79,10 @@ For convenience, ESLint provides shortcuts that pre-define global variables expo
 
 ### browser
 
-Defines common browser globals.
+Examples of **correct** code for this rule with `browser` environment:
 
 ```js
+/*eslint no-undef: 2*/
 /*eslint-env browser*/
 
 setTimeout(function() {
@@ -91,9 +92,10 @@ setTimeout(function() {
 
 ### node
 
-Defines globals for Node.js development.
+Examples of **correct** code for this rule with `node` environment:
 
 ```js
+/*eslint no-undef: 2*/
 /*eslint-env node*/
 
 var fs = require("fs");

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -4,7 +4,7 @@ Variables that are declared and not used anywhere in the code are most likely an
 
 ## Rule Details
 
-This rule is aimed at eliminating unused variables, functions and variables in parameters of functions, as such, warns when one is found.
+This rule is aimed at eliminating unused variables, functions, and parameters of functions.
 
 A variable is considered to be used if any of the following are true:
 
@@ -58,7 +58,7 @@ myFunc(function foo() {
 })();
 ```
 
-### Exporting Variables
+### exported
 
 In environments outside of CommonJS or ECMAScript modules, you may use `var` to create a global variable that may be used by other scripts. You can use the `/* exported variableName */` comment block to indicate that this variable is being exported and therefore should not be considered unused. Note that `/* exported */` has no effect when used with the `node` or `commonjs` environments or when `ecmaFeatures.modules` or `ecmaFeatures.globalReturn` are true.
 
@@ -82,6 +82,17 @@ The `vars` option has two settings:
 
 * `all` checks all variables for usage, including those in the global scope. This is the default setting.
 * `local` checks only that locally-declared variables are used but will allow global variables to be unused.
+
+#### vars: local
+
+Examples of **correct** code for the `{ "vars": "local" }` option:
+
+```js
+/*eslint no-unused-vars: [2, { "vars": "local" }]*/
+/*global some_unused_var */
+
+some_unused_var = 42;
+```
 
 ### varsIgnorePattern
 


### PR DESCRIPTION
* no-restricted-globals: delete json which had syntax error highlight on the colon, maybe because not enclosed in braces; replace example sentences (rule was introduced in ESLint 2.3.0 after #5375 was merged)
* no-undef-init: added example sentence under When Not To Use It; added correct code for eslint-disable-line configuration comment
* no-undef: add details to example sentences and adjust grammar
* no-unused-vars: simplify details sentence; replace h3 Exported Variables with exported, which is the actual keyword; added h4 vars: local correct code
