### PR TITLE
Docs: Separate parser and config questions in issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -10,7 +10,9 @@ Note that leaving sections blank will make it difficult for us to troubleshoot a
 
 **What version of ESLint are you using?**
 
-**What configuration and parser (Espree, Babel-ESLint, etc.) are you using?**
+**What parser (default, Babel-ESLint, etc.) are you using?**
+
+**Please show your full configuration:**
 
 **What did you do? Please include the actual source code causing the issue.**
 


### PR DESCRIPTION
Per discussion in chat, it seems like it might be worthwhile to separate the parser question from configuration. As it is, people will sometimes only include parser information.

I phrased the configuration line as a request rather than a question-- please let me know if I should change that.