### PR TITLE
Docs: Distinguish examples in rules under Best Practices part 3

### DIFF
--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -31,7 +31,7 @@ In this case, each function created within the loop returns a different number a
 
 This error is raised to highlight a piece of code that may not work as you expect it to and could also indicate a misunderstanding of how the language works. Your code may run without any problems if you do not fix this error, but in some situations it could behave unexpectedly.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-loop-func: 2*/
@@ -59,7 +59,7 @@ for (let i=10; i; i--) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-loop-func: 2*/

--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -13,56 +13,106 @@ var now = Date.now(),
 The `no-magic-numbers` rule aims to make code more readable and refactoring easier by ensuring that special numbers
 are declared as constants to make their meaning explicit.
 
-The following pattern is considered a problem:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-magic-numbers: 2*/
 
 var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * 0.25);
-
-
-/*eslint no-magic-numbers: 2*/
-
-var data = ['foo', 'bar', 'baz'];
-var thirdValue = data[3];
 ```
-
-The following pattern is considered okay:
 
 ```js
 /*eslint no-magic-numbers: 2*/
 
-var TAX_PERCENTAGE = 0.25;
+var data = ['foo', 'bar', 'baz'];
+
+var dataLast = data[2];
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-magic-numbers: 2*/
+
+var TAX = 0.25;
 
 var dutyFreePrice = 100,
-    finalPrice = dutyFreePrice + (dutyFreePrice * TAX_PERCENTAGE);
+    finalPrice = dutyFreePrice + (dutyFreePrice * TAX);
 ```
 
 ## Options
 
-### `ignore`
+### ignore
 
 An array of numbers to ignore. It's set to `[]` by default.
 If provided, it must be an `Array`.
 
-### `ignoreArrayIndexes`
+Examples of **correct** code for the sample { "ignore": [1] } option:
+
+```js
+/*eslint no-magic-numbers: [2, { "ignore": [1] }]*/
+
+var data = ['foo', 'bar', 'baz'];
+var dataLast = data.length && data[data.length - 1];
+```
+
+### ignoreArrayIndexes
 
 A boolean to specify if numbers used as array indexes are considered okay. `false` by default.
 
-The following pattern is considered okay:
+Examples of **correct** code for the { "ignoreArrayIndexes": true } option:
 
 ```js
-/*eslint no-magic-numbers: [2, {"ignoreArrayIndexes": true }]*/
+/*eslint no-magic-numbers: [2, { "ignoreArrayIndexes": true }]*/
 
 var data = ['foo', 'bar', 'baz'];
-var thirdValue = data[3];
+var dataLast = data[2];
 ```
 
-### `enforceConst`
+### enforceConst
 
 A boolean to specify if we should check for the const keyword in variable declaration of numbers. `false` by default.
 
-### `detectObjects`
+Examples of **incorrect** code for the { "enforceConst": true } option:
+
+```js
+/*eslint no-magic-numbers: [2, { "enforceConst": true }]*/
+
+var TAX = 0.25;
+
+var dutyFreePrice = 100,
+    finalPrice = dutyFreePrice + (dutyFreePrice * TAX);
+```
+
+### detectObjects
 
 A boolean to specify if we should detect numbers when setting object properties for example. `false` by default.
+
+Examples of **incorrect** code for the { "detectObjects": true } option:
+
+```js
+/*eslint no-magic-numbers: [2, { "detectObjects": true }]*/
+
+var magic = {
+  tax: 0.25
+};
+
+var dutyFreePrice = 100,
+    finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
+```
+
+Examples of **correct** code for the { "detectObjects": true } option:
+
+```js
+/*eslint no-magic-numbers: [2, { "detectObjects": true }]*/
+
+var TAX = 0.25;
+
+var magic = {
+  tax: TAX
+};
+
+var dutyFreePrice = 100,
+    finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
+```

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -22,7 +22,7 @@ if(foo === "bar") {}
 
 This rule aims to disallow multiple whitespace around logical expressions, conditional expressions, declarations, array elements, object properties, sequences and function parameters.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-multi-spaces: 2*/
@@ -38,7 +38,7 @@ var arr = [1,  2];
 a ?  b: c
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-multi-spaces: 2*/
@@ -56,13 +56,15 @@ a ? b: c
 
 ## Options
 
-Some rules, like key-spacing in one of its alignment modes, might require multiple spaces in some instances. To support this case, this rule accepts an options object with a property named `exceptions`. The `exceptions` object expects property names to be AST node types as defined by [ESTree](https://github.com/estree/estree). The easiest way to determine the node types for `exceptions` is to use the [online demo](http://eslint.org/parser).
-
-You can ignore certain parts of your code by setting node types as properties on the `exceptions` object with a value of `true`. By default, all node types are `false` except for `Property`, which is `true` by default in order to skip properties.
+To avoid contradictions if some other rules require multiple spaces, this rule has an option to ignore certain node types in the abstract syntax tree (AST) of JavaScript code.
 
 ### exceptions
 
-With this option, The following patterns are not considered problems:
+The `exceptions` object expects property names to be AST node types as defined by [ESTree](https://github.com/estree/estree). The easiest way to determine the node types for `exceptions` is to use the [online demo](http://eslint.org/parser).
+
+Only the `Property` node type is ignored by default, because for the [key-spacing](key-spacing.md) rule some alignment options require multiple spaces in properties of object literals.
+
+Examples of **correct** code for the default `"exceptions": { "Property": true }` option:
 
 ```js
 /* eslint no-multi-spaces: 2 */
@@ -74,12 +76,7 @@ var obj = {
 };
 ```
 
-```js
-/* eslint no-multi-spaces: [2, { exceptions: { "BinaryExpression": true } }] */
-var a = 1  *  2;
-```
-
-The default `Property` exception can be disabled by setting it to `false`, so the following pattern is considered a warning:
+Examples of **incorrect** code for the `"exceptions": { "Property": false }` option:
 
 ```js
 /* eslint no-multi-spaces: [2, { exceptions: { "Property": false } }] */
@@ -91,7 +88,15 @@ var obj = {
 };
 ```
 
-You may wish to align variable declarations or import declarations with spaces. You can add exceptions for these cases:
+Examples of **correct** code for the `"exceptions": { "BinaryExpression": true }` option:
+
+```js
+/* eslint no-multi-spaces: [2, { exceptions: { "BinaryExpression": true } }] */
+
+var a = 1  *  2;
+```
+
+Examples of **correct** code for the `"exceptions": { "VariableDeclarator": true }` option:
 
 ```js
 /* eslint no-multi-spaces: [2, { exceptions: { "VariableDeclarator": true } }] */
@@ -100,7 +105,9 @@ var someVar      = 'foo';
 var someOtherVar = 'barBaz';
 ```
 
-```
+Examples of **correct** code for the `"exceptions": { "ImportDeclaration": true }` option:
+
+```js
 /* eslint no-multi-spaces: [2, { exceptions: { "ImportDeclaration": true } }] */
 
 import mod          from 'mod';

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -13,14 +13,14 @@ Some consider this to be a bad practice as it was an undocumented feature of Jav
 
 This rule is aimed at preventing the use of multiline strings.
 
-The following generates a warning:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-multi-str: 2*/ var x = "Line 1 \
          Line 2";
 ```
 
-The following does not generate a warning:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-multi-str: 2*/

--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -10,7 +10,7 @@ String = "hello world";
 
 The native objects reported by this rule are the `builtin` variables from [globals](https://github.com/sindresorhus/globals/).
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-native-reassign: 2*/

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -12,6 +12,8 @@ This is considered by many to be a bad practice due to the difficulty in debuggi
 
 This error is raised to highlight the use of a bad practice. By passing a string to the Function constructor, you are requiring the engine to parse that string much in the way it has to when you call the `eval` function.
 
+Examples of **incorrect** code for this rule:
+
 ```js
 /*eslint no-new-func: 2*/
 
@@ -19,7 +21,7 @@ var x = new Function("a", "b", "return a + b");
 var x = Function("a", "b", "return a + b");
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new-func: 2*/

--- a/docs/rules/no-new-wrappers.md
+++ b/docs/rules/no-new-wrappers.md
@@ -39,7 +39,7 @@ For these reasons, it's considered a best practice to avoid using primitive wrap
 
 This rule aims to eliminate the use of `String`, `Number`, and `Boolean` with the `new` operator. As such, it warns whenever it sees `new String`, `new Number`, or `new Boolean`.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-new-wrappers: 2*/
@@ -53,7 +53,7 @@ var numberObject = new Number;
 var booleanObject = new Boolean;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new-wrappers: 2*/

--- a/docs/rules/no-new.md
+++ b/docs/rules/no-new.md
@@ -18,7 +18,7 @@ In this case, the created object is thrown away because its reference isn't stor
 
 This rule is aimed at maintaining consistency and convention by disallowing constructor calls using the `new` keyword that do not assign the resulting object to a variable.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-new: 2*/
@@ -26,7 +26,7 @@ The following patterns are considered problems:
 new Thing();
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new: 2*/

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -10,7 +10,7 @@ var foo = "Copyright \251";
 
 The rule is aimed at preventing the use of a deprecated JavaScript feature, the use of octal escape sequences. As such it will warn whenever an octal escape sequence is found in a string literal.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-octal-escape: 2*/
@@ -18,7 +18,7 @@ The following patterns are considered problems:
 var foo = "Copyright \251";
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-octal-escape: 2*/

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -14,7 +14,7 @@ It's therefore recommended to avoid using octal literals in JavaScript code.
 
 The rule is aimed at preventing the use of a deprecated JavaScript feature, the use of octal literals. As such it will warn whenever an octal literal is found.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-octal: 2*/
@@ -23,7 +23,7 @@ var num = 071;
 var result = 5 + 07;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-octal: 2*/

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -6,21 +6,7 @@ Assignment to variables declared as function parameters can be misleading and le
 
 This rule aims to prevent unintended behavior caused by overwriting function parameters.
 
-## Options
-
-This rule takes one option, an object, with a property `"props"`.
-
-```json
-{
-    "no-param-reassign": [2, {"props": false}]
-}
-```
-
-### `props`
-
-It is `false` by default. If it is `true` is set, this rule warns modifying of properties of parameters.
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-param-reassign: 2*/
@@ -34,10 +20,26 @@ function foo(bar) {
 }
 ```
 
-When `{"props": true}`:
+Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-param-reassign: [2, { "props": true }]*/
+/*eslint no-param-reassign: 2*/
+
+function foo(bar) {
+    var baz = bar;
+}
+```
+
+## Options
+
+This rule takes one option, an object, with a property `"props"`. It is `false` by default. If it is `true` is set, this rule warns modifying of properties of parameters.
+
+### props
+
+Examples of **correct** code for the default `{ "props": false }` option:
+
+```js
+/*eslint no-param-reassign: [2, { "props": false }]*/
 
 function foo(bar) {
     bar.prop = "value";
@@ -52,20 +54,10 @@ function foo(bar) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **incorrect** code for the `{ "props": true }` option:
 
 ```js
-/*eslint no-param-reassign: 2*/
-
-function foo(a) {
-    var b = a;
-}
-```
-
-When `{"props": false}`:
-
-```js
-/*eslint no-param-reassign: [2, { "props": false }]*/
+/*eslint no-param-reassign: [2, { "props": true }]*/
 
 function foo(bar) {
     bar.prop = "value";

--- a/docs/rules/no-process-env.md
+++ b/docs/rules/no-process-env.md
@@ -7,7 +7,7 @@ The `process.env` object in Node.js is used to store deployment/configuration pa
 
 This rule is aimed at discouraging use of `process.env` to avoid global dependencies. As such, it will warn whenever `process.env` is used.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-process-env: 2*/
@@ -17,7 +17,7 @@ if(process.env.NODE_ENV === "development") {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-process-env: 2*/

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -6,7 +6,7 @@
 
 When an object is created `__proto__` is set to the original prototype property of the object’s constructor function. `getPrototypeOf` is the preferred method of getting "the prototype".
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-proto: 2*/
@@ -16,7 +16,7 @@ var a = obj.__proto__;
 var a = obj["__proto__"];
 ```
 
-The following patterns are considered okay and could be used alternatively:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-proto: 2*/

--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -6,7 +6,7 @@ In JavaScript, it's possible to redeclare the same variable name using `var`. Th
 
 This rule is aimed at eliminating variables that have multiple declarations in the same scope.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-redeclare: 2*/
@@ -15,7 +15,7 @@ var a = 3;
 var a = 10;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-redeclare: 2*/
@@ -27,20 +27,12 @@ a = 10;
 
 ## Options
 
-This rule takes one option, an object, with a property `"builtinGlobals"`.
-
-```json
-{
-    "no-redeclare": [2, {"builtinGlobals": true}]
-}
-```
+This rule takes one option, an object, with a property `"builtinGlobals"`. `false` by default.
+If this is `true`, this rule checks with built-in global variables such as `Object`, `Array`, `Number`, ...
 
 ### builtinGlobals
 
-`false` by default.
-If this is `true`, this rule checks with built-in global variables such as `Object`, `Array`, `Number`, ...
-
-When `{"builtinGlobals": true}`, the following patterns are considered problems:
+Examples of **incorrect** code for the `{ "builtinGlobals": true }` option:
 
 ```js
 /*eslint no-redeclare: [2, { "builtinGlobals": true }]*/
@@ -48,21 +40,13 @@ When `{"builtinGlobals": true}`, the following patterns are considered problems:
 var Object = 0;
 ```
 
-When `{"builtinGlobals": true}` and under `browser` environment, the following patterns are considered problems:
+Examples of **incorrect** code for the `{ "builtinGlobals": true }` option and the `browser` environment:
 
 ```js
-/*eslint-env browser*/
 /*eslint no-redeclare: [2, { "builtinGlobals": true }]*/
+/*eslint-env browser*/
 
 var top = 0;
 ```
 
-* Note: The `browser` environment has many built-in global variables, `top` is one of them.
-  Some of built-in global variables cannot be redeclared. It's a trap.
-
-  ```js
-  var top = 0;
-  var left = 0;
-  console.log(top + " " + left); // prints "[object Window] 0"
-  console.log(top * left); // prints "NaN"
-  ```
+The `browser` environment has many built-in global variables (for example, `top`). Some of built-in global variables cannot be redeclared.

--- a/docs/rules/no-return-assign.md
+++ b/docs/rules/no-return-assign.md
@@ -23,12 +23,12 @@ The rule takes one option, a string, which must contain one of the following val
 * `except-parens` (default): Disallow assignments unless they are enclosed in parentheses.
 * `always`: Disallow all assignments.
 
-### "except-parens"
+### except-parens
 
 This is the default option.
 It disallows assignments unless they are enclosed in parentheses.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `"except-parens"` option:
 
 ```js
 /*eslint no-return-assign: 2*/
@@ -42,7 +42,7 @@ function doSomething() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `"except-parens"` option:
 
 ```js
 /*eslint no-return-assign: 2*/
@@ -60,12 +60,12 @@ function doSomething() {
 }
 ```
 
-### "always"
+### always
 
 This option disallows all assignments in `return` statements.
 All assignments are treated as problems.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"always"` option:
 
 ```js
 /*eslint no-return-assign: [2, "always"]*/
@@ -83,7 +83,7 @@ function doSomething() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the `"always"` option:
 
 ```js
 /*eslint no-return-assign: [2, "always"]*/

--- a/docs/rules/no-script-url.md
+++ b/docs/rules/no-script-url.md
@@ -4,7 +4,7 @@ Using `javascript:` URLs is considered by some as a form of `eval`. Code passed 
 
 ## Rule Details
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-script-url: 2*/


### PR DESCRIPTION
3 of 4 pull requests for rules under **Best Practices**

This gets us to 40% of the rules.

Here are the changes beyond example sentences:

* no-magic-numbers: replace out-of-bounds index [3] with last [2] and add examples for some options
* no-multi-spaces: simplify description of exceptions option; reorganize example code for option
* no-param-reassign *the cut-and-paste winner for this batch*: move first example code pair to Rule Details; move example code for default option first
* no-redeclare: delete json and move sentence; delete redundant incorrect code for browser environment

Add to missing examples:
* no-native-reassign: correct code for this rule; correct code for sample exceptions option
* no-script-url: correct code for this rule