### PR TITLE
Fix: object-curly-spacing doesn't know types

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -121,11 +121,11 @@ module.exports = function(context) {
      * @returns {void}
      */
     function validateBraceSpacing(node, first, second, penultimate, last) {
-        var closingCurlyBraceMustBeSpaced =
-            options.arraysInObjectsException && penultimate.value === "]" ||
-            options.objectsInObjectsException && penultimate.value === "}"
-                ? !options.spaced : options.spaced,
-            firstSpaced, lastSpaced;
+        var shouldCheckPenultimate,
+            penultimateType,
+            closingCurlyBraceMustBeSpaced,
+            firstSpaced,
+            lastSpaced;
 
         if (astUtils.isTokenOnSameLine(first, second)) {
             firstSpaced = sourceCode.isSpaceBetweenTokens(first, second);
@@ -138,7 +138,19 @@ module.exports = function(context) {
         }
 
         if (astUtils.isTokenOnSameLine(penultimate, last)) {
+            shouldCheckPenultimate = (
+                options.arraysInObjectsException && penultimate.value === "]" ||
+                options.objectsInObjectsException && penultimate.value === "}"
+            );
+            penultimateType = shouldCheckPenultimate && sourceCode.getNodeByRangeIndex(penultimate.start).type;
+
+            closingCurlyBraceMustBeSpaced = (
+                options.arraysInObjectsException && penultimateType === "ArrayExpression" ||
+                options.objectsInObjectsException && penultimateType === "ObjectExpression"
+            ) ? !options.spaced : options.spaced;
+
             lastSpaced = sourceCode.isSpaceBetweenTokens(penultimate, last);
+
             if (closingCurlyBraceMustBeSpaced && !lastSpaced) {
                 reportRequiredEndingSpace(node, last);
             }

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -61,9 +61,11 @@ ruleTester.run("object-curly-spacing", rule, {
 
         // always - objectsInObjects
         { code: "var obj = { 'foo': { 'bar': 1, 'baz': 2 }};", options: ["always", {"objectsInObjects": false}] },
+        { code: "var a = { noop: function () {} };", options: ["always", {"objectsInObjects": false}] },
 
         // always - arraysInObjects
         { code: "var obj = { 'foo': [ 1, 2 ]};", options: ["always", {"arraysInObjects": false}] },
+        { code: "var a = { thingInList: list[0] };", options: ["always", {"arraysInObjects": false}] },
 
         // always - arraysInObjects, objectsInObjects
         { code: "var obj = { 'qux': [ 1, 2 ], 'foo': { 'bar': 1, 'baz': 2 }};", options: ["always", {"arraysInObjects": false, "objectsInObjects": false}] },


### PR DESCRIPTION
Fixes #5537, fixes #5538.

`object-curly-spacing` was blindly checking the penultimate token for
`objectsInObjects` and `arraysInObjects` options and it was confusing
computed member expressions and function expressions with array and
object expressions respectively. This patch adds a type check for the
penultimate tokens owner node.