### PR TITLE
Fix: `brace-style` erroneously ignoring certain errors

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -57,8 +57,8 @@ module.exports = function(context) {
         var blockProperties = arguments;
 
         return function(node) {
-            [].forEach.call(blockProperties, function(blockProp) {
-                var block = node[blockProp], previousToken, curlyToken, curlyTokenEnd, curlyTokensOnSameLine;
+            Array.prototype.forEach.call(blockProperties, function(blockProp) {
+                var block = node[blockProp], previousToken, curlyToken, curlyTokenEnd, allOnSameLine;
 
                 if (!isBlock(block)) {
                     return;
@@ -67,21 +67,27 @@ module.exports = function(context) {
                 previousToken = sourceCode.getTokenBefore(block);
                 curlyToken = sourceCode.getFirstToken(block);
                 curlyTokenEnd = sourceCode.getLastToken(block);
-                curlyTokensOnSameLine = curlyToken.loc.start.line === curlyTokenEnd.loc.start.line;
+                allOnSameLine = previousToken.loc.start.line === curlyTokenEnd.loc.start.line;
+
+                if (allOnSameLine && params.allowSingleLine) {
+                    return;
+                }
 
                 if (style !== "allman" && previousToken.loc.start.line !== curlyToken.loc.start.line) {
                     context.report(node, OPEN_MESSAGE);
-                } else if (style === "allman" && previousToken.loc.start.line === curlyToken.loc.start.line && !params.allowSingleLine) {
+                } else if (style === "allman" && previousToken.loc.start.line === curlyToken.loc.start.line) {
                     context.report(node, OPEN_MESSAGE_ALLMAN);
                 }
 
-                if (!block.body.length || curlyTokensOnSameLine && params.allowSingleLine) {
+                if (!block.body.length) {
                     return;
                 }
 
                 if (curlyToken.loc.start.line === block.body[0].loc.start.line) {
                     context.report(block.body[0], BODY_MESSAGE);
-                } else if (curlyTokenEnd.loc.start.line === block.body[block.body.length - 1].loc.start.line) {
+                }
+
+                if (curlyTokenEnd.loc.start.line === block.body[block.body.length - 1].loc.start.line) {
                     context.report(block.body[block.body.length - 1], CLOSE_MESSAGE_SINGLE);
                 }
             });

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -91,12 +91,12 @@ ruleTester.run("brace-style", rule, {
     ],
     invalid: [
         { code: "if (f) {\nbar;\n}\nelse\nbaz;", errors: [{ message: CLOSE_MESSAGE, type: "ExpressionStatement"}] },
-        { code: "var foo = () => { return; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}] },
-        { code: "function foo() { return; }", errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}] },
+        { code: "var foo = () => { return; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
+        { code: "function foo() { return; }", errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
         { code: "function foo() \n { \n return; }", errors: [{ message: OPEN_MESSAGE, type: "FunctionDeclaration"}, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
         { code: "!function foo() \n { \n return; }", errors: [{ message: OPEN_MESSAGE, type: "FunctionExpression"}, { message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
         { code: "if (foo) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "IfStatement"}, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}] },
-        { code: "if (a) { \nb();\n } else \n { c(); }", errors: [{ message: OPEN_MESSAGE, type: "IfStatement"}, { message: BODY_MESSAGE, type: "ExpressionStatement"}] },
+        { code: "if (a) { \nb();\n } else \n { c(); }", errors: [{ message: OPEN_MESSAGE, type: "IfStatement"}, { message: BODY_MESSAGE, type: "ExpressionStatement"}, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}] },
         { code: "while (foo) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "WhileStatement"}, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}] },
         { code: "for (;;) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "ForStatement"}, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}] },
         { code: "with (foo) \n { \n bar(); }", errors: [{ message: OPEN_MESSAGE, type: "WithStatement"}, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}] },
@@ -155,7 +155,11 @@ ruleTester.run("brace-style", rule, {
         { code: "function foo() { \n return; }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
         { code: "function foo() {\na();\nb();\nreturn; }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
         { code: "!function foo() { \n return; }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ReturnStatement"}] },
-        { code: "if (foo) \n { bar(); }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: OPEN_MESSAGE, type: "IfStatement"}] },
+        { code: "if (foo) \n { bar(); }", options: ["1tbs", { allowSingleLine: true }], errors: [
+            { message: OPEN_MESSAGE, type: "IfStatement"},
+            { message: BODY_MESSAGE, type: "ExpressionStatement"},
+            { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}
+        ] },
         { code: "if (a) { b();\n } else { c(); }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement"}] },
         { code: "if (a) { b(); }\nelse { c(); }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }] },
         { code: "while (foo) { \n bar(); }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement"}] },
@@ -173,6 +177,13 @@ ruleTester.run("brace-style", rule, {
         { code: "if (a) { \nb();\n } \n else { \nc();\n }", options: ["1tbs", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE, type: "BlockStatement" }]},
         { code: "try { \n bar(); \n }\ncatch (e) {\n} finally {\n}", options: ["stroustrup", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement"}] },
         { code: "try { \n bar(); \n } catch (e) {\n}\n finally {\n}", options: ["stroustrup", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "CatchClause"}] },
-        { code: "if (a) { \nb();\n } else { \nc();\n }", options: ["stroustrup", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement" }]}
+        { code: "if (a) { \nb();\n } else { \nc();\n }", options: ["stroustrup", { allowSingleLine: true }], errors: [{ message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "BlockStatement" }]},
+        { code: "if (foo)\n{ poop();\n} \nelse if (bar) {\nbaz();\n} else if (thing) {\nboom();\n}\nelse {\nqux();\n}", options: ["allman", { allowSingleLine: true }], errors: [
+            { message: BODY_MESSAGE, type: "ExpressionStatement" },
+            { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
+            { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "IfStatement" },
+            { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
+            { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" }
+        ] }
     ]
 });


### PR DESCRIPTION
Fixes #5197.

`brace-style` was ignoring almost all `allman` checks when
`allowSingleLine` option was set. It was also ignoring closing brace
errors when there was a body error with a single-line body.