### PR TITLE
Update: replace MD5 hashing of cache files with MurmurHash (fixes #5522)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -35,8 +35,8 @@ var fs = require("fs"),
     SourceCodeFixer = require("./util/source-code-fixer"),
     validator = require("./config/config-validator"),
     stringify = require("json-stable-stringify"),
+    hash = require("./util/hash"),
 
-    crypto = require( "crypto" ),
     pkg = require("../package.json");
 
 
@@ -261,17 +261,6 @@ function isErrorMessage(message) {
     return message.severity === 2;
 }
 
-/**
- * create a md5Hash of a given string
- * @param  {string} str the string to calculate the hash for
- * @returns {string}    the calculated hash
- */
-function md5Hash(str) {
-    return crypto
-        .createHash("md5")
-        .update(str, "utf8")
-        .digest("hex");
-}
 
 /**
  * return the cacheFile to be used by eslint, based on whether the provided parameter is
@@ -297,7 +286,7 @@ function getCacheFile(cacheFile, cwd) {
      * @returns {string} the resolved path to the cacheFile
      */
     function getCacheFileForDirectory() {
-        return path.join(resolvedCacheFile, ".cache_" + md5Hash(cwd));
+        return path.join(resolvedCacheFile, ".cache_" + hash(cwd));
     }
 
     var fileStats;
@@ -515,7 +504,7 @@ CLIEngine.prototype = {
 
                 var eslintVersion = pkg.version;
 
-                prevConfig.hash = md5Hash(eslintVersion + "_" + stringify(config));
+                prevConfig.hash = hash(eslintVersion + "_" + stringify(config));
             }
 
             return prevConfig.hash;

--- a/lib/util/hash.js
+++ b/lib/util/hash.js
@@ -1,0 +1,37 @@
+/**
+ * @fileoverview Defining the hashing function in one place.
+ * @author Michael Ficarra
+ * @copyright 2016 Michael Ficarra. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var murmur = require("imurmurhash");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+//------------------------------------------------------------------------------
+// Private
+//------------------------------------------------------------------------------
+
+/**
+ * hash the given string
+ * @param  {string} str the string to hash
+ * @returns {string}    the hash
+ */
+function hash(str) {
+    return murmur(str).result().toString(36);
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = hash;

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "glob": "^7.0.3",
     "globals": "^8.18.0",
     "ignore": "^3.0.10",
+    "imurmurhash": "^0.1.4",
     "inquirer": "^0.12.0",
     "is-my-json-valid": "^2.10.0",
     "is-resolvable": "^1.0.0",

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -20,7 +20,7 @@ var assert = require("chai").assert,
     Plugins = require("../../lib/config/plugins"),
     fs = require("fs"),
     os = require("os"),
-    crypto = require("crypto");
+    hash = require("../../lib/util/hash");
 
 require("shelljs/global");
 proxyquire = proxyquire.noCallThru().noPreserveCache();
@@ -1311,17 +1311,6 @@ describe("CLIEngine", function() {
                 it("should create the cache file inside the provided directory", function() {
                     assert.isFalse(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
 
-                    sandbox.stub(crypto, "createHash", function() {
-                        return {
-                            update: function() {
-                                return this;
-                            },
-                            digest: function() {
-                                return "hashOfCurrentWorkingDirectory";
-                            }
-                        };
-                    });
-
                     engine = new CLIEngine({
                         useEslintrc: false,
                         // specifying cache true the cache will be created
@@ -1339,7 +1328,7 @@ describe("CLIEngine", function() {
 
                     engine.executeOnFiles([file]);
 
-                    assert.isTrue(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint was created");
+                    assert.isTrue(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
 
                     sandbox.restore();
                 });
@@ -1347,17 +1336,6 @@ describe("CLIEngine", function() {
 
             it("should create the cache file inside the provided directory using the cacheLocation option", function() {
                 assert.isFalse(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
-
-                sandbox.stub(crypto, "createHash", function() {
-                    return {
-                        update: function() {
-                            return this;
-                        },
-                        digest: function() {
-                            return "hashOfCurrentWorkingDirectory";
-                        }
-                    };
-                });
 
                 engine = new CLIEngine({
                     useEslintrc: false,
@@ -1376,7 +1354,7 @@ describe("CLIEngine", function() {
 
                 engine.executeOnFiles([file]);
 
-                assert.isTrue(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint was created");
+                assert.isTrue(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
 
                 sandbox.restore();
             });


### PR DESCRIPTION
Fixes #5522. Removes the dependency on the `crypto` module, which is not available when node is built with the `--without-ssl` flag.