### PR TITLE
Update: add options to make `no-sequences` stricter

### DIFF
--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -61,6 +61,45 @@ while ((val = foo(), val < 42));
 // with ((doSomething(), val)) {}
 ```
 
+## Options
+
+This rule, in its default state, does not require any arguments. If you would like to enable one or more of the following you may pass an object with the options set as follows:
+
+* `ignoreParenthesized` set to `false` will warn on all sequences, even if they are within a parentheses context (such as a condition) or are double-parenthesized (Default: `true`).
+* `allowIndirectEval` set to `false` will warn on indirect `eval` calls too such as `(0, eval)("foo")`. This check only gets active if `allowParenthesized` is set to `false` (Default: `true`).
+
+By default the following patterns are _not_ considered problems:
+
+```js
+/*eslint no-sequences: 2*/
+
+while ((doSomething(), !!test));
+
+(0, eval)("foo");
+
+a = (1, 2);
+
+```
+
+The following patterns are considered problems if `ignoreParenthesized` is disabled:
+
+```js
+/*eslint no-sequences: [2, { ignoreParenthesized: false }]*/
+
+while ((doSomething(), !!test));
+
+a = (1, 2);
+```
+
+If you disable `allowIndirectEval` along with `ignoreParenthesized`, the following pattern will also be disallowed:
+
+```js
+/*eslint no-sequences: [2, { ignoreParenthesized: false, allowIndirectEval: false }]*/
+
+(0, eval)("foo");
+```
+
+
 ## When Not To Use It
 
 Disable this rule if sequence expressions with the comma operator are acceptable.

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -5,11 +5,15 @@
 
 "use strict";
 
+var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var config = context.options[0] || {},
+        ignoreParenthesized = config.ignoreParenthesized !== false,
+        allowIndirectEval = config.allowIndirectEval !== false;
 
     /**
      * Parts of the grammar that are required to have parens.
@@ -27,6 +31,8 @@ module.exports = function(context) {
         // Omitting ForStatement - parts aren't individually parenthesised
     };
 
+    var isParenthesised = astUtils.isParenthesised.bind(astUtils, context);
+
     /**
      * Determines whether a node is required by the grammar to be wrapped in
      * parens, e.g. the test of an if statement.
@@ -36,20 +42,6 @@ module.exports = function(context) {
     function requiresExtraParens(node) {
         return node.parent && parenthesized[node.parent.type] &&
                 node === node.parent[parenthesized[node.parent.type]];
-    }
-
-    /**
-     * Check if a node is wrapped in parens.
-     * @param {ASTNode} node - The AST node
-     * @returns {boolean} True if the node has a paren on each side.
-     */
-    function isParenthesised(node) {
-        var previousToken = context.getTokenBefore(node),
-            nextToken = context.getTokenAfter(node);
-
-        return previousToken && nextToken &&
-            previousToken.value === "(" && previousToken.range[1] <= node.range[0] &&
-            nextToken.value === ")" && nextToken.range[0] >= node.range[1];
     }
 
     /**
@@ -76,13 +68,15 @@ module.exports = function(context) {
 
             // Wrapping a sequence in extra parens indicates intent
             if (requiresExtraParens(node)) {
-                if (isParenthesisedTwice(node)) {
+                if (ignoreParenthesized && isParenthesisedTwice(node)) {
                     return;
                 }
-            } else {
-                if (isParenthesised(node)) {
-                    return;
-                }
+            } else if (
+                isParenthesised(node) && (
+                ignoreParenthesized ||
+                node.expressions[node.expressions.length - 1].name === "eval" && allowIndirectEval
+            )) {
+                return;
             }
 
             var child = context.getTokenAfter(node.expressions[0]);
@@ -92,4 +86,18 @@ module.exports = function(context) {
 
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "ignoreParenthesized": {
+                "type": "boolean"
+            },
+            "allowIndirectEval": {
+                "type": "boolean"
+            }
+        },
+        "additionalProperties": false
+    }
+];
+

--- a/tests/lib/rules/no-sequences.js
+++ b/tests/lib/rules/no-sequences.js
@@ -47,17 +47,23 @@ ruleTester.run("no-sequences", rule, {
         "if ((doSomething(), !!test));",
         "switch ((doSomething(), !!test)) {}",
         "while ((doSomething(), !!test));",
-        "with ((doSomething(), val)) {}"
+        "with ((doSomething(), val)) {}",
+        { code: "(0,eval)(\"foo()\");", options: [{ ignoreParenthesized: false }] },
+        // Below is a valid case since ignoreParenthesized simply ignores anything in parens
+        { code: "(0,eval)(1)", options: [{ allowIndirectEval: false }] }
     ],
 
     // Examples of code that should trigger the rule
     invalid: [
         { code: "a = 1, 2", errors: errors(6) },
+        { code: "a = (1, 2)", options: [{ ignoreParenthesized: false }], errors: errors(7) },
+        { code: "(0,eval)(1)", options: [{ ignoreParenthesized: false, allowIndirectEval: false }], errors: errors(3) },
         { code: "do {} while (doSomething(), !!test);", errors: errors(27) },
         { code: "for (; doSomething(), !!test; );", errors: errors(21) },
         { code: "if (doSomething(), !!test);", errors: errors(18) },
         { code: "switch (doSomething(), val) {}", errors: errors(22) },
         { code: "while (doSomething(), !!test);", errors: errors(21) },
-        { code: "with (doSomething(), val) {}", errors: errors(20) }
+        { code: "with (doSomething(), val) {}", errors: errors(20) },
+        { code: "while ((doSomething(), !!test));", options: [{ ignoreParenthesized: false }], errors: errors(22) }
     ]
 });


### PR DESCRIPTION
Fixes #5535.

Adds `ignoreParenthesized` and `allowIndirectEval` options which both
default to `true` for backwards compatibility.