### PR TITLE
Docs: Make `prefer-template` examples consistent.

### DIFF
--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -33,7 +33,7 @@ The following patterns are not considered problems:
 
 var str = "Hello World!";
 var str = `Hello, ${name}!`;
-var str = `Time: ${12 * 60 * 60}`;
+var str = `Time: ${12 * 60 * 60 * 1000}`;
 
 // This is reported by `no-useless-concat`.
 var str = "Hello, " + "World!";


### PR DESCRIPTION
Replaces #5419