### PR TITLE
Docs: Remove ES2016 from experimental section of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,9 +117,14 @@ ESLint has full support for ECMAScript 6. By default, this support is off. You c
 
 Yes, ESLint natively supports parsing JSX syntax (this must be enabled in [configuration](http://eslint.org/docs/user-guide/configuring).). Please note that supporting JSX syntax *is not* the same as supporting React. React applies specific semantics to JSX syntax that ESLint doesn't recognize. We recommend using [eslint-plugin-react](https://www.npmjs.com/package/eslint-plugin-react) if you are using React and want React semantics.
 
-### What about ECMAScript 7/2016 and experimental features?
+### What about experimental features?
 
 ESLint doesn't natively support experimental ECMAScript language features. You can use [babel-eslint](https://github.com/babel/babel-eslint) to use any option available in Babel.
+
+Once a language feature has been adopted into the ECMAScript standard, we will accept
+issues and pull requests related to the new feature, subject to our [contributing
+guidelines](http://eslint.org/docs/developer-guide/contributing). Until then, please use
+the appropriate parser and plugin(s) for your experimental feature.
 
 ### Where to ask for help?
 


### PR DESCRIPTION
Also added a paragraph indicating criteria for when we will consider those features for ESLint rules (i.e., when it has been added to the ECMAScript standard).

I added the extra paragraph somewhat on a whim-- let me know if it should be struck.