### PR TITLE
Docs: Fix typo in CLI help message

### DIFF
--- a/lib/options.js
+++ b/lib/options.js
@@ -207,7 +207,7 @@ module.exports = optionator({
             option: "version",
             alias: "v",
             type: "Boolean",
-            description: "Outputs the version number"
+            description: "Output the version number"
         },
         {
             option: "inline-config",


### PR DESCRIPTION
Actually I edited a JavaScript file but the change is just a typo fix of the CLI help message. I think the help message is a part of documentation so I tagged the commit as `Docs`.  But if it is wrong and I need to create a issue for this PR, I'll do it.