### PR TITLE
Fix: `no-useless-constructor` clash (fixes #5573)

### DIFF
--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -7,62 +7,142 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether a given array of statements is a single call of `super`.
+ *
+ * @param {ASTNode[]} body - An array of statements to check.
+ * @returns {boolean} `true` if the body is a single call of `super`.
+ */
+function isSingleSuperCall(body) {
+    return (
+        body.length === 1 &&
+        body[0].type === "ExpressionStatement" &&
+        body[0].expression.type === "CallExpression" &&
+        body[0].expression.callee.type === "Super"
+    );
+}
+
+/**
+ * Checks whether a given node is a pattern which doesn't have any side effects.
+ * Default parameters and Destructuring parameters can have side effects.
+ *
+ * @param {ASTNode} node - A pattern node.
+ * @returns {boolean} `true` if the node doesn't have any side effects.
+ */
+function isSimple(node) {
+    return node.type === "Identifier" || node.type === "RestElement";
+}
+
+/**
+ * Checks whether a given array of expressions is `...arguments` or not.
+ * `super(...arguments)` passes all arguments through.
+ *
+ * @param {ASTNode[]} superArgs - An array of expressions to check.
+ * @returns {boolean} `true` if the superArgs is `...arguments`.
+ */
+function isSpreadArguments(superArgs) {
+    return (
+        superArgs.length === 1 &&
+        superArgs[0].type === "SpreadElement" &&
+        superArgs[0].argument.type === "Identifier" &&
+        superArgs[0].argument.name === "arguments"
+    );
+}
+
+/**
+ * Checks whether given 2 nodes are identifiers which have the same name or not.
+ *
+ * @param {ASTNode} ctorParam - A node to check.
+ * @param {ASTNode} superArg - A node to check.
+ * @returns {boolean} `true` if the nodes are identifiers which have the same
+ *      name.
+ */
+function isValidIdentifierPair(ctorParam, superArg) {
+    return (
+        ctorParam.type === "Identifier" &&
+        superArg.type === "Identifier" &&
+        ctorParam.name === superArg.name
+    );
+}
+
+/**
+ * Checks whether given 2 nodes are a rest/spread pair which has the same values.
+ *
+ * @param {ASTNode} ctorParam - A node to check.
+ * @param {ASTNode} superArg - A node to check.
+ * @returns {boolean} `true` if the nodes are a rest/spread pair which has the
+ *      same values.
+ */
+function isValidRestSpreadPair(ctorParam, superArg) {
+    return (
+        ctorParam.type === "RestElement" &&
+        superArg.type === "SpreadElement" &&
+        isValidIdentifierPair(ctorParam.argument, superArg.argument)
+    );
+}
+
+/**
+ * Checks whether given 2 nodes have the same value or not.
+ *
+ * @param {ASTNode} ctorParam - A node to check.
+ * @param {ASTNode} superArg - A node to check.
+ * @returns {boolean} `true` if the nodes have the same value or not.
+ */
+function isValidPair(ctorParam, superArg) {
+    return (
+        isValidIdentifierPair(ctorParam, superArg) ||
+        isValidRestSpreadPair(ctorParam, superArg)
+    );
+}
+
+/**
+ * Checks whether the parameters of a constructor and the arguments of `super()`
+ * have the same values or not.
+ *
+ * @param {ASTNode} ctorParams - The parameters of a constructor to check.
+ * @param {ASTNode} superArgs - The arguments of `super()` to check.
+ * @returns {boolean} `true` if those have the same values.
+ */
+function isPassingThrough(ctorParams, superArgs) {
+    if (ctorParams.length !== superArgs.length) {
+        return false;
+    }
+
+    for (var i = 0; i < ctorParams.length; ++i) {
+        if (!isValidPair(ctorParams[i], superArgs[i])) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+/**
+ * Checks whether the constructor body is a redundant super call.
+ *
+ * @param {Array} body - constructor body content.
+ * @param {Array} ctorParams - The params to check against super call.
+ * @returns {boolean} true if the construtor body is redundant
+ */
+function isRedundantSuperCall(body, ctorParams) {
+    return (
+        isSingleSuperCall(body) &&
+        ctorParams.every(isSimple) &&
+        (
+            isSpreadArguments(body[0].expression.arguments) ||
+            isPassingThrough(ctorParams, body[0].expression.arguments)
+        )
+    );
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    /**
-     * Checks whether the constructor body is a redundant super call.
-     * @param {Array} body - constructor body content.
-     * @param {Array} ctorParams - The params to check against super call.
-     * @returns {boolean} true if the construtor body is redundant
-     */
-    function isRedundantSuperCall(body, ctorParams) {
-        if (body.length !== 1 ||
-            body[0].type !== "ExpressionStatement" ||
-            body[0].expression.callee.type !== "Super") {
-            return false;
-        }
-
-        var superArgs = body[0].expression.arguments;
-        var firstSuperArg = superArgs[0];
-        var lastSuperArgIndex = superArgs.length - 1;
-        var lastSuperArg = superArgs[lastSuperArgIndex];
-        var isSimpleParameterList = ctorParams.every(function(param) {
-            return param.type === "Identifier" || param.type === "RestElement";
-        });
-
-        /**
-         * Checks if a super argument is the same with constructor argument
-         * @param {ASTNode} arg argument node
-         * @param {number} index argument index
-         * @returns {boolean} true if the arguments are same, false otherwise
-         */
-        function isSameIdentifier(arg, index) {
-            return (
-                arg.type === "Identifier" &&
-                arg.name === ctorParams[index].name
-            );
-        }
-
-        var spreadsArguments =
-            superArgs.length === 1 &&
-            firstSuperArg.type === "SpreadElement" &&
-            firstSuperArg.argument.name === "arguments";
-
-        var passesParamsAsArgs =
-            superArgs.length === ctorParams.length &&
-            superArgs.every(isSameIdentifier) ||
-            superArgs.length <= ctorParams.length &&
-            superArgs.slice(0, -1).every(isSameIdentifier) &&
-            lastSuperArg.type === "SpreadElement" &&
-            ctorParams[lastSuperArgIndex].type === "RestElement" &&
-            lastSuperArg.argument.name === ctorParams[lastSuperArgIndex].argument.name;
-
-        return isSimpleParameterList && (spreadsArguments || passesParamsAsArgs);
-    }
-
     /**
      * Checks whether a node is a redundant constructor
      * @param {ASTNode} node - node to check
@@ -74,13 +154,15 @@ module.exports = function(context) {
         }
 
         var body = node.value.body.body;
-
-        if (!node.parent.parent.superClass && body.length === 0 ||
-            node.parent.parent.superClass && isRedundantSuperCall(body, node.value.params)) {
-            context.report(node, "Useless constructor.");
+        var ctorParams = node.value.params;
+        var superClass = node.parent.parent.superClass;
+        if (superClass ? isRedundantSuperCall(body, ctorParams) : (body.length === 0)) {
+            context.report({
+                node: node,
+                message: "Useless constructor."
+            });
         }
     }
-
 
     return {
         "MethodDefinition": checkForConstructor

--- a/tests/lib/rules/no-useless-constructor.js
+++ b/tests/lib/rules/no-useless-constructor.js
@@ -76,6 +76,18 @@ ruleTester.run("no-useless-constructor", rule, {
         {
             code: "class A extends B { constructor(foo, bar){ super(foo); } }",
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class A extends B { constructor(test) { super(); } }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class A extends B { constructor() { foo; } }",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "class A extends B { constructor(foo, bar) { super(bar); } }",
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [


### PR DESCRIPTION
Fixes #5573 

I refactored this rule for readability.

The cause is that checking the type of `body[0].expression` and the length of `superArgs` were lacking.