### PR TITLE
Fix: Ensure allowing `await` as a property name (fixes #5564)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "doctrine": "^1.2.0",
     "es6-map": "^0.1.3",
     "escope": "^3.6.0",
-    "espree": "^3.1.1",
+    "espree": "^3.1.2",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",
     "file-entry-cache": "^1.1.1",

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -3120,6 +3120,14 @@ describe("eslint", function() {
             eslint.verify("function render() { return <div className='test'>{hello}</div> }", { parserOptions: { ecmaVersion: 6, ecmaFeatures: {jsx: true} }});
             eslint.verify(eslint.getSourceCode(), { parserOptions: { ecmaVersion: 6, ecmaFeatures: {jsx: true} }});
         });
+
+        it("should allow 'await' as a property name in modules", function() {
+            var result = eslint.verify(
+                "obj.await",
+                {parserOptions: {ecmaVersion: 6, sourceType: "module"}}
+            );
+            assert(result.length === 0);
+        });
     });
 
     describe("Variables and references", function() {


### PR DESCRIPTION
fixes #5564 

I added a test.