### PR TITLE
Fix: respect 'ignoreTrailingComments' in max-len rule (fixes #5563)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -118,7 +118,7 @@ module.exports = function(context) {
         // split (honors line-ending)
         var lines = context.getSourceLines(),
             // list of comments to ignore
-            comments = ignoreComments || maxCommentLength ? context.getAllComments() : [],
+            comments = ignoreComments || maxCommentLength || ignoreTrailingComments ? context.getAllComments() : [],
             // we iterate over comments in parallel with the lines
             commentsIndex = 0;
 

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -43,6 +43,9 @@ ruleTester.run("max-len", rule, {
             code: "var foo = module.exports = {}; // really long trailing comment",
             options: [40, 4, {ignoreComments: true}]
         }, {
+            code: "var foo = module.exports = {}; // really long trailing comment",
+            options: [40, 4, {ignoreTrailingComments: true}]
+        }, {
             code: "foo(); \t// strips entire comment *and* trailing whitespace",
             options: [6, 4, {ignoreComments: true}]
         }, {


### PR DESCRIPTION
We are considering `ignoreComments` and `maxCommentLength`  alone to see if comments need to be considered. As these two are false , the comments is empty array and trailing comments are not stripped. 

Fix : Added this condition also along with other two. If either of them are true, we are considering the comments in our calculation. 