### PR TITLE
WIP: New: Auto-fix now works in processors (fixes #5121)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -142,6 +142,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
         stats,
         fileExtension = path.extname(filename),
         processor,
+        selectedProcessorPlugin,
         loadedPlugins,
         fixedResult;
 
@@ -162,12 +163,13 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
     for (var plugin in loadedPlugins) {
         if (loadedPlugins[plugin].processors && Object.keys(loadedPlugins[plugin].processors).indexOf(fileExtension) >= 0) {
             processor = loadedPlugins[plugin].processors[fileExtension];
+            selectedProcessorPlugin = plugin;
             break;
         }
     }
 
     if (processor) {
-        debug("Using processor");
+        debug("Using processor (plugin: " + selectedProcessorPlugin + ")");
         var parsedBlocks = processor.preprocess(text, filename);
         var unprocessedMessages = [];
         parsedBlocks.forEach(function(block) {
@@ -177,9 +179,18 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
             }));
         });
 
-        // TODO(nzakas): Figure out how fixes might work for processors
-
         messages = processor.postprocess(unprocessedMessages, filename);
+
+        if (fix && processor.handlesFixes) {
+            debug([
+                "Generating fixed text for",
+                filename,
+                "(processed by plugin " + plugin + ")"
+            ].join(" "));
+
+            fixedResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
+            messages = fixedResult.messages;
+        }
 
     } else {
 

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -75,7 +75,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         prefix = (sourceCode.hasBOM ? BOM : "");
 
     messages.forEach(function(problem) {
-        if (problem.hasOwnProperty("fix")) {
+        if (problem.fix) {
             fixes.push(problem);
         } else {
             remainingMessages.push(problem);

--- a/tests/fixtures/processors/first-line-processor/nofix.js
+++ b/tests/fixtures/processors/first-line-processor/nofix.js
@@ -1,0 +1,28 @@
+var newlineRegex = /\r\n|\r|\n|\u0028|\u0029/,
+    offset;
+
+/*
+ * This fake plugin ignores the first line and returns the rest of the file as
+ * JavaScript.
+ * Auto-fix is "supported" by this version of the fake plugin by removing fix
+ * info.
+ */
+
+module.exports = {
+    preprocess: function(text) {
+        var result = newlineRegex.exec(text);
+
+        offset = result.index + result[0].length;
+
+        return [text.slice(offset)];
+    },
+    postprocess: function(messages) {
+        messages[0].forEach(function(message) {
+            message.line += 1;
+            message.fix = null;
+        });
+
+        return messages[0];
+    },
+    handlesFixes: true
+};

--- a/tests/fixtures/processors/first-line-processor/test/test.txt
+++ b/tests/fixtures/processors/first-line-processor/test/test.txt
@@ -1,0 +1,2 @@
+This line does not matter!
+var foo = true;

--- a/tests/fixtures/processors/first-line-processor/willfix.js
+++ b/tests/fixtures/processors/first-line-processor/willfix.js
@@ -1,0 +1,31 @@
+var newlineRegex = /\r\n|\r|\n|\u0028|\u0029/,
+    offset;
+
+/*
+ * This fake plugin ignores the first line and returns the rest of the file as
+ * JavaScript.
+ * Auto-fix is supported by this version of the fake plugin by adjusting fix
+ * info.
+ */
+
+module.exports = {
+    preprocess: function(text) {
+        var result = newlineRegex.exec(text);
+
+        offset = result.index + result[0].length;
+
+        return [text.slice(offset)];
+    },
+    postprocess: function(messages) {
+        messages[0].forEach(function(message) {
+            message.line += 1;
+            if (message.fix) {
+                message.fix.range[0] += offset;
+                message.fix.range[1] += offset;
+            }
+        });
+
+        return messages[0];
+    },
+    handlesFixes: true
+};


### PR DESCRIPTION
Processors can support auto-fix by declaring `handlesFixes: true` in their exports. (N.B. Changed from `allowFixes: true` in the issue.)

Processors who do this are expected to handle fix information in postprocess() method: Either a message must have its range adjusted to match the original file location, or its fix must be nulled out. ESLint will then apply any remaining fixes in the usual way.

N.B. I modified the tests so that `Plugins.testReset()` is invoked more often, to avoid tests bleeding into each other. Hope that's okay!