### PR TITLE
Update: adds nestedBinaryExpressions for no-extra-parens rule (fixes #3065)

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -52,7 +52,7 @@ Examples of **correct** code for the default `"all"` option:
 
 When setting the first option as `"all"`, an additional option can be added to allow extra parens for assignment in conditional statements.
 
-Examples of **correct** code for the `"all"` and `{ "conditionalAssign": true }` options:
+Examples of **correct** code for the `"all"` and `{ "conditionalAssign": false }` options:
 
 ```js
 /*eslint no-extra-parens: ["error", "all", { "conditionalAssign": false }]*/
@@ -64,6 +64,18 @@ if ((foo = bar())) {}
 do; while ((foo = bar()))
 
 for (;(a = b););
+```
+
+### nestedBinaryExpressions
+
+When setting the first option as `"all"`, an additional option can be added to allow extra parens in nested binary expressions.
+
+Examples of **correct* for the `"all"` and `{ "nestedBinaryExpressions": false }` options:
+
+```js
+x = a || (b && c);
+x = a + (b * c);
+x = (a * b) / c;
 ```
 
 ### functions
@@ -97,7 +109,6 @@ a = (b * c);
 
 typeof (a);
 ```
-
 
 ## Further Reading
 

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -16,6 +16,7 @@ module.exports = function(context) {
     var isParenthesised = astUtils.isParenthesised.bind(astUtils, context);
     var ALL_NODES = context.options[0] !== "functions";
     var EXCEPT_COND_ASSIGN = ALL_NODES && context.options[1] && context.options[1].conditionalAssign === false;
+    var NESTED_BINARY = ALL_NODES && context.options[1] && context.options[1].nestedBinaryExpressions === false;
     var sourceCode = context.getSourceCode();
 
     /**
@@ -305,13 +306,15 @@ module.exports = function(context) {
      * @private
      */
     function dryBinaryLogical(node) {
-        var prec = precedence(node);
+        if (!NESTED_BINARY) {
+            var prec = precedence(node);
 
-        if (hasExcessParens(node.left) && precedence(node.left) >= prec) {
-            report(node.left);
-        }
-        if (hasExcessParens(node.right) && precedence(node.right) > prec) {
-            report(node.right);
+            if (hasExcessParens(node.left) && precedence(node.left) >= prec) {
+                report(node.left);
+            }
+            if (hasExcessParens(node.right) && precedence(node.right) > prec) {
+                report(node.right);
+            }
         }
     }
 
@@ -568,7 +571,8 @@ module.exports.schema = {
                 {
                     "type": "object",
                     "properties": {
-                        "conditionalAssign": {"type": "boolean"}
+                        "conditionalAssign": {"type": "boolean"},
+                        "nestedBinaryExpressions": {"type": "boolean"}
                     },
                     "additionalProperties": false
                 }

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -192,6 +192,12 @@ ruleTester.run("no-extra-parens", rule, {
         {code: "do; while ((foo = bar()))", options: ["all", {conditionalAssign: false}]},
         {code: "for (;(a = b););", options: ["all", {conditionalAssign: false}]},
 
+        // ["all", { nestedBinaryExpressions: false }] enables extra parens around conditional assignments
+        {code: "a + (b * c)", options: ["all", {nestedBinaryExpressions: false}]},
+        {code: "(a * b) + c", options: ["all", {nestedBinaryExpressions: false}]},
+        {code: "(a * b) / c", options: ["all", {nestedBinaryExpressions: false}]},
+        {code: "a || (b && c)", options: ["all", {nestedBinaryExpressions: false}]},
+
         // https://github.com/eslint/eslint/issues/3653
         "(function(){}).foo(), 1, 2;",
         "(function(){}).foo++;",
@@ -291,6 +297,10 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("a + (b * c)", "BinaryExpression"),
         invalid("(a * b) + c", "BinaryExpression"),
         invalid("(a * b) / c", "BinaryExpression"),
+
+        invalid("a = (b * c)", "BinaryExpression", null, { options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("(b * c)", "BinaryExpression", null, { options: ["all", {nestedBinaryExpressions: false}]}),
+
         invalid("a = (b = c)", "AssignmentExpression"),
         invalid("(a).b", "Identifier"),
         invalid("(0)[a]", "Literal"),


### PR DESCRIPTION
As per the discussion in #3065 (and my duplicate request in #5587), this introduces an option for `no-extra-parens` to allow for parens to be used in binary expressions.

```js
x = a || (b && c);
```

This was done by simply ignoring the BinaryExpression nodes when the option is set, which kinda seems too good to be true, however all the tests (of valid and invalid code) seem to pass, so ... :tada: yay? It's quite possible that I've missed a test case here.

There was also a typo in the docs for the `conditionalAssign` option, which described usage when set to `true`, but it should read `false`.