### PR TITLE
Docs: Distinguish examples in rules under Best Practices part 4

### DIFF
--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -12,7 +12,7 @@ foo = foo;
 
 This rule is aimed at eliminating self assignments.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-self-assign: 2*/
@@ -26,7 +26,7 @@ foo = foo;
 ({a, b} = {a, x});
 ```
 
-The following patterns are considered not problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-self-assign: 2*/

--- a/docs/rules/no-self-compare.md
+++ b/docs/rules/no-self-compare.md
@@ -8,6 +8,8 @@ The only time you would compare a variable against itself is when you are testin
 
 This error is raised to highlight a potentially confusing and potentially pointless piece of code. There are almost no situations in which you would need to compare something to itself.
 
+Examples of **incorrect** code for this rule:
+
 ```js
 /*eslint no-self-compare: 2*/
 

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -19,7 +19,7 @@ This rule forbids the use of the comma operator, with the following exceptions:
 * In the initialization or update portions of a `for` statement.
 * If the expression sequence is explicitly wrapped in parentheses.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-sequences: 2*/
@@ -39,7 +39,7 @@ while (val = foo(), val < 42);
 with (doSomething(), val) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-sequences: 2*/

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -9,7 +9,7 @@ This rule restricts what can be thrown as an exception.  When it was first creat
 
 This rule is aimed at maintaining consistency when throwing exception by disallowing to throw literals and other expressions which cannot possibly be an `Error` object.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-throw-literal: 2*/
@@ -32,7 +32,7 @@ throw `${err}`
 
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-throw-literal: 2*/
@@ -53,7 +53,9 @@ try {
 
 ## Known Limitations
 
-Due to the limits of static analysis, this rule cannot guarantee that you will only throw `Error` objects.  For instance, the following cases do not throw an `Error` object, but they will not be considered problems:
+Due to the limits of static analysis, this rule cannot guarantee that you will only throw `Error` objects.
+
+Examples of **correct** code for this rule, but which do not throw an `Error` object:
 
 ```js
 /*eslint no-throw-literal: 2*/

--- a/docs/rules/no-unmodified-loop-condition.md
+++ b/docs/rules/no-unmodified-loop-condition.md
@@ -26,7 +26,7 @@ the expression instead.
 If a reference is inside of a dynamic expression (e.g. `CallExpression`,
 `YieldExpression`, ...), this rule ignores it.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 while (node) {
@@ -43,7 +43,7 @@ while (node !== root) {
 }
 ```
 
-The following patterns are considered not problems:
+Examples of **correct** code for this rule:
 
 ```js
 while (node) {

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -1,20 +1,28 @@
 # Disallow Unused Expressions (no-unused-expressions)
 
-Unused expressions are those expressions that evaluate to a value but are never used. For example:
+An unused expression which has no effect on the state of the program indicates a logic error.
 
-```js
-n + 1;
-```
-
-This is a valid JavaScript expression, but isn't actually used. Even though it's not a syntax error it is clearly a logic error and it has no effect on the code being executed.
+For example, `n + 1;` is not a syntax error, but it might be a typing mistake where a programmer meant an assignment statement `n += 1;` instead.
 
 ## Rule Details
 
-This rule aims to eliminate unused expressions. The value of an expression should always be used, except in the case of expressions that side effect: function calls, assignments, and the `new` operator.
+This rule aims to eliminate unused expressions which have no effect on the state of the program.
 
-Note that sequence expressions (those using a comma, such as `a = 1, b = 2`) are always considered unused unless their return value is assigned or used in a condition evaluation, or a function call is made with the sequence expression value.
+This rule does not apply to function calls or constructor calls with the `new` operator, because they could have *side effects* on the state of the program.
 
-Please also note that this rule does not apply to directives (which are in the form of literal string expressions (e.g., `"use strict";`) at the beginning of a script, module, or function).
+```js
+var i = 0;
+function increment() { i += 1; }
+increment(); // return value is unused, but i changed as a side effect
+
+var nThings = 0;
+function Thing() { nThings += 1; }
+new Thing(); // constructed object is unused, but nThings changed as a side effect
+```
+
+This rule does not apply to directives (which are in the form of literal string expressions such as `"use strict";` at the beginning of a script, module, or function).
+
+Sequence expressions (those using a comma, such as `a = 1, b = 2`) are always considered unused unless their return value is assigned or used in a condition evaluation, or a function call is made with the sequence expression value.
 
 ## Options
 
@@ -23,7 +31,9 @@ This rule, in its default state, does not require any arguments. If you would li
 * `allowShortCircuit` set to `true` will allow you to use short circuit evaluations in your expressions (Default: `false`).
 * `allowTernary` set to `true` will enable you use ternary operators in your expressions similarly to short circuit evaluations (Default: `false`).
 
-By default the following patterns are considered problems:
+These options allow unused expressions *only if all* of the code paths either directly change the state (for example, assignment statement) or could have *side effects* (for example, function call).
+
+Examples of **incorrect** code for the default `{ "allowShortCircuit": false, "allowTernary": false }` options:
 
 ```js
 /*eslint no-unused-expressions: 2*/
@@ -58,7 +68,7 @@ Note that one or more string expression statements (with or without semi-colons)
 "any other strings like this in the prologue";
 ```
 
-The following patterns are not considered problems by default:
+Examples of **correct** code for the default `{ "allowShortCircuit": false, "allowTernary": false }` options:
 
 ```js
 /*eslint no-unused-expressions: 2*/
@@ -82,42 +92,51 @@ delete a.b
 void a
 ```
 
-The following patterns are not considered problems if `allowShortCircuit` is enabled:
+### allowShortCircuit
+
+Examples of **incorrect** code for the `{ "allowShortCircuit": true }` option:
 
 ```js
-/*eslint no-unused-expressions: [2, { allowShortCircuit: true }]*/
+/*eslint no-unused-expressions: [2, { "allowShortCircuit": true }]*/
+
+a || b
+```
+
+Examples of **correct** code for the `{ "allowShortCircuit": true }` option:
+
+```js
+/*eslint no-unused-expressions: [2, { "allowShortCircuit": true }]*/
 
 a && b()
-
 a() || (b = c)
 ```
 
-If you enable the `allowTernary` the following patterns will be allowed:
+### allowTernary
+
+Examples of **incorrect** code for the `{ "allowTernary": true }` option:
 
 ```js
-/*eslint no-unused-expressions: [2, { allowTernary: true }]*/
+/*eslint no-unused-expressions: [2, { "allowTernary": true }]*/
+
+a ? b : 0
+a ? b : c()
+```
+
+Examples of **correct** code for the `{ "allowTernary": true }` option:
+
+```js
+/*eslint no-unused-expressions: [2, { "allowTernary": true }]*/
 
 a ? b() : c()
-
 a ? (b = c) : d()
 ```
 
-Enabling both options will allow a combination of both ternary and short circuit evaluation:
+### allowShortCircuit and allowTernary
+
+Examples of **correct** code for the `{ "allowShortCircuit": true, "allowTernary": true }` options:
 
 ```js
-/*eslint no-unused-expressions: [2, { allowShortCircuit: true, allowTernary: true }]*/
+/*eslint no-unused-expressions: [2, { "allowShortCircuit": true, "allowTernary": true }]*/
 
 a ? b() || (c = d) : e()
-```
-
-The above options still will not allow expressions that have code paths without side effects such as the following:
-
-```js
-/*eslint no-unused-expressions: [2, { allowShortCircuit: true, allowTernary: true }]*/
-
-a || b
-
-a ? b : 0
-
-a ? b : c()
 ```

--- a/docs/rules/no-unused-labels.md
+++ b/docs/rules/no-unused-labels.md
@@ -19,7 +19,7 @@ Such labels take up space in the code and can lead to confusion by readers.
 
 This rule is aimed at eliminating unused labels.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-unused-labels: 2*/
@@ -36,7 +36,7 @@ for (let i = 0; i < 10; ++i) {
 }
 ```
 
-The following patterns are considered not problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-unused-labels: 2*/

--- a/docs/rules/no-useless-call.md
+++ b/docs/rules/no-useless-call.md
@@ -7,7 +7,7 @@ But `Function.prototype.call()` and `Function.prototype.apply()` are slower than
 
 This rule is aimed to flag usage of `Function.prototype.call()` and `Function.prototype.apply()` that can be replaced with the normal function invocation.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-call: 2*/
@@ -23,7 +23,7 @@ obj.foo.call(obj, 1, 2, 3);
 obj.foo.apply(obj, [1, 2, 3]);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-useless-call: 2*/
@@ -42,18 +42,24 @@ foo.apply(null, args);
 obj.foo.apply(obj, args);
 ```
 
-Known limitations:
+## Known Limitations
 
 This rule compares code statically to check whether or not `thisArg` is changed.
 So if the code about `thisArg` is a dynamic expression, this rule cannot judge correctly.
 
+Examples of **incorrect** code for this rule:
+
 ```js
 /*eslint no-useless-call: 2*/
 
-// This is warned.
 a[i++].foo.call(a[i++], 1, 2, 3);
+```
 
-// This is not warned.
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-useless-call: 2*/
+
 a[++i].foo.call(a[i], 1, 2, 3);
 ```
 

--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -16,7 +16,7 @@ var foo = "ab";
 
 This rule aims to flag the concatenation of 2 literals when they could be combined into a single literal. Literals can be strings or template literals.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-concat: 2*/
@@ -30,7 +30,7 @@ var a = `1` + '0';
 var a = `1` + `0`;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-useless-concat: 2*/

--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -48,7 +48,7 @@ Some code styles prohibit `void` operator marking it as non-obvious and hard to 
 
 This rule aims to eliminate use of void operator.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-void: 2*/

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -1,33 +1,57 @@
 # Disallow Warning Comments (no-warning-comments)
 
-Often code is marked during development process for later work on it or with additional thoughts. Examples are typically `// TODO: do something` or `// FIXME: this is not a good idea`. These comments are a warning signal, that there is something not production ready in your code. Most likely you want to fix it or remove the comments before you roll out your code with a good feeling.
+Developers often add comments to code which is not complete or needs review. Most likely you want to fix or review the code, and then remove the comment, before you consider the code to be production ready.
+
+```js
+// TODO: do something
+// FIXME: this is not a good idea
+```
 
 ## Rule Details
 
-This rule can be used to help finding these `warning-comments`. It can be configured with an array of terms you don't want to exist in your code. It will raise a warning when one or more of the configured `warning-comments` are present in the checked files.
+This rule reports comments that include any of the predefined terms specified in its configuration.
 
-The default configuration looks like this:
+## Options
 
-```json
-"no-warning-comments": [0, { "terms": ["todo", "fixme", "xxx"], "location": "start" }]
+This rule has an options object literal:
+
+* `"terms"`: optional array of terms to match. Defaults to `["todo", "fixme", "xxx"]`. Terms are matched case-insensitive and as whole words: `fix` would match `FIX` but not `fixing`. Terms can consist of multiple words: `really bad idea`.
+* `"location"`: optional string that configures where in your comments to check for matches. Defaults to `"start"`. The other value is match `anywhere` in comments.
+
+Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
+
+```js
+/*eslint no-warning-comments: 2*/
+
+function callback(err, results) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+  // TODO
+}
 ```
 
-This preconfigures
+Example of **correct** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
-* the rule is disabled because it is set to `0`. Changing this to `1` for warn or `2` for error mode activates it (this works exactly the same as everywhere else in `ESLint`).
-* the `terms` array is set to `todo`, `fixme` and `xxx` as `warning-comments`. `terms` has to be an array. It can hold any terms you might want to warn about in your comments - they do not have to be single words. E.g. `really bad idea` is as valid as `attention`.
-* the `terms` are case-insensitive and are matched as whole words. E.g. `fix` would not match `fixing`.
-* the `location`-option set to `start` configures the rule to check only the start of comments. E.g. `// TODO` would be matched, `// This is a TODO` would not. You can change this to `anywhere` to check your complete comments.
+```js
+/*eslint no-warning-comments: 2*/
 
-As already seen above, the configuration is quite simple. Example that enables the rule and configures it to check the complete comment, not only the start:
-
-```json
-"no-warning-comments": [2, { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]
+function callback(err, results) {
+  if (err) {
+    console.error(err);
+    return;
+  }
+  // NOT READY FOR PRIME TIME
+  // but too bad, it is not a predefined warning term
+}
 ```
 
-The following patterns are considered problems:
+### terms and location
 
-```
+Examples of **incorrect** code for the `{ "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }` options:
+
+```js
 /*eslint no-warning-comments: [2, { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
 
 // TODO: this
@@ -40,9 +64,9 @@ The following patterns are considered problems:
  */
 ```
 
-These patterns would not be considered problems:
+Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }` options:
 
-```
+```js
 /*eslint no-warning-comments: [2, { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
 
 // This is to do
@@ -53,50 +77,7 @@ These patterns would not be considered problems:
  * with any other interesting term
  * or fix me this
  */
-
 ```
-
-## Options
-
-```json
-"no-warning-comments": [<enabled>, { "terms": <terms>, "location": <location> }]
-```
-
-* `enabled`: for enabling the rule. 0=off, 1=warn, 2=error. Defaults to `0`.
-* `terms`: optional array of terms to match. Terms are matched ignoring the case. Defaults to `["todo", "fixme", "xxx"]`.
-* `location`: optional string that configures where in your comments to check for matches. Defaults to `"start"`.
-
-### Examples
-
-* Rule configured to warn on matches and search the complete comment, not only the start of it. Note that the `term` configuration is omitted to use the defaults terms.
-
-   ```json
-   "no-warning-comments": [1, { "location": "anywhere" }]
-   ```
-
-* Rule configured to warn on matches of the term `bad string` at the start of comments. Note that the `location` configuration is omitted to use the default location.
-
-   ```json
-   "no-warning-comments": [1, { "terms": ["bad string"] }]
-   ```
-
-* Rule configured to warn with error on matches of the default terms at the start of comments. Note that the complete configuration object (that normally holds `terms` and/or `location`) can be omitted for simplicity.
-
-   ```json
-   "no-warning-comments": [2]
-   ```
-
-* Rule configured to warn on matches of the default terms at the start of comments. Note that the complete configuration object (as already seen in the example above) and even the square brackets can be omitted for simplicity.
-
-   ```json
-   "no-warning-comments": 1
-   ```
-
-* Rule configured to warn on matches of the specified terms at any location in the comments. Note that you can use as many terms as you want.
-
-   ```json
-   "no-warning-comments": [1, { "terms": ["really any", "term", "can be matched"], "location": "anywhere" }]
-   ```
 
 ## When Not To Use It
 

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -6,7 +6,7 @@ The `with` statement is potentially problematic because it adds members of an ob
 
 This rule is aimed at eliminating `with` statements.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-with: 2*/

--- a/docs/rules/radix.md
+++ b/docs/rules/radix.md
@@ -29,15 +29,10 @@ There are two options for this rule:
 * `"always"` enforces providing a radix (default)
 * `"as-needed"` disallows providing the `10` radix
 
-Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
-```json
-"radix": [2, "always"]
-```
+### always
 
-### "always"
-
-The following patterns are considered problems:
+Examples of **incorrect** code for the default `"always"` option:
 
 ```js
 /*eslint radix: 2*/
@@ -51,7 +46,7 @@ var num = parseInt("071", "abc");
 var num = parseInt();
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the default `"always"` option:
 
 ```js
 /*eslint radix: 2*/
@@ -63,12 +58,12 @@ var num = parseInt("071", 8);
 var num = parseFloat(someValue);
 ```
 
-### "as-needed"
+### as-needed
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"as-needed"` option:
 
 ```js
-/*eslint radix: [2. "as-needed"] */
+/*eslint radix: [2, "as-needed"]*/
 
 var num = parseInt("071", 10);
 
@@ -77,10 +72,10 @@ var num = parseInt("071", "abc");
 var num = parseInt();
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for the `"as-needed"` option:
 
 ```js
-/*eslint radix: [2. "as-needed"] */
+/*eslint radix: [2, "as-needed"]*/
 
 var num = parseInt("071");
 

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -1,12 +1,14 @@
 # Strict Mode Directives (strict)
 
-A strict mode directive at the beginning of a script or function body enables strict mode semantics:
+A strict mode directive at the beginning of a script or function body enables strict mode semantics.
+
+When used globally, the entire script, including all contained functions, are strict mode code:
 
 ```js
 "use strict";
 ```
 
-When used globally, as in the preceding example, the entire script, including all contained functions, are strict mode code. It is also possible to specify function-level strict mode, such that strict mode applies only to the function in which the directive occurs:
+It is also possible to specify function-level strict mode, such that strict mode applies only to the function in which the directive occurs:
 
 ```js
 function foo() {
@@ -30,18 +32,22 @@ This rule is aimed at using strict mode directives effectively, and as such, wil
 
 There are four options for this rule:
 
-* `"never"` - don't use `"use strict"` at all
-* `"global"` - require `"use strict"` in the global scope
-* `"function"` - require `"use strict"` in function scopes only
-* `"safe"` - require `"use strict"` globally when inside a module wrapper and in function scopes everywhere else.
+* `"safe"` - require `"use strict"` globally when inside a module wrapper and in function scopes everywhere else. This is the default.
+* `"never"` - disallow `"use strict"`.
+* `"global"` - require `"use strict"` in the global scope.
+* `"function"` - require `"use strict"` in function scopes only.
 
 All strict mode directives are flagged as unnecessary if ECMAScript modules or implied strict mode are enabled (see [Specifying Parser Options](../user-guide/configuring#specifying-parser-options)). This behaviour does not depend on the rule options, but can be silenced by disabling this rule.
 
-### "never"
+### safe
+
+Node.js and the CommonJS module system wrap modules inside a hidden function wrapper that defines each module's scope. The wrapper makes it safe to concatenate strict mode modules while maintaining their original strict mode directives. When the `node` or `commonjs` environments are enabled or `globalReturn` is enabled in `ecmaFeatures`, ESLint considers code to be inside the module wrapper, and `"safe"` mode corresponds to `"global"` mode and enforces global strict mode directives. Everywhere else, `"safe"` mode corresponds to `"function"` mode and enforces strict mode directives inside top-level functions.
+
+### never
 
 This mode forbids any occurrence of a strict mode directive.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"never"` option:
 
 ```js
 /*eslint strict: [2, "never"]*/
@@ -62,7 +68,7 @@ foo();
 bar();
 ```
 
-The following patterns are considered valid:
+Examples of **correct** code for the `"never"` option:
 
 ```js
 /*eslint strict: [2, "never"]*/
@@ -79,13 +85,13 @@ foo();
 bar();
 ```
 
-### "global"
+### global
 
 This mode ensures that all code is in strict mode and that there are no extraneous strict mode directives at the top level or in nested functions, which are themselves already strict by virtue of being contained in strict global code. It requires that global code contains exactly one strict mode directive. Strict mode directives inside functions are considered unnecessary. Multiple strict mode directives at any level also trigger warnings.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"global"` option:
 
-```
+```js
 /*eslint strict: [2, "global"]*/
 
 "use strict";
@@ -105,9 +111,9 @@ function foo() {
 foo();
 ```
 
-The following patterns are considered valid:
+Examples of **correct** code for the `"global"` option:
 
-```
+```js
 /*eslint strict: [2, "global"]*/
 
 "use strict";
@@ -121,13 +127,13 @@ function foo() {
 foo();
 ```
 
-### "function"
+### function
 
 This mode ensures that all function bodies are strict mode code, while global code is not. Particularly if a build step concatenates multiple scripts, a strict mode directive in global code of one script could unintentionally enable strict mode in another script that was not intended to be strict code. It forbids any occurrence of a strict mode directive in global code. It requires exactly one strict mode directive in each function declaration or expression whose parent is global code. Strict mode directives inside nested functions are considered unnecessary. Multiple strict mode directives at any level also trigger warnings.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for the `"function"` option:
 
-```
+```js
 /*eslint strict: [2, "function"]*/
 
 "use strict";
@@ -146,9 +152,9 @@ function foo() {
 foo();
 ```
 
-The following patterns are considered valid:
+Examples of **correct** code for the `"function"` option:
 
-```
+```js
 /*eslint strict: [2, "function"]*/
 
 function foo() {
@@ -168,17 +174,13 @@ function foo() {
 foo();
 ```
 
-### "safe" (default)
-
-Node.js and the CommonJS module system wrap modules inside a hidden function wrapper that defines each module's scope. The wrapper makes it safe to concatenate strict mode modules while maintaining their original strict mode directives. When the `node` or `commonjs` environments are enabled or `globalReturn` is enabled in `ecmaFeatures`, ESLint considers code to be inside the module wrapper, and `"safe"` mode corresponds to `"global"` mode and enforces global strict mode directives. Everywhere else, `"safe"` mode corresponds to `"function"` mode and enforces strict mode directives inside top-level functions.
-
-### "deprecated" (Removed)
+### earlier default (removed)
 
 **Replacement notice**: This mode, previously enabled by turning on the rule without specifying a mode, has been removed in ESLint v1.0. `"function"` mode is most similar to the deprecated behavior.
 
 This mode ensures that all functions are executed in strict mode. A strict mode directive must be present in global code or in every top-level function declaration or expression. It does not concern itself with unnecessary strict mode directives in nested functions that are already strict, nor with multiple strict mode directives at the same level.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for an earlier default option which has been removed:
 
 ```js
 // "strict": 2
@@ -188,7 +190,7 @@ function foo() {
 }
 ```
 
-The following patterns do not cause a warning:
+Examples of **correct** code for an earlier default option which has been removed:
 
 ```js
 // "strict": 2
@@ -198,8 +200,10 @@ The following patterns do not cause a warning:
 function foo() {
     return true;
 }
+```
 
-// ----------------
+```js
+// "strict": 2
 
 function foo() {
 
@@ -207,8 +211,10 @@ function foo() {
 
     return true;
 }
+```
 
-// ----------------
+```js
+// "strict": 2
 
 (function() {
     "use strict";

--- a/docs/rules/vars-on-top.md
+++ b/docs/rules/vars-on-top.md
@@ -9,7 +9,7 @@ This rule forces the programmer to represent that behaviour by manually moving t
 This rule aims to keep all variable declarations in the leading series of statements.
 Allowing multiple declarations helps promote maintainability and is thus allowed.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint vars-on-top: 2*/
@@ -27,13 +27,17 @@ function doSomething() {
 function doSomething() {
     for (var i=0; i<10; i++) {}
 }
+```
+
+```js
+/*eslint vars-on-top: 2*/
 
 // Variables after other statements:
 f();
 var a;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint vars-on-top: 2*/

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -1,67 +1,80 @@
 # Require IIFEs to be Wrapped (wrap-iife)
 
-Require immediate function invocation to be wrapped in parentheses.
+You can immediately invoke function expressions, but not function declarations. A common technique to create an immediately-invoked function expression (IIFE) is to wrap a function declaration in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.
 
 ```js
+// function expression could be unwrapped
 var x = function () { return { y: 1 };}();
+
+// function declaration must be wrapped
+function () { /* side effects */ }(); // SyntaxError
 ```
 
 ## Rule Details
 
-Since function statements cannot be immediately invoked, and function expressions can be, a common technique to create an immediately-invoked function expression is to simply wrap a function statement in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.
+This rule requires all immediately-invoked function expressions to be wrapped in parentheses.
 
 ## Options
 
-The rule takes one option which can enforce a consistent wrapping style. The default is `outside`.
+The rule takes one option which can enforce a consistent wrapping style:
 
-```json
-"wrap-iife": [2, "outside"]
-```
+* `"outside"` enforces always wrapping the *call* expression. The default is `"outside"`.
+* `"inside"` enforces always wrapping the *function* expression.
+* `"any"` enforces always wrapping, but allows either style.
 
-This configures the rule to enforce wrapping always the call expression.
+### outside
 
-```json
-"wrap-iife": [2, "inside"]
-```
-
-This configures the rule to enforce wrapping always the function expression.
-
-```json
-"wrap-iife": [2, "any"]
-```
-
-This allows any wrapping style.
-
-The following patterns are considered problems:
-
-```js
-/*eslint wrap-iife: 2*/
-
-var x = function () { return { y: 1 };}();
-```
+Examples of **incorrect** code for the default `"outside"` option:
 
 ```js
 /*eslint wrap-iife: [2, "outside"]*/
 
-var x = (function () { return { y: 1 };})();
+var x = function () { return { y: 1 };}(); // unwrapped
+var x = (function () { return { y: 1 };})(); // wrapped function expression
 ```
 
-```js
-/*eslint wrap-iife: [2, "inside"]*/
-
-var x = (function () { return { y: 1 };}());
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint wrap-iife: [2, "inside"]*/
-
-var x = (function () { return { y: 1 };})();
-```
+Examples of **correct** code for the default `"outside"` option:
 
 ```js
 /*eslint wrap-iife: [2, "outside"]*/
 
-var x = (function () { return { y: 1 };}());
+var x = (function () { return { y: 1 };}()); // wrapped call expression
+```
+
+### inside
+
+Examples of **incorrect** code for the `"inside"` option:
+
+```js
+/*eslint wrap-iife: [2, "inside"]*/
+
+var x = function () { return { y: 1 };}(); // unwrapped
+var x = (function () { return { y: 1 };}()); // wrapped call expression
+```
+
+Examples of **correct** code for the `"inside"` option:
+
+```js
+/*eslint wrap-iife: [2, "inside"]*/
+
+var x = (function () { return { y: 1 };})(); // wrapped function expression
+```
+
+### any
+
+Examples of **incorrect** code for the `"any"` option:
+
+```js
+/*eslint wrap-iife: [2, "any"]*/
+
+var x = function () { return { y: 1 };}(); // unwrapped
+```
+
+Examples of **correct** code for the `"any"` option:
+
+```js
+/*eslint wrap-iife: [2, "any"]*/
+
+var x = (function () { return { y: 1 };}()); // wrapped call expression
+var x = (function () { return { y: 1 };})(); // wrapped function expression
 ```

--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -24,9 +24,25 @@ Opponents of Yoda conditions point out that tooling has made us better programme
 
 ## Rule Details
 
-This rule takes one argument. If it is `"never"` then comparisons must never be a Yoda condition. If `"always"`, then the literal must always come first. The default is `"never"`.
+This rule aims to enforce consistent style of conditions which compare a variable to a literal value.
 
-The following patterns are considered problems:
+## Options
+
+This rule can take a string option:
+
+* If it is the default `"never"`, then comparisons must never be Yoda conditions.
+* If it is `"always"`, then the literal value must always come first.
+
+The default `"never"` option can have exception options in an object literal:
+
+* If the `"exceptRange"` property is `true`, the rule *allows* yoda conditions in range comparisons which are wrapped directly in parentheses, including the parentheses of an `if` or `while` condition. The default value is `false`. A *range* comparison tests whether a variable is inside or outside the range between two literal values.
+* If the `"onlyEquality"` property is `true`, the rule reports yoda conditions *only* for the equality operators `==` and `===`. The default value is `false`.
+
+The `onlyEquality` option allows a superset of the exceptions which `exceptRange` allows, thus both options are not useful together.
+
+### never
+
+Examples of **incorrect** code for the default `"never"` option:
 
 ```js
 /*eslint yoda: 2*/
@@ -52,16 +68,7 @@ if (0 <= x && x < 1) {
 }
 ```
 
-```js
-/*eslint yoda: [2, "always"]*/
-
-if (color == "blue") {
-    // ...
-}
-```
-
-
-The following patterns are not considered problems:
+Examples of **correct** code for the default `"never"` option:
 
 ```js
 /*eslint yoda: 2*/
@@ -75,40 +82,9 @@ if (value === "red") {
 }
 ```
 
-```js
-/*eslint yoda: [2, "always"]*/
+### exceptRange
 
-if ("blue" == value) {
-    // ...
-}
-
-if (-1 < str.indexOf(substr)) {
-    // ...
-}
-```
-
-## Options
-
-There are a few options to the rule:
-
-```json
-"yoda": [2, "never", {
-    "exceptRange": false,
-    "onlyEquality": false
-}]
-```
-
-The `onlyEquality` option is a superset of `exceptRange`, thus both options are hardly useful together.
-
-### Range Tests
-
-"Range" comparisons test whether a variable is inside or outside the range between two literals. When configured with the `exceptRange` option, range tests are allowed when the comparison itself is wrapped directly in parentheses, such as those of an `if` or `while` condition.
-
-```json
-"yoda": [2, "never", { "exceptRange": true }]
-```
-
-With the `exceptRange` option enabled, the following patterns become valid:
+Examples of **correct** code for the `"never", { "exceptRange": true }` options:
 
 ```js
 /*eslint yoda: [2, "never", { "exceptRange": true }]*/
@@ -130,9 +106,9 @@ function howLong(arr) {
 }
 ```
 
-### Apply only to equality, but not other operators
+### onlyEquality
 
-Some developers might prefer to only enforce the rule for the equality operators `==` and `===`, and not showing any warnings for any code around other operators. With `onlyEquality` option, these patterns will not be considered problems:
+Examples of **correct** code for the `"never", { "onlyEquality": true }` options:
 
 ```js
 /*eslint yoda: [2, "never", { "onlyEquality": true }]*/
@@ -141,6 +117,32 @@ if (x < -1 || 9 < x) {
 }
 
 if (x !== 'foo' && 'bar' != x) {
+}
+```
+
+### always
+
+Examples of **incorrect** code for the `"always"` option:
+
+```js
+/*eslint yoda: [2, "always"]*/
+
+if (color == "blue") {
+    // ...
+}
+```
+
+Examples of **correct** code for the `"always"` option:
+
+```js
+/*eslint yoda: [2, "always"]*/
+
+if ("blue" == value) {
+    // ...
+}
+
+if (-1 < str.indexOf(substr)) {
+    // ...
 }
 ```
 


### PR DESCRIPTION
4 of 4 pull requests for rules under **Best Practices** plus strict under **Strict Mode**

Here are the changes beyond example sentences:
* no-unused-expressions has much cut-and-paste: for options all code paths must have side effects; move incorrect/correct code pairs together for options
* no-useless-call: Replace p with h2 Known Limitations; reverse order of its examples to incorrect/correct
* no-warning-comments has much cut-and-paste: simplify introduction and Rule Details; delete json, info about error level, and examples of config without code
* radix: delete redundant p and json after ul under Options
* vars-on-top: split incorrect code to make it parallel with correct code
* wrap-iife has much cut-and-paste: Swap introduction sentence and Rule Details paragraph; replace statement with declaration; Options ul; separate example code pairs for options
* yoda has much cut-and-paste: add sentence to Rule Details; Add Options ul; separate example code; move exception options to follow default never
* strict: move default safe option first; separate correct code for earlier default

Add to missing examples:
* no-self-compare: correct code for this rule
* no-void: correct code for this rule
* no-warning-comments: incorrect/correct code for the default options?
* no-with: correct code for this rule
* strict: incorrect and correct for the default safe option
