### PR TITLE
Fix: respect 'ignoreTrailingComments' in max-len rule (fixes #5563)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -118,7 +118,7 @@ module.exports = function(context) {
         // split (honors line-ending)
         var lines = context.getSourceLines(),
             // list of comments to ignore
-            comments = ignoreComments || maxCommentLength ? context.getAllComments() : [],
+            comments = ignoreComments || maxCommentLength || ignoreTrailingComments ? context.getAllComments() : [],
             // we iterate over comments in parallel with the lines
             commentsIndex = 0;
 

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -76,6 +76,12 @@ ruleTester.run("max-len", rule, {
                 "// Full line comment\n" +
                 "someCode(); // With a long trailing comment.",
             options: [{code: 30, tabWidth: 4, comments: 20, ignoreTrailingComments: true}]
+        }, {
+            code: "var foo = module.exports = {}; // really long trailing comment",
+            options: [40, 4, {ignoreTrailingComments: true}]
+        }, {
+            code: "var foo = module.exports = {}; // really long trailing comment",
+            options: [40, 4, {ignoreComments: true, ignoreTrailingComments: false}]
         },
         // blank line
         ""
@@ -224,6 +230,17 @@ ruleTester.run("max-len", rule, {
             errors: [
                 {
                     message: "Line 1 exceeds the maximum line length of 20.",
+                    type: "Program",
+                    line: 1,
+                    column: 1
+                }
+            ]
+        }, {
+            code: "//This is very long comment with more than 40 characters which is invalid",
+            options: [40, 4, {ignoreTrailingComments: true }],
+            errors: [
+                {
+                    message: "Line 1 exceeds the maximum line length of 40.",
                     type: "Program",
                     line: 1,
                     column: 1


### PR DESCRIPTION
Older pull request(#5585) failed to push changes to travis , so created this again . 

We are considering `ignoreComments` and `maxCommentLength`  alone to see if comments need to be considered. As these two are false , the comments is empty array and trailing comments are not stripped. 

Fix : Added this condition also along with other two. If any of the three are true, we are considering the comments in our calculation. 