### PR TITLE
Docs: Distinguish examples in rules under Node.js and CommonJS

### DIFF
--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -20,10 +20,13 @@ To prevent calling the callback multiple times it is important to `return` anyti
 ## Rule Details
 
 This rule is aimed at ensuring that callbacks used outside of the main function block are always part-of or immediately
-preceding a `return` statement. This rules decides what is a callback based on the name of the function being called.
-By default the rule treats `cb`, `callback`, and `next` as callbacks.
+preceding a `return` statement. This rule decides what is a callback based on the name of the function being called.
 
-The following patterns are considered problems:
+## Options
+
+The rule takes a single option, which is an array of possible callback names. The default callback names are `callback`, `cb`, `next`.
+
+Examples of **incorrect** code for this rule with the default `["callback", "cb", "next"]` option:
 
 ```js
 /*eslint callback-return: 2*/
@@ -36,7 +39,7 @@ function foo() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `["callback", "cb", "next"]` option:
 
 ```js
 /*eslint callback-return: 2*/
@@ -49,24 +52,18 @@ function foo() {
 }
 ```
 
-## Options
-
-The rule takes a single option, which is an array of possible callback names.
-
-```json
-callback-return: [2, ["callback", "cb", "next"]]
-```
-
 ## Known Limitations
 
-There are several cases of bad behavior that this rule will not catch and even a few cases where
-the rule will warn even though you are handling your callbacks correctly. Most of these issues arise
-in areas where it is difficult to understand the meaning of the code through static analysis.
+Because it is difficult to understand the meaning of a program through static analysis, this rule has limitations:
 
-### Passing the Callback by Reference
+* *false negatives* when this rule reports correct code, but the program calls the callback more than one time (which is incorrect behavior)
+* *false positives* when this rule reports incorrect code, but the program calls the callback only one time (which is correct behavior)
 
-Here is a case where we pass the callback to the `setTimeout` function. Our rule does not detect this pattern, but
-it is likely a mistake.
+### Passing the callback by reference
+
+The static analysis of this rule does not detect that the program calls the callback if it is an argument of a function (for example,  `setTimeout`).
+
+Example of a *false negative* when this rule reports correct code:
 
 ```js
 /*eslint callback-return: 2*/
@@ -79,11 +76,11 @@ function foo(callback) {
 }
 ```
 
-### Triggering the Callback within a Nested Function
+### Triggering the callback within a nested function
 
-If you are calling the callback from within a nested function or an immediately invoked
-function expression, we won't be able to detect that you're calling the callback and so
-we won't warn.
+The static analysis of this rule does not detect that the program calls the callback from within a nested function or an immediately-invoked function expression (IIFE).
+
+Example of a *false negative* when this rule reports correct code:
 
 ```js
 /*eslint callback-return: 2*/
@@ -98,10 +95,11 @@ function foo(callback) {
 }
 ```
 
-### If/Else Statements
+### If/else statements
 
-Here is a case where you're doing the right thing in making sure to only `callback()` once, but because of the
-difficulty in determining what you're doing, this rule does not allow for this pattern.
+The static analysis of this rule does not detect that the program calls the callback only one time in each branch of an `if` statement.
+
+Example of a *false positive* when this rule reports incorrect code:
 
 ```js
 /*eslint callback-return: 2*/

--- a/docs/rules/global-require.md
+++ b/docs/rules/global-require.md
@@ -1,4 +1,4 @@
-# Enforce require() on the top-level module scope. (global-require)
+# Enforce require() on the top-level module scope (global-require)
 
 In Node.js, module dependencies are included using the `require()` function, such as:
 
@@ -25,13 +25,7 @@ Further, ES6 modules mandate that `import` and `export` statements can only occu
 
 This rule requires all calls to `require()` to be at the top level of the module, similar to ES6 `import` and `export` statements, which also can occur only at the top level.
 
-You can enable this rule with the following syntax:
-
-```json
-"global-require": 2
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint global-require: 2*/
@@ -63,7 +57,7 @@ try {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint global-require: 2*/

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -12,10 +12,13 @@ function loadData (err, data) {
 
 ## Rule Details
 
-This rule expects that when you're using the callback pattern in Node.js you'll handle the error and
-requires that you specify the name of your error object. The name of the argument will default to `err`.
+This rule expects that when you're using the callback pattern in Node.js you'll handle the error.
 
-The following are considered problems:
+## Options
+
+The rule takes a single string option: the name of the error parameter. The default is `"err"`.
+
+Examples of **incorrect** code for this rule with the default `"err"` parameter name:
 
 ```js
 /*eslint handle-callback-err: 2*/
@@ -26,7 +29,7 @@ function loadData (err, data) {
 
 ```
 
-The following are not considered problems:
+Examples of **correct** code for this rule with the default `"err"` parameter name:
 
 ```js
 /*eslint handle-callback-err: 2*/
@@ -43,7 +46,7 @@ function generateError (err) {
 }
 ```
 
-You can also customize the name of the error object:
+Examples of **correct** code for this rule with a sample `"error"` parameter name:
 
 ```js
 /*eslint handle-callback-err: [2, "error"]*/
@@ -52,41 +55,20 @@ function loadData (error, data) {
     if (error) {
        console.log(error.stack);
     }
+    doSomething();
 }
 ```
 
-### Advanced configuration
+### regular expression
 
 Sometimes (especially in big projects) the name of the error variable is not consistent across the project,
-so you need a more flexible configuration to ensure all unhandled error getting recognized by this rule.
+so you need a more flexible configuration to ensure that the rule reports all unhandled errors.
 
 If the configured name of the error variable begins with a `^` it is considered to be a regexp pattern.
 
-Examples for valid configurations:
-
-1. Rule configured to warn if an unhandled error is detected where the name of the error variable can be `err`, `error` or `anySpecificError`.
-
-    ```json
-    // ...
-    "handle-callback-err": [2, "^(err|error|anySpecificError)$" ]
-    // ...
-    ```
-
-2. Rule configured to warn if an unhandled error is detected where the name of the error variable ends with `Error` (e. g. `connectionError` or `validationError` will match).
-
-    ```json
-    // ...
-    "handle-callback-err": [2, "^.+Error$" ]
-    // ...
-    ```
-
-3. Rule configured to warn if an unhandled error is detected where the name of the error variable matches any string that contains `err` or `Err` (e. g. `err`, `error`, `anyError`, `some_err` will match).
-
-    ```json
-    // ...
-    "handle-callback-err": [2, "^.*(e|E)rr" ]
-    // ...
-    ```
+* If the option is `"^(err|error|anySpecificError)$"`, the rule reports unhandled errors where the parameter name can be `err`, `error` or `anySpecificError`.
+* If the option is `"^.+Error$"`, the rule reports unhandled errors where the parameter name ends with `Error` (for example, `connectionError` or `validationError` will match).
+* If the option is `"^.*(e|E)rr"`, the rule reports unhandled errors where the parameter name matches any string that contains `err` or `Err` (for example, `err`, `error`, `anyError`, `some_err` will match).
 
 ## When Not To Use It
 

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -1,6 +1,6 @@
 # Disallow Mixed Requires (no-mixed-requires)
 
-In the Node.js community it is often customary to separate the `require`d modules from other variable declarations, sometimes also grouping them by their type. This rule helps you enforce this convention.
+In the Node.js community it is often customary to separate initializations with calls to `require` modules from other variable declarations, sometimes also grouping them by the type of module. This rule helps you enforce this convention.
 
 ## Rule Details
 
@@ -20,7 +20,7 @@ This rule distinguishes between six kinds of variable declaration types:
 
 In this document, the first four types are summed up under the term *require declaration*.
 
-```javascript
+```js
 var fs = require('fs'),        // "core"     \
     async = require('async'),  // "module"   |- these are "require declaration"s
     foo = require('./foo'),    // "file"     |
@@ -31,34 +31,24 @@ var fs = require('fs'),        // "core"     \
 
 ## Options
 
-This rule comes with two boolean options. Both are turned off by default. You can set those in your `eslint.json`:
+This rule can have an object literal option whose two properties have `false` values by default.
 
-```json
-{
-    "no-mixed-requires": [2, {"grouping": true, "allowCall": true}]
-}
-```
+Configuring this rule with one boolean option `true` is deprecated.
 
-The second way to configure this rule is with boolean. This way of setting is deprecated.
-
-```json
-{
-    "no-mixed-requires": [2, true]
-}
-```
-
-If enabled, violations will be reported whenever a single `var` statement contains require declarations of mixed types (see the examples below).
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `{ "grouping": false, "allowCall": false }` options:
 
 ```js
 /*eslint no-mixed-requires: 2*/
 
 var fs = require('fs'),
     i = 0;
+
+var async = require('async'),
+    debug = require('diagnostics').someFunction('my-module'),
+    eslint = require('eslint');
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "grouping": false, "allowCall": false }` options:
 
 ```js
 /*eslint no-mixed-requires: 2*/
@@ -81,10 +71,10 @@ var foo = require('foo' + VERSION),
 
 ### grouping
 
-The following patterns are considered problems when grouping is turned on:
+Examples of **incorrect** code for this rule with the `{ "grouping": true }` option:
 
 ```js
-/*eslint no-mixed-requires: [2, {"grouping": true}]*/
+/*eslint no-mixed-requires: [2, { "grouping": true }]*/
 
 // invalid because of mixed types "core" and "file"
 var fs = require('fs'),
@@ -97,19 +87,23 @@ var foo = require('foo'),
 
 ### allowCall
 
-The following patterns are not considered problems when `allowCall` is turned on:
+Examples of **incorrect** code for this rule with the `{ "allowCall": true }` option:
 
 ```js
+/*eslint no-mixed-requires: [2, { "allowCall": true }]*/
+
 var async = require('async'),
-    debug = require('diagnostics')('my-module'),
+    debug = require('diagnostics').someFunction('my-module'), /* allowCall doesn't allow calling any function */
     eslint = require('eslint');
 ```
 
-The following patterns are always considered problems regardless of `allowCall`:
+Examples of **correct** code for this rule with the `{ "allowCall": true }` option:
 
 ```js
+/*eslint no-mixed-requires: [2, { "allowCall": true }]*/
+
 var async = require('async'),
-    debug = require('diagnostics').someFunction('my-module'), /* Allow Call doesn't allow calling any function */
+    debug = require('diagnostics')('my-module'),
     eslint = require('eslint');
 ```
 

--- a/docs/rules/no-new-require.md
+++ b/docs/rules/no-new-require.md
@@ -22,9 +22,9 @@ For this reason, it is usually best to disallow this particular expression.
 
 ## Rule Details
 
-This rule aims to eliminate use of the `new require` expression. As such, it warns whenever `new require` is found in code.
+This rule aims to eliminate use of the `new require` expression.
 
-The following pattern is considered a warning:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-new-require: 2*/
@@ -32,15 +32,15 @@ The following pattern is considered a warning:
 var appHeader = new require('app-header');
 ```
 
-The following pattern is not a warning:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new-require: 2*/
 
 var AppHeader = require('app-header');
+var appHeader = new AppHeader();
 ```
 
 ## When Not To Use It
 
 If you are using a custom implementation of `require` and your code will never be used in projects where a standard `require` (CommonJS, Node.js, AMD) is expected, you can safely turn this rule off.
-

--- a/docs/rules/no-path-concat.md
+++ b/docs/rules/no-path-concat.md
@@ -26,7 +26,7 @@ Both `path.join()` and `path.resolve()` are suitable replacements for string con
 
 This rule aims to prevent string concatenation of directory paths in Node.js
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-path-concat: 2*/
@@ -37,7 +37,7 @@ var fullPath = __filename + "/foo.js";
 
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-path-concat: 2*/

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -23,7 +23,7 @@ By throwing an error in this way, other parts of the application have an opportu
 
 This rule aims to prevent the use of `process.exit()` in Node.js JavaScript. As such, it warns whenever `process.exit()` is found in code.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-process-exit: 2*/
@@ -32,7 +32,7 @@ process.exit(1);
 process.exit(0);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-process-exit: 2*/

--- a/docs/rules/no-restricted-modules.md
+++ b/docs/rules/no-restricted-modules.md
@@ -10,40 +10,31 @@ Blocking the `os` module can be useful if you don't want to allow any operating 
 
 This rule allows you to specify modules that you don't want to use in your application.
 
-To restrict the use of all Node.js core modules (via https://github.com/nodejs/node/tree/master/lib):
+## Options
+
+The rule takes one or more strings as options: the names of restricted modules.
+
+For example, to restrict the use of all Node.js core modules (via https://github.com/nodejs/node/tree/master/lib):
 
 ```json
     "no-restricted-modules": [2,
          "assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"
-    ],
+    ]
 ```
 
-## Options
-
-The syntax to specify restricted modules looks like this:
-
-```json
-"no-restricted-modules": [2, <...moduleNames>]
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with sample `"fs", "cluster"` restricted modules:
 
 ```js
-/*eslint no-restricted-modules: [2, "fs"]*/
+/*eslint no-restricted-modules: [2, "fs", "cluster"]*/
 
 var fs = require('fs');
+var cluster = require(' cluster ');
 ```
 
-```js
-/*eslint no-restricted-modules: [2, "cluster"]*/
-
-var fs = require(' cluster ');
-```
-
-The following patterns are not considered problems:
+Examples of **incorrect** code for this rule with sample `"fs", "cluster"` restricted modules:
 
 ```js
-/*eslint no-restricted-modules: [2, "fs"]*/
+/*eslint no-restricted-modules: [2, "fs", "cluster"]*/
 
 var crypto = require('crypto');
 ```

--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -6,7 +6,7 @@ In Node.js, most I/O is done through asynchronous methods. However, there are of
 
 This rule is aimed at preventing synchronous methods from being called in Node.js. It looks specifically for the method suffix "`Sync`" (as is the convention with Node.js operations).
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-sync: 2*/
@@ -16,7 +16,7 @@ fs.existsSync(somePath);
 var contents = fs.readFileSync(somePath).toString();
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-sync: 2*/


### PR DESCRIPTION
A pull request for rules under **Node.js and CommonJS**

This gets us to 50% of the rules. About 7 pull requests to go. Hang in there.

What do you think about the wording of these example sentences?
* Example of **correct** code for this rule, **but** it is probably a mistake:
* Example of **incorrect** code for this rule, **but** it is probably not a mistake:
* Examples of **correct** code for the default `"err"` parameter name:
* Examples of **correct** code for a sample `"error"` parameter name:
* Examples of **incorrect** code for a sample module:

Here are the changes beyond example sentences:
* callback-return: move examples from Rule Details to Options; change capitalization in h3 from title case to sentence case
* global-require: delete period in main heading; delete json and You can enable this rule with the following syntax
* handle-callback-err: replace h3 Advanced configuration with h2 Options and h3 regular expression; move example from Rule Details to Options; replace ol and json with ul and inline code; replace error variable with error parameter
* no-mixed-requires: add allowCall incorrect code to default incorrect example; put example code for allowCall in incorrect/correct order
* no-new-require: delete As such sentence under Rule Details; add new to correct code
* no-restricted-modules: sample instead of meta-notation in json
