### PR TITLE
Update: Enforce repo coding conventions via ESLint (refs #5188)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -332,6 +332,7 @@ function getBranches() {
 function lintMarkdown(files) {
     var config = {
             default: true,
+
             // Exclusions for deliberate/widespread violations
             MD001: false, // Header levels should only increment by one level at a time
             MD002: false, // First header should be a h1 header
@@ -1081,6 +1082,7 @@ target.perf = function() {
             "tests/performance/jshint.js",
             PERF_MULTIPLIER,
             function() {
+
                 // Count test target files.
                 var count = glob.sync(
                     process.platform === "win32"

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -33,14 +33,21 @@ var thisTagPattern = /^[\s\*]*@this/m;
  * @private
  */
 function isModifyingReference(reference, index, references) {
-    var identifier = reference.identifier;
+    var identifier = reference.identifier,
+        modifyingDifferentIdentifier;
+
+    /*
+     * Destructuring assignments can have multiple default value, so
+     * possibly there are multiple writeable references for the same
+     * identifier.
+     */
+    modifyingDifferentIdentifier = index === 0 ||
+        references[index - 1].identifier !== identifier;
 
     return (identifier &&
         reference.init === false &&
         reference.isWrite() &&
-            // Destructuring assignments can have multiple default value,
-            // so possibly there are multiple writeable references for the same identifier.
-        (index === 0 || references[index - 1].identifier !== identifier)
+        modifyingDifferentIdentifier
     );
 }
 
@@ -352,9 +359,11 @@ module.exports = {
         while (node) {
             var parent = node.parent;
             switch (parent.type) {
-                // Looks up the destination.
-                // e.g.
-                //   obj.foo = nativeFoo || function foo() { ... };
+
+                /*
+                 * Looks up the destination.
+                 * e.g., obj.foo = nativeFoo || function foo() { ... };
+                 */
                 case "LogicalExpression":
                 case "ConditionalExpression":
                     node = parent;

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -274,8 +274,11 @@ function isErrorMessage(message) {
  * @returns {string} the resolved path to the cache file
  */
 function getCacheFile(cacheFile, cwd) {
-    // make sure the path separators are normalized for the environment/os
-    // keeping the trailing path separator if present
+
+    /*
+     * make sure the path separators are normalized for the environment/os
+     * keeping the trailing path separator if present
+     */
     cacheFile = path.normalize(cacheFile);
 
     var resolvedCacheFile = path.resolve(cwd, cacheFile);
@@ -298,23 +301,31 @@ function getCacheFile(cacheFile, cwd) {
     }
 
 
-    // in case the file exists we need to verify if the provided path
-    // is a directory or a file. If it is a directory we want to create a file
-    // inside that directory
+    /*
+     * in case the file exists we need to verify if the provided path
+     * is a directory or a file. If it is a directory we want to create a file
+     * inside that directory
+     */
     if (fileStats) {
-        // is a directory or is a file, but the original file the user provided
-        // looks like a directory but `path.resolve` removed the `last path.sep`
-        // so we need to still treat this like a directory
+
+        /*
+         * is a directory or is a file, but the original file the user provided
+         * looks like a directory but `path.resolve` removed the `last path.sep`
+         * so we need to still treat this like a directory
+         */
         if (fileStats.isDirectory() || looksLikeADirectory) {
             return getCacheFileForDirectory();
         }
+
         // is file so just use that file
         return resolvedCacheFile;
     }
 
-    // here we known the file or directory doesn't exist,
-    // so we will try to infer if its a directory if it looks like a directory
-    // for the current operating system.
+    /*
+     * here we known the file or directory doesn't exist,
+     * so we will try to infer if its a directory if it looks like a directory
+     * for the current operating system.
+     */
 
     // if the last character passed is a path separator we assume is a directory
     if (looksLikeADirectory) {
@@ -346,8 +357,9 @@ function CLIEngine(options) {
     var cacheFile = getCacheFile(this.options.cacheLocation || this.options.cacheFile, this.options.cwd);
 
     /**
-     * cache used to not operate on files that haven't changed since last successful
-     * execution (e.g. file passed with no errors and no warnings
+     * Cache used to avoid operating on files that haven't changed since the
+     * last successful execution (e.g., file passed linting with no errors and
+     * no warnings).
      * @type {Object}
      */
     this._fileCache = fileEntryCache.create(cacheFile);
@@ -498,8 +510,11 @@ CLIEngine.prototype = {
 
             // reuse the previously hashed config if the config hasn't changed
             if (prevConfig.config !== config) {
-                // config changed so we need to calculate the hash of the config
-                // and the hash of the plugins being used
+
+                /*
+                 * config changed so we need to calculate the hash of the config
+                 * and the hash of the plugins being used
+                 */
                 prevConfig.config = config;
 
                 var eslintVersion = pkg.version;
@@ -526,9 +541,12 @@ CLIEngine.prototype = {
             }
 
             if (options.cache) {
-                // get the descriptor for this file
-                // with the metadata and the flag that determines if
-                // the file has changed
+
+                /*
+                 * get the descriptor for this file
+                 * with the metadata and the flag that determines if
+                 * the file has changed
+                 */
                 var descriptor = fileCache.getFileDescriptor(filename);
                 var meta = descriptor.meta || {};
 
@@ -538,15 +556,19 @@ CLIEngine.prototype = {
                 if (!changed) {
                     debug("Skipping file since hasn't changed: " + filename);
 
-                    // Adding the filename to the processed hashmap
-                    // so the reporting is not affected (showing a warning about .eslintignore being used
-                    // when it is not really used)
-
+                    /*
+                     * Adding the filename to the processed hashmap
+                     * so the reporting is not affected (showing a warning about .eslintignore being used
+                     * when it is not really used)
+                     */
                     processed[filename] = true;
 
-                    // Add the the cached results (always will be 0 error and 0 warnings)
-                    // cause we don't save to cache files that failed
-                    // to guarantee that next execution will process those files as well
+                    /*
+                     * Add the the cached results (always will be 0 error and
+                     * 0 warnings). We should not cache results for files that
+                     * failed, in order to guarantee that next execution will
+                     * process those files as well.
+                     */
                     results.push(descriptor.meta.results);
 
                     // move to the next file
@@ -561,17 +583,25 @@ CLIEngine.prototype = {
             var res = processFile(filename, configHelper, options);
 
             if (options.cache) {
-                // if a file contains errors or warnings we don't want to
-                // store the file in the cache so we can guarantee that
-                // next execution will also operate on this file
-                if ( res.errorCount > 0 || res.warningCount > 0 ) {
+
+                /*
+                 * if a file contains errors or warnings we don't want to
+                 * store the file in the cache so we can guarantee that
+                 * next execution will also operate on this file
+                 */
+                if (res.errorCount > 0 || res.warningCount > 0) {
                     debug("File has problems, skipping it: " + filename);
+
                     // remove the entry from the cache
-                    fileCache.removeEntry( filename );
+                    fileCache.removeEntry(filename);
                 } else {
-                    // since the file passed we store the result here
-                    // TODO: check this as we might not need to store the
-                    // successful runs as it will always should be 0 error 0 warnings
+
+                    /*
+                     * since the file passed we store the result here
+                     * TODO: check this as we might not need to store the
+                     * successful runs as it will always should be 0 errors and
+                     * 0 warnings.
+                     */
                     descriptor.meta.hashOfConfig = hashOfConfig;
                     descriptor.meta.results = res;
                 }
@@ -593,6 +623,7 @@ CLIEngine.prototype = {
         stats = calculateStatsPerRun(results);
 
         if (options.cache) {
+
             // persist the cache to disk
             fileCache.reconcile();
         }

--- a/lib/code-path-analysis/code-path-analyzer.js
+++ b/lib/code-path-analysis/code-path-analyzer.js
@@ -128,8 +128,8 @@ function isIdentifierReference(node) {
  *
  * To separate the current and the head is in order to not make useless segments.
  *
- * In this process, both "onCodePathSegmentStart" and "onCodePathSegmentEnd" events
- * are fired.
+ * In this process, both "onCodePathSegmentStart" and "onCodePathSegmentEnd"
+ * events are fired.
  *
  * @param {CodePathAnalyzer} analyzer - The instance.
  * @param {ASTNode} node - The current AST node.
@@ -206,6 +206,7 @@ function leaveFromCurrentSegment(analyzer, node) {
                 node);
         }
     }
+
     state.currentSegments = [];
 }
 
@@ -234,9 +235,12 @@ function preprocess(analyzer, node) {
 
         case "ConditionalExpression":
         case "IfStatement":
-            // Fork if this node is at `consequent`/`alternate`.
-            // `popForkContext()` exists at `IfStatement:exit` and
-            // `ConditionalExpression:exit`.
+
+            /*
+             * Fork if this node is at `consequent`/`alternate`.
+             * `popForkContext()` exists at `IfStatement:exit` and
+             * `ConditionalExpression:exit`.
+             */
             if (parent.consequent === node) {
                 state.makeIfConsequent();
             } else if (parent.alternate === node) {
@@ -299,9 +303,12 @@ function preprocess(analyzer, node) {
             break;
 
         case "AssignmentPattern":
-            // Fork if this node is at `right`.
-            // `left` is executed always, so it uses the current path.
-            // `popForkContext()` exists at `AssignmentPattern:exit`.
+
+            /*
+             * Fork if this node is at `right`.
+             * `left` is executed always, so it uses the current path.
+             * `popForkContext()` exists at `AssignmentPattern:exit`.
+             */
             if (parent.right === node) {
                 state.pushForkContext();
                 state.forkBypassPath();
@@ -332,6 +339,7 @@ function processCodePathToEnter(analyzer, node) {
         case "FunctionExpression":
         case "ArrowFunctionExpression":
             if (codePath) {
+
                 // Emits onCodePathSegmentStart events if updated.
                 forwardCurrentToHead(analyzer, node);
                 debug.dumpState(node, state, false);
@@ -370,9 +378,12 @@ function processCodePathToEnter(analyzer, node) {
             break;
 
         case "SwitchCase":
-            // Fork if this node is after the 2st node in `cases`.
-            // It's similar to `else` blocks.
-            // The next `test` node is processed in this path.
+
+            /*
+             * Fork if this node is after the 2st node in `cases`.
+             * It's similar to `else` blocks.
+             * The next `test` node is processed in this path.
+             */
             if (parent.discriminant !== node && parent.cases[0] !== node) {
                 state.forkPath();
             }
@@ -425,9 +436,12 @@ function processCodePathToExit(analyzer, node) {
             break;
 
         case "SwitchCase":
-            // This is the same as the process at the 1st `consequent` node in
-            // `preprocess` function.
-            // Must do if this `consequent` is empty.
+
+            /*
+             * This is the same as the process at the 1st `consequent` node in
+             * `preprocess` function.
+             * Must do if this `consequent` is empty.
+             */
             if (node.consequent.length === 0) {
                 state.makeSwitchCaseBody(true, !node.test);
             }
@@ -499,9 +513,12 @@ function processCodePathToExit(analyzer, node) {
             break;
     }
 
-    // Skip updating the current segment to avoid creating useless segments if
-    // the node type is the same as the parent node type.
+    /*
+     * Skip updating the current segment to avoid creating useless segments if
+     * the node type is the same as the parent node type.
+     */
     if (!dontForward && (!node.parent || node.type !== node.parent.type)) {
+
         // Emits onCodePathSegmentStart events if updated.
         forwardCurrentToHead(analyzer, node);
     }

--- a/lib/code-path-analysis/code-path-segment.js
+++ b/lib/code-path-analysis/code-path-segment.js
@@ -79,6 +79,7 @@ function isReachable(segment) {
  * @param {boolean} reachable - A flag which shows this is reachable.
  */
 function CodePathSegment(id, allPrevSegments, reachable) {
+
     /**
      * The identifier of this code path.
      * Rules use it to store additional information of each rule.

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -374,16 +374,21 @@ CodePathState.prototype = {
         switch (context.kind) {
             case "&&":
             case "||":
-                // If any result were not transferred from child contexts,
-                // this sets the head segments to both cases.
-                // The head segments are the path of the right-hand operand.
+
+                /*
+                 * If any result were not transferred from child contexts,
+                 * this sets the head segments to both cases.
+                 * The head segments are the path of the right-hand operand.
+                 */
                 if (!context.processed) {
                     context.trueForkContext.add(headSegments);
                     context.falseForkContext.add(headSegments);
                 }
 
-                // Transfers results to upper context if this context is in
-                // test chunk.
+                /*
+                 * Transfers results to upper context if this context is in
+                 * test chunk.
+                 */
                 if (context.isForkingAsResult) {
                     var parentContext = this.choiceContext;
                     parentContext.trueForkContext.addAll(context.trueForkContext);
@@ -392,25 +397,37 @@ CodePathState.prototype = {
 
                     return context;
                 }
+
                 break;
 
             case "test":
                 if (!context.processed) {
-                    // The head segments are the path of the `if` block here.
-                    // Updates the `true` path with the end of the `if` block.
+
+                    /*
+                     * The head segments are the path of the `if` block here.
+                     * Updates the `true` path with the end of the `if` block.
+                     */
                     context.trueForkContext.clear();
                     context.trueForkContext.add(headSegments);
                 } else {
-                    // The head segments are the path of the `else` block here.
-                    // Updates the `false` path with the end of the `else` block.
+
+                    /*
+                     * The head segments are the path of the `else` block here.
+                     * Updates the `false` path with the end of the `else`
+                     * block.
+                     */
                     context.falseForkContext.clear();
                     context.falseForkContext.add(headSegments);
                 }
+
                 break;
 
             case "loop":
-                // Loops are addressed in popLoopContext().
-                // This is called from popLoopContext().
+
+                /*
+                 * Loops are addressed in popLoopContext().
+                 * This is called from popLoopContext().
+                 */
                 return context;
 
             /* istanbul ignore next */
@@ -437,8 +454,11 @@ CodePathState.prototype = {
         var forkContext = this.forkContext;
 
         if (context.processed) {
-            // This got segments already from the child choice context.
-            // Creates the next path from own true/false fork context.
+
+            /*
+             * This got segments already from the child choice context.
+             * Creates the next path from own true/false fork context.
+             */
             var prevForkContext =
                 context.kind === "&&" ? context.trueForkContext :
                 /* kind === "||" */ context.falseForkContext;
@@ -448,13 +468,18 @@ CodePathState.prototype = {
 
             context.processed = false;
         } else {
-            // This did not get segments from the child choice context.
-            // So addresses the head segments.
-            // The head segments are the path of the left-hand operand.
+
+            /*
+             * This did not get segments from the child choice context.
+             * So addresses the head segments.
+             * The head segments are the path of the left-hand operand.
+             */
             if (context.kind === "&&") {
+
                 // The path does short-circuit if false.
                 context.falseForkContext.add(forkContext.head);
             } else {
+
                 // The path does short-circuit if true.
                 context.trueForkContext.add(forkContext.head);
             }
@@ -472,13 +497,16 @@ CodePathState.prototype = {
         var context = this.choiceContext;
         var forkContext = this.forkContext;
 
-        // If any result were not transferred from child contexts,
-        // this sets the head segments to both cases.
-        // The head segments are the path of the test expression.
+        /*
+         * If any result were not transferred from child contexts,
+         * this sets the head segments to both cases.
+         * The head segments are the path of the test expression.
+         */
         if (!context.processed) {
             context.trueForkContext.add(forkContext.head);
             context.falseForkContext.add(forkContext.head);
         }
+
         context.processed = false;
 
         // Creates new path from the `true` case.
@@ -496,8 +524,10 @@ CodePathState.prototype = {
         var context = this.choiceContext;
         var forkContext = this.forkContext;
 
-        // The head segments are the path of the `if` block.
-        // Updates the `true` path with the end of the `if` block.
+        /*
+         * The head segments are the path of the `if` block.
+         * Updates the `true` path with the end of the `if` block.
+         */
         context.trueForkContext.clear();
         context.trueForkContext.add(forkContext.head);
         context.processed = true;
@@ -530,6 +560,7 @@ CodePathState.prototype = {
             lastIsDefault: false,
             countForks: 0
         };
+
         this.pushBreakContext(true, label);
     },
 
@@ -551,13 +582,17 @@ CodePathState.prototype = {
         var brokenForkContext = this.popBreakContext().brokenForkContext;
 
         if (context.countForks === 0) {
-            // When there is only one `default` chunk and there is one or more
-            // `break` statements, even if forks are nothing, it needs to merge
-            // those.
+
+            /*
+             * When there is only one `default` chunk and there is one or more
+             * `break` statements, even if forks are nothing, it needs to merge
+             * those.
+             */
             if (!brokenForkContext.empty) {
                 brokenForkContext.add(forkContext.makeNext(-1, -1));
                 forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
             }
+
             return;
         }
 
@@ -565,21 +600,31 @@ CodePathState.prototype = {
         this.forkBypassPath();
         var lastCaseSegments = forkContext.head;
 
-        // `brokenForkContext` is used to make the next segment.
-        // It must add the last segment into `brokenForkContext`.
+        /*
+         * `brokenForkContext` is used to make the next segment.
+         * It must add the last segment into `brokenForkContext`.
+         */
         brokenForkContext.add(lastSegments);
 
-        // A path which is failed in all case test should be connected to path
-        // of `default` chunk.
+        /*
+         * A path which is failed in all case test should be connected to path
+         * of `default` chunk.
+         */
         if (!context.lastIsDefault) {
             if (context.defaultBodySegments) {
-                // Remove a link from `default` label to its chunk.
-                // It's false route.
+
+                /*
+                 * Remove a link from `default` label to its chunk.
+                 * It's false route.
+                 */
                 removeConnection(context.defaultSegments, context.defaultBodySegments);
                 makeLooped(this, lastCaseSegments, context.defaultBodySegments);
             } else {
-                // It handles the last case body as broken if `default` chunk
-                // does not exist.
+
+                /*
+                 * It handles the last case body as broken if `default` chunk
+                 * does not exist.
+                 */
                 brokenForkContext.add(lastCaseSegments);
             }
         }
@@ -588,8 +633,11 @@ CodePathState.prototype = {
         for (var i = 0; i < context.countForks; ++i) {
             this.forkContext = this.forkContext.upper;
         }
-        // Creates a path from all brokenForkContext paths.
-        // This is a path after switch statement.
+
+        /*
+         * Creates a path from all brokenForkContext paths.
+         * This is a path after switch statement.
+         */
         this.forkContext.replaceHead(brokenForkContext.makeNext(0, -1));
     },
 
@@ -606,16 +654,20 @@ CodePathState.prototype = {
             return;
         }
 
-        // Merge forks.
-        // The parent fork context has two segments.
-        // Those are from the current case and the body of the previous case.
+        /*
+         * Merge forks.
+         * The parent fork context has two segments.
+         * Those are from the current case and the body of the previous case.
+         */
         var parentForkContext = this.forkContext;
         var forkContext = this.pushForkContext();
         forkContext.add(parentForkContext.makeNext(0, -1));
 
-        // Save `default` chunk info.
-        // If the `default` label is not at the last, we must make a path from
-        // the last `case` to the `default` chunk.
+        /*
+         * Save `default` chunk info.
+         * If the `default` label is not at the last, we must make a path from
+         * the last `case` to the `default` chunk.
+         */
         if (isDefault) {
             context.defaultSegments = parentForkContext.head;
             if (isEmpty) {
@@ -629,6 +681,7 @@ CodePathState.prototype = {
                 context.defaultBodySegments = forkContext.head;
             }
         }
+
         context.lastIsDefault = isDefault;
         context.countForks += 1;
     },
@@ -649,9 +702,11 @@ CodePathState.prototype = {
             upper: this.tryContext,
             position: "try",
             hasFinalizer: hasFinalizer,
+
             returnedForkContext: hasFinalizer
                 ? ForkContext.newEmpty(this.forkContext)
                 : null,
+
             thrownForkContext: ForkContext.newEmpty(this.forkContext),
             lastOfTryIsReachable: false,
             lastOfCatchIsReachable: false
@@ -668,15 +723,20 @@ CodePathState.prototype = {
         this.tryContext = context.upper;
 
         if (context.position === "catch") {
+
             // Merges two paths from the `try` block and `catch` block merely.
             this.popForkContext();
             return;
         }
-        // The following process is executed only when there is the `finally`
-        // block.
+
+        /*
+         * The following process is executed only when there is the `finally`
+         * block.
+         */
 
         var returned = context.returnedForkContext;
         var thrown = context.thrownForkContext;
+
         if (returned.empty && thrown.empty) {
             return;
         }
@@ -748,6 +808,7 @@ CodePathState.prototype = {
 
         // Update state.
         if (context.position === "catch") {
+
             // Merges two paths from the `try` block and `catch` block.
             this.popForkContext();
             forkContext = this.forkContext;
@@ -759,12 +820,15 @@ CodePathState.prototype = {
         context.position = "finally";
 
         if (returned.empty && thrown.empty) {
+
             // This path does not leave.
             return;
         }
 
-        // Create a parallel segment from merging returned and thrown.
-        // This segment will leave at the end of this finally block.
+        /*
+         * Create a parallel segment from merging returned and thrown.
+         * This segment will leave at the end of this finally block.
+         */
         var segments = forkContext.makeNext(-1, -1);
         var j;
         for (var i = 0; i < forkContext.count; ++i) {
@@ -1108,9 +1172,13 @@ CodePathState.prototype = {
         }
 
         var bodySegments = context.endOfTestSegments;
+
         if (!bodySegments) {
-            // If there is not the `test` part, the `body` path comes from the
-            // `init` part and the `update` part.
+
+            /*
+             * If there is not the `test` part, the `body` path comes from the
+             * `init` part and the `update` part.
+             */
             var prevForkContext = ForkContext.newEmpty(forkContext);
             prevForkContext.add(context.endOfInitSegments);
             if (context.endOfUpdateSegments) {
@@ -1239,10 +1307,12 @@ CodePathState.prototype = {
         }
 
         var context = getBreakContext(this, label);
+
         /* istanbul ignore else: foolproof (syntax error) */
         if (context) {
             context.brokenForkContext.add(forkContext.head);
         }
+
         forkContext.replaceHead(forkContext.makeUnreachable(-1, -1));
     },
 
@@ -1262,6 +1332,7 @@ CodePathState.prototype = {
         }
 
         var context = getContinueContext(this, label);
+
         /* istanbul ignore else: foolproof (syntax error) */
         if (context) {
             if (context.continueDestSegments) {

--- a/lib/code-path-analysis/code-path.js
+++ b/lib/code-path-analysis/code-path.js
@@ -27,6 +27,7 @@ var IdGenerator = require("./id-generator");
  * @param {function} onLooped - A callback function to notify looping.
  */
 function CodePath(id, upper, onLooped) {
+
     /**
      * The identifier of this code path.
      * Rules use it to store additional information of each rule.
@@ -173,11 +174,13 @@ CodePath.prototype = {
             index = item[1];
 
             if (index === 0) {
-                // Skip this has been visited already.
+
+                // Skip if this segment has been visited already.
                 if (visited[segment.id]) {
                     stack.pop();
                     continue;
                 }
+
                 // Skip if all previous segments have not been visited.
                 if (segment !== startSegment &&
                     segment.prevSegments.length > 0 &&
@@ -186,6 +189,7 @@ CodePath.prototype = {
                     stack.pop();
                     continue;
                 }
+
                 // Reset the flag of skipping if all branches have been skipped.
                 if (skippedSegment && segment.prevSegments.indexOf(skippedSegment) !== -1) {
                     skippedSegment = null;

--- a/lib/code-path-analysis/debug-helpers.js
+++ b/lib/code-path-analysis/debug-helpers.js
@@ -32,6 +32,7 @@ function getId(segment) { // eslint-disable-line require-jsdoc
 //------------------------------------------------------------------------------
 
 module.exports = {
+
     /**
      * A flag that debug dumping is enabled or not.
      * @type {boolean}

--- a/lib/code-path-analysis/id-generator.js
+++ b/lib/code-path-analysis/id-generator.js
@@ -33,10 +33,12 @@ function IdGenerator(prefix) {
  */
 IdGenerator.prototype.next = function() {
     this.n = 1 + this.n | 0;
+
     /* istanbul ignore if */
     if (this.n < 0) {
         this.n = 1;
     }
+
     return this.prefix + this.n;
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -177,10 +177,17 @@ function Config(options) {
         return envs;
     }, {});
 
+    /*
+     * Handle declared globals.
+     * For global variable foo, handle "foo:false" and "foo:true" to set
+     * whether global is writable.
+     * If user declares "foo", convert to "foo:false".
+     */
     this.globals = (options.globals || []).reduce(function(globals, def) {
-        // Default "foo" to false and handle "foo:false" and "foo:true"
         var parts = def.split(":");
+
         globals[parts[0]] = (parts.length > 1 && parts[1] === "true");
+
         return globals;
     }, {});
 
@@ -238,6 +245,7 @@ Config.prototype.getConfig = function(filePath) {
 
         config = ConfigOps.merge(config, this.useSpecificConfig);
     }
+
     // Step 5: Merge in command line environments
     debug("Merging command line environment settings");
     config = ConfigOps.merge(config, { env: this.env });

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -124,18 +124,32 @@ Registry.prototype = {
          * @returns {void}
          */
         var addRuleToRuleSet = function(rule) {
-            // This check ensures that there is a rule configuration, and that
-            // it either has fewer than the max cominbations allowed, or if it has
-            // too many configs, we will only use the most basic of them.
+
+            /*
+             * This check ensures that there is a rule configuration and that
+             * it has fewer than the max combinations allowed.
+             * If it has too many configs, we will only use the most basic of
+             * the possible configurations.
+             */
             var hasFewCombos = (this.rules[rule].length <= MAX_CONFIG_COMBINATIONS);
+
             if (this.rules[rule][idx] && (hasFewCombos || this.rules[rule][idx].specificity <= 2)) {
-                // If the rule has too many possible combinations, only take simple ones, avoiding objects.
+
+                /*
+                 * If the rule has too many possible combinations, only take
+                 * simple ones, avoiding objects.
+                 */
                 if (!hasFewCombos && typeof this.rules[rule][idx].config[1] === "object") {
                     return;
                 }
+
                 ruleSets[idx] = ruleSets[idx] || {};
                 ruleSets[idx][rule] = this.rules[rule][idx].config;
-                // Initialize errorCount to zero, since this is a config which will be linted
+
+                /*
+                 * Initialize errorCount to zero, since this is a config which
+                 * will be linted.
+                 */
                 this.rules[rule][idx].errorCount = 0;
             }
         }.bind(this);
@@ -274,26 +288,36 @@ Registry.prototype = {
 
         lintedRegistry = new Registry();
         lintedRegistry.rules = lodash.assign({}, this.rules);
+
         ruleSets = lintedRegistry.buildRuleSets();
+
         lintedRegistry = lintedRegistry.stripExtraConfigs();
 
         debug("Linting with all possible rule combinations");
+
         filenames = Object.keys(sourceCodes);
+
         totalFilesLinting = filenames.length * ruleSets.length;
+
         filenames.forEach(function(filename) {
             debug("Linting file: " + filename);
+
             ruleSetIdx = 0;
+
             ruleSets.forEach(function(ruleSet) {
                 lintConfig = lodash.assign({}, config, {rules: ruleSet});
                 var lintResults = eslint.verify(sourceCodes[filename], lintConfig);
                 lintResults.forEach(function(result) {
                     lintedRegistry.rules[result.ruleId][ruleSetIdx].errorCount += 1;
                 });
+
                 ruleSetIdx += 1;
+
                 if (cb) {
                     cb(totalFilesLinting);  // eslint-disable-line callback-return
                 }
             });
+
             // Deallocate for GC
             sourceCodes[filename] = null;
         });

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -4,7 +4,9 @@
  * @copyright 2015 Nicholas C. Zakas. All rights reserved.
  * See LICENSE file in root directory for full license.
  */
+
 /* eslint no-use-before-define: 0 */
+
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -94,6 +96,7 @@ function loadYAMLConfigFile(filePath) {
     var yaml = require("js-yaml");
 
     try {
+
         // empty YAML file can be null, so always use
         return yaml.safeLoad(readFile(filePath)) || {};
     } catch (e) {
@@ -188,9 +191,8 @@ function loadPackageJSONConfigFile(filePath) {
  * @private
  */
 function loadConfigFile(file) {
-    var config;
-
-    var filePath = file.filePath;
+    var config,
+        filePath = file.filePath;
 
     switch (path.extname(filePath)) {
         case ".js":
@@ -265,6 +267,7 @@ function writeJSConfigFile(config, filePath) {
     debug("Writing JS config file: " + filePath);
 
     var content = "module.exports = " + stringify(config, {cmp: sortByKey, space: 4}) + ";";
+
     fs.writeFileSync(filePath, content, "utf8");
 }
 
@@ -304,15 +307,20 @@ function write(config, filePath) {
  * @private
  */
 function getLookupPath(configFilePath) {
+
     // calculates the path of the project including ESLint as dependency
     var projectPath = path.resolve(__dirname, "../../../");
+
     if (configFilePath && pathIsInside(configFilePath, projectPath)) {
+
         // be careful of https://github.com/substack/node-resolve/issues/78
         return path.resolve(configFilePath);
     }
 
-    // default to ESLint project path since it's unlikely that plugins will be
-    // in this directory
+    /*
+     * default to ESLint project path since it's unlikely that plugins will be
+     * in this directory
+     */
     return projectPath;
 }
 
@@ -338,12 +346,18 @@ function applyExtends(config, filePath, relativeTo) {
     config = configExtends.reduceRight(function(previousValue, parentPath) {
 
         if (parentPath === "eslint:recommended") {
-            // Add an explicit substitution for eslint:recommended to conf/eslint.json
-            // this lets us use the eslint.json file as the recommended rules
+
+            /*
+             * Add an explicit substitution for eslint:recommended to conf/eslint.json
+             * this lets us use the eslint.json file as the recommended rules
+             */
             parentPath = path.resolve(__dirname, "../../conf/eslint.json");
         } else if (isFilePath(parentPath)) {
-            // If the `extends` path is relative, use the directory of the current configuration
-            // file as the reference point. Otherwise, use as-is.
+
+            /*
+             * If the `extends` path is relative, use the directory of the current configuration
+             * file as the reference point. Otherwise, use as-is.
+             */
             parentPath = (!isAbsolutePath(parentPath) ?
                 path.join(path.dirname(filePath), parentPath) :
                 parentPath
@@ -354,9 +368,13 @@ function applyExtends(config, filePath, relativeTo) {
             debug("Loading " + parentPath);
             return ConfigOps.merge(load(parentPath, false, relativeTo), previousValue);
         } catch (e) {
-            // If the file referenced by `extends` failed to load, add the path to the
-            // configuration file that referenced it to the error message so the user is
-            // able to see where it was referenced from, then re-throw
+
+            /*
+             * If the file referenced by `extends` failed to load, add the path
+             * to the configuration file that referenced it to the error
+             * message so the user is able to see where it was referenced from,
+             * then re-throw.
+             */
             e.message += "\nReferenced from: " + filePath;
             throw e;
         }
@@ -375,15 +393,22 @@ function applyExtends(config, filePath, relativeTo) {
  */
 function normalizePackageName(name, prefix) {
     if (name.charAt(0) === "@") {
-        // it's a scoped package
-        // package name is "eslint-config", or just a username
+
+        /*
+         * it's a scoped package
+         * package name is "eslint-config", or just a username
+         */
         var scopedPackageShortcutRegex = new RegExp("^(@[^\/]+)(?:\/(?:" + prefix + ")?)?$"),
             scopedPackageNameRegex = new RegExp("^" + prefix + "(-|$)");
+
         if (scopedPackageShortcutRegex.test(name)) {
             name = name.replace(scopedPackageShortcutRegex, "$1/" + prefix);
         } else if (!scopedPackageNameRegex.test(name.split("/")[1])) {
-            // for scoped packages, insert the eslint-config after the first / unless
-            // the path is already @scope/eslint or @scope/eslint-config-xxx
+
+            /*
+             * for scoped packages, insert the eslint-config after the first / unless
+             * the path is already @scope/eslint or @scope/eslint-config-xxx
+             */
             name = name.replace(/^@([^\/]+)\/(.*)$/, "@$1/" + prefix + "-$2");
         }
     } else if (name.indexOf(prefix + "-") !== 0) {
@@ -456,13 +481,16 @@ function load(filePath, applyEnvironments, relativeTo) {
         // validate the configuration before continuing
         validator.validate(config, filePath);
 
-        // If an `extends` property is defined, it represents a configuration file to use as
-        // a "parent". Load the referenced file and merge the configuration recursively.
+        /*
+         * If an `extends` property is defined, it represents a configuration file to use as
+         * a "parent". Load the referenced file and merge the configuration recursively.
+         */
         if (config.extends) {
             config = applyExtends(config, filePath, basedir);
         }
 
         if (config.env && applyEnvironments) {
+
             // Merge in environment-specific globals and parserOptions.
             config = ConfigOps.applyEnvironments(config);
         }

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -154,7 +154,9 @@ function configureRules(answers, config) {
 
     // Find and disable rules which had no error-free configuration
     failingRegistry = registry.getFailingRulesRegistry();
+
     Object.keys(failingRegistry.rules).forEach(function(ruleId) {
+
         // If the rule is recommended, set it to error, otherwise disable it
         disabledConfigs[ruleId] = (recRules.indexOf(ruleId) !== -1) ? 2 : 0;
     });

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -105,6 +105,7 @@ module.exports = {
      * @returns {Object} merged config object.
      */
     merge: function deepmerge(target, src, combine, isRule) {
+
         /*
          The MIT License (MIT)
 
@@ -128,7 +129,12 @@ module.exports = {
          OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
          THE SOFTWARE.
          */
-        // This code is taken from deepmerge repo (https://github.com/KyleAMathews/deepmerge) and modified to meet our needs.
+
+        /*
+         * This code is taken from deepmerge repo
+         * (https://github.com/KyleAMathews/deepmerge)
+         * and modified to meet our needs.
+         */
         var array = Array.isArray(src) || Array.isArray(target);
         var dst = array && [] || {};
 

--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -201,10 +201,12 @@ RuleConfigSet.prototype = {
     */
     addErrorSeverity: function(severity) {
         severity = severity || 2;
+
         this.ruleConfigs = this.ruleConfigs.map(function(config) {
             config.unshift(severity);
             return config;
         });
+
         // Add a single config at the beginning consisting of only the severity
         this.ruleConfigs.unshift(severity);
     },
@@ -241,8 +243,11 @@ RuleConfigSet.prototype = {
                 }, []);
             }
         };
-        // The object schema could have multiple independent properties.
-        // If any contain enums or booleans, they can be added and then combined
+
+        /*
+         * The object schema could have multiple independent properties.
+         * If any contain enums or booleans, they can be added and then combined
+         */
         Object.keys(obj.properties).forEach(function(prop) {
             if (obj.properties[prop].enum) {
                 objectConfigSet.add(prop, obj.properties[prop].enum);
@@ -271,10 +276,13 @@ function generateConfigsFromSchema(schema) {
             if (opt.enum) {
                 configSet.addEnums(opt.enum);
             }
+
             if (opt.type && opt.type === "object") {
                 configSet.addObject(opt);
             }
+
             if (opt.oneOf) {
+
                 // TODO (IanVS): not yet implemented
             }
         });

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -43,10 +43,13 @@ var DEFAULT_PARSER = require("../conf/eslint.json").parser;
  */
 function parseBooleanConfig(string, comment) {
     var items = {};
+
     // Collapse whitespace around : to make parsing easier
     string = string.replace(/\s*:\s*/g, ":");
+
     // Collapse whitespace around ,
     string = string.replace(/\s*,\s*/g, ",");
+
     string.split(/\s|,+/).forEach(function(name) {
         if (!name) {
             return;
@@ -103,8 +106,10 @@ function parseJsonConfig(string, location, messages) {
  */
 function parseListConfig(string) {
     var items = {};
+
     // Collapse whitespace around ,
     string = string.replace(/\s*,\s*/g, ",");
+
     string.split(/,+/).forEach(function(name) {
         name = name.trim();
         if (!name) {
@@ -177,18 +182,27 @@ function addDeclaredGlobals(program, globalScope, config) {
         }
     });
 
-    // "through" contains all references that their definition cannot be found.
-    // Since we augment the global scope using configuration, we need to update references and remove the ones that were added by configuration.
+    /*
+     * "through" contains all references which definitions cannot be found.
+     * Since we augment the global scope using configuration, we need to update
+     * references and remove the ones that were added by configuration.
+     */
     globalScope.through = globalScope.through.filter(function(reference) {
         var name = reference.identifier.name;
         var variable = globalScope.set.get(name);
+
         if (variable) {
-            // Links the variable and the reference.
-            // And this reference is removed from `Scope#through`.
+
+            /*
+             * Links the variable and the reference.
+             * And this reference is removed from `Scope#through`.
+             */
             reference.resolved = variable;
             variable.references.push(reference);
+
             return false;
         }
+
         return true;
     });
 }
@@ -234,13 +248,14 @@ function enableReporting(reportingConfig, start, rulesToEnable) {
     if (rulesToEnable.length) {
         rulesToEnable.forEach(function(rule) {
             for (i = reportingConfig.length - 1; i >= 0; i--) {
-                if (!reportingConfig[i].end && reportingConfig[i].rule === rule ) {
+                if (!reportingConfig[i].end && reportingConfig[i].rule === rule) {
                     reportingConfig[i].end = start;
                     break;
                 }
             }
         });
     } else {
+
         // find all previous disabled locations if they was started as list of rules
         var prevStart;
         for (i = reportingConfig.length - 1; i >= 0; i--) {
@@ -319,8 +334,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
 
                     // no default
                 }
-            } else {
-                // comment.type === "Line"
+            } else {        // comment.type === "Line"
                 if (match[1] === "eslint-disable-line") {
                     disableReporting(reportingConfig, { "line": comment.loc.start.line, "column": 0 }, Object.keys(parseListConfig(value)));
                     enableReporting(reportingConfig, comment.loc.end, Object.keys(parseListConfig(value)));
@@ -421,7 +435,7 @@ function prepareConfig(config) {
         // can't have global return inside of modules
         preparedConfig.parserOptions.ecmaFeatures.globalReturn = false;
 
-        // also need at least ES6 six for modules
+        // also need at least ES6 for modules
         if (!preparedConfig.parserOptions.ecmaVersion || preparedConfig.parserOptions.ecmaVersion < 6) {
             preparedConfig.parserOptions.ecmaVersion = 6;
         }
@@ -467,6 +481,7 @@ function getRuleReplacementMessage(ruleId) {
         var newRules = replacements.rules[ruleId];
         return "Rule \'" + ruleId + "\' was removed and replaced by: " + newRules.join(", ");
     }
+
     return null;
 }
 
@@ -481,6 +496,7 @@ function findEslintEnv(text) {
     var match, retv;
 
     eslintEnvPattern.lastIndex = 0;
+
     while ((match = eslintEnvPattern.exec(text))) {
         retv = lodash.assign(retv || {}, parseListConfig(match[1]));
     }
@@ -495,9 +511,12 @@ function findEslintEnv(text) {
  * @returns {string} The stripped text.
  */
 function stripUnicodeBOM(text) {
-    // Check Unicode BOM.
-    // In JavaScript, string data is stored as UTF-16, so BOM is 0xFEFF.
-    // http://www.ecma-international.org/ecma-262/6.0/#sec-unicode-format-control-characters
+
+    /*
+     * Check Unicode BOM.
+     * In JavaScript, string data is stored as UTF-16, so BOM is 0xFEFF.
+     * http://www.ecma-international.org/ecma-262/6.0/#sec-unicode-format-control-characters
+     */
     if (text.charCodeAt(0) === 0xFEFF) {
         return text.slice(1);
     }
@@ -706,6 +725,7 @@ module.exports = (function() {
 
         // only do this for text
         if (text !== null) {
+
             // there's no input, just exit here
             if (text.trim().length === 0) {
                 sourceCode = new SourceCode(text, blankScriptAST);
@@ -750,6 +770,7 @@ module.exports = (function() {
                     rule;
 
                 ruleCreator = rules.get(key);
+
                 if (!ruleCreator) {
                     var replacementMsg = getRuleReplacementMessage(key);
                     if (replacementMsg) {
@@ -790,7 +811,7 @@ module.exports = (function() {
             ecmaFeatures = currentConfig.parserOptions.ecmaFeatures || {};
             ecmaVersion = currentConfig.parserOptions.ecmaVersion || 5;
 
-            // gather data that may be needed by the rules
+            // gather scope data that may be needed by the rules
             scopeManager = escope.analyze(ast, {
                 ignoreEval: true,
                 nodejsScope: ecmaFeatures.globalReturn,
@@ -799,6 +820,7 @@ module.exports = (function() {
                 sourceType: currentConfig.parserOptions.sourceType || "script",
                 fallback: Traverser.getKeys
             });
+
             currentScopes = scopeManager.scopes;
 
             /*
@@ -806,11 +828,14 @@ module.exports = (function() {
              * lookup in getScope.
              */
             scopeMap = [];
+
             currentScopes.forEach(function(scope, index) {
                 var range = scope.block.range[0];
 
-                // Sometimes two scopes are returned for a given node. This is
-                // handled later in a known way, so just don't overwrite here.
+                /*
+                 * Sometimes two scopes are returned for a given node. This is
+                 * handled later in a known way, so just don't overwrite here.
+                 */
                 if (!scopeMap[range]) {
                     scopeMap[range] = index;
                 }
@@ -833,9 +858,10 @@ module.exports = (function() {
             eventGenerator = new CommentEventGenerator(eventGenerator, sourceCode);
 
             /*
-             * Each node has a type property. Whenever a particular type of node is found,
-             * an event is fired. This allows any listeners to automatically be informed
-             * that this type of node has been found and react accordingly.
+             * Each node has a type property. Whenever a particular type of
+             * node is found, an event is fired. This allows any listeners to
+             * automatically be informed that this type of node has been found
+             * and react accordingly.
              */
             traverser.traverse(ast, {
                 enter: function(node, parent) {
@@ -891,6 +917,7 @@ module.exports = (function() {
             message = location;
             location = node.loc.start;
         }
+
         // else, assume location was provided, so node may be omitted
 
         if (isDisabledByReportingConfig(reportingConfig, ruleId, location)) {
@@ -1046,7 +1073,7 @@ module.exports = (function() {
                     return true;
                 }
             }
-        } while ( (scope = scope.upper) );
+        } while ((scope = scope.upper));
 
         return false;
     };

--- a/lib/formatters/html.js
+++ b/lib/formatters/html.js
@@ -64,6 +64,7 @@ function renderColor(totalErrors, totalWarnings) {
  * @returns {string} HTML (table rows) describing the messages.
  */
 function renderMessages(messages, parentIndex) {
+
     /**
      * Get HTML (table row) describing a message.
      * @param {Object} message Message.

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -108,8 +108,11 @@ function IgnoredPaths(options) {
     this.ig.custom.ignoreFiles = [];
 
     if (options.dotfiles !== true) {
-        // ignore files beginning with a dot, but not files in a parent or ancestor
-        // directory (which in relative format will begin with `../`).
+
+        /*
+         * ignore files beginning with a dot, but not files in a parent or
+         * ancestor directory (which in relative format will begin with `../`).
+         */
         addPattern(this.ig.default, [".*", "!../"]);
     }
 

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Handle logging for Eslint
+ * @fileoverview Handle logging for ESLint
  * @author Gyandeep Singh
  * @copyright 2015 Gyandeep Singh. All rights reserved.
  */
@@ -7,6 +7,7 @@
 
 /* istanbul ignore next */
 module.exports = {
+
     /**
      * Cover for console.log
      * @returns {void}

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -73,6 +73,7 @@ var PASSTHROUGHS = [
  * @param {Object} meta The metadata of the rule
  */
 function RuleContext(ruleId, eslint, severity, options, settings, parserOptions, parserPath, meta) {
+
     // public.
     this.id = ruleId;
     this.options = options;
@@ -149,9 +150,8 @@ RuleContext.prototype = {
     }
 };
 
-// copy over passthrough methods
+// Copy over passthrough methods. All functions will have 5 or fewer parameters.
 PASSTHROUGHS.forEach(function(name) {
-    // All functions expected to have less arguments than 5.
     this[name] = function(a, b, c, d, e) {
         return this.eslint[name](a, b, c, d, e);
     };

--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -46,6 +46,7 @@ function isArgumentOfMethodCall(node, index, object, property) {
  * @returns {boolean} `true` if the node is a property descriptor.
  */
 function isPropertyDescriptor(node) {
+
     // Object.defineProperty(obj, "foo", {set: ...})
     if (isArgumentOfMethodCall(node, 2, "Object", "defineProperty") ||
         isArgumentOfMethodCall(node, 2, "Reflect", "defineProperty")
@@ -53,9 +54,12 @@ function isPropertyDescriptor(node) {
         return true;
     }
 
-    // Object.defineProperties(obj, {foo: {set: ...}})
-    // Object.create(proto, {foo: {set: ...}})
+    /*
+     * Object.defineProperties(obj, {foo: {set: ...}})
+     * Object.create(proto, {foo: {set: ...}})
+     */
     node = node.parent.parent;
+
     return node.type === "ObjectExpression" && (
         isArgumentOfMethodCall(node, 1, "Object", "create") ||
         isArgumentOfMethodCall(node, 1, "Object", "defineProperties")
@@ -124,6 +128,7 @@ module.exports = {
                         break;
 
                     default:
+
                         // Do nothing
                 }
 

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -108,9 +108,11 @@ function isCallbackOfArrayMethod(node) {
     while (node) {
         var parent = node.parent;
         switch (parent.type) {
-            // Looks up the destination.
-            // e.g.
-            //   foo.every(nativeFoo || function foo() { ... });
+
+            /*
+             * Looks up the destination. e.g.,
+             * foo.every(nativeFoo || function foo() { ... });
+             */
             case "LogicalExpression":
             case "ConditionalExpression":
                 node = parent;
@@ -195,6 +197,7 @@ module.exports = function(context) {
     }
 
     return {
+
         // Stacks this function's information.
         "onCodePathStart": function(codePath, node) {
             funcInfo = {

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -10,9 +10,11 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     // merge rules with default
-    var rule = { before: true, after: true };
-    var option = context.options[0] || {};
+    var rule = { before: true, after: true },
+        option = context.options[0] || {};
+
     rule.before = option.before !== false;
     rule.after = option.after !== false;
 
@@ -55,6 +57,7 @@ module.exports = function(context) {
         var countSpace = countSpaces(tokens);
 
         if (rule.before) {
+
             // should be space(s) before arrow
             if (countSpace.before === 0) {
                 context.report({
@@ -66,6 +69,7 @@ module.exports = function(context) {
                 });
             }
         } else {
+
             // should be no space before arrow
             if (countSpace.before > 0) {
                 context.report({
@@ -79,6 +83,7 @@ module.exports = function(context) {
         }
 
         if (rule.after) {
+
             // should be space(s) after arrow
             if (countSpace.after === 0) {
                 context.report({
@@ -90,6 +95,7 @@ module.exports = function(context) {
                 });
             }
         } else {
+
             // should be no space after arrow
             if (countSpace.after > 0) {
                 context.report({

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -69,7 +69,9 @@ module.exports = function(context) {
 
         // Gets declared variables, and checks its references.
         var variables = context.getDeclaredVariables(node);
+
         for (var i = 0; i < variables.length; ++i) {
+
             // Reports.
             variables[i]
                 .references

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -56,6 +56,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function checkSpacingInsideBraces(node) {
+
         // Gets braces and the first/last token of content.
         var openBrace = getOpenBrace(node);
         var closeBrace = context.getLastToken(node);

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -106,7 +106,7 @@ module.exports = function(context) {
             if (style === "1tbs") {
                 if (tokens[0].loc.start.line !== tokens[1].loc.start.line &&
                     node.consequent.type === "BlockStatement" &&
-                    isCurlyPunctuator(tokens[0]) ) {
+                    isCurlyPunctuator(tokens[0])) {
                     context.report(node.alternate, CLOSE_MESSAGE);
                 }
             } else if (tokens[0].loc.start.line === tokens[1].loc.start.line) {

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -49,6 +49,7 @@ module.exports = function(context) {
      * @returns {boolean} Whether or not this is part of a callback expression
      */
     function isCallbackExpression(node, parentNode) {
+
         // ensure the parent node exists and is an expression
         if (!parentNode || parentNode.type !== "ExpressionStatement") {
             return false;
@@ -86,7 +87,7 @@ module.exports = function(context) {
                 lastItem, parentType;
 
             // if our parent is a return we know we're ok
-            if (closestBlock.type === "ReturnStatement" ) {
+            if (closestBlock.type === "ReturnStatement") {
                 return;
             }
 

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -54,7 +54,11 @@ module.exports = function(context) {
     return {
 
         "Identifier": function(node) {
-            // Leading and trailing underscores are commonly used to flag private/protected identifiers, strip them
+
+            /*
+             * Leading and trailing underscores are commonly used to flag
+             * private/protected identifiers, strip them
+             */
             var name = node.name.replace(/^_+|_+$/g, ""),
                 effectiveParent = (node.parent.type === "MemberExpression") ? node.parent.parent : node.parent;
 
@@ -83,6 +87,7 @@ module.exports = function(context) {
 
             // Properties have their own rules
             } else if (node.parent.type === "Property") {
+
                 // "never" check properties
                 if (properties === "never") {
                     return;

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -26,6 +26,7 @@ var lodash = require("lodash");
 function isTrailingCommaAllowed(node, lastItem) {
     switch (node.type) {
         case "ArrayPattern":
+
             // TODO(t-nagashima): Remove SpreadElement after https://github.com/eslint/espree/issues/194 was fixed.
             return (
                 lastItem.type !== "RestElement" &&

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -65,7 +65,7 @@ module.exports = function(context) {
      */
     function increaseComplexity() {
         if (fns.length) {
-            fns[fns.length - 1] ++;
+            fns[fns.length - 1]++;
         }
     }
 
@@ -76,6 +76,7 @@ module.exports = function(context) {
      * @private
      */
     function increaseSwitchComplexity(node) {
+
         // Avoiding `default`
         if (node.test) {
             increaseComplexity(node);
@@ -89,6 +90,7 @@ module.exports = function(context) {
      * @private
      */
     function increaseLogicalComplexity(node) {
+
         // Avoiding &&
         if (node.operator === "||") {
             increaseComplexity(node);

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -40,8 +40,10 @@ module.exports = function(context) {
     function checkLastSegment(node) {
         var loc, type;
 
-        // Skip if it expected no return value or unreachable.
-        // When unreachable, all paths are returned or thrown.
+        /*
+         * Skip if it expected no return value or unreachable.
+         * When unreachable, all paths are returned or thrown.
+         */
         if (!funcInfo.hasReturnValue ||
             funcInfo.codePath.currentSegments.every(isUnreachable) ||
             astUtils.isES5Constructor(node)
@@ -51,10 +53,12 @@ module.exports = function(context) {
 
         // Adjust a location and a message.
         if (node.type === "Program") {
+
             // The head of program.
             loc = {line: 1, column: 0};
             type = "program";
         } else if (node.type === "ArrowFunctionExpression") {
+
             // `=>` token
             loc = context.getSourceCode().getTokenBefore(node.body).loc.start;
             type = "function";
@@ -62,10 +66,12 @@ module.exports = function(context) {
             node.parent.type === "MethodDefinition" ||
             (node.parent.type === "Property" && node.parent.method)
         ) {
+
             // Method name.
             loc = node.parent.key.loc.start;
             type = "method";
         } else {
+
             // Function name or `function` keyword.
             loc = (node.id || node).loc.start;
             type = "function";
@@ -81,6 +87,7 @@ module.exports = function(context) {
     }
 
     return {
+
         // Initializes/Disposes state of each code path.
         "onCodePathStart": function(codePath) {
             funcInfo = {

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -36,20 +36,25 @@ function isConstructorFunction(node) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    // {{hasExtends: boolean, scope: Scope, codePath: CodePath}[]}
-    // Information for each constructor.
-    // - upper:      Information of the upper constructor.
-    // - hasExtends: A flag which shows whether own class has a valid `extends`
-    //               part.
-    // - scope:      The scope of own class.
-    // - codePath:   The code path object of the constructor.
+
+    /*
+     * {{hasExtends: boolean, scope: Scope, codePath: CodePath}[]}
+     * Information for each constructor.
+     * - upper:      Information of the upper constructor.
+     * - hasExtends: A flag which shows whether own class has a valid `extends`
+     *               part.
+     * - scope:      The scope of own class.
+     * - codePath:   The code path object of the constructor.
+     */
     var funcInfo = null;
 
-    // {Map<string, {calledInSomePaths: boolean, calledInEveryPaths: boolean}>}
-    // Information for each code path segment.
-    // - calledInSomePaths:  A flag of be called `super()` in some code paths.
-    // - calledInEveryPaths: A flag of be called `super()` in all code paths.
-    // - validNodes:
+    /*
+     * {Map<string, {calledInSomePaths: boolean, calledInEveryPaths: boolean}>}
+     * Information for each code path segment.
+     * - calledInSomePaths:  A flag of be called `super()` in some code paths.
+     * - calledInEveryPaths: A flag of be called `super()` in all code paths.
+     * - validNodes:
+     */
     var segInfoMap = Object.create(null);
 
     /**
@@ -67,9 +72,12 @@ module.exports = function(context) {
      * @returns {boolean} The flag which shows `super()` is called in all paths.
      */
     function isCalledInEveryPath(segment) {
-        // If specific segment is the looped segment of the current segment,
-        // skip the segment.
-        // If not skipped, this never becomes true after a loop.
+
+        /*
+         * If specific segment is the looped segment of the current segment,
+         * skip the segment.
+         * If not skipped, this never becomes true after a loop.
+         */
         if (segment.nextSegments.length === 1 &&
             segment.nextSegments[0].isLoopedPrevSegment(segment)
         ) {
@@ -79,6 +87,7 @@ module.exports = function(context) {
     }
 
     return {
+
         /**
          * Stacks a constructor information.
          * @param {CodePath} codePath - A code path which was started.
@@ -87,8 +96,10 @@ module.exports = function(context) {
          */
         "onCodePathStart": function(codePath, node) {
             if (isConstructorFunction(node)) {
+
                 // Class > ClassBody > MethodDefinition > FunctionExpression
                 var classNode = node.parent.parent.parent;
+
                 funcInfo = {
                     upper: funcInfo,
                     isConstructor: true,
@@ -116,9 +127,12 @@ module.exports = function(context) {
          * @returns {void}
          */
         "onCodePathEnd": function(codePath, node) {
+
             // Skip if own class which has a valid `extends` part.
             var hasExtends = funcInfo.hasExtends;
+
             funcInfo = funcInfo.upper;
+
             if (!hasExtends) {
                 return;
             }
@@ -143,8 +157,11 @@ module.exports = function(context) {
          * @returns {void}
          */
         "onCodePathSegmentStart": function(segment) {
-            // Skip if this is not in a constructor of a class which has a valid
-            // `extends` part.
+
+            /*
+             * Skip if this is not in a constructor of a class which has a
+             * valid `extends` part.
+             */
             if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
                 return;
             }
@@ -174,14 +191,18 @@ module.exports = function(context) {
          * @returns {void}
          */
         "onCodePathSegmentLoop": function(fromSegment, toSegment) {
-            // Skip if this is not in a constructor of a class which has a valid
-            // `extends` part.
+
+            /*
+             * Skip if this is not in a constructor of a class which has a
+             * valid `extends` part.
+             */
             if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
                 return;
             }
 
             // Update information inside of the loop.
             var isRealLoop = toSegment.prevSegments.length >= 2;
+
             funcInfo.codePath.traverseSegments(
                 {first: toSegment, last: fromSegment},
                 function(segment) {
@@ -215,6 +236,7 @@ module.exports = function(context) {
          * @returns {void}
          */
         "CallExpression:exit": function(node) {
+
             // Skip if the node is not `super()`.
             if (node.callee.type !== "Super") {
                 return;
@@ -227,8 +249,11 @@ module.exports = function(context) {
 
             // Reports if needed.
             if (funcInfo.hasExtends) {
-                // This class has a valid `extends` part.
-                // Checks duplicate `super()`;
+
+                /*
+                 * This class has a valid `extends` part.
+                 * Checks duplicate `super()`;
+                 */
                 var segments = funcInfo.codePath.currentSegments;
                 var duplicate = false;
                 for (var i = 0; i < segments.length; ++i) {
@@ -247,8 +272,11 @@ module.exports = function(context) {
                     info.validNodes.push(node);
                 }
             } else {
-                // This class does not have a valid `extends` part.
-                // Disallow `super()`.
+
+                /*
+                 * This class does not have a valid `extends` part.
+                 * Disallow `super()`.
+                 */
                 context.report({
                     message: "Unexpected 'super()'.",
                     node: node

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -207,8 +207,12 @@ module.exports = function(context) {
         } while (node);
 
         if (consistent) {
-            // If any node should have or already have braces, make sure they all have braces.
-            // If all nodes shouldn't have braces, make sure they don't.
+
+            /*
+             * If any node should have or already have braces, make sure they
+             * all have braces.
+             * If all nodes shouldn't have braces, make sure they don't.
+             */
             var expected = preparedChecks.some(function(preparedCheck) {
                 if (preparedCheck.expected !== null) {
                     return preparedCheck.expected;

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -34,8 +34,11 @@ module.exports = function(context) {
         "SwitchStatement": function(node) {
 
             if (!node.cases.length) {
-                // skip check of empty switch because there is no easy way
-                // to extract comments inside it now
+
+                /*
+                 * skip check of empty switch because there is no easy way
+                 * to extract comments inside it now
+                 */
                 return;
             }
 

--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -15,8 +15,10 @@ var astUtils = require("../ast-utils");
 module.exports = function(context) {
 
     var config = context.options[0],
-        // default to onObject if no preference is passed
-        onObject = config === "object" || !config;
+        onObject;
+
+    // default to onObject if no preference is passed
+    onObject = config === "object" || !config;
 
     /**
      * Reports if the dot between object and property is on the correct loccation.

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -17,6 +17,7 @@ module.exports = function(context) {
     return {
 
         "Program": function checkBadEOF(node) {
+
             // Get the whole source code, not for node only.
             var src = context.getSource(),
                 location = {column: 1},
@@ -24,6 +25,7 @@ module.exports = function(context) {
                 linebreak = linebreakStyle === "unix" ? "\n" : "\r\n";
 
             if (src[src.length - 1] !== "\n") {
+
                 // file is not newline-terminated
                 location.line = src.split(/\n/g).length;
                 context.report({

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -27,8 +27,10 @@ module.exports = function(context) {
     var SUPPORTED_EXPRESSIONS = {
         "MemberExpression": properties && function(parent) {
             return !parent.computed && (
+
                 // regular property assignment
                 parent.parent.left === parent || (
+
                     // or the last identifier in an ObjectPattern destructuring
                     parent.parent.type === "Property" && parent.parent.value === parent &&
                     parent.parent.parent.type === "ObjectPattern" && parent.parent.parent.parent.left === parent.parent.parent

--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -71,6 +71,7 @@ module.exports = function(context) {
 
             // MemberExpressions get special rules
             if (node.parent.type === "MemberExpression") {
+
                 // return early if properties is false
                 if (!properties) {
                     return;
@@ -95,6 +96,7 @@ module.exports = function(context) {
 
             // Properties have their own rules
             } else if (node.parent.type === "Property") {
+
                 // return early if properties is false
                 if (!properties) {
                     return;

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -26,6 +26,7 @@
  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  THE SOFTWARE.
 */
+
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -318,26 +319,30 @@ module.exports = function(context) {
      */
     function checkIndentInFunctionBlock(node) {
 
-        // Search first caller in chain.
-        // Ex.:
-        //
-        // Models <- Identifier
-        //   .User
-        //   .find()
-        //   .exec(function() {
-        //   // function body
-        // });
-        //
-        // Looks for 'Models'
+        /*
+         * Search first caller in chain.
+         * Ex.:
+         *
+         * Models <- Identifier
+         *   .User
+         *   .find()
+         *   .exec(function() {
+         *   // function body
+         * });
+         *
+         * Looks for 'Models'
+         */
         var calleeNode = node.parent; // FunctionExpression
         var indent;
 
         if (calleeNode.parent &&
             (calleeNode.parent.type === "Property" ||
             calleeNode.parent.type === "ArrayExpression")) {
+
             // If function is part of array or object, comma can be put at left
             indent = getNodeIndent(calleeNode, false, false);
         } else {
+
             // If function is standalone, simple calculate indent
             indent = getNodeIndent(calleeNode);
         }
@@ -408,6 +413,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function checkIndentInArrayOrObjectBlock(node) {
+
         // Skip inline
         if (isSingleLineNode(node)) {
             return;
@@ -468,8 +474,10 @@ module.exports = function(context) {
             elementsIndent = nodeIndent + indentSize;
         }
 
-        // check if the node is a multiple variable declaration, if yes then make sure indentation takes into account
-        // variable indentation concept
+        /*
+         * Check if the node is a multiple variable declaration; if so, then
+         * make sure indentation takes that into account.
+         */
         if (isNodeInVarOnTop(node, parentVarNode)) {
             elementsIndent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind];
         }
@@ -478,6 +486,7 @@ module.exports = function(context) {
         checkNodesIndent(elements, elementsIndent, true);
 
         if (elements.length > 0) {
+
             // Skip last block line check if last item in same line
             if (elements[elements.length - 1].loc.end.line === node.loc.end.line) {
                 return;
@@ -503,6 +512,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function blockIndentationCheck(node) {
+
         // Skip inline blocks
         if (isSingleLineNode(node)) {
             return;
@@ -520,8 +530,10 @@ module.exports = function(context) {
         var indent;
         var nodesToCheck = [];
 
-        // For this statements we should check indent from statement begin
-        // (not from block begin)
+        /*
+         * For this statements we should check indent from statement beginning,
+         * not from the beginning of the block.
+         */
         var statementsWithProperties = [
             "IfStatement", "WhileStatement", "ForStatement", "ForInStatement", "ForOfStatement", "DoWhileStatement"
         ];
@@ -591,6 +603,7 @@ module.exports = function(context) {
         var tokenBeforeLastElement = context.getTokenBefore(lastElement);
 
         if (tokenBeforeLastElement.value === ",") {
+
             // Special case for comma-first syntax where the semicolon is indented
             checkLastNodeLineIndent(node, getNodeIndent(tokenBeforeLastElement));
         } else {
@@ -641,6 +654,7 @@ module.exports = function(context) {
     return {
         "Program": function(node) {
             if (node.body.length > 0) {
+
                 // Root nodes should have no indent
                 checkNodesIndent(node.body, getNodeIndent(node));
             }
@@ -681,6 +695,7 @@ module.exports = function(context) {
         },
 
         "SwitchStatement": function(node) {
+
             // Switch is not a 'BlockStatement'
             var switchIndent = getNodeIndent(node);
             var caseIndent = expectedCaseIndent(node, switchIndent);
@@ -691,6 +706,7 @@ module.exports = function(context) {
         },
 
         "SwitchCase": function(node) {
+
             // Skip inline cases
             if (isSingleLineNode(node)) {
                 return;

--- a/lib/rules/init-declarations.js
+++ b/lib/rules/init-declarations.js
@@ -50,6 +50,7 @@ module.exports = function(context) {
 
     var mode = context.options[0] || MODE_ALWAYS;
     var params = context.options[1] || {};
+
     //--------------------------------------------------------------------------
     // Public API
     //--------------------------------------------------------------------------

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -445,6 +445,7 @@ module.exports = function(context) {
     }
 
     return {
+
         // Statements
         DebuggerStatement: checkSpacingAroundFirstToken,
         WithStatement: checkSpacingAroundFirstToken,

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -76,6 +76,7 @@ module.exports = function(context) {
     options.allowBlockEnd = options.allowBlockEnd || false;
 
     var sourceCode = context.getSourceCode();
+
     /**
      * Returns whether or not comments are on lines starting with or ending with code
      * @param {ASTNode} node The comment node to check.

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -11,11 +11,15 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    // takes some ideas from http://tools.ietf.org/html/rfc3986#appendix-B, however:
-    // - They're matching an entire string that we know is a URI
-    // - We're matching part of a string where we think there *might* be a URL
-    // - We're only concerned about URLs, as picking out any URI would cause too many false positives
-    // - We don't care about matching the entire URL, any small segment is fine
+
+    /*
+     * Inspired by http://tools.ietf.org/html/rfc3986#appendix-B, however:
+     * - They're matching an entire string that we know is a URI
+     * - We're matching part of a string where we think there *might* be a URL
+     * - We're only concerned about URLs, as picking out any URI would cause
+     *   too many false positives
+     * - We don't care about matching the entire URL, any small segment is fine
+     */
     var URL_REGEXP = /[^:/?#]:\/\/[^?#]/;
 
     /**
@@ -40,10 +44,12 @@ module.exports = function(context) {
     // The options object must be the last option specified…
     var lastOption = context.options[context.options.length - 1];
     var options = typeof lastOption === "object" ? Object.create(lastOption) : {};
+
     // …but max code length…
     if (typeof context.options[0] === "number") {
         options.code = context.options[0];
     }
+
     // …and tabWidth can be optionally specified directly as integers.
     if (typeof context.options[1] === "number") {
         options.tabWidth = context.options[1];
@@ -104,6 +110,7 @@ module.exports = function(context) {
      * @returns {string} Line without comment and trailing whitepace
      */
     function stripTrailingComment(line, lineNumber, comment) {
+
         // loc.column is zero-indexed
         return line.slice(0, comment.loc.start.column).replace(/\s+$/, "");
     }
@@ -115,26 +122,38 @@ module.exports = function(context) {
      * @private
      */
     function checkProgramForMaxLength(node) {
+
         // split (honors line-ending)
         var lines = context.getSourceLines(),
+
             // list of comments to ignore
             comments = ignoreComments || maxCommentLength || ignoreTrailingComments ? context.getAllComments() : [],
+
             // we iterate over comments in parallel with the lines
             commentsIndex = 0;
 
         lines.forEach(function(line, i) {
+
             // i is zero-indexed, line numbers are one-indexed
             var lineNumber = i + 1;
-            // if we're checking comment length; we need to know whether this
-            // line is a comment
+
+            /*
+             * if we're checking comment length; we need to know whether this
+             * line is a comment
+             */
             var lineIsComment = false;
 
-            // we can short-circuit the comment checks if we're already out of comments to check
+            /*
+             * We can short-circuit the comment checks if we're already out of
+             * comments to check.
+             */
             if (commentsIndex < comments.length) {
+
                 // iterate over comments until we find one past the current line
                 do {
                     var comment = comments[++commentsIndex];
                 } while (comment && comment.loc.start.line <= lineNumber);
+
                 // and step back by one
                 comment = comments[--commentsIndex];
 
@@ -146,6 +165,7 @@ module.exports = function(context) {
             }
             if (ignorePattern && ignorePattern.test(line) ||
                 ignoreUrls && URL_REGEXP.test(line)) {
+
                 // ignore this line
                 return;
             }

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -38,6 +38,7 @@ var CAPS_ALLOWED = [
  * @returns {string[]} Returns obj[key] if it's an Array, otherwise `fallback`
  */
 function checkArray(obj, key, fallback) {
+
     /* istanbul ignore if */
     if (Object.prototype.hasOwnProperty.call(obj, key) && !Array.isArray(obj[key])) {
         throw new TypeError(key + ", if provided, must be an Array");
@@ -129,6 +130,7 @@ module.exports = function(context) {
         var firstCharUpper = firstChar.toUpperCase();
 
         if (firstCharLower === firstCharUpper) {
+
             // char has no uppercase variant, so it's non-alphabetic
             return "non-alpha";
         } else if (firstChar === firstCharLower) {
@@ -151,6 +153,7 @@ module.exports = function(context) {
         }
 
         if (calleeName === "UTC" && node.callee.type === "MemberExpression") {
+
             // allow if callee is Date.UTC
             return node.callee.object.type === "Identifier" &&
                 node.callee.object.name === "Date";

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -83,10 +83,12 @@ module.exports = function(context) {
      */
     function hasBlankLineAfterComment(token, commentStartLine) {
         var commentEnd = commentEndLine[commentStartLine];
+
         // If there's another comment, repeat check for blank line
         if (commentEndLine[commentEnd + 1]) {
             return hasBlankLineAfterComment(token, commentEnd + 1);
         }
+
         return (token.loc.start.line > commentEndLine[commentStartLine] + 1);
     }
 

--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -87,6 +87,7 @@ module.exports = function(context) {
                 !isParenthesisedTwice(node.test)
             )
         ) {
+
             // must match JSHint's error message
             context.report({
                 node: node,

--- a/lib/rules/no-console.js
+++ b/lib/rules/no-console.js
@@ -19,7 +19,7 @@ module.exports = function(context) {
             if (node.object.name === "console") {
                 var blockConsole = true;
 
-                if ( context.options.length > 0 ) {
+                if (context.options.length > 0) {
                     var allowedProperties = context.options[0].allow;
                     var passedProperty = node.property.name;
                     var propertyIsAllowed = (allowedProperties.indexOf(passedProperty) > -1);

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -30,15 +30,20 @@ module.exports = function(context) {
             case "ObjectExpression":
             case "ArrayExpression":
                 return true;
+
             case "UnaryExpression":
                 return isConstant(node.argument);
+
             case "BinaryExpression":
             case "LogicalExpression":
                 return isConstant(node.left) && isConstant(node.right) && node.operator !== "in";
+
             case "AssignmentExpression":
                 return (node.operator === "=") && isConstant(node.right);
+
             case "SequenceExpression":
                 return isConstant(node.expressions[node.expressions.length - 1]);
+
             // no default
         }
         return false;

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -26,6 +26,7 @@ module.exports = function(context) {
             if ((parent.type === "NewExpression" || parent.type === "CallExpression") &&
                 parent.callee.type === "Identifier" && parent.callee.name === "RegExp"
             ) {
+
                 // there could be an invalid regular expression string
                 try {
                     return new RegExp(node.value);

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -53,6 +53,7 @@ module.exports = function(context) {
     }
 
     return {
+
         // Initializes the stack of state of member declarations.
         "Program": function() {
             stack = [];

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -97,12 +97,16 @@ module.exports = function(context) {
      * @returns {boolean} `true` if it returns on every codepath.
      */
     function alwaysReturns(node) {
-        // If we have a BlockStatement, check each consequent body node.
         if (node.type === "BlockStatement") {
+
+            // If we have a BlockStatement, check each consequent body node.
             return node.body.some(checkForReturnOrIf);
-        // If not a block statement, make sure the consequent isn't a ReturnStatement
-        // or an IfStatement with returns on both paths
         } else {
+
+            /*
+             * If not a block statement, make sure the consequent isn't a
+             * ReturnStatement or an IfStatement with returns on both paths.
+             */
             return checkForReturnOrIf(node);
         }
     }

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -15,6 +15,7 @@ var FUNCTION_TYPE = /^(?:ArrowFunctionExpression|Function(?:Declaration|Expressi
 module.exports = function(context) {
     return {
         "BlockStatement": function(node) {
+
             // if the body is not empty, we can just return immediately
             if (node.body.length !== 0) {
                 return;

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -197,6 +197,7 @@ module.exports = function(context) {
             var id = reference.identifier;
 
             if (id.name === "eval" && !astUtils.isCallee(id)) {
+
                 // Is accessing to eval (excludes direct calls to eval)
                 report(id);
             }
@@ -204,8 +205,8 @@ module.exports = function(context) {
     }
 
     if (allowIndirect) {
-        // Checks only direct calls to eval.
-        // It's simple!
+
+        // Checks only direct calls to eval. It's simple!
         return {
             "CallExpression:exit": function(node) {
                 var callee = node.callee;
@@ -261,8 +262,10 @@ module.exports = function(context) {
                 return;
             }
 
-            // `this.eval` is found.
-            // Checks whether or not the value of `this` is the global object.
+            /*
+             * `this.eval` is found.
+             * Checks whether or not the value of `this` is the global object.
+             */
             if (!funcInfo.initialized) {
                 funcInfo.initialized = true;
                 funcInfo.defaultThis = astUtils.isDefaultThisBinding(
@@ -270,7 +273,9 @@ module.exports = function(context) {
                     sourceCode
                 );
             }
+
             if (!funcInfo.strict && funcInfo.defaultThis) {
+
                 // `this.eval` is possible built-in `eval`.
                 report(node.parent);
             }

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -45,6 +45,7 @@ module.exports = function(context) {
                     if (node.property.expressions.length === 0) {
                         return node.property.quasis[0].value.cooked;
                     }
+
                     // fallthrough
                 default:
                     return false;

--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -31,6 +31,7 @@ module.exports = function(context) {
         return (
             (BOOLEAN_NODE_TYPES.indexOf(parent.type) !== -1 &&
                 node === parent.test) ||
+
             // !<bool>
             (parent.type === "UnaryExpression" &&
                 parent.operator === "!")
@@ -52,6 +53,7 @@ module.exports = function(context) {
             }
 
             if (isInBooleanContext(parent, grandparent) ||
+
                 // Boolean(<bool>) and new Boolean(<bool>)
                 ((grandparent.type === "CallExpression" || grandparent.type === "NewExpression") &&
                     grandparent.callee.type === "Identifier" &&

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -178,11 +178,14 @@ module.exports = function(context) {
                         return 4;
                     case "&&":
                         return 5;
+
                     // no default
                 }
 
                 /* falls through */
+
             case "BinaryExpression":
+
                 switch (node.operator) {
                     case "|":
                         return 6;
@@ -213,21 +216,29 @@ module.exports = function(context) {
                     case "/":
                     case "%":
                         return 13;
+
                     // no default
                 }
+
                 /* falls through */
+
             case "UnaryExpression":
                 return 14;
+
             case "UpdateExpression":
                 return 15;
+
             case "CallExpression":
+
                 // IIFE is allowed to have parens in any position (#655)
                 if (node.callee.type === "FunctionExpression") {
                     return -1;
                 }
                 return 16;
+
             case "NewExpression":
                 return 17;
+
             // no default
         }
         return 18;
@@ -266,6 +277,7 @@ module.exports = function(context) {
         if (hasExcessParens(node.callee) && precedence(node.callee) >= precedence(node) && !(
             node.type === "CallExpression" &&
             node.callee.type === "FunctionExpression" &&
+
             // One set of parentheses are allowed for a function expression
             !hasDoubleExcessParens(node.callee)
         )) {
@@ -308,6 +320,7 @@ module.exports = function(context) {
                 }
             });
         },
+
         "ArrowFunctionExpression": function(node) {
             if (node.body.type !== "BlockStatement") {
                 if (node.body.type !== "ObjectExpression" && hasExcessParens(node.body) && precedence(node.body) >= precedence({type: "AssignmentExpression"})) {
@@ -322,13 +335,16 @@ module.exports = function(context) {
                 }
             }
         },
+
         "AssignmentExpression": function(node) {
             if (hasExcessParens(node.right) && precedence(node.right) >= precedence(node)) {
                 report(node.right);
             }
         },
+
         "BinaryExpression": dryBinaryLogical,
         "CallExpression": dryCallNew,
+
         "ConditionalExpression": function(node) {
             if (hasExcessParens(node.test) && precedence(node.test) >= precedence({type: "LogicalExpression", operator: "||"})) {
                 report(node.test);
@@ -340,11 +356,13 @@ module.exports = function(context) {
                 report(node.alternate);
             }
         },
+
         "DoWhileStatement": function(node) {
             if (hasDoubleExcessParens(node.test) && !isCondAssignException(node)) {
                 report(node.test);
             }
         },
+
         "ExpressionStatement": function(node) {
             var firstToken, secondToken, firstTokens;
             if (hasExcessParens(node.expression)) {
@@ -367,16 +385,19 @@ module.exports = function(context) {
                 }
             }
         },
+
         "ForInStatement": function(node) {
             if (hasExcessParens(node.right)) {
                 report(node.right);
             }
         },
+
         "ForOfStatement": function(node) {
             if (hasExcessParens(node.right)) {
                 report(node.right);
             }
         },
+
         "ForStatement": function(node) {
             if (node.init && hasExcessParens(node.init)) {
                 report(node.init);
@@ -390,12 +411,15 @@ module.exports = function(context) {
                 report(node.update);
             }
         },
+
         "IfStatement": function(node) {
             if (hasDoubleExcessParens(node.test) && !isCondAssignException(node)) {
                 report(node.test);
             }
         },
+
         "LogicalExpression": dryBinaryLogical,
+
         "MemberExpression": function(node) {
             if (
                 hasExcessParens(node.object) &&
@@ -407,6 +431,7 @@ module.exports = function(context) {
                         typeof node.object.value === "number" &&
                         /^[0-9]+$/.test(context.getFirstToken(node.object).value))
                         ||
+
                         // RegExp literal is allowed to have parens (#1589)
                         (node.object.type === "Literal" && node.object.regex)
                     )
@@ -423,7 +448,9 @@ module.exports = function(context) {
                 report(node.property);
             }
         },
+
         "NewExpression": dryCallNew,
+
         "ObjectExpression": function(node) {
             [].forEach.call(node.properties, function(e) {
                 var v = e.value;
@@ -432,16 +459,19 @@ module.exports = function(context) {
                 }
             });
         },
+
         "ReturnStatement": function(node) {
             var returnToken = sourceCode.getFirstToken(node);
 
             if (node.argument &&
                     hasExcessParensNoLineTerminator(returnToken, node.argument) &&
+
                     // RegExp literal is allowed to have parens (#1589)
                     !(node.argument.type === "Literal" && node.argument.regex)) {
                 report(node.argument);
             }
         },
+
         "SequenceExpression": function(node) {
             [].forEach.call(node.expressions, function(e) {
                 if (hasExcessParens(e) && precedence(e) >= precedence(node)) {
@@ -449,16 +479,19 @@ module.exports = function(context) {
                 }
             });
         },
+
         "SwitchCase": function(node) {
             if (node.test && hasExcessParens(node.test)) {
                 report(node.test);
             }
         },
+
         "SwitchStatement": function(node) {
             if (hasDoubleExcessParens(node.discriminant)) {
                 report(node.discriminant);
             }
         },
+
         "ThrowStatement": function(node) {
             var throwToken = sourceCode.getFirstToken(node);
 
@@ -466,26 +499,32 @@ module.exports = function(context) {
                 report(node.argument);
             }
         },
+
         "UnaryExpression": dryUnaryUpdate,
         "UpdateExpression": dryUnaryUpdate,
+
         "VariableDeclarator": function(node) {
             if (node.init && hasExcessParens(node.init) &&
                     precedence(node.init) >= precedence({type: "AssignmentExpression"}) &&
+
                     // RegExp literal is allowed to have parens (#1589)
                     !(node.init.type === "Literal" && node.init.regex)) {
                 report(node.init);
             }
         },
+
         "WhileStatement": function(node) {
             if (hasDoubleExcessParens(node.test) && !isCondAssignException(node)) {
                 report(node.test);
             }
         },
+
         "WithStatement": function(node) {
             if (hasDoubleExcessParens(node.object)) {
                 report(node.object);
             }
         },
+
         "YieldExpression": function(node) {
             var yieldToken;
 

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -45,6 +45,7 @@ module.exports = function(context) {
     }
 
     return {
+
         /**
          * Reports this empty statement, except if the parent node is a loop.
          * @param {Node} node - A EmptyStatement node to be reported.

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -45,8 +45,10 @@ function isReachable(segment) {
 module.exports = function(context) {
     var currentCodePath = null;
 
-    // We need to use leading comments of the next SwitchCase node because
-    // trailing comments is wrong if semicolons are omitted.
+    /*
+     * We need to use leading comments of the next SwitchCase node because
+     * trailing comments is wrong if semicolons are omitted.
+     */
     var fallthroughCase = null;
 
     return {
@@ -58,8 +60,11 @@ module.exports = function(context) {
         },
 
         "SwitchCase": function(node) {
-            // Checks whether or not there is a fallthrough comment.
-            // And reports the previous fallthrough node if that does not exist.
+
+            /*
+             * Checks whether or not there is a fallthrough comment.
+             * And reports the previous fallthrough node if that does not exist.
+             */
             if (fallthroughCase && !hasFallthroughComment(node, context)) {
                 context.report({
                     message: "Expected a 'break' statement before '{{type}}'.",
@@ -71,9 +76,12 @@ module.exports = function(context) {
         },
 
         "SwitchCase:exit": function(node) {
-            // `reachable` meant fall through because statements preceded by
-            // `break`, `return`, or `throw` are unreachable.
-            // And allows empty cases and the last case.
+
+            /*
+             * `reachable` meant fall through because statements preceded by
+             * `break`, `return`, or `throw` are unreachable.
+             * And allows empty cases and the last case.
+             */
             if (currentCodePath.currentSegments.some(isReachable) &&
                 node.consequent.length > 0 &&
                 lodash.last(node.parent.cases) !== node

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -13,6 +13,7 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     /**
      * Reports a reference if is non initializer and writable.
      * @param {References} references - Collection of reference to check.

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -139,6 +139,7 @@ function getOtherOperand(node, value) {
     }
     return node.left;
 }
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -149,6 +150,7 @@ module.exports = function(context) {
 
     return {
         "UnaryExpression": function(node) {
+
             // !!foo
             operatorAllowed = options.allow.indexOf("!!") >= 0;
             if (!operatorAllowed && options.boolean && isDoubleLogicalNegating(node)) {
@@ -158,6 +160,7 @@ module.exports = function(context) {
                         code: context.getSource(node.argument.argument)
                     });
             }
+
             // ~foo.indexOf(bar)
             operatorAllowed = options.allow.indexOf("~") >= 0;
             if (!operatorAllowed && options.boolean && isBinaryNegatingOfIndexOf(node)) {
@@ -181,6 +184,7 @@ module.exports = function(context) {
 
         // Use `:exit` to prevent double reporting
         "BinaryExpression:exit": function(node) {
+
             // 1 * foo
             operatorAllowed = options.allow.indexOf("*") >= 0;
             var nonNumericOperand = !operatorAllowed && options.number && isMultiplyByOne(node) && getNonNumericOperand(node);
@@ -204,6 +208,7 @@ module.exports = function(context) {
         },
 
         "AssignmentExpression": function(node) {
+
             // foo += ""
             operatorAllowed = options.allow.indexOf("+") >= 0;
             if (options.string && isAppendEmptyString(node)) {

--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -14,8 +14,10 @@
 module.exports = function(context) {
     var CALLEE_RE = /set(?:Timeout|Interval)|execScript/;
 
-    // Figures out if we should inspect a given binary expression. Is a stack of
-    // stacks, where the first element in each substack is a CallExpression.
+    /*
+     * Figures out if we should inspect a given binary expression. Is a stack
+     * of stacks, where the first element in each substack is a CallExpression.
+     */
     var impliedEvalAncestorsStack = [];
 
     //--------------------------------------------------------------------------
@@ -72,8 +74,10 @@ module.exports = function(context) {
      * @private
      */
     function hasImpliedEvalParent(node) {
+
         // make sure our parent is marked
         return node.parent === last(last(impliedEvalAncestorsStack)) &&
+
             // if our parent is a CallExpression, make sure we're the first argument
             (node.parent.type !== "CallExpression" || node === node.parent.arguments[0]);
     }
@@ -88,6 +92,7 @@ module.exports = function(context) {
      */
     function checkString(node) {
         if (hasImpliedEvalParent(node)) {
+
             // remove the entire substack, to avoid duplicate reports
             var substack = impliedEvalAncestorsStack.pop();
             context.report(substack[0], "Implied eval. Consider passing a function instead of a string.");
@@ -101,6 +106,7 @@ module.exports = function(context) {
     return {
         "CallExpression": function(node) {
             if (isImpliedEvalCallExpression(node)) {
+
                 // call expressions create a new substack
                 impliedEvalAncestorsStack.push([node]);
             }
@@ -108,9 +114,11 @@ module.exports = function(context) {
 
         "CallExpression:exit": function(node) {
             if (node === last(last(impliedEvalAncestorsStack))) {
-                // destroys the entire sub-stack, rather than just using
-                // last(impliedEvalAncestorsStack).pop(), as a CallExpression is
-                // always the bottom of a impliedEvalAncestorsStack substack.
+
+                /* Destroys the entire sub-stack, rather than just using
+                 * last(impliedEvalAncestorsStack).pop(), as a CallExpression is
+                 * always the bottom of a impliedEvalAncestorsStack substack.
+                 */
                 impliedEvalAncestorsStack.pop();
             }
         },

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -29,8 +29,10 @@ module.exports = function(context) {
         }
 
         return {
+
             // Type of containing ancestor
             type: ancestor.type,
+
             // Separation between ancestor and node
             distance: generation
         };

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -52,6 +52,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function enterFunction(node) {
+
         // `this` can be invalid only under strict mode.
         stack.push({
             init: !context.getScope().isStrict,
@@ -69,8 +70,11 @@ module.exports = function(context) {
     }
 
     return {
-        // `this` is invalid only under strict mode.
-        // Modules is always strict mode.
+
+        /*
+         * `this` is invalid only under strict mode.
+         * Modules is always strict mode.
+         */
         "Program": function(node) {
             var scope = context.getScope(),
                 features = context.parserOptions.ecmaFeatures || {};
@@ -85,6 +89,7 @@ module.exports = function(context) {
                 )
             });
         },
+
         "Program:exit": function() {
             stack.pop();
         },

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -55,6 +55,7 @@ module.exports = function(context) {
      */
     function removeInvalidNodeErrorsInIdentifierOrLiteral(node) {
         if (typeof node.value === "string") {
+
             // If we have irregular characters remove them from the errors list
             if (node.raw.match(irregularWhitespace) || node.raw.match(irregularLineTerminators)) {
                 removeWhitespaceError(node);
@@ -146,11 +147,16 @@ module.exports = function(context) {
 
     return {
         "Program": function(node) {
-            /**
-             * As we can easily fire warnings for all white space issues with all the source its simpler to fire them here
-             * This means we can check all the application code without having to worry about issues caused in the parser tokens
-             * When writing this code also evaluating per node was missing out connecting tokens in some cases
-             * We can later filter the errors when they are found to be not an issue in nodes we don't care about
+
+            /*
+             * As we can easily fire warnings for all white space issues with
+             * all the source its simpler to fire them here.
+             * This means we can check all the application code without having
+             * to worry about issues caused in the parser tokens.
+             * When writing this code also evaluating per node was missing out
+             * connecting tokens in some cases.
+             * We can later filter the errors when they are found to be not an
+             * issue in nodes we don't care about.
              */
 
             checkForIrregularWhitespace(node);
@@ -164,6 +170,7 @@ module.exports = function(context) {
         "Program:exit": function() {
 
             if (skipComments) {
+
                 // First strip errors occurring in comment nodes.  We have to do this post-`Program` to deal with top-of-file comments.
                 commentNodes.forEach(removeInvalidNodeErrorsInComment);
             }

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -29,6 +29,7 @@ function getContainingLoopNode(node) {
                 return parent;
 
             case "ForStatement":
+
                 // `init` is outside of the loop.
                 if (parent.init !== node) {
                     return parent;
@@ -37,6 +38,7 @@ function getContainingLoopNode(node) {
 
             case "ForInStatement":
             case "ForOfStatement":
+
                 // `right` is outside of the loop.
                 if (parent.right !== node) {
                     return parent;
@@ -46,6 +48,7 @@ function getContainingLoopNode(node) {
             case "ArrowFunctionExpression":
             case "FunctionExpression":
             case "FunctionDeclaration":
+
                 // We don't need to check nested functions.
                 return null;
 
@@ -148,6 +151,7 @@ function isSafe(funcNode, loopNode, reference) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     /**
      * Reports functions which match the following condition:
      *

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -28,8 +28,12 @@ module.exports = function(context) {
      * @returns {string[]} An array of built-in Node.js modules.
      */
     function getBuiltinModules() {
-        // This list is generated using `require("repl")._builtinLibs.concat('repl').sort()`
-        // This particular list is as per nodejs v0.12.2 and iojs v0.7.1
+
+        /*
+         * This list is generated using:
+         * `require("repl")._builtinLibs.concat('repl').sort()`
+         * This particular list is as per nodejs v0.12.2 and iojs v0.7.1
+         */
         return [
             "assert", "buffer", "child_process", "cluster", "crypto",
             "dgram", "dns", "domain", "events", "fs", "http", "https",
@@ -57,6 +61,7 @@ module.exports = function(context) {
      */
     function getDeclarationType(initExpression) {
         if (!initExpression) {
+
             // "var x;"
             return DECL_UNINITIALIZED;
         }
@@ -65,15 +70,18 @@ module.exports = function(context) {
             initExpression.callee.type === "Identifier" &&
             initExpression.callee.name === "require"
         ) {
+
             // "var x = require('util');"
             return DECL_REQUIRE;
         } else if (allowCall &&
             initExpression.type === "CallExpression" &&
             initExpression.callee.type === "CallExpression"
         ) {
+
             // "var x = require('diagnose')('sub-module');"
             return getDeclarationType(initExpression.callee);
         } else if (initExpression.type === "MemberExpression") {
+
             // "var x = require('glob').Glob;"
             return getDeclarationType(initExpression.object);
         }
@@ -89,9 +97,11 @@ module.exports = function(context) {
      */
     function inferModuleType(initExpression) {
         if (initExpression.type === "MemberExpression") {
+
             // "var x = require('glob').Glob;"
             return inferModuleType(initExpression.object);
         } else if (initExpression.arguments.length === 0) {
+
             // "var x = require();"
             return REQ_COMPUTED;
         }
@@ -99,17 +109,21 @@ module.exports = function(context) {
         var arg = initExpression.arguments[0];
 
         if (arg.type !== "Literal" || typeof arg.value !== "string") {
+
             // "var x = require(42);"
             return REQ_COMPUTED;
         }
 
         if (BUILTIN_MODULES.indexOf(arg.value) !== -1) {
+
             // "var fs = require('fs');"
             return REQ_CORE;
         } else if (/^\.{0,2}\//.test(arg.value)) {
+
             // "var utils = require('./utils');"
             return REQ_FILE;
         } else {
+
             // "var async = require('async');"
             return REQ_MODULE;
         }

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -66,6 +66,7 @@ module.exports = function(context) {
         },
 
         "Program:exit": function(node) {
+
             /*
              * At least one space followed by a tab
              * or the reverse before non-tab/-space
@@ -93,6 +94,7 @@ module.exports = function(context) {
             });
 
             if (smartTabs) {
+
                 /*
                  * At least one space followed by a tab
                  * before non-tab/-space characters begin.

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -66,13 +66,18 @@ module.exports = function(context) {
             });
 
             if (typeof maxEOF === "undefined") {
-                // swallow the final newline, as some editors add it
-                // automatically and we don't want it to cause an issue
+
+                /*
+                 * Swallow the final newline, as some editors add it
+                 * automatically and we don't want it to cause an issue
+                 */
                 if (trimmedLines[trimmedLines.length - 1] === "") {
                     trimmedLines = trimmedLines.slice(0, -1);
                 }
+
                 firstOfEndingBlankLines = trimmedLines.length;
             } else {
+
                 // save the number of the first of the last blank lines
                 firstOfEndingBlankLines = trimmedLines.length;
                 while (trimmedLines[firstOfEndingBlankLines - 1] === ""
@@ -99,17 +104,26 @@ module.exports = function(context) {
                         line: lastLocation + 1,
                         column: 1
                     };
+
                     if (lastLocation < firstOfEndingBlankLines) {
+
                         // within the file, not at the end
                         if (blankCounter >= max) {
-                            context.report(node, location,
-                                    "More than " + max + " blank " + (max === 1 ? "line" : "lines") + " not allowed.");
+                            context.report({
+                                node: node,
+                                loc: location,
+                                message: "More than " + max + " blank " + (max === 1 ? "line" : "lines") + " not allowed."
+                            });
                         }
                     } else {
+
                         // inside the last blank lines
                         if (blankCounter > maxEOF) {
-                            context.report(node, location,
-                                    "Too many blank lines at the end of file. Max of " + maxEOF + " allowed.");
+                            context.report({
+                                node: node,
+                                loc: location,
+                                message: "Too many blank lines at the end of file. Max of " + maxEOF + " allowed."
+                            });
                         }
                     }
 

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -25,6 +25,7 @@ module.exports = function(context) {
 
         if (reference.init === false &&
             reference.isWrite() &&
+
             // Destructuring assignments can have multiple default value,
             // so possibly there are multiple writeable references for the same identifier.
             (index === 0 || references[index - 1].identifier !== identifier)

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -31,6 +31,7 @@ module.exports = function(context) {
             var parent = node.parent;
             while (parent && !stopNodePattern.test(parent.type)) {
                 switch (parent.type) {
+
                     // e.g. foo.a = 0;
                     case "AssignmentExpression":
                         return parent.left === node;
@@ -85,6 +86,7 @@ module.exports = function(context) {
         if (identifier &&
             !reference.init &&
             isModifying(reference) &&
+
             // Destructuring assignments can have multiple default value,
             // so possibly there are multiple writeable references for the same identifier.
             (index === 0 || references[index - 1].identifier !== identifier)
@@ -117,6 +119,7 @@ module.exports = function(context) {
     }
 
     return {
+
         // `:exit` is needed for the `node.parent` property of identifier nodes.
         "FunctionDeclaration:exit": checkForFunction,
         "FunctionExpression:exit": checkForFunction,

--- a/lib/rules/no-restricted-modules.js
+++ b/lib/rules/no-restricted-modules.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     // trim restricted module names
     var restrictedModules = context.options;
 

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -12,6 +12,7 @@
 var nodeTypes = require("espree").Syntax;
 
 module.exports = function(context) {
+
     /**
      * Generates a warning from the provided node, saying that node type is not allowed.
      * @param {ASTNode} node The node to warn on

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -25,6 +25,7 @@ function eachSelfAssignment(left, right, report) {
     var i, j;
 
     if (!left || !right) {
+
         // do nothing
     } else if (
         left.type === "Identifier" &&
@@ -57,6 +58,7 @@ function eachSelfAssignment(left, right, report) {
         right.type === "ObjectExpression" &&
         right.properties.length >= 1
     ) {
+
         // Gets the index of the last spread property.
         // It's possible to overwrite properties followed by it.
         var startJ = 0;
@@ -94,6 +96,7 @@ function eachSelfAssignment(left, right, report) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     /**
      * Reports a given node as self assignments.
      *

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -68,6 +68,7 @@ module.exports = function(context) {
 
     return {
         "SequenceExpression": function(node) {
+
             // Always allow sequences in for statement update
             if (node.parent.type === "ForStatement" &&
                     (node === node.parent.init || node === node.parent.update)) {

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -100,6 +100,7 @@ module.exports = function(context) {
             inner &&
             outer &&
             inner[1] < outer[0] &&
+
             // Excepts FunctionDeclaration if is {"hoist":"function"}.
             (options.hoist !== "functions" || !outerDef || outerDef.node.type !== "FunctionDeclaration")
         );

--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -36,19 +36,24 @@ function isConstructorFunction(node) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    // Information for each constructor.
-    // - upper:      Information of the upper constructor.
-    // - hasExtends: A flag which shows whether the owner class has a valid
-    //               `extends` part.
-    // - scope:      The scope of the owner class.
-    // - codePath:   The code path of this constructor.
+
+    /*
+     * Information for each constructor.
+     * - upper:      Information of the upper constructor.
+     * - hasExtends: A flag which shows whether the owner class has a valid
+     *   `extends` part.
+     * - scope:      The scope of the owner class.
+     * - codePath:   The code path of this constructor.
+     */
     var funcInfo = null;
 
-    // Information for each code path segment.
-    // Each key are the ids of code path segments.
-    // Each value are an object:
-    // - superCalled:  The flag which shows `super()` called in all code paths.
-    // - invalidNodes: The array of invalid ThisExpression and Super nodes.
+    /*
+     * Information for each code path segment.
+     * Each key is the id of a code path segment.
+     * Each value is an object:
+     * - superCalled:  The flag which shows `super()` called in all code paths.
+     * - invalidNodes: The array of invalid ThisExpression and Super nodes.
+     */
     var segInfoMap = Object.create(null);
 
     /**
@@ -104,6 +109,7 @@ module.exports = function(context) {
     }
 
     return {
+
         /**
          * Adds information of a constructor into the stack.
          * @param {CodePath} codePath - A code path which was started.
@@ -112,8 +118,10 @@ module.exports = function(context) {
          */
         "onCodePathStart": function(codePath, node) {
             if (isConstructorFunction(node)) {
+
                 // Class > ClassBody > MethodDefinition > FunctionExpression
                 var classNode = node.parent.parent.parent;
+
                 funcInfo = {
                     upper: funcInfo,
                     isConstructor: true,

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -26,9 +26,13 @@ module.exports = function(context) {
      * @returns {void}
      */
     function report(node, location, fixRange) {
-        // Passing node is a bit dirty, because message data will contain
-        // big text in `source`. But... who cares :) ?
-        // One more kludge will not make worse the bloody wizardry of this plugin.
+
+        /*
+         * Passing node is a bit dirty, because message data will contain big
+         * text in `source`. But... who cares :) ?
+         * One more kludge will not make worse the bloody wizardry of this
+         * plugin.
+         */
         context.report({
             node: node,
             loc: location,

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -60,6 +60,7 @@ module.exports = function(context) {
      * @private
      */
     function isSpecialCaseIdentifierInVariableExpression(identifier) {
+
         // Checks for the underscore library usage here
         return identifier === "_";
     }

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -146,9 +146,11 @@ function toLoopCondition(reference) {
     var group = null;
     var child = reference.identifier;
     var node = child.parent;
+
     while (node) {
         if (SENTINEL_PATTERN.test(node.type)) {
             if (LOOP_PATTERN.test(node.type) && node.test === child) {
+
                 // This reference is inside of a loop condition.
                 return {
                     reference: reference,
@@ -157,15 +159,19 @@ function toLoopCondition(reference) {
                     modified: false
                 };
             }
+
             // This reference is outside of a loop condition.
             break;
         }
 
-        // If it's inside of a group, OK if either operand is modified.
-        // So stores the group this reference belongs to.
+        /*
+         * If it's inside of a group, OK if either operand is modified.
+         * So stores the group this reference belongs to.
+         */
         if (GROUP_PATTERN.test(node.type)) {
+
+            // If this expression is dynamic, no need to check.
             if (hasDynamicExpressions(node)) {
-                // This expression is dynamic, so don't check.
                 break;
             } else {
                 group = node;
@@ -214,9 +220,16 @@ function updateModifiedFlag(conditions, modifiers) {
         var condition = conditions[i];
 
         for (var j = 0; !condition.modified && j < modifiers.length; ++j) {
-            var modifier = modifiers[j];
-            var inLoop = condition.isInLoop(modifier) || Boolean(
-                // Checks the function that this modifier is belonging to is used in the loop.
+            var modifier = modifiers[j],
+                inLoop;
+
+            /*
+             * Besides checking for the condition being in the loop, we want to
+             * check the function that this modifier is belonging to is called
+             * in the loop.
+             * FIXME: This should probably be extracted to a function.
+             */
+            inLoop = condition.isInLoop(modifier) || Boolean(
                 (funcNode = getEncloseFunctionDeclaration(modifier)) &&
                 (funcVar = astUtils.getVariableByName(modifier.from.upper, funcNode.id.name)) &&
                 funcVar.references.some(condition.isInLoop)
@@ -291,6 +304,7 @@ module.exports = function(context) {
      * @returns {void}
      */
     function checkReferences(variable) {
+
         // Gets references that exist in loop conditions.
         var conditions = variable
             .references
@@ -310,8 +324,10 @@ module.exports = function(context) {
             updateModifiedFlag(conditions, modifiers);
         }
 
-        // Reports the conditions which are not belonging to groups.
-        // Others will be reported after all variables are done.
+        /*
+         * Reports the conditions which are not belonging to groups.
+         * Others will be reported after all variables are done.
+         */
         conditions
             .filter(isUnmodifiedAndNotBelongToGroup)
             .forEach(report);

--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -47,10 +47,12 @@ module.exports = function(context) {
     }
 
     return {
+
         // Manages the current code path.
         "onCodePathStart": function(codePath) {
             currentCodePath = codePath;
         },
+
         "onCodePathEnd": function() {
             currentCodePath = currentCodePath.upper;
         },
@@ -74,11 +76,13 @@ module.exports = function(context) {
         SwitchStatement: reportIfUnreachable,
         ThrowStatement: reportIfUnreachable,
         TryStatement: reportIfUnreachable,
+
         VariableDeclaration: function(node) {
             if (node.kind !== "var" || node.declarations.some(isInitialized)) {
                 reportIfUnreachable(node);
             }
         },
+
         WhileStatement: reportIfUnreachable,
         WithStatement: reportIfUnreachable,
         ExportNamedDeclaration: reportIfUnreachable,

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -65,6 +65,7 @@ module.exports = function(context) {
      */
     function isValidExpression(node) {
         if (allowTernary) {
+
             // Recursive check for ternary and logical expressions
             if (node.type === "ConditionalExpression") {
                 return isValidExpression(node.consequent) && isValidExpression(node.alternate);

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -142,10 +142,12 @@ module.exports = function(context) {
                 if (scope.type === "class" && scope.block.id === variable.identifiers[0]) {
                     continue;
                 }
+
                 // skip function expression names and variables marked with markVariableAsUsed()
                 if (scope.functionExpressionScope || variable.eslintUsed) {
                     continue;
                 }
+
                 // skip implicit "arguments" variable
                 if (scope.type === "function" && variable.name === "arguments" && variable.identifiers.length === 0) {
                     continue;
@@ -162,6 +164,7 @@ module.exports = function(context) {
                     }
 
                     if (type === "Parameter") {
+
                         // skip any setter argument
                         if (def.node.parent.type === "Property" && def.node.parent.kind === "set") {
                             continue;
@@ -182,6 +185,7 @@ module.exports = function(context) {
                             continue;
                         }
                     } else {
+
                         // skip ignored variables
                         if (config.varsIgnorePattern && config.varsIgnorePattern.test(def.name.name)) {
                             continue;
@@ -236,6 +240,7 @@ module.exports = function(context) {
         if (lineInComment > 0) {
             column -= 1 + prefix.lastIndexOf("\n");
         } else {
+
             // 2 is for `/*`
             column += baseLoc.column + 2;
         }

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -58,6 +58,7 @@ function getRight(node) {
 module.exports = function(context) {
     return {
         BinaryExpression: function(node) {
+
             // check if not concatenation
             if (node.operator !== "+") {
                 return;
@@ -71,6 +72,7 @@ module.exports = function(context) {
                 astUtils.isStringLiteral(right) &&
                 astUtils.isTokenOnSameLine(left, right)
             ) {
+
                 // move warning location to operator
                 var operatorToken = context.getTokenAfter(left);
                 while (operatorToken.value !== "+") {

--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -143,6 +143,7 @@ function isRedundantSuperCall(body, ctorParams) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     /**
      * Checks whether a node is a redundant constructor
      * @param {ASTNode} node - node to check

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -29,16 +29,27 @@ module.exports = function(context) {
      */
     function convertToRegExp(term) {
         var escaped = term.replace(/[-\/\\$\^*+?.()|\[\]{}]/g, "\\$&"),
-            // If the term ends in a word character (a-z0-9_), ensure a word boundary at the end, so that substrings do
-            // not get falsely matched. eg "todo" in a string such as "mastodon".
-            // If the term ends in a non-word character, then \b won't match on the boundary to the next non-word
-            // character, which would likely be a space. For example `/\bFIX!\b/.test('FIX! blah') === false`.
-            // In these cases, use no bounding match. Same applies for the prefix, handled below.
-            suffix = /\w$/.test(term) ? "\\b" : "",
+            suffix,
             prefix;
 
+        /*
+         * If the term ends in a word character (a-z0-9_), ensure a word
+         * boundary at the end, so that substrings do not get falsely
+         * matched. eg "todo" in a string such as "mastodon".
+         * If the term ends in a non-word character, then \b won't match on
+         * the boundary to the next non-word character, which would likely
+         * be a space. For example `/\bFIX!\b/.test('FIX! blah') === false`.
+         * In these cases, use no bounding match. Same applies for the
+         * prefix, handled below.
+         */
+        suffix = /\w$/.test(term) ? "\\b" : "";
+
         if (location === "start") {
-            // When matching at the start, ignore leading whitespace, and there's no need to worry about word boundaries
+
+            /*
+             * When matching at the start, ignore leading whitespace, and
+             * there's no need to worry about word boundaries.
+             */
             prefix = "^\\s*";
         } else if (/^\w/.test(term)) {
             prefix = "\\b";

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -243,6 +243,7 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
 
     return {
+
         // var {x} = y;
         ObjectPattern: checkForObject,
 

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -246,18 +246,24 @@ module.exports = function(context) {
                     }
                 }
             }
+
             // never
             if (parent.type !== "ForStatement" || parent.init !== node) {
                 var totalDeclarations = declarationCounts.uninitialized + declarationCounts.initialized;
+
                 if (totalDeclarations > 1) {
-                    // both initialized and uninitialized
+
                     if (options[type].initialized === MODE_NEVER && options[type].uninitialized === MODE_NEVER) {
+
+                        // both initialized and uninitialized
                         context.report(node, "Split '" + type + "' declarations into multiple statements.");
-                    // initialized
                     } else if (options[type].initialized === MODE_NEVER && declarationCounts.initialized > 0) {
+
+                        // initialized
                         context.report(node, "Split initialized '" + type + "' declarations into multiple statements.");
-                    // uninitialized
                     } else if (options[type].uninitialized === MODE_NEVER && declarationCounts.uninitialized > 0) {
+
+                        // uninitialized
                         context.report(node, "Split uninitialized '" + type + "' declarations into multiple statements.");
                     }
                 }

--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -53,13 +53,19 @@ function same(a, b) {
     switch (a.type) {
         case "Identifier":
             return a.name === b.name;
+
         case "Literal":
             return a.value === b.value;
+
         case "MemberExpression":
-            // x[0] = x[0]
-            // x[y] = x[y]
-            // x.y = x.y
+
+            /*
+             * x[0] = x[0]
+             * x[y] = x[y]
+             * x.y = x.y
+             */
             return same(a.object, b.object) && same(a.property, b.property);
+
         default:
             return false;
     }

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -107,6 +107,7 @@ module.exports = function(context) {
                 return options.switches;
             case "ClassBody":
                 return options.classes;
+
             /* istanbul ignore next */
             default:
                 throw new Error("unreachable");

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -27,6 +27,7 @@ function isFunctionName(variable) {
  * @returns {boolean} `true` if the node is the specific value.
  */
 function checkMetaProperty(node, metaName, propertyName) {
+
     // TODO: Remove this if block after https://github.com/eslint/espree/issues/206 was fixed.
     if (typeof node.meta === "string") {
         return node.meta === metaName && node.property === propertyName;
@@ -44,8 +45,12 @@ function getVariableOfArguments(scope) {
     for (var i = 0; i < variables.length; ++i) {
         var variable = variables[i];
         if (variable.name === "arguments") {
-            // If there was a parameter which is named "arguments", the implicit "arguments" is not defined.
-            // So does fast return with null.
+
+            /*
+             * If there was a parameter which is named "arguments", the
+             * implicit "arguments" is not defined.
+             * So does fast return with null.
+             */
             return (variable.identifiers.length === 0) ? variable : null;
         }
     }
@@ -66,7 +71,9 @@ function getCallbackInfo(node) {
     var parent = node.parent;
     while (node) {
         switch (parent.type) {
+
             // Checks parents recursively.
+
             case "LogicalExpression":
             case "ConditionalExpression":
                 break;
@@ -116,10 +123,13 @@ function getCallbackInfo(node) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-    // {Array<{this: boolean, super: boolean, meta: boolean}>}
-    // - this - A flag which shows there are one or more ThisExpression.
-    // - super - A flag which shows there are one or more Super.
-    // - meta - A flag which shows there are one or more MethProperty.
+
+    /*
+     * {Array<{this: boolean, super: boolean, meta: boolean}>}
+     * - this - A flag which shows there are one or more ThisExpression.
+     * - super - A flag which shows there are one or more Super.
+     * - meta - A flag which shows there are one or more MethProperty.
+     */
     var stack = [];
 
     /**
@@ -139,6 +149,7 @@ module.exports = function(context) {
     }
 
     return {
+
         // Reset internal state.
         Program: function() {
             stack = [];
@@ -151,12 +162,14 @@ module.exports = function(context) {
                 info.this = true;
             }
         },
+
         Super: function() {
             var info = stack[stack.length - 1];
             if (info) {
                 info.super = true;
             }
         },
+
         MetaProperty: function(node) {
             var info = stack[stack.length - 1];
             if (info && checkMetaProperty(node, "new", "target")) {

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -68,6 +68,7 @@ function getWriteReferenceIfOnce(variable) {
 
         if (reference.isWrite()) {
             if (retv && !(retv.init && reference.init)) {
+
                 // This variable is reassigned.
                 return null;
             }

--- a/lib/rules/prefer-rest-params.js
+++ b/lib/rules/prefer-rest-params.js
@@ -21,6 +21,7 @@ function getVariableOfArguments(scope) {
     for (var i = 0; i < variables.length; ++i) {
         var variable = variables[i];
         if (variable.name === "arguments") {
+
             // If there was a parameter which is named "arguments", the implicit "arguments" is not defined.
             // So does fast return with null.
             return (variable.identifiers.length === 0) ? variable : null;

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -44,6 +44,7 @@ function getTopConcatBinaryExpression(node) {
  */
 function hasNonStringLiteral(node) {
     if (isConcatenation(node)) {
+
         // `left` is deeper than `right` normally.
         return hasNonStringLiteral(node.right) || hasNonStringLiteral(node.left);
     }

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -34,6 +34,7 @@ var QUOTE_SETTINGS = {
         description: "backtick"
     }
 };
+
 /**
  * Switches quoting of javascript string between ' " and `
  * escaping and unescaping as necessary.
@@ -142,6 +143,7 @@ module.exports = function(context) {
         var parent = node.parent;
 
         switch (parent.type) {
+
             // Directive Prologues.
             case "ExpressionStatement":
                 return isPartOfDirectivePrologue(node);

--- a/lib/rules/require-yield.js
+++ b/lib/rules/require-yield.js
@@ -51,6 +51,7 @@ module.exports = function(context) {
 
         // Increases the count of `yield` keyword.
         "YieldExpression": function() {
+
             /* istanbul ignore else */
             if (stack.length > 0) {
                 stack[stack.length - 1] += 1;

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -223,6 +223,7 @@ module.exports = function(context) {
                         }
                     });
                 } else if (token.value === ")" && shouldCloserHaveSpace(prevToken, token)) {
+
                     // context.report(node, token.loc.start, MISSING_SPACE_MESSAGE);
                     context.report({
                         node: node,

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -65,43 +65,57 @@ function parseMarkersOption(markers) {
 function createAlwaysStylePattern(markers, exceptions) {
     var pattern = "^";
 
-    // A marker or nothing.
-    //   ["*"]            ==> "\*?"
-    //   ["*", "!"]       ==> "(?:\*|!)?"
-    //   ["*", "/", "!<"] ==> "(?:\*|\/|(?:!<))?" ==> https://jex.im/regulex/#!embed=false&flags=&re=(%3F%3A%5C*%7C%5C%2F%7C(%3F%3A!%3C))%3F
+    /*
+     * A marker or nothing.
+     * ["*"]            ==> "\*?"
+     * ["*", "!"]       ==> "(?:\*|!)?"
+     * ["*", "/", "!<"] ==> "(?:\*|\/|(?:!<))?" ==> https://jex.im/regulex/#!embed=false&flags=&re=(%3F%3A%5C*%7C%5C%2F%7C(%3F%3A!%3C))%3F
+     */
     if (markers.length === 1) {
+
         // the marker.
         pattern += escape(markers[0]);
     } else {
+
         // one of markers.
         pattern += "(?:";
         pattern += markers.map(escape).join("|");
         pattern += ")";
     }
+
     pattern += "?"; // or nothing.
 
-    // A space or an exception pattern sequence.
-    //   []                 ==> "\s"
-    //   ["-"]              ==> "(?:\s|\-+$)"
-    //   ["-", "="]         ==> "(?:\s|(?:\-+|=+)$)"
-    //   ["-", "=", "--=="] ==> "(?:\s|(?:\-+|=+|(?:\-\-==)+)$)" ==> https://jex.im/regulex/#!embed=false&flags=&re=(%3F%3A%5Cs%7C(%3F%3A%5C-%2B%7C%3D%2B%7C(%3F%3A%5C-%5C-%3D%3D)%2B)%24)
+    /*
+     * A space or an exception pattern sequence.
+     * []                 ==> "\s"
+     * ["-"]              ==> "(?:\s|\-+$)"
+     * ["-", "="]         ==> "(?:\s|(?:\-+|=+)$)"
+     * ["-", "=", "--=="] ==> "(?:\s|(?:\-+|=+|(?:\-\-==)+)$)" ==> https://jex.im/regulex/#!embed=false&flags=&re=(%3F%3A%5Cs%7C(%3F%3A%5C-%2B%7C%3D%2B%7C(%3F%3A%5C-%5C-%3D%3D)%2B)%24)
+     */
     if (exceptions.length === 0) {
+
         // a space.
         pattern += "\\s";
     } else {
+
         // a space or...
         pattern += "(?:\\s|";
+
         if (exceptions.length === 1) {
+
             // a sequence of the exception pattern.
             pattern += escapeAndRepeat(exceptions[0]);
         } else {
+
             // a sequence of one of exception patterns.
             pattern += "(?:";
             pattern += exceptions.map(escapeAndRepeat).join("|");
             pattern += ")";
         }
+
         pattern += "(?:$|[\n\r]))"; // the sequence continues until the end.
     }
+
     return new RegExp(pattern);
 }
 
@@ -125,11 +139,15 @@ function createNeverStylePattern(markers) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+
     // Unless the first option is never, require a space
     var requireSpace = context.options[0] !== "never";
 
-    // Parse the second options.
-    // If markers don't include `"*"`, it's added automatically for JSDoc comments.
+    /*
+     * Parse the second options.
+     * If markers don't include `"*"`, it's added automatically for JSDoc
+     * comments.
+     */
     var config = context.options[1] || {};
     var styleRules = ["block", "line"].reduce(function(rule, type) {
         var markers = parseMarkersOption(config[type] && config[type].markers || config.markers);

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -189,6 +189,7 @@ module.exports = function(context) {
 
     if (mode === "function") {
         lodash.assign(rule, {
+
             // Inside of class bodies are always strict mode.
             "ClassBody": function() {
                 classScopes.push(true);

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -96,15 +96,20 @@ function same(a, b) {
     switch (a.type) {
         case "Identifier":
             return a.name === b.name;
+
         case "Literal":
             return a.value === b.value;
+
         case "MemberExpression":
+
             // x[0] = x[0]
             // x[y] = x[y]
             // x.y = x.y
             return same(a.object, b.object) && same(a.property, b.property);
+
         case "ThisExpression":
             return true;
+
         default:
             return false;
     }

--- a/lib/testers/event-generator-tester.js
+++ b/lib/testers/event-generator-tester.js
@@ -19,6 +19,7 @@ var assert = require("assert");
 //------------------------------------------------------------------------------
 
 module.exports = {
+
     /**
      * Overrideable `describe` function to test.
      * @param {string} text - A description.

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -57,12 +57,18 @@ var lodash = require("lodash"),
 //------------------------------------------------------------------------------
 // Private Members
 //------------------------------------------------------------------------------
-// testerDefaultConfig must not be modified as it allows to reset the tester to
-// the initial default configuration
+
+/*
+ * testerDefaultConfig must not be modified as it allows to reset the tester to
+ * the initial default configuration
+ */
 var testerDefaultConfig = { rules: {} };
 var defaultConfig = { rules: {} };
-// List every parameters possible on a test case that are not related to eslint
-// configuration
+
+/*
+ * List every parameters possible on a test case that are not related to eslint
+ * configuration
+ */
 var RuleTesterParameters = [
     "code",
     "filename",
@@ -139,8 +145,8 @@ function RuleTester(testerConfig) {
      * @type {Object}
      */
     this.testerConfig = lodash.merge(
-        // we have to clone because merge uses the object on the left for
-        // recipient
+
+        // we have to clone because merge uses the first argument for recipient
         lodash.cloneDeep(defaultConfig),
         testerConfig
     );
@@ -228,9 +234,11 @@ RuleTester.prototype = {
                 code = item;
             } else {
                 code = item.code;
+
                 // Assumes everything on the item is a config except for the
                 // parameters used by this tester
                 var itemConfig = lodash.omit(item, RuleTesterParameters);
+
                 // Create the config object from the tester config and this item
                 // specific configurations.
                 config = lodash.merge(
@@ -269,8 +277,11 @@ RuleTester.prototype = {
 
             validator.validate(config, "rule-tester");
 
-            // Setup AST getters.
-            // To check whether or not AST was not modified in verify.
+            /*
+             * Setup AST getters.
+             * The goal is to check whether or not AST was modified when
+             * running the rule under test.
+             */
             eslint.reset();
             eslint.on("Program", function(node) {
                 beforeAST = cloneDeeplyExcludesParent(node);
@@ -371,13 +382,16 @@ RuleTester.prototype = {
                     assert.equal(messages[i].ruleId, ruleName, "Error rule name should be the same as the name of the rule being tested");
 
                     if (typeof item.errors[i] === "string") {
-                        // Just an error message.
 
+                        // Just an error message.
                         assert.equal(messages[i].message, item.errors[i], "Error message should be " + item.errors[i]);
                     } else if (typeof item.errors[i] === "object") {
-                        // Error object. This may have a message, node type,
-                        // line, and/or column.
 
+                        /*
+                         * Error object.
+                         * This may have a message, node type, line, and/or
+                         * column.
+                         */
                         if (item.errors[i].message) {
                             assert.equal(messages[i].message, item.errors[i].message, "Error message should be " + item.errors[i].message);
                         }
@@ -394,6 +408,7 @@ RuleTester.prototype = {
                             assert.equal(messages[i].column, item.errors[i].column, "Error column should be " + item.errors[i].column);
                         }
                     } else {
+
                         // Only string or object errors are valid.
                         assert.fail(messages[i], null, "Error should be a string or object.");
                     }
@@ -413,8 +428,10 @@ RuleTester.prototype = {
             );
         }
 
-        // this creates a mocha test suite and pipes all supplied info
-        // through one of the templates above.
+        /*
+         * This creates a mocha test suite and pipes all supplied info through
+         * one of the templates above.
+         */
         RuleTester.describe(ruleName, function() {
             RuleTester.describe("valid", function() {
                 test.valid.forEach(function(valid) {

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -105,11 +105,14 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
 
             if (end < lastFixPos) {
                 if (start < 0) {
+
                     // Remove BOM.
                     prefix = "";
                     start = 0;
                 }
+
                 if (start === 0 && insertionText[0] === BOM) {
+
                     // Set BOM.
                     prefix = BOM;
                     insertionText = insertionText.slice(1);

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -20,6 +20,12 @@ rules:
     guard-for-in: "error"
     key-spacing: ["error", { beforeColon: false, afterColon: true }]
     keyword-spacing: "error"
+    lines-around-comment: ["error", {
+        beforeBlockComment: true,
+        afterBlockComment: false,
+        beforeLineComment: true,
+        afterLineComment: false
+    }]
     new-cap: "error"
     new-parens: "error"
     no-alert: "error"
@@ -78,6 +84,7 @@ rules:
     semi-spacing: ["error", {before: false, after: true}]
     space-before-blocks: "error"
     space-before-function-paren: ["error", "never"]
+    space-in-parens: "error"
     space-infix-ops: "error"
     space-unary-ops: ["error", {words: true, nonwords: false}]
     spaced-comment: ["error", "always", { exceptions: ["-"]}]

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -35,6 +35,7 @@ describe("ast-utils", function() {
 
     describe("isTokenOnSameLine", function() {
         it("should return false if its not on sameline", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -50,6 +51,7 @@ describe("ast-utils", function() {
         });
 
         it("should return true if its on sameline", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -67,6 +69,7 @@ describe("ast-utils", function() {
 
     describe("isNullOrUndefined", function() {
         it("should return true if its null", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -82,6 +85,7 @@ describe("ast-utils", function() {
         });
 
         it("should return true if its undefined", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -97,6 +101,7 @@ describe("ast-utils", function() {
         });
 
         it("should return false if its a number", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -112,6 +117,7 @@ describe("ast-utils", function() {
         });
 
         it("should return false if its a string", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -127,6 +133,7 @@ describe("ast-utils", function() {
         });
 
         it("should return false if its a boolean", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -142,6 +149,7 @@ describe("ast-utils", function() {
         });
 
         it("should return false if its an object", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -158,8 +166,10 @@ describe("ast-utils", function() {
     });
 
     describe("checkReference", function() {
+
         // catch
         it("should return true if reference is assigned for catch", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -177,6 +187,7 @@ describe("ast-utils", function() {
 
         // const
         it("should return true if reference is assigned for const", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -193,6 +204,7 @@ describe("ast-utils", function() {
         });
 
         it("should return false if reference is not assigned for const", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -210,6 +222,7 @@ describe("ast-utils", function() {
 
         // class
         it("should return true if reference is assigned for class", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -227,6 +240,7 @@ describe("ast-utils", function() {
         });
 
         it("should return false if reference is not assigned for class", function() {
+
             /**
              * Check the node for tokens
              * @param {ASTNode} node node to examine
@@ -244,6 +258,7 @@ describe("ast-utils", function() {
     });
 
     describe("isDirectiveComment", function() {
+
         /**
          * Asserts the node is NOT a directive comment
          * @param {ASTNode} node node to assert

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -816,6 +816,7 @@ describe("CLIEngine", function() {
         describe("Fix Mode", function() {
 
             it("should return fixed text on multiple files when in fix mode", function() {
+
                 /**
                  * Converts CRLF to LF in output.
                  * This is a workaround for git's autocrlf option on Windows.
@@ -1264,6 +1265,7 @@ describe("CLIEngine", function() {
 
         describe("cache", function() {
             var sandbox;
+
             /**
              * helper method to delete the cache files created during testing
              * @returns {void}
@@ -1273,8 +1275,11 @@ describe("CLIEngine", function() {
                     fs.unlinkSync(path.resolve(".eslintcache"));
                     fs.unlinkSync(path.resolve(".cache/custom-cache"));
                 } catch (ex) {
-                    // we don't care if the file didn't exist
-                    // since our intention was to remove the file
+
+                    /*
+                     * we don't care if the file didn't exist, since our
+                     * intention was to remove the file
+                     */
                 }
             }
 
@@ -1288,6 +1293,7 @@ describe("CLIEngine", function() {
             });
 
             describe("when the cacheFile is a directory or looks like a directory", function() {
+
                 /**
                 * helper method to delete the cache files created during testing
                 * @returns {void}
@@ -1296,8 +1302,11 @@ describe("CLIEngine", function() {
                     try {
                         fs.unlinkSync("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory");
                     } catch (ex) {
-                        // we don't care if the file didn't exist
-                        // since we wanted it to be deleted anyway
+
+                        /*
+                         * we don't care if the file didn't exist, since our
+                         * intention was to remove the file
+                         */
                     }
                 }
                 beforeEach(function() {
@@ -1313,6 +1322,7 @@ describe("CLIEngine", function() {
 
                     engine = new CLIEngine({
                         useEslintrc: false,
+
                         // specifying cache true the cache will be created
                         cache: true,
                         cacheFile: "./tmp/.cacheFileDir/",
@@ -1339,6 +1349,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
+
                     // specifying cache true the cache will be created
                     cache: true,
                     cacheLocation: "./tmp/.cacheFileDir/",
@@ -1385,6 +1396,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
+
                     // specifying cache true the cache will be created
                     cache: true,
                     rules: {
@@ -1411,6 +1423,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
+
                     // specifying cache true the cache will be created
                     cache: true,
                     rules: {
@@ -1437,6 +1450,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
+
                     // specifying cache true the cache will be created
                     cache: true,
                     rules: {
@@ -1462,6 +1476,7 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     useEslintrc: false,
+
                     // specifying cache true the cache will be created
                     cache: true,
                     rules: {
@@ -1488,6 +1503,7 @@ describe("CLIEngine", function() {
                 var cacheFile = getFixturePath(".eslintcache");
                 var cliEngineOptions = {
                     useEslintrc: false,
+
                     // specifying cache true the cache will be created
                     cache: true,
                     cacheFile: cacheFile,
@@ -1526,6 +1542,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
+
                     // specifying cache true the cache will be created
                     cache: true,
                     cacheFile: cacheFile,
@@ -1562,8 +1579,10 @@ describe("CLIEngine", function() {
 
                     engine = new CLIEngine({
                         useEslintrc: false,
+
                         // specify a custom cache file
                         cacheFile: customCacheFile,
+
                         // specifying cache true the cache will be created
                         cache: true,
                         rules: {
@@ -2012,6 +2031,7 @@ describe("CLIEngine", function() {
             var config = {
                 envs: ["browser"],
                 ignore: true,
+
                 // allowInlineConfig: true is the default
                 rules: {
                     "eol-last": 0,

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -67,6 +67,7 @@ describe("cli", function() {
         localCLI.execute(cmd);
         sandbox.verifyAndRestore();
     }
+
     // verifyCLIEngineOpts
 
     /**
@@ -132,6 +133,7 @@ describe("cli", function() {
         var code = "lib/cli.js";
 
         it("should load the local config file", function() {
+
             // Mock CWD
             process.eslintCwd = getFixturePath("configurations", "single-quotes");
 
@@ -711,6 +713,7 @@ describe("cli", function() {
         });
 
         it("should not error and allowInlineConfig should be true by default", function() {
+
             // create a fake CLIEngine to test with
             var fakeCLIEngine = sandbox.mock().withExactArgs(sinon.match({ allowInlineConfig: true }));
             fakeCLIEngine.prototype = leche.fake(CLIEngine.prototype);

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -490,7 +490,9 @@ describe("CodePathAnalyzer", function() {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
+
                         if (count === 1) {
+
                             // connect path: "update" -> "test"
                             assert(node.parent.type === "ForStatement");
                         } else if (count === 2) {
@@ -516,7 +518,9 @@ describe("CodePathAnalyzer", function() {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
+
                         if (count === 1) {
+
                             // connect path: "right" -> "left"
                             assert(node.parent.type === "ForInStatement");
                         } else if (count === 2) {
@@ -542,7 +546,9 @@ describe("CodePathAnalyzer", function() {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
+
                         if (count === 1) {
+
                             // connect path: "right" -> "left"
                             assert(node.parent.type === "ForOfStatement");
                         } else if (count === 2) {

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -76,6 +76,7 @@ describe("CodePathAnalyzer", function() {
                 var order = getOrderOfTraversing(codePath);
 
                 assert.deepEqual(order, ["s1_1"]);
+
                 /*
                 digraph {
                     node[shape=box,style="rounded,filled",fillcolor=white];
@@ -92,6 +93,7 @@ describe("CodePathAnalyzer", function() {
                 var order = getOrderOfTraversing(codePath);
 
                 assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+
                 /*
                 digraph {
                     node[shape=box,style="rounded,filled",fillcolor=white];
@@ -112,6 +114,7 @@ describe("CodePathAnalyzer", function() {
                 var order = getOrderOfTraversing(codePath);
 
                 assert.deepEqual(order, ["s1_1", "s1_2", "s1_4", "s1_5", "s1_6"]);
+
                 /*
                 digraph {
                     node[shape=box,style="rounded,filled",fillcolor=white];
@@ -136,6 +139,7 @@ describe("CodePathAnalyzer", function() {
                 var order = getOrderOfTraversing(codePath);
 
                 assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+
                 /*
                 digraph {
                     node[shape=box,style="rounded,filled",fillcolor=white];
@@ -155,6 +159,7 @@ describe("CodePathAnalyzer", function() {
                 var order = getOrderOfTraversing(codePath);
 
                 assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4", "s1_5"]);
+
                 /*
                 digraph {
                     node[shape=box,style="rounded,filled",fillcolor=white];
@@ -175,6 +180,7 @@ describe("CodePathAnalyzer", function() {
                 var order = getOrderOfTraversing(codePath);
 
                 assert.deepEqual(order, ["s1_1", "s1_3", "s1_2", "s1_4", "s1_5"]);
+
                 /*
                 digraph {
                     node[shape=box,style="rounded,filled",fillcolor=white];
@@ -197,6 +203,7 @@ describe("CodePathAnalyzer", function() {
                 var order = getOrderOfTraversing(codePath);
 
                 assert.deepEqual(order, ["s1_1", "s1_2", "s1_3", "s1_4"]);
+
                 /*
                 digraph {
                     node[shape=box,style="rounded,filled",fillcolor=white];
@@ -222,6 +229,7 @@ describe("CodePathAnalyzer", function() {
             });
 
             assert.deepEqual(order, ["s1_2", "s1_3", "s1_4"]);
+
             /*
             digraph {
                 node[shape=box,style="rounded,filled",fillcolor=white];
@@ -250,6 +258,7 @@ describe("CodePathAnalyzer", function() {
             });
 
             assert.deepEqual(order, ["s1_1", "s1_2"]);
+
             /*
             digraph {
                 node[shape=box,style="rounded,filled",fillcolor=white];
@@ -278,6 +287,7 @@ describe("CodePathAnalyzer", function() {
             });
 
             assert.deepEqual(order, ["s1_1", "s1_2", "s1_5", "s1_6"]);
+
             /*
             digraph {
                 node[shape=box,style="rounded,filled",fillcolor=white];

--- a/tests/lib/config/autoconfig.js
+++ b/tests/lib/config/autoconfig.js
@@ -156,6 +156,7 @@ describe("autoconfig", function() {
             });
 
             it("should create as many ruleSets as the highest number of configs in a rule", function() {
+
                 // `quotes` has 7 possible configurations
                 assert.lengthOf(ruleSets, 7);
             });

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -153,6 +153,7 @@ describe("ConfigFile", function() {
             target.push(path.resolve(PROJECT_PATH, "./node_modules/eslint-config-foo/index.js"));
 
             var configDeps = {
+
                 // Hacky: need to override isFile for each call for testing
                 "resolve": {
                     sync: function(filename, opts) {
@@ -193,6 +194,7 @@ describe("ConfigFile", function() {
             target.push(path.resolve("/whatever/node_modules/eslint-config-foo/index.js"));
 
             var configDeps = {
+
                 // Hacky: need to override isFile for each call for testing
                 "resolve": {
                     sync: function(filename, opts) {
@@ -223,6 +225,7 @@ describe("ConfigFile", function() {
             target.push(path.resolve(PROJECT_PATH, "./node_modules/eslint-config-bar/index.js"));
 
             var configDeps = {
+
                 // Hacky: need to override isFile for each call for testing
                 "resolve": {
                     sync: function(filename, opts) {
@@ -676,6 +679,7 @@ describe("ConfigFile", function() {
 
         beforeEach(function() {
             StubbedConfigFile = proxyquire("../../../lib/config/config-file", {
+
                 // Hacky: need to override isFile for each call for testing
                 "resolve": {
                     sync: function(filename, opts) {

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -224,6 +224,7 @@ describe("configInitializer", function() {
                     config = init.processAnswers(answers);
                     process.chdir(originalDir);
                 } catch (err) {
+
                     // if processAnswers crashes, we need to be sure to restore cwd and console.log
                     console.log = origLog;
                     process.chdir(originalDir);

--- a/tests/lib/config/config-rule.js
+++ b/tests/lib/config/config-rule.js
@@ -72,6 +72,7 @@ describe("ConfigRule", function() {
             });
 
             it("should return configs with option objects", function() {
+
                 // Skip first config (severity only)
                 actualConfigs.slice(1).forEach(function(actualConfig) {
                     var actualConfigOption = actualConfig[1]; // severity is first element, option is second

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -181,6 +181,7 @@ describe("eslint", function() {
         var code = TEST_CODE;
 
         it("should retrieve all text when used without parameters", function() {
+
             /**
              * Callback handler
              * @returns {void}
@@ -201,6 +202,7 @@ describe("eslint", function() {
         });
 
         it("should retrieve all text for root node", function() {
+
             /**
              * Callback handler
              * @param {ASTNode} node node to examine
@@ -222,6 +224,7 @@ describe("eslint", function() {
         });
 
         it("should clamp to valid range when retrieving characters before start of source", function() {
+
             /**
              * Callback handler
              * @param {ASTNode} node node to examine
@@ -2320,11 +2323,13 @@ describe("eslint", function() {
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 2);
 
-            // Incorrectly formatted comment threw error;
-            // message from caught exception
-            // may differ amongst UAs, so verifying
-            // first part only as defined in the
-            // parseJsonConfig function in lib/eslint.js
+            /*
+             * Incorrectly formatted comment threw error;
+             * message from caught exception
+             * may differ amongst UAs, so verifying
+             * first part only as defined in the
+             * parseJsonConfig function in lib/eslint.js
+             */
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":'1'':/);
             assert.equal(messages[0].line, 1);
             assert.equal(messages[0].column, 1);
@@ -2342,11 +2347,13 @@ describe("eslint", function() {
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 2);
 
-            // Incorrectly formatted comment threw error;
-            // message from caught exception
-            // may differ amongst UAs, so verifying
-            // first part only as defined in the
-            // parseJsonConfig function in lib/eslint.js
+            /*
+             * Incorrectly formatted comment threw error;
+             * message from caught exception
+             * may differ amongst UAs, so verifying
+             * first part only as defined in the
+             * parseJsonConfig function in lib/eslint.js
+             */
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":abc':/);
             assert.equal(messages[0].line, 1);
             assert.equal(messages[0].column, 1);
@@ -2364,11 +2371,13 @@ describe("eslint", function() {
             var messages = eslint.verify(code, config, filename);
             assert.equal(messages.length, 2);
 
-            // Incorrectly formatted comment threw error;
-            // message from caught exception
-            // may differ amongst UAs, so verifying
-            // first part only as defined in the
-            // parseJsonConfig function in lib/eslint.js
+            /*
+             * Incorrectly formatted comment threw error;
+             * message from caught exception
+             * may differ amongst UAs, so verifying
+             * first part only as defined in the
+             * parseJsonConfig function in lib/eslint.js
+             */
             assert.match(messages[0].message, /^Failed to parse JSON from ' "no-alert":0 2':/);
             assert.equal(messages[0].line, 1);
             assert.equal(messages[0].column, 1);
@@ -3241,6 +3250,7 @@ describe("eslint", function() {
     });
 
     describe("getDeclaredVariables(node)", function() {
+
         /**
          * Assert `eslint.getDeclaredVariables(node)` is empty.
          * @param {ASTNode} node - A node to check.
@@ -3346,6 +3356,7 @@ describe("eslint", function() {
         });
 
         it("VariableDeclaration (on for-in/of loop)", function() {
+
             // TDZ scope is created here, so tests to exclude those.
             var code = "\n for (var {a, x: [b], y: {c = 0}} in foo) {\n let g;\n }\n for (let {d, x: [e], y: {f = 0}} of foo) {\n let h;\n }\n ";
             var namesList = [
@@ -3359,6 +3370,7 @@ describe("eslint", function() {
         });
 
         it("VariableDeclarator", function() {
+
             // TDZ scope is created here, so tests to exclude those.
             var code = "\n var {a, x: [b], y: {c = 0}} = foo;\n let {d, x: [e], y: {f = 0}} = foo;\n const {g, x: [h], y: {i = 0}} = foo, {j, k = function(z) { let l; }} = bar;\n ";
             var namesList = [
@@ -3506,6 +3518,7 @@ describe("eslint", function() {
         });
 
         it("should not rewrite env setting in core (https://github.com/eslint/eslint/issues/4814)", function() {
+
             // This test focuses on the instance of https://github.com/eslint/eslint/blob/v2.0.0-alpha-2/conf/environments.js#L26-L28
 
             // This `verify()` takes the instance and runs https://github.com/eslint/eslint/blob/v2.0.0-alpha-2/lib/eslint.js#L416

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -244,8 +244,10 @@ describe("IgnoredPaths", function() {
         });
 
         it("should return false for files outside of the cwd (with no ignore file provided)", function() {
+
             // Default ignore patterns should not inadvertantly ignore files in parent directories
             var ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath("no-ignore-file") });
+
             assert.isFalse(ignoredPaths.contains(getFixturePath("undef.js")));
         });
 

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -177,6 +177,7 @@ ruleTester.run("array-bracket-spacing", rule, {
                 }
             ]
         },
+
         // objectsInArrays
         {
             code: "var foo = [ { 'bar': 'baz' }, 1,  5];",

--- a/tests/lib/rules/block-scoped-var.js
+++ b/tests/lib/rules/block-scoped-var.js
@@ -20,6 +20,7 @@ var rule = require("../../../lib/rules/block-scoped-var"),
 var ruleTester = new RuleTester();
 ruleTester.run("block-scoped-var", rule, {
     valid: [
+
         // See issue https://github.com/eslint/eslint/issues/2242
         { code: "function f() { } f(); var exports = { f: f };", parserOptions: { ecmaVersion: 6 } },
         { code: "var f = () => {}; f(); var exports = { f: f };", parserOptions: { sourceType: "module" } },

--- a/tests/lib/rules/block-spacing.js
+++ b/tests/lib/rules/block-spacing.js
@@ -20,6 +20,7 @@ var RuleTester = require("../../../lib/testers/rule-tester");
 var ruleTester = new RuleTester();
 ruleTester.run("block-spacing", rule, {
     valid: [
+
         // default/always
         {code: "{ foo(); }", options: ["always"]},
         {code: "{ foo(); }"},
@@ -63,7 +64,9 @@ ruleTester.run("block-spacing", rule, {
         {code: "if (a) {/* comment */ foo(); /* comment */}", options: ["never"]},
         {code: "if (a) { //comment\n foo();}", options: ["never"]}
     ],
+
     invalid: [
+
         // default/always
         {
             code: "{foo();}",

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -53,6 +53,7 @@ ruleTester.run("brace-style", rule, {
         { code: "if (foo)\n{\n}\nelse\n{\n}", options: ["allman"] },
         { code: "try { \n bar();\n }\ncatch (e) {\n baz(); \n }", options: ["stroustrup"] },
         { code: "try\n{\n bar();\n}\ncatch (e)\n{\n baz(); \n}", options: ["allman"] },
+
         // allowSingleLine: true
         { code: "function foo () { return; }", options: ["1tbs", { allowSingleLine: true }] },
         { code: "function foo () { a(); b(); return; }", options: ["1tbs", { allowSingleLine: true }] },
@@ -89,6 +90,7 @@ ruleTester.run("brace-style", rule, {
             options: ["allman"]
         }
     ],
+
     invalid: [
         { code: "if (f) {\nbar;\n}\nelse\nbaz;", errors: [{ message: CLOSE_MESSAGE, type: "ExpressionStatement"}] },
         { code: "var foo = () => { return; }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: BODY_MESSAGE, type: "ReturnStatement"}] },

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -20,6 +20,7 @@ var RuleTester = require("../../../lib/testers/rule-tester");
 var ruleTester = new RuleTester();
 ruleTester.run("constructor-super", rule, {
     valid: [
+
         // non derived classes.
         { code: "class A { }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A { constructor() { } }", parserOptions: { ecmaVersion: 6 } },
@@ -67,6 +68,7 @@ ruleTester.run("constructor-super", rule, {
         }
     ],
     invalid: [
+
         // non derived classes.
         {
             code: "class A { constructor() { super(); } }",

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -15,9 +15,11 @@ var rule = require("../../../lib/rules/indent"),
     RuleTester = require("../../../lib/testers/rule-tester");
 var fs = require("fs");
 var path = require("path");
+
 //------------------------------------------------------------------------------
 // Tests
 //------------------------------------------------------------------------------
+
 var fixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/indent/indent-invalid-fixture-1.js"), "utf8");
 var fixedFixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/indent/indent-valid-fixture-1.js"), "utf8");
 

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -126,6 +126,7 @@ function unexpectedBeforeAndAfter(keyword) {
 var ruleTester = new RuleTester();
 ruleTester.run("keyword-spacing", rule, {
     valid: [
+
         //----------------------------------------------------------------------
         // as
         //----------------------------------------------------------------------
@@ -1196,7 +1197,9 @@ ruleTester.run("keyword-spacing", rule, {
         {code: "function* foo() { <Foo onClick={yield} /> }", parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}},
         {code: "function* foo() { <Foo onClick={ yield } /> }", options: [NEITHER], parserOptions: {ecmaVersion: 6, ecmaFeatures: {jsx: true}}}
     ],
+
     invalid: [
+
         //----------------------------------------------------------------------
         // as
         //----------------------------------------------------------------------

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -83,6 +83,7 @@ ruleTester.run("max-len", rule, {
             code: "var foo = module.exports = {}; // really long trailing comment",
             options: [40, 4, {ignoreComments: true, ignoreTrailingComments: false}]
         },
+
         // blank line
         ""
     ],

--- a/tests/lib/rules/newline-after-var.js
+++ b/tests/lib/rules/newline-after-var.js
@@ -105,6 +105,7 @@ var ruleTester = new RuleTester();
 
 ruleTester.run("newline-after-var", rule, {
     valid: [
+
         // should skip rule entirely
         { code: NO_VAR, options: ["always"] },
         { code: NO_VAR, options: ["never"] },
@@ -229,6 +230,7 @@ ruleTester.run("newline-after-var", rule, {
     ],
 
     invalid: [
+
         // should disallow no line break in "always" mode
         { code: NO_BREAK, options: ["always"], errors: [ALWAYS_ERROR] },
         { code: MULTI_VAR_NO_BREAK, options: ["always"], errors: [ALWAYS_ERROR] },

--- a/tests/lib/rules/no-empty-function.js
+++ b/tests/lib/rules/no-empty-function.js
@@ -38,6 +38,7 @@ var ALLOW_OPTIONS = Object.freeze([
  * @returns {{valid: object[], invalid: object[]}} The result.
  */
 function toValidInvalid(patterns, item) {
+
     // Valid Patterns
     patterns.valid.push(
         {
@@ -70,6 +71,7 @@ function toValidInvalid(patterns, item) {
             return allow !== item.allow;
         })
         .forEach(function(allow) {
+
             // non related "allow" option has no effect.
             patterns.invalid.push({
                 code: item.code + " // allow: " + allow,

--- a/tests/lib/rules/no-eval.js
+++ b/tests/lib/rules/no-eval.js
@@ -63,6 +63,7 @@ ruleTester.run("no-eval", rule, {
     ],
 
     invalid: [
+
         // Direct eval
         { code: "eval(foo)", errors: [{ message: "eval can be harmful.", type: "CallExpression"}] },
         { code: "eval('foo')", errors: [{ message: "eval can be harmful.", type: "CallExpression"}] },

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -48,6 +48,7 @@ function invalid(code, type, line, config) {
 var ruleTester = new RuleTester();
 ruleTester.run("no-extra-parens", rule, {
     valid: [
+
         // all precedence boundaries
         "a = b, c = d",
         "a = b ? c : d",
@@ -251,6 +252,7 @@ ruleTester.run("no-extra-parens", rule, {
             parserOptions: { ecmaVersion: 6 }
         }
     ],
+
     invalid: [
         invalid("(0)", "Literal"),
         invalid("(  0  )", "Literal"),

--- a/tests/lib/rules/no-implied-eval.js
+++ b/tests/lib/rules/no-implied-eval.js
@@ -22,27 +22,36 @@ var ruleTester = new RuleTester(),
 
 ruleTester.run("no-implied-eval", rule, {
     valid: [
+
         // normal usage
         "setInterval(function() { x = 1; }, 100);",
+
         // only checks on top-level statements or window.*
         "foo.setTimeout('hi')",
+
         // identifiers are fine
         "setTimeout(foo, 10)",
+
         // as are function expressions
         "setTimeout(function() {}, 10)",
+
         // setInterval
         "foo.setInterval('hi')",
         "setInterval(foo, 10)",
         "setInterval(function() {}, 10)",
+
         // execScript
         "foo.execScript('hi')",
         "execScript(foo)",
         "execScript(function() {})",
+
         // a binary plus on non-strings doesn't guarantee a string
         "setTimeout(foo + bar, 10)",
+
         // doesn't check anything but the first argument
         "setTimeout(foobar, 'buzz')",
         "setTimeout(foobar, foo + 'bar')",
+
         // only checks immediate subtrees of the argument
         "setTimeout(function() { return 'foobar'; }, 10)"
     ],
@@ -52,18 +61,22 @@ ruleTester.run("no-implied-eval", rule, {
         { code: "setTimeout(\"x = 1;\", 100);", errors: [expectedError] },
         { code: "setInterval(\"x = 1;\");", errors: [expectedError] },
         { code: "execScript(\"x = 1;\");", errors: [expectedError] },
+
         // member expressions
         { code: "window.setTimeout('foo')", errors: [expectedError] },
         { code: "window.setInterval('foo')", errors: [expectedError] },
         { code: "window['setTimeout']('foo')", errors: [expectedError] },
         { code: "window['setInterval']('foo')", errors: [expectedError] },
+
         // template literals
         { code: "setTimeout(`foo${bar}`)", errors: [expectedError], parserOptions: { ecmaVersion: 6 } },
+
         // string concatination
         { code: "setTimeout('foo' + bar)", errors: [expectedError] },
         { code: "setTimeout(foo + 'bar')", errors: [expectedError] },
         { code: "setTimeout(`foo` + bar)", errors: [expectedError], parserOptions: { ecmaVersion: 6 } },
         { code: "setTimeout(1 + ';' + 1)", errors: [expectedError] },
+
         // gives the correct node when dealing with nesting
         {
             code:
@@ -78,6 +91,7 @@ ruleTester.run("no-implied-eval", rule, {
                     type: "CallExpression",
                     line: "1"
                 },
+
                 // no error on line 2
                 {
                     message: expectedErrorMessage,

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -23,7 +23,8 @@ var RuleTester = require("../../../lib/testers/rule-tester");
  * @returns {void}
  */
 function NORMAL() {
-    // do nohting.
+
+    // do nothing.
 }
 
 /**
@@ -66,6 +67,7 @@ function MODULES(pattern) {
  * @returns {object[]} Test patterns.
  */
 function extractPatterns(patterns, type) {
+
     // Clone and apply the pattern environment.
     var patternsList = patterns.map(function(pattern) {
         return pattern[type].map(function(applyCondition) {
@@ -97,6 +99,7 @@ var errors = [
 ];
 
 var patterns = [
+
     // Global.
     {
         code: "console.log(this); z(x => console.log(x, this));",

--- a/tests/lib/rules/no-irregular-whitespace.js
+++ b/tests/lib/rules/no-irregular-whitespace.js
@@ -122,6 +122,7 @@ ruleTester.run("no-irregular-whitespace", rule, {
         { code: "/* \u202F */", options: [{ skipComments: true }] },
         { code: "/* \u205f */", options: [{ skipComments: true }] },
         { code: "/* \u3000 */", options: [{ skipComments: true }] },
+
         // Unicode BOM.
         "\uFEFFconsole.log('hello BOM');"
     ],

--- a/tests/lib/rules/no-plusplus.js
+++ b/tests/lib/rules/no-plusplus.js
@@ -20,14 +20,17 @@ var ruleTester = new RuleTester();
 ruleTester.run("no-plusplus", rule, {
     valid: [
         "var foo = 0; foo=+1;",
+
         // With "allowForLoopAfterthoughts" allowed
         { code: "var foo = 0; foo=+1;", options: [{allowForLoopAfterthoughts: true}] },
         { code: "for (i = 0; i < l; i++) { console.log(i); }", options: [{allowForLoopAfterthoughts: true}] }
     ],
+
     invalid: [
         { code: "var foo = 0; foo++;", errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression"}] },
         { code: "var foo = 0; foo--;", errors: [{ message: "Unary operator '--' used.", type: "UpdateExpression"}] },
         { code: "for (i = 0; i < l; i++) { console.log(i); }", errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression"}] },
+
         // With "allowForLoopAfterthoughts" allowed
         { code: "var foo = 0; foo++;", options: [{allowForLoopAfterthoughts: true}], errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression"}] },
         { code: "for (i = 0; i < l; i++) { v++; }", options: [{allowForLoopAfterthoughts: true}], errors: [{ message: "Unary operator '++' used.", type: "UpdateExpression"}] }

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -40,6 +40,7 @@ ruleTester.run("no-self-assign", rule, {
         {code: "({a} = {a: b})", parserOptions: {ecmaVersion: 6}},
         {code: "({a} = {a() {}})", parserOptions: {ecmaVersion: 6}},
         {code: "({a} = {[a]: a})", parserOptions: {ecmaVersion: 6}}
+
         // TODO: https://github.com/eslint/espree/issues/247
         // {code: "({a, ...b} = {a, ...b})", parserOptions: {ecmaVersion: 6, ecmaFeatures: {experimentalObjectRestSpread: true}}},
     ],

--- a/tests/lib/rules/no-this-before-super.js
+++ b/tests/lib/rules/no-this-before-super.js
@@ -20,8 +20,11 @@ var RuleTester = require("../../../lib/testers/rule-tester");
 var ruleTester = new RuleTester();
 ruleTester.run("no-this-before-super", rule, {
     valid: [
-        // if the class has no extends or `extends null`, just ignores.
-        // those cannot call `super()`.
+
+        /*
+         * if the class has no extends or `extends null`, just ignore.
+         * those classes cannot call `super()`.
+         */
         { code: "class A { }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A { constructor() { } }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A { constructor() { this.b = 0; } }", parserOptions: { ecmaVersion: 6 } },
@@ -76,6 +79,7 @@ ruleTester.run("no-this-before-super", rule, {
         }
     ],
     invalid: [
+
         // disallows all `this`/`super` if `super()` is missing.
         {
             code: "class A extends B { constructor() { this.c = 0; } }",

--- a/tests/lib/rules/no-throw-literal.js
+++ b/tests/lib/rules/no-throw-literal.js
@@ -75,6 +75,7 @@ ruleTester.run("no-throw-literal", rule, {
                 type: "ThrowStatement"
             }]
         },
+
         // String concatenation
         {
             code: "throw 'a' + 'b';",
@@ -90,6 +91,7 @@ ruleTester.run("no-throw-literal", rule, {
                 type: "ThrowStatement"
             }]
         },
+
         // AssignmentExpression
         {
             code: "throw foo = 'error';",
@@ -98,6 +100,7 @@ ruleTester.run("no-throw-literal", rule, {
                 type: "ThrowStatement"
             }]
         },
+
         // SequenceExpression
         {
             code: "throw new Error(), 1, 2, 3;",
@@ -106,6 +109,7 @@ ruleTester.run("no-throw-literal", rule, {
                 type: "ThrowStatement"
             }]
         },
+
         // LogicalExpression
         {
             code: "throw 'literal' && 'not an Error';",
@@ -114,6 +118,7 @@ ruleTester.run("no-throw-literal", rule, {
                 type: "ThrowStatement"
             }]
         },
+
         // ConditionalExpression
         {
             code: "throw foo ? 'not an Error' : 'literal';",
@@ -122,6 +127,7 @@ ruleTester.run("no-throw-literal", rule, {
                 type: "ThrowStatement"
             }]
         },
+
         // TemplateLiteral
         {
             code: "throw `${err}`;",

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -18,6 +18,7 @@ var rule = require("../../../lib/rules/no-unused-vars"),
 
 var ruleTester = new RuleTester();
 ruleTester.defineRule("use-every-a", function(context) {
+
     /**
      * Mark a variable as used
      * @returns {void}
@@ -215,6 +216,7 @@ ruleTester.run("no-unused-vars", rule, {
                 {line: 1, column: 10, message: "'foo' is defined but never used" }
             ]
         },
+
         // non ascii.
         {
             code: "/*global 変数, 数*/\n変数;",
@@ -222,6 +224,7 @@ ruleTester.run("no-unused-vars", rule, {
                 {line: 1, column: 14, message: "'数' is defined but never used" }
             ]
         },
+
         // surrogate pair.
         // TODO: https://github.com/eslint/espree/issues/181
         // {

--- a/tests/lib/rules/no-useless-call.js
+++ b/tests/lib/rules/no-useless-call.js
@@ -20,6 +20,7 @@ var RuleTester = require("../../../lib/testers/rule-tester");
 var ruleTester = new RuleTester();
 ruleTester.run("no-useless-call", rule, {
     valid: [
+
         // `this` binding is different.
         {code: "foo.apply(obj, 1, 2);"},
         {code: "obj.foo.apply(null, 1, 2);"},
@@ -46,6 +47,7 @@ ruleTester.run("no-useless-call", rule, {
         {code: "obj.foo.apply();"}
     ],
     invalid: [
+
         // call.
         {code: "foo.call(undefined, 1, 2);", errors: [{message: "unnecessary '.call()'.", type: "CallExpression"}]},
         {code: "foo.call(void 0, 1, 2);", errors: [{message: "unnecessary '.call()'.", type: "CallExpression"}]},

--- a/tests/lib/rules/prefer-reflect.js
+++ b/tests/lib/rules/prefer-reflect.js
@@ -18,6 +18,7 @@ var rule = require("../../../lib/rules/prefer-reflect"),
 var ruleTester = new RuleTester();
 ruleTester.run("prefer-reflect", rule, {
     valid: [
+
         // Reflect.apply
         { code: "Reflect.apply(function(){}, null, 1, 2);" },
         { code: "Reflect.apply(function(){}, null, 1, 2);", options: [{ exceptions: ["apply"] }] },

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -272,8 +272,12 @@ ruleTester.run("spaced-comment", rule, {
             options: ["never"]
         },
         {
-            // note that the first line in the comment is not a valid exception block pattern
-            // because of the minus sign at the end of the line: `//*********************-`
+
+            /*
+             * note that the first line in the comment is not a valid exception
+             * block pattern because of the minus sign at the end of the line:
+             * `//*********************-`
+             */
             code: "//*********************-\n// Comment Block 3\n//***********************",
             output: "//* ********************-\n// Comment Block 3\n//***********************",
             errors: [{

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -339,6 +339,7 @@ ruleTester.run("strict", rule, {
             options: ["function"],
             errors: [{ message: "Use the function form of 'use strict'.", type: "ArrowFunctionExpression"}]
         },
+
         // Classes
         {
             code: "class A { constructor() { \"use strict\"; } }",

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -265,6 +265,7 @@ ruleTester.run("valid-jsdoc", rule, {
                 "function foo() {}",
             options: [{requireReturn: false}]
         },
+
         // type validations
         {
             code:
@@ -738,6 +739,7 @@ ruleTester.run("valid-jsdoc", rule, {
                 type: "Block"
             }]
         },
+
         // classes
         {
             code:

--- a/tests/lib/rules/yield-star-spacing.js
+++ b/tests/lib/rules/yield-star-spacing.js
@@ -167,6 +167,7 @@ ruleTester.run("yield-star-spacing", rule, {
     ],
 
     invalid: [
+
         // default (after)
         {
             code: "function *foo(){ yield *foo1; }",

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -18,6 +18,7 @@ var rule = require("../../../lib/rules/yoda"),
 var ruleTester = new RuleTester();
 ruleTester.run("yoda", rule, {
     valid: [
+
         // "never" mode
         { code: "if (value === \"red\") {}", options: ["never"] },
         { code: "if (value === value) {}", options: ["never"] },

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -112,6 +112,7 @@ describe("RuleTester", function() {
     it("should throw an error when the error message is wrong", function() {
         assert.throws(function() {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+
                 // Only the invalid test matters here
                 valid: [
                     "bar = baz;"
@@ -126,6 +127,7 @@ describe("RuleTester", function() {
     it("should throw an error when the error is neither an object nor a string", function() {
         assert.throws(function() {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+
                 // Only the invalid test matters here
                 valid: [
                     "bar = baz;"
@@ -140,6 +142,7 @@ describe("RuleTester", function() {
     it("should throw an error when the error is a string and it does not match error message", function() {
         assert.throws(function() {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+
                 // Only the invalid test matters here
                 valid: [
                     "bar = baz;"
@@ -154,6 +157,7 @@ describe("RuleTester", function() {
     it("should not throw an error when the error is a string and it matches error message", function() {
         assert.doesNotThrow(function() {
             ruleTester.run("no-var", require("../../fixtures/testers/rule-tester/no-var"), {
+
                 // Only the invalid test matters here
                 valid: [
                     "bar = baz;"
@@ -512,6 +516,7 @@ describe("RuleTester", function() {
     });
 
     it("should enforce the global configuration to be an object", function() {
+
         /**
          * Set the default config for the rules tester
          * @param {object} config configuration object

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -228,6 +228,7 @@ describe("globUtil", function() {
         });
 
         it("should not return an ignored file", function() {
+
             // Relying here on the .eslintignore from the repo root
             var patterns = ["tests/fixtures/glob-util/ignored/**/*.js"];
             var result = globUtil.listFilesToProcess(patterns);

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -846,6 +846,7 @@ describe("SourceCode", function() {
 
     describe("getComments()", function() {
         var config = { rules: {} };
+
         /**
          * Check comment count
          * @param {int} leading Leading comment count


### PR DESCRIPTION
Dogfood space-in-parens and lines-around-comment rules in ESLint repo.

Apologies for the large volume of changes. Not much I can do when there are just that many violations in the codebase. If absolutely necessary, I can break this up into smaller PRs, but I'd much rather just turn the rules on in one go if possible.