### PR TITLE
Update: `destructuring` option of `prefer-const` rule (fixes #5594)

### DIFF
--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -8,47 +8,69 @@ If a variable is never reassigned, using the `const` declaration is better.
 
 This rule is aimed at flagging variables that are declared using `let` keyword, but never reassigned after the initial assignment.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint prefer-const: "error"*/
 /*eslint-env es6*/
 
+// it's initialized and never reassigned.
 let a = 3;
 console.log(a);
 
+let a;
+a = 0;
+console.log(a);
+
 // `i` is redefined (not reassigned) on each loop step.
-for (let i in [1,2,3]) {
+for (let i in [1, 2, 3]) {
     console.log(i);
 }
 
 // `a` is redefined (not reassigned) on each loop step.
-for (let a of [1,2,3]) {
+for (let a of [1, 2, 3]) {
     console.log(a);
 }
-
-// the initializer is separated.
-let a;
-a = 0;
-console.log(a);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint prefer-const: "error"*/
 /*eslint-env es6*/
 
-let a; // there is no initialization.
+// using const.
+const a = 0;
+
+// it's never initialized.
+let a;
+console.log(a);
+
+// it's reassigned after initialized.
+let a;
+a = 0;
+a = 1;
+console.log(a);
+
+// it's initialized in a different block from the declaration.
+let a;
+if (true) {
+    a = 0;
+}
+console.log(a);
+
+// it's initialized at a place that we cannot write a variable declaration.
+let a;
+if (true) a = 0;
 console.log(a);
 
 // `i` gets a new binding each iteration
-for (const i in [1,2,3]) {
+for (const i in [1, 2, 3]) {
   console.log(i);
 }
 
 // `a` gets a new binding each iteration
-for (const a of [1,2,3]) {
+for (const a of [1, 2, 3]) {
   console.log(a);
 }
 
@@ -57,16 +79,73 @@ for (let i = 0, end = 10; i < end; ++i) {
     console.log(a);
 }
 
-// the initializer is located at another block.
-let a;
-if (true) {
-    a = 0;
-}
-console.log(a);
-
 // suggest to use `no-var` rule.
 var b = 3;
 console.log(b);
+```
+
+## Options
+
+```json
+{
+    "prefer-const": ["error", {"destructuring": "any"}]
+}
+```
+
+### destructuring
+
+The kind of the way to address variables in destructuring.
+There are 2 values:
+
+* `"any"` (default) - If any variables in destructuring should be `const`, this rule warns for those variables.
+* `"all"` - If all variables in destructuring should be `const`, this rule warns the variables. Otherwise, ignores them.
+
+Examples of **incorrect** code for the default `{"destructuring": "any"}` option:
+
+```js
+/*eslint prefer-const: "error"*/
+/*eslint-env es6*/
+
+let {a, b} = obj;    /*error 'b' is never reassigned, use 'const' instead.*/
+a = a + 1;
+```
+
+Examples of **correct** code for the default `{"destructuring": "any"}` option:
+
+```js
+/*eslint prefer-const: "error"*/
+/*eslint-env es6*/
+
+// using const.
+const {a: a0, b} = obj;
+const a = a0 + 1;
+
+// all variables are reassigned.
+let {a, b} = obj;
+a = a + 1;
+b = b + 1;
+```
+
+Examples of **incorrect** code for the `{"destructuring": "all"}` option:
+
+```js
+/*eslint prefer-const: ["error", {"destructuring": "all"}]*/
+/*eslint-env es6*/
+
+// all of `a` and `b` should be const, so those are warned.
+let {a, b} = obj;    /*error 'a' is never reassigned, use 'const' instead.
+                             'b' is never reassigned, use 'const' instead.*/
+```
+
+Examples of **correct** code for the `{"destructuring": "all"}` option:
+
+```js
+/*eslint prefer-const: ["error", {"destructuring": "all"}]*/
+/*eslint-env es6*/
+
+// 'b' is never reassigned, but all of `a` and `b` should not be const, so those are ignored.
+let {a, b} = obj;
+a = a + 1;
 ```
 
 ## When Not To Use It

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -7,11 +7,18 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var Map = require("es6-map");
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
 var PATTERN_TYPE = /^(?:.+?Pattern|RestElement|Property)$/;
 var DECLARATION_HOST_TYPE = /^(?:Program|BlockStatement|SwitchCase)$/;
+var DESTRUCTURING_HOST_TYPE = /^(?:VariableDeclarator|AssignmentExpression)$/;
 
 /**
  * Adds multiple items to the tail of an array.
@@ -56,31 +63,116 @@ function canBecomeVariableDeclaration(identifier) {
 }
 
 /**
- * Gets the WriteReference of a given variable if the variable is never
- * reassigned.
+ * Gets the WriteReference of a given variable if the variable should be
+ * declared as const.
  *
  * @param {escope.Variable} variable - A variable to get.
  * @returns {escope.Reference|null} The singular WriteReference or null.
  */
-function getWriteReferenceIfOnce(variable) {
-    var retv = null;
+function getWriteReferenceIfShouldBeConst(variable) {
+    if (variable.eslintUsed) {
+        return null;
+    }
 
+    // Finds the singular WriteReference.
+    var retv = null;
     var references = variable.references;
 
     for (var i = 0; i < references.length; ++i) {
         var reference = references[i];
 
         if (reference.isWrite()) {
-            if (retv && !(retv.init && reference.init)) {
+            var isReassigned = Boolean(
+                retv && retv.identifier !== reference.identifier
+            );
 
-                // This variable is reassigned.
+            if (isReassigned) {
                 return null;
             }
             retv = reference;
         }
     }
 
-    return retv;
+    // Checks the writer is located in the same scope and can be modified to
+    // const.
+    var isSameScopeAndCanBecomeVariableDeclaration = Boolean(
+        retv &&
+        retv.from === variable.scope &&
+        canBecomeVariableDeclaration(retv.identifier)
+    );
+
+    return isSameScopeAndCanBecomeVariableDeclaration ? retv : null;
+}
+
+/**
+ * Gets the VariableDeclarator/AssignmentExpression node that a given reference
+ * belongs to.
+ * This is used to detect a mix of reassigned and never reassigned in a
+ * destructuring.
+ *
+ * @param {escope.Reference} reference - A reference to get.
+ * @returns {ASTNode|null} A VariableDeclarator/AssignmentExpression node or
+ *      null.
+ */
+function getDestructuringHost(reference) {
+    if (!reference.isWrite()) {
+        return null;
+    }
+    var node = reference.identifier.parent;
+
+    while (PATTERN_TYPE.test(node.type)) {
+        node = node.parent;
+    }
+
+    if (!DESTRUCTURING_HOST_TYPE.test(node.type)) {
+        return null;
+    }
+    return node;
+}
+
+/**
+ * Groups by the VariableDeclarator/AssignmentExpression node that each
+ * reference of given variables belongs to.
+ * This is used to detect a mix of reassigned and never reassigned in a
+ * destructuring.
+ *
+ * @param {escope.Variable[]} variables - Variables to group by destructuring.
+ * @returns {Map<ASTNode, (escope.Reference|null)[]>} Grouped references.
+ */
+function groupByDestructuring(variables) {
+    var writersMap = new Map();
+
+    for (var i = 0; i < variables.length; ++i) {
+        var variable = variables[i];
+        var references = variable.references;
+        var writer = getWriteReferenceIfShouldBeConst(variable);
+        var prevId = null;
+
+        for (var j = 0; j < references.length; ++j) {
+            var reference = references[j];
+            var id = reference.identifier;
+
+            // Avoid counting a reference twice or more for default values of
+            // destructuring.
+            if (id === prevId) {
+                continue;
+            }
+            prevId = id;
+
+            // Add the writer into the destructuring group.
+            var group = getDestructuringHost(reference);
+
+            if (group) {
+                if (writersMap.has(group)) {
+                    writersMap.get(group).push(writer);
+                } else {
+                    writersMap.set(group, [writer]);
+                }
+            }
+        }
+    }
+
+    return writersMap;
 }
 
 //------------------------------------------------------------------------------
@@ -88,31 +180,57 @@ function getWriteReferenceIfOnce(variable) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var options = context.options[0] || {};
+    var checkingMixedDestructuring = options.destructuring !== "all";
     var variables = null;
 
     /**
-     * Reports a given variable if the singular WriteReference of the variable
-     * exists in the same scope as the declaration.
+     * Reports a given reference.
      *
-     * @param {escope.Variable} variable - A variable to check.
+     * @param {escope.Reference} reference - A reference to report.
+     * @returns {void}
+     */
+    function report(reference) {
+        var id = reference.identifier;
+
+        context.report({
+            node: id,
+            message: "'{{name}}' is never reassigned, use 'const' instead.",
+            data: id
+        });
+    }
+
+    /**
+     * Reports a given variable if the variable should be declared as const.
+     *
+     * @param {escope.Variable} variable - A variable to report.
      * @returns {void}
      */
     function checkVariable(variable) {
-        if (variable.eslintUsed) {
-            return;
+        var writer = getWriteReferenceIfShouldBeConst(variable);
+
+        if (writer) {
+            report(writer);
         }
+    }
 
-        var writer = getWriteReferenceIfOnce(variable);
-
-        if (writer &&
-            writer.from === variable.scope &&
-            canBecomeVariableDeclaration(writer.identifier)
-        ) {
-            context.report({
-                node: writer.identifier,
-                message: "'{{name}}' is never reassigned, use 'const' instead.",
-                data: variable
-            });
+    /**
+     * Reports given references if all of the reference should be declared as
+     * const.
+     *
+     * The argument 'writers' is an array of references.
+     * This reference is the result of
+     * 'getWriteReferenceIfShouldBeConst(variable)', so it's nullable.
+     * In simple declaration or assignment cases, the length of the array is 1.
+     * In destructuring cases, the length of the array can be 2 or more.
+     *
+     * @param {(escope.Reference|null)[]} writers - References which are grouped
+     *      by destructuring to report.
+     * @returns {void}
+     */
+    function checkGroup(writers) {
+        if (writers.every(Boolean)) {
+            writers.forEach(report);
         }
     }
 
@@ -122,7 +240,12 @@ module.exports = function(context) {
         },
 
         "Program:exit": function() {
-            variables.forEach(checkVariable);
+            if (checkingMixedDestructuring) {
+                variables.forEach(checkVariable);
+            } else {
+                groupByDestructuring(variables).forEach(checkGroup);
+            }
+
             variables = null;
         },
 
@@ -134,4 +257,12 @@ module.exports = function(context) {
     };
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        type: "object",
+        properties: {
+            destructuring: {enum: ["any", "all"]}
+        },
+        additionalProperties: false
+    }
+];

--- a/tests/lib/rules/prefer-const.js
+++ b/tests/lib/rules/prefer-const.js
@@ -72,7 +72,18 @@ ruleTester.run("prefer-const", rule, {
         { code: "(function() { let x; { x = 0; foo(x); } })();", parserOptions: { ecmaVersion: 6 } },
         { code: "let x; for (const a of [1,2,3]) { x = foo(); bar(x); }", parserOptions: { ecmaVersion: 6 } },
         { code: "(function() { let x; for (const a of [1,2,3]) { x = foo(); bar(x); } })();", parserOptions: { ecmaVersion: 6 } },
-        { code: "let x; for (x of array) { x; }", parserOptions: { ecmaVersion: 6 } }
+        { code: "let x; for (x of array) { x; }", parserOptions: { ecmaVersion: 6 } },
+
+        {
+            code: "let {a, b} = obj; b = 0;",
+            options: [{destructuring: "all"}],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "let a, b; ({a, b} = obj); b++;",
+            options: [{destructuring: "all"}],
+            parserOptions: {ecmaVersion: 6}
+        }
     ],
     invalid: [
         {
@@ -158,6 +169,52 @@ ruleTester.run("prefer-const", rule, {
             code: "(function() { let x; x = 1; })();",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "'x' is never reassigned, use 'const' instead.", type: "Identifier"}]
+        },
+
+        {
+            code: "let {a = 0, b} = obj; b = 0; foo(a, b);",
+            options: [{destructuring: "any"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [{ message: "'a' is never reassigned, use 'const' instead.", type: "Identifier"}]
+        },
+        {
+            code: "let a, b; ({a = 0, b} = obj); b = 0; foo(a, b);",
+            options: [{destructuring: "any"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [{ message: "'a' is never reassigned, use 'const' instead.", type: "Identifier"}]
+        },
+        {
+            code: "let {a = 0, b} = obj; foo(a, b);",
+            options: [{destructuring: "all"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { message: "'a' is never reassigned, use 'const' instead.", type: "Identifier"},
+                { message: "'b' is never reassigned, use 'const' instead.", type: "Identifier"}
+            ]
+        },
+        {
+            code: "let a, b; ({a = 0, b} = obj); foo(a, b);",
+            options: [{destructuring: "all"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { message: "'a' is never reassigned, use 'const' instead.", type: "Identifier"},
+                { message: "'b' is never reassigned, use 'const' instead.", type: "Identifier"}
+            ]
+        },
+        {
+            code: "let {a = 0, b} = obj, c = a; b = a;",
+            options: [{destructuring: "any"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { message: "'a' is never reassigned, use 'const' instead.", type: "Identifier"},
+                { message: "'c' is never reassigned, use 'const' instead.", type: "Identifier"}
+            ]
+        },
+        {
+            code: "let {a = 0, b} = obj, c = a; b = a;",
+            options: [{destructuring: "all"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [{ message: "'c' is never reassigned, use 'const' instead.", type: "Identifier"}]
         }
     ]
 });


### PR DESCRIPTION
Fixes #5594.

I added `mixed` option, default is `true`.

```json
{
    "prefer-const": ["error", {"mixed": true}]
}
```

If `{"mixed": false}` is specified, this rule groups variables by destructuring, then doesn't warn variables in destructuring if the variables are a mix of reassigned and never reassigned.