### PR TITLE
Fix: Allow default ignored files to be unignored (fixes #5410)

### DIFF
--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -24,8 +24,8 @@ debug = debug("eslint:ignored-paths");
 
 var ESLINT_IGNORE_FILENAME = ".eslintignore";
 var DEFAULT_IGNORE_PATTERNS = [
-    "/node_modules/",
-    "/bower_components/"
+    "/node_modules/*",
+    "/bower_components/*"
 ];
 var DEFAULT_OPTIONS = {
     dotfiles: false,
@@ -106,6 +106,7 @@ function IgnoredPaths(options) {
     // Add a way to keep track of ignored files.  This was present in node-ignore
     // 2.x, but dropped for now as of 3.0.10.
     this.ig.custom.ignoreFiles = [];
+    this.ig.default.ignoreFiles = [];
 
     if (options.dotfiles !== true) {
         // ignore files beginning with a dot, but not files in a parent or ancestor
@@ -121,6 +122,7 @@ function IgnoredPaths(options) {
 
         if (options.ignorePattern) {
             addPattern(this.ig.custom, options.ignorePattern);
+            addPattern(this.ig.default, options.ignorePattern);
         }
 
         if (options.ignorePath) {
@@ -150,6 +152,7 @@ function IgnoredPaths(options) {
             debug("Adding " + ignorePath);
             this.baseDir = path.dirname(path.resolve(options.cwd, ignorePath));
             addIgnoreFile(this.ig.custom, ignorePath);
+            addIgnoreFile(this.ig.default, ignorePath);
         }
 
     }

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -122,16 +122,20 @@ function listFilesToProcess(globPatterns, options) {
      */
     function addFile(filename, shouldWarnIgnored) {
         var ignored = false;
+        var isSilentlyIgnored;
         if (options.ignore !== false) {
             if (ignoredPaths.contains(filename, "default")) {
-                return;
+                isSilentlyIgnored = true;
             }
             if (ignoredPaths.contains(filename, "custom")) {
                 if (shouldWarnIgnored) {
                     ignored = true;
                 } else {
-                    return;
+                    isSilentlyIgnored = true;
                 }
+            }
+            if (isSilentlyIgnored && !ignored) {
+                return;
             }
         }
         if (added[filename]) {

--- a/tests/fixtures/glob-util/node_modules/dependency.js
+++ b/tests/fixtures/glob-util/node_modules/dependency.js
@@ -1,0 +1,1 @@
+'single quotes';

--- a/tests/fixtures/ignored-paths/.eslintignoreWithUnignoredDefaults
+++ b/tests/fixtures/ignored-paths/.eslintignoreWithUnignoredDefaults
@@ -1,0 +1,2 @@
+!/node_modules/package
+!/bower_components/package

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -14,7 +14,8 @@ var assert = require("chai").assert,
     os = require("os"),
     IgnoredPaths = require("../../lib/ignored-paths.js"),
     sinon = require("sinon"),
-    fs = require("fs");
+    fs = require("fs"),
+    includes = require("lodash").includes;
 
 require("shelljs/global");
 
@@ -36,7 +37,18 @@ function getIgnoreRules(ignoredPaths) {
     var ignoreRules = [];
 
     Object.keys(ignoredPaths.ig).forEach(function(key) {
-        ignoreRules = ignoreRules.concat(ignoredPaths.ig[key][ignoreRulesProperty]);
+        var rules = ignoredPaths.ig[key][ignoreRulesProperty];
+        rules.forEach(function(rule) {
+            var ruleOrigins = ignoreRules.map(function(ruleObj) {
+                return ruleObj.origin;
+            });
+            // Don't include duplicate ignore rules.
+            // (Duplicates occur because we add custom ignore patterns to the
+            // defaults as well, to allow unignoring default ignores)
+            if (!includes(ruleOrigins, rule.origin)) {
+                ignoreRules = ignoreRules.concat(rule);
+            }
+        });
     });
 
     return ignoreRules;
@@ -339,14 +351,14 @@ describe("IgnoredPaths", function() {
 
     describe("default ignores", function() {
 
-        it("should contain /bower_components/", function() {
+        it("should contain /bower_components/*", function() {
             var ignoredPaths = new IgnoredPaths();
-            assert.include(ignoredPaths.defaultPatterns, "/bower_components/");
+            assert.include(ignoredPaths.defaultPatterns, "/bower_components/*");
         });
 
-        it("should contain /node_modules/", function() {
+        it("should contain /node_modules/*", function() {
             var ignoredPaths = new IgnoredPaths();
-            assert.include(ignoredPaths.defaultPatterns, "/node_modules/");
+            assert.include(ignoredPaths.defaultPatterns, "/node_modules/*");
         });
 
         it("should always apply defaultPatterns if ignore option is true", function() {
@@ -367,6 +379,15 @@ describe("IgnoredPaths", function() {
             assert.isFalse(ignoredPaths.contains(getFixturePath("subdir/node_modules/package/file.js")));
         });
 
+        it("should allow subfolders of defaultPatterns to be unignored by ignorePattern", function() {
+            var ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath(), ignorePattern: "!/node_modules/package" });
+            assert.isFalse(ignoredPaths.contains(getFixturePath("node_modules", "package", "file.js")));
+        });
+
+        it("should allow subfolders of defaultPatterns to be unignored by ignorePath", function() {
+            var ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath(), ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults") });
+            assert.isFalse(ignoredPaths.contains(getFixturePath("node_modules", "package", "file.js")));
+        });
 
         it("should ignore dotfiles", function() {
             var ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });


### PR DESCRIPTION
This PR changes the default ignores from:

```
/node_modules/
/bower_components/
```

to:

```
/node_modules/*
/bower_components/*
```

as suggested by @alberto in https://github.com/eslint/eslint/issues/5410#issuecomment-189542288.  

However, I'm keeping `this.ig.default` so that we can continue avoiding showing warning messages for files in those folders.

To allow custom-specified ignore patterns to override the defaults, the custom patterns will be added to the defaults as well.  A warning will only be shown if a file is ignored by custom ignore rules but not by default. 