### PR TITLE
Fix: `radix` rule false positive at shadowed variables (fixes #5639)

### DIFF
--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -6,67 +6,152 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var MODE_ALWAYS = "always",
+    MODE_AS_NEEDED = "as-needed";
+
+/**
+ * Checks whether a given variable is shadowed or not.
+ *
+ * @param {escope.Variable} variable - A variable to check.
+ * @returns {boolean} `true` if the variable is shadowed.
+ */
+function isShadowed(variable) {
+    return variable.defs.length >= 1;
+}
+
+/**
+ * Checks whether a given node is a MemberExpression of `parseInt` method or not.
+ *
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node is a MemberExpression of `parseInt`
+ *      method.
+ */
+function isParseIntMethod(node) {
+    return (
+        node.type === "MemberExpression" &&
+        !node.computed &&
+        node.property.type === "Identifier" &&
+        node.property.name === "parseInt"
+    );
+}
+
+/**
+ * Checks whether a given node is a valid value of radix or not.
+ *
+ * The following values are invalid.
+ *
+ * - A literal except numbers.
+ * - undefined.
+ *
+ * @param {ASTNode} radix - A node of radix to check.
+ * @returns {boolean} `true` if the node is valid.
+ */
+function isValidRadix(radix) {
+    return !(
+        (radix.type === "Literal" && typeof radix.value !== "number") ||
+        (radix.type === "Identifier" && radix.name === "undefined")
+    );
+}
+
+/**
+ * Checks whether a given node is a default value of radix or not.
+ *
+ * @param {ASTNode} radix - A node of radix to check.
+ * @returns {boolean} `true` if the node is the literal node of `10`.
+ */
+function isDefaultRadix(radix) {
+    return radix.type === "Literal" && radix.value === 10;
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
-    var MODE_ALWAYS = "always",
-        MODE_AS_NEEDED = "as-needed";
-
     var mode = context.options[0] || MODE_ALWAYS;
 
-    return {
-        "CallExpression": function(node) {
+    /**
+     * Checks the arguments of a given CallExpression node and reports it if it
+     * offends this rule.
+     *
+     * @param {ASTNode} node - A CallExpression node to check.
+     * @returns {void}
+     */
+    function checkArguments(node) {
+        var args = node.arguments;
 
-            var radix;
-
-            if (!(node.callee.name === "parseInt" || (
-                    node.callee.type === "MemberExpression" &&
-                    node.callee.object.name === "Number" &&
-                    node.callee.property.name === "parseInt"
-                )
-            )) {
-                return;
-            }
-
-            if (node.arguments.length === 0) {
+        switch (args.length) {
+            case 0:
                 context.report({
                     node: node,
                     message: "Missing parameters."
                 });
-            } else if (node.arguments.length < 2 && mode === MODE_ALWAYS) {
-                context.report({
-                    node: node,
-                    message: "Missing radix parameter."
-                });
-            } else if (node.arguments.length > 1 && mode === MODE_AS_NEEDED &&
-                (node.arguments[1] && node.arguments[1].type === "Literal" &&
-                    node.arguments[1].value === 10)
-            ) {
-                context.report({
-                    node: node,
-                    message: "Redundant radix parameter."
-                });
-            } else {
+                break;
 
-                radix = node.arguments[1];
+            case 1:
+                if (mode === MODE_ALWAYS) {
+                    context.report({
+                        node: node,
+                        message: "Missing radix parameter."
+                    });
+                }
+                break;
 
-                // don't allow non-numeric literals or undefined
-                if (radix &&
-                    ((radix.type === "Literal" && typeof radix.value !== "number") ||
-                    (radix.type === "Identifier" && radix.name === "undefined"))
-                ) {
+            default:
+                if (mode === MODE_AS_NEEDED && isDefaultRadix(args[1])) {
+                    context.report({
+                        node: node,
+                        message: "Redundant radix parameter."
+                    });
+                } else if (!isValidRadix(args[1])) {
                     context.report({
                         node: node,
                         message: "Invalid radix parameter."
                     });
                 }
+                break;
+        }
+    }
+
+    return {
+        "Program:exit": function() {
+            var scope = context.getScope();
+            var variable;
+
+            // Check `parseInt()`
+            variable = astUtils.getVariableByName(scope, "parseInt");
+            if (!isShadowed(variable)) {
+                variable.references.forEach(function(reference) {
+                    var node = reference.identifier;
+
+                    if (astUtils.isCallee(node)) {
+                        checkArguments(node.parent);
+                    }
+                });
             }
 
+            // Check `Number.parseInt()`
+            variable = astUtils.getVariableByName(scope, "Number");
+            if (!isShadowed(variable)) {
+                variable.references.forEach(function(reference) {
+                    var node = reference.identifier.parent;
+
+                    if (isParseIntMethod(node) && astUtils.isCallee(node)) {
+                        checkArguments(node.parent);
+                    }
+                });
+            }
         }
     };
-
 };
 
 module.exports.schema = [

--- a/tests/lib/rules/radix.js
+++ b/tests/lib/rules/radix.js
@@ -35,7 +35,18 @@ ruleTester.run("radix", rule, {
         {
             code: "parseInt(\"10\", foo);",
             options: ["as-needed"]
-        }
+        },
+        "parseInt",
+        "Number.foo();",
+        "Number[parseInt]();",
+
+        // Ignores if it's shadowed.
+        {code: "var parseInt; parseInt();"},
+        {code: "var parseInt; parseInt(foo);", options: ["always"]},
+        {code: "var parseInt; parseInt(foo, 10);", options: ["as-needed"]},
+        {code: "var Number; Number.parseInt();"},
+        {code: "var Number; Number.parseInt(foo);", options: ["always"]},
+        {code: "var Number; Number.parseInt(foo, 10);", options: ["as-needed"]}
     ],
 
     invalid: [


### PR DESCRIPTION
Fixes #5639.

I made this rule relying on escope's variables to handle shadowings.