### PR TITLE
Update: Basic valid-jsdoc default parameter support (fixes #5658)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -288,9 +288,12 @@ module.exports = function(context) {
             if (node.params) {
                 node.params.forEach(function(param, i) {
                     var name = param.name;
+                    if (param.type === "AssignmentPattern") {
+                        name = param.left.name;
+                    }
 
                     // TODO(nzakas): Figure out logical things to do with destructured, default, rest params
-                    if (param.type === "Identifier") {
+                    if (param.type === "Identifier" || param.type === "AssignmentPattern") {
                         if (jsdocParams[i] && (name !== jsdocParams[i])) {
                             context.report(jsdocNode, "Expected JSDoc for '{{name}}' but found '{{jsdocName}}'.", {
                                 name: name,

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -391,6 +391,18 @@ ruleTester.run("valid-jsdoc", rule, {
                     "String": "string"
                 }
             }]
+        },
+        {
+            code: "/**\n* Description\n* @param {string} a bar\n* @returns {string} desc */\nfunction foo(a = 1){}",
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "/**\n* Description\n* @param {string} b bar\n* @param {string} a bar\n* @returns {string} desc */\nfunction foo(b, a = 1){}",
+            parserOptions: {
+                ecmaVersion: 6
+            }
         }
     ],
 
@@ -594,6 +606,26 @@ ruleTester.run("valid-jsdoc", rule, {
             code: "/**\n* Foo\n* @returns {string} something \n*/\nfunction foo(p){}",
             errors: [{
                 message: "Missing JSDoc for parameter 'p'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "/**\n* Foo\n* @returns {string} something \n*/\nvar foo = \nfunction foo(a = 1){}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Missing JSDoc for parameter 'a'.",
+                type: "Block"
+            }]
+        },
+        {
+            code: "/**\n* Foo\n* @param {string} a Description \n* @param {string} b Description \n* @returns {string} something \n*/\nvar foo = \nfunction foo(b, a = 1){}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{
+                message: "Expected JSDoc for 'b' but found 'a'.",
+                type: "Block"
+            },
+            {
+                message: "Expected JSDoc for 'a' but found 'b'.",
                 type: "Block"
             }]
         },


### PR DESCRIPTION
This will cause validation errors if a parameter with a default values
does not have a JS Doc param field.

This is the absolute smallest change to make this work and could be extended much further. I intend to do that at a later point but wanted to get these changes in tiny bit by tiny bit.