### PR TITLE
fix: don't use path.extname with undefined value

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -140,13 +140,14 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
         config,
         messages,
         stats,
-        fileExtension = path.extname(filename),
+        fileExtension,
         processor,
         loadedPlugins,
         fixedResult;
 
     if (filename) {
         filePath = path.resolve(filename);
+        fileExtension = path.extname(filename);
     }
 
     filename = filename || "<text>";


### PR DESCRIPTION
In the current versions of node path.* can be called on any arbitrary
value and will return an empty string on invalid input.

As of node v6 path will assert that values passed to it are strings,
and as such will throw on `undefined`

This commit moved the logic of using `path.extname` inside of the
processText  function in `lib/cli-engine.js`. so that it will not call
`path.extname` if a filename is not passed.

This change should not affect any other parts of the system, and the
test suite is 100% working on node v4, v5, and master.

fixes #5678