### PR TITLE
Docs: Use string severity

### DIFF
--- a/docs/rules/accessor-pairs.md
+++ b/docs/rules/accessor-pairs.md
@@ -42,7 +42,7 @@ By activating the option `getWithoutSet` it enforces the presence of a setter fo
 Examples of **incorrect** code for the default `{ "setWithoutGet": true }` option:
 
 ```js
-/*eslint accessor-pairs: 2*/
+/*eslint accessor-pairs: "error"*/
 
 var o = {
     set a(value) {
@@ -61,7 +61,7 @@ Object.defineProperty(o, 'c', {
 Examples of **correct** code for the default `{ "setWithoutGet": true }` option:
 
 ```js
-/*eslint accessor-pairs: 2*/
+/*eslint accessor-pairs: "error"*/
 
 var o = {
     set a(value) {
@@ -89,7 +89,7 @@ Object.defineProperty(o, 'c', {
 Examples of **incorrect** code for the `{ "getWithoutSet": true }` option:
 
 ```js
-/*eslint accessor-pairs: [2, { "getWithoutSet": true }]*/
+/*eslint accessor-pairs: ["error", { "getWithoutSet": true }]*/
 
 var o = {
     set a(value) {
@@ -121,7 +121,7 @@ Object.defineProperty(o, 'c', {
 Examples of **correct** code for the `{ "getWithoutSet": true }` option:
 
 ```js
-/*eslint accessor-pairs: [2, { "getWithoutSet": true }]*/
+/*eslint accessor-pairs: ["error", { "getWithoutSet": true }]*/
 var o = {
     set a(value) {
         this.val = value;

--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -32,7 +32,7 @@ There are two options for this rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"array-bracket-spacing": [2, "always"]
+"array-bracket-spacing": ["error", "always"]
 ```
 
 ### "never"
@@ -40,7 +40,7 @@ Depending on your coding conventions, you can choose either option by specifying
 When `"never"` is set, the following patterns are considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "never"]*/
+/*eslint array-bracket-spacing: ["error", "never"]*/
 /*eslint-env es6*/
 
 var arr = [ 'foo', 'bar' ];
@@ -59,7 +59,7 @@ var [ ,,x, ] = z;
 The following patterns are not considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "never"]*/
+/*eslint array-bracket-spacing: ["error", "never"]*/
 /*eslint-env es6*/
 
 var arr = [];
@@ -85,7 +85,7 @@ var [,,x,] = z;
 When `"always"` is used, the following patterns are considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always"]*/
+/*eslint array-bracket-spacing: ["error", "always"]*/
 /*eslint-env es6*/
 
 var arr = ['foo', 'bar'];
@@ -107,7 +107,7 @@ var [,,x,] = z;
 The following patterns are not considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always"]*/
+/*eslint array-bracket-spacing: ["error", "always"]*/
 /*eslint-env es6*/
 
 var arr = [];
@@ -136,7 +136,7 @@ You can add exceptions like so:
 In case of `"always"` option, set an exception to `false` to enable it:
 
 ```json
-"array-bracket-spacing": [2, "always", {
+"array-bracket-spacing": ["error", "always", {
   "singleValue": false,
   "objectsInArrays": false,
   "arraysInArrays": false
@@ -146,7 +146,7 @@ In case of `"always"` option, set an exception to `false` to enable it:
 In case of `"never"` option, set an exception to `true` to enable it:
 
 ```json
-"array-bracket-spacing": [2, "never", {
+"array-bracket-spacing": ["error", "never", {
   "singleValue": true,
   "objectsInArrays": true,
   "arraysInArrays": true
@@ -164,7 +164,7 @@ In each of the following examples, the `"always"` option is assumed.
 When `"singleValue"` is set to `false`, the following patterns are considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always", { singleValue: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { singleValue: false }]*/
 
 var foo = [ 'foo' ];
 var foo = [ 'foo'];
@@ -179,7 +179,7 @@ var foo = [ { 'foo': 'bar' } ];
 The following patterns are not considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always", { singleValue: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { singleValue: false }]*/
 
 var foo = ['foo'];
 var foo = [1];
@@ -190,7 +190,7 @@ var foo = [{ 'foo': 'bar' }];
 When `"objectsInArrays"` is set to `false`, the following patterns are considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always", { objectsInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { objectsInArrays: false }]*/
 
 var arr = [ { 'foo': 'bar' } ];
 var arr = [ {
@@ -201,7 +201,7 @@ var arr = [ {
 The following patterns are not considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always", { objectsInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { objectsInArrays: false }]*/
 
 var arr = [{ 'foo': 'bar' }];
 var arr = [{
@@ -212,7 +212,7 @@ var arr = [{
 When `"arraysInArrays"` is set to `false`, the following patterns are considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always", { arraysInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { arraysInArrays: false }]*/
 
 var arr = [ [ 1, 2 ], 2, 3, 4 ];
 var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
@@ -221,7 +221,7 @@ var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 The following patterns are not considered problems:
 
 ```js
-/*eslint array-bracket-spacing: [2, "always", { arraysInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { arraysInArrays: false }]*/
 
 var arr = [[ 1, 2 ], 2, 3, 4 ];
 var arr = [[ 1, 2 ], 2, [ 3, 4 ]];

--- a/docs/rules/array-callback-return.md
+++ b/docs/rules/array-callback-return.md
@@ -31,7 +31,7 @@ This rule finds callback functions of the following methods, then checks usage o
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint array-callback-return: 2*/
+/*eslint array-callback-return: "error"*/
 
 var indexMap = myArray.reduce(function(memo, item, index) {
     memo[item] = index;
@@ -55,7 +55,7 @@ var bar = foo.filter(function(x) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint array-callback-return: 2*/
+/*eslint array-callback-return: "error"*/
 
 var indexMap = myArray.reduce(function(memo, item, index) {
     memo[item] = index;

--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -16,13 +16,13 @@ The rule takes one option, a string, which can be:
 ### "always"
 
 ```json
-"arrow-body-style": [2, "always"]
+"arrow-body-style": ["error", "always"]
 ```
 
 When the rule is set to `"always"` the following patterns are considered problems:
 
 ```js
-/*eslint arrow-body-style: [2, "always"]*/
+/*eslint arrow-body-style: ["error", "always"]*/
 /*eslint-env es6*/
 let foo = () => 0;
 ```
@@ -44,7 +44,7 @@ let foo = (retv, name) => {
 When the rule is set to `"as-needed"` the following patterns are considered problems:
 
 ```js
-/*eslint arrow-body-style: [2, "as-needed"]*/
+/*eslint arrow-body-style: ["error", "as-needed"]*/
 /*eslint-env es6*/
 
 let foo = () => {
@@ -55,7 +55,7 @@ let foo = () => {
 The following patterns are not considered problems:
 
 ```js
-/*eslint arrow-body-style: [2, "as-needed"]*/
+/*eslint arrow-body-style: ["error", "as-needed"]*/
 /*eslint-env es6*/
 
 let foo = () => 0;

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -58,7 +58,7 @@ You can set the option in configuration like this:
 When the rule is set to `"always"` the following patterns are considered problems:
 
 ```js
-/*eslint arrow-parens: [2, "always"]*/
+/*eslint arrow-parens: ["error", "always"]*/
 /*eslint-env es6*/
 
 a => {};
@@ -72,7 +72,7 @@ a(foo => { if (true) {}; });
 The following patterns are not considered problems:
 
 ```js
-/*eslint arrow-parens: [2, "always"]*/
+/*eslint arrow-parens: ["error", "always"]*/
 /*eslint-env es6*/
 
 () => {};
@@ -145,7 +145,7 @@ var f = (a) => b ? c: d;
 When the rule is set to `"as-needed"` the following patterns are considered problems:
 
 ```js
-/*eslint arrow-parens: [2, "as-needed"]*/
+/*eslint arrow-parens: ["error", "as-needed"]*/
 /*eslint-env es6*/
 
 (a) => {};
@@ -159,7 +159,7 @@ a((foo) => { if (true) {}; });
 The following patterns are not considered problems:
 
 ```js
-/*eslint arrow-parens: [2, "as-needed"]*/
+/*eslint arrow-parens: ["error", "as-needed"]*/
 /*eslint-env es6*/
 
 () => {};

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -25,7 +25,7 @@ The default configuration is `{ "before": true, "after": true }`.
 The following patterns are considered problems if `{ "before": true, "after": true }`.
 
 ```js
-/*eslint arrow-spacing: 2*/
+/*eslint arrow-spacing: "error"*/
 /*eslint-env es6*/
 
 ()=> {};
@@ -41,7 +41,7 @@ a=> a;
 The following patterns are not considered problems if `{ "before": true, "after": true }`.
 
 ```js
-/*eslint arrow-spacing: 2*/
+/*eslint arrow-spacing: "error"*/
 /*eslint-env es6*/
 
 () => {};
@@ -53,7 +53,7 @@ a => a;
 The following patterns are not considered problems if `{ "before": false, "after": false }`.
 
 ```js
-/*eslint arrow-spacing: [2, { "before": false, "after": false }]*/
+/*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
 /*eslint-env es6*/
 
 ()=>{};
@@ -65,7 +65,7 @@ a=>a;
 The following patterns are not considered problems if `{ "before": true, "after": false }`.
 
 ```js
-/*eslint arrow-spacing: [2, { "before": true, "after": false }]*/
+/*eslint arrow-spacing: ["error", { "before": true, "after": false }]*/
 /*eslint-env es6*/
 
 () =>{};
@@ -77,7 +77,7 @@ a =>a;
 The following patterns are not considered problems if `{ "before": false, "after": true }`.
 
 ```js
-/*eslint arrow-spacing: [2, { "before": false, "after": true }]*/
+/*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/
 /*eslint-env es6*/
 
 ()=> {};

--- a/docs/rules/block-scoped-var.md
+++ b/docs/rules/block-scoped-var.md
@@ -9,7 +9,7 @@ This rule aims to reduce the usage of variables outside of their binding context
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint block-scoped-var: 2*/
+/*eslint block-scoped-var: "error"*/
 
 function doIf() {
     if (true) {
@@ -39,7 +39,7 @@ function doTryCatch() {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint block-scoped-var: 2*/
+/*eslint block-scoped-var: "error"*/
 
 function doIf() {
     var build;

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -19,14 +19,14 @@ This rule has a option, its value is `"always"` or `"never"`.
 
 ```json
 {
-  "block-spacing": [2, "always"]
+  "block-spacing": ["error", "always"]
 }
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint block-spacing: 2*/
+/*eslint block-spacing: "error"*/
 function foo() {return true;}
 if (foo) { bar = 0;}
 ```
@@ -34,7 +34,7 @@ if (foo) { bar = 0;}
 The following patterns are not considered problems:
 
 ```js
-/*eslint block-spacing: 2*/
+/*eslint block-spacing: "error"*/
 
 function foo() { return true; }
 if (foo) { bar = 0; }
@@ -44,14 +44,14 @@ if (foo) { bar = 0; }
 
 ```json
 {
-  "block-spacing": [2, "never"]
+  "block-spacing": ["error", "never"]
 }
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint block-spacing: [2, "never"]*/
+/*eslint block-spacing: ["error", "never"]*/
 
 function foo() { return true; }
 if (foo) { bar = 0;}
@@ -60,7 +60,7 @@ if (foo) { bar = 0;}
 The following patterns are not considered problems:
 
 ```js
-/*eslint block-spacing: [2, "never"]*/
+/*eslint block-spacing: ["error", "never"]*/
 
 function foo() {return true;}
 if (foo) {bar = 0;}

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -52,7 +52,7 @@ The rule takes two options:
 You can set the style in configuration like this:
 
 ```json
-"brace-style": [2, "stroustrup", { "allowSingleLine": true }]
+"brace-style": ["error", "stroustrup", { "allowSingleLine": true }]
 ```
 
 ### "1tbs"
@@ -60,7 +60,7 @@ You can set the style in configuration like this:
 This is the default setting for this rule and enforces one true brace style. While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint brace-style: 2*/
+/*eslint brace-style: "error"*/
 function foo()
 {
   return true;
@@ -90,7 +90,7 @@ else {
 The following patterns use the one true brace style and are not considered problems:
 
 ```js
-/*eslint brace-style: 2*/
+/*eslint brace-style: "error"*/
 
 function foo() {
   return true;
@@ -120,7 +120,7 @@ else if (baz) boom();
 With one-line form enabled, the following is also valid:
 
 ```js
-/*eslint brace-style: [2, "1tbs", { "allowSingleLine": true }]*/
+/*eslint brace-style: ["error", "1tbs", { "allowSingleLine": true }]*/
 
 function nop() { return; }
 
@@ -137,7 +137,7 @@ try { somethingRisky(); } catch(e) { handleError(); }
 This enforces Stroustrup style. While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint brace-style: [2, "stroustrup"]*/
+/*eslint brace-style: ["error", "stroustrup"]*/
 
 function foo()
 {
@@ -167,7 +167,7 @@ if (foo) {
 The following patterns use the Stroustrup style and are not considered problems:
 
 ```js
-/*eslint brace-style: [2, "stroustrup"]*/
+/*eslint brace-style: ["error", "stroustrup"]*/
 
 function foo() {
   return true;
@@ -199,7 +199,7 @@ else if (baz) boom();
 With one-line form enabled, the following is also valid:
 
 ```js
-/*eslint brace-style: [2, "stroustrup", { "allowSingleLine": true }]*/
+/*eslint brace-style: ["error", "stroustrup", { "allowSingleLine": true }]*/
 
 function nop() { return; }
 
@@ -218,7 +218,7 @@ catch(e) { handleError(); }
 This enforces Allman style. While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint brace-style: [2, "allman"]*/
+/*eslint brace-style: ["error", "allman"]*/
 
 function foo() {
   return true;
@@ -246,7 +246,7 @@ if (foo) {
 The following patterns use the Allman style and are not considered problems:
 
 ```js
-/*eslint brace-style: [2, "allman"]*/
+/*eslint brace-style: ["error", "allman"]*/
 
 function foo()
 {
@@ -284,7 +284,7 @@ else if (baz) boom();
 With one-line form enabled, the following is also valid:
 
 ```js
-/*eslint brace-style: [2, "allman", { "allowSingleLine": true }]*/
+/*eslint brace-style: ["error", "allman", { "allowSingleLine": true }]*/
 
 function nop() { return; }
 

--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -29,7 +29,7 @@ The rule takes a single option, which is an array of possible callback names. Th
 Examples of **incorrect** code for this rule with the default `["callback", "cb", "next"]` option:
 
 ```js
-/*eslint callback-return: 2*/
+/*eslint callback-return: "error"*/
 
 function foo() {
     if (err) {
@@ -42,7 +42,7 @@ function foo() {
 Examples of **correct** code for this rule with the default `["callback", "cb", "next"]` option:
 
 ```js
-/*eslint callback-return: 2*/
+/*eslint callback-return: "error"*/
 
 function foo() {
     if (err) {
@@ -66,7 +66,7 @@ The static analysis of this rule does not detect that the program calls the call
 Example of a *false negative* when this rule reports correct code:
 
 ```js
-/*eslint callback-return: 2*/
+/*eslint callback-return: "error"*/
 
 function foo(callback) {
     if (err) {
@@ -83,7 +83,7 @@ The static analysis of this rule does not detect that the program calls the call
 Example of a *false negative* when this rule reports correct code:
 
 ```js
-/*eslint callback-return: 2*/
+/*eslint callback-return: "error"*/
 
 function foo(callback) {
     if (err) {
@@ -102,7 +102,7 @@ The static analysis of this rule does not detect that the program calls the call
 Example of a *false positive* when this rule reports incorrect code:
 
 ```js
-/*eslint callback-return: 2*/
+/*eslint callback-return: "error"*/
 
 function foo(callback) {
     if (err) {

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -13,7 +13,7 @@ This rule accepts a single options argument with the following defaults:
 ```json
 {
     "rules": {
-        "camelcase": [2, {"properties": "always"}]
+        "camelcase": ["error", {"properties": "always"}]
     }
 }
 ```
@@ -26,7 +26,7 @@ This rule accepts a single options argument with the following defaults:
 The following patterns are considered problems:
 
 ```js
-/*eslint camelcase: 2*/
+/*eslint camelcase: "error"*/
 var my_favorite_color = "#112C85";
 
 function do_something() {
@@ -45,7 +45,7 @@ var obj = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint camelcase: 2*/
+/*eslint camelcase: "error"*/
 var myFavoriteColor   = "#112C85";
 var _myFavoriteColor  = "#112C85";
 var myFavoriteColor_  = "#112C85";
@@ -60,7 +60,7 @@ var { category_id: category } = query;
 
 
 ```js
-/*eslint camelcase: [2, {properties: "never"}]*/
+/*eslint camelcase: ["error", {properties: "never"}]*/
 
 var obj = {
     my_pref: 1

--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -29,7 +29,7 @@ This rule takes one argument, which can be one of the following options:
 Examples of **incorrect** code for the default `"never"` option:
 
 ```js
-/*eslint comma-dangle: [2, "never"]*/
+/*eslint comma-dangle: ["error", "never"]*/
 
 var foo = {
     bar: "baz",
@@ -47,7 +47,7 @@ foo({
 Examples of **correct** code for the default `"never"` option:
 
 ```js
-/*eslint comma-dangle: [2, "never"]*/
+/*eslint comma-dangle: ["error", "never"]*/
 
 var foo = {
     bar: "baz",
@@ -67,7 +67,7 @@ foo({
 Examples of **incorrect** code for the `"always"` option:
 
 ```js
-/*eslint comma-dangle: [2, "always"]*/
+/*eslint comma-dangle: ["error", "always"]*/
 
 var foo = {
     bar: "baz",
@@ -85,7 +85,7 @@ foo({
 Examples of **correct** code for the `"always"` option:
 
 ```js
-/*eslint comma-dangle: [2, "always"]*/
+/*eslint comma-dangle: ["error", "always"]*/
 
 var foo = {
     bar: "baz",
@@ -105,7 +105,7 @@ foo({
 Examples of **incorrect** code for the `"always-multiline"` option:
 
 ```js
-/*eslint comma-dangle: [2, "always-multiline"]*/
+/*eslint comma-dangle: ["error", "always-multiline"]*/
 
 var foo = {
     bar: "baz",
@@ -133,7 +133,7 @@ foo({
 Examples of **correct** code for the `"always-multiline"` option:
 
 ```js
-/*eslint comma-dangle: [2, "always-multiline"]*/
+/*eslint comma-dangle: ["error", "always-multiline"]*/
 
 var foo = {
     bar: "baz",
@@ -162,7 +162,7 @@ foo({
 Examples of **incorrect** code for the `"only-multiline"` option:
 
 ```js
-/*eslint comma-dangle: [2, "only-multiline"]*/
+/*eslint comma-dangle: ["error", "only-multiline"]*/
 
 var foo = { bar: "baz", qux: "quux", };
 
@@ -176,7 +176,7 @@ var arr = [1,
 Examples of **correct** code for the `"only-multiline"` option:
 
 ```js
-/*eslint comma-dangle: [2, "only-multiline"]*/
+/*eslint comma-dangle: ["error", "only-multiline"]*/
 
 var foo = {
     bar: "baz",

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -19,7 +19,7 @@ This rule aims to enforce spacing around a comma. As such, it warns whenever it 
 The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`. If `before` is `true`, space is enforced before commas and if it's `false`, space is disallowed before commas. If `after` is `true`, space is enforced after commas and if it's `false`, space is disallowed after commas. The default is `{"before": false, "after": true}`.
 
 ```json
-    "comma-spacing": [2, {"before": false, "after": true}]
+    "comma-spacing": ["error", {"before": false, "after": true}]
 ```
 
 The following examples show two primary usages of this option.
@@ -31,7 +31,7 @@ This is the default option. It enforces spacing after commas and disallows spaci
 The following patterns are considered problems:
 
 ```js
-/*eslint comma-spacing: [2, {"before": false, "after": true}]*/
+/*eslint comma-spacing: ["error", {"before": false, "after": true}]*/
 
 var foo = 1 ,bar = 2;
 var arr = [1 , 2];
@@ -45,7 +45,7 @@ a ,b
 The following patterns are not considered problems:
 
 ```js
-/*eslint comma-spacing: [2, {"before": false, "after": true}]*/
+/*eslint comma-spacing: ["error", {"before": false, "after": true}]*/
 
 var foo = 1, bar = 2
     , baz = 3;
@@ -64,7 +64,7 @@ This option enforces spacing before commas and disallows spacing after commas.
 The following patterns are considered problems:
 
 ```js
-/*eslint comma-spacing: [2, {"before": true, "after": false}]*/
+/*eslint comma-spacing: ["error", {"before": true, "after": false}]*/
 
 var foo = 1, bar = 2;
 var arr = [1 , 2];
@@ -77,7 +77,7 @@ a, b
 The following patterns are not considered problems:
 
 ```js
-/*eslint comma-spacing: [2, {"before": true, "after": false}]*/
+/*eslint comma-spacing: ["error", {"before": true, "after": false}]*/
 
 var foo = 1 ,bar = 2 ,
     baz = true;

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -17,7 +17,7 @@ The rule takes an option, a string, which could be either `"last"` or `"first"`.
 You can set the style in configuration like this:
 
 ```json
-"comma-style": [2, "first"]
+"comma-style": ["error", "first"]
 ```
 
 ### "last"
@@ -27,7 +27,7 @@ This is the default setting for this rule. This option requires that the comma b
 While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint comma-style: [2, "last"]*/
+/*eslint comma-style: ["error", "last"]*/
 
 var foo = 1
 ,
@@ -53,7 +53,7 @@ function bar() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint comma-style: [2, "last"]*/
+/*eslint comma-style: ["error", "last"]*/
 
 var foo = 1, bar = 2;
 
@@ -81,7 +81,7 @@ This option requires that the comma be placed before and be in the same line as 
 While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint comma-style: [2, "first"]*/
+/*eslint comma-style: ["error", "first"]*/
 
 var foo = 1,
     bar = 2;
@@ -103,7 +103,7 @@ function bar() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint comma-style: [2, "first"]*/
+/*eslint comma-style: ["error", "first"]*/
 
 var foo = 1, bar = 2;
 
@@ -139,7 +139,7 @@ An example use case is if a user wanted to only enforce comma style in var state
 The following is considered a warning:
 
 ```js
-/*eslint comma-style: [2, "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }]*/
+/*eslint comma-style: ["error", "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }]*/
 
 var o = {},
     a = [];
@@ -148,7 +148,7 @@ var o = {},
 But the following would not be a warning:
 
 ```js
-/*eslint comma-style: [2, "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }]*/
+/*eslint comma-style: ["error", "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }]*/
 
 var o = {fst:1,
          snd: [1,

--- a/docs/rules/complexity.md
+++ b/docs/rules/complexity.md
@@ -21,7 +21,7 @@ This rule is aimed at reducing code complexity by capping the amount of cyclomat
 Examples of **incorrect** code for a maximum of 2:
 
 ```js
-/*eslint complexity: [2, 2]*/
+/*eslint complexity: ["error", 2]*/
 
 function a(x) {
     if (true) {
@@ -37,7 +37,7 @@ function a(x) {
 Examples of **correct** code for a maximum of 2:
 
 ```js
-/*eslint complexity: [2, 2]*/
+/*eslint complexity: ["error", 2]*/
 
 function a(x) {
     if (true) {
@@ -53,13 +53,13 @@ function a(x) {
 Optionally, you may specify a `maximum` object property:
 
 ```json
-"complexity": [2, 2]
+"complexity": ["error", 2]
 ```
 
 is equivalent to
 
 ```json
-"complexity": [2, { "maximum": 2 }]
+"complexity": ["error", { "maximum": 2 }]
 ```
 
 ## When Not To Use It

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -35,7 +35,7 @@ There are two main options for the rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"computed-property-spacing": [2, "never"]
+"computed-property-spacing": ["error", "never"]
 ```
 
 ### "never"
@@ -43,7 +43,7 @@ Depending on your coding conventions, you can choose either option by specifying
 When `"never"` is set, the following patterns will give a warning:
 
 ```js
-/*eslint computed-property-spacing: [2, "never"]*/
+/*eslint computed-property-spacing: ["error", "never"]*/
 /*eslint-env es6*/
 
 obj[foo ]
@@ -55,7 +55,7 @@ obj[foo[ bar ]]
 The following patterns are considered correct:
 
 ```js
-/*eslint computed-property-spacing: [2, "never"]*/
+/*eslint computed-property-spacing: ["error", "never"]*/
 /*eslint-env es6*/
 
 obj[foo]
@@ -69,7 +69,7 @@ obj[foo[bar]]
 When `"always"` is used, the following patterns will give a warning:
 
 ```js
-/*eslint computed-property-spacing: [2, "always"]*/
+/*eslint computed-property-spacing: ["error", "always"]*/
 /*eslint-env es6*/
 
 obj[foo]
@@ -84,7 +84,7 @@ var x = {[ b]: a}
 The following patterns are considered correct:
 
 ```js
-/*eslint computed-property-spacing: [2, "always"]*/
+/*eslint computed-property-spacing: ["error", "always"]*/
 /*eslint-env es6*/
 
 obj[ foo ]

--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -26,7 +26,7 @@ It excludes constructors which, when invoked with the `new` operator, return the
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint consistent-return: 2*/
+/*eslint consistent-return: "error"*/
 
 function doSomething(condition) {
 
@@ -57,7 +57,7 @@ function doSomething(condition) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint consistent-return: 2*/
+/*eslint consistent-return: "error"*/
 
 function doSomething(condition) {
 

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -24,19 +24,19 @@ This rule designates a variable as the chosen alias for `this`. It then enforces
 This rule takes one option, a string, which is the designated `this` variable. The default is `that`.
 
 ```json
-"consistent-this": [2, "that"]
+"consistent-this": ["error", "that"]
 ```
 
 Additionally, you may configure extra aliases for cases where there are more than one supported alias for `this`.
 
 ```js
-{ "consistent-this": [ 2, "self",  "vm" ] }
+{ "consistent-this": [ "error", "self",  "vm" ] }
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint consistent-this: [2, "that"]*/
+/*eslint consistent-this: ["error", "that"]*/
 
 var that = 42;
 
@@ -50,7 +50,7 @@ self = this;
 The following patterns are not considered problems:
 
 ```js
-/*eslint consistent-this: [2, "that"]*/
+/*eslint consistent-this: ["error", "that"]*/
 
 var that = this;
 
@@ -66,7 +66,7 @@ foo.bar = this;
 A declaration of an alias does not need to assign `this` in the declaration, but it must perform an appropriate assignment in the same scope as the declaration. The following patterns are also considered okay:
 
 ```js
-/*eslint consistent-this: [2, "that"]*/
+/*eslint consistent-this: ["error", "that"]*/
 
 var that;
 that = this;
@@ -79,7 +79,7 @@ that = this;
 But the following pattern is considered a warning:
 
 ```js
-/*eslint consistent-this: [2, "that"]*/
+/*eslint consistent-this: ["error", "that"]*/
 
 var that;
 function f() {

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -13,7 +13,7 @@ This rule is aimed to flag invalid/missing `super()` calls.
 The following patterns are considered problems:
 
 ```js
-/*eslint constructor-super: 2*/
+/*eslint constructor-super: "error"*/
 /*eslint-env es6*/
 
 class A {
@@ -36,7 +36,7 @@ class A extends B {
 The following patterns are not considered problems:
 
 ```js
-/*eslint constructor-super: 2*/
+/*eslint constructor-super: "error"*/
 /*eslint-env es6*/
 
 class A {

--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -27,7 +27,7 @@ This rule is aimed at preventing bugs and increasing code clarity by ensuring th
 Examples of **incorrect** code for the default `"all"` option:
 
 ```js
-/*eslint curly: 2*/
+/*eslint curly: "error"*/
 
 if (foo) foo++;
 
@@ -42,7 +42,7 @@ if (foo) {
 Examples of **correct** code for the default `"all"` option:
 
 ```js
-/*eslint curly: 2*/
+/*eslint curly: "error"*/
 
 if (foo) {
     foo++;
@@ -66,7 +66,7 @@ By default, this rule warns whenever `if`, `else`, `for`, `while`, or `do` are u
 Examples of **incorrect** code for the `"multi"` option:
 
 ```js
-/*eslint curly: [2, "multi"]*/
+/*eslint curly: ["error", "multi"]*/
 
 if (foo) {
     foo++;
@@ -89,7 +89,7 @@ for (var i=0; i < items.length; i++) {
 Examples of **correct** code for the `"multi"` option:
 
 ```js
-/*eslint curly: [2, "multi"]*/
+/*eslint curly: ["error", "multi"]*/
 
 if (foo) foo++;
 
@@ -108,7 +108,7 @@ Alternatively, you can relax the rule to allow brace-less single-line `if`, `els
 Examples of **incorrect** code for the `"multi-line"` option:
 
 ```js
-/*eslint curly: [2, "multi-line"]*/
+/*eslint curly: ["error", "multi-line"]*/
 
 if (foo)
   doSomething();
@@ -123,7 +123,7 @@ if (foo) foo(
 Examples of **correct** code for the `"multi-line"` option:
 
 ```js
-/*eslint curly: [2, "multi-line"]*/
+/*eslint curly: ["error", "multi-line"]*/
 
 if (foo) foo++; else doSomething();
 
@@ -156,7 +156,7 @@ You can use another configuration that forces brace-less `if`, `else if`, `else`
 Examples of **incorrect** code for the `"multi-or-nest"` option:
 
 ```js
-/*eslint curly: [2, "multi-or-nest"]*/
+/*eslint curly: ["error", "multi-or-nest"]*/
 
 if (!foo)
     foo = {
@@ -186,7 +186,7 @@ for (var i = 0; foo; i++) {
 Examples of **correct** code for the `"multi-or-nest"` option:
 
 ```js
-/*eslint curly: [2, "multi-or-nest"]*/
+/*eslint curly: ["error", "multi-or-nest"]*/
 
 if (!foo) {
     foo = {
@@ -220,7 +220,7 @@ When using any of the `multi*` options, you can add an option to enforce all bod
 Examples of **incorrect** code for the `"multi", "consistent"` options:
 
 ```js
-/*eslint curly: [2, "multi", "consistent"]*/
+/*eslint curly: ["error", "multi", "consistent"]*/
 
 if (foo) {
     bar();
@@ -251,7 +251,7 @@ if (foo) {
 Examples of **correct** code for the `"multi", "consistent"` options:
 
 ```js
-/*eslint curly: [2, "multi", "consistent"]*/
+/*eslint curly: ["error", "multi", "consistent"]*/
 
 if (foo) {
     bar();

--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -44,7 +44,7 @@ This rule aims to require `default` case in `switch` statements. You may optiona
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint default-case: 2*/
+/*eslint default-case: "error"*/
 
 switch (a) {
     case 1:
@@ -57,7 +57,7 @@ switch (a) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint default-case: 2*/
+/*eslint default-case: "error"*/
 
 switch (a) {
     case 1:

--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -30,7 +30,7 @@ The default `"object"` option requires the dot to be on the same line as the obj
 Examples of **incorrect** code for the default `"object"` option:
 
 ```js
-/*eslint dot-location: [2, "object"]*/
+/*eslint dot-location: ["error", "object"]*/
 
 var foo = object
 .property;
@@ -39,7 +39,7 @@ var foo = object
 Examples of **correct** code for the default `"object"` option:
 
 ```js
-/*eslint dot-location: [2, "object"]*/
+/*eslint dot-location: ["error", "object"]*/
 
 var foo = object.
 property;
@@ -53,7 +53,7 @@ The `"property"` option requires the dot to be on the same line as the property.
 Examples of **incorrect** code for the `"property"` option:
 
 ```js
-/*eslint dot-location: [2, "property"]*/
+/*eslint dot-location: ["error", "property"]*/
 
 var foo = object.
 property;
@@ -62,7 +62,7 @@ property;
 Examples of **correct** code for the `"property"` option:
 
 ```js
-/*eslint dot-location: [2, "property"]*/
+/*eslint dot-location: ["error", "property"]*/
 
 var foo = object
 .property;

--- a/docs/rules/dot-notation.md
+++ b/docs/rules/dot-notation.md
@@ -13,7 +13,7 @@ This rule is aimed at maintaining code consistency and improving code readabilit
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint dot-notation: 2*/
+/*eslint dot-notation: "error"*/
 
 var x = foo["bar"];
 ```
@@ -21,7 +21,7 @@ var x = foo["bar"];
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint dot-notation: 2*/
+/*eslint dot-notation: "error"*/
 
 var x = foo.bar;
 
@@ -40,7 +40,7 @@ This rule accepts a single options argument:
 Examples of **correct** code for the `{ "allowKeywords": false }` option:
 
 ```js
-/*eslint dot-notation: [2, { "allowKeywords": false }]*/
+/*eslint dot-notation: ["error", { "allowKeywords": false }]*/
 
 var foo = { "class": "CS 101" }
 var x = foo["class"]; // Property name is a reserved word, square-bracket notation required
@@ -53,8 +53,8 @@ For example, when preparing data to be sent to an external API, it is often requ
 Examples of **correct** code for the sample `{ "allowPattern": "^[a-z]+(_[a-z]+)+$" }` option:
 
 ```js
-/*eslint camelcase: 2*/
-/*eslint dot-notation: [2, { "allowPattern": "^[a-z]+(_[a-z]+)+$" }]*/
+/*eslint camelcase: "error"*/
+/*eslint dot-notation: ["error", { "allowPattern": "^[a-z]+(_[a-z]+)+$" }]*/
 
 var data = {};
 data.foo_bar = 42;

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -17,7 +17,7 @@ the end of the file. If you still want this behaviour, consider enabling
 The following patterns are considered problems:
 
 ```js
-/*eslint eol-last: 2*/
+/*eslint eol-last: "error"*/
 
 function doSmth() {
   var foo = 2;
@@ -27,7 +27,7 @@ function doSmth() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint eol-last: 2*/
+/*eslint eol-last: "error"*/
 
 function doSmth() {
   var foo = 2;

--- a/docs/rules/eqeqeq.md
+++ b/docs/rules/eqeqeq.md
@@ -18,7 +18,7 @@ This rule is aimed at eliminating the type-unsafe equality operators.
 Examples of **incorrect** code for this rule:
 
 ```js
-/* eslint eqeqeq: 2 */
+/*eslint eqeqeq: "error"*/
 
 if (x == 42) { }
 
@@ -40,7 +40,7 @@ The `"smart"` option enforces the use of `===` and `!==` except for these cases:
 Examples of **incorrect** code for the `"smart"` option:
 
 ```js
-/* eslint eqeqeq: [2, "smart"] */
+/*eslint eqeqeq: ["error", "smart"]*/
 
 // comparing two variables requires ===
 a == b
@@ -56,7 +56,7 @@ value == undefined
 Examples of **correct** code for the `"smart"` option:
 
 ```js
-/* eslint eqeqeq: [2, "smart"] */
+/*eslint eqeqeq: ["error", "smart"]*/
 
 typeof foo == 'undefined'
 'hello' != 'world'
@@ -72,7 +72,7 @@ The `"allow-null"` option will enforce `===` and `!==` in your code with one exc
 Examples of **incorrect** code for the `"allow-null"` option:
 
 ```js
-/* eslint eqeqeq: [2, "allow-null"] */
+/*eslint eqeqeq: ["error", "allow-null"]*/
 
 bananas != 1
 typeof foo == 'undefined'
@@ -84,7 +84,7 @@ foo == undefined
 Examples of **correct** code for the `"allow-null"` option:
 
 ```js
-/* eslint eqeqeq: [2, "allow-null"] */
+/*eslint eqeqeq: ["error", "allow-null"]*/
 
 foo == null
 ```

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -13,7 +13,7 @@ Adding the second `bar` in the above example is optional.  If you leave off the 
 The following patterns are considered problems:
 
 ```js
-/* eslint func-names: 2*/
+/*eslint func-names: "error"*/
 
 Foo.prototype.bar = function() {};
 
@@ -25,7 +25,7 @@ Foo.prototype.bar = function() {};
 The following patterns are not considered problems:
 
 ```js
-/* eslint func-names: 2*/
+/*eslint func-names: "error"*/
 
 Foo.prototype.bar = function bar() {};
 

--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -53,13 +53,13 @@ This rule is aimed at enforcing a particular type of function style throughout a
 This is the default configuration.  It reports an error when function declarations are used instead of function expressions.
 
 ```json
-"func-style": [2, "expression"]
+"func-style": ["error", "expression"]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint func-style: [2, "expression"]*/
+/*eslint func-style: ["error", "expression"]*/
 
 function foo() {
     // ...
@@ -69,7 +69,7 @@ function foo() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint func-style: [2, "expression"]*/
+/*eslint func-style: ["error", "expression"]*/
 
 var foo = function() {
     // ...
@@ -81,19 +81,19 @@ var foo = function() {
 This reports an error if any function expressions are used where function declarations are expected. You can specify to use expressions instead:
 
 ```json
-"func-style": [2, "declaration"]
+"func-style": ["error", "declaration"]
 ```
 
 An additional option object can be added with a property `"allowArrowFunctions"`.  Setting this to `true` will allow arrow functions.
 
 ```json
-"func-style": [2, "declaration", { "allowArrowFunctions": true }]
+"func-style": ["error", "declaration", { "allowArrowFunctions": true }]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint func-style: [2, "declaration"]*/
+/*eslint func-style: ["error", "declaration"]*/
 
 var foo = function() {
     // ...
@@ -101,7 +101,7 @@ var foo = function() {
 ```
 
 ```js
-/*eslint func-style: [2, "declaration"]*/
+/*eslint func-style: ["error", "declaration"]*/
 
 var foo = () => {};
 ```
@@ -109,7 +109,7 @@ var foo = () => {};
 The following patterns are not considered problems:
 
 ```js
-/*eslint func-style: [2, "declaration"]*/
+/*eslint func-style: ["error", "declaration"]*/
 
 function foo() {
     // ...
@@ -122,7 +122,7 @@ SomeObject.foo = function() {
 ```
 
 ```js
-/*eslint func-style: [2, "declaration", { "allowArrowFunctions": true }]*/
+/*eslint func-style: ["error", "declaration", { "allowArrowFunctions": true }]*/
 
 var foo = () => {};
 ```

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -57,7 +57,7 @@ The rule takes one option, an object, which has two keys `before` and `after` ha
 The default is `{"before": true, "after": false}`.
 
 ```json
-"generator-star-spacing": [2, {"before": false, "after": true}]
+"generator-star-spacing": ["error", {"before": false, "after": true}]
 ```
 
 And the option has shorthand as a string keyword:
@@ -68,13 +68,13 @@ And the option has shorthand as a string keyword:
 * `{"before": false, "after": false}` → `"neither"`
 
 ```json
-"generator-star-spacing": [2, "after"]
+"generator-star-spacing": ["error", "after"]
 ```
 
 When using `{"before": true, "after": false}` this placement will be enforced:
 
 ```js
-/*eslint generator-star-spacing: [2, {"before": true, "after": false}]*/
+/*eslint generator-star-spacing: ["error", {"before": true, "after": false}]*/
 /*eslint-env es6*/
 
 function *generator() {}
@@ -87,7 +87,7 @@ var shorthand = { *generator() {} };
 When using `{"before": false, "after": true}` this placement will be enforced:
 
 ```js
-/*eslint generator-star-spacing: [2, {"before": false, "after": true}]*/
+/*eslint generator-star-spacing: ["error", {"before": false, "after": true}]*/
 /*eslint-env es6*/
 
 function* generator() {}
@@ -100,7 +100,7 @@ var shorthand = { * generator() {} };
 When using `{"before": true, "after": true}` this placement will be enforced:
 
 ```js
-/*eslint generator-star-spacing: [2, {"before": true, "after": true}]*/
+/*eslint generator-star-spacing: ["error", {"before": true, "after": true}]*/
 /*eslint-env es6*/
 
 function * generator() {}
@@ -113,7 +113,7 @@ var shorthand = { * generator() {} };
 When using `{"before": false, "after": false}` this placement will be enforced:
 
 ```js
-/*eslint generator-star-spacing: [2, {"before": false, "after": false}]*/
+/*eslint generator-star-spacing: ["error", {"before": false, "after": false}]*/
 /*eslint-env es6*/
 
 function*generator() {}

--- a/docs/rules/generator-star.md
+++ b/docs/rules/generator-star.md
@@ -49,7 +49,7 @@ option for this rule is a string specifying the placement of the asterisk. For t
 You can set the style in configuration like this:
 
 ```json
-"generator-star": [2, "start"]
+"generator-star": ["error", "start"]
 ```
 
 When using `"start"` this placement will be enforced:

--- a/docs/rules/global-require.md
+++ b/docs/rules/global-require.md
@@ -28,7 +28,7 @@ This rule requires all calls to `require()` to be at the top level of the module
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint global-require: 2*/
+/*eslint global-require: "error"*/
 /*eslint-env es6*/
 
 // calling require() inside of a function is not allowed
@@ -60,7 +60,7 @@ try {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint global-require: 2*/
+/*eslint global-require: "error"*/
 
 // all these variations of require() are ok
 require('x');

--- a/docs/rules/global-strict.md
+++ b/docs/rules/global-strict.md
@@ -45,13 +45,13 @@ function foo() {
 ## Options
 
 ```json
-"global-strict": [2, "always"]
+"global-strict": ["error", "always"]
 ```
 
 Requires that every file have a top-level `"use strict"` statement.
 
 ```json
-"global-strict": [2, "never"]
+"global-strict": ["error", "never"]
 ```
 
 Warns whenever `"use strict"` is used in the global scope such that it could contaminate concatenated files.

--- a/docs/rules/guard-for-in.md
+++ b/docs/rules/guard-for-in.md
@@ -15,7 +15,7 @@ This rule is aimed at preventing unexpected behavior that could arise from using
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint guard-for-in: 2*/
+/*eslint guard-for-in: "error"*/
 
 for (key in foo) {
     doSomething(key);
@@ -25,7 +25,7 @@ for (key in foo) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint guard-for-in: 2*/
+/*eslint guard-for-in: "error"*/
 
 for (key in foo) {
     if ({}.hasOwnProperty.call(foo, key)) {

--- a/docs/rules/handle-callback-err.md
+++ b/docs/rules/handle-callback-err.md
@@ -21,7 +21,7 @@ The rule takes a single string option: the name of the error parameter. The defa
 Examples of **incorrect** code for this rule with the default `"err"` parameter name:
 
 ```js
-/*eslint handle-callback-err: 2*/
+/*eslint handle-callback-err: "error"*/
 
 function loadData (err, data) {
     doSomething();
@@ -32,7 +32,7 @@ function loadData (err, data) {
 Examples of **correct** code for this rule with the default `"err"` parameter name:
 
 ```js
-/*eslint handle-callback-err: 2*/
+/*eslint handle-callback-err: "error"*/
 
 function loadData (err, data) {
     if (err) {
@@ -49,7 +49,7 @@ function generateError (err) {
 Examples of **correct** code for this rule with a sample `"error"` parameter name:
 
 ```js
-/*eslint handle-callback-err: [2, "error"]*/
+/*eslint handle-callback-err: ["error", "error"]*/
 
 function loadData (error, data) {
     if (error) {

--- a/docs/rules/id-blacklist.md
+++ b/docs/rules/id-blacklist.md
@@ -27,7 +27,7 @@ This rule needs a a set of identifier names to blacklist, like so:
 ```json
 {
     "rules": {
-        "id-blacklist": [2, "data", "err", "e", "cb", "callback"]
+        "id-blacklist": ["error", "data", "err", "e", "cb", "callback"]
     }
 }
 ```
@@ -35,7 +35,7 @@ This rule needs a a set of identifier names to blacklist, like so:
 For the rule in this example, the following patterns are considered problems:
 
 ```js
-/*eslint id-blacklist: [2, "data", "err", "e", "cb", "callback"] */
+/*eslint id-blacklist: ["error", "data", "err", "e", "cb", "callback"] */
 
 var data = {...};
 
@@ -55,7 +55,7 @@ var itemSet = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint id-blacklist: [2, "data", "err", "e", "cb", "callback"] */
+/*eslint id-blacklist: ["error", "data", "err", "e", "cb", "callback"] */
 
 var encodingOptions = {...};
 

--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -16,7 +16,7 @@ It allows the programmers to silently by-pass this check by using `"quoted"` pro
 The following patterns are considered problems:
 
 ```js
-/*eslint id-length: 2*/     // default is minimum 2-chars ({ min: 2})
+/*eslint id-length: "error"*/     // default is minimum 2-chars ({ min: 2})
 /*eslint-env es6*/
 
 var x = 5;
@@ -63,7 +63,7 @@ export var x = 0;
 The following patterns are not considered problems:
 
 ```js
-/*eslint id-length: 2*/     // default is minimum 2-chars ({ min: 2})
+/*eslint id-length: "error"*/     // default is minimum 2-chars ({ min: 2})
 /*eslint-env es6*/
 
 var num = 5;
@@ -129,13 +129,13 @@ The `id-length` rule has no required options and has 4 optional ones that needs 
 For example, to specify a minimum identifier length of 3, a maximum of 10, ignore property names and add `x` to exception list, use the following configuration:
 
 ```json
-"id-length": [2, {"min": 3, "max": 10, "properties": "never", "exceptions": ["x"]}]
+"id-length": ["error", {"min": 3, "max": 10, "properties": "never", "exceptions": ["x"]}]
 ```
 
 The following patterns will not be considered problems
 
 ```js
-/*eslint id-length: [2, {"properties": "never"}]*/
+/*eslint id-length: ["error", {"properties": "never"}]*/
 /*eslint-env es6*/
 
 var myObj = { a: 1 };

--- a/docs/rules/id-match.md
+++ b/docs/rules/id-match.md
@@ -19,7 +19,7 @@ This rule needs a text RegExp to operate with, and accepts an options map. Its s
 ```json
 {
     "rules": {
-        "id-match": [2, "^[a-z]+([A-Z][a-z]+)*$", {"properties": false}]
+        "id-match": ["error", "^[a-z]+([A-Z][a-z]+)*$", {"properties": false}]
     }
 }
 ```
@@ -32,7 +32,7 @@ This rule needs a text RegExp to operate with, and accepts an options map. Its s
 For the rule in this example, which is simply camelcase, the following patterns are considered problems:
 
 ```js
-/*eslint id-match: [2, "^[a-z]+([A-Z][a-z]+)*$", {"properties": true}]*/
+/*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$", {"properties": true}]*/
 
 var my_favorite_color = "#112C85";
 
@@ -58,7 +58,7 @@ var obj = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint id-match: [2, "^[a-z]+([A-Z][a-z]+)*$", {"properties": false}]*/
+/*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$", {"properties": false}]*/
 
 var myFavoriteColor   = "#112C85";
 var foo = bar.baz_boom;
@@ -66,7 +66,7 @@ var foo = { qux: bar.baz_boom };
 
 obj.do_something();
 
-/*eslint id-match: [2, "", {properties: false}]*/
+/*eslint id-match: ["error", "", {properties: false}]*/
 var obj = {
     my_pref: 1
 };

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -49,31 +49,31 @@ Level of indentation denotes the multiple of the indent specified. Example:
 2 space indentation with enabled switch cases indentation
 
 ```json
- "indent": [2, 2, {"SwitchCase": 1}]
+ "indent": ["error", 2, {"SwitchCase": 1}]
 ```
 
 4 space indention
 
 ```json
-"indent": 2
+"indent": "error"
 ```
 
 2 space indentation
 
 ```json
-"indent": [2, 2]
+"indent": ["error", 2]
 ```
 
 tabbed indentation
 
 ```json
-"indent": [2, "tab"]
+"indent": ["error", "tab"]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint indent: [2, 2]*/
+/*eslint indent: ["error", 2]*/
 
 if (a) {
    b=c;
@@ -84,7 +84,7 @@ function foo(d) {
 ```
 
 ```js
-/*eslint indent: [2, "tab"]*/
+/*eslint indent: ["error", "tab"]*/
 
 if (a) {
      b=c;
@@ -95,7 +95,7 @@ function foo(d) {
 ```
 
 ```js
-/*eslint indent: [2, 2, {"VariableDeclarator": 1}]*/
+/*eslint indent: ["error", 2, {"VariableDeclarator": 1}]*/
 /*eslint-env es6*/
 
 var a,
@@ -110,7 +110,7 @@ const a = 1,
 ```
 
 ```js
-/*eslint indent: [2, 2, {"SwitchCase": 1}]*/
+/*eslint indent: ["error", 2, {"SwitchCase": 1}]*/
 
 switch(a){
 case "a":
@@ -123,7 +123,7 @@ case "b":
 The following patterns are not considered problems:
 
 ```js
-/*eslint indent: [2, 2]*/
+/*eslint indent: ["error", 2]*/
 
 if (a) {
   b=c;
@@ -134,7 +134,7 @@ if (a) {
 ```
 
 ```js
-/*indent: [2, "tab"]*/
+/*indent: ["error", "tab"]*/
 
 if (a) {
 /*tab*/b=c;
@@ -145,7 +145,7 @@ if (a) {
 ```
 
 ```js
-/*eslint indent: [2, 2, {"VariableDeclarator": 2}]*/
+/*eslint indent: ["error", 2, {"VariableDeclarator": 2}]*/
 /*eslint-env es6*/
 
 var a,
@@ -160,7 +160,7 @@ const a = 1,
 ```
 
 ```js
-/*eslint indent: [2, 2, {"VariableDeclarator": { "var": 2, "let": 2, "const": 3}}]*/
+/*eslint indent: ["error", 2, {"VariableDeclarator": { "var": 2, "let": 2, "const": 3}}]*/
 /*eslint-env es6*/
 
 var a,
@@ -175,7 +175,7 @@ const a = 1,
 ```
 
 ```js
-/*eslint indent: [2, 4, {"SwitchCase": 1}]*/
+/*eslint indent: ["error", 4, {"SwitchCase": 1}]*/
 
 switch(a){
     case "a":

--- a/docs/rules/init-declarations.md
+++ b/docs/rules/init-declarations.md
@@ -39,7 +39,7 @@ Variables must be initialized at declaration (default)
 
 ```json
 {
-    "init-declarations": [2, "always"],
+    "init-declarations": ["error", "always"],
 }
 ```
 
@@ -47,7 +47,7 @@ Variables must not be initialized at declaration
 
 ```json
 {
-    "init-declarations": [2, "never"]
+    "init-declarations": ["error", "never"]
 }
 ```
 
@@ -55,7 +55,7 @@ Variables must not be initialized at declaration, except in for loops, where it 
 
 ```json
 {
-    "init-declarations": [2, "never", { "ignoreForLoopInit": true }]
+    "init-declarations": ["error", "never", { "ignoreForLoopInit": true }]
 }
 ```
 
@@ -64,7 +64,7 @@ Variables must not be initialized at declaration, except in for loops, where it 
 Examples of **incorrect** code for the default `"always"` option:
 
 ```js
-/*eslint init-declarations: [2, "always"]*/
+/*eslint init-declarations: ["error", "always"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -76,7 +76,7 @@ function foo() {
 Examples of **correct** code for the default `"always"` option:
 
 ```js
-/*eslint init-declarations: [2, "always"]*/
+/*eslint init-declarations: ["error", "always"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -91,7 +91,7 @@ function foo() {
 Examples of **incorrect** code for the `"never"` option:
 
 ```js
-/*eslint init-declarations: [2, "never"]*/
+/*eslint init-declarations: ["error", "never"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -105,7 +105,7 @@ function foo() {
 Examples of **correct** code for the `"never"` option:
 
 ```js
-/*eslint init-declarations: [2, "never"]*/
+/*eslint init-declarations: ["error", "never"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -122,7 +122,7 @@ The `"never"` option ignores `const` variable initializations.
 Examples of **correct** code for the `"never", { "ignoreForLoopInit": true }` options:
 
 ```js
-/*eslint init-declarations: [2, "never", { "ignoreForLoopInit": true }]*/
+/*eslint init-declarations: ["error", "never", { "ignoreForLoopInit": true }]*/
 for (var i = 0; i < 1; i++) {}
 ```
 

--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -28,7 +28,7 @@ The default is `"prefer-double"`.
 The following patterns are considered problems when set to `"prefer-double"`:
 
 ```xml
-/*eslint jsx-quotes: [2, "prefer-double"]*/
+/*eslint jsx-quotes: ["error", "prefer-double"]*/
 
 <a b='c' />
 ```
@@ -36,7 +36,7 @@ The following patterns are considered problems when set to `"prefer-double"`:
 The following patterns are not considered problems when set to `"prefer-double"`:
 
 ```xml
-/*eslint jsx-quotes: [2, "prefer-double"]*/
+/*eslint jsx-quotes: ["error", "prefer-double"]*/
 
 <a b="c" />
 <a b='"' />
@@ -45,7 +45,7 @@ The following patterns are not considered problems when set to `"prefer-double"`
 The following patterns are considered problems when set to `"prefer-single"`:
 
 ```xml
-/*eslint jsx-quotes: [2, "prefer-single"]*/
+/*eslint jsx-quotes: ["error", "prefer-single"]*/
 
 <a b="c" />
 ```
@@ -53,7 +53,7 @@ The following patterns are considered problems when set to `"prefer-single"`:
 The following patterns are not considered problems when set to `"prefer-single"`:
 
 ```xml
-/*eslint jsx-quotes: [2, "prefer-single"]*/
+/*eslint jsx-quotes: ["error", "prefer-single"]*/
 
 <a b='c' />
 <a b="'" />

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -16,7 +16,7 @@ The following patterns are considered valid:
 
 ```js
 // DEFAULT
-/*eslint key-spacing: [2, {"beforeColon": false, "afterColon": true}]*/
+/*eslint key-spacing: ["error", {"beforeColon": false, "afterColon": true}]*/
 
 var obj = { "foo": (42) };
 
@@ -25,7 +25,7 @@ foo = { thisLineWouldBeTooLong:
 ```
 
 ```js
-/*eslint key-spacing: [2, {"beforeColon": true, "afterColon": false}]*/
+/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": false}]*/
 
 call({
     foobar :42,
@@ -34,7 +34,7 @@ call({
 ```
 
 ```js
-/*eslint key-spacing: [2, {"beforeColon": true, "afterColon": false, "mode": "minimum"}]*/
+/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": false, "mode": "minimum"}]*/
 
 call({
     foobar   :42,
@@ -45,7 +45,7 @@ call({
 The following patterns are considered problems:
 
 ```js
-/*eslint key-spacing: [2, {"beforeColon": false, "afterColon": false}]*/
+/*eslint key-spacing: ["error", {"beforeColon": false, "afterColon": false}]*/
 
 var obj = { foo: 42 };
 var bar = { baz :52 };
@@ -55,7 +55,7 @@ foo = { thisLineWouldBeTooLong:
 ```
 
 ```js
-/*eslint key-spacing: [2, {"beforeColon": true, "afterColon": true}]*/
+/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": true}]*/
 
 function foo() {
     return {
@@ -66,7 +66,7 @@ function foo() {
 ```
 
 ```js
-/*eslint key-spacing: [2, {"beforeColon": true, "afterColon": true}]*/
+/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": true}]*/
 
 function foo() {
     return {
@@ -83,7 +83,7 @@ Use the `align` option to enforce vertical alignment of values in an object lite
 The following patterns are considered valid:
 
 ```js
-/*eslint key-spacing: [2, { "align": "value" }]*/
+/*eslint key-spacing: ["error", { "align": "value" }]*/
 // beforeColon and afterColon default to false and true, respectively
 
 var obj = {
@@ -101,7 +101,7 @@ var obj = { a: "foo", longPropertyName: "bar" };
 ```
 
 ```js
-/*eslint key-spacing: [2, { "align": "value", "beforeColon": true, "afterColon": false }]*/
+/*eslint key-spacing: ["error", { "align": "value", "beforeColon": true, "afterColon": false }]*/
 
 call({
     'a' :[],
@@ -112,7 +112,7 @@ call({
 The following patterns are considered problems:
 
 ```js
-/*eslint key-spacing: [2, { "align": "value" }]*/
+/*eslint key-spacing: ["error", { "align": "value" }]*/
 
 var obj = {
     a: value,
@@ -128,7 +128,7 @@ The `align` option can also vertically align colons and values together. Whereas
 The following patterns are considered valid:
 
 ```js
-/*eslint key-spacing: [2, { "align": "colon" }]*/
+/*eslint key-spacing: ["error", { "align": "colon" }]*/
 
 var obj = {
     foobar   : 42,
@@ -141,7 +141,7 @@ var obj = {
 ```
 
 ```js
-/*eslint key-spacing: [2, { "align": "colon", "beforeColon": true, "afterColon": false }]*/
+/*eslint key-spacing: ["error", { "align": "colon", "beforeColon": true, "afterColon": false }]*/
 
 obj = {
     first  :1,
@@ -153,7 +153,7 @@ obj = {
 The following patterns are considered problems:
 
 ```js
-/*eslint key-spacing: [2, { "align": "colon" }]*/
+/*eslint key-spacing: ["error", { "align": "colon" }]*/
 
 var obj = {
     one:   1,

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -24,7 +24,7 @@ This rule will enforce consistency of spacing around keywords and keyword-like t
 The following patterns are considered problems:
 
 ```js
-/*eslint keyword-spacing: 2*/
+/*eslint keyword-spacing: "error"*/
 /*eslint-env es6*/
 
 if(foo){
@@ -70,7 +70,7 @@ import*as bar from "foo";
 The following patterns are considered not problems:
 
 ```js
-/*eslint keyword-spacing: 2*/
+/*eslint keyword-spacing: "error"*/
 /*eslint-env es6*/
 
 if (foo) {
@@ -118,7 +118,7 @@ Basically this rule ignores usage of spacing at places that other rules are catc
 So the following patterns are considered not problems.
 
 ```js
-/*eslint keyword-spacing: 2*/
+/*eslint keyword-spacing: "error"*/
 /*eslint-env es6*/
 
 // not conflict with `array-bracket-spacing`
@@ -187,7 +187,7 @@ This rule has 3 options.
 
 ```json
 {
-    "keyword-spacing": [2, {"before": true, "after": true, "overrides": {}}]
+    "keyword-spacing": ["error", {"before": true, "after": true, "overrides": {}}]
 }
 ```
 
@@ -205,7 +205,7 @@ This rule has 3 options.
 
   ```json
   {
-      "keyword-spacing": [2, {"overrides": {
+      "keyword-spacing": ["error", {"overrides": {
           "if": {"after": false},
           "for": {"after": false},
           "while": {"after": false}
@@ -218,7 +218,7 @@ This rule has 3 options.
 The following patterns are considered problems when configured `{"before": false, "after": false}`:
 
 ```js
-/*eslint keyword-spacing: [2, {before: false, after: false}]*/
+/*eslint keyword-spacing: ["error", {before: false, after: false}]*/
 /*eslint-env es6*/
 
 if (foo){
@@ -264,7 +264,7 @@ import * as bar from"foo";
 The following patterns are considered not problems when configured `{"before": false, "after": false}`:
 
 ```js
-/*eslint keyword-spacing: [2, {before: false, after: false}]*/
+/*eslint keyword-spacing: ["error", {before: false, after: false}]*/
 /*eslint-env es6*/
 
 if(foo) {

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -17,20 +17,20 @@ This rule aims to ensure having consistent line endings independent of operating
 The following patterns are considered problems:
 
 ```js
-/*eslint linebreak-style: 2*/
+/*eslint linebreak-style: "error"*/
 
 var a = 'a'; // \r\n
 ```
 
 ```js
-/*eslint linebreak-style: [2, "unix"]*/
+/*eslint linebreak-style: ["error", "unix"]*/
 
 var a = 'a'; // \r\n
 
 ```
 
 ```js
-/*eslint linebreak-style: [2, "windows"]*/
+/*eslint linebreak-style: ["error", "windows"]*/
 
 var a = 'a';// \n
 ```
@@ -38,7 +38,7 @@ var a = 'a';// \n
 The following patterns are not considered problems:
 
 ```js
-/*eslint linebreak-style: [2, "unix"]*/
+/*eslint linebreak-style: ["error", "unix"]*/
 
 var a = 'a', // \n
     b = 'b'; // \n
@@ -49,7 +49,7 @@ function foo(params) {// \n
 ```
 
 ```js
-/*eslint linebreak-style: [2, "windows"]*/
+/*eslint linebreak-style: ["error", "windows"]*/
 
 var a = 'a', // \r\n
     b = 'b'; // \r\n

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -38,7 +38,7 @@ Inline comments are always excluded from the rule.
 The following would be acceptable:
 
 ```js
-/*eslint lines-around-comment: 2*/
+/*eslint lines-around-comment: "error"*/
 
 var x = 0;
 var y = 10; /* the vertical position */
@@ -74,7 +74,7 @@ Any combination of these rules may be applied at the same time.
 
 ```json
 {
-    "lines-around-comment": [2, { "beforeBlockComment": true, "beforeLineComment": true }]
+    "lines-around-comment": ["error", { "beforeBlockComment": true, "beforeLineComment": true }]
 }
 ```
 
@@ -89,7 +89,7 @@ With both `beforeBlockComment` and `afterBlockComment` set to `true` the followi
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeBlockComment": true, "afterBlockComment": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "afterBlockComment": true }]*/
 
 var night = "long";
 
@@ -101,7 +101,7 @@ var day = "great"
 This however would provide 2 warnings:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeBlockComment": true, "afterBlockComment": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "afterBlockComment": true }]*/
 
 var night = "long";
 /* what a great and wonderful day */
@@ -112,7 +112,7 @@ With only `beforeBlockComment` set to `true` the following code
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeBlockComment": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true }]*/
 
 var night = "long";
 
@@ -123,7 +123,7 @@ var day = "great"
 But this would cause 1 warning:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeBlockComment": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true }]*/
 
 var night = "long";
 /* what a great and wonderful day */
@@ -138,7 +138,7 @@ With both `beforeLineComment` and `afterLineComment` set to `true` the following
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeLineComment": true, "afterLineComment": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "afterLineComment": true }]*/
 
 var night = "long";
 
@@ -151,7 +151,7 @@ With only `beforeLineComment` set to `true` the following code
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeLineComment": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true }]*/
 
 var night = "long";
 
@@ -167,7 +167,7 @@ With both `beforeLineComment` and `allowBlockStart` set to `true` the following 
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeLineComment": true, "allowBlockStart": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowBlockStart": true }]*/
 
 function foo(){
     // what a great and wonderful day
@@ -180,7 +180,7 @@ With both `beforeBlockComment` and `allowBlockStart` set to `true` the following
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeBlockComment": true, "allowBlockStart": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowBlockStart": true }]*/
 
 function foo(){
     /* what a great and wonderful day */
@@ -197,7 +197,7 @@ With both `afterLineComment` and `allowBlockEnd` set to `true` the following cod
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "afterLineComment": true, "allowBlockEnd": true }]*/
+/*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowBlockEnd": true }]*/
 
 function foo(){
     var day = "great"
@@ -210,7 +210,7 @@ With both `afterBlockComment` and `allowBlockEnd` set to `true` the following co
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "afterBlockComment": true, "allowBlockEnd": true }]*/
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowBlockEnd": true }]*/
 
 function foo(){
     var day = "great"
@@ -228,7 +228,7 @@ With both `beforeLineComment` and `allowObjectStart` set to `true` the following
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeLineComment": true, "allowObjectStart": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowObjectStart": true }]*/
 
 var foo = {
     // what a great and wonderful day
@@ -250,7 +250,7 @@ With both `beforeBlockComment` and `allowObjectStart` set to `true` the followin
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeBlockComment": true, "allowObjectStart": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowObjectStart": true }]*/
 
 var foo = {
     /* what a great and wonderful day */
@@ -276,7 +276,7 @@ With both `afterLineComment` and `allowObjectEnd` set to `true` the following co
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "afterLineComment": true, "allowObjectEnd": true }]*/
+/*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowObjectEnd": true }]*/
 
 var foo = {
     day: "great"
@@ -298,7 +298,7 @@ With both `afterBlockComment` and `allowObjectEnd` set to `true` the following c
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "afterBlockComment": true, "allowObjectEnd": true }]*/
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowObjectEnd": true }]*/
 
 var foo = {
     day: "great"
@@ -327,7 +327,7 @@ With both `beforeLineComment` and `allowArrayStart` set to `true` the following 
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeLineComment": true, "allowArrayStart": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowArrayStart": true }]*/
 
 var day = [
     // what a great and wonderful day
@@ -345,7 +345,7 @@ With both `beforeBlockComment` and `allowArrayStart` set to `true` the following
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "beforeBlockComment": true, "allowArrayStart": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowArrayStart": true }]*/
 
 var day = [
     /* what a great and wonderful day */
@@ -367,7 +367,7 @@ With both `afterLineComment` and `allowArrayEnd` set to `true` the following cod
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "afterLineComment": true, "allowArrayEnd": true }]*/
+/*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowArrayEnd": true }]*/
 
 var day = [
     "great",
@@ -385,7 +385,7 @@ With both `afterBlockComment` and `allowArrayEnd` set to `true` the following co
 would not warn:
 
 ```js
-/*eslint lines-around-comment: [2, { "afterBlockComment": true, "allowArrayEnd": true }]*/
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowArrayEnd": true }]*/
 
 var day = [
     "great",

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -23,17 +23,17 @@ This rule aims to reduce the complexity of your code by allowing you to configur
 The default depth above which this rule will warn is `4`.  You can configure the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error with a maximum depth of 10:
 
 ```json
-"max-depth": [2, 10]
+"max-depth": ["error", 10]
 
 // or you can use an object property
 
-"max-depth": [2, {"maximum": 10}]
+"max-depth": ["error", {"maximum": 10}]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint max-depth: [2, 2]*/
+/*eslint max-depth: ["error", 2]*/
 
 function foo() {
   for (;;) {
@@ -49,7 +49,7 @@ function foo() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint max-depth: [2, 2]*/
+/*eslint max-depth: ["error", 2]*/
 
 function foo() {
   for (;;) {

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -3,7 +3,7 @@
 Very long lines of code in any language can be difficult to read. In order to aid in readability and maintainability many coders have developed a convention to limit lines of code to X number of characters (traditionally 80 characters).
 
 ```js
-// max-len: [1, 80, 4]; // maximum length of 80 characters
+// max-len: ["error", 80, 4]; // maximum length of 80 characters
 var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" }; // too long
 ```
 
@@ -17,7 +17,7 @@ This rule is aimed at increasing code readability and maintainability by enforci
 The following patterns are considered problems:
 
 ```js
-/*eslint max-len: [2, 80, 4]*/ // maximum length of 80 characters
+/*eslint max-len: ["error", 80, 4]*/ // maximum length of 80 characters
 
 var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" };
 ```
@@ -25,7 +25,7 @@ var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficu
 The following patterns are not considered problems:
 
 ```js
-/*eslint max-len: [2, 80, 4]*/ // maximum length of 80 characters
+/*eslint max-len: ["error", 80, 4]*/ // maximum length of 80 characters
 
 var foo = {
     "bar": "This is a bar.",
@@ -57,13 +57,13 @@ The `max-len` rule supports the following options:
 Optionally, you may specify `code` and `tabWidth` as integers before the options object:
 
 ```json
-"max-len": [2, 80, 4, {"ignoreUrls": true}]
+"max-len": ["error", 80, 4, {"ignoreUrls": true}]
 ```
 
 is equivalent to
 
 ```json
-"max-len": [2, {"code": 80, "tabWidth": 4, "ignoreUrls": true}]
+"max-len": ["error", {"code": 80, "tabWidth": 4, "ignoreUrls": true}]
 ```
 
 

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -23,17 +23,17 @@ This rule is aimed at increasing code clarity by discouraging deeply nesting cal
 The default max depth for this rule is 10. You can define the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error (code is 2) with a maximum depth of 3:
 
 ```json
-"max-nested-callbacks": [2, 3]
+"max-nested-callbacks": ["error", 3]
 
 // or you can use an object property
 
-"max-nested-callbacks": [2, {"maximum": 3}]
+"max-nested-callbacks": ["error", {"maximum": 3}]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint max-nested-callbacks: [2, 3]*/
+/*eslint max-nested-callbacks: ["error", 3]*/
 
 foo(function () {
     bar(function () {
@@ -49,7 +49,7 @@ foo(function () {
 The following patterns are not considered problems:
 
 ```js
-/*eslint max-nested-callbacks: [2, 3]*/
+/*eslint max-nested-callbacks: ["error", 3]*/
 
 foo(handleFoo);
 

--- a/docs/rules/max-params.md
+++ b/docs/rules/max-params.md
@@ -15,7 +15,7 @@ This rule is aimed at making functions easier to read and write by capping the n
 The following patterns are considered problems:
 
 ```js
-/*eslint max-params: [2, 3]*/
+/*eslint max-params: ["error", 3]*/
 
 function foo (bar, baz, qux, qxx) {
     doSomething();
@@ -25,7 +25,7 @@ function foo (bar, baz, qux, qxx) {
 The following patterns are not considered problems:
 
 ```js
-/*eslint max-params: [2, 3]*/
+/*eslint max-params: ["error", 3]*/
 
 function foo (bar, baz, qux) {
     doSomething();
@@ -35,13 +35,13 @@ function foo (bar, baz, qux) {
 Optionally, you may specify a `maximum` object property:
 
 ```json
-"max-params": [2, 2]
+"max-params": ["error", 2]
 ```
 
 is equivalent to
 
 ```json
-"max-params": [2, {"maximum": 2}]
+"max-params": ["error", {"maximum": 2}]
 ```
 
 

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -19,17 +19,17 @@ This rule allows you to configure the maximum number of statements allowed in a 
 There is an additional optional argument to ignore top level functions.
 
 ```json
-"max-statements": [2, 10, {"ignoreTopLevelFunctions": true}]
+"max-statements": ["error", 10, {"ignoreTopLevelFunctions": true}]
 
 // or you can use an object property to set the maximum
 
-"max-statements": [2, {"maximum": 10}, {"ignoreTopLevelFunctions": true}]
+"max-statements": ["error", {"maximum": 10}, {"ignoreTopLevelFunctions": true}]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint max-statements: [2, 2]*/  // Maximum of 2 statements.
+/*eslint max-statements: ["error", 2]*/  // Maximum of 2 statements.
 function foo() {
   var bar = 1;
   var baz = 2;
@@ -41,7 +41,7 @@ function foo() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint max-statements: [2, 2]*/  // Maximum of 2 statements.
+/*eslint max-statements: ["error", 2]*/  // Maximum of 2 statements.
 function foo() {
   var bar = 1;
   return function () {
@@ -55,7 +55,7 @@ function foo() {
 ```
 
 ```js
-/*eslint max-statements: [2, 1, {ignoreTopLevelFunctions: true}]*/  // Maximum of 1 statement.
+/*eslint max-statements: ["error", 1, {ignoreTopLevelFunctions: true}]*/  // Maximum of 1 statement.
 (function() {
   var bar = 1;
   return function () {

--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -13,7 +13,7 @@ This rule is aimed at helping to distinguish regular functions from constructor 
 The following patterns are considered problems:
 
 ```js
-/*eslint new-cap: 2*/
+/*eslint new-cap: "error"*/
 
 var friend = new person();
 var colleague = Person();
@@ -22,14 +22,14 @@ var colleague = Person();
 The following patterns are not considered problems:
 
 ```js
-/*eslint new-cap: 2*/
+/*eslint new-cap: "error"*/
 
 var friend = new Person();
 var colleague = person();
 ```
 
 ```js
-/*eslint new-cap: [2, {"capIsNewExceptions": ["Person"]}]*/
+/*eslint new-cap: ["error", {"capIsNewExceptions": ["Person"]}]*/
 
 var colleague = Person();
 var colleague = foo.Person();
@@ -37,7 +37,7 @@ var colleague = foo.bar.Person();
 ```
 
 ```js
-/*eslint new-cap: [2, {"capIsNewExceptions": ["foo.Person"]}]*/
+/*eslint new-cap: ["error", {"capIsNewExceptions": ["foo.Person"]}]*/
 
 var colleague = foo.Person();
 ```

--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -13,7 +13,7 @@ This rule is aimed at highlighting a lack of convention and increasing code clar
 The following patterns are considered problems:
 
 ```js
-/*eslint new-parens: 2*/
+/*eslint new-parens: "error"*/
 
 var person = new Person;
 ```
@@ -21,7 +21,7 @@ var person = new Person;
 The following patterns are not considered problems:
 
 ```js
-/*eslint new-parens: 2*/
+/*eslint new-parens: "error"*/
 
 var person = new Person();
 ```

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -31,7 +31,7 @@ This rule takes one option, a string, which can be:
 The following patterns are considered problems:
 
 ```js
-/*eslint newline-after-var: [2, "always"]*/
+/*eslint newline-after-var: ["error", "always"]*/
 
 var greet = "hello,",
     name = "world";
@@ -39,7 +39,7 @@ console.log(greet, name);
 ```
 
 ```js
-/*eslint newline-after-var: [2, "never"]*/
+/*eslint newline-after-var: ["error", "never"]*/
 /*eslint-env es6*/
 
 let greet = "hello,",
@@ -49,7 +49,7 @@ console.log(greet, name);
 ```
 
 ```js
-/*eslint newline-after-var: 2*/  // defaults to always
+/*eslint newline-after-var: "error"*/  // defaults to always
 /*eslint-env es6*/
 
 var greet = "hello,";
@@ -60,7 +60,7 @@ console.log(greet, NAME);
 The following patterns are not considered problems:
 
 ```js
-/*eslint newline-after-var: [2, "always"]*/
+/*eslint newline-after-var: ["error", "always"]*/
 
 var greet = "hello,",
     name = "world";
@@ -69,7 +69,7 @@ console.log(greet, name);
 ```
 
 ```js
-/*eslint newline-after-var: [2, "never"]*/
+/*eslint newline-after-var: ["error", "never"]*/
 /*eslint-env es6*/
 
 let greet = "hello,",
@@ -78,7 +78,7 @@ console.log(greet, name);
 ```
 
 ```js
-/*eslint newline-after-var: 2*/  // defaults to always
+/*eslint newline-after-var: "error"*/  // defaults to always
 /*eslint-env es6*/
 
 var greet = "hello,";
@@ -93,7 +93,7 @@ That is, they do not require a blank line between themselves and the var stateme
 The following patterns are considered problems:
 
 ```js
-/*eslint newline-after-var: [2, "always"]*/
+/*eslint newline-after-var: ["error", "always"]*/
 
 var greet = "hello,";
 var name = "world";
@@ -111,7 +111,7 @@ console.log(greet, name);
 The following patterns are not considered problems:
 
 ```js
-/*eslint newline-after-var: [2, "always"]*/
+/*eslint newline-after-var: ["error", "always"]*/
 
 var greet = "hello,";
 var name = "world";

--- a/docs/rules/newline-per-chained-call.md
+++ b/docs/rules/newline-per-chained-call.md
@@ -44,7 +44,7 @@ The rule takes a single option `ignoreChainWithDepth`. The level/depth to be all
 Following patterns are considered problems with default configuration:
 
 ```js
-/*eslint newline-per-chained-call: 2*/
+/*eslint newline-per-chained-call: "error"*/
 
 _.chain({}).map(foo).filter(bar).value();
 
@@ -63,7 +63,7 @@ obj.method().method2().method3();
 Following patterns are not considered problems with default configuration:
 
 ```js
-/*eslint newline-per-chained-call: [2]*/
+/*eslint newline-per-chained-call: "error"*/
 
 _
   .chain({})
@@ -100,7 +100,7 @@ For example, when configuration is like this:
 
 ```js
 {
-    "newline-per-chained-call": [2, {"ignoreChainWithDepth": 3}]
+    "newline-per-chained-call": ["error", {"ignoreChainWithDepth": 3}]
 }
 ```
 

--- a/docs/rules/no-alert.md
+++ b/docs/rules/no-alert.md
@@ -13,7 +13,7 @@ This rule is aimed at catching debugging code that should be removed and popup U
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-alert: 2*/
+/*eslint no-alert: "error"*/
 
 alert("here!");
 
@@ -25,7 +25,7 @@ prompt("What's your name?", "John Doe");
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-alert: 2*/
+/*eslint no-alert: "error"*/
 
 customAlert("Something happened!");
 

--- a/docs/rules/no-array-constructor.md
+++ b/docs/rules/no-array-constructor.md
@@ -11,13 +11,13 @@ specified size by giving the constructor a single numeric argument.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-array-constructor: 2*/
+/*eslint no-array-constructor: "error"*/
 
 Array(0, 1, 2)
 ```
 
 ```js
-/*eslint no-array-constructor: 2*/
+/*eslint no-array-constructor: "error"*/
 
 new Array(0, 1, 2)
 ```
@@ -25,13 +25,13 @@ new Array(0, 1, 2)
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-array-constructor: 2*/
+/*eslint no-array-constructor: "error"*/
 
 Array(500)
 ```
 
 ```js
-/*eslint no-array-constructor: 2*/
+/*eslint no-array-constructor: "error"*/
 
 new Array(someOtherArray.length)
 ```

--- a/docs/rules/no-arrow-condition.md
+++ b/docs/rules/no-arrow-condition.md
@@ -29,7 +29,7 @@ var x = a <= 1 ? 2 : 3
 The following patterns are considered warnings:
 
 ```js
-/*eslint no-arrow-condition: 2*/
+/*eslint no-arrow-condition: "error"*/
 /*eslint-env es6*/
 
 if (a => 1) {}

--- a/docs/rules/no-bitwise.md
+++ b/docs/rules/no-bitwise.md
@@ -13,7 +13,7 @@ This rule is aimed at catching typos that end up as bitwise operators, but are m
 The following patterns are considered problems:
 
 ```js
-/*eslint no-bitwise: 2*/
+/*eslint no-bitwise: "error"*/
 
 var x = y | z;
 
@@ -45,7 +45,7 @@ x >>>= y;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-bitwise: 2*/
+/*eslint no-bitwise: "error"*/
 
 var x = y || z;
 
@@ -65,7 +65,7 @@ This rule supports the following options:
 `allow`: The list of bitwise operators to be used as exceptions to the rule. For example:
 
 ```js
-/*eslint no-bitwise: [2, { allow: ["~"] }] */
+/*eslint no-bitwise: ["error", { allow: ["~"] }] */
 
 ~[1,2,3].indexOf(1) === -1;
 ```
@@ -73,7 +73,7 @@ This rule supports the following options:
 `int32Hint`: Allows the use of bitwise OR in `|0` pattern for type casting:
 
 ```js
-/*eslint no-bitwise: [2, { int32Hint: true }] */
+/*eslint no-bitwise: ["error", { int32Hint: true }] */
 
 var b = a|0;
 ```

--- a/docs/rules/no-caller.md
+++ b/docs/rules/no-caller.md
@@ -15,7 +15,7 @@ This rule is aimed at discouraging the use of deprecated and sub-optimal code, b
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-caller: 2*/
+/*eslint no-caller: "error"*/
 
 function foo(n) {
     if (n <= 0) {
@@ -33,7 +33,7 @@ function foo(n) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-caller: 2*/
+/*eslint no-caller: "error"*/
 
 function foo(n) {
     if (n <= 0) {

--- a/docs/rules/no-case-declarations.md
+++ b/docs/rules/no-case-declarations.md
@@ -15,7 +15,7 @@ This rule aims to prevent access to uninitialized lexical bindings as well as ac
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-case-declarations: 2*/
+/*eslint no-case-declarations: "error"*/
 /*eslint-env es6*/
 
 switch (foo) {
@@ -36,7 +36,7 @@ switch (foo) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-case-declarations: 2*/
+/*eslint no-case-declarations: "error"*/
 /*eslint-env es6*/
 
 switch (foo) {

--- a/docs/rules/no-catch-shadow.md
+++ b/docs/rules/no-catch-shadow.md
@@ -21,7 +21,7 @@ This rule is aimed at preventing unexpected behavior in your program that may ar
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-catch-shadow: 2*/
+/*eslint no-catch-shadow: "error"*/
 
 var err = "x";
 
@@ -45,7 +45,7 @@ try {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-catch-shadow: 2*/
+/*eslint no-catch-shadow: "error"*/
 
 var err = "x";
 

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -18,7 +18,7 @@ This rule is aimed to flag modifying variables of class declarations.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-class-assign: 2*/
+/*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
 
 class A { }
@@ -26,7 +26,7 @@ A = 0;
 ```
 
 ```js
-/*eslint no-class-assign: 2*/
+/*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
 
 A = 0;
@@ -34,7 +34,7 @@ class A { }
 ```
 
 ```js
-/*eslint no-class-assign: 2*/
+/*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
 
 class A {
@@ -45,7 +45,7 @@ class A {
 ```
 
 ```js
-/*eslint no-class-assign: 2*/
+/*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
 
 let A = class A {
@@ -59,7 +59,7 @@ let A = class A {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-class-assign: 2*/
+/*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
 
 let A = class A { }
@@ -67,7 +67,7 @@ A = 0; // A is a variable.
 ```
 
 ```js
-/*eslint no-class-assign: 2*/
+/*eslint no-class-assign: "error"*/
 /*eslint-env es6*/
 
 let A = class {

--- a/docs/rules/no-cond-assign.md
+++ b/docs/rules/no-cond-assign.md
@@ -29,7 +29,7 @@ The default `"except-parens"` option disallows assignment expressions unless the
 Examples of **incorrect** code for the default `"except-parens"` option:
 
 ```js
-/*eslint no-cond-assign: 2*/
+/*eslint no-cond-assign: "error"*/
 
 // Unintentional assignment
 var x;
@@ -49,7 +49,7 @@ function setHeight(someNode) {
 Examples of **correct** code for the default `"except-parens"` option:
 
 ```js
-/*eslint no-cond-assign: 2*/
+/*eslint no-cond-assign: "error"*/
 
 // Assignment replaced by comparison
 var x;
@@ -81,7 +81,7 @@ The `"always"` option disallows assignment expressions in the test of a conditio
 Examples of **incorrect** code for the `"always"` option:
 
 ```js
-/*eslint no-cond-assign: [2, "always"]*/
+/*eslint no-cond-assign: ["error", "always"]*/
 
 // Unintentional assignment
 var x;
@@ -117,7 +117,7 @@ function setHeight(someNode) {
 Examples of **correct** code for the `"always"` option:
 
 ```js
-/*eslint no-cond-assign: [2, "always"]*/
+/*eslint no-cond-assign: ["error", "always"]*/
 
 // Assignment replaced by comparison
 var x;

--- a/docs/rules/no-confusing-arrow.md
+++ b/docs/rules/no-confusing-arrow.md
@@ -18,7 +18,7 @@ var x = a <= 1 ? 2 : 3;
 The following patterns are considered warnings:
 
 ```js
-/*eslint no-confusing-arrow: 2*/
+/*eslint no-confusing-arrow: "error"*/
 /*eslint-env es6*/
 
 var x = a => 1 ? 2 : 3;
@@ -29,7 +29,7 @@ var x = (a) => (1 ? 2 : 3);
 The following patterns are not considered warnings:
 
 ```js
-/*eslint no-confusing-arrow: 2*/
+/*eslint no-confusing-arrow: "error"*/
 /*eslint-env es6*/
 
 var x = a => { return 1 ? 2 : 3; };
@@ -43,7 +43,7 @@ This rule accepts a single options argument with the following defaults:
 ```json
 {
     "rules": {
-        "no-confusing-arrow": [2, {"allowParens": false}]
+        "no-confusing-arrow": ["error", {"allowParens": false}]
     }
 }
 ```
@@ -56,7 +56,7 @@ This rule accepts a single options argument with the following defaults:
 When `allowParens` is set to `true` following patterns are no longer considered as warnings:
 
 ```js
-/*eslint no-confusing-arrow: [2, {allowParens: true}]*/
+/*eslint no-confusing-arrow: ["error", {allowParens: true}]*/
 /*eslint-env es6*/
 var x = a => (1 ? 2 : 3);
 var x = (a) => (1 ? 2 : 3);

--- a/docs/rules/no-console.md
+++ b/docs/rules/no-console.md
@@ -15,7 +15,7 @@ This rule is aimed at eliminating unwanted `console` references from your JavaSc
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-console: 2*/
+/*eslint no-console: "error"*/
 
 console.log("Hello world!");
 console.error("Something bad happened.");
@@ -24,7 +24,7 @@ console.error("Something bad happened.");
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-console: 2*/
+/*eslint no-console: "error"*/
 
 // custom console
 Console.log("Hello world!");
@@ -37,7 +37,7 @@ This rule supports the following options:
 `allow`: The list of console operations to be used as exceptions to the rule. For example:
 
 ```js
-/*eslint no-console: [2, { allow: ["warn", "error"] }] */
+/*eslint no-console: ["error", { allow: ["warn", "error"] }] */
 
 console.log("this will be considered a problem");
 console.warn("this will not be considered a problem");

--- a/docs/rules/no-const-assign.md
+++ b/docs/rules/no-const-assign.md
@@ -12,7 +12,7 @@ This rule is aimed to flag modifying variables that are declared using `const` k
 The following patterns are considered problems:
 
 ```js
-/*eslint no-const-assign: 2*/
+/*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
 
 const a = 0;
@@ -20,7 +20,7 @@ a = 1;
 ```
 
 ```js
-/*eslint no-const-assign: 2*/
+/*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
 
 const a = 0;
@@ -28,7 +28,7 @@ a += 1;
 ```
 
 ```js
-/*eslint no-const-assign: 2*/
+/*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
 
 const a = 0;
@@ -38,7 +38,7 @@ const a = 0;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-const-assign: 2*/
+/*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
 
 const a = 0;
@@ -46,7 +46,7 @@ console.log(a);
 ```
 
 ```js
-/*eslint no-const-assign: 2*/
+/*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
 
 for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.
@@ -55,7 +55,7 @@ for (const a in [1, 2, 3]) { // `a` is re-defined (not modified) on each loop st
 ```
 
 ```js
-/*eslint no-const-assign: 2*/
+/*eslint no-const-assign: "error"*/
 /*eslint-env es6*/
 
 for (const a of [1, 2, 3]) { // `a` is re-defined (not modified) on each loop step.

--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -20,7 +20,7 @@ The rule is aimed at preventing a constant expression in the test of:
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 if (true) {
     doSomething();
@@ -28,13 +28,13 @@ if (true) {
 ```
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 var result = 0 ? a : b;
 ```
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 while (-2) {
     doSomething();
@@ -42,7 +42,7 @@ while (-2) {
 ```
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 for (;true;) {
     doSomething();
@@ -50,7 +50,7 @@ for (;true;) {
 ```
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 do{
     something();
@@ -60,7 +60,7 @@ do{
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 if (x === 0) {
     doSomething();
@@ -68,7 +68,7 @@ if (x === 0) {
 ```
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 do {
     something();
@@ -76,7 +76,7 @@ do {
 ```
 
 ```js
-/*eslint no-constant-condition: 2*/
+/*eslint no-constant-condition: "error"*/
 
 for (;;) {
     something();

--- a/docs/rules/no-continue.md
+++ b/docs/rules/no-continue.md
@@ -23,7 +23,7 @@ As such it warns whenever it sees `continue` statement.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-continue: 2*/
+/*eslint no-continue: "error"*/
 
 var sum = 0,
     i;
@@ -38,7 +38,7 @@ for(i = 0; i < 10; i++) {
 ```
 
 ```js
-/*eslint no-continue: 2*/
+/*eslint no-continue: "error"*/
 
 var sum = 0,
     i;
@@ -55,7 +55,7 @@ labeledLoop: for(i = 0; i < 10; i++) {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-continue: 2*/
+/*eslint no-continue: "error"*/
 
 var sum = 0,
     i;

--- a/docs/rules/no-control-regex.md
+++ b/docs/rules/no-control-regex.md
@@ -10,7 +10,7 @@ This rule is aimed at ensuring all regular expressions don't use control charact
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-control-regex: 2*/
+/*eslint no-control-regex: "error"*/
 
 var pattern1 = /\\x1f/;
 var pattern2 = new RegExp("\x1f");
@@ -19,7 +19,7 @@ var pattern2 = new RegExp("\x1f");
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-control-regex: 2*/
+/*eslint no-control-regex: "error"*/
 
 var pattern1 = /\\x20/;
 var pattern2 = new RegExp("\x20");

--- a/docs/rules/no-delete-var.md
+++ b/docs/rules/no-delete-var.md
@@ -9,7 +9,7 @@ This rule prevents the use of `delete` operator on variables.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-delete-var: 2*/
+/*eslint no-delete-var: "error"*/
 
 var x;
 delete x;

--- a/docs/rules/no-div-regex.md
+++ b/docs/rules/no-div-regex.md
@@ -13,7 +13,7 @@ This is used to disambiguate the division operator to not confuse users.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-div-regex: 2*/
+/*eslint no-div-regex: "error"*/
 
 function bar() { return /=foo/; }
 ```
@@ -21,7 +21,7 @@ function bar() { return /=foo/; }
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-div-regex: 2*/
+/*eslint no-div-regex: "error"*/
 
 function bar() { return /\=foo/; }
 ```

--- a/docs/rules/no-dupe-args.md
+++ b/docs/rules/no-dupe-args.md
@@ -10,7 +10,7 @@ This rule prevents duplicate parameter names in a function.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-dupe-args: 2*/
+/*eslint no-dupe-args: "error"*/
 
 function foo(a, b, a) {
     console.log("which a is it?", a);
@@ -20,7 +20,7 @@ function foo(a, b, a) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-dupe-args: 2*/
+/*eslint no-dupe-args: "error"*/
 
 function foo(a, b, c) {
     console.log(a, b, c);

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -22,7 +22,7 @@ This rule is aimed to flag the use of duplicate names in class members.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-dupe-class-members: 2*/
+/*eslint no-dupe-class-members: "error"*/
 /*eslint-env es6*/
 
 class Foo {
@@ -44,7 +44,7 @@ class Foo {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-dupe-class-members: 2*/
+/*eslint no-dupe-class-members: "error"*/
 /*eslint-env es6*/
 
 class Foo {

--- a/docs/rules/no-dupe-keys.md
+++ b/docs/rules/no-dupe-keys.md
@@ -16,7 +16,7 @@ This rule is aimed at preventing possible errors and unexpected behavior that mi
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-dupe-keys: 2*/
+/*eslint no-dupe-keys: "error"*/
 
 var foo = {
     bar: "baz",
@@ -37,7 +37,7 @@ var foo = {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-dupe-keys: 2*/
+/*eslint no-dupe-keys: "error"*/
 
 var foo = {
     bar: "baz",

--- a/docs/rules/no-duplicate-case.md
+++ b/docs/rules/no-duplicate-case.md
@@ -9,7 +9,7 @@ This rule is aimed at eliminating duplicate case labels in switch statements
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-duplicate-case: 2*/
+/*eslint no-duplicate-case: "error"*/
 
 var a = 1,
     one = 1;
@@ -51,7 +51,7 @@ switch (a) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-duplicate-case: 2*/
+/*eslint no-duplicate-case: "error"*/
 
 var a = 1,
     one = 1;

--- a/docs/rules/no-duplicate-imports.md
+++ b/docs/rules/no-duplicate-imports.md
@@ -17,7 +17,7 @@ This inspection reports any duplicated module in an import statement.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-duplicate-imports: 2*/
+/*eslint no-duplicate-imports: "error"*/
 
 import { merge } from 'module';
 import path from 'another-module';
@@ -31,7 +31,7 @@ import _, { find } from 'module';
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-duplicate-imports: 2*/
+/*eslint no-duplicate-imports: "error"*/
 
 import { merge, find } from 'module';
 import path from 'another-module';
@@ -44,7 +44,7 @@ This rule takes one optional argument, an object with a single key, `includeExpo
 With this option set to `true`, the following patterns are considered problems:
 
 ```js
-/*eslint no-duplicate-imports: [2, { includeExports: true }]*/
+/*eslint no-duplicate-imports: ["error", { includeExports: true }]*/
 
 import { merge } from 'module';
 import path from 'another-module';
@@ -61,7 +61,7 @@ export { find as lodashFind } from 'module';
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-duplicate-imports: [2, { includeExports: true }]*/
+/*eslint no-duplicate-imports: ["error", { includeExports: true }]*/
 
 import { merge, find } from 'module';
 

--- a/docs/rules/no-else-return.md
+++ b/docs/rules/no-else-return.md
@@ -19,7 +19,7 @@ This rule is aimed at highlighting an unnecessary block of code following an `if
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-else-return: 2*/
+/*eslint no-else-return: "error"*/
 
 function foo() {
     if (x) {
@@ -66,7 +66,7 @@ function foo() {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-else-return: 2*/
+/*eslint no-else-return: "error"*/
 
 function foo() {
     if (x) {

--- a/docs/rules/no-empty-character-class.md
+++ b/docs/rules/no-empty-character-class.md
@@ -13,7 +13,7 @@ This rule is aimed at highlighting possible typos and unexpected behavior in reg
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-empty-character-class: 2*/
+/*eslint no-empty-character-class: "error"*/
 
 var foo = /^abc[]/;
 
@@ -25,7 +25,7 @@ bar.match(/^abc[]/);
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-empty-character-class: 2*/
+/*eslint no-empty-character-class: "error"*/
 
 var foo = /^abc/;
 

--- a/docs/rules/no-empty-function.md
+++ b/docs/rules/no-empty-function.md
@@ -25,7 +25,7 @@ A function will not be considered a problem if it contains a comment.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-empty-function: 2*/
+/*eslint no-empty-function: "error"*/
 
 function foo() {}
 
@@ -75,7 +75,7 @@ class A {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-empty-function: 2*/
+/*eslint no-empty-function: "error"*/
 
 function foo() {
     // do nothing.
@@ -166,7 +166,7 @@ class A {
 
 ```json
 {
-    "no-empty-function": [2, {"allow": []}]
+    "no-empty-function": ["error", {"allow": []}]
 }
 ```
 
@@ -185,7 +185,7 @@ This rule has an option to allow empty of specific kind's functions.
 The following patterns are not considered problems when configured with `{"allow": ["functions"]}`:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["functions"]}]*/
+/*eslint no-empty-function: ["error", {"allow": ["functions"]}]*/
 
 function foo() {}
 
@@ -199,7 +199,7 @@ var obj = {
 The following patterns are not considered problems when configured with `{"allow": ["arrowFunctions"]}`:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["arrowFunctions"]}]*/
+/*eslint no-empty-function: ["error", {"allow": ["arrowFunctions"]}]*/
 
 var foo = () => {};
 ```
@@ -207,7 +207,7 @@ var foo = () => {};
 The following patterns are not considered problems when configured with `{"allow": ["generatorFunctions"]}`:
 
 ```js
-/*eslint no-empty-function: [2, {"allow": ["generatorFunctions"]}]*/
+/*eslint no-empty-function: ["error", {"allow": ["generatorFunctions"]}]*/
 
 function* foo() {}
 

--- a/docs/rules/no-empty-label.md
+++ b/docs/rules/no-empty-label.md
@@ -12,7 +12,7 @@ This error occurs when a label is used to mark a statement that is not an iterat
 The following patterns are considered problems:
 
 ```js
-/*eslint no-empty-label: 2*/
+/*eslint no-empty-label: "error"*/
 
 labeled:
 var x = 10;
@@ -21,7 +21,7 @@ var x = 10;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-empty-label: 2*/
+/*eslint no-empty-label: "error"*/
 
 labeled:
 for (var i=10; i; i--) {

--- a/docs/rules/no-empty-pattern.md
+++ b/docs/rules/no-empty-pattern.md
@@ -30,7 +30,7 @@ This rule aims to flag any empty patterns in destructured objects and arrays, an
 The following patterns are considered problems:
 
 ```js
-/*eslint no-empty-pattern: 2*/
+/*eslint no-empty-pattern: "error"*/
 
 var {} = foo;
 var [] = foo;
@@ -45,7 +45,7 @@ function foo({a: []}) {}
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-empty-pattern: 2*/
+/*eslint no-empty-pattern: "error"*/
 
 var {a = {}} = foo;
 var {a = []} = foo;

--- a/docs/rules/no-empty.md
+++ b/docs/rules/no-empty.md
@@ -9,7 +9,7 @@ This rule is aimed at eliminating empty block statements. A block will not be co
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-empty: 2*/
+/*eslint no-empty: "error"*/
 
 if (foo) {
 }
@@ -32,7 +32,7 @@ try {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-empty: 2*/
+/*eslint no-empty: "error"*/
 
 if (foo) {
     // empty

--- a/docs/rules/no-eq-null.md
+++ b/docs/rules/no-eq-null.md
@@ -15,7 +15,7 @@ The `no-eq-null` rule aims reduce potential bug and unwanted behavior by ensurin
 The following patterns are considered problems:
 
 ```js
-/*eslint no-eq-null: 2*/
+/*eslint no-eq-null: "error"*/
 
 if (foo == null) {
   bar();
@@ -29,7 +29,7 @@ while (qux != null) {
 The following patterns are considered okay:
 
 ```js
-/*eslint no-eq-null: 2*/
+/*eslint no-eq-null: "error"*/
 
 if (foo === null) {
   bar();

--- a/docs/rules/no-eval.md
+++ b/docs/rules/no-eval.md
@@ -15,7 +15,7 @@ This rule is aimed at preventing potentially dangerous, unnecessary, and slow co
 The following patterns are considered problems:
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 
 var obj = { x: "foo" },
     key = "x",
@@ -31,14 +31,14 @@ this.eval("var a = 0");
 ```
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 /*eslint-env browser*/
 
 window.eval("var a = 0");
 ```
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 /*eslint-env node*/
 
 global.eval("var a = 0");
@@ -47,7 +47,7 @@ global.eval("var a = 0");
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 
 var obj = { x: "foo" },
     key = "x",
@@ -71,14 +71,14 @@ Indirect calls to `eval` are less dangerous than direct calls to `eval` because 
 
 ```js
 {
-    "no-eval": [2, {"allowIndirect": true}] // default is false
+    "no-eval": ["error", {"allowIndirect": true}] // default is false
 }
 ```
 
 With this option the following patterns are considered problems:
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 
 var obj = { x: "foo" },
     key = "x",
@@ -88,7 +88,7 @@ var obj = { x: "foo" },
 With this option the following patterns are not considered problems:
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 
 (0, eval)("var a = 0");
 
@@ -99,14 +99,14 @@ this.eval("var a = 0");
 ```
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 /*eslint-env browser*/
 
 window.eval("var a = 0");
 ```
 
 ```js
-/*eslint no-eval: 2*/
+/*eslint no-eval: "error"*/
 /*eslint-env node*/
 
 global.eval("var a = 0");

--- a/docs/rules/no-ex-assign.md
+++ b/docs/rules/no-ex-assign.md
@@ -20,7 +20,7 @@ This rule's purpose is to enforce convention. Assigning a value to the exception
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-ex-assign: 2*/
+/*eslint no-ex-assign: "error"*/
 
 try {
     // code
@@ -32,7 +32,7 @@ try {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-ex-assign: 2*/
+/*eslint no-ex-assign: "error"*/
 
 try {
     // code

--- a/docs/rules/no-extend-native.md
+++ b/docs/rules/no-extend-native.md
@@ -43,7 +43,7 @@ This rule accepts an `exceptions` option, which can be used to specify a list of
 ```json
 {
     "rules": {
-        "no-extend-native": [2, {"exceptions": ["Object"]}]
+        "no-extend-native": ["error", {"exceptions": ["Object"]}]
     }
 }
 ```

--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -34,7 +34,7 @@ This rule is aimed at avoiding the unnecessary use of `bind()` and as such will 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-extra-bind: 2*/
+/*eslint no-extra-bind: "error"*/
 /*eslint-env es6*/
 
 var x = function () {
@@ -65,7 +65,7 @@ var x = function () {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-extra-bind: 2*/
+/*eslint no-extra-bind: "error"*/
 
 var x = function () {
     this.foo();

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -23,7 +23,7 @@ This rule aims to eliminate the use of Boolean casts in an already Boolean conte
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-extra-boolean-cast: 2*/
+/*eslint no-extra-boolean-cast: "error"*/
 
 var foo = !!!bar;
 
@@ -57,7 +57,7 @@ for (; !!foo; ) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-extra-boolean-cast: 2*/
+/*eslint no-extra-boolean-cast: "error"*/
 
 var foo = !!bar;
 var foo = Boolean(bar);

--- a/docs/rules/no-extra-label.md
+++ b/docs/rules/no-extra-label.md
@@ -18,7 +18,7 @@ This rule is aimed at eliminating unnecessary labels.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-extra-label: 2*/
+/*eslint no-extra-label: "error"*/
 
 A: while (a) {
     break A;
@@ -37,7 +37,7 @@ C: switch (a) {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-extra-label: 2*/
+/*eslint no-extra-label: "error"*/
 
 while (a) {
     break;

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -23,7 +23,7 @@ The second one is an object for more fine-grained configuration when the first o
 Examples of **incorrect** code for the default `"all"` option:
 
 ```js
-/*eslint no-extra-parens: 2*/
+/*eslint no-extra-parens: "error"*/
 
 a = (b * c);
 
@@ -37,7 +37,7 @@ typeof (a);
 Examples of **correct** code for the default `"all"` option:
 
 ```js
-/*eslint no-extra-parens: 2*/
+/*eslint no-extra-parens: "error"*/
 
 (0).toString();
 
@@ -55,7 +55,7 @@ When setting the first option as `"all"`, an additional option can be added to a
 Examples of **correct** code for the `"all"` and `{ "conditionalAssign": true }` options:
 
 ```js
-/*eslint no-extra-parens: [2, "all", { "conditionalAssign": false }]*/
+/*eslint no-extra-parens: ["error", "all", { "conditionalAssign": false }]*/
 
 while ((foo = bar())) {}
 
@@ -71,7 +71,7 @@ for (;(a = b););
 Examples of **incorrect** code for the `"functions"` option:
 
 ```js
-/*eslint no-extra-parens: [2, "functions"]*/
+/*eslint no-extra-parens: ["error", "functions"]*/
 
 ((function foo() {}))();
 
@@ -81,7 +81,7 @@ var y = (function () {return 1;});
 Examples of **correct** code for the `"functions"` option:
 
 ```js
-/*eslint no-extra-parens: [2, "functions"]*/
+/*eslint no-extra-parens: ["error", "functions"]*/
 
 (0).toString();
 

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -11,7 +11,7 @@ This rule is aimed at eliminating extra unnecessary semicolons. While not techni
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-extra-semi: 2*/
+/*eslint no-extra-semi: "error"*/
 
 var x = 5;;
 
@@ -24,7 +24,7 @@ function foo() {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-extra-semi: 2*/
+/*eslint no-extra-semi: "error"*/
 
 var x = 5;
 

--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -65,7 +65,7 @@ This rule is aimed at eliminating unintentional fallthrough of one case to the o
 The following patterns are considered problems:
 
 ```js
-/*eslint no-fallthrough: 2*/
+/*eslint no-fallthrough: "error"*/
 
 switch(foo) {
     case 1:
@@ -79,7 +79,7 @@ switch(foo) {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-fallthrough: 2*/
+/*eslint no-fallthrough: "error"*/
 
 switch(foo) {
     case 1:

--- a/docs/rules/no-floating-decimal.md
+++ b/docs/rules/no-floating-decimal.md
@@ -17,7 +17,7 @@ This rule is aimed at eliminating floating decimal points and will warn whenever
 The following patterns are considered problems:
 
 ```js
-/*eslint no-floating-decimal: 2*/
+/*eslint no-floating-decimal: "error"*/
 
 var num = .5;
 var num = 2.;
@@ -27,7 +27,7 @@ var num = -.7;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-floating-decimal: 2*/
+/*eslint no-floating-decimal: "error"*/
 
 var num = 0.5;
 var num = 2.0;

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -14,7 +14,7 @@ This rule is aimed at flagging probable mistakes and issues in the form of overw
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-func-assign: 2*/
+/*eslint no-func-assign: "error"*/
 
 function foo() {}
 foo = bar;
@@ -27,7 +27,7 @@ function foo() {
 Examples of **incorrect** code for this rule, unlike the corresponding rule in JSHint:
 
 ```js
-/*eslint no-func-assign: 2*/
+/*eslint no-func-assign: "error"*/
 
 foo = bar;
 function foo() {}
@@ -36,7 +36,7 @@ function foo() {}
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-func-assign: 2*/
+/*eslint no-func-assign: "error"*/
 
 var foo = function () {}
 foo = bar;

--- a/docs/rules/no-implicit-coercion.md
+++ b/docs/rules/no-implicit-coercion.md
@@ -58,7 +58,7 @@ Note that operator `+` in `allow` list would allow `+foo` (number coercion) as w
 The following patterns are considered problems:
 
 ```js
-/*eslint no-implicit-coercion: 2*/
+/*eslint no-implicit-coercion: "error"*/
 
 var b = !!foo;
 var b = ~foo.indexOf(".");
@@ -69,7 +69,7 @@ var b = ~foo.indexOf(".");
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-implicit-coercion: 2*/
+/*eslint no-implicit-coercion: "error"*/
 
 var b = Boolean(foo);
 var b = foo.indexOf(".") !== -1;
@@ -82,7 +82,7 @@ var n = ~foo; // This is a just binary negating.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-implicit-coercion: 2*/
+/*eslint no-implicit-coercion: "error"*/
 
 var n = +foo;
 var n = 1 * foo;
@@ -91,7 +91,7 @@ var n = 1 * foo;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-implicit-coercion: 2*/
+/*eslint no-implicit-coercion: "error"*/
 
 var b = Number(foo);
 var b = parseFloat(foo);
@@ -103,7 +103,7 @@ var b = parseInt(foo, 10);
 The following patterns are considered problems:
 
 ```js
-/*eslint no-implicit-coercion: 2*/
+/*eslint no-implicit-coercion: "error"*/
 
 var n = "" + foo;
 
@@ -113,7 +113,7 @@ foo += "";
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-implicit-coercion: 2*/
+/*eslint no-implicit-coercion: "error"*/
 
 var b = String(foo);
 ```

--- a/docs/rules/no-implicit-globals.md
+++ b/docs/rules/no-implicit-globals.md
@@ -9,7 +9,7 @@ This rule disallows `var` and named `function` declarations at the top-level scr
 The following patterns are considered problems:
 
 ```js
-/*eslint no-implicit-globals: 2*/
+/*eslint no-implicit-globals: "error"*/
 
 var foo = 1;
 
@@ -19,7 +19,7 @@ function bar() {}
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-implicit-globals: 2*/
+/*eslint no-implicit-globals: "error"*/
 
 // explicitly set on window
 window.foo = 1;

--- a/docs/rules/no-implied-eval.md
+++ b/docs/rules/no-implied-eval.md
@@ -27,7 +27,7 @@ This rule aims to eliminate implied `eval()` through the use of `setTimeout()`, 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-implied-eval: 2*/
+/*eslint no-implied-eval: "error"*/
 
 setTimeout("alert('Hi!');", 100);
 
@@ -43,7 +43,7 @@ window.setInterval("foo = bar", 10);
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-implied-eval: 2*/
+/*eslint no-implied-eval: "error"*/
 
 setTimeout(function() {
     alert("Hi!");

--- a/docs/rules/no-inline-comments.md
+++ b/docs/rules/no-inline-comments.md
@@ -14,7 +14,7 @@ This rule takes no arguments.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-inline-comments: 2*/
+/*eslint no-inline-comments: "error"*/
 
 var a = 1; // declaring a to 1
 
@@ -31,7 +31,7 @@ var c = 3; /* A block comment after code */
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-inline-comments: 2*/
+/*eslint no-inline-comments: "error"*/
 
 // This is a comment above a line of code
 var foo = 5;

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -73,7 +73,7 @@ You can set the option in configuration like this:
 Examples of **incorrect** code for the default `"functions"` option:
 
 ```js
-/*eslint no-inner-declarations: 2*/
+/*eslint no-inner-declarations: "error"*/
 
 if (test) {
     function doSomething() { }
@@ -89,7 +89,7 @@ function doSomethingElse() {
 Examples of **correct** code for the default `"functions"` option:
 
 ```js
-/*eslint no-inner-declarations: 2*/
+/*eslint no-inner-declarations: "error"*/
 
 function doSomething() { }
 
@@ -112,7 +112,7 @@ if (test) {
 Examples of **incorrect** code for the `"both"` option:
 
 ```js
-/*eslint no-inner-declarations: [2, "both"]*/
+/*eslint no-inner-declarations: ["error", "both"]*/
 
 if (test) {
     var foo = 42;
@@ -128,7 +128,7 @@ function doAnotherThing() {
 Examples of **correct** code for the `"both"` option:
 
 ```js
-/*eslint no-inner-declarations: 2*/
+/*eslint no-inner-declarations: "error"*/
 /*eslint-env es6*/
 
 var bar = 42;

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -7,7 +7,7 @@ This rule validates string arguments passed to the `RegExp` constructor.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-invalid-regexp: 2*/
+/*eslint no-invalid-regexp: "error"*/
 
 RegExp('[')
 
@@ -19,7 +19,7 @@ new RegExp('\\')
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-invalid-regexp: 2*/
+/*eslint no-invalid-regexp: "error"*/
 
 RegExp('.')
 
@@ -42,7 +42,7 @@ If you want to allow additional constructor flags for any reason, you can specif
 This takes in an array of flags. With this option, the following patterns aren't considered problems:
 
 ```js
-/*eslint no-invalid-regexp: [2, {"allowConstructorFlags": ["u", "y"]}]*/
+/*eslint no-invalid-regexp: ["error", {"allowConstructorFlags": ["u", "y"]}]*/
 
 new RegExp('.', 'y')
 

--- a/docs/rules/no-invalid-this.md
+++ b/docs/rules/no-invalid-this.md
@@ -33,7 +33,7 @@ This rule warns below **only** under the strict mode.
 Please note your code in ES2015 Modules/Classes is always the strict mode.
 
 ```js
-/*eslint no-invalid-this: 2*/
+/*eslint no-invalid-this: "error"*/
 /*eslint-env es6*/
 
 this.a = 0;
@@ -83,7 +83,7 @@ foo.forEach(function() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-invalid-this: 2*/
+/*eslint no-invalid-this: "error"*/
 /*eslint-env es6*/
 
 function Foo() {

--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -46,7 +46,7 @@ With this rule enabled the following characters will cause warnings outside of s
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-irregular-whitespace: 2*/
+/*eslint no-irregular-whitespace: "error"*/
 
 function thing() /*<NBSP>*/{
   return 'test';
@@ -76,7 +76,7 @@ function thing() {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-irregular-whitespace: 2*/
+/*eslint no-irregular-whitespace: "error"*/
 
 function thing() {
   return ' <NBSP>thing';
@@ -106,7 +106,7 @@ The `no-irregular-whitespace` rule has no required option and has one optional o
 For example, to specify that you want to skip checking for irregular whitespace within comments, use the following configuration:
 
 ```json
-"no-irregular-whitespace": [2, { "skipComments": true }]
+"no-irregular-whitespace": ["error", { "skipComments": true }]
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-iterator.md
+++ b/docs/rules/no-iterator.md
@@ -17,7 +17,7 @@ This rule is aimed at preventing errors that may arise from using the `__iterato
 The following patterns are considered problems:
 
 ```js
-/*eslint no-iterator: 2*/
+/*eslint no-iterator: "error"*/
 
 Foo.prototype.__iterator__ = function() {
     return new FooIterator(this);
@@ -32,7 +32,7 @@ foo["__iterator__"] = function () {};
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-iterator: 2*/
+/*eslint no-iterator: "error"*/
 
 var __iterator__ = foo; // Not using the `__iterator__` property.
 ```

--- a/docs/rules/no-label-var.md
+++ b/docs/rules/no-label-var.md
@@ -7,7 +7,7 @@ This rule aims to create clearer code by disallowing the bad practice of creatin
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-label-var: 2*/
+/*eslint no-label-var: "error"*/
 
 var x = foo;
 function bar() {
@@ -21,7 +21,7 @@ x:
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-label-var: 2*/
+/*eslint no-label-var: "error"*/
 
 // The variable that has the same name as the label is not in scope.
 

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -23,7 +23,7 @@ This rule aims to eliminate the use of labeled statements in JavaScript. It will
 The following patterns are considered problems:
 
 ```js
-/*eslint no-labels: 2*/
+/*eslint no-labels: "error"*/
 
 label:
     while(true) {
@@ -60,7 +60,7 @@ label:
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-labels: 2*/
+/*eslint no-labels: "error"*/
 
 var f = {
     label: "foo"
@@ -79,7 +79,7 @@ while (true) {
 
 ```json
 {
-    "no-labels": [2, {"allowLoop": false, "allowSwitch": false}]
+    "no-labels": ["error", {"allowLoop": false, "allowSwitch": false}]
 }
 ```
 

--- a/docs/rules/no-lone-blocks.md
+++ b/docs/rules/no-lone-blocks.md
@@ -17,7 +17,7 @@ This rule aims to eliminate unnecessary and potentially confusing blocks at the 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-lone-blocks: 2*/
+/*eslint no-lone-blocks: "error"*/
 
 {}
 
@@ -48,7 +48,7 @@ The following patterns are not considered problems:
 
 ```js
 /*eslint-env es6*/
-/*eslint no-lone-blocks: 2*/
+/*eslint no-lone-blocks: "error"*/
 
 while (foo) {
     bar();
@@ -84,7 +84,7 @@ In strict mode, the following will not warn:
 
 ```js
 /*eslint-env es6*/
-/*eslint no-lone-blocks: 2*/
+/*eslint no-lone-blocks: "error"*/
 "use strict";
 
 {

--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -29,7 +29,7 @@ This rule warns when an `if` statement's `else` block contains only another `if`
 The following patterns are considered problems:
 
 ```js
-/*eslint no-lonely-if: 2*/
+/*eslint no-lonely-if: "error"*/
 
 if (condition) {
     // ...
@@ -53,7 +53,7 @@ if (condition) {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-lonely-if: 2*/
+/*eslint no-lonely-if: "error"*/
 
 if (condition) {
     // ...

--- a/docs/rules/no-loop-func.md
+++ b/docs/rules/no-loop-func.md
@@ -34,7 +34,7 @@ This error is raised to highlight a piece of code that may not work as you expec
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-loop-func: 2*/
+/*eslint no-loop-func: "error"*/
 /*eslint-env es6*/
 
 for (var i=10; i; i--) {
@@ -62,7 +62,7 @@ for (let i=10; i; i--) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-loop-func: 2*/
+/*eslint no-loop-func: "error"*/
 /*eslint-env es6*/
 
 var a = function() {};

--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -16,14 +16,14 @@ are declared as constants to make their meaning explicit.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-magic-numbers: 2*/
+/*eslint no-magic-numbers: "error"*/
 
 var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * 0.25);
 ```
 
 ```js
-/*eslint no-magic-numbers: 2*/
+/*eslint no-magic-numbers: "error"*/
 
 var data = ['foo', 'bar', 'baz'];
 
@@ -33,7 +33,7 @@ var dataLast = data[2];
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-magic-numbers: 2*/
+/*eslint no-magic-numbers: "error"*/
 
 var TAX = 0.25;
 
@@ -51,7 +51,7 @@ If provided, it must be an `Array`.
 Examples of **correct** code for the sample { "ignore": [1] } option:
 
 ```js
-/*eslint no-magic-numbers: [2, { "ignore": [1] }]*/
+/*eslint no-magic-numbers: ["error", { "ignore": [1] }]*/
 
 var data = ['foo', 'bar', 'baz'];
 var dataLast = data.length && data[data.length - 1];
@@ -64,7 +64,7 @@ A boolean to specify if numbers used as array indexes are considered okay. `fals
 Examples of **correct** code for the { "ignoreArrayIndexes": true } option:
 
 ```js
-/*eslint no-magic-numbers: [2, { "ignoreArrayIndexes": true }]*/
+/*eslint no-magic-numbers: ["error", { "ignoreArrayIndexes": true }]*/
 
 var data = ['foo', 'bar', 'baz'];
 var dataLast = data[2];
@@ -77,7 +77,7 @@ A boolean to specify if we should check for the const keyword in variable declar
 Examples of **incorrect** code for the { "enforceConst": true } option:
 
 ```js
-/*eslint no-magic-numbers: [2, { "enforceConst": true }]*/
+/*eslint no-magic-numbers: ["error", { "enforceConst": true }]*/
 
 var TAX = 0.25;
 
@@ -92,7 +92,7 @@ A boolean to specify if we should detect numbers when setting object properties 
 Examples of **incorrect** code for the { "detectObjects": true } option:
 
 ```js
-/*eslint no-magic-numbers: [2, { "detectObjects": true }]*/
+/*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/
 
 var magic = {
   tax: 0.25
@@ -105,7 +105,7 @@ var dutyFreePrice = 100,
 Examples of **correct** code for the { "detectObjects": true } option:
 
 ```js
-/*eslint no-magic-numbers: [2, { "detectObjects": true }]*/
+/*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/
 
 var TAX = 0.25;
 

--- a/docs/rules/no-mixed-requires.md
+++ b/docs/rules/no-mixed-requires.md
@@ -38,7 +38,7 @@ Configuring this rule with one boolean option `true` is deprecated.
 Examples of **incorrect** code for this rule with the default `{ "grouping": false, "allowCall": false }` options:
 
 ```js
-/*eslint no-mixed-requires: 2*/
+/*eslint no-mixed-requires: "error"*/
 
 var fs = require('fs'),
     i = 0;
@@ -51,7 +51,7 @@ var async = require('async'),
 Examples of **correct** code for this rule with the default `{ "grouping": false, "allowCall": false }` options:
 
 ```js
-/*eslint no-mixed-requires: 2*/
+/*eslint no-mixed-requires: "error"*/
 
 // only require declarations (grouping off)
 var eventEmitter = require('events').EventEmitter,
@@ -74,7 +74,7 @@ var foo = require('foo' + VERSION),
 Examples of **incorrect** code for this rule with the `{ "grouping": true }` option:
 
 ```js
-/*eslint no-mixed-requires: [2, { "grouping": true }]*/
+/*eslint no-mixed-requires: ["error", { "grouping": true }]*/
 
 // invalid because of mixed types "core" and "file"
 var fs = require('fs'),
@@ -90,7 +90,7 @@ var foo = require('foo'),
 Examples of **incorrect** code for this rule with the `{ "allowCall": true }` option:
 
 ```js
-/*eslint no-mixed-requires: [2, { "allowCall": true }]*/
+/*eslint no-mixed-requires: ["error", { "allowCall": true }]*/
 
 var async = require('async'),
     debug = require('diagnostics').someFunction('my-module'), /* allowCall doesn't allow calling any function */
@@ -100,7 +100,7 @@ var async = require('async'),
 Examples of **correct** code for this rule with the `{ "allowCall": true }` option:
 
 ```js
-/*eslint no-mixed-requires: [2, { "allowCall": true }]*/
+/*eslint no-mixed-requires: ["error", { "allowCall": true }]*/
 
 var async = require('async'),
     debug = require('diagnostics')('my-module'),

--- a/docs/rules/no-mixed-spaces-and-tabs.md
+++ b/docs/rules/no-mixed-spaces-and-tabs.md
@@ -15,13 +15,13 @@ This option suppresses warnings about mixed tabs and spaces when the latter are 
 You can enable this option by using the following configuration:
 
 ```json
-"no-mixed-spaces-and-tabs": [2, "smart-tabs"]
+"no-mixed-spaces-and-tabs": ["error", "smart-tabs"]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-mixed-spaces-and-tabs: 2*/
+/*eslint no-mixed-spaces-and-tabs: "error"*/
 
 function add(x, y) {
 // --->..return x + y;
@@ -41,7 +41,7 @@ function main() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-mixed-spaces-and-tabs: 2*/
+/*eslint no-mixed-spaces-and-tabs: "error"*/
 
 function add(x, y) {
 // --->return x + y;
@@ -52,7 +52,7 @@ function add(x, y) {
 When the SmartTabs option is enabled the following does not produce a warning:
 
 ```js
-/*eslint no-mixed-spaces-and-tabs: [2, "smart-tabs"]*/
+/*eslint no-mixed-spaces-and-tabs: ["error", "smart-tabs"]*/
 
 function main() {
 // --->var x = 5,

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -25,7 +25,7 @@ This rule aims to disallow multiple whitespace around logical expressions, condi
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-multi-spaces: 2*/
+/*eslint no-multi-spaces: "error"*/
 
 var a =  1;
 
@@ -41,7 +41,7 @@ a ?  b: c
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-multi-spaces: 2*/
+/*eslint no-multi-spaces: "error"*/
 
 var a = 1;
 
@@ -67,8 +67,8 @@ Only the `Property` node type is ignored by default, because for the [key-spacin
 Examples of **correct** code for the default `"exceptions": { "Property": true }` option:
 
 ```js
-/* eslint no-multi-spaces: 2 */
-/* eslint key-spacing: [2, { align: "value" }] */
+/*eslint no-multi-spaces: "error"*/
+/*eslint key-spacing: ["error", { align: "value" }]*/
 
 var obj = {
     first:  "first",
@@ -79,8 +79,8 @@ var obj = {
 Examples of **incorrect** code for the `"exceptions": { "Property": false }` option:
 
 ```js
-/* eslint no-multi-spaces: [2, { exceptions: { "Property": false } }] */
-/* eslint key-spacing: [2, { align: "value" }] */
+/*eslint no-multi-spaces: ["error", { exceptions: { "Property": false } }]*/
+/*eslint key-spacing: ["error", { align: "value" }]*/
 
 var obj = {
     first:  "first",
@@ -91,7 +91,7 @@ var obj = {
 Examples of **correct** code for the `"exceptions": { "BinaryExpression": true }` option:
 
 ```js
-/* eslint no-multi-spaces: [2, { exceptions: { "BinaryExpression": true } }] */
+/*eslint no-multi-spaces: ["error", { exceptions: { "BinaryExpression": true } }]*/
 
 var a = 1  *  2;
 ```
@@ -99,7 +99,7 @@ var a = 1  *  2;
 Examples of **correct** code for the `"exceptions": { "VariableDeclarator": true }` option:
 
 ```js
-/* eslint no-multi-spaces: [2, { exceptions: { "VariableDeclarator": true } }] */
+/*eslint no-multi-spaces: ["error", { exceptions: { "VariableDeclarator": true } }]*/
 
 var someVar      = 'foo';
 var someOtherVar = 'barBaz';
@@ -108,7 +108,7 @@ var someOtherVar = 'barBaz';
 Examples of **correct** code for the `"exceptions": { "ImportDeclaration": true }` option:
 
 ```js
-/* eslint no-multi-spaces: [2, { exceptions: { "ImportDeclaration": true } }] */
+/*eslint no-multi-spaces: ["error", { exceptions: { "ImportDeclaration": true } }]*/
 
 import mod          from 'mod';
 import someOtherMod from 'some-other-mod';

--- a/docs/rules/no-multi-str.md
+++ b/docs/rules/no-multi-str.md
@@ -16,14 +16,15 @@ This rule is aimed at preventing the use of multiline strings.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-multi-str: 2*/ var x = "Line 1 \
+/*eslint no-multi-str: "error"*/
+var x = "Line 1 \
          Line 2";
 ```
 
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-multi-str: 2*/
+/*eslint no-multi-str: "error"*/
 
 var x = "Line 1\n" +
         "Line 2";

--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -24,13 +24,13 @@ In the following example, the first 2 is the code for an error
 and the second 2 is the maximum number of empty lines:
 
 ```json
-"no-multiple-empty-lines": [2, {"max": 2}]
+"no-multiple-empty-lines": ["error", {"max": 2}]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2}]*/
+/*eslint no-multiple-empty-lines: ["error", {max: 2}]*/
 
 
 var foo = 5;
@@ -45,7 +45,7 @@ var bar = 3;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2}]*/
+/*eslint no-multiple-empty-lines: ["error", {max: 2}]*/
 
 
 var foo = 5;
@@ -59,13 +59,13 @@ var bar = 3;
 ### maxEOF
 
 ```json
-"no-multiple-empty-lines": [2, {"max": 2, "maxEOF": 1}]
+"no-multiple-empty-lines": ["error", {"max": 2, "maxEOF": 1}]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 1}]*/
+/*eslint no-multiple-empty-lines: ["error", {max: 2, maxEOF: 1}]*/
 
 
 var foo = 5;
@@ -79,7 +79,7 @@ var bar = 3;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2, maxEOF: 1}]*/
+/*eslint no-multiple-empty-lines: ["error", {max: 2, maxEOF: 1}]*/
 
 
 var foo = 5;
@@ -92,13 +92,13 @@ var bar = 3;
 ### maxBOF
 
 ```json
-"no-multiple-empty-lines": [2, {"max": 2, "maxBOF": 0}]
+"no-multiple-empty-lines": ["error", {"max": 2, "maxBOF": 0}]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2, maxBOF: 0}]*/
+/*eslint no-multiple-empty-lines: ["error", {max: 2, maxBOF: 0}]*/
 
 
 var foo = 5;
@@ -112,7 +112,7 @@ var bar = 3;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-multiple-empty-lines: [2, {max: 2, maxBOF: 0}]*/
+/*eslint no-multiple-empty-lines: ["error", {max: 2, maxBOF: 0}]*/
 var foo = 5;
 
 

--- a/docs/rules/no-native-reassign.md
+++ b/docs/rules/no-native-reassign.md
@@ -13,7 +13,7 @@ The native objects reported by this rule are the `builtin` variables from [globa
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-native-reassign: 2*/
+/*eslint no-native-reassign: "error"*/
 
 String = new Object();
 ```
@@ -25,7 +25,7 @@ This rule accepts an `exceptions` option, which can be used to specify a list of
 ```json
 {
     "rules": {
-        "no-native-reassign": [2, {"exceptions": ["Object"]}]
+        "no-native-reassign": ["error", {"exceptions": ["Object"]}]
     }
 }
 ```

--- a/docs/rules/no-negated-condition.md
+++ b/docs/rules/no-negated-condition.md
@@ -31,7 +31,7 @@ The rule is aimed at preventing the use of a negated expression in a condition.
 The following patterns are considered warnings:
 
 ```js
-/*eslint no-negated-condition: 2*/
+/*eslint no-negated-condition: "error"*/
 
 if (!a) {
     doSomething();
@@ -60,7 +60,7 @@ The following patterns are not warnings:
 
 
 ```js
-/*eslint no-negated-condition: 2*/
+/*eslint no-negated-condition: "error"*/
 
 if (!a) {
     doSomething();

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -29,7 +29,7 @@ if(('' + !a) in b) {
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-negated-in-lhs: 2*/
+/*eslint no-negated-in-lhs: "error"*/
 
 if(!a in b) {
     // do something
@@ -39,7 +39,7 @@ if(!a in b) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-negated-in-lhs: 2*/
+/*eslint no-negated-in-lhs: "error"*/
 
 if(!(a in b)) {
     // do something

--- a/docs/rules/no-nested-ternary.md
+++ b/docs/rules/no-nested-ternary.md
@@ -13,7 +13,7 @@ The `no-nested-ternary` rule aims to increase the clarity and readability of cod
 The following patterns are considered problems:
 
 ```js
-/*eslint no-nested-ternary: 2*/
+/*eslint no-nested-ternary: "error"*/
 
 var thing = foo ? bar : baz === qux ? quxx : foobar;
 
@@ -23,7 +23,7 @@ foo ? baz === qux ? quxx() : foobar() : bar();
 The following patterns are considered okay and could be used alternatively:
 
 ```js
-/*eslint no-nested-ternary: 2*/
+/*eslint no-nested-ternary: "error"*/
 
 var thing;
 

--- a/docs/rules/no-new-func.md
+++ b/docs/rules/no-new-func.md
@@ -15,7 +15,7 @@ This error is raised to highlight the use of a bad practice. By passing a string
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-new-func: 2*/
+/*eslint no-new-func: "error"*/
 
 var x = new Function("a", "b", "return a + b");
 var x = Function("a", "b", "return a + b");
@@ -24,7 +24,7 @@ var x = Function("a", "b", "return a + b");
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-new-func: 2*/
+/*eslint no-new-func: "error"*/
 
 var x = function (a, b) {
     return a + b;

--- a/docs/rules/no-new-object.md
+++ b/docs/rules/no-new-object.md
@@ -23,7 +23,7 @@ This rule aims to eliminate use of the `Object` constructor. As such, it warns w
 The following patterns are considered problems:
 
 ```js
-/*eslint no-new-object: 2*/
+/*eslint no-new-object: "error"*/
 
 var myObject = new Object();
 
@@ -33,7 +33,7 @@ var myObject = new Object;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-new-object: 2*/
+/*eslint no-new-object: "error"*/
 
 var myObject = new CustomObject();
 

--- a/docs/rules/no-new-require.md
+++ b/docs/rules/no-new-require.md
@@ -27,7 +27,7 @@ This rule aims to eliminate use of the `new require` expression.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-new-require: 2*/
+/*eslint no-new-require: "error"*/
 
 var appHeader = new require('app-header');
 ```
@@ -35,7 +35,7 @@ var appHeader = new require('app-header');
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-new-require: 2*/
+/*eslint no-new-require: "error"*/
 
 var AppHeader = require('app-header');
 var appHeader = new AppHeader();

--- a/docs/rules/no-new-symbol.md
+++ b/docs/rules/no-new-symbol.md
@@ -15,7 +15,7 @@ This rule is aimed at preventing the accidental calling of `Symbol` with the `ne
 The following patterns are considered problems:
 
 ```js
-/*eslint no-new-symbol: 2*/
+/*eslint no-new-symbol: "error"*/
 /*eslint-env es6*/
 
 var foo = new Symbol('foo');
@@ -24,7 +24,7 @@ var foo = new Symbol('foo');
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-new-symbol: 2*/
+/*eslint no-new-symbol: "error"*/
 /*eslint-env es6*/
 
 var foo = Symbol('foo');

--- a/docs/rules/no-new-wrappers.md
+++ b/docs/rules/no-new-wrappers.md
@@ -42,7 +42,7 @@ This rule aims to eliminate the use of `String`, `Number`, and `Boolean` with th
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-new-wrappers: 2*/
+/*eslint no-new-wrappers: "error"*/
 
 var stringObject = new String("Hello world");
 var numberObject = new Number(33);
@@ -56,7 +56,7 @@ var booleanObject = new Boolean;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-new-wrappers: 2*/
+/*eslint no-new-wrappers: "error"*/
 
 var text = String(someValue);
 var num = Number(someValue);

--- a/docs/rules/no-new.md
+++ b/docs/rules/no-new.md
@@ -21,7 +21,7 @@ This rule is aimed at maintaining consistency and convention by disallowing cons
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-new: 2*/
+/*eslint no-new: "error"*/
 
 new Thing();
 ```
@@ -29,7 +29,7 @@ new Thing();
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-new: 2*/
+/*eslint no-new: "error"*/
 
 var thing = new Thing();
 

--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -13,7 +13,7 @@ This rule is aimed at preventing the accidental calling of global objects as fun
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-obj-calls: 2*/
+/*eslint no-obj-calls: "error"*/
 
 var x = Math();
 var y = JSON();
@@ -22,7 +22,7 @@ var y = JSON();
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-obj-calls: 2*/
+/*eslint no-obj-calls: "error"*/
 
 var x = math();
 var y = json();

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -13,7 +13,7 @@ The rule is aimed at preventing the use of a deprecated JavaScript feature, the 
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-octal-escape: 2*/
+/*eslint no-octal-escape: "error"*/
 
 var foo = "Copyright \251";
 ```
@@ -21,7 +21,7 @@ var foo = "Copyright \251";
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-octal-escape: 2*/
+/*eslint no-octal-escape: "error"*/
 
 var foo = "Copyright \u00A9";   // unicode
 

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -17,7 +17,7 @@ The rule is aimed at preventing the use of a deprecated JavaScript feature, the 
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-octal: 2*/
+/*eslint no-octal: "error"*/
 
 var num = 071;
 var result = 5 + 07;
@@ -26,7 +26,7 @@ var result = 5 + 07;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-octal: 2*/
+/*eslint no-octal: "error"*/
 
 var num  = "071";
 ```

--- a/docs/rules/no-param-reassign.md
+++ b/docs/rules/no-param-reassign.md
@@ -9,7 +9,7 @@ This rule aims to prevent unintended behavior caused by overwriting function par
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-param-reassign: 2*/
+/*eslint no-param-reassign: "error"*/
 
 function foo(bar) {
     bar = 13;
@@ -23,7 +23,7 @@ function foo(bar) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-param-reassign: 2*/
+/*eslint no-param-reassign: "error"*/
 
 function foo(bar) {
     var baz = bar;
@@ -39,7 +39,7 @@ This rule takes one option, an object, with a property `"props"`. It is `false` 
 Examples of **correct** code for the default `{ "props": false }` option:
 
 ```js
-/*eslint no-param-reassign: [2, { "props": false }]*/
+/*eslint no-param-reassign: ["error", { "props": false }]*/
 
 function foo(bar) {
     bar.prop = "value";
@@ -57,7 +57,7 @@ function foo(bar) {
 Examples of **incorrect** code for the `{ "props": true }` option:
 
 ```js
-/*eslint no-param-reassign: [2, { "props": true }]*/
+/*eslint no-param-reassign: ["error", { "props": true }]*/
 
 function foo(bar) {
     bar.prop = "value";

--- a/docs/rules/no-path-concat.md
+++ b/docs/rules/no-path-concat.md
@@ -29,7 +29,7 @@ This rule aims to prevent string concatenation of directory paths in Node.js
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-path-concat: 2*/
+/*eslint no-path-concat: "error"*/
 
 var fullPath = __dirname + "/foo.js";
 
@@ -40,7 +40,7 @@ var fullPath = __filename + "/foo.js";
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-path-concat: 2*/
+/*eslint no-path-concat: "error"*/
 
 var fullPath = dirname + "/foo.js";
 ```

--- a/docs/rules/no-plusplus.md
+++ b/docs/rules/no-plusplus.md
@@ -41,7 +41,7 @@ This rule, in its default state, does not require any arguments. If you would li
 The following patterns are considered problems:
 
 ```js
-/*eslint no-plusplus: 2*/
+/*eslint no-plusplus: "error"*/
 
 var foo = 0;
 foo++;
@@ -57,7 +57,7 @@ for (i = 0; i < l; i++) {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-plusplus: 2*/
+/*eslint no-plusplus: "error"*/
 
 var foo = 0;
 foo += 1;
@@ -73,7 +73,7 @@ for (i = 0; i < l; i += 1) {
 The following patterns are not considered problems if `allowForLoopAfterthoughts` is set to true:
 
 ```js
-/*eslint no-plusplus: [2, { allowForLoopAfterthoughts: true }]*/
+/*eslint no-plusplus: ["error", { allowForLoopAfterthoughts: true }]*/
 
 for (i = 0; i < l; i++) {
     return;

--- a/docs/rules/no-process-env.md
+++ b/docs/rules/no-process-env.md
@@ -10,7 +10,7 @@ This rule is aimed at discouraging use of `process.env` to avoid global dependen
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-process-env: 2*/
+/*eslint no-process-env: "error"*/
 
 if(process.env.NODE_ENV === "development") {
     //...
@@ -20,7 +20,7 @@ if(process.env.NODE_ENV === "development") {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-process-env: 2*/
+/*eslint no-process-env: "error"*/
 
 var config = require("./config");
 

--- a/docs/rules/no-process-exit.md
+++ b/docs/rules/no-process-exit.md
@@ -26,7 +26,7 @@ This rule aims to prevent the use of `process.exit()` in Node.js JavaScript. As 
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-process-exit: 2*/
+/*eslint no-process-exit: "error"*/
 
 process.exit(1);
 process.exit(0);
@@ -35,7 +35,7 @@ process.exit(0);
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-process-exit: 2*/
+/*eslint no-process-exit: "error"*/
 
 Process.exit();
 var exit = process.exit;

--- a/docs/rules/no-proto.md
+++ b/docs/rules/no-proto.md
@@ -9,7 +9,7 @@ When an object is created `__proto__` is set to the original prototype property 
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-proto: 2*/
+/*eslint no-proto: "error"*/
 
 var a = obj.__proto__;
 
@@ -19,7 +19,7 @@ var a = obj["__proto__"];
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-proto: 2*/
+/*eslint no-proto: "error"*/
 
 var a = Object.getPrototypeOf(obj);
 ```

--- a/docs/rules/no-redeclare.md
+++ b/docs/rules/no-redeclare.md
@@ -9,7 +9,7 @@ This rule is aimed at eliminating variables that have multiple declarations in t
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-redeclare: 2*/
+/*eslint no-redeclare: "error"*/
 
 var a = 3;
 var a = 10;
@@ -18,7 +18,7 @@ var a = 10;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-redeclare: 2*/
+/*eslint no-redeclare: "error"*/
 
 var a = 3;
 // ...
@@ -35,7 +35,7 @@ If this is `true`, this rule checks with built-in global variables such as `Obje
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option:
 
 ```js
-/*eslint no-redeclare: [2, { "builtinGlobals": true }]*/
+/*eslint no-redeclare: ["error", { "builtinGlobals": true }]*/
 
 var Object = 0;
 ```
@@ -43,7 +43,7 @@ var Object = 0;
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option and the `browser` environment:
 
 ```js
-/*eslint no-redeclare: [2, { "builtinGlobals": true }]*/
+/*eslint no-redeclare: ["error", { "builtinGlobals": true }]*/
 /*eslint-env browser*/
 
 var top = 0;

--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -21,7 +21,7 @@ This rule aims to eliminate errors due to multiple spaces inside of a regular ex
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-regex-spaces: 2*/
+/*eslint no-regex-spaces: "error"*/
 
 var re = /foo   bar/;
 ```
@@ -29,7 +29,7 @@ var re = /foo   bar/;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-regex-spaces: 2*/
+/*eslint no-regex-spaces: "error"*/
 
 var re = /foo {3}bar/;
 

--- a/docs/rules/no-restricted-globals.md
+++ b/docs/rules/no-restricted-globals.md
@@ -19,7 +19,7 @@ Examples of **incorrect** code for sample `"event", "fdescribe"` global variable
 
 ```js
 /*global event, fdescribe*/
-/*eslint no-restricted-globals: [2, "event", "fdescribe"]*/
+/*eslint no-restricted-globals: ["error", "event", "fdescribe"]*/
 
 function onClick() {
     console.log(event);
@@ -33,14 +33,14 @@ Examples of **correct** code for a sample `"event"` global variable name:
 
 ```js
 /*global event*/
-/*eslint no-restricted-globals: [2, "event"]*/
+/*eslint no-restricted-globals: ["error", "event"]*/
 
 import event from "event-module";
 ```
 
 ```js
 /*global event*/
-/*eslint no-restricted-globals: [2, "event"]*/
+/*eslint no-restricted-globals: ["error", "event"]*/
 
 var event = 1;
 ```

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -17,13 +17,13 @@ This rule allows you to specify imports that you don't want to use in your appli
 The syntax to specify restricted modules looks like this:
 
 ```json
-"no-restricted-imports": [2, "import1", "import2"]
+"no-restricted-imports": ["error", "import1", "import2"]
 ```
 
 To restrict the use of all Node.js core imports (via https://github.com/nodejs/node/tree/master/lib):
 
 ```json
-    "no-restricted-imports": [2,
+    "no-restricted-imports": ["error",
          "assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"
     ],
 ```
@@ -31,13 +31,13 @@ To restrict the use of all Node.js core imports (via https://github.com/nodejs/n
 The following patterns are considered problems:
 
 ```js
-/*eslint no-restricted-imports: [2, "fs"]*/
+/*eslint no-restricted-imports: ["error", "fs"]*/
 
 import fs from 'fs';
 ```
 
 ```js
-/*eslint no-restricted-imports: [2, "cluster"]*/
+/*eslint no-restricted-imports: ["error", "cluster"]*/
 
 import cluster from ' cluster ';
 ```
@@ -45,7 +45,7 @@ import cluster from ' cluster ';
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-restricted-imports: [2, "fs"]*/
+/*eslint no-restricted-imports: ["error", "fs"]*/
 
 import crypto from 'crypto';
 ```

--- a/docs/rules/no-restricted-modules.md
+++ b/docs/rules/no-restricted-modules.md
@@ -17,7 +17,7 @@ The rule takes one or more strings as options: the names of restricted modules.
 For example, to restrict the use of all Node.js core modules (via https://github.com/nodejs/node/tree/master/lib):
 
 ```json
-    "no-restricted-modules": [2,
+    "no-restricted-modules": ["error",
          "assert","buffer","child_process","cluster","crypto","dgram","dns","domain","events","freelist","fs","http","https","module","net","os","path","punycode","querystring","readline","repl","smalloc","stream","string_decoder","sys","timers","tls","tracing","tty","url","util","vm","zlib"
     ]
 ```
@@ -25,7 +25,7 @@ For example, to restrict the use of all Node.js core modules (via https://github
 Examples of **incorrect** code for this rule with sample `"fs", "cluster"` restricted modules:
 
 ```js
-/*eslint no-restricted-modules: [2, "fs", "cluster"]*/
+/*eslint no-restricted-modules: ["error", "fs", "cluster"]*/
 
 var fs = require('fs');
 var cluster = require(' cluster ');
@@ -34,7 +34,7 @@ var cluster = require(' cluster ');
 Examples of **incorrect** code for this rule with sample `"fs", "cluster"` restricted modules:
 
 ```js
-/*eslint no-restricted-modules: [2, "fs", "cluster"]*/
+/*eslint no-restricted-modules: ["error", "fs", "cluster"]*/
 
 var crypto = require('crypto');
 ```

--- a/docs/rules/no-restricted-syntax.md
+++ b/docs/rules/no-restricted-syntax.md
@@ -15,7 +15,7 @@ This rule takes a list of strings where strings denote the node types:
 ```json
 {
     "rules": {
-        "no-restricted-syntax": [2, "FunctionExpression", "WithStatement"]
+        "no-restricted-syntax": ["error", "FunctionExpression", "WithStatement"]
     }
 }
 ```
@@ -23,7 +23,7 @@ This rule takes a list of strings where strings denote the node types:
 The following patterns are considered problems:
 
 ```js
-/* eslint no-restricted-syntax: [2, "FunctionExpression", "WithStatement"] */
+/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
 
 with (me) {
     dontMess();
@@ -35,7 +35,7 @@ var doSomething = function () {};
 The following patterns are not considered problems:
 
 ```js
-/* eslint no-restricted-syntax: [2, "FunctionExpression", "WithStatement"] */
+/* eslint no-restricted-syntax: ["error", "FunctionExpression", "WithStatement"] */
 
 me.dontMess();
 

--- a/docs/rules/no-return-assign.md
+++ b/docs/rules/no-return-assign.md
@@ -31,7 +31,7 @@ It disallows assignments unless they are enclosed in parentheses.
 Examples of **incorrect** code for the default `"except-parens"` option:
 
 ```js
-/*eslint no-return-assign: 2*/
+/*eslint no-return-assign: "error"*/
 
 function doSomething() {
     return foo = bar + 2;
@@ -45,7 +45,7 @@ function doSomething() {
 Examples of **correct** code for the default `"except-parens"` option:
 
 ```js
-/*eslint no-return-assign: 2*/
+/*eslint no-return-assign: "error"*/
 
 function doSomething() {
     return foo == bar + 2;
@@ -68,7 +68,7 @@ All assignments are treated as problems.
 Examples of **incorrect** code for the `"always"` option:
 
 ```js
-/*eslint no-return-assign: [2, "always"]*/
+/*eslint no-return-assign: ["error", "always"]*/
 
 function doSomething() {
     return foo = bar + 2;
@@ -86,7 +86,7 @@ function doSomething() {
 Examples of **correct** code for the `"always"` option:
 
 ```js
-/*eslint no-return-assign: [2, "always"]*/
+/*eslint no-return-assign: ["error", "always"]*/
 
 function doSomething() {
     return foo == bar + 2;

--- a/docs/rules/no-script-url.md
+++ b/docs/rules/no-script-url.md
@@ -7,7 +7,7 @@ Using `javascript:` URLs is considered by some as a form of `eval`. Code passed 
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-script-url: 2*/
+/*eslint no-script-url: "error"*/
 
 location.href = "javascript:void(0)";
 ```

--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -15,7 +15,7 @@ This rule is aimed at eliminating self assignments.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-self-assign: 2*/
+/*eslint no-self-assign: "error"*/
 
 foo = foo;
 
@@ -29,7 +29,7 @@ foo = foo;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-self-assign: 2*/
+/*eslint no-self-assign: "error"*/
 
 foo = bar;
 [a, b] = [b, a];

--- a/docs/rules/no-self-compare.md
+++ b/docs/rules/no-self-compare.md
@@ -11,7 +11,7 @@ This error is raised to highlight a potentially confusing and potentially pointl
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-self-compare: 2*/
+/*eslint no-self-compare: "error"*/
 
 var x = 10;
 if (x === x) {

--- a/docs/rules/no-sequences.md
+++ b/docs/rules/no-sequences.md
@@ -22,7 +22,7 @@ This rule forbids the use of the comma operator, with the following exceptions:
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-sequences: 2*/
+/*eslint no-sequences: "error"*/
 
 foo = doSomething(), val;
 
@@ -44,7 +44,7 @@ with (doSomething(), val) {}
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-sequences: 2*/
+/*eslint no-sequences: "error"*/
 
 foo = (doSomething(), val);
 

--- a/docs/rules/no-shadow-restricted-names.md
+++ b/docs/rules/no-shadow-restricted-names.md
@@ -13,7 +13,7 @@ Then any code used within the same scope would not get the global `undefined`, b
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-shadow-restricted-names: 2*/
+/*eslint no-shadow-restricted-names: "error"*/
 
 function NaN(){}
 
@@ -27,7 +27,7 @@ try {} catch(eval){}
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-shadow-restricted-names: 2*/
+/*eslint no-shadow-restricted-names: "error"*/
 
 var Object;
 

--- a/docs/rules/no-shadow.md
+++ b/docs/rules/no-shadow.md
@@ -18,7 +18,7 @@ This rule aims to eliminate shadowed variable declarations.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-shadow: 2*/
+/*eslint no-shadow: "error"*/
 /*eslint-env es6*/
 
 var a = 3;
@@ -46,7 +46,7 @@ This rule takes one option, an object, with properties `"builtinGlobals"`, `"hoi
 
 ```json
 {
-    "no-shadow": [2, { "builtinGlobals": false, "hoist": "functions", "allow": [] }]
+    "no-shadow": ["error", { "builtinGlobals": false, "hoist": "functions", "allow": [] }]
 }
 ```
 
@@ -58,7 +58,7 @@ If it is `true`, the rule prevents shadowing of built-in global variables: `Obje
 Examples of **incorrect** code for the `{ "builtinGlobals": true }` option:
 
 ```js
-/*eslint no-shadow: [2, { "builtinGlobals": true }]*/
+/*eslint no-shadow: ["error", { "builtinGlobals": true }]*/
 
 function foo() {
     var Object = 0;
@@ -78,7 +78,7 @@ The `hoist` option has three settings:
 Examples of **incorrect** code for the default `{ "hoist": "functions" }` option:
 
 ```js
-/*eslint no-shadow: [2, { "hoist": "functions" }]*/
+/*eslint no-shadow: ["error", { "hoist": "functions" }]*/
 /*eslint-env es6*/
 
 if (true) {
@@ -93,7 +93,7 @@ Although `let b` in the `if` statement is before the *function* declaration in t
 Examples of **correct** code for the default `{ "hoist": "functions" }` option:
 
 ```js
-/*eslint no-shadow: [2, { "hoist": "functions" }]*/
+/*eslint no-shadow: ["error", { "hoist": "functions" }]*/
 /*eslint-env es6*/
 
 if (true) {
@@ -110,7 +110,7 @@ Because `let a` in the `if` statement is before the *variable* declaration in th
 Examples of **incorrect** code for the `{ "hoist": "all" }` option:
 
 ```js
-/*eslint no-shadow: [2, { "hoist": "all" }]*/
+/*eslint no-shadow: ["error", { "hoist": "all" }]*/
 /*eslint-env es6*/
 
 if (true) {
@@ -127,7 +127,7 @@ function b() {}
 Examples of **correct** code for the `{ "hoist": "never" }` option:
 
 ```js
-/*eslint no-shadow: [2, { "hoist": "never" }]*/
+/*eslint no-shadow: ["error", { "hoist": "never" }]*/
 /*eslint-env es6*/
 
 if (true) {
@@ -148,7 +148,7 @@ The `allow` option is an array of identifier names for which shadowing is allowe
 Examples of **correct** code for the `{ "allow": ["done"] }` option:
 
 ```js
-/*eslint no-shadow: [2, { "allow": ["done"] }]*/
+/*eslint no-shadow: ["error", { "allow": ["done"] }]*/
 /*eslint-env es6*/
 
 import async from 'async';

--- a/docs/rules/no-spaced-func.md
+++ b/docs/rules/no-spaced-func.md
@@ -15,7 +15,7 @@ fn ()
 The following patterns are considered problems:
 
 ```js
-/*eslint no-spaced-func: 2*/
+/*eslint no-spaced-func: "error"*/
 
 fn ()
 
@@ -26,8 +26,7 @@ fn
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-spaced-func: 2*/
+/*eslint no-spaced-func: "error"*/
 
 fn()
 ```
-

--- a/docs/rules/no-sparse-arrays.md
+++ b/docs/rules/no-sparse-arrays.md
@@ -23,7 +23,7 @@ This rule aims to eliminate sparse arrays that are defined by extra commas.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-sparse-arrays: 2*/
+/*eslint no-sparse-arrays: "error"*/
 
 var items = [,];
 var colors = [ "red",, "blue" ];
@@ -32,7 +32,7 @@ var colors = [ "red",, "blue" ];
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-sparse-arrays: 2*/
+/*eslint no-sparse-arrays: "error"*/
 
 var items = [];
 var items = new Array(23);

--- a/docs/rules/no-sync.md
+++ b/docs/rules/no-sync.md
@@ -9,7 +9,7 @@ This rule is aimed at preventing synchronous methods from being called in Node.j
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-sync: 2*/
+/*eslint no-sync: "error"*/
 
 fs.existsSync(somePath);
 
@@ -19,7 +19,7 @@ var contents = fs.readFileSync(somePath).toString();
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-sync: 2*/
+/*eslint no-sync: "error"*/
 
 obj.sync();
 

--- a/docs/rules/no-ternary.md
+++ b/docs/rules/no-ternary.md
@@ -13,7 +13,7 @@ The `no-ternary` rule aims to disallow the use of ternary operators.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-ternary: 2*/
+/*eslint no-ternary: "error"*/
 
 var foo = isBar ? baz : qux;
 
@@ -27,7 +27,7 @@ function quux() {
 The following patterns are considered okay and could be used alternatively:
 
 ```js
-/*eslint no-ternary: 2*/
+/*eslint no-ternary: "error"*/
 
 var foo;
 

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -11,7 +11,7 @@ This rule is aimed to flag `this`/`super` keywords before `super()` callings.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-this-before-super: 2*/
+/*eslint no-this-before-super: "error"*/
 /*eslint-env es6*/
 
 class A extends B {
@@ -45,7 +45,7 @@ class A extends B {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-this-before-super: 2*/
+/*eslint no-this-before-super: "error"*/
 /*eslint-env es6*/
 
 class A {

--- a/docs/rules/no-throw-literal.md
+++ b/docs/rules/no-throw-literal.md
@@ -12,7 +12,7 @@ This rule is aimed at maintaining consistency when throwing exception by disallo
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-throw-literal: 2*/
+/*eslint no-throw-literal: "error"*/
 /*eslint-env es6*/
 
 throw "error";
@@ -35,7 +35,7 @@ throw `${err}`
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-throw-literal: 2*/
+/*eslint no-throw-literal: "error"*/
 
 throw new Error();
 
@@ -58,7 +58,7 @@ Due to the limits of static analysis, this rule cannot guarantee that you will o
 Examples of **correct** code for this rule, but which do not throw an `Error` object:
 
 ```js
-/*eslint no-throw-literal: 2*/
+/*eslint no-throw-literal: "error"*/
 
 var err = "error";
 throw err;

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -9,7 +9,7 @@ Sometimes in the course of editing files, you can end up with extra whitespace a
 The following patterns are considered problems:
 
 ```js
-/*eslint no-trailing-spaces: 2*/
+/*eslint no-trailing-spaces: "error"*/
 
 // spaces, tabs and unicode whitespaces
 // are not allowed at the end of lines
@@ -20,7 +20,7 @@ var baz = 5;//••
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-trailing-spaces: 2*/
+/*eslint no-trailing-spaces: "error"*/
 
 var foo = 0;
 
@@ -35,14 +35,14 @@ You can enable this option in your config like this:
 
 ```json
 {
-    "no-trailing-spaces": [2, { "skipBlankLines": true }]
+    "no-trailing-spaces": ["error", { "skipBlankLines": true }]
 }
 ```
 
 With this option enabled, The following patterns are not considered problems:
 
 ```js
-/*eslint no-trailing-spaces: [2, { "skipBlankLines": true }]*/
+/*eslint no-trailing-spaces: ["error", { "skipBlankLines": true }]*/
 
 var foo = 0;
 //••••

--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -24,7 +24,7 @@ This rule aims to eliminate variable declarations that initialize to `undefined`
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-undef-init: 2*/
+/*eslint no-undef-init: "error"*/
 /*eslint-env es6*/
 
 var foo = undefined;
@@ -34,7 +34,7 @@ let bar = undefined;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-undef-init: 2*/
+/*eslint no-undef-init: "error"*/
 /*eslint-env es6*/
 
 var foo;
@@ -96,7 +96,7 @@ If you're using such an initialization inside of a loop, then you should disable
 Example of **correct** code for this rule, because it is disabled on a specific line:
 
 ```js
-/*eslint no-undef-init: 2*/
+/*eslint no-undef-init: "error"*/
 
 for (i = 0; i < 10; i++) {
     var x = undefined; // eslint-disable-line no-undef-init

--- a/docs/rules/no-undef.md
+++ b/docs/rules/no-undef.md
@@ -9,7 +9,7 @@ Any reference to an undeclared variable causes a warning, unless the variable is
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-undef: 2*/
+/*eslint no-undef: "error"*/
 
 var a = someFunction();
 b = 10;
@@ -19,7 +19,7 @@ Examples of **correct** code for this rule with `global` declaration:
 
 ```js
 /*global someFunction b:true*/
-/*eslint no-undef: 2*/
+/*eslint no-undef: "error"*/
 
 var a = someFunction();
 b = 10;
@@ -31,7 +31,7 @@ Examples of **incorrect** code for this rule with `global` declaration:
 
 ```js
 /*global b*/
-/*eslint no-undef: 2*/
+/*eslint no-undef: "error"*/
 
 b = 10;
 ```
@@ -47,7 +47,7 @@ By default, variables declared in `/*global */` are read-only, therefore assignm
 Examples of **correct** code for the default `{ "typeof": false }` option:
 
 ```js
-/*eslint no-undef: 2*/
+/*eslint no-undef: "error"*/
 
 if (typeof UndefinedIdentifier === "undefined") {
     // do something ...
@@ -59,7 +59,7 @@ You can use this option if you want to prevent `typeof` check on a variable whic
 Examples of **incorrect** code for the `{ "typeof": true }` option:
 
 ```js
-/*eslint no-undef: [2, { "typeof": true }] */
+/*eslint no-undef: ["error", { "typeof": true }] */
 
 if(typeof a === "string"){}
 ```
@@ -68,7 +68,7 @@ Examples of **correct** code for the `{ "typeof": true }` option with `global` d
 
 ```js
 /*global a*/
-/*eslint no-undef: [2, { "typeof": true }] */
+/*eslint no-undef: ["error", { "typeof": true }] */
 
 if(typeof a === "string"){}
 ```
@@ -82,7 +82,7 @@ For convenience, ESLint provides shortcuts that pre-define global variables expo
 Examples of **correct** code for this rule with `browser` environment:
 
 ```js
-/*eslint no-undef: 2*/
+/*eslint no-undef: "error"*/
 /*eslint-env browser*/
 
 setTimeout(function() {
@@ -95,7 +95,7 @@ setTimeout(function() {
 Examples of **correct** code for this rule with `node` environment:
 
 ```js
-/*eslint no-undef: 2*/
+/*eslint no-undef: "error"*/
 /*eslint-env node*/
 
 var fs = require("fs");

--- a/docs/rules/no-undefined.md
+++ b/docs/rules/no-undefined.md
@@ -39,7 +39,7 @@ This rule aims to eliminate the use of `undefined`, and as such, generates a war
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-undefined: 2*/
+/*eslint no-undefined: "error"*/
 
 var foo = undefined;
 
@@ -57,7 +57,7 @@ function foo(undefined) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-undefined: 2*/
+/*eslint no-undefined: "error"*/
 
 var foo = void 0;
 

--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -19,7 +19,7 @@ This rule aims to eliminate the use of dangling underscores in identifiers.
 ### `allow`
 
 ```json
-"no-underscore-dangle": [2, { "allow": [] }]
+"no-underscore-dangle": ["error", { "allow": [] }]
 ```
 
 Array of variable names that are permitted to be used with underscore. If provided, it must be an `Array`.
@@ -27,7 +27,7 @@ Array of variable names that are permitted to be used with underscore. If provid
 ### `allowAfterThis`
 
 ```json
-"no-underscore-dangle": [2, { "allowAfterThis": true }]
+"no-underscore-dangle": ["error", { "allowAfterThis": true }]
 ```
 
 This option allows usage of dangled variables as members of `this`.
@@ -35,7 +35,7 @@ This option allows usage of dangled variables as members of `this`.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-underscore-dangle: 2*/
+/*eslint no-underscore-dangle: "error"*/
 
 var foo_;
 var __proto__ = {};
@@ -45,7 +45,7 @@ foo._bar();
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-underscore-dangle: 2*/
+/*eslint no-underscore-dangle: "error"*/
 
 var _ = require('underscore');
 var obj = _.contains(items, item);
@@ -55,14 +55,14 @@ var file = __filename;
 
 
 ```js
-/*eslint no-underscore-dangle: [2, { "allow": ["foo_", "_bar"] }]*/
+/*eslint no-underscore-dangle: ["error", { "allow": ["foo_", "_bar"] }]*/
 
 var foo_;
 foo._bar();
 ```
 
 ```js
-/*eslint no-underscore-dangle: [2, { "allowAfterThis": true }]*/
+/*eslint no-underscore-dangle: ["error", { "allowAfterThis": true }]*/
 
 var a = this.foo_;
 this._bar();

--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -18,7 +18,7 @@ This rule is aimed at ensuring that two unrelated consecutive lines are not acci
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-unexpected-multiline: 2*/
+/*eslint no-unexpected-multiline: "error"*/
 
 var foo = bar
 (1 || 2).baz();
@@ -37,7 +37,7 @@ x
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-unexpected-multiline: 2*/
+/*eslint no-unexpected-multiline: "error"*/
 
 var foo = bar;
 (1 || 2).baz();

--- a/docs/rules/no-unneeded-ternary.md
+++ b/docs/rules/no-unneeded-ternary.md
@@ -40,7 +40,7 @@ This rule enforces a coding style where it disallows conditional expressions tha
 The following patterns are considered problems:
 
 ```js
-/*eslint no-unneeded-ternary: 2*/
+/*eslint no-unneeded-ternary: "error"*/
 
 var a = x === 2 ? true : false;
 
@@ -56,7 +56,7 @@ var a = x ? x : 1;
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-unneeded-ternary: 2*/
+/*eslint no-unneeded-ternary: "error"*/
 
 var a = x === 2 ? "Yes" : "No";
 

--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -17,7 +17,7 @@ This rule is aimed at detecting unreachable code. It produces an error when a st
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-unreachable: 2*/
+/*eslint no-unreachable: "error"*/
 
 function foo() {
     return true;
@@ -53,7 +53,7 @@ console.log("done");
 Examples of **correct** code for this rule, because of JavaScript function and variable hoisting:
 
 ```js
-/*eslint no-unreachable: 2*/
+/*eslint no-unreachable: "error"*/
 
 function foo() {
     return bar();

--- a/docs/rules/no-unused-expressions.md
+++ b/docs/rules/no-unused-expressions.md
@@ -36,7 +36,7 @@ These options allow unused expressions *only if all* of the code paths either di
 Examples of **incorrect** code for the default `{ "allowShortCircuit": false, "allowTernary": false }` options:
 
 ```js
-/*eslint no-unused-expressions: 2*/
+/*eslint no-unused-expressions: "error"*/
 
 0
 
@@ -71,7 +71,7 @@ Note that one or more string expression statements (with or without semi-colons)
 Examples of **correct** code for the default `{ "allowShortCircuit": false, "allowTernary": false }` options:
 
 ```js
-/*eslint no-unused-expressions: 2*/
+/*eslint no-unused-expressions: "error"*/
 
 {} // In this context, this is a block statement, not an object literal
 
@@ -97,7 +97,7 @@ void a
 Examples of **incorrect** code for the `{ "allowShortCircuit": true }` option:
 
 ```js
-/*eslint no-unused-expressions: [2, { "allowShortCircuit": true }]*/
+/*eslint no-unused-expressions: ["error", { "allowShortCircuit": true }]*/
 
 a || b
 ```
@@ -105,7 +105,7 @@ a || b
 Examples of **correct** code for the `{ "allowShortCircuit": true }` option:
 
 ```js
-/*eslint no-unused-expressions: [2, { "allowShortCircuit": true }]*/
+/*eslint no-unused-expressions: ["error", { "allowShortCircuit": true }]*/
 
 a && b()
 a() || (b = c)
@@ -116,7 +116,7 @@ a() || (b = c)
 Examples of **incorrect** code for the `{ "allowTernary": true }` option:
 
 ```js
-/*eslint no-unused-expressions: [2, { "allowTernary": true }]*/
+/*eslint no-unused-expressions: ["error", { "allowTernary": true }]*/
 
 a ? b : 0
 a ? b : c()
@@ -125,7 +125,7 @@ a ? b : c()
 Examples of **correct** code for the `{ "allowTernary": true }` option:
 
 ```js
-/*eslint no-unused-expressions: [2, { "allowTernary": true }]*/
+/*eslint no-unused-expressions: ["error", { "allowTernary": true }]*/
 
 a ? b() : c()
 a ? (b = c) : d()
@@ -136,7 +136,7 @@ a ? (b = c) : d()
 Examples of **correct** code for the `{ "allowShortCircuit": true, "allowTernary": true }` options:
 
 ```js
-/*eslint no-unused-expressions: [2, { "allowShortCircuit": true, "allowTernary": true }]*/
+/*eslint no-unused-expressions: ["error", { "allowShortCircuit": true, "allowTernary": true }]*/
 
 a ? b() || (c = d) : e()
 ```

--- a/docs/rules/no-unused-labels.md
+++ b/docs/rules/no-unused-labels.md
@@ -22,7 +22,7 @@ This rule is aimed at eliminating unused labels.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-unused-labels: 2*/
+/*eslint no-unused-labels: "error"*/
 
 A: var foo = 0;
 
@@ -39,7 +39,7 @@ for (let i = 0; i < 10; ++i) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-unused-labels: 2*/
+/*eslint no-unused-labels: "error"*/
 
 A: {
     if (foo()) {

--- a/docs/rules/no-unused-vars.md
+++ b/docs/rules/no-unused-vars.md
@@ -17,8 +17,8 @@ A variable is *not* considered to be used if it is only ever assigned to (`var x
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-unused-vars: 2*/
-/*global some_unused_var */
+/*eslint no-unused-vars: "error"*/
+/*global some_unused_var*/
 
 //It checks variables you have defined as global
 some_unused_var = 42;
@@ -43,7 +43,7 @@ function fact(n) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-unused-vars: 2*/
+/*eslint no-unused-vars: "error"*/
 
 var x = 10;
 alert(x);
@@ -77,7 +77,7 @@ By default this rule is enabled with `all` option for variables and `after-used`
 ```json
 {
     "rules": {
-        "no-unused-vars": [2, { "vars": "all", "args": "after-used" }]
+        "no-unused-vars": ["error", { "vars": "all", "args": "after-used" }]
     }
 }
 ```
@@ -94,7 +94,7 @@ The `vars` option has two settings:
 Examples of **correct** code for the `{ "vars": "local" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "vars": "local" }]*/
+/*eslint no-unused-vars: ["error", { "vars": "local" }]*/
 /*global some_unused_var */
 
 some_unused_var = 42;
@@ -107,7 +107,7 @@ The `varsIgnorePattern` option specifies exceptions not to check for usage: vari
 Examples of **correct** code for the `{ "varsIgnorePattern": "[iI]gnored" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "varsIgnorePattern": "[iI]gnored" }]*/
+/*eslint no-unused-vars: ["error", { "varsIgnorePattern": "[iI]gnored" }]*/
 
 var firstVarIgnored = 1;
 var secondVar = 2;
@@ -127,7 +127,7 @@ The `args` option has three settings:
 Examples of **incorrect** code for the default `{ "args": "after-used" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "args": "after-used" }]*/
+/*eslint no-unused-vars: ["error", { "args": "after-used" }]*/
 
 // 1 error
 // "baz" is defined but never used
@@ -139,7 +139,7 @@ Examples of **incorrect** code for the default `{ "args": "after-used" }` option
 Examples of **correct** code for the default `{ "args": "after-used" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, {"args": "after-used"}]*/
+/*eslint no-unused-vars: ["error", {"args": "after-used"}]*/
 
 (function(foo, bar, baz) {
     return baz;
@@ -151,7 +151,7 @@ Examples of **correct** code for the default `{ "args": "after-used" }` option:
 Examples of **incorrect** code for the `{ "args": "all" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "args": "all" }]*/
+/*eslint no-unused-vars: ["error", { "args": "all" }]*/
 
 // 2 errors
 // "foo" is defined but never used
@@ -166,7 +166,7 @@ Examples of **incorrect** code for the `{ "args": "all" }` option:
 Examples of **correct** code for the `{ "args": "none" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "args": "none" }]*/
+/*eslint no-unused-vars: ["error", { "args": "none" }]*/
 
 (function(foo, bar, baz) {
     return bar;
@@ -180,7 +180,7 @@ The `argsIgnorePattern` option specifies exceptions not to check for usage: argu
 Examples of **correct** code for the `{ "argsIgnorePattern": "^_" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "argsIgnorePattern": "^_" }]*/
+/*eslint no-unused-vars: ["error", { "argsIgnorePattern": "^_" }]*/
 
 function foo(x, _y) {
     return x + 1;
@@ -204,7 +204,7 @@ Not specifying this rule is equivalent of assigning it to `none`.
 Examples of **correct** code for the `{ "caughtErrors": "none" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "caughtErrors": "none" }]*/
+/*eslint no-unused-vars: ["error", { "caughtErrors": "none" }]*/
 
 try {
     //...
@@ -218,7 +218,7 @@ try {
 Examples of **incorrect** code for the `{ "caughtErrors": "all" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "caughtErrors": "all" }]*/
+/*eslint no-unused-vars: ["error", { "caughtErrors": "all" }]*/
 
 // 1 error
 // "err" is defined but never used
@@ -236,7 +236,7 @@ The `caughtErrorsIgnorePattern` option specifies exceptions not to check for usa
 Examples of **correct** code for the `{ "caughtErrorsIgnorePattern": "^ignore" }` option:
 
 ```js
-/*eslint no-unused-vars: [2, { "caughtErrorsIgnorePattern": "^ignore" }]*/
+/*eslint no-unused-vars: ["error", { "caughtErrorsIgnorePattern": "^ignore" }]*/
 
 try {
     //...

--- a/docs/rules/no-use-before-define.md
+++ b/docs/rules/no-use-before-define.md
@@ -11,7 +11,7 @@ This rule will warn when it encounters a reference to an identifier that has not
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-use-before-define: 2*/
+/*eslint no-use-before-define: "error"*/
 /*eslint-env es6*/
 
 alert(a);
@@ -35,7 +35,7 @@ var b = 1;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-use-before-define: 2*/
+/*eslint no-use-before-define: "error"*/
 /*eslint-env es6*/
 
 var a;
@@ -61,7 +61,7 @@ function g() {
 
 ```json
 {
-    "no-use-before-define": [2, { "functions": true, "classes": true }]
+    "no-use-before-define": ["error", { "functions": true, "classes": true }]
 }
 ```
 
@@ -86,7 +86,7 @@ This rule accepts `"nofunc"` string as a option.
 Examples of **correct** code for the `{ "functions": false }` option:
 
 ```js
-/*eslint no-use-before-define: [2, { "functions": false }]*/
+/*eslint no-use-before-define: ["error", { "functions": false }]*/
 
 f();
 function f() {}
@@ -97,7 +97,7 @@ function f() {}
 Examples of **incorrect** code for the `{ "classes": false }` option:
 
 ```js
-/*eslint no-use-before-define: [2, { "classes": false }]*/
+/*eslint no-use-before-define: ["error", { "classes": false }]*/
 /*eslint-env es6*/
 
 new A();
@@ -108,7 +108,7 @@ class A {
 Examples of **correct** code for the `{ "classes": false }` option:
 
 ```js
-/*eslint no-use-before-define: [2, { "classes": false }]*/
+/*eslint no-use-before-define: ["error", { "classes": false }]*/
 /*eslint-env es6*/
 
 function foo() {

--- a/docs/rules/no-useless-call.md
+++ b/docs/rules/no-useless-call.md
@@ -10,7 +10,7 @@ This rule is aimed to flag usage of `Function.prototype.call()` and `Function.pr
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-useless-call: 2*/
+/*eslint no-useless-call: "error"*/
 
 // These are same as `foo(1, 2, 3);`
 foo.call(undefined, 1, 2, 3);
@@ -26,7 +26,7 @@ obj.foo.apply(obj, [1, 2, 3]);
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-useless-call: 2*/
+/*eslint no-useless-call: "error"*/
 
 // The `this` binding is different.
 foo.call(obj, 1, 2, 3);
@@ -50,7 +50,7 @@ So if the code about `thisArg` is a dynamic expression, this rule cannot judge c
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-useless-call: 2*/
+/*eslint no-useless-call: "error"*/
 
 a[i++].foo.call(a[i++], 1, 2, 3);
 ```
@@ -58,7 +58,7 @@ a[i++].foo.call(a[i++], 1, 2, 3);
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-useless-call: 2*/
+/*eslint no-useless-call: "error"*/
 
 a[++i].foo.call(a[i], 1, 2, 3);
 ```

--- a/docs/rules/no-useless-concat.md
+++ b/docs/rules/no-useless-concat.md
@@ -19,7 +19,7 @@ This rule aims to flag the concatenation of 2 literals when they could be combin
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-useless-concat: 2*/
+/*eslint no-useless-concat: "error"*/
 /*eslint-env es6*/
 
 // these are the same as "10"
@@ -33,7 +33,7 @@ var a = `1` + `0`;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-useless-concat: 2*/
+/*eslint no-useless-concat: "error"*/
 
 // when a non string is included
 var c = a + b;

--- a/docs/rules/no-useless-constructor.md
+++ b/docs/rules/no-useless-constructor.md
@@ -22,7 +22,7 @@ This rule flags class constructors that can be safely removed without changing h
 The following patterns are considered problems:
 
 ```js
-/*eslint no-useless-constructor: 2*/
+/*eslint no-useless-constructor: "error"*/
 /*eslint-env es6*/
 
 class A {
@@ -40,7 +40,7 @@ class A extends B {
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-useless-constructor: 2*/
+/*eslint no-useless-constructor: "error"*/
 
 class A { }
 

--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -14,7 +14,7 @@ This rule flags escapes that can be safely removed without changing behavior.
 The following patterns are considered problems:
 
 ```js
-/*eslint no-useless-escape: 2*/
+/*eslint no-useless-escape: "error"*/
 
 "\'";
 '\"';
@@ -28,7 +28,7 @@ The following patterns are considered problems:
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-useless-escape: 2*/
+/*eslint no-useless-escape: "error"*/
 
 "\"";
 '\'';

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -24,7 +24,7 @@ This rule is aimed at discouraging the use of `var` and encouraging the use of `
 The following patterns are considered problems:
 
 ```js
-/*eslint no-var: 2*/
+/*eslint no-var: "error"*/
 
 var x = "y";
 var CONFIG = {};
@@ -33,7 +33,7 @@ var CONFIG = {};
 The following patterns are not considered problems:
 
 ```js
-/*eslint no-var: 2*/
+/*eslint no-var: "error"*/
 /*eslint-env es6*/
 
 let x = "y";

--- a/docs/rules/no-void.md
+++ b/docs/rules/no-void.md
@@ -51,7 +51,7 @@ This rule aims to eliminate use of void operator.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-void: 2*/
+/*eslint no-void: "error"*/
 
 void foo
 

--- a/docs/rules/no-warning-comments.md
+++ b/docs/rules/no-warning-comments.md
@@ -21,7 +21,7 @@ This rule has an options object literal:
 Example of **incorrect** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
 ```js
-/*eslint no-warning-comments: 2*/
+/*eslint no-warning-comments: "error"*/
 
 function callback(err, results) {
   if (err) {
@@ -35,7 +35,7 @@ function callback(err, results) {
 Example of **correct** code for the default `{ "terms": ["todo", "fixme", "xxx"], "location": "start" }` options:
 
 ```js
-/*eslint no-warning-comments: 2*/
+/*eslint no-warning-comments: "error"*/
 
 function callback(err, results) {
   if (err) {
@@ -52,7 +52,7 @@ function callback(err, results) {
 Examples of **incorrect** code for the `{ "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }` options:
 
 ```js
-/*eslint no-warning-comments: [2, { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
+/*eslint no-warning-comments: ["error", { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
 
 // TODO: this
 // todo: this too
@@ -67,7 +67,7 @@ Examples of **incorrect** code for the `{ "terms": ["todo", "fixme", "any other 
 Examples of **correct** code for the `{ "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }` options:
 
 ```js
-/*eslint no-warning-comments: [2, { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
+/*eslint no-warning-comments: ["error", { "terms": ["todo", "fixme", "any other term"], "location": "anywhere" }]*/
 
 // This is to do
 // even not any other    term

--- a/docs/rules/no-whitespace-before-property.md
+++ b/docs/rules/no-whitespace-before-property.md
@@ -20,7 +20,7 @@ foo
 The following patterns are considered problems when this rule is turned on:
 
 ```js
-/*eslint no-whitespace-before-property: 2*/
+/*eslint no-whitespace-before-property: "error"*/
 
 foo [bar]
 
@@ -40,7 +40,7 @@ foo
 And the following patterns are not considered problems:
 
 ```js
-/*eslint no-whitespace-before-property: 2*/
+/*eslint no-whitespace-before-property: "error"*/
 
 foo.bar
 
@@ -65,4 +65,3 @@ foo.
 ## When Not To Use It
 
 Turn this rule off if you do not care about allowing whitespace around the dot or before the opening bracket before properties of objects if they are on the same line.
-

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -9,7 +9,7 @@ This rule is aimed at eliminating `with` statements.
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-with: 2*/
+/*eslint no-with: "error"*/
 with (foo) {
     // ...
 }

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -38,7 +38,7 @@ There are two main options for the rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"object-curly-spacing": [2, "always"]
+"object-curly-spacing": ["error", "always"]
 ```
 
 ### "never"
@@ -46,7 +46,7 @@ Depending on your coding conventions, you can choose either option by specifying
 When `"never"` is set, the following patterns are considered problems:
 
 ```
-/*eslint object-curly-spacing: [2, "never"]*/
+/*eslint object-curly-spacing: ["error", "never"]*/
 
 var obj = { 'foo': 'bar' };
 var obj = {'foo': 'bar' };
@@ -59,7 +59,7 @@ import { foo } from 'bar';
 The following patterns are not considered problems:
 
 ```
-/*eslint object-curly-spacing: [2, "never"]*/
+/*eslint object-curly-spacing: ["error", "never"]*/
 
 var obj = {'foo': 'bar'};
 var obj = {'foo': {'bar': 'baz'}, 'qux': 'quxx'};
@@ -80,7 +80,7 @@ import {foo} from 'bar';
 When `"always"` is used, the following patterns are considered problems:
 
 ```
-/*eslint object-curly-spacing: [2, "always"]*/
+/*eslint object-curly-spacing: ["error", "always"]*/
 
 var obj = {'foo': 'bar'};
 var obj = {'foo': 'bar' };
@@ -97,7 +97,7 @@ import {foo } from 'bar';
 The following patterns are not considered problems:
 
 ```
-/*eslint object-curly-spacing: [2, "always"]*/
+/*eslint object-curly-spacing: ["error", "always"]*/
 
 var obj = {};
 var obj = { 'foo': 'bar' };
@@ -126,7 +126,7 @@ it will enforce spacing for cases matching the exception.
 You can add exceptions like so:
 
 ```json
-"object-curly-spacing": [2, "always", {
+"object-curly-spacing": ["error", "always", {
   "objectsInObjects": false,
   "arraysInObjects": false
 }]

--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -45,7 +45,7 @@ Each of the following properties would warn:
 
 
 ```js
-/*eslint object-shorthand: 2*/
+/*eslint object-shorthand: "error"*/
 /*eslint-env es6*/
 
 var foo = {
@@ -58,7 +58,7 @@ var foo = {
 In that case the expected syntax would have been:
 
 ```js
-/*eslint object-shorthand: 2*/
+/*eslint object-shorthand: "error"*/
 /*eslint-env es6*/
 
 var foo = {
@@ -72,7 +72,7 @@ This rule does not flag arrow functions inside of object literals.
 The following will *not* warn:
 
 ```js
-/*eslint object-shorthand: 2*/
+/*eslint object-shorthand: "error"*/
 /*eslint-env es6*/
 
 var foo = {
@@ -94,7 +94,7 @@ You can set the option in configuration like this:
 
 ```json
 {
-    "object-shorthand": [2, "always"]
+    "object-shorthand": ["error", "always"]
 }
 ```
 
@@ -102,14 +102,14 @@ While set to `"always"` or `"methods"`, constructor functions can be ignored wit
 
 ```json
 {
-    "object-shorthand": [2, "always", { "ignoreConstructors": true }]
+    "object-shorthand": ["error", "always", { "ignoreConstructors": true }]
 }
 ```
 
 The following will *not* warn when `"ignoreConstructors"` is enabled:
 
 ```js
-/*eslint object-shorthand: [2, "always", { "ignoreConstructors": true }]*/
+/*eslint object-shorthand: ["error", "always", { "ignoreConstructors": true }]*/
 /*eslint-env es6*/
 
 var foo = {

--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -30,7 +30,7 @@ This rule takes one option, a string, which can be:
 The following patterns are considered problems when set to `"always"`:
 
 ```js
-/*eslint one-var-declaration-per-line: [2, "always"]*/
+/*eslint one-var-declaration-per-line: ["error", "always"]*/
 /*eslint-env es6*/
 
 var a, b;
@@ -43,7 +43,7 @@ const a = 0, b = 0;
 The following patterns are not considered problems when set to `"always"`:
 
 ```js
-/*eslint one-var-declaration-per-line: [2, "always"]*/
+/*eslint one-var-declaration-per-line: ["error", "always"]*/
 /*eslint-env es6*/
 
 var a,
@@ -56,7 +56,7 @@ let a,
 The following patterns are considered problems when set to `"initializations"`:
 
 ```js
-/*eslint one-var-declaration-per-line: [2, "initializations"]*/
+/*eslint one-var-declaration-per-line: ["error", "initializations"]*/
 /*eslint-env es6*/
 
 var a, b, c = 0;
@@ -68,7 +68,7 @@ let a,
 The following patterns are not considered problems when set to `"initializations"`:
 
 ```js
-/*eslint one-var-declaration-per-line: [2, "initializations"]*/
+/*eslint one-var-declaration-per-line: ["error", "initializations"]*/
 /*eslint-env es6*/
 
 var a, b;

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -56,13 +56,13 @@ You can configure the rule as follows:
 Exactly one declarator per declaration per function (var) or block (let or const)
 
 ```json
-"one-var": [2, "never"]
+"one-var": ["error", "never"]
 ```
 
 Configure each declaration type individually. Defaults to `"always"` if key not present.
 
 ```json
-"one-var": [2, {
+"one-var": ["error", {
     "var": "always", // Exactly one var declaration per function
     "let": "always", // Exactly one let declaration per block
     "const": "never" // Exactly one declarator per const declaration per block
@@ -81,7 +81,7 @@ Configure uninitialized and initialized seperately. Defaults to `"always"` if ke
 When configured with `"always"` as the first option (the default), the following patterns are considered problems:
 
 ```js
-/*eslint one-var: [2, "always"]*/
+/*eslint one-var: ["error", "always"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -110,7 +110,7 @@ function foo() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint one-var: [2, "always"]*/
+/*eslint one-var: ["error", "always"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -148,7 +148,7 @@ function foo(){
 When configured with `"never"` as the first option, the following patterns are considered problems:
 
 ```js
-/*eslint one-var: [2, "never"]*/
+/*eslint one-var: ["error", "never"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -176,7 +176,7 @@ function foo(){
 The following patterns are not considered problems:
 
 ```js
-/*eslint one-var: [2, "never"]*/
+/*eslint one-var: ["error", "never"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -206,7 +206,7 @@ When configured with an object as the first option, you can individually control
 The following patterns are not considered problems:
 
 ```js
-/*eslint one-var: [2, { var: "always", let: "never", const: "never" }]*/
+/*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -227,7 +227,7 @@ function foo() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint one-var: [2, { uninitialized: "always", initialized: "never" }]*/
+/*eslint one-var: ["error", { uninitialized: "always", initialized: "never" }]*/
 
 function foo() {
     var a, b, c;
@@ -239,7 +239,7 @@ function foo() {
 If you are configuring the rule with an object, by default, if you didn't specify declaration type it will not be checked. So the following pattern is not considered a warning when options are set to: `{ var: "always", let: "always" }`
 
 ```js
-/*eslint one-var: [2, { var: "always", let: "always" }]*/
+/*eslint one-var: ["error", { var: "always", let: "always" }]*/
 /*eslint-env es6*/
 
 function foo() {

--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -28,14 +28,14 @@ This rule has two options: `always` and `never`. The default is `always`.
 
 ### "always"
 
-`"operator-assignment": [2, "always"]`
+`"operator-assignment": ["error", "always"]`
 
 This mode enforces use of operator assignment shorthand where possible.
 
 The following are examples of valid patterns:
 
 ```js
-/*eslint operator-assignment: [2, "always"]*/
+/*eslint operator-assignment: ["error", "always"]*/
 
 x = y;
 x += y;
@@ -49,7 +49,7 @@ x = y + x; // `+` is not always commutative (e.g. x = "abc")
 The following patterns are considered problems and should be replaced by their shorthand equivalents:
 
 ```js
-/*eslint operator-assignment: [2, "always"]*/
+/*eslint operator-assignment: ["error", "always"]*/
 
 x = x + y;
 x = y * x;
@@ -59,14 +59,14 @@ x.y = x.y << z;
 
 ### "never"
 
-`"operator-assignment": [2, "never"]`
+`"operator-assignment": ["error", "never"]`
 
 This mode warns on any use of operator assignment shorthand.
 
 The following are examples of valid patterns:
 
 ```js
-/*eslint operator-assignment: [2, "never"]*/
+/*eslint operator-assignment: ["error", "never"]*/
 
 x = x + y;
 x.y = x.y / a.b;
@@ -75,7 +75,7 @@ x.y = x.y / a.b;
 The following patterns are considered problems and should be written out fully without the shorthand assignments:
 
 ```js
-/*eslint operator-assignment: [2, "never"]*/
+/*eslint operator-assignment: ["error", "never"]*/
 
 x *= y;
 x ^= (y + z) / foo();

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -27,7 +27,7 @@ The rule takes two options, a string, which can be `"after"`, `"before"` or `"no
 You can set the style in configuration like this:
 
 ```json
-"operator-linebreak": [2, "before", { "overrides": { "?": "after" } }]
+"operator-linebreak": ["error", "before", { "overrides": { "?": "after" } }]
 ```
 
 The default configuration is to enforce line breaks _after_ the operator except for the ternary operator `?` and `:` following that.
@@ -39,7 +39,7 @@ This is the default setting for this rule. This option requires the line break t
 While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint operator-linebreak: [2, "after"]*/
+/*eslint operator-linebreak: ["error", "after"]*/
 
 foo = 1
 +
@@ -63,7 +63,7 @@ answer = everything
 The following patterns are not considered problems:
 
 ```js
-/*eslint operator-linebreak: [2, "after"]*/
+/*eslint operator-linebreak: ["error", "after"]*/
 
 foo = 1 + 2;
 
@@ -89,7 +89,7 @@ This option requires the line break to be placed before the operator.
 While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint operator-linebreak: [2, "before"]*/
+/*eslint operator-linebreak: ["error", "before"]*/
 
 foo = 1 +
       2;
@@ -109,7 +109,7 @@ answer = everything ?
 The following patterns are not considered problems:
 
 ```js
-/*eslint operator-linebreak: [2, "before"]*/
+/*eslint operator-linebreak: ["error", "before"]*/
 
 foo = 1 + 2;
 
@@ -135,7 +135,7 @@ This option disallows line breaks on either side of the operator.
 While using this setting, the following patterns are considered problems:
 
 ```js
-/*eslint operator-linebreak: [2, "none"]*/
+/*eslint operator-linebreak: ["error", "none"]*/
 
 foo = 1 +
       2;
@@ -163,7 +163,7 @@ answer = everything ?
 The following patterns are not considered problems:
 
 ```js
-/*eslint operator-linebreak: [2, "none"]*/
+/*eslint operator-linebreak: ["error", "none"]*/
 
 foo = 1 + 2;
 
@@ -180,7 +180,7 @@ answer = everything ? 42 : foo;
 The rule allows you to have even finer-grained control over individual operators by specifying an `overrides` dictionary:
 
 ```json
-"operator-linebreak": [2, "before", { "overrides": { "?": "after", "+=": "none" } }]
+"operator-linebreak": ["error", "before", { "overrides": { "?": "after", "+=": "none" } }]
 ```
 
 This would override the global setting for that specific operator.
@@ -192,7 +192,7 @@ This option is only supported using overrides and ignores line breaks on either 
 While using this setting, the following patterns are not considered problems:
 
 ```js
-/*eslint operator-linebreak: [2, "after", { "overrides": { "?": "ignore", ":": "ignore"} }]*/
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "ignore", ":": "ignore"} }]*/
 
 answer = everything ?
   42

--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -26,7 +26,7 @@ If you want to enforce padding within switches and classes, a configuration obje
 The following patterns are considered problems when set to `"always"`:
 
 ```js
-/*eslint padded-blocks: [2, "always"]*/
+/*eslint padded-blocks: ["error", "always"]*/
 
 if (a) {
     b();
@@ -59,7 +59,7 @@ if (a) {
 The following patterns are not considered problems when set to `"always"`:
 
 ```js
-/*eslint padded-blocks: [2, "always"]*/
+/*eslint padded-blocks: ["error", "always"]*/
 
 if (a) {
 
@@ -85,7 +85,7 @@ if (a) {
 The following patterns are considered problems when set to `"never"`:
 
 ```js
-/*eslint padded-blocks: [2, "never"]*/
+/*eslint padded-blocks: ["error", "never"]*/
 
 if (a) {
 
@@ -114,7 +114,7 @@ if (a) {
 The following patterns are not considered problems when set to `"never"`:
 
 ```js
-/*eslint padded-blocks: [2, "never"]*/
+/*eslint padded-blocks: ["error", "never"]*/
 
 if (a) {
     b();
@@ -129,7 +129,7 @@ if (a)
 The following patterns are considered problems when configured `{ "switches": "always" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "switches": "always" }]*/
+/*eslint padded-blocks: ["error", { "switches": "always" }]*/
 
 switch (a) {
     case 0: foo();
@@ -139,7 +139,7 @@ switch (a) {
 The following patterns are not considered problems when configured `{ "switches": "always" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "switches": "always" }]*/
+/*eslint padded-blocks: ["error", { "switches": "always" }]*/
 
 switch (a) {
 
@@ -155,7 +155,7 @@ if (a) {
 The following patterns are considered problems when configured `{ "switches": "never" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "switches": "never" }]*/
+/*eslint padded-blocks: ["error", { "switches": "never" }]*/
 
 switch (a) {
 
@@ -167,7 +167,7 @@ switch (a) {
 The following patterns are not considered problems when configured `{ "switches": "never" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "switches": "never" }]*/
+/*eslint padded-blocks: ["error", { "switches": "never" }]*/
 
 switch (a) {
     case 0: foo();
@@ -183,7 +183,7 @@ if (a) {
 The following patterns are considered problems when configured `{ "classes": "always" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "classes": "always" }]*/
+/*eslint padded-blocks: ["error", { "classes": "always" }]*/
 
 class  A {
     constructor(){
@@ -194,7 +194,7 @@ class  A {
 The following patterns are not considered problems when configured `{ "classes": "always" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "classes": "always" }]*/
+/*eslint padded-blocks: ["error", { "classes": "always" }]*/
 
 class  A {
 
@@ -207,7 +207,7 @@ class  A {
 The following patterns are considered problems when configured `{ "classes": "never" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "classes": "never" }]*/
+/*eslint padded-blocks: ["error", { "classes": "never" }]*/
 
 class  A {
 
@@ -220,7 +220,7 @@ class  A {
 The following patterns are not considered problems when configured `{ "classes": "never" }`:
 
 ```js
-/*eslint padded-blocks: [2, { "classes": "never" }]*/
+/*eslint padded-blocks: ["error", { "classes": "never" }]*/
 
 class  A {
     constructor(){

--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -12,7 +12,7 @@ This rule is aimed to flag usage of function expressions in an argument list.
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-arrow-callback: 2*/
+/*eslint prefer-arrow-callback: "error"*/
 
 foo(function(a) { return a; });
 foo(function() { return this.a; }.bind(this));
@@ -21,7 +21,7 @@ foo(function() { return this.a; }.bind(this));
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-arrow-callback: 2*/
+/*eslint prefer-arrow-callback: "error"*/
 /*eslint-env es6*/
 
 foo(a => a);

--- a/docs/rules/prefer-const.md
+++ b/docs/rules/prefer-const.md
@@ -11,7 +11,7 @@ This rule is aimed at flagging variables that are declared using `let` keyword, 
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-const: 2*/
+/*eslint prefer-const: "error"*/
 /*eslint-env es6*/
 
 let a = 3;
@@ -36,7 +36,7 @@ console.log(a);
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-const: 2*/
+/*eslint prefer-const: "error"*/
 /*eslint-env es6*/
 
 let a; // there is no initialization.

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -34,7 +34,7 @@ These can be combined as much as you like. To make all methods exceptions (there
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 foo.apply(undefined, args);
 foo.apply(null, args);
@@ -50,7 +50,7 @@ obj.foo.call(other, arg);
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.apply(undefined, args);
 Reflect.apply(null, args);
@@ -63,7 +63,7 @@ Reflect.apply(obj.foo, other, [arg]);
 ```
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["apply"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["apply"] }]*/
 
 foo.apply(undefined, args);
 foo.apply(null, args);
@@ -76,7 +76,7 @@ Reflect.apply(obj.foo, other, args);
 ```
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["call"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["call"] }]*/
 
 foo.call(undefined, arg);
 foo.call(null, arg);
@@ -93,7 +93,7 @@ Reflect.apply(obj.foo, other, [arg]);
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Object.defineProperty({}, 'foo', {value: 1})
 ```
@@ -101,13 +101,13 @@ Object.defineProperty({}, 'foo', {value: 1})
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.defineProperty({}, 'foo', {value: 1})
 ```
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["defineProperty"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["defineProperty"] }]*/
 
 Object.defineProperty({}, 'foo', {value: 1})
 Reflect.defineProperty({}, 'foo', {value: 1})
@@ -118,7 +118,7 @@ Reflect.defineProperty({}, 'foo', {value: 1})
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Object.getOwnPropertyDescriptor({}, 'foo')
 ```
@@ -126,15 +126,15 @@ Object.getOwnPropertyDescriptor({}, 'foo')
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.getOwnPropertyDescriptor({}, 'foo')
 ```
 
-__config:__ `prefer-reflect: [2, { exceptions: ["getOwnPropertyDescriptor"] }]`
+__config:__ `prefer-reflect: ["error", { exceptions: ["getOwnPropertyDescriptor"] }]`
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["getOwnPropertyDescriptor"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["getOwnPropertyDescriptor"] }]*/
 
 Object.getOwnPropertyDescriptor({}, 'foo')
 Reflect.getOwnPropertyDescriptor({}, 'foo')
@@ -145,7 +145,7 @@ Reflect.getOwnPropertyDescriptor({}, 'foo')
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Object.getPrototypeOf({}, 'foo')
 ```
@@ -153,13 +153,13 @@ Object.getPrototypeOf({}, 'foo')
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.getPrototypeOf({}, 'foo')
 ```
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["getPrototypeOf"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["getPrototypeOf"] }]*/
 
 Object.getPrototypeOf({}, 'foo')
 Reflect.getPrototypeOf({}, 'foo')
@@ -170,7 +170,7 @@ Reflect.getPrototypeOf({}, 'foo')
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Object.setPrototypeOf({}, Object.prototype)
 ```
@@ -178,15 +178,15 @@ Object.setPrototypeOf({}, Object.prototype)
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.setPrototypeOf({}, Object.prototype)
 ```
 
-__config:__ `prefer-reflect: [2, { exceptions: ["setPrototypeOf"] }]`
+__config:__ `prefer-reflect: ["error", { exceptions: ["setPrototypeOf"] }]`
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["setPrototypeOf"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["setPrototypeOf"] }]*/
 
 Object.setPrototypeOf({}, Object.prototype)
 Reflect.setPrototypeOf({}, Object.prototype)
@@ -197,7 +197,7 @@ Reflect.setPrototypeOf({}, Object.prototype)
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Object.isExtensible({})
 ```
@@ -205,13 +205,13 @@ Object.isExtensible({})
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.isExtensible({})
 ```
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["isExtensible"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["isExtensible"] }]*/
 
 Object.isExtensible({})
 Reflect.isExtensible({})
@@ -222,7 +222,7 @@ Reflect.isExtensible({})
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Object.getOwnPropertyNames({})
 ```
@@ -230,13 +230,13 @@ Object.getOwnPropertyNames({})
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.getOwnPropertyNames({})
 ```
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["getOwnPropertyNames"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["getOwnPropertyNames"] }]*/
 
 Object.getOwnPropertyNames({})
 Reflect.getOwnPropertyNames({})
@@ -247,7 +247,7 @@ Reflect.getOwnPropertyNames({})
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Object.preventExtensions({})
 ```
@@ -255,13 +255,13 @@ Object.preventExtensions({})
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 Reflect.preventExtensions({})
 ```
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["preventExtensions"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["preventExtensions"] }]*/
 
 Object.preventExtensions({})
 Reflect.preventExtensions({})
@@ -272,7 +272,7 @@ Reflect.preventExtensions({})
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 delete foo.bar;
 ```
@@ -280,7 +280,7 @@ delete foo.bar;
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-reflect: 2*/
+/*eslint prefer-reflect: "error"*/
 
 delete bar; // Does not reference an object, just a var
 Reflect.deleteProperty(foo, 'bar');
@@ -289,7 +289,7 @@ Reflect.deleteProperty(foo, 'bar');
 (Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md))
 
 ```js
-/*eslint prefer-reflect: [2, { exceptions: ["delete"] }]*/
+/*eslint prefer-reflect: ["error", { exceptions: ["delete"] }]*/
 
 delete bar
 delete foo.bar

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -23,7 +23,7 @@ This rule is aimed to flag usage of `Function.prototype.apply()` that can be rep
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-spread: 2*/
+/*eslint prefer-spread: "error"*/
 
 foo.apply(undefined, args);
 
@@ -35,7 +35,7 @@ obj.foo.apply(obj, args);
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-spread: 2*/
+/*eslint prefer-spread: "error"*/
 
 // The `this` binding is different.
 foo.apply(obj, args);
@@ -55,7 +55,7 @@ This rule analyzes code statically to check whether or not the `this` argument i
 So if the `this` argument is computed in a dynamic expression, this rule cannot detect a violation.
 
 ```js
-/*eslint prefer-spread: 2*/
+/*eslint prefer-spread: "error"*/
 
 // This warns.
 a[i++].foo.apply(a[i++], args);

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -19,7 +19,7 @@ This rule is aimed to flag usage of `+` operators with strings.
 The following patterns are considered problems:
 
 ```js
-/*eslint prefer-template: 2*/
+/*eslint prefer-template: "error"*/
 
 var str = "Hello, " + name + "!";
 var str = "Time: " + (12 * 60 * 60 * 1000);
@@ -28,7 +28,7 @@ var str = "Time: " + (12 * 60 * 60 * 1000);
 The following patterns are not considered problems:
 
 ```js
-/*eslint prefer-template: 2*/
+/*eslint prefer-template: "error"*/
 /*eslint-env es6*/
 
 var str = "Hello World!";

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -40,7 +40,7 @@ There are four behaviors for this rule: `"always"` (default), `"as-needed"`, `"c
 
 ```json
 {
-    "quote-props": [2, "as-needed"]
+    "quote-props": ["error", "as-needed"]
 }
 ```
 
@@ -79,7 +79,7 @@ var object = {
 When configured with `"always"` as the first option (the default), quoting for all properties will be enforced. The following patterns are considered problems:
 
 ```js
-/*eslint quote-props: [2, "always"]*/
+/*eslint quote-props: ["error", "always"]*/
 
 var object = {
     foo: "bar",
@@ -91,7 +91,7 @@ var object = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint quote-props: [2, "always"]*/
+/*eslint quote-props: ["error", "always"]*/
 /*eslint-env es6*/
 
 var object1 = {
@@ -118,7 +118,7 @@ var object3 = {
 When configured with `"as-needed"` as the first option, quotes will be enforced when they are strictly required, and unnecessary quotes will cause warnings. The following patterns are considered problems:
 
 ```js
-/*eslint quote-props: [2, "as-needed"]*/
+/*eslint quote-props: ["error", "as-needed"]*/
 
 var object = {
     "a": 0,
@@ -131,7 +131,7 @@ var object = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint quote-props: [2, "as-needed"]*/
+/*eslint quote-props: ["error", "as-needed"]*/
 /*eslint-env es6*/
 
 var object1 = {
@@ -159,14 +159,14 @@ When the `"as-needed"` mode is selected, an additional `keywords` option can be 
 
 ```json
 {
-    "quote-props": [2, "as-needed", { "keywords": true }]
+    "quote-props": ["error", "as-needed", { "keywords": true }]
 }
 ```
 
 When `keywords` is set to `true`, the following patterns become problems:
 
 ```js
-/*eslint quote-props: [2, "as-needed", { "keywords": true }]*/
+/*eslint quote-props: ["error", "as-needed", { "keywords": true }]*/
 
 var x = {
     while: 1,
@@ -178,14 +178,14 @@ Another modifier for this rule is the `unnecessary` option which defaults to `tr
 
 ```json
 {
-    "quote-props": [2, "as-needed", { "keywords": true, "unnecessary": false }]
+    "quote-props": ["error", "as-needed", { "keywords": true, "unnecessary": false }]
 }
 ```
 
 When `unnecessary` is set to `false`, the following patterns _stop_ being problems:
 
 ```js
-/*eslint quote-props: [2, "as-needed", { "keywords": true, "unnecessary": false }]*/
+/*eslint quote-props: ["error", "as-needed", { "keywords": true, "unnecessary": false }]*/
 
 var x = {
     "while": 1,
@@ -197,14 +197,14 @@ A `numbers` flag, with default value `false`, can also be used as a modifier for
 
 ```json
 {
-    "quote-props": [2, "as-needed", {"numbers": true}]
+    "quote-props": ["error", "as-needed", {"numbers": true}]
 }
 ```
 
 When `numbers` is set to `true`, the following patterns become problems:
 
 ```js
-/*eslint quote-props: [2, "as-needed", { "numbers": true }]*/
+/*eslint quote-props: ["error", "as-needed", { "numbers": true }]*/
 
 var x = {
     100: 1
@@ -224,7 +224,7 @@ var x = {
 When configured with `"consistent"`, the patterns below are considered problems. Basically `"consistent"` means all or no properties are expected to be quoted, in other words quoting style can't be mixed within an object. Please note the latter situation (no quotation at all) isn't always possible as some property names require quoting.
 
 ```js
-/*eslint quote-props: [2, "consistent"]*/
+/*eslint quote-props: ["error", "consistent"]*/
 
 var object1 = {
     foo: "bar",
@@ -241,7 +241,7 @@ var object2 = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint quote-props: [2, "consistent"]*/
+/*eslint quote-props: ["error", "consistent"]*/
 
 var object1 = {
     "foo": "bar",
@@ -265,7 +265,7 @@ var object3 = {
 When configured with `"consistent-as-needed"`, the behavior is similar to `"consistent"` with one difference. Namely, properties' quoting should be consistent (as in `"consistent"`) but whenever all quotes are redundant a warning is raised. In other words if at least one property name has to be quoted (like `qux-lorem`) then all property names must be quoted, otherwise no properties can be quoted. The following patterns are considered problems:
 
 ```js
-/*eslint quote-props: [2, "consistent-as-needed"]*/
+/*eslint quote-props: ["error", "consistent-as-needed"]*/
 
 var object1 = {
     foo: "bar",
@@ -282,7 +282,7 @@ var object2 = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint quote-props: [2, "consistent-as-needed"]*/
+/*eslint quote-props: ["error", "consistent-as-needed"]*/
 
 var object1 = {
     "foo": "bar",
@@ -300,14 +300,14 @@ When the `"consistent-as-needed"` mode is selected, an additional `keywords` opt
 
 ```json
 {
-    "quote-props": [2, "consistent-as-needed", { "keywords": true }]
+    "quote-props": ["error", "consistent-as-needed", { "keywords": true }]
 }
 ```
 
 When `keywords` is set to `true`, the following patterns are considered problems:
 
 ```js
-/*eslint quote-props: [2, "consistent-as-needed", { "keywords": true }]*/
+/*eslint quote-props: ["error", "consistent-as-needed", { "keywords": true }]*/
 
 var x = {
     while: 1,

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -37,35 +37,35 @@ Configuration looks like this:
 The following patterns are considered problems:
 
 ```js
-/*eslint quotes: [2, "double"]*/
+/*eslint quotes: ["error", "double"]*/
 
 var single = 'single';
 var unescaped = 'a string containing "double" quotes';
 ```
 
 ```js
-/*eslint quotes: [2, "single"]*/
+/*eslint quotes: ["error", "single"]*/
 
 var double = "double";
 var unescaped = "a string containing 'single' quotes";
 ```
 
 ```js
-/*eslint quotes: [2, "double", "avoid-escape"]*/
+/*eslint quotes: ["error", "double", "avoid-escape"]*/
 
 var single = 'single';
 var single = `single`;
 ```
 
 ```js
-/*eslint quotes: [2, "single", "avoid-escape"]*/
+/*eslint quotes: ["error", "single", "avoid-escape"]*/
 
 var double = "double";
 var double = `double`;
 ```
 
 ```js
-/*eslint quotes: [2, "backtick"]*/
+/*eslint quotes: ["error", "backtick"]*/
 
 var single = 'single';
 var double = "double";
@@ -73,7 +73,7 @@ var unescaped = 'a string containing `backticks`';
 ```
 
 ```js
-/*eslint quotes: [2, "backtick", "avoid-escape"]*/
+/*eslint quotes: ["error", "backtick", "avoid-escape"]*/
 
 var single = 'single';
 var double = "double";
@@ -82,7 +82,7 @@ var double = "double";
 The following patterns are not considered problems:
 
 ```js
-/*eslint quotes: [2, "double"]*/
+/*eslint quotes: ["error", "double"]*/
 /*eslint-env es6*/
 
 var double = "double";
@@ -91,7 +91,7 @@ var backtick = tag`backtick`; // backticks are allowed due to tag
 ```
 
 ```js
-/*eslint quotes: [2, "single"]*/
+/*eslint quotes: ["error", "single"]*/
 /*eslint-env es6*/
 
 var single = 'single';
@@ -99,26 +99,26 @@ var backtick = `back${x}tick`; // backticks are allowed due to substitution
 ```
 
 ```js
-/*eslint quotes: [2, "double", "avoid-escape"]*/
+/*eslint quotes: ["error", "double", "avoid-escape"]*/
 
 var single = 'a string containing "double" quotes';
 ```
 
 ```js
-/*eslint quotes: [2, "single", "avoid-escape"]*/
+/*eslint quotes: ["error", "single", "avoid-escape"]*/
 
 var double = "a string containing 'single' quotes";
 ```
 
 ```js
-/*eslint quotes: [2, "backtick"]*/
+/*eslint quotes: ["error", "backtick"]*/
 /*eslint-env es6*/
 
 var backtick = `backtick`;
 ```
 
 ```js
-/*eslint quotes: [2, "backtick", "avoid-escape"]*/
+/*eslint quotes: ["error", "backtick", "avoid-escape"]*/
 
 var double = "a string containing `backtick` quotes"
 ```

--- a/docs/rules/radix.md
+++ b/docs/rules/radix.md
@@ -35,7 +35,7 @@ There are two options for this rule:
 Examples of **incorrect** code for the default `"always"` option:
 
 ```js
-/*eslint radix: 2*/
+/*eslint radix: "error"*/
 
 var num = parseInt("071");
 
@@ -49,7 +49,7 @@ var num = parseInt();
 Examples of **correct** code for the default `"always"` option:
 
 ```js
-/*eslint radix: 2*/
+/*eslint radix: "error"*/
 
 var num = parseInt("071", 10);
 
@@ -63,7 +63,7 @@ var num = parseFloat(someValue);
 Examples of **incorrect** code for the `"as-needed"` option:
 
 ```js
-/*eslint radix: [2, "as-needed"]*/
+/*eslint radix: ["error", "as-needed"]*/
 
 var num = parseInt("071", 10);
 
@@ -75,7 +75,7 @@ var num = parseInt();
 Examples of **correct** code for the `"as-needed"` option:
 
 ```js
-/*eslint radix: [2, "as-needed"]*/
+/*eslint radix: ["error", "as-needed"]*/
 
 var num = parseInt("071");
 

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -36,7 +36,7 @@ Default option settings are
 
 ```json
 {
-    "require-jsdoc": [2, {
+    "require-jsdoc": ["error", {
         "require": {
             "FunctionDeclaration": true,
             "MethodDefinition": false,
@@ -49,7 +49,7 @@ Default option settings are
 The following patterns are considered problems:
 
 ```js
-/*eslint "require-jsdoc": [2, {
+/*eslint "require-jsdoc": ["error", {
     "require": {
         "FunctionDeclaration": true,
         "MethodDefinition": true,
@@ -69,7 +69,7 @@ class Test{
 The following patterns are not considered problems:
 
 ```js
-/*eslint "require-jsdoc": [2, {
+/*eslint "require-jsdoc": ["error", {
     "require": {
         "FunctionDeclaration": true,
         "MethodDefinition": true,

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -7,7 +7,7 @@ This rule generates warnings for generator functions that do not have the `yield
 The following patterns are considered problems:
 
 ```js
-/*eslint require-yield: 2*/
+/*eslint require-yield: "error"*/
 /*eslint-env es6*/
 
 function* foo() {
@@ -18,7 +18,7 @@ function* foo() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint require-yield: 2*/
+/*eslint require-yield: "error"*/
 /*eslint-env es6*/
 
 function* foo() {

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -34,7 +34,7 @@ The `after` option will be only applied if a semicolon is not at the end of line
 The default is `{"before": false, "after": true}`.
 
 ```json
-    "semi-spacing": [2, {"before": false, "after": true}]
+    "semi-spacing": ["error", {"before": false, "after": true}]
 ```
 
 ### `{"before": false, "after": true}`
@@ -44,7 +44,7 @@ This is the default option. It enforces spacing after semicolons and disallows s
 The following patterns are considered problems:
 
 ```js
-/*eslint semi-spacing: 2*/
+/*eslint semi-spacing: "error"*/
 
 var foo ;
 var foo;var bar;
@@ -57,7 +57,7 @@ for (i = 0;i < 10;i++) {}
 The following patterns are not considered problems:
 
 ```js
-/*eslint semi-spacing: 2*/
+/*eslint semi-spacing: "error"*/
 
 var foo;
 var foo; var bar;
@@ -76,7 +76,7 @@ This option enforces spacing before semicolons and disallows spacing after semic
 The following patterns are considered problems:
 
 ```js
-/*eslint semi-spacing: [2, { "before": true, "after": false }]*/
+/*eslint semi-spacing: ["error", { "before": true, "after": false }]*/
 
 var foo;
 var foo ; var bar;
@@ -89,7 +89,7 @@ for (i = 0; i < 10; i++) {}
 The following patterns are not considered problems:
 
 ```js
-/*eslint semi-spacing: [2, { "before": true, "after": false }]*/
+/*eslint semi-spacing: ["error", { "before": true, "after": false }]*/
 
 var foo ;
 var foo ;var bar ;

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -70,13 +70,13 @@ You can set the option in configuration like this:
 By using the default option, semicolons must be used any place where they are valid.
 
 ```json
-semi: [2, "always"]
+semi: ["error", "always"]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint semi: 2*/
+/*eslint semi: "error"*/
 
 var name = "ESLint"
 
@@ -88,7 +88,7 @@ object.method = function() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint semi: 2*/
+/*eslint semi: "error"*/
 
 var name = "ESLint";
 
@@ -102,13 +102,13 @@ object.method = function() {
 When setting the first option as "always", an additional option can be added to omit the last semicolon in a one-line block, that is, a block in which its braces (and therefore the content of the block) are in the same line:
 
 ```json
-semi: [2, "always", { "omitLastInOneLineBlock": true}]
+semi: ["error", "always", { "omitLastInOneLineBlock": true}]
 ```
 
 The following patterns are considered problems:
 
 ```js
-/*eslint semi: [2, "always", { "omitLastInOneLineBlock": true}] */
+/*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
 
 if (foo) {
     bar()
@@ -120,7 +120,7 @@ if (foo) { bar(); }
 The following patterns are not considered problems:
 
 ```js
-/*eslint semi: [2, "always", { "omitLastInOneLineBlock": true}] */
+/*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
 
 if (foo) { bar() }
 
@@ -138,7 +138,7 @@ semi: [2, "never"]
 Then, the following patterns are considered problems:
 
 ```js
-/*eslint semi: [2, "never"]*/
+/*eslint semi: ["error", "never"]*/
 
 var name = "ESLint";
 
@@ -150,7 +150,7 @@ object.method = function() {
 And the following patterns are not considered problems:
 
 ```js
-/*eslint semi: [2, "never"]*/
+/*eslint semi: ["error", "never"]*/
 
 var name = "ESLint"
 
@@ -162,7 +162,7 @@ object.method = function() {
 Even in `"never"` mode, semicolons are still allowed to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`:
 
 ```js
-/*eslint semi: [2, "never"]*/
+/*eslint semi: ["error", "never"]*/
 
 var name = "ESLint"
 

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -38,7 +38,7 @@ The default member syntax sort order is:
 The following example shows correct sorted import declarations:
 
 ```js
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import 'module-without-export.js';
 import * as foo from 'foo.js';
 import * as bar from 'bar.js';
@@ -51,45 +51,45 @@ import b from 'qux.js';
 The following patterns are considered problems:
 
 ```js
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import b from 'foo.js';
 import a from 'bar.js';
 
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import a from 'foo.js';
 import A from 'bar.js';
 
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import {b, c} from 'foo.js';
 import {a, b} from 'bar.js';
 
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import a from 'foo.js';
 import {b, c} from 'bar.js';
 
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import a from 'foo.js';
 import * as b from 'bar.js';
 
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import {b, a, c} from 'foo.js'
 ```
 
 The following patterns are not considered problems:
 
 ```js
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import a from 'foo.js';
 import b from 'bar.js';
 import c from 'baz.js';
 
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import 'foo.js'
 import * from 'bar.js';
 import {a, b} from 'baz.js';
 import c from 'qux.js';
 
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import {a, b, c} from 'foo.js'
 ```
 
@@ -106,7 +106,7 @@ Default option settings are
 
 ```json
 {
-    "sort-imports": [2, {
+    "sort-imports": ["error", {
         "ignoreCase": false,
         "ignoreMemberSort": false,
         "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
@@ -121,7 +121,7 @@ When `true` the rule ignores the case-sensitivity of the imports local name.
 The following patterns are considered problems:
 
 ```js
-/*eslint sort-imports: [2, { "ignoreCase": true }]*/
+/*eslint sort-imports: ["error", { "ignoreCase": true }]*/
 
 import B from 'foo.js';
 import a from 'bar.js';
@@ -130,7 +130,7 @@ import a from 'bar.js';
 The following patterns are not considered problems:
 
 ```js
-/*eslint sort-imports: [2, { "ignoreCase": true }]*/
+/*eslint sort-imports: ["error", { "ignoreCase": true }]*/
 
 import a from 'foo.js';
 import B from 'bar.js';
@@ -146,14 +146,14 @@ Ignores the member sorting within a `multiple` member import declaration.
 The following patterns are considered problems:
 
 ```js
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import {b, a, c} from 'foo.js'
 ```
 
 The following patterns are not considered problems:
 
 ```js
-/*eslint sort-imports: [2, { "ignoreMemberSort": true }]*/
+/*eslint sort-imports: ["error", { "ignoreMemberSort": true }]*/
 import {b, a, c} from 'foo.js'
 ```
 
@@ -173,7 +173,7 @@ Use this option if you want a different sort order. Every style must be defined 
 The following patterns are considered problems:
 
 ```js
-/*eslint sort-imports: 2*/
+/*eslint sort-imports: "error"*/
 import a from 'foo.js';
 import * as b from 'bar.js';
 ```
@@ -181,12 +181,12 @@ import * as b from 'bar.js';
 The following patterns are not considered problems:
 
 ```js
-/*eslint sort-imports: [2, { "memberSyntaxSortOrder": ['single', 'all', 'multiple', 'none'] }]*/
+/*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['single', 'all', 'multiple', 'none'] }]*/
 
 import a from 'foo.js';
 import * as b from 'bar.js';
 
-/*eslint sort-imports: [2, { "memberSyntaxSortOrder": ['all', 'single', 'multiple', 'none'] }]*/
+/*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['all', 'single', 'multiple', 'none'] }]*/
 
 import * as foo from 'foo.js';
 import z from 'zoo.js';

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -10,7 +10,7 @@ The default configuration of the rule is case-sensitive.
 The following patterns are considered problems:
 
 ```js
-/*eslint sort-vars: 2*/
+/*eslint sort-vars: "error"*/
 
 var b, a;
 
@@ -22,7 +22,7 @@ var a, A;
 The following patterns are not considered problems:
 
 ```js
-/*eslint sort-vars: 2*/
+/*eslint sort-vars: "error"*/
 
 var a, b, c, d;
 
@@ -37,7 +37,7 @@ var B, a, c;
 Alphabetical list is maintained starting from the first variable and excluding any that are considered problems. So the following code will produce two problems:
 
 ```js
-/*eslint sort-vars: 2*/
+/*eslint sort-vars: "error"*/
 
 var c, d, a, b;
 ```
@@ -45,7 +45,7 @@ var c, d, a, b;
 But this one, will only produce one:
 
 ```js
-/*eslint sort-vars: 2*/
+/*eslint sort-vars: "error"*/
 
 var c, d, a, e;
 ```
@@ -63,7 +63,7 @@ When `true` the rule ignores the case-sensitivity of the variables order.
 The following patterns are not considered problems:
 
 ```js
-/*eslint sort-vars: [2, { "ignoreCase": true }]*/
+/*eslint sort-vars: ["error", { "ignoreCase": true }]*/
 
 var a, A;
 

--- a/docs/rules/space-after-function-name.md
+++ b/docs/rules/space-after-function-name.md
@@ -30,7 +30,7 @@ function foo (x) {
 
 var x = function named (x) {};
 
-// When [1, "always"]
+// When ["error", "always"]
 function bar(x) {
     // ...
 }
@@ -45,7 +45,7 @@ function foo(x) {
 
 var x = function named(x) {};
 
-// When [1, "always"]
+// When ["error", "always"]
 function bar (x) {
     // ...
 }

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -30,7 +30,7 @@ then there should be no spaces following. The default is `"always"`.
 The following patterns are considered problems:
 
 ```js
-/*eslint space-after-keywords: 2*/
+/*eslint space-after-keywords: "error"*/
 
 if(a) {}
 
@@ -40,7 +40,7 @@ do{} while (a);
 ```
 
 ```js
-/*eslint space-after-keywords: [2, "never"]*/
+/*eslint space-after-keywords: ["error", "never"]*/
 
 if (a) {}
 ```
@@ -48,7 +48,7 @@ if (a) {}
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-after-keywords: 2*/
+/*eslint space-after-keywords: "error"*/
 
 if (a) {}
 
@@ -56,7 +56,7 @@ if (a) {} else {}
 ```
 
 ```js
-/*eslint space-after-keywords: [2, "never"]*/
+/*eslint space-after-keywords: ["error", "never"]*/
 
 if(a) {}
 ```

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -30,7 +30,7 @@ The default is `"always"`.
 The following patterns are considered problems:
 
 ```js
-/*eslint space-before-blocks: 2*/
+/*eslint space-before-blocks: "error"*/
 
 if (a){
     b();
@@ -52,7 +52,7 @@ class Foo{
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-before-blocks: 2*/
+/*eslint space-before-blocks: "error"*/
 
 if (a) {
     b();
@@ -79,7 +79,7 @@ try {} catch(a) {}
 The following patterns are considered problems:
 
 ```js
-/*eslint space-before-blocks: [2, "never"]*/
+/*eslint space-before-blocks: ["error", "never"]*/
 
 if (a) {
     b();
@@ -97,7 +97,7 @@ try {} catch(a) {}
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-before-blocks: [2, "never"]*/
+/*eslint space-before-blocks: ["error", "never"]*/
 
 if (a){
     b();
@@ -119,7 +119,7 @@ class Foo{
 The following patterns are considered problems when configured `{ "functions": "never", "keywords": "always", classes: "never" }`:
 
 ```js
-/*eslint space-before-blocks: [2, { "functions": "never", "keywords": "always", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", classes: "never" }]*/
 /*eslint-env es6*/
 
 function a() {}
@@ -135,7 +135,7 @@ class Foo{
 The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "always", classes: "never" }`:
 
 ```js
-/*eslint space-before-blocks: [2, { "functions": "never", "keywords": "always", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", classes: "never" }]*/
 /*eslint-env es6*/
 
 for (;;) {
@@ -154,7 +154,7 @@ class Foo {
 The following patterns are considered problems when configured `{ "functions": "always", "keywords": "never", classes: "never" }`:
 
 ```js
-/*eslint space-before-blocks: [2, { "functions": "always", "keywords": "never", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", classes: "never" }]*/
 /*eslint-env es6*/
 
 function a(){}
@@ -170,7 +170,7 @@ class Foo {
 The following patterns are not considered problems when configured `{ "functions": "always", "keywords": "never", classes: "never" }`:
 
 ```js
-/*eslint space-before-blocks: [2, { "functions": "always", "keywords": "never", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", classes: "never" }]*/
 /*eslint-env es6*/
 
 if (a){
@@ -187,7 +187,7 @@ class Foo{
 The following patterns are considered problems when configured `{ "functions": "never", "keywords": "never", classes: "always" }`:
 
 ```js
-/*eslint space-before-blocks: [2, { "functions": "never", "keywords": "never", classes: "always" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", classes: "always" }]*/
 /*eslint-env es6*/
 
 class Foo{
@@ -199,7 +199,7 @@ class Foo{
 The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "never", classes: "always" }`:
 
 ```js
-/*eslint space-before-blocks: [2, { "functions": "never", "keywords": "never", classes: "always" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", classes: "always" }]*/
 /*eslint-env es6*/
 
 class Foo {

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -35,7 +35,7 @@ The default configuration is `"always"`.
 The following patterns are considered problems:
 
 ```js
-/*eslint space-before-function-paren: 2*/
+/*eslint space-before-function-paren: "error"*/
 /*eslint-env es6*/
 
 function foo() {
@@ -66,7 +66,7 @@ var foo = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-before-function-paren: 2*/
+/*eslint space-before-function-paren: "error"*/
 /*eslint-env es6*/
 
 function foo () {
@@ -99,7 +99,7 @@ var foo = {
 The following patterns are considered problems:
 
 ```js
-/*eslint space-before-function-paren: [2, "never"]*/
+/*eslint space-before-function-paren: ["error", "never"]*/
 /*eslint-env es6*/
 
 function foo () {
@@ -130,7 +130,7 @@ var foo = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-before-function-paren: [2, "never"]*/
+/*eslint space-before-function-paren: ["error", "never"]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -163,7 +163,7 @@ var foo = {
 The following patterns are considered problems:
 
 ```js
-/*eslint space-before-function-paren: [2, { "anonymous": "always", "named": "never" }]*/
+/*eslint space-before-function-paren: ["error", { "anonymous": "always", "named": "never" }]*/
 /*eslint-env es6*/
 
 function foo () {
@@ -190,7 +190,7 @@ var foo = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-before-function-paren: [2, { "anonymous": "always", "named": "never" }]*/
+/*eslint space-before-function-paren: ["error", { "anonymous": "always", "named": "never" }]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -219,7 +219,7 @@ var foo = {
 The following patterns are considered problems:
 
 ```js
-/*eslint space-before-function-paren: [2, { "anonymous": "never", "named": "always" }]*/
+/*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -246,7 +246,7 @@ var foo = {
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-before-function-paren: [2, { "anonymous": "never", "named": "always" }]*/
+/*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
 /*eslint-env es6*/
 
 function foo () {

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -33,7 +33,7 @@ this behaviour, consider using the [block-spacing](block-spacing.md) rule.
 The following patterns are considered errors when configured `"never"`:
 
 ```js
-/*eslint space-before-keywords: [2, "never"]*/
+/*eslint space-before-keywords: ["error", "never"]*/
 
 if (foo) {
     // ...
@@ -52,7 +52,7 @@ try {} catch(e) {}
 The following patterns are not considered errors when configured `"never"`:
 
 ```js
-/*eslint space-before-keywords: [2, "never"]*/
+/*eslint space-before-keywords: ["error", "never"]*/
 
 if (foo) {
     // ...
@@ -68,7 +68,7 @@ try{}catch(e) {}
 The following patterns are considered errors when configured `"always"`:
 
 ```js
-/*eslint space-before-keywords: [2, "always"]*/
+/*eslint space-before-keywords: ["error", "always"]*/
 /*eslint-env es6*/
 
 if (foo) {
@@ -87,7 +87,7 @@ function bar() {
 The following patterns are not considered errors when configured `"always"`:
 
 ```js
-/*eslint space-before-keywords: [2, "always"]*/
+/*eslint space-before-keywords: ["error", "always"]*/
 /*eslint-env es6*/
 
 if (foo) {

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -28,7 +28,7 @@ There are two options for this rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"space-in-brackets": [2, "always"]
+"space-in-brackets": ["error", "always"]
 ```
 
 ### "never"
@@ -58,7 +58,7 @@ var obj = {baz: { 'foo': 'qux' }, bar};
 The following patterns are not considered problems:
 
 ```js
-// When options are [2, "never"]
+// When options are ["error", "never"]
 
 foo['bar'];
 foo[
@@ -165,7 +165,7 @@ You can add exceptions like so:
 In case of `"always"` option, set an exception to `false` to enable it:
 
 ```json
-"space-in-brackets": [2, "always", {
+"space-in-brackets": ["error", "always", {
   "singleValue": false,
   "objectsInArrays": false,
   "arraysInArrays": false,
@@ -178,7 +178,7 @@ In case of `"always"` option, set an exception to `false` to enable it:
 In case of `"never"` option, set an exception to `true` to enable it:
 
 ```json
-"space-in-brackets": [2, "never", {
+"space-in-brackets": ["error", "never", {
   "singleValue": true,
   "objectsInArrays": true,
   "arraysInArrays": true,

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -26,7 +26,7 @@ There are two options for this rule:
 Depending on your coding conventions, you can choose either option by specifying it in your configuration:
 
 ```json
-"space-in-parens": [2, "always"]
+"space-in-parens": ["error", "always"]
 ```
 
 ### "always"
@@ -34,7 +34,7 @@ Depending on your coding conventions, you can choose either option by specifying
 When `"always"` is set, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always"]*/
+/*eslint space-in-parens: ["error", "always"]*/
 
 foo( 'bar');
 foo('bar' );
@@ -47,7 +47,7 @@ var foo = (1 + 2) * 3;
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always"]*/
+/*eslint space-in-parens: ["error", "always"]*/
 
 foo();
 
@@ -62,7 +62,7 @@ var foo = ( 1 + 2 ) * 3;
 When `"never"` is used, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never"]*/
+/*eslint space-in-parens: ["error", "never"]*/
 
 foo( 'bar');
 foo('bar' );
@@ -75,7 +75,7 @@ var foo = ( 1 + 2 ) * 3;
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never"]*/
+/*eslint space-in-parens: ["error", "never"]*/
 
 foo();
 
@@ -91,10 +91,10 @@ An object literal may be used as a third array item to specify exceptions, with 
 
 The following exceptions are available: `["{}", "[]", "()", "empty"]`.
 
-For example, given `"space-in-parens": [2, "always", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
+For example, given `"space-in-parens": ["error", "always", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["{}"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
 
 foo( {bar: 'baz'} );
 foo( 1, {bar: 'baz'} );
@@ -103,16 +103,16 @@ foo( 1, {bar: 'baz'} );
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["{}"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
 
 foo({bar: 'baz'});
 foo( 1, {bar: 'baz'});
 ```
 
-Or, given `"space-in-parens": [2, "never", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
+Or, given `"space-in-parens": ["error", "never", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["{}"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
 
 foo({bar: 'baz'});
 foo(1, {bar: 'baz'});
@@ -121,16 +121,16 @@ foo(1, {bar: 'baz'});
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["{}"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
 
 foo( {bar: 'baz'} );
 foo(1, {bar: 'baz'} );
 ```
 
-Given `"space-in-parens": [2, "always", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
+Given `"space-in-parens": ["error", "always", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["[]"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
 
 foo( [bar, baz] );
 foo( [bar, baz], 1 );
@@ -139,16 +139,16 @@ foo( [bar, baz], 1 );
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["[]"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
 
 foo([bar, baz]);
 foo([bar, baz], 1 );
 ```
 
-Or, given `"space-in-parens": [2, "never", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
+Or, given `"space-in-parens": ["error", "never", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["[]"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
 
 foo([bar, baz]);
 foo([bar, baz], 1);
@@ -157,16 +157,16 @@ foo([bar, baz], 1);
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["[]"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
 
 foo( [bar, baz] );
 foo( [bar, baz], 1);
 ```
 
-Given `"space-in-parens": [2, "always", { "exceptions": ["()"] }]`, the following patterns are considered problems:
+Given `"space-in-parens": ["error", "always", { "exceptions": ["()"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["()"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
 
 foo( ( 1 + 2 ) );
 foo( ( 1 + 2 ), 1 );
@@ -175,16 +175,16 @@ foo( ( 1 + 2 ), 1 );
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["()"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
 
 foo(( 1 + 2 ));
 foo(( 1 + 2 ), 1 );
 ```
 
-Or, given `"space-in-parens": [2, "never", { "exceptions": ["()"] }]`, the following patterns are considered problems:
+Or, given `"space-in-parens": ["error", "never", { "exceptions": ["()"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["()"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
 
 foo((1 + 2));
 foo((1 + 2), 1);
@@ -193,7 +193,7 @@ foo((1 + 2), 1);
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["()"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
 
 foo( (1 + 2) );
 foo( (1 + 2), 1);
@@ -201,10 +201,10 @@ foo( (1 + 2), 1);
 
 The `"empty"` exception concerns empty parentheses, and works the same way as the other exceptions, inverting the first option.
 
-For example, given `"space-in-parens": [2, "always", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
+For example, given `"space-in-parens": ["error", "always", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["empty"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
 
 foo( );
 ```
@@ -212,15 +212,15 @@ foo( );
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["empty"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
 
 foo();
 ```
 
-Or, given `"space-in-parens": [2, "never", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
+Or, given `"space-in-parens": ["error", "never", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["empty"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
 
 foo();
 ```
@@ -228,15 +228,15 @@ foo();
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "never", { "exceptions": ["empty"] }]*/
+/*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
 
 foo( );
 ```
 
-You can include multiple entries in the `"exceptions"` array. For example, given `"space-in-parens": [2, "always", { "exceptions": ["{}", "[]"] }]`, the following patterns are considered problems:
+You can include multiple entries in the `"exceptions"` array. For example, given `"space-in-parens": ["error", "always", { "exceptions": ["{}", "[]"] }]`, the following patterns are considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["{}", "[]"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/
 
 bar( {bar:'baz'} );
 baz( 1, [1,2] );
@@ -246,7 +246,7 @@ foo( {bar: 'baz'}, [1, 2] );
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-in-parens: [2, "always", { "exceptions": ["{}", "[]"] }]*/
+/*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/
 
 bar({bar:'baz'});
 baz( 1, [1,2]);

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -25,7 +25,7 @@ This rule is aimed at ensuring there are spaces around infix operators.
 This rule accepts a single options argument with the following defaults:
 
 ```json
-"space-infix-ops": [2, {"int32Hint": false}]
+"space-infix-ops": ["error", {"int32Hint": false}]
 ```
 
 ### `int32Hint`
@@ -39,7 +39,7 @@ var foo = bar|0; // `foo` is forced to be signed 32 bit integer
 The following patterns are considered problems:
 
 ```js
-/*eslint space-infix-ops: 2*/
+/*eslint space-infix-ops: "error"*/
 /*eslint-env es6*/
 
 a+b
@@ -60,7 +60,7 @@ function foo(a=0) { }
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-infix-ops: 2*/
+/*eslint space-infix-ops: "error"*/
 /*eslint-env es6*/
 
 a + b

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -11,7 +11,7 @@ Require spaces following `return`, `throw`, and `case`.
 The following patterns are considered problems:
 
 ```js
-/*eslint space-return-throw-case: 2*/
+/*eslint space-return-throw-case: "error"*/
 
 throw{a:0}
 
@@ -23,7 +23,7 @@ switch(a){ case'a': break; }
 The following patterns are not considered problems:
 
 ```js
-/*eslint space-return-throw-case: 2*/
+/*eslint space-return-throw-case: "error"*/
 
 throw {a: 0};
 

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -64,7 +64,7 @@ In this case, spacing will be disallowed after a `new` operator and required bef
 Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are considered problems:
 
 ```js
-/*eslint space-unary-ops: 2*/
+/*eslint space-unary-ops: "error"*/
 
 typeof!foo;
 
@@ -84,7 +84,7 @@ foo --;
 ```
 
 ```js
-/*eslint space-unary-ops: 2*/
+/*eslint space-unary-ops: "error"*/
 /*eslint-env es6*/
 
 function *foo() {
@@ -95,7 +95,7 @@ function *foo() {
 Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are not considered problems:
 
 ```js
-/*eslint space-unary-ops: 2*/
+/*eslint space-unary-ops: "error"*/
 
 // Word unary operator "delete" is followed by a whitespace.
 delete foo.bar;
@@ -120,7 +120,7 @@ foo--;
 ```
 
 ```js
-/*eslint space-unary-ops: 2*/
+/*eslint space-unary-ops: "error"*/
 /*eslint-env es6*/
 
 function *foo() {

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -27,7 +27,7 @@ The rule takes two options.
     Please note that exceptions are ignored if the first argument is `"never"`.
 
     ```json
-    "spaced-comment": [2, "always", { "exceptions": ["-", "+"] }]
+    "spaced-comment": ["error", "always", { "exceptions": ["-", "+"] }]
     ```
 
     * The `"markers"` value is an array of string patterns which are considered markers for docblock-style comments,
@@ -35,7 +35,7 @@ The rule takes two options.
     The `"markers"` array will apply regardless of the value of the first argument, e.g. `"always"` or `"never"`.
 
     ```json
-    "spaced-comment": [2, "always", { "markers": ["/"] }]
+    "spaced-comment": ["error", "always", { "markers": ["/"] }]
     ```
 
 The difference between a marker and an exception is that a marker only appears at the beginning of the comment whereas
@@ -44,7 +44,7 @@ exceptions can occur anywhere in the comment string.
 You can also define separate exceptions and markers for block and line comments:
 
 ```json
-"spaced-comment": [2, "always", {
+"spaced-comment": ["error", "always", {
     "line": {
         "markers": ["/"],
         "exceptions": ["-", "+"]
@@ -61,7 +61,7 @@ You can also define separate exceptions and markers for block and line comments:
 The following patterns are considered problems:
 
 ```js
-/*eslint spaced-comment: [2, "always"]*/
+/*eslint spaced-comment: ["error", "always"]*/
 
 //This is a comment with no whitespace at the beginning
 
@@ -71,7 +71,7 @@ The following patterns are considered problems:
 The following patterns are not considered problems:
 
 ```js
-/* eslint spaced-comment: [2, "always"] */
+/* eslint spaced-comment: ["error", "always"] */
 
 // This is a comment with a whitespace at the beginning
 
@@ -87,7 +87,7 @@ This comment has a newline
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always"] */
+/* eslint spaced-comment: ["error", "always"] */
 
 /**
 * I am jsdoc
@@ -99,7 +99,7 @@ This comment has a newline
 The following patterns are considered problems:
 
 ```js
-/*eslint spaced-comment: [2, "never"]*/
+/*eslint spaced-comment: ["error", "never"]*/
 
 // This is a comment with a whitespace at the beginning
 
@@ -111,13 +111,13 @@ The following patterns are considered problems:
 The following patterns are not considered problems:
 
 ```js
-/*eslint spaced-comment: [2, "never"]*/
+/*eslint spaced-comment: ["error", "never"]*/
 
 /*This is a comment with no whitespace at the beginning */
 ```
 
 ```js
-/*eslint spaced-comment: [2, "never"]*/
+/*eslint spaced-comment: ["error", "never"]*/
 
 /**
 * I am jsdoc
@@ -129,7 +129,7 @@ The following patterns are not considered problems:
 The following patterns are considered problems:
 
 ```js
-/* eslint spaced-comment: [2, "always", { "block": { "exceptions": ["-"] } }] */
+/* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["-"] } }] */
 
 //--------------
 // Comment block
@@ -137,7 +137,7 @@ The following patterns are considered problems:
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
+/* eslint spaced-comment: ["error", "always", { "exceptions": ["-", "+"] }] */
 
 //------++++++++
 // Comment block
@@ -145,7 +145,7 @@ The following patterns are considered problems:
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["-", "+"] }] */
+/* eslint spaced-comment: ["error", "always", { "exceptions": ["-", "+"] }] */
 
 /*------++++++++*/
 /* Comment block */
@@ -153,7 +153,7 @@ The following patterns are considered problems:
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "line": { "exceptions": ["-+"] } }] */
+/* eslint spaced-comment: ["error", "always", { "line": { "exceptions": ["-+"] } }] */
 
 /*-+-+-+-+-+-+-+*/
 // Comment block
@@ -163,7 +163,7 @@ The following patterns are considered problems:
 The following patterns are not considered problems:
 
 ```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["-"] }] */
+/* eslint spaced-comment: ["error", "always", { "exceptions": ["-"] }] */
 
 //--------------
 // Comment block
@@ -171,7 +171,7 @@ The following patterns are not considered problems:
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "line": { "exceptions": ["-"] } }] */
+/* eslint spaced-comment: ["error", "always", { "line": { "exceptions": ["-"] } }] */
 
 //--------------
 // Comment block
@@ -179,7 +179,7 @@ The following patterns are not considered problems:
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["*"] }] */
+/* eslint spaced-comment: ["error", "always", { "exceptions": ["*"] }] */
 
 /****************
  * Comment block
@@ -187,7 +187,7 @@ The following patterns are not considered problems:
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "exceptions": ["-+"] }] */
+/* eslint spaced-comment: ["error", "always", { "exceptions": ["-+"] }] */
 
 //-+-+-+-+-+-+-+
 // Comment block
@@ -199,7 +199,7 @@ The following patterns are not considered problems:
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "block": { "exceptions": ["-+"] } }] */
+/* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["-+"] } }] */
 
 /*-+-+-+-+-+-+-+*/
 // Comment block
@@ -211,7 +211,7 @@ The following patterns are not considered problems:
 The following patterns are considered problems:
 
 ```js
-/* eslint spaced-comment: [2, "always", { "markers": ["/"] }] */
+/* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */
 
 ///This is a comment with a marker but without whitespace
 ```
@@ -219,13 +219,13 @@ The following patterns are considered problems:
 The following patterns are not considered problems:
 
 ```js
-/* eslint spaced-comment: [2, "always", { "markers": ["/"] }] */
+/* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */
 
 /// This is a comment with a marker
 ```
 
 ```js
-/*eslint spaced-comment: [2, "never", { "markers": ["!<"] }]*/
+/*eslint spaced-comment: ["error", "never", { "markers": ["!<"] }]*/
 
 //!<This is a line comment with a marker
 
@@ -235,7 +235,7 @@ subsequent lines are ignored
 ```
 
 ```js
-/* eslint spaced-comment: [2, "always", { "markers": ["global"] }] */
+/* eslint spaced-comment: ["error", "always", { "markers": ["global"] }] */
 
 /*global ABC*/
 ```

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -50,7 +50,7 @@ This mode forbids any occurrence of a strict mode directive.
 Examples of **incorrect** code for the `"never"` option:
 
 ```js
-/*eslint strict: [2, "never"]*/
+/*eslint strict: ["error", "never"]*/
 
 "use strict";
 
@@ -71,7 +71,7 @@ bar();
 Examples of **correct** code for the `"never"` option:
 
 ```js
-/*eslint strict: [2, "never"]*/
+/*eslint strict: ["error", "never"]*/
 
 function foo() {
     return;
@@ -92,7 +92,7 @@ This mode ensures that all code is in strict mode and that there are no extraneo
 Examples of **incorrect** code for the `"global"` option:
 
 ```js
-/*eslint strict: [2, "global"]*/
+/*eslint strict: ["error", "global"]*/
 
 "use strict";
 "use strict";
@@ -114,7 +114,7 @@ foo();
 Examples of **correct** code for the `"global"` option:
 
 ```js
-/*eslint strict: [2, "global"]*/
+/*eslint strict: ["error", "global"]*/
 
 "use strict";
 
@@ -134,7 +134,7 @@ This mode ensures that all function bodies are strict mode code, while global co
 Examples of **incorrect** code for the `"function"` option:
 
 ```js
-/*eslint strict: [2, "function"]*/
+/*eslint strict: ["error", "function"]*/
 
 "use strict";
 
@@ -155,7 +155,7 @@ foo();
 Examples of **correct** code for the `"function"` option:
 
 ```js
-/*eslint strict: [2, "function"]*/
+/*eslint strict: ["error", "function"]*/
 
 function foo() {
     "use strict";
@@ -183,7 +183,7 @@ This mode ensures that all functions are executed in strict mode. A strict mode 
 Examples of **incorrect** code for an earlier default option which has been removed:
 
 ```js
-// "strict": 2
+// "strict": "error"
 
 function foo() {
     return true;
@@ -193,7 +193,7 @@ function foo() {
 Examples of **correct** code for an earlier default option which has been removed:
 
 ```js
-// "strict": 2
+// "strict": "error"
 
 "use strict";
 
@@ -203,7 +203,7 @@ function foo() {
 ```
 
 ```js
-// "strict": 2
+// "strict": "error"
 
 function foo() {
 
@@ -214,7 +214,7 @@ function foo() {
 ```
 
 ```js
-// "strict": 2
+// "strict": "error"
 
 (function() {
     "use strict";

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -17,7 +17,7 @@ This rule aims to maintain consistency around the spacing inside of template lit
 
 ```json
 {
-    "template-curly-spacing": [2, "never"]
+    "template-curly-spacing": ["error", "never"]
 }
 ```
 
@@ -29,7 +29,7 @@ This rule has one option which has either `"never"` or `"always"` as value.
 The following patterns are considered problems when configured `"never"`:
 
 ```js
-/*eslint template-curly-spacing: 2*/
+/*eslint template-curly-spacing: "error"*/
 
 `hello, ${ people.name}!`;
 `hello, ${people.name }!`;
@@ -40,7 +40,7 @@ The following patterns are considered problems when configured `"never"`:
 The following patterns are considered problems when configured `"always"`:
 
 ```js
-/*eslint template-curly-spacing: [2, "always"]*/
+/*eslint template-curly-spacing: ["error", "always"]*/
 
 `hello, ${ people.name}!`;
 `hello, ${people.name }!`;
@@ -51,7 +51,7 @@ The following patterns are considered problems when configured `"always"`:
 The following patterns are not considered problems when configured `"never"`:
 
 ```js
-/*eslint template-curly-spacing: 2*/
+/*eslint template-curly-spacing: "error"*/
 
 `hello, ${people.name}!`;
 
@@ -63,7 +63,7 @@ The following patterns are not considered problems when configured `"never"`:
 The following patterns are not considered problems when configured `"always"`:
 
 ```js
-/*eslint template-curly-spacing: [2, "always"]*/
+/*eslint template-curly-spacing: ["error", "always"]*/
 
 `hello, ${ people.name }!`;
 

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -9,7 +9,7 @@ This rule is aimed at eliminating potential errors as the result of comparing ag
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint use-isnan: 2*/
+/*eslint use-isnan: "error"*/
 
 if (foo == NaN) {
     // ...
@@ -23,7 +23,7 @@ if (foo != NaN) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint use-isnan: 2*/
+/*eslint use-isnan: "error"*/
 
 if (isNaN(foo)) {
     // ...

--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -30,7 +30,7 @@ This rule aims to prevent invalid and incomplete JSDoc comments. It will warn wh
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint valid-jsdoc: 2*/
+/*eslint valid-jsdoc: "error"*/
 
 // missing type for @param and missing @returns
 /**                                 // 2 errors
@@ -92,7 +92,7 @@ function foo(a) {
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint valid-jsdoc: 2*/
+/*eslint valid-jsdoc: "error"*/
 
 /**
  * Adds two numbers together.
@@ -140,7 +140,7 @@ class Foo {
 JSDoc offers a lot of tags with overlapping meaning. For example, both `@return` and `@returns` are acceptable for specifying the return value of a function. However, you may want to enforce a certain tag be used instead of others. You can specify your preferences regarding tag substitution by providing a mapping called `prefer` in the rule configuration. For example, to specify that `@returns` should be used instead of `@return`, you can use the following configuration:
 
 ```json
-"valid-jsdoc": [2, {
+"valid-jsdoc": ["error", {
     "prefer": {
         "return": "returns"
     }
@@ -154,7 +154,7 @@ With this configuration, ESLint will warn when it finds `@return` and recommend 
 By default ESLint requires you to document every function with a `@return` tag regardless of whether there is anything returned by the function. If instead you want to enforce that only functions with a `return` statement are documented with a `@return` tag, set the `requireReturn` option to `false`.  When `requireReturn` is `false`, every function documented with a `@return` tag must have a `return` statement, and every function with a `return` statement must have a `@return` tag.
 
 ```json
-"valid-jsdoc": [2, {
+"valid-jsdoc": ["error", {
     "requireReturn": false
 }]
 ```
@@ -164,7 +164,7 @@ By default ESLint requires you to document every function with a `@return` tag r
 By default ESLint requires you to specify a description for each `@param`. You can choose not to require descriptions for parameters by setting `requireParamDescription` to `false`.
 
 ```json
-"valid-jsdoc": [2, {
+"valid-jsdoc": ["error", {
     "requireParamDescription": false
 }]
 ```
@@ -174,7 +174,7 @@ By default ESLint requires you to specify a description for each `@param`. You c
 By default ESLint requires you to specify a description for each `@return`. You can choose not to require descriptions for `@return` by setting `requireReturnDescription` to `false`.
 
 ```json
-"valid-jsdoc": [2, {
+"valid-jsdoc": ["error", {
     "requireReturnDescription": false
 }]
 ```
@@ -184,7 +184,7 @@ By default ESLint requires you to specify a description for each `@return`. You 
 Specify a regular expression to validate jsdoc comment block description against.
 
 ```json
-"valid-jsdoc": [2, {
+"valid-jsdoc": ["error", {
     "matchDescription": "^[A-Z][A-Za-z0-9\\s]*[.]$"
 }]
 ```
@@ -194,7 +194,7 @@ Specify a regular expression to validate jsdoc comment block description against
 By default ESLint requires you to specify `type` for `@return` tag for every documented function.
 
 ```json
-"valid-jsdoc": [2, {
+"valid-jsdoc": ["error", {
     "requireReturnType": false
 }]
 ```
@@ -205,7 +205,7 @@ It will validate all the types from jsdoc with the options setup by the user. In
 In the example below, it will expect the "object" to start with an uppercase and all the "string" type to start with a lowercase.
 
 ```json
-"valid-jsdoc": [2, {
+"valid-jsdoc": ["error", {
     "preferType": {
         "String": "string",
         "object": "Object",
@@ -217,7 +217,7 @@ In the example below, it will expect the "object" to start with an uppercase and
 Examples of **incorrect** code for a sample of `"preferType"` options:
 
 ```js
-/*eslint valid-jsdoc: [2, { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
+/*eslint valid-jsdoc: ["error", { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
 
 /**
  * Adds two numbers together.
@@ -251,7 +251,7 @@ function foo(param1) {
 Examples of **correct** code for a sample of `"preferType"` options:
 
 ```js
-/*eslint valid-jsdoc: [2, { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
+/*eslint valid-jsdoc: ["error", { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
 
 /**
  * Adds two numbers together.

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -9,7 +9,7 @@ This rule aims to prevent errors from likely typos by ensuring that when the res
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint valid-typeof: 2*/
+/*eslint valid-typeof: "error"*/
 
 typeof foo === "strnig"
 typeof foo == "undefimed"
@@ -20,7 +20,7 @@ typeof bar !== "fucntion"
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint valid-typeof: 2*/
+/*eslint valid-typeof: "error"*/
 
 typeof foo === "string"
 typeof bar == "undefined"

--- a/docs/rules/vars-on-top.md
+++ b/docs/rules/vars-on-top.md
@@ -12,7 +12,7 @@ Allowing multiple declarations helps promote maintainability and is thus allowed
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint vars-on-top: 2*/
+/*eslint vars-on-top: "error"*/
 
 // Variable declarations in a block:
 function doSomething() {
@@ -30,7 +30,7 @@ function doSomething() {
 ```
 
 ```js
-/*eslint vars-on-top: 2*/
+/*eslint vars-on-top: "error"*/
 
 // Variables after other statements:
 f();
@@ -40,7 +40,7 @@ var a;
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint vars-on-top: 2*/
+/*eslint vars-on-top: "error"*/
 
 function doSomething() {
     var first;
@@ -57,14 +57,14 @@ function doSomething() {
 ```
 
 ```js
-/*eslint vars-on-top: 2*/
+/*eslint vars-on-top: "error"*/
 
 var a;
 f();
 ```
 
 ```js
-/*eslint vars-on-top: 2*/
+/*eslint vars-on-top: "error"*/
 
 // Directives may precede variable declarations.
 "use strict";

--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -27,7 +27,7 @@ The rule takes one option which can enforce a consistent wrapping style:
 Examples of **incorrect** code for the default `"outside"` option:
 
 ```js
-/*eslint wrap-iife: [2, "outside"]*/
+/*eslint wrap-iife: ["error", "outside"]*/
 
 var x = function () { return { y: 1 };}(); // unwrapped
 var x = (function () { return { y: 1 };})(); // wrapped function expression
@@ -36,7 +36,7 @@ var x = (function () { return { y: 1 };})(); // wrapped function expression
 Examples of **correct** code for the default `"outside"` option:
 
 ```js
-/*eslint wrap-iife: [2, "outside"]*/
+/*eslint wrap-iife: ["error", "outside"]*/
 
 var x = (function () { return { y: 1 };}()); // wrapped call expression
 ```
@@ -46,7 +46,7 @@ var x = (function () { return { y: 1 };}()); // wrapped call expression
 Examples of **incorrect** code for the `"inside"` option:
 
 ```js
-/*eslint wrap-iife: [2, "inside"]*/
+/*eslint wrap-iife: ["error", "inside"]*/
 
 var x = function () { return { y: 1 };}(); // unwrapped
 var x = (function () { return { y: 1 };}()); // wrapped call expression
@@ -55,7 +55,7 @@ var x = (function () { return { y: 1 };}()); // wrapped call expression
 Examples of **correct** code for the `"inside"` option:
 
 ```js
-/*eslint wrap-iife: [2, "inside"]*/
+/*eslint wrap-iife: ["error", "inside"]*/
 
 var x = (function () { return { y: 1 };})(); // wrapped function expression
 ```
@@ -65,7 +65,7 @@ var x = (function () { return { y: 1 };})(); // wrapped function expression
 Examples of **incorrect** code for the `"any"` option:
 
 ```js
-/*eslint wrap-iife: [2, "any"]*/
+/*eslint wrap-iife: ["error", "any"]*/
 
 var x = function () { return { y: 1 };}(); // unwrapped
 ```
@@ -73,7 +73,7 @@ var x = function () { return { y: 1 };}(); // unwrapped
 Examples of **correct** code for the `"any"` option:
 
 ```js
-/*eslint wrap-iife: [2, "any"]*/
+/*eslint wrap-iife: ["error", "any"]*/
 
 var x = (function () { return { y: 1 };}()); // wrapped call expression
 var x = (function () { return { y: 1 };})(); // wrapped function expression

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -15,7 +15,7 @@ This is used to disambiguate the slash operator and facilitates more readable co
 The following patterns are considered problems:
 
 ```js
-/*eslint wrap-regex: 2*/
+/*eslint wrap-regex: "error"*/
 
 function a() {
     return /foo/.test("bar");
@@ -25,7 +25,7 @@ function a() {
 The following patterns are not considered problems:
 
 ```js
-/*eslint wrap-regex: 2*/
+/*eslint wrap-regex: "error"*/
 
 function a() {
     return (/foo/).test("bar");

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -17,7 +17,7 @@ The rule takes one option, an object, which has two keys `before` and `after` ha
 The default is `{"before": false, "after": true}`.
 
 ```json
-"yield-star-spacing": [2, {"before": true, "after": false}]
+"yield-star-spacing": ["error", {"before": true, "after": false}]
 ```
 
 The option also has a string shorthand:
@@ -28,13 +28,13 @@ The option also has a string shorthand:
 * `{"before": false, "after": false}` → `"neither"`
 
 ```json
-"yield-star-spacing": [2, "after"]
+"yield-star-spacing": ["error", "after"]
 ```
 
 When using `"after"` this spacing will be enforced:
 
 ```js
-/*eslint yield-star-spacing: [2, "after"]*/
+/*eslint yield-star-spacing: ["error", "after"]*/
 /*eslint-env es6*/
 
 function* generator() {
@@ -45,7 +45,7 @@ function* generator() {
 When using `"before"` this spacing will be enforced:
 
 ```js
-/*eslint yield-star-spacing: [2, "before"]*/
+/*eslint yield-star-spacing: ["error", "before"]*/
 /*eslint-env es6*/
 
 function *generator() {
@@ -56,7 +56,7 @@ function *generator() {
 When using `"both"` this spacing will be enforced:
 
 ```js
-/*eslint yield-star-spacing: [2, "both"]*/
+/*eslint yield-star-spacing: ["error", "both"]*/
 /*eslint-env es6*/
 
 function * generator() {
@@ -67,7 +67,7 @@ function * generator() {
 When using `"neither"` this spacing will be enforced:
 
 ```js
-/*eslint yield-star-spacing: [2, "neither"]*/
+/*eslint yield-star-spacing: ["error", "neither"]*/
 /*eslint-env es6*/
 
 function*generator() {

--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -45,7 +45,7 @@ The `onlyEquality` option allows a superset of the exceptions which `exceptRange
 Examples of **incorrect** code for the default `"never"` option:
 
 ```js
-/*eslint yoda: 2*/
+/*eslint yoda: "error"*/
 
 if ("red" === color) {
     // ...
@@ -71,7 +71,7 @@ if (0 <= x && x < 1) {
 Examples of **correct** code for the default `"never"` option:
 
 ```js
-/*eslint yoda: 2*/
+/*eslint yoda: "error"*/
 
 if (5 & value) {
     // ...
@@ -87,7 +87,7 @@ if (value === "red") {
 Examples of **correct** code for the `"never", { "exceptRange": true }` options:
 
 ```js
-/*eslint yoda: [2, "never", { "exceptRange": true }]*/
+/*eslint yoda: ["error", "never", { "exceptRange": true }]*/
 
 function isReddish(color) {
     return (color.hue < 60 || 300 < color.hue);
@@ -111,7 +111,7 @@ function howLong(arr) {
 Examples of **correct** code for the `"never", { "onlyEquality": true }` options:
 
 ```js
-/*eslint yoda: [2, "never", { "onlyEquality": true }]*/
+/*eslint yoda: ["error", "never", { "onlyEquality": true }]*/
 
 if (x < -1 || 9 < x) {
 }
@@ -125,7 +125,7 @@ if (x !== 'foo' && 'bar' != x) {
 Examples of **incorrect** code for the `"always"` option:
 
 ```js
-/*eslint yoda: [2, "always"]*/
+/*eslint yoda: ["error", "always"]*/
 
 if (color == "blue") {
     // ...
@@ -135,7 +135,7 @@ if (color == "blue") {
 Examples of **correct** code for the `"always"` option:
 
 ```js
-/*eslint yoda: [2, "always"]*/
+/*eslint yoda: ["error", "always"]*/
 
 if ("blue" == value) {
     // ...


### PR DESCRIPTION
Picking some low hanging fruit.

Since rule severity can now be denoted as a string, and given that it seems to be the new standard for rule docs from recent pull requests, I thought I'd update the rest of the docs to follow suit.