### PR TITLE
Fix: Fix bundleDeps for npm@2 shrinkwrap (fixes #5687)

### DIFF
--- a/package.json
+++ b/package.json
@@ -119,6 +119,7 @@
     "es6-map",
     "escope",
     "espree",
+    "esprima",
     "estraverse",
     "esutils",
     "file-entry-cache",
@@ -144,6 +145,7 @@
     "strip-json-comments",
     "table",
     "text-table",
+    "through",
     "user-home"
   ]
 }


### PR DESCRIPTION
Include sub-dependencies that are also dev dependencies in bundled dependencies