### PR TITLE
Fix: make the default of `options.cwd` in runtime (fixes #5694)

### DIFF
--- a/conf/cli-options.js
+++ b/conf/cli-options.js
@@ -28,6 +28,5 @@ module.exports = {
     cacheLocation: "",
     cacheFile: ".eslintcache",
     fix: false,
-    allowInlineConfig: true,
-    cwd: process.cwd()
+    allowInlineConfig: true
 };

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -73,12 +73,6 @@ var fs = require("fs"),
  */
 
 //------------------------------------------------------------------------------
-// Private
-//------------------------------------------------------------------------------
-
-defaultOptions = lodash.assign({}, defaultOptions, {cwd: process.cwd()});
-
-//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -347,7 +341,12 @@ function getCacheFile(cacheFile, cwd) {
  */
 function CLIEngine(options) {
 
-    options = lodash.assign(Object.create(null), defaultOptions, options);
+    options = lodash.assign(
+        Object.create(null),
+        defaultOptions,
+        {cwd: process.cwd()},
+        options
+    );
 
     /**
      * Stored options for this instance

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -80,6 +80,18 @@ describe("CLIEngine", function() {
         Plugins.testReset();
     });
 
+    describe("new CLIEngine(options)", function() {
+        it("the default value of 'options.cwd' should be the current working directory.", function() {
+            process.chdir(__dirname);
+            try {
+                var engine = new CLIEngine();
+                assert.equal(engine.options.cwd, __dirname);
+            } finally {
+                process.chdir(originalDir);
+            }
+        });
+    });
+
     describe("executeOnText()", function() {
 
         var engine;


### PR DESCRIPTION
fixes #5694.