### PR TITLE
Fix: Update doctrine to allow hyphens in JSDoc names (fixes #5612)

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "chalk": "^1.0.0",
     "concat-stream": "^1.4.6",
     "debug": "^2.1.1",
-    "doctrine": "^1.2.0",
+    "doctrine": "^1.2.1",
     "es6-map": "^0.1.3",
     "escope": "^3.6.0",
     "espree": "3.1.3",

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -368,6 +368,28 @@ ruleTester.run("valid-jsdoc", rule, {
         {
             code:
             "/**\n" +
+            " * Foo\n" +
+            " * @module module-name\n" +
+            " */\n" +
+            "function foo() {}",
+            options: [{
+                "requireReturn": false
+            }]
+        },
+        {
+            code:
+            "/**\n" +
+            " * Foo\n" +
+            " * @alias module:module-name\n" +
+            " */\n" +
+            "function foo() {}",
+            options: [{
+                "requireReturn": false
+            }]
+        },
+        {
+            code:
+            "/**\n" +
             "* Foo\n" +
             "* @param {Array.<string>} hi - desc\n" +
             "* @returns {Array.<string|number>} desc\n" +


### PR DESCRIPTION
~~The doctrine changes that fix this have been merged (https://github.com/eslint/doctrine/pull/158). Waiting on the next release so I can bump up the version here.~~ All set!

fixes #5612