### PR TITLE
Fix: Lint issue with `valid-jsdoc` rule (refs #5188)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -288,6 +288,7 @@ module.exports = function(context) {
             if (node.params) {
                 node.params.forEach(function(param, i) {
                     var name = param.name;
+
                     if (param.type === "AssignmentPattern") {
                         name = param.left.name;
                     }


### PR DESCRIPTION
Latest PR merge had this issue in it. Fixing it now so that the build on master starts working.