### PR TITLE
Docs: Correct explanation about properties

### DIFF
--- a/docs/rules/no-multiple-empty-lines.md
+++ b/docs/rules/no-multiple-empty-lines.md
@@ -20,8 +20,8 @@ The second argument can be used to configure this rule:
 
 ### max
 
-In the following example, the first 2 is the code for an error
-and the second 2 is the maximum number of empty lines:
+In the following example, the `error` is the severity of the rule, and the
+`max` property is the maximum number of empty lines (2 in this example).
 
 ```json
 "no-multiple-empty-lines": ["error", {"max": 2}]


### PR DESCRIPTION
When the severities were changed to strings in 09659d6f7e4e06bf602f0e5ea74bd378a048a21d, the information about the properties for the `no-multiple-empty-lines` was not updated.