### PR TITLE
Fix: Old Chalk.JS deprecated method (fixes #5716)

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "homepage": "http://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
-    "chalk": "^1.0.0",
+    "chalk": "^1.1.3",
     "concat-stream": "^1.4.6",
     "debug": "^2.1.1",
     "doctrine": "^1.2.0",


### PR DESCRIPTION
Picks up where https://github.com/eslint/eslint/pull/5731 left off.