### PR TITLE
Fix: logical expression should handle constant condition test separately (fixes #5693)

### DIFF
--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -41,6 +41,15 @@ do{
 var result = 0 ? a : b;
 ```
 
+```js
+/*eslint no-constant-condition: "error"*/
+
+if (typeof x) {
+    doSomething();
+}
+```
+
+
 Examples of **correct** code for this rule:
 
 ```js
@@ -63,4 +72,12 @@ do{
 } while (x);
 
 var result = x !== 0 ? a : b;
+```
+
+```js
+/*eslint no-constant-condition: "error"*/
+
+if (typeof x === 'undefined') {
+    doSomething();
+}
 ```

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -17,12 +17,34 @@ module.exports = function(context) {
     //--------------------------------------------------------------------------
 
     /**
+    * Checks if a branch node of LogicalExpression short circuits the whole condition
+    * @param {ASTNode} node The branch of main condition which needs to be checked
+    * @param {string} operator The operator of the main LogicalExpression.
+    * @returns {boolean} true when condition short circuits whole condition
+    */
+    function isShortCircuit(node, operator) {
+        switch (node.type) {
+            case "Literal":
+                return (operator === "||" && node.raw === "true") ||
+                  (operator === "&&" && node.raw === "false");
+            case "LogicalExpression":
+                return isShortCircuit(node.left, node.operator) ||
+                    isShortCircuit(node.right, node.operator);
+
+            // no default
+        }
+        return false;
+    }
+
+    /**
      * Checks if a node has a constant truthiness value.
      * @param {ASTNode} node The AST node to check.
+     * @param {boolean} inBooleanPosition `false` if checking branch of a condition.
+     *  `true` in all other cases
      * @returns {Bool} true when node's truthiness is constant
      * @private
      */
-    function isConstant(node) {
+    function isConstant(node, inBooleanPosition) {
         switch (node.type) {
             case "Literal":
             case "ArrowFunctionExpression":
@@ -32,17 +54,27 @@ module.exports = function(context) {
                 return true;
 
             case "UnaryExpression":
-                return isConstant(node.argument);
+                return (node.operator === "typeof" && inBooleanPosition) ||
+                    isConstant(node.argument, true);
 
             case "BinaryExpression":
+                return isConstant(node.left, false) &&
+                        isConstant(node.right, false) &&
+                        node.operator !== "in";
+
             case "LogicalExpression":
-                return isConstant(node.left) && isConstant(node.right) && node.operator !== "in";
+                var isLeftConstant = isConstant(node.left, inBooleanPosition);
+                var isRightConstant = isConstant(node.right, inBooleanPosition);
+                var isLeftShortCircuit = (isLeftConstant && isShortCircuit(node.left, node.operator));
+                var isRightShortCircuit = (isRightConstant && isShortCircuit(node.right, node.operator));
+
+                return (isLeftConstant && isRightConstant) || isLeftShortCircuit || isRightShortCircuit;
 
             case "AssignmentExpression":
-                return (node.operator === "=") && isConstant(node.right);
+                return (node.operator === "=") && isConstant(node.right, inBooleanPosition);
 
             case "SequenceExpression":
-                return isConstant(node.expressions[node.expressions.length - 1]);
+                return isConstant(node.expressions[node.expressions.length - 1], inBooleanPosition);
 
             // no default
         }
@@ -56,7 +88,7 @@ module.exports = function(context) {
      * @private
      */
     function checkConstantCondition(node) {
-        if (node.test && isConstant(node.test)) {
+        if (node.test && isConstant(node.test, true)) {
             context.report(node, "Unexpected constant condition.");
         }
     }

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -32,7 +32,26 @@ ruleTester.run("no-constant-condition", rule, {
         "for(;;);",
         "do{ }while(x)",
         "q > 0 ? 1 : 2;",
-        "while(x += 3) {}"
+        "while(x += 3) {}",
+
+        // #5228, typeof conditions
+        "if(typeof x === 'undefined'){}",
+        "if(a === 'str' && typeof b){}",
+        "typeof a == typeof b",
+        "typeof 'a'==='string'|| typeof b ==='string'",
+
+        // #5693
+        "if(xyz === 'str1' && abc==='str2'){}",
+        "if(xyz === 'str1' || abc==='str2'){}",
+        "if(xyz === 'str1' || abc==='str2' && pqr === 5){}",
+        "if(typeof abc === 'string' && abc==='str2'){}",
+        "if(false || abc==='str'){}",
+        "if(true && abc==='str'){}",
+        "if(typeof 'str' && abc==='str'){}",
+        "if(abc==='str' || false || def ==='str'){}",
+        "if(true && abc==='str' || def ==='str'){}",
+        "if(true && typeof abc==='string'){}"
+
     ],
     invalid: [
         { code: "for(;true;);", errors: [{ message: "Unexpected constant condition.", type: "ForStatement"}] },
@@ -51,6 +70,22 @@ ruleTester.run("no-constant-condition", rule, {
         { code: "while(~!0);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
         { code: "while(x = 1);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
         { code: "while(function(){});", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
-        { code: "while(() => {});", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] }
+        { code: "while(() => {});", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
+
+        // #5228 , typeof conditions
+        { code: "if(typeof x){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(typeof 'abc' === 'string'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(a = typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(a, typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(typeof 'a' =='string' || typeof 'b' =='string'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "while(typeof x){}", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
+
+        // #5693
+        { code: "if(false && abc==='str'){}", errors: [{message: "Unexpected constant condition.", type: "IfStatement"}]},
+        { code: "if(true || abc==='str'){}", errors: [{message: "Unexpected constant condition.", type: "IfStatement"}]},
+        { code: "if(abc==='str' || true){}", errors: [{message: "Unexpected constant condition.", type: "IfStatement"}]},
+        { code: "if(abc==='str' || true || def ==='str'){}", errors: [{message: "Unexpected constant condition.", type: "IfStatement"}]},
+        { code: "if(false || true){}", errors: [{message: "Unexpected constant condition.", type: "IfStatement"}]},
+        { code: "if(typeof abc==='str' || true){}", errors: [{message: "Unexpected constant condition.", type: "IfStatement"}]}
     ]
 });


### PR DESCRIPTION
`LogicalExpression` and `BinaryExpression` were treated the same and this caused the issue. There are no regression issues from unit tests, let me know if you find any condition which might fail now. 