### PR TITLE
Fix: Treat SwitchCase like a block in lines-around-comment (fixes #5718)

### DIFF
--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -165,7 +165,7 @@ module.exports = function(context) {
      * @returns {boolean} True if the comment is at block start.
      */
     function isCommentAtBlockStart(node) {
-        return isCommentAtParentStart(node, "ClassBody") || isCommentAtParentStart(node, "BlockStatement");
+        return isCommentAtParentStart(node, "ClassBody") || isCommentAtParentStart(node, "BlockStatement") || isCommentAtParentStart(node, "SwitchCase");
     }
 
     /**
@@ -174,7 +174,7 @@ module.exports = function(context) {
      * @returns {boolean} True if the comment is at block end.
      */
     function isCommentAtBlockEnd(node) {
-        return isCommentAtParentEnd(node, "ClassBody") || isCommentAtParentEnd(node, "BlockStatement");
+        return isCommentAtParentEnd(node, "ClassBody") || isCommentAtParentEnd(node, "BlockStatement") || isCommentAtParentEnd(node, "SwitchCase") || isCommentAtParentEnd(node, "SwitchStatement");
     }
 
     /**

--- a/tests/lib/rules/lines-around-comment.js
+++ b/tests/lib/rules/lines-around-comment.js
@@ -158,6 +158,34 @@ ruleTester.run("lines-around-comment", rule, {
             }]
         },
         {
+            code: "switch ('foo'){\ncase 'foo':\n// line at switch case start\nbreak;\n}",
+            options: [{
+                beforeLineComment: true,
+                allowBlockStart: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\n\n// line at switch case start\nbreak;\n}",
+            options: [{
+                beforeLineComment: true,
+                allowBlockStart: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\n// line at switch case start\nbreak;\n}",
+            options: [{
+                beforeLineComment: true,
+                allowBlockStart: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\n\n// line at switch case start\nbreak;\n}",
+            options: [{
+                beforeLineComment: true,
+                allowBlockStart: true
+            }]
+        },
+        {
             code: "function foo(){   \n/* block comment at block start */\nvar g = 1;\n}",
             options: [{
                 allowBlockStart: true
@@ -203,6 +231,30 @@ ruleTester.run("lines-around-comment", rule, {
             options: [{ allowBlockStart: true }],
             parserOptions: { ecmaVersion: 6 }
         },
+        {
+            code: "switch ('foo'){\ncase 'foo':\n/* block comment at switch case start */\nbreak;\n}",
+            options: [{
+                allowBlockStart: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\n\n/* block comment at switch case start */\nbreak;\n}",
+            options: [{
+                allowBlockStart: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\n/* block comment at switch case start */\nbreak;\n}",
+            options: [{
+                allowBlockStart: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\n\n/* block comment at switch case start */\nbreak;\n}",
+            options: [{
+                allowBlockStart: true
+            }]
+        },
 
         // check for block end comments
         {
@@ -242,6 +294,34 @@ ruleTester.run("lines-around-comment", rule, {
         },
         {
             code: "if(true){\nvar g = 1;\n\n// line at block end\n}",
+            options: [{
+                afterLineComment: true,
+                allowBlockEnd: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nvar g = 1;\n\n// line at switch case end\n}",
+            options: [{
+                afterLineComment: true,
+                allowBlockEnd: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nvar g = 1;\n\n// line at switch case end\n\n}",
+            options: [{
+                afterLineComment: true,
+                allowBlockEnd: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\nvar g = 1;\n\n// line at switch case end\n}",
+            options: [{
+                afterLineComment: true,
+                allowBlockEnd: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\nvar g = 1;\n\n// line at switch case end\n\n}",
             options: [{
                 afterLineComment: true,
                 allowBlockEnd: true
@@ -339,6 +419,34 @@ ruleTester.run("lines-around-comment", rule, {
                 allowBlockEnd: true
             }],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nvar g = 1;\n\n/* block comment at switch case end */\n}",
+            options: [{
+                afterBlockComment: true,
+                allowBlockEnd: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nvar g = 1;\n\n/* block comment at switch case end */\n\n}",
+            options: [{
+                afterBlockComment: true,
+                allowBlockEnd: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\nvar g = 1;\n\n/* block comment at switch case end */\n}",
+            options: [{
+                afterBlockComment: true,
+                allowBlockEnd: true
+            }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\nvar g = 1;\n\n/* block comment at switch case end */\n\n}",
+            options: [{
+                afterBlockComment: true,
+                allowBlockEnd: true
+            }]
         },
 
         // check for object start comments
@@ -777,6 +885,20 @@ ruleTester.run("lines-around-comment", rule, {
             errors: [{ message: afterMessage, type: "Line", line: 4 }]
         },
         {
+            code: "switch ('foo'){\ncase 'foo':\n// line at switch case start\nbreak;\n}",
+            options: [{
+                beforeLineComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Line", line: 3 }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\n// line at switch case start\nbreak;\n}",
+            options: [{
+                beforeLineComment: true
+            }],
+            errors: [{ message: beforeMessage, type: "Line", line: 6 }]
+        },
+        {
             code: "while(true){\n// line at block start and end\n}",
             options: [{
                 afterLineComment: true,
@@ -791,6 +913,20 @@ ruleTester.run("lines-around-comment", rule, {
                 allowBlockEnd: true
             }],
             errors: [{ message: beforeMessage, type: "Line", line: 2 }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nvar g = 1;\n\n// line at switch case end\n}",
+            options: [{
+                afterLineComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Line", line: 5 }]
+        },
+        {
+            code: "switch ('foo'){\ncase 'foo':\nbreak;\n\ndefault:\nvar g = 1;\n\n// line at switch case end\n}",
+            options: [{
+                afterLineComment: true
+            }],
+            errors: [{ message: afterMessage, type: "Line", line: 8 }]
         },
 
         // object start comments


### PR DESCRIPTION
When `allowBlockStart`/`allowBlockEnd` are true, comments at the start/end
of a switch case are treated the same as if they were in a block.

Example:

```
/* eslint lines-around-comment: ["error", {beforeLineComment: true, allowBlockStart:true}] */
switch ('foo') {
  case 'foo':
    // Previously failed because no preceding newline and not first line of block
    break;
}
```