### PR TITLE
Update: Deprecate option `maximum` in favor of `max` (fixes #5685)

### DIFF
--- a/docs/rules/complexity.md
+++ b/docs/rules/complexity.md
@@ -50,7 +50,7 @@ function a(x) {
 
 ## Options
 
-Optionally, you may specify a `maximum` object property:
+Optionally, you may specify a `max` object property:
 
 ```json
 "complexity": ["error", 2]
@@ -59,8 +59,10 @@ Optionally, you may specify a `maximum` object property:
 is equivalent to
 
 ```json
-"complexity": ["error", { "maximum": 2 }]
+"complexity": ["error", { "max": 2 }]
 ```
+
+**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
 
 ## When Not To Use It
 

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -27,8 +27,10 @@ The default depth above which this rule will warn is `4`.  You can configure the
 
 // or you can use an object property
 
-"max-depth": ["error", {"maximum": 10}]
+"max-depth": ["error", {"max": 10}]
 ```
+
+**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
 
 The following patterns are considered problems:
 

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -27,8 +27,10 @@ The default max depth for this rule is 10. You can define the depth as an option
 
 // or you can use an object property
 
-"max-nested-callbacks": ["error", {"maximum": 3}]
+"max-nested-callbacks": ["error", {"max": 3}]
 ```
+
+**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
 
 The following patterns are considered problems:
 

--- a/docs/rules/max-params.md
+++ b/docs/rules/max-params.md
@@ -32,7 +32,7 @@ function foo (bar, baz, qux) {
 }
 ```
 
-Optionally, you may specify a `maximum` object property:
+Optionally, you may specify a `max` object property:
 
 ```json
 "max-params": ["error", 2]
@@ -41,8 +41,10 @@ Optionally, you may specify a `maximum` object property:
 is equivalent to
 
 ```json
-"max-params": ["error", {"maximum": 2}]
+"max-params": ["error", {"max": 2}]
 ```
+
+**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
 
 
 ## Related Rules

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -23,8 +23,10 @@ There is an additional optional argument to ignore top level functions.
 
 // or you can use an object property to set the maximum
 
-"max-statements": ["error", {"maximum": 10}, {"ignoreTopLevelFunctions": true}]
+"max-statements": ["error", {"max": 10}, {"ignoreTopLevelFunctions": true}]
 ```
+
+**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
 
 The following patterns are considered problems:
 

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -17,6 +17,9 @@ module.exports = function(context) {
     if (typeof option === "object" && option.hasOwnProperty("maximum") && typeof option.maximum === "number") {
         THRESHOLD = option.maximum;
     }
+    if (typeof option === "object" && option.hasOwnProperty("max") && typeof option.max === "number") {
+        THRESHOLD = option.max;
+    }
     if (typeof option === "number") {
         THRESHOLD = option;
     }
@@ -134,6 +137,10 @@ module.exports.schema = [
                 "type": "object",
                 "properties": {
                     "maximum": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "max": {
                         "type": "integer",
                         "minimum": 0
                     }

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -23,6 +23,9 @@ module.exports = function(context) {
     if (typeof option === "object" && option.hasOwnProperty("maximum") && typeof option.maximum === "number") {
         maxDepth = option.maximum;
     }
+    if (typeof option === "object" && option.hasOwnProperty("max") && typeof option.max === "number") {
+        maxDepth = option.max;
+    }
     if (typeof option === "number") {
         maxDepth = option;
     }
@@ -122,6 +125,10 @@ module.exports.schema = [
                 "type": "object",
                 "properties": {
                     "maximum": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "max": {
                         "type": "integer",
                         "minimum": 0
                     }

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -21,6 +21,9 @@ module.exports = function(context) {
     if (typeof option === "object" && option.hasOwnProperty("maximum") && typeof option.maximum === "number") {
         THRESHOLD = option.maximum;
     }
+    if (typeof option === "object" && option.hasOwnProperty("max") && typeof option.max === "number") {
+        THRESHOLD = option.max;
+    }
     if (typeof option === "number") {
         THRESHOLD = option;
     }
@@ -85,6 +88,10 @@ module.exports.schema = [
                 "type": "object",
                 "properties": {
                     "maximum": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "max": {
                         "type": "integer",
                         "minimum": 0
                     }

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -19,6 +19,9 @@ module.exports = function(context) {
     if (typeof option === "object" && option.hasOwnProperty("maximum") && typeof option.maximum === "number") {
         numParams = option.maximum;
     }
+    if (typeof option === "object" && option.hasOwnProperty("max") && typeof option.max === "number") {
+        numParams = option.max;
+    }
     if (typeof option === "number") {
         numParams = option;
     }
@@ -57,6 +60,10 @@ module.exports.schema = [
                 "type": "object",
                 "properties": {
                     "maximum": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "max": {
                         "type": "integer",
                         "minimum": 0
                     }

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -25,6 +25,9 @@ module.exports = function(context) {
     if (typeof option === "object" && option.hasOwnProperty("maximum") && typeof option.maximum === "number") {
         maxStatements = option.maximum;
     }
+    if (typeof option === "object" && option.hasOwnProperty("max") && typeof option.max === "number") {
+        maxStatements = option.max;
+    }
     if (typeof option === "number") {
         maxStatements = option;
     }
@@ -123,6 +126,10 @@ module.exports.schema = [
                 "type": "object",
                 "properties": {
                     "maximum": {
+                        "type": "integer",
+                        "minimum": 0
+                    },
+                    "max": {
                         "type": "integer",
                         "minimum": 0
                     }

--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -60,7 +60,7 @@ ruleTester.run("complexity", rule, {
         { code: "var a = (x) => {do {'foo';} while (true)}", options: [2], parserOptions: { ecmaVersion: 6 } },
 
         // object property options
-        { code: "function b(x) {}", options: [{ "maximum": 1 }] }
+        { code: "function b(x) {}", options: [{ "max": 1 }] }
     ],
     invalid: [
         { code: "function a(x) {}", options: [0], errors: [{ message: "Function 'a' has a complexity of 1."}] },
@@ -93,6 +93,6 @@ ruleTester.run("complexity", rule, {
         },
 
         // object property options
-        { code: "function a(x) {}", options: [{ "maximum": 0 }], errors: [{ message: "Function 'a' has a complexity of 1."}] }
+        { code: "function a(x) {}", options: [{ "max": 0 }], errors: [{ message: "Function 'a' has a complexity of 1."}] }
     ]
 });

--- a/tests/lib/rules/max-depth.js
+++ b/tests/lib/rules/max-depth.js
@@ -27,7 +27,7 @@ ruleTester.run("max-depth", rule, {
         { code: "function foo() { if (true) { if (false) { if (true) { } } } }" },
 
         // object property options
-        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ "maximum": 3 }] }
+        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ "max": 3 }] }
     ],
     invalid: [
         { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [2], errors: [{ message: "Blocks are nested too deeply (3).", type: "IfStatement"}] },
@@ -39,6 +39,6 @@ ruleTester.run("max-depth", rule, {
         { code: "function foo() { if (true) { if (false) { if (true) { if (false) { if (true) { } } } } } }", errors: [{ message: "Blocks are nested too deeply (5).", type: "IfStatement"}] },
 
         // object property options
-        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ "maximum": 2 }], errors: [{ message: "Blocks are nested too deeply (3).", type: "IfStatement"}] }
+        { code: "function foo() { if (true) { if (false) { if (true) { } } } }", options: [{ "max": 2 }], errors: [{ message: "Blocks are nested too deeply (3).", type: "IfStatement"}] }
     ]
 });

--- a/tests/lib/rules/max-nested-callbacks.js
+++ b/tests/lib/rules/max-nested-callbacks.js
@@ -47,7 +47,7 @@ ruleTester.run("max-nested-callbacks", rule, {
         { code: nestFunctions(10)},
 
         // object property options
-        { code: "foo(function() { bar(thing, function(data) {}); });", options: [{ "maximum": 3 }] }
+        { code: "foo(function() { bar(thing, function(data) {}); });", options: [{ "max": 3 }] }
     ],
     invalid: [
         {
@@ -80,7 +80,7 @@ ruleTester.run("max-nested-callbacks", rule, {
         // object property options
         {
             code: "foo(function() { bar(thing, function(data) { baz(function() {}); }); });",
-            options: [{ "maximum": 2 }],
+            options: [{ "max": 2 }],
             errors: [{ message: "Too many nested callbacks (3). Maximum allowed is 2.", type: "FunctionExpression"}]
         }
     ]

--- a/tests/lib/rules/max-params.js
+++ b/tests/lib/rules/max-params.js
@@ -27,7 +27,7 @@ ruleTester.run("max-params", rule, {
         { code: "var test = function test(a, b, c) {};", options: [3] },
 
         // object property options
-        { code: "var test = function(a, b, c) {};", options: [{ "maximum": 3 }] }
+        { code: "var test = function(a, b, c) {};", options: [{ "max": 3 }] }
     ],
     invalid: [
         { code: "function test(a, b, c) {}", options: [2], errors: [{ message: "This function has too many parameters (3). Maximum allowed is 2.", type: "FunctionDeclaration"}] },
@@ -38,6 +38,6 @@ ruleTester.run("max-params", rule, {
         { code: "var test = function test(a, b, c) {};", options: [1], errors: [{ message: "This function has too many parameters (3). Maximum allowed is 1.", type: "FunctionExpression"}] },
 
         // object property options
-        { code: "function test(a, b, c) {}", options: [{ "maximum": 2 }], errors: [{ message: "This function has too many parameters (3). Maximum allowed is 2.", type: "FunctionDeclaration"}] }
+        { code: "function test(a, b, c) {}", options: [{ "max": 2 }], errors: [{ message: "This function has too many parameters (3). Maximum allowed is 2.", type: "FunctionDeclaration"}] }
     ]
 });

--- a/tests/lib/rules/max-statements.js
+++ b/tests/lib/rules/max-statements.js
@@ -32,7 +32,7 @@ ruleTester.run("max-statements", rule, {
         { code: "define(['foo', 'qux'], function(foo, qux) { var bar = 1; var baz = 2; })", options: [1, {ignoreTopLevelFunctions: true}] },
 
         // object property options
-        { code: "var foo = { thing: function() { var bar = 1; var baz = 2; } }", options: [{ "maximum": 2 }] }
+        { code: "var foo = { thing: function() { var bar = 1; var baz = 2; } }", options: [{ "max": 2 }] }
     ],
     invalid: [
         { code: "function foo() { var bar = 1; var baz = 2; var qux = 3; }", options: [2], errors: [{ message: "This function has too many statements (3). Maximum allowed is 2."}] },
@@ -49,6 +49,6 @@ ruleTester.run("max-statements", rule, {
         { code: "function foo() { var a; var b; var c; var x; var y; var z; bar(); baz(); qux(); quxx(); foo(); }", errors: [{ message: "This function has too many statements (11). Maximum allowed is 10."}] },
 
         // object property options
-        { code: "function foo() { var bar = 1; var baz = 2; var qux = 3; }", options: [{ "maximum": 2 }], errors: [{ message: "This function has too many statements (3). Maximum allowed is 2."}] }
+        { code: "function foo() { var bar = 1; var baz = 2; var qux = 3; }", options: [{ "max": 2 }], errors: [{ message: "This function has too many statements (3). Maximum allowed is 2."}] }
     ]
 });


### PR DESCRIPTION
Add the option name `max` to all rules that currently accept an option
name `maximum` and add deprecation notes to the docs of each of those
rules.