### PR TITLE
Docs: Typo in `sort-imports`

### DIFF
--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -198,4 +198,4 @@ Default is `["none", "all", "multiple", "single"]`.
 
 ## When Not To Use It
 
-This rule is a formatting preference and not following it won't negatively affect the quality of your code. If you alphabetizing imports isn't a part of your coding standards, then you can leave this rule disabled.
+This rule is a formatting preference and not following it won't negatively affect the quality of your code. If alphabetizing imports isn't a part of your coding standards, then you can leave this rule disabled.


### PR DESCRIPTION
Replaces #5664