### PR TITLE
Fix: vars-on-top conflicts with `export`

### DIFF
--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -55,7 +55,9 @@ module.exports = function(context) {
         }
 
         for (; i < l; ++i) {
-            if (statements[i].type !== "VariableDeclaration") {
+            if (statements[i].type !== "VariableDeclaration" &&
+                    (statements[i].type !== "ExportNamedDeclaration" ||
+                    statements[i].declaration.type !== "VariableDeclaration")) {
                 return false;
             }
             if (statements[i] === node) {
@@ -104,6 +106,12 @@ module.exports = function(context) {
             var grandParent = ancestors.pop();
 
             if (node.kind === "var") { // check variable is `var` type and not `let` or `const`
+                if (parent.type === "ExportNamedDeclaration") {
+                    node = parent;
+                    parent = grandParent;
+                    grandParent = ancestors.pop();
+                }
+
                 if (parent.type === "Program") { // That means its a global variable
                     globalVarCheck(node, parent);
                 } else {

--- a/tests/lib/rules/vars-on-top.js
+++ b/tests/lib/rules/vars-on-top.js
@@ -159,7 +159,40 @@ ruleTester.run("vars-on-top", rule, {
         {code: "import { square, diag } from 'lib'; 'use strict'; var y; function f() { 'use strict'; var x; var y; f(); }", parserOptions: { sourceType: "module" }},
         {code: "import { default as foo } from 'lib'; 'use strict'; var y; function f() { 'use strict'; var x; var y; f(); }", parserOptions: { sourceType: "module" }},
         {code: "import 'src/mylib'; 'use strict'; var y; function f() { 'use strict'; var x; var y; f(); }", parserOptions: { sourceType: "module" }},
-        {code: "import theDefault, { named1, named2 } from 'src/mylib'; 'use strict'; var y; function f() { 'use strict'; var x; var y; f(); }", parserOptions: { sourceType: "module" }}
+        {code: "import theDefault, { named1, named2 } from 'src/mylib'; 'use strict'; var y; function f() { 'use strict'; var x; var y; f(); }", parserOptions: { sourceType: "module" }},
+        {
+            code: [
+                "export var x;",
+                "var y;",
+                "var z;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            }
+        },
+        {
+            code: [
+                "var x;",
+                "export var y;",
+                "var z;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            }
+        },
+        {
+            code: [
+                "var x;",
+                "var y;",
+                "export var z;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            }
+        }
     ],
 
     invalid: [
@@ -402,6 +435,29 @@ ruleTester.run("vars-on-top", rule, {
         },
         {
             code: "function f() { 'use strict'; var x; 'directive';  var y; f(); }",
+            errors: [{message: "All 'var' declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: [
+                "export function f() {}",
+                "var x;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            },
+            errors: [{message: "All 'var' declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: [
+                "var x;",
+                "export function f() {}",
+                "var y;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            },
             errors: [{message: "All 'var' declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
         }
     ]


### PR DESCRIPTION
Fixes #5711 

The `vars-on-top` rule complained about `export`ed variables, even though they were at the top of a file.