### PR TITLE
Update: `commentPattern` option for `no-fallthrough` rule (fixes #5757)

### DIFF
--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -128,6 +128,38 @@ switch(foo) {
 
 Note that the last `case` statement in these examples does not cause a warning because there is nothing to fall through into.
 
+## Options
+
+This rule accepts a single options argument:
+
+* Set the `commentPattern` option to a regular expression string to change the test for intentional fallthrough comment
+
+### commentPattern
+
+Examples of **correct** code for the `{ "commentPattern": "break[\\s\\w]*omitted" }` option:
+
+```js
+/*eslint no-fallback: ["error", { "commentPattern": "break[\\s\\w]*omitted" }]*/
+
+switch(foo) {
+    case 1:
+        doSomething();
+        // break omitted
+
+    case 2:
+        doSomething();
+}
+
+switch(foo) {
+    case 1:
+        doSomething();
+        // caution: break is omitted intentionally
+
+    default:
+        doSomething();
+}
+```
+
 ## When Not To Use It
 
 If you don't want to enforce that each `case` statement should end with a `throw`, `return`, `break`, or comment, then you can safely turn this rule off.

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -14,19 +14,20 @@ var lodash = require("lodash");
 // Helpers
 //------------------------------------------------------------------------------
 
-var FALLTHROUGH_COMMENT = /falls?\s?through/i;
+var DEFAULT_FALLTHROUGH_COMMENT = /falls?\s?through/i;
 
 /**
  * Checks whether or not a given node has a fallthrough comment.
  * @param {ASTNode} node - A SwitchCase node to get comments.
  * @param {RuleContext} context - A rule context which stores comments.
- * @returns {boolean} `true` if the node has a fallthrough comment.
+ * @param {RegExp} fallthroughCommentPattern - A pattern to match comment to.
+ * @returns {boolean} `true` if the node has a valid fallthrough comment.
  */
-function hasFallthroughComment(node, context) {
+function hasFallthroughComment(node, context, fallthroughCommentPattern) {
     var sourceCode = context.getSourceCode();
     var comment = lodash.last(sourceCode.getComments(node).leading);
 
-    return Boolean(comment && FALLTHROUGH_COMMENT.test(comment.value));
+    return Boolean(comment && fallthroughCommentPattern.test(comment.value));
 }
 
 /**
@@ -43,6 +44,7 @@ function isReachable(segment) {
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
+    var options = context.options[0] || {};
     var currentCodePath = null;
 
     /*
@@ -50,6 +52,13 @@ module.exports = function(context) {
      * trailing comments is wrong if semicolons are omitted.
      */
     var fallthroughCase = null;
+    var fallthroughCommentPattern = null;
+
+    if (options.commentPattern) {
+        fallthroughCommentPattern = new RegExp(options.commentPattern);
+    } else {
+        fallthroughCommentPattern = DEFAULT_FALLTHROUGH_COMMENT;
+    }
 
     return {
         "onCodePathStart": function(codePath) {
@@ -65,7 +74,7 @@ module.exports = function(context) {
              * Checks whether or not there is a fallthrough comment.
              * And reports the previous fallthrough node if that does not exist.
              */
-            if (fallthroughCase && !hasFallthroughComment(node, context)) {
+            if (fallthroughCase && !hasFallthroughComment(node, context, fallthroughCommentPattern)) {
                 context.report({
                     message: "Expected a 'break' statement before '{{type}}'.",
                     data: {type: node.test ? "case" : "default"},
@@ -92,4 +101,14 @@ module.exports = function(context) {
     };
 };
 
-module.exports.schema = [];
+module.exports.schema = [
+    {
+        "type": "object",
+        "properties": {
+            "commentPattern": {
+                "type": "string"
+            }
+        },
+        "additionalProperties": false
+    }
+];

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -53,7 +53,37 @@ ruleTester.run("no-fallthrough", rule, {
         "switch (foo) { case 0: try { break; } finally {} default: b(); }",
         "switch (foo) { case 0: try {} finally { break; } default: b(); }",
         "switch (foo) { case 0: try { throw 0; } catch (err) { break; } default: b(); }",
-        "switch (foo) { case 0: do { throw 0; } while(a); default: b(); }"
+        "switch (foo) { case 0: do { throw 0; } while(a); default: b(); }",
+        {
+            code: "switch(foo) { case 0: a(); /* no break */ case 1: b(); }",
+            options: [{
+                commentPattern: "no break"
+            }]
+        },
+        {
+            code: "switch(foo) { case 0: a(); /* no break: need to execute b() */ case 1: b(); }",
+            options: [{
+                commentPattern: "no break:\\s?\\w+"
+            }]
+        },
+        {
+            code: "switch(foo) { case 0: a();\n// need to execute b(), so\n// falling through\n case 1: b(); }",
+            options: [{
+                commentPattern: "falling through"
+            }]
+        },
+        {
+            code: "switch(foo) { case 0: a(); /* break omitted */ default:  b(); /* comment */ }",
+            options: [{
+                commentPattern: "break omitted"
+            }]
+        },
+        {
+            code: "switch(foo) { case 0: a(); /* caution: break is omitted intentionally */ case 1: b(); /* break omitted */ default: c(); }",
+            options: [{
+                commentPattern: "break[\\s\\w]+omitted"
+            }]
+        }
     ],
     invalid: [
         {
@@ -78,10 +108,57 @@ ruleTester.run("no-fallthrough", rule, {
                 }
             ]
         },
-        {code: "switch(foo) { case 0: a(); default: b() }", errors: errorsDefault},
-        {code: "switch(foo) { case 0: if (a) { break; } default: b() }", errors: errorsDefault},
-        {code: "switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }", errors: errorsDefault},
-        {code: "switch(foo) { case 0: while (a) { break; } default: b() }", errors: errorsDefault},
-        {code: "switch(foo) { case 0: do { break; } while (a); default: b() }", errors: errorsDefault}
+        {
+            code: "switch(foo) { case 0: a(); default: b() }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch(foo) { case 0: if (a) { break; } default: b() }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch(foo) { case 0: try { throw 0; } catch (err) {} default: b() }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch(foo) { case 0: while (a) { break; } default: b() }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch(foo) { case 0: do { break; } while (a); default: b() }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch(foo) { case 0: a(); /* falling through */ default: b() }",
+            errors: errorsDefault
+        },
+        {
+            code: "switch(foo) { case 0: a();\n/* no break */\ncase 1: b(); }",
+            options: [{
+                commentPattern: "break omitted"
+            }],
+            errors: [
+                {
+                    message: "Expected a 'break' statement before 'case'.",
+                    type: "SwitchCase",
+                    line: 3,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "switch(foo) { case 0: a();\n/* no break */\n/* todo: fix readability */\ndefault: b() }",
+            options: [{
+                commentPattern: "no break"
+            }],
+            errors: [
+                {
+                    message: errorsDefault.message,
+                    type: errorsDefault.type,
+                    line: 4,
+                    column: 1
+                }
+            ]
+        }
     ]
 });


### PR DESCRIPTION
So this PR adds the `commentPattern` option to `no-fallthrough` rule which may be a string or a regular expression string and which overrides the default `/falls?\s?through/i` RegEx for switch-case fallthrough comment. If no option is specified, the default pattern for fallthrough comment is used.