### PR TITLE
Fix: improve `constructor-super` errors for literals (fixes #5449)

### DIFF
--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -18,18 +18,23 @@ The following patterns are considered problems:
 
 class A {
     constructor() {
-        super();
-    }
-}
-
-class A extends null {
-    constructor() {
-        super();
+        super();  // This is a SyntaxError.
     }
 }
 
 class A extends B {
-    constructor() { }
+    constructor() { }  // Would throw a ReferenceError.
+}
+
+// Classes which inherits from a non constructor are always problems.
+class A extends null {
+    constructor() {
+        super();  // Would throw a TypeError.
+    }
+}
+
+class A extends null {
+    constructor() { }  // Would throw a ReferenceError.
 }
 ```
 
@@ -40,10 +45,6 @@ The following patterns are not considered problems:
 /*eslint-env es6*/
 
 class A {
-    constructor() { }
-}
-
-class A extends null {
     constructor() { }
 }
 

--- a/lib/code-path-analysis/code-path-segment.js
+++ b/lib/code-path-analysis/code-path-segment.js
@@ -11,8 +11,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var assert = require("assert"),
-    debug = require("./debug-helpers");
+var debug = require("./debug-helpers");
 
 //------------------------------------------------------------------------------
 // Helpers
@@ -178,7 +177,13 @@ CodePathSegment.newNext = function(id, allPrevSegments) {
  * @returns {CodePathSegment} The created segment.
  */
 CodePathSegment.newUnreachable = function(id, allPrevSegments) {
-    return new CodePathSegment(id, flattenUnusedSegments(allPrevSegments), false);
+    var segment = new CodePathSegment(id, flattenUnusedSegments(allPrevSegments), false);
+
+    // In `if (a) return a; foo();` case, the unreachable segment preceded by
+    // the return statement is not used but must not be remove.
+    CodePathSegment.markUsed(segment);
+
+    return segment;
 };
 
 /**
@@ -203,7 +208,9 @@ CodePathSegment.newDisconnected = function(id, allPrevSegments) {
  * @returns {void}
  */
 CodePathSegment.markUsed = function(segment) {
-    assert(!segment.internal.used, segment.id + " is marked twice.");
+    if (segment.internal.used) {
+        return;
+    }
     segment.internal.used = true;
 
     var i;

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -7,12 +7,6 @@
 "use strict";
 
 //------------------------------------------------------------------------------
-// Requirements
-//------------------------------------------------------------------------------
-
-var astUtils = require("../ast-utils");
-
-//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -29,6 +23,57 @@ function isConstructorFunction(node) {
         node.parent.type === "MethodDefinition" &&
         node.parent.kind === "constructor"
     );
+}
+
+/**
+ * Checks whether a given node can be a constructor or not.
+ *
+ * @param {ASTNode} node - A node to check.
+ * @returns {boolean} `true` if the node can be a constructor.
+ */
+function isPossibleConstructor(node) {
+    if (!node) {
+        return false;
+    }
+
+    switch (node.type) {
+        case "ClassExpression":
+        case "FunctionExpression":
+        case "ThisExpression":
+        case "MemberExpression":
+        case "CallExpression":
+        case "NewExpression":
+        case "YieldExpression":
+        case "TaggedTemplateExpression":
+        case "MetaProperty":
+            return true;
+
+        case "Identifier":
+            return node.name !== "undefined";
+
+        case "AssignmentExpression":
+            return isPossibleConstructor(node.right);
+
+        case "LogicalExpression":
+            return (
+                isPossibleConstructor(node.left) ||
+                isPossibleConstructor(node.right)
+            );
+
+        case "ConditionalExpression":
+            return (
+                isPossibleConstructor(node.alternate) ||
+                isPossibleConstructor(node.consequent)
+            );
+
+        case "SequenceExpression":
+            var lastExpression = node.expressions[node.expressions.length - 1];
+
+            return isPossibleConstructor(lastExpression);
+
+        default:
+            return false;
+    }
 }
 
 //------------------------------------------------------------------------------
@@ -99,14 +144,13 @@ module.exports = function(context) {
 
                 // Class > ClassBody > MethodDefinition > FunctionExpression
                 var classNode = node.parent.parent.parent;
+                var superClass = classNode.superClass;
 
                 funcInfo = {
                     upper: funcInfo,
                     isConstructor: true,
-                    hasExtends: Boolean(
-                        classNode.superClass &&
-                        !astUtils.isNullOrUndefined(classNode.superClass)
-                    ),
+                    hasExtends: Boolean(superClass),
+                    superIsConstructor: isPossibleConstructor(superClass),
                     codePath: codePath
                 };
             } else {
@@ -114,6 +158,7 @@ module.exports = function(context) {
                     upper: funcInfo,
                     isConstructor: false,
                     hasExtends: false,
+                    superIsConstructor: false,
                     codePath: codePath
                 };
             }
@@ -127,10 +172,9 @@ module.exports = function(context) {
          * @returns {void}
          */
         "onCodePathEnd": function(codePath, node) {
-
-            // Skip if own class which has a valid `extends` part.
             var hasExtends = funcInfo.hasExtends;
 
+            // Pop.
             funcInfo = funcInfo.upper;
 
             if (!hasExtends) {
@@ -158,11 +202,6 @@ module.exports = function(context) {
          * @returns {void}
          */
         "onCodePathSegmentStart": function(segment) {
-
-            /*
-             * Skip if this is not in a constructor of a class which has a
-             * valid `extends` part.
-             */
             if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
                 return;
             }
@@ -193,11 +232,6 @@ module.exports = function(context) {
          * @returns {void}
          */
         "onCodePathSegmentLoop": function(fromSegment, toSegment) {
-
-            /*
-             * Skip if this is not in a constructor of a class which has a
-             * valid `extends` part.
-             */
             if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
                 return;
             }
@@ -209,10 +243,9 @@ module.exports = function(context) {
                 {first: toSegment, last: fromSegment},
                 function(segment) {
                     var info = segInfoMap[segment.id];
-
-                    // Updates flags.
                     var prevSegments = segment.prevSegments;
 
+                    // Updates flags.
                     info.calledInSomePaths = prevSegments.some(isCalledInSomePath);
                     info.calledInEveryPaths = prevSegments.every(isCalledInEveryPath);
 
@@ -241,24 +274,17 @@ module.exports = function(context) {
          * @returns {void}
          */
         "CallExpression:exit": function(node) {
-
-            // Skip if the node is not `super()`.
-            if (node.callee.type !== "Super") {
+            if (!(funcInfo && funcInfo.isConstructor)) {
                 return;
             }
 
-            // Skip if this is not in a constructor.
-            if (!(funcInfo && funcInfo.isConstructor)) {
+            // Skips except `super()`.
+            if (node.callee.type !== "Super") {
                 return;
             }
 
             // Reports if needed.
             if (funcInfo.hasExtends) {
-
-                /*
-                 * This class has a valid `extends` part.
-                 * Checks duplicate `super()`;
-                 */
                 var segments = funcInfo.codePath.currentSegments;
                 var duplicate = false;
 
@@ -274,19 +300,44 @@ module.exports = function(context) {
                         message: "Unexpected duplicate 'super()'.",
                         node: node
                     });
+                } else if (!funcInfo.superIsConstructor) {
+                    context.report({
+                        message: "Unexpected 'super()' because 'super' is not a constructor.",
+                        node: node
+                    });
                 } else {
                     info.validNodes.push(node);
                 }
             } else {
-
-                /*
-                 * This class does not have a valid `extends` part.
-                 * Disallow `super()`.
-                 */
                 context.report({
                     message: "Unexpected 'super()'.",
                     node: node
                 });
+            }
+        },
+
+        /**
+         * Set the mark to the returned path as `super()` was called.
+         * @param {ASTNode} node - A ReturnStatement node to check.
+         * @returns {void}
+         */
+        "ReturnStatement": function(node) {
+            if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
+                return;
+            }
+
+            // Skips if no argument.
+            if (!node.argument) {
+                return;
+            }
+
+            // Returning argument is a substitute of 'super()'.
+            var segments = funcInfo.codePath.currentSegments;
+
+            for (var i = 0; i < segments.length; ++i) {
+                var info = segInfoMap[segments[i].id];
+
+                info.calledInSomePaths = info.calledInEveryPaths = true;
             }
         },
 

--- a/tests/fixtures/code-path-analysis/if-5.js
+++ b/tests/fixtures/code-path-analysis/if-5.js
@@ -1,0 +1,25 @@
+/*eslint-env node*/
+/*expected
+initial->s1_1->s1_2->s1_3->s1_4;
+s1_1->s1_4;
+s1_2->final;
+s1_4->final;
+*/
+if (a) return 0;
+foo();
+
+/*DOT
+digraph {
+    node[shape=box,style="rounded,filled",fillcolor=white];
+    initial[label="",shape=circle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    final[label="",shape=doublecircle,style=filled,fillcolor=black,width=0.25,height=0.25];
+    s1_1[label="Program\nIfStatement\nIdentifier (a)"];
+    s1_2[label="ReturnStatement\nLiteral (0)"];
+    s1_3[style="rounded,dashed,filled",fillcolor="#FF9800",label="<<unreachable>>\n????"];
+    s1_4[label="ExpressionStatement\nCallExpression\nIdentifier (foo)"];
+    initial->s1_1->s1_2->s1_3->s1_4;
+    s1_1->s1_4;
+    s1_2->final;
+    s1_4->final;
+}
+*/

--- a/tests/lib/rules/constructor-super.js
+++ b/tests/lib/rules/constructor-super.js
@@ -25,13 +25,20 @@ ruleTester.run("constructor-super", rule, {
         // non derived classes.
         { code: "class A { }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A { constructor() { } }", parserOptions: { ecmaVersion: 6 } },
+
+        // inherit from non constructors.
+        // those are valid if we don't define the constructor.
         { code: "class A extends null { }", parserOptions: { ecmaVersion: 6 } },
-        { code: "class A extends null { constructor() { } }", parserOptions: { ecmaVersion: 6 } },
 
         // derived classes.
         { code: "class A extends B { }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A extends B { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A extends B { constructor() { if (true) { super(); } else { super(); } } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends (class B {}) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends (B = C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends (B || C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends (a ? B : C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends (B, C) { constructor() { super(); } }", parserOptions: { ecmaVersion: 6 } },
 
         // nested.
         { code: "class A { constructor() { class B extends C { constructor() { super(); } } } }", parserOptions: { ecmaVersion: 6 } },
@@ -48,6 +55,11 @@ ruleTester.run("constructor-super", rule, {
         { code: "class A extends B { constructor() { switch (a) { case 0: super(); break; default: super(); } } }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A extends B { constructor() { try {} finally { super(); } } }", parserOptions: { ecmaVersion: 6 } },
         { code: "class A extends B { constructor() { if (a) throw Error(); super(); } }", parserOptions: { ecmaVersion: 6 } },
+
+        // returning value is a substitute of 'super()'.
+        { code: "class A extends B { constructor() { if (true) return a; super(); } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A extends null { constructor() { return a; } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class A { constructor() { return a; } }", parserOptions: { ecmaVersion: 6 } },
 
         // https://github.com/eslint/eslint/issues/5261
         { code: "class A extends B { constructor(a) { super(); for (const b of a) { this.a(); } } }", parserOptions: { ecmaVersion: 6 } },
@@ -76,10 +88,27 @@ ruleTester.run("constructor-super", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unexpected 'super()'.", type: "CallExpression"}]
         },
+
+        // inherit from non constructors.
         {
             code: "class A extends null { constructor() { super(); } }",
             parserOptions: { ecmaVersion: 6 },
-            errors: [{ message: "Unexpected 'super()'.", type: "CallExpression"}]
+            errors: [{ message: "Unexpected 'super()' because 'super' is not a constructor.", type: "CallExpression"}]
+        },
+        {
+            code: "class A extends null { constructor() { } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Expected to call 'super()'.", type: "MethodDefinition"}]
+        },
+        {
+            code: "class A extends 100 { constructor() { super(); } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Unexpected 'super()' because 'super' is not a constructor.", type: "CallExpression"}]
+        },
+        {
+            code: "class A extends 'test' { constructor() { super(); } }",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Unexpected 'super()' because 'super' is not a constructor.", type: "CallExpression"}]
         },
 
         // derived classes.


### PR DESCRIPTION
Fixes #5449 .

This PR was squashed from 2 commits:

- d93552a86098bb4690d230142a87f8a4e98c14ac Fixes a bug of code path analysis. I found it while I wrote this change.
- 2497bf7f42a71c6570023ef05661827447af8ec5 Improves the behavior for classes which inherit from a non-constructor.
  - The error message for classes which inherit from a non-constructor is improved.
    - `"Unexpected 'super()' because 'super' is not a constructor."`
  - The lacking `super()` cases for classes which inherit from a non-constructor are now invalid cases.
  - Enhancements the check whether a class inherits from a constructor or not.