### PR TITLE
Fix: Allow `require` inside of object literals (fixes #5773)

### DIFF
--- a/docs/rules/global-require.md
+++ b/docs/rules/global-require.md
@@ -67,6 +67,9 @@ require('x');
 var y = require('y');
 var z;
 z = require('z').initialize();
+var my = {
+    func: require('my.func')
+};
 
 // requiring a module and using it in a function is ok
 var fs = require('fs');

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -14,7 +14,9 @@ var ACCEPTABLE_PARENTS = [
     "CallExpression",
     "ConditionalExpression",
     "Program",
-    "VariableDeclaration"
+    "VariableDeclaration",
+    "ObjectExpression",
+    "Property"
 ];
 
 /**

--- a/tests/lib/rules/global-require.js
+++ b/tests/lib/rules/global-require.js
@@ -31,7 +31,8 @@ var valid = [
     { code: "var logger = require(DEBUG ? 'dev-logger' : 'logger');" },
     { code: "var logger = DEBUG ? require('dev-logger') : require('logger');" },
     { code: "function localScopedRequire(require) { require('y'); }" },
-    { code: "var someFunc = require('./someFunc'); someFunc(function(require) { return('bananas'); });" }
+    { code: "var someFunc = require('./someFunc'); someFunc(function(require) { return('bananas'); });" },
+    { code: "var x = {\n\ty: require('z')\n};" }
 ];
 
 var message = "Unexpected require().";
@@ -59,6 +60,15 @@ var invalid = [
         }]
     },
     {
+        code: "var x; if (y) { x = { z: require('debug') }; }",
+        errors: [{
+            line: 1,
+            column: 26,
+            message: message,
+            type: type
+        }]
+    },
+    {
         code: "var x; if (y) { x = require('debug').baz; }",
         errors: [{
             line: 1,
@@ -77,10 +87,28 @@ var invalid = [
         }]
     },
     {
+        code: "function x() { var z = { y: require('y') }; }",
+        errors: [{
+            line: 1,
+            column: 29,
+            message: message,
+            type: type
+        }]
+    },
+    {
         code: "try { require('x'); } catch (e) { console.log(e); }",
         errors: [{
             line: 1,
             column: 7,
+            message: message,
+            type: type
+        }]
+    },
+    {
+        code: "try { var y = { x: require('x') }; } catch (e) { console.log(e); }",
+        errors: [{
+            line: 1,
+            column: 20,
             message: message,
             type: type
         }]
@@ -112,6 +140,15 @@ var invalid = [
         errors: [{
             line: 1,
             column: 23,
+            message: message,
+            type: type
+        }]
+    },
+    {
+        code: "switch(x) { case '1': var v = { mod: require('1') }; break; }",
+        errors: [{
+            line: 1,
+            column: 38,
             message: message,
             type: type
         }]


### PR DESCRIPTION
Fixes #5773 .

Added `ObjectExpression` and `Property` as acceptable ancestors for calls to `require`.