### PR TITLE
Fix: indent rule uses wrong node for class indent level (fixes #5764)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -508,7 +508,7 @@ module.exports = function(context) {
      * @returns {boolean} True if it or its body is a block statement
      */
     function isNodeBodyBlock(node) {
-        return node.type === "BlockStatement" || (node.body && node.body.type === "BlockStatement") ||
+        return node.type === "BlockStatement" || node.type === "ClassBody" || (node.body && node.body.type === "BlockStatement") ||
             (node.consequent && node.consequent.type === "BlockStatement");
     }
 
@@ -541,7 +541,7 @@ module.exports = function(context) {
          * not from the beginning of the block.
          */
         var statementsWithProperties = [
-            "IfStatement", "WhileStatement", "ForStatement", "ForInStatement", "ForOfStatement", "DoWhileStatement"
+            "IfStatement", "WhileStatement", "ForStatement", "ForInStatement", "ForOfStatement", "DoWhileStatement", "ClassDeclaration"
         ];
 
         if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1 && isNodeBodyBlock(node)) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1120,6 +1120,24 @@ ruleTester.run("indent", rule, {
             "};",
             parserOptions: { ecmaVersion: 6 },
             options: [2]
+        },
+        {
+            code:
+            "class Foo\n" +
+            "  extends Bar {\n" +
+            "  baz() {}" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2]
+        },
+        {
+            code:
+            "class Foo extends\n" +
+            "  Bar {\n" +
+            "  baz() {}" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2]
         }
     ],
     invalid: [


### PR DESCRIPTION
Fixes #5764