### PR TITLE
Docs: Update sentence in fixable rules

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -215,7 +215,7 @@ These rules are purely matters of style and are quite subjective.
 * [space-in-parens](space-in-parens.md): require or disallow spaces inside parentheses (fixable)
 * [space-infix-ops](space-infix-ops.md): require spaces around operators (fixable)
 * [space-unary-ops](space-unary-ops.md): require or disallow spaces before/after unary operators (fixable)
-* [spaced-comment](spaced-comment.md): require or disallow a space immediately following the `//` or `/*` in a comment
+* [spaced-comment](spaced-comment.md): require or disallow a space immediately following the `//` or `/*` in a comment (fixable)
 * [wrap-regex](wrap-regex.md): require regex literals to be wrapped in parentheses
 
 ## ECMAScript 6

--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -1,5 +1,7 @@
 # Disallow or enforce spaces inside of brackets. (array-bracket-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 A number of style guides require or disallow spaces between array brackets. This rule
 applies to both array literals and destructuring assignment (EcmaScript 6) using arrays.
 
@@ -12,8 +14,6 @@ var [ x, y ] = z;
 var arr = ['foo', 'bar'];
 var [x,y] = z;
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -1,5 +1,7 @@
 # Require space before/after arrow function's arrow (arrow-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 This rule normalize style of spacing before/after an arrow function's arrow(`=>`).
 
 ```js
@@ -11,8 +13,6 @@ This rule normalize style of spacing before/after an arrow function's arrow(`=>`
 // { "before": false, "after": false }
 (a)=>{}
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -1,8 +1,8 @@
 # Disallow or enforce spaces inside of single line blocks. (block-spacing)
 
-This rule is for spacing style within single line blocks.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+This rule is for spacing style within single line blocks.
 
 ## Rule Details
 

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -1,6 +1,6 @@
 # Enforces spacing around commas (comma-spacing)
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
 Spacing around commas improve readability of a list of items. Although most of the style guidelines for languages prescribe adding a space after a comma and not before it, it is subjective to the preferences of a project.
 

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -1,5 +1,7 @@
 # Disallow or enforce spaces inside of computed properties. (computed-property-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 While formatting preferences are very personal, a number of style guides require
 or disallow spaces between computed properties in the following situations:
 
@@ -15,8 +17,6 @@ var x = obj[a];
 var a = "prop";
 var obj = { [a]: "value" };
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -1,5 +1,7 @@
 # Require file to end with single newline (eol-last)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Trailing newlines in non-empty files are a common UNIX idiom. Benefits of
 trailing newlines include the ability to concatenate or append to files as well
 as output files to the terminal without interfering with shell prompts. This
@@ -9,8 +11,6 @@ Prior to v0.16.0 this rule also enforced that there was only a single line at
 the end of the file. If you still want this behaviour, consider enabling
 [no-multiple-empty-lines](no-multiple-empty-lines.md) with `maxEOF` and/or
 [no-trailing-spaces](no-trailing-spaces.md).
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -1,5 +1,7 @@
 # Enforce spacing around the * in generator functions (generator-star-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Generators are a new type of function in ECMAScript 6 that can return multiple values over time.
 These special functions are indicated by placing an `*` after the `function` keyword.
 
@@ -37,8 +39,6 @@ function * generator() {
 ```
 
 To keep a sense of consistency when using generators this rule enforces a single position for the `*`.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -1,5 +1,7 @@
 # Validate Indentation (indent)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 This option validates a specific tab width for your code in block statements.
 
 There are several common guidelines which require specific indentation of nested blocks and statements, like:
@@ -17,8 +19,6 @@ This is the most common scenarios recommended in different style guides:
 * Two spaces, not longer and no tabs: Google, npm, Node.js, Idiomatic, Felix
 * Tabs: jQuery
 * Four spaces: Crockford
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -1,5 +1,7 @@
 # Enforce JSX Quote Style (jsx-quotes)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 JSX attribute values can contain string literals, which are delimited with single or double quotes.
 
 ```xml
@@ -14,8 +16,6 @@ If you want to have e.g. a double quote within a JSX attribute value, you have t
 <a b="'" />
 <a b='"' />
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -1,5 +1,7 @@
 # Enforce spacing before and after keywords (keyword-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Keywords are syntax elements of JavaScript, such as `function` and `if`.
 These identifiers have special meaning to the language and so often appear in a different color in code editors.
 As an important part of the language, style guides often refer to the spacing that should be used around keywords.
@@ -14,8 +16,6 @@ if (foo) {
 ```
 
 Of course, you could also have a style guide that disallows spaces around keywords.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -1,5 +1,7 @@
 # Enforce linebreak style (linebreak-style)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 When developing with a lot of people all having different editors, VCS applications and operating systems it may occur that
 different line endings are written by either of the mentioned (might especially happen when using the windows and mac versions of SourceTree together).
 
@@ -7,8 +9,6 @@ The linebreaks (new lines) used in windows operating system are usually _carriag
 whereas Linux and Unix use a simple _line feed_ (LF). The corresponding _control sequences_ are `"\n"` (for LF) and `"\r\n"` for (CRLF).
 
 Many versioning systems (like git and subversion) can automatically ensure the correct ending. However to cover all contingencies you can activate this rule.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -1,8 +1,8 @@
 # Disallow Extra Semicolons (no-extra-semi)
 
-JavaScript will more or less let you put semicolons after any statement without complaining. Typos and misunderstandings about where semicolons are required can lead to extra semicolons that are unnecessary.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+JavaScript will more or less let you put semicolons after any statement without complaining. Typos and misunderstandings about where semicolons are required can lead to extra semicolons that are unnecessary.
 
 ## Rule Details
 

--- a/docs/rules/no-multi-spaces.md
+++ b/docs/rules/no-multi-spaces.md
@@ -1,5 +1,7 @@
 # Disallow multiple spaces (no-multi-spaces)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Multiple spaces in a row that are not used for indentation are typically mistakes. For example:
 
 ```js
@@ -15,8 +17,6 @@ It's hard to tell, but there are two spaces between `foo` and `===`. Multiple sp
 if(foo === "bar") {}
 
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/no-spaced-func.md
+++ b/docs/rules/no-spaced-func.md
@@ -1,8 +1,8 @@
 # Disallow Spaces in Function Calls (no-spaced-func)
 
-While it's possible to have whitespace between the name of a function and the parentheses that execute it, such patterns tend to look more like errors.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+While it's possible to have whitespace between the name of a function and the parentheses that execute it, such patterns tend to look more like errors.
 
 ## Rule Details
 

--- a/docs/rules/no-trailing-spaces.md
+++ b/docs/rules/no-trailing-spaces.md
@@ -1,8 +1,8 @@
 # Disallow trailing spaces at the end of lines (no-trailing-spaces)
 
-Sometimes in the course of editing files, you can end up with extra whitespace at the end of lines. These whitespace differences can be picked up by source control systems and flagged as diffs, causing frustration for developers. While this extra whitespace causes no functional issues, many code conventions require that trailing spaces be removed before checkin.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+Sometimes in the course of editing files, you can end up with extra whitespace at the end of lines. These whitespace differences can be picked up by source control systems and flagged as diffs, causing frustration for developers. While this extra whitespace causes no functional issues, many code conventions require that trailing spaces be removed before checkin.
 
 ## Rule Details
 

--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -1,9 +1,11 @@
 # Disallow or enforce spaces inside of curly braces in objects. (object-curly-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 While formatting preferences are very personal, a number of style guides require
 or disallow spaces between curly braces in the following situations:
 
-```
+```js
 // simple object literals
 var obj = { foo: "bar" };
 
@@ -17,8 +19,6 @@ var { x, y } = y;
 import { foo } from "bar";
 export { foo };
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 
@@ -45,7 +45,7 @@ Depending on your coding conventions, you can choose either option by specifying
 
 When `"never"` is set, the following patterns are considered problems:
 
-```
+```js
 /*eslint object-curly-spacing: ["error", "never"]*/
 
 var obj = { 'foo': 'bar' };
@@ -58,7 +58,7 @@ import { foo } from 'bar';
 
 The following patterns are not considered problems:
 
-```
+```js
 /*eslint object-curly-spacing: ["error", "never"]*/
 
 var obj = {'foo': 'bar'};
@@ -79,7 +79,7 @@ import {foo} from 'bar';
 
 When `"always"` is used, the following patterns are considered problems:
 
-```
+```js
 /*eslint object-curly-spacing: ["error", "always"]*/
 
 var obj = {'foo': 'bar'};
@@ -96,7 +96,7 @@ import {foo } from 'bar';
 
 The following patterns are not considered problems:
 
-```
+```js
 /*eslint object-curly-spacing: ["error", "always"]*/
 
 var obj = {};

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -1,5 +1,7 @@
 # Enforce Quote Style (quotes)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 JavaScript allows you to define strings in one of three ways: double quotes, single quotes, and backticks (as of ECMAScript 6). For example:
 
 ```js
@@ -17,8 +19,6 @@ Many codebases require strings to be defined in a consistent manner.
 ## Rule Details
 
 This rule is aimed at ensuring consistency of string quotes and as such will report a problem when an inconsistent style is found.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 The rule configuration takes up to two options:
 

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -1,5 +1,7 @@
 # Enforce spacing before and after semicolons (semi-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 JavaScript allows you to place unnecessary spaces before or after a semicolon.
 
 Disallowing or enforcing space around a semicolon can improve the readability of your program.
@@ -9,8 +11,6 @@ var a = "b" ;
 
 var c = "d";var e = "f";
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -1,5 +1,7 @@
 # Enforce or Disallow Semicolons (semi)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 JavaScript is unique amongst the C-like languages in that it doesn't require semicolons at the end of each statement. In many cases, the JavaScript engine can determine that a semicolon should be in a certain spot and will automatically add it. This feature is known as **automatic semicolon insertion (ASI)** and is considered one of the more controversial features of JavaScript. For example, the following lines are both valid:
 
 ```js
@@ -56,8 +58,6 @@ Although ASI allows for more freedom over your coding style, it can also make yo
 ## Rule Details
 
 This rule is aimed at ensuring consistent use of semicolons. You can decide whether or not to require semicolons at the end of statements.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Options
 

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -2,6 +2,8 @@
 
 **Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixed problems reported by this rule.
+
 Some style guides will require or disallow spaces following the certain keywords.
 
 ```js
@@ -17,8 +19,6 @@ if(condition) {
     doSomethingElse();
 }
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -1,11 +1,11 @@
 # Require Or Disallow Space Before Blocks (space-before-blocks)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Consistency is an important part of any style guide.
 While it is a personal preference where to put the opening brace of blocks,
 it should be consistent across a whole project.
 Having an inconsistent style distracts the reader from seeing the important parts of the code.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -1,5 +1,7 @@
 # Require or disallow a space before function parenthesis (space-before-function-paren)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 When formatting a function, whitespace is allowed between the function name or `function` keyword and the opening paren. Named functions also require a space between the `function` keyword and the function name, but anonymous functions require no whitespace. For example:
 
 ```js
@@ -17,8 +19,6 @@ var anonymousWithSpace = function () {};
 ```
 
 Style guides may require a space after the `function` keyword for anonymous functions, while others specify no whitespace. Similarly, the space after a function name may or may not be required.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -2,6 +2,8 @@
 
 **Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixed problems reported by this rule.
+
 Keywords are syntax elements of JavaScript, such as `function` and `if`. These identifiers have special meaning to the language and so often appear in a different color in code editors. As an important part of the language, style guides often refer to the spacing that should be used around keywords. For example, you might have a style guide that says keywords should be always be preceded by spaces, which would mean `if-else` statements must look like this:
 
 ```js
@@ -13,8 +15,6 @@ if (foo) {
 ```
 
 Of course, you could also have a style guide that disallows spaces before keywords.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -1,5 +1,7 @@
 # Disallow or enforce spaces inside of parentheses (space-in-parens)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Some style guides require or disallow spaces inside of parentheses:
 
 ```js
@@ -9,8 +11,6 @@ var x = ( 1 + 2 ) * 3;
 foo('bar');
 var x = (1 + 2) * 3;
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -1,5 +1,7 @@
 # Require Spaces Around Infix Operators (space-infix-ops)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 While formatting preferences are very personal, a number of style guides require spaces around operators, such as:
 
 ```js
@@ -13,8 +15,6 @@ var sum = i+++2;
 ```
 
 While this is valid JavaScript syntax, it is hard to determine what the author intended.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -2,9 +2,9 @@
 
 **Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
 
-Require spaces following `return`, `throw`, and `case`.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixed problems reported by this rule.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+Require spaces following `return`, `throw`, and `case`.
 
 ## Rule Details
 

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -1,8 +1,8 @@
 # Require or disallow spaces before/after unary operators (space-unary-ops)
 
-Some styleguides require or disallow spaces before or after unary operators. This is mainly a stylistic issue, however, some JavaScript expressions can be written without spacing which makes it harder to read and maintain.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+Some styleguides require or disallow spaces before or after unary operators. This is mainly a stylistic issue, however, some JavaScript expressions can be written without spacing which makes it harder to read and maintain.
 
 ## Rule Details
 

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -1,10 +1,10 @@
 # Requires or disallows a whitespace (space or tab) beginning a comment (spaced-comment)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Some style guides require or disallow a whitespace immediately after the initial `//` or `/*` of a comment.
 Whitespace after the `//` or `/*` makes it easier to read text in comments.
 On the other hand, commenting out code is easier without having to put a whitespace right after the `//` or `/*`.
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -1,13 +1,13 @@
 # Enforce Usage of Spacing in Template Strings (template-curly-spacing)
 
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 We can embed expressions in template strings with using a pair of `${` and `}`.
 This rule can force usage of spacing inside of the curly brace pair according to style guides.
 
 ```js
 let hello = `hello, ${people.name}!`;
 ```
-
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
 
 ## Rule Details
 

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -1,6 +1,6 @@
 # Enforce spacing around the `*` in `yield*` expressions (yield-star-spacing)
 
-**Fixable:** This rule is automatically fixable using the `--fix` flag on the command line.
+(fixable) The --fix option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
 ## Rule Details
 


### PR DESCRIPTION
One change in **README.md**: add (fixable) to spaced-comment

One change in each of 30 docs for fixable rules:
* Move sentence to **immediately follow** the main heading, so people know if not there, rule not fixable.
* Display (fixable) as **wrench icon** at the left with replacement and style rule from https://github.com/eslint/eslint.github.io/pull/231
* Add link from **command line** to relevant info
* Past tense **fixed** for removed rules: space-after-keywords, space-before-keywords, space-return-throw-case

One additional change in object-curly-spacing: add **js** to some code fences