### PR TITLE
Add an 'ignore' option to space-before-function-parens.

### DIFF
--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -26,7 +26,7 @@ This rule aims to enforce consistent spacing before function parentheses and as 
 
 ## Options
 
-This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`).
+This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`). In this case, you can use "ignore" to only set the apply the rule to one type of function (e. g. `{"anonymous": "ignore", "named": "never"}` will warn on spaces for named functions, but will not warn on anonymous functions one way or the other).
 
 The default configuration is `"always"`.
 
@@ -265,6 +265,58 @@ class Foo {
 
 var foo = {
     bar () {
+        // ...
+    }
+};
+```
+
+### `{"anonymous": "ignore", "named": "always"}`
+
+The following patterns are considered problems:
+
+```js
+/*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
+/*eslint-env es6*/
+
+function foo() {
+    // ...
+}
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
+/*eslint-env es6*/
+
+var bar = function() {
+    // ...
+};
+
+var bar = function () {
+    // ...
+};
+
+class Foo {
+    constructor () {
+        // ...
+    }
+}
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar () {
+        // ...
+    }
+};
+
+var foo = {
+    bar() {
         // ...
     }
 };

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -15,14 +15,22 @@ module.exports = function(context) {
     var configuration = context.options[0],
         sourceCode = context.getSourceCode(),
         requireAnonymousFunctionSpacing = true,
-        requireNamedFunctionSpacing = true;
+        forbidAnonymousFunctionSpacing = false,
+        requireNamedFunctionSpacing = true,
+        forbidNamedFunctionSpacing = false;
 
     if (typeof configuration === "object") {
-        requireAnonymousFunctionSpacing = configuration.anonymous !== "never";
-        requireNamedFunctionSpacing = configuration.named !== "never";
+        requireAnonymousFunctionSpacing = (
+            !configuration.anonymous || configuration.anonymous === "always");
+        forbidAnonymousFunctionSpacing = configuration.anonymous === "never";
+        requireNamedFunctionSpacing = (
+            !configuration.named || configuration.named === "always");
+        forbidNamedFunctionSpacing = configuration.named === "never";
     } else if (configuration === "never") {
         requireAnonymousFunctionSpacing = false;
+        forbidAnonymousFunctionSpacing = true;
         requireNamedFunctionSpacing = false;
+        forbidNamedFunctionSpacing = true;
     }
 
     /**
@@ -71,7 +79,7 @@ module.exports = function(context) {
         location = leftToken.loc.end;
 
         if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken)) {
-            if ((isNamed && !requireNamedFunctionSpacing) || (!isNamed && !requireAnonymousFunctionSpacing)) {
+            if ((isNamed && forbidNamedFunctionSpacing) || (!isNamed && forbidAnonymousFunctionSpacing)) {
                 context.report({
                     node: node,
                     loc: location,
@@ -111,10 +119,10 @@ module.exports.schema = [
                 "type": "object",
                 "properties": {
                     "anonymous": {
-                        "enum": ["always", "never"]
+                        "enum": ["always", "never", "ignore"]
                     },
                     "named": {
-                        "enum": ["always", "never"]
+                        "enum": ["always", "never", "ignore"]
                     }
                 },
                 "additionalProperties": false

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -83,6 +83,18 @@ ruleTester.run("space-before-function-paren", rule, {
             code: "class Foo { constructor () {} *method () {} }",
             options: [ { named: "always", anonymous: "never" } ],
             parserOptions: { ecmaVersion: 6 }
+        },
+        { code: "var foo = function() {}",
+          options: [ { named: "always", anonymous: "ignore" } ]
+        },
+        { code: "var foo = function () {}",
+          options: [ { named: "always", anonymous: "ignore" } ]
+        },
+        { code: "var bar = function foo() {}",
+          options: [ { named: "ignore", anonymous: "always" } ]
+        },
+        { code: "var bar = function foo () {}",
+          options: [ { named: "ignore", anonymous: "always" } ]
         }
     ],
 
@@ -392,6 +404,54 @@ ruleTester.run("space-before-function-paren", rule, {
                 "var bar = function() {}",
                 "var obj = { get foo () {}, set foo (val) {}, bar () {} };"
             ].join("\n")
+        },
+        {
+            code: "var foo = function() {}",
+            options: [ { named: "ignore", anonymous: "always" } ],
+            errors: [
+                {
+                    type: "FunctionExpression",
+                    message: "Missing space before function parentheses.",
+                    line: 1,
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "var foo = function () {}",
+            options: [ { named: "ignore", anonymous: "never" } ],
+            errors: [
+                {
+                    type: "FunctionExpression",
+                    message: "Unexpected space before function parentheses.",
+                    line: 1,
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "var bar = function foo() {}",
+            options: [ { named: "always", anonymous: "ignore" } ],
+            errors: [
+                {
+                    type: "FunctionExpression",
+                    message: "Missing space before function parentheses.",
+                    line: 1,
+                    column: 23
+                }
+            ]
+        },
+        {
+            code: "var bar = function foo () {}",
+            options: [ { named: "never", anonymous: "ignore" } ],
+            errors: [
+                {
+                    type: "FunctionExpression",
+                    message: "Unexpected space before function parentheses.",
+                    line: 1,
+                    column: 23
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
This allows a configuration where you can enforce
space-before-function for named functions, say, while letting
anonymous functions use spaces or not, without error either way.
Without this change, enabling this rule for one or the other of
named/anonymous, but not both, was impossible.

Fixes #4127