### PR TITLE
Docs: fix the examples for space-before-function-paren.

### DIFF
--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -26,7 +26,7 @@ This rule aims to enforce consistent spacing before function parentheses and as 
 
 ## Options
 
-This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`). In this case, you can use "ignore" to only set the apply the rule to one type of function (e. g. `{"anonymous": "ignore", "named": "never"}` will warn on spaces for named functions, but will not warn on anonymous functions one way or the other).
+This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`). In this case, you can use "ignore" to only apply the rule to one type of function (e. g. `{"anonymous": "ignore", "named": "never"}` will warn on spaces for named functions, but will not warn on anonymous functions one way or the other).
 
 The default configuration is `"always"`.
 
@@ -281,6 +281,18 @@ The following patterns are considered problems:
 function foo() {
     // ...
 }
+
+class Foo {
+    constructor() {
+        // ...
+    }
+}
+
+var foo = {
+    bar() {
+        // ...
+    }
+};
 ```
 
 The following patterns are not considered problems:
@@ -297,26 +309,18 @@ var bar = function () {
     // ...
 };
 
+function foo () {
+    // ...
+}
+
 class Foo {
     constructor () {
         // ...
     }
 }
 
-class Foo {
-    constructor() {
-        // ...
-    }
-}
-
 var foo = {
     bar () {
-        // ...
-    }
-};
-
-var foo = {
-    bar() {
         // ...
     }
 };


### PR DESCRIPTION
I was confused about whether es6-style functions were considered named
or anonymous.

I also fixed a typo that had gotten in there.