### PR TITLE
Docs: Clarify disable inline comments

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -194,13 +194,13 @@ The [no-undef](../rules/no-undef.md) rule will warn on variables that are access
 To specify globals using a comment inside of your JavaScript file, use the following format:
 
 ```js
-/*global var1, var2*/
+/* global var1, var2 */
 ```
 
 This defines two global variables, `var1` and `var2`. If you want to optionally specify that these global variables should never be written to (only read), then you can set each with a `false` flag:
 
 ```js
-/*global var1:false, var2:false*/
+/* global var1:false, var2:false */
 ```
 
 To configure global variables inside of a configuration file, use the `globals` key and indicate the global variables you want to use. Set each global variable name equal to `true` to allow the variable to be overwritten or `false` to disallow overwriting. For example:
@@ -262,13 +262,13 @@ ESLint comes with a large number of rules. You can modify which rules your proje
 To configure rules inside of a file using configuration comments, use a comment in the following format:
 
 ```js
-/*eslint eqeqeq: "off", curly: "error"*/
+/* eslint eqeqeq: "off", curly: "error" */
 ```
 
 In this example, [`eqeqeq`](../rules/eqeqeq) is turned off and [`curly`](../rules/curly) is turned on as an error. You can also use the numeric equivalent for the rule severity:
 
 ```js
-/*eslint eqeqeq: 0, curly: 2*/
+/* eslint eqeqeq: 0, curly: 2 */
 ```
 
 This example is the same as the last example, only it uses the numeric codes instead of the string values. The `eqeqeq` rule is off and the `curly` rule is set to be an error.
@@ -276,7 +276,7 @@ This example is the same as the last example, only it uses the numeric codes ins
 If a rule has additional options, you can specify them using array literal syntax, such as:
 
 ```js
-/*eslint quotes: ["error", "double"], curly: 2*/
+/* eslint quotes: ["error", "double"], curly: 2 */
 ```
 
 This comment specifies the "double" option for the [`quotes`](../rules/quotes) rule. The first item in the array is always the rule severity (number or string).
@@ -340,31 +340,52 @@ rules:
 In these configuration files, the rule `plugin1/rule1` comes from the plugin named `plugin1`. You can also use this format with configuration comments, such as:
 
 ```js
-/*eslint "plugin1/rule1": "error" */
+/* eslint "plugin1/rule1": "error" */
 ```
 
 **Note:** When specifying rules from plugins, make sure to omit `eslint-plugin-`. ESLint uses only the unprefixed name internally to locate rules.
 
+## Disabling Rules with Inline Comments
+
 To temporarily disable rule warnings in your file use the following format:
 
 ```js
-/*eslint-disable */
+/* eslint-disable */
 
-//Disable all rules between comments
+// Disables all rules between comments
 alert('foo');
 
-/*eslint-enable */
+/* eslint-enable */
 ```
 
 You can also disable or enable warnings for specific rules:
 
 ```js
-/*eslint-disable no-alert, no-console */
+/* eslint-disable no-alert, no-console */
 
+// Disables no-alert and no-console warnings between comments
 alert('foo');
 console.log('bar');
 
-/*eslint-enable no-alert */
+/* eslint-enable no-alert, no-console */
+```
+
+To disable rule warnings in an entire file, put `/* eslint-disable */` at the top of the file:
+
+```js
+/* eslint-disable */
+
+// Disables all rules for the rest of the file
+alert('foo');
+```
+
+You can also disable specific rules for an entire file:
+
+```js
+/* eslint-disable no-alert */
+
+// Disables no-alert for the rest of the file
+alert('foo');
 ```
 
 To disable all rules on a specific line:


### PR DESCRIPTION
I personally was looking for info on disabling rules for an entire file (an edge case, I know, but a valid one, in my opinion) and thought we could make this clearer.

Also made whitespace padding in comments consistent throughout the file while I was at it.