### PR TITLE
Docs: Distinguish examples in rules under Stylistic Issues part 1

### DIFF
--- a/docs/rules/array-bracket-spacing.md
+++ b/docs/rules/array-bracket-spacing.md
@@ -1,9 +1,9 @@
-# Disallow or enforce spaces inside of brackets. (array-bracket-spacing)
+# Disallow or enforce spaces inside of brackets (array-bracket-spacing)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-A number of style guides require or disallow spaces between array brackets. This rule
-applies to both array literals and destructuring assignment (EcmaScript 6) using arrays.
+A number of style guides require or disallow spaces between array brackets and other tokens. This rule
+applies to both array literals and destructuring assignments (ECMAScript 6).
 
 ```js
 /*eslint-env es6*/
@@ -17,27 +17,35 @@ var [x,y] = z;
 
 ## Rule Details
 
-This rule aims to maintain consistency around the spacing inside of array brackets, either by disallowing
-spaces inside of brackets between the brackets and other tokens or enforcing spaces. Brackets that are
-separated from the adjacent value by a new line are excepted from this rule, as this is a common pattern.
-  Object literals that are used as the first or last element in an array are also ignored.
+This rule enforces consistent spacing inside array brackets.
 
 ## Options
 
-There are two options for this rule:
+This rule has a string option:
 
-* `"always"` enforces a space inside of array brackets
-* `"never"` enforces no space inside of array brackets (default)
+* `"never"` (default) disallows spaces inside array brackets
+* `"always"` requires one or more spaces or newlines inside array brackets
 
-Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+This rule has an object option for exceptions to the `"never"` option:
 
-```json
-"array-bracket-spacing": ["error", "always"]
-```
+* `"singleValue": true` requires one or more spaces or newlines inside brackets of array literals that contain a single element
+* `"objectsInArrays": true` requires one or more spaces or newlines between brackets of array literals and braces of their object literal elements `[ {` or `} ]`
+* `"arraysInArrays": true` requires one or more spaces or newlines between brackets of array literals and brackets of their array literal elements `[ [` or `] ]`
 
-### "never"
+This rule has an object option for exceptions to the `"always"` option:
 
-When `"never"` is set, the following patterns are considered problems:
+* `"singleValue": false` disallows spaces inside brackets of array literals that contain a single element
+* `"objectsInArrays": false` disallows spaces between brackets of array literals and braces of their object literal elements `[{` or `}]`
+* `"arraysInArrays": false` disallows spaces between brackets of array literals and brackets of their array literal elements `[[` or `]]`
+
+This rule has built-in exceptions:
+
+* `"never"` (and also the exceptions to the `"always"` option) allows newlines inside array brackets, because this is a common pattern
+* `"always"` does not require spaces or newlines in empty array literals `[]`
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
@@ -56,7 +64,7 @@ var [ x, ...y ] = z;
 var [ ,,x, ] = z;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "never"]*/
@@ -83,9 +91,9 @@ var [x, ...y] = z;
 var [,,x,] = z;
 ```
 
-### "always"
+### always
 
-When `"always"` is used, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
@@ -107,7 +115,7 @@ var [x, ...y] = z;
 var [,,x,] = z;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint array-bracket-spacing: ["error", "always"]*/
@@ -134,46 +142,12 @@ var [ x, ...y ] = z;
 var [ ,,x, ] = z;
 ```
 
-Note that `"always"` has a special case where `{}` and `[]` are not considered problems.
+### singleValue
 
-### Exceptions
-
-An object literal may be used as a third array item to specify spacing exceptions. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing and an exception is set to `false`, it will disallow spacing for cases matching the exception. Likewise, if `"never"` is set to disallow spacing and an exception is set to `true`, it will enforce spacing for cases matching the exception.
-
-You can add exceptions like so:
-
-In case of `"always"` option, set an exception to `false` to enable it:
-
-```json
-"array-bracket-spacing": ["error", "always", {
-  "singleValue": false,
-  "objectsInArrays": false,
-  "arraysInArrays": false
-}]
-```
-
-In case of `"never"` option, set an exception to `true` to enable it:
-
-```json
-"array-bracket-spacing": ["error", "never", {
-  "singleValue": true,
-  "objectsInArrays": true,
-  "arraysInArrays": true
-}]
-```
-
-The following exceptions are available:
-
-* `singleValue` sets the spacing of a single value inside of square brackets of an array.
-* `objectsInArrays` sets the spacings between the curly braces and square brackets of object literals that are the first or last element in an array.
-* `arraysInArrays` sets the spacing between the square brackets of array literals that are the first or last element in an array.
-
-In each of the following examples, the `"always"` option is assumed.
-
-When `"singleValue"` is set to `false`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always", { "singleValue": false }` options:
 
 ```js
-/*eslint array-bracket-spacing: ["error", "always", { singleValue: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
 var foo = [ 'foo' ];
 var foo = [ 'foo'];
@@ -185,10 +159,10 @@ var foo = [ [ 1, 2 ] ];
 var foo = [ { 'foo': 'bar' } ];
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always", { "singleValue": false }` options:
 
 ```js
-/*eslint array-bracket-spacing: ["error", "always", { singleValue: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { "singleValue": false }]*/
 
 var foo = ['foo'];
 var foo = [1];
@@ -196,10 +170,12 @@ var foo = [[ 1, 1 ]];
 var foo = [{ 'foo': 'bar' }];
 ```
 
-When `"objectsInArrays"` is set to `false`, the following patterns are considered problems:
+### objectsInArrays
+
+Examples of **incorrect**  this rule with the `"always", { "objectsInArrays": false }` options:
 
 ```js
-/*eslint array-bracket-spacing: ["error", "always", { objectsInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
 var arr = [ { 'foo': 'bar' } ];
 var arr = [ {
@@ -207,10 +183,10 @@ var arr = [ {
 } ]
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always", { "objectsInArrays": false }` options:
 
 ```js
-/*eslint array-bracket-spacing: ["error", "always", { objectsInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { "objectsInArrays": false }]*/
 
 var arr = [{ 'foo': 'bar' }];
 var arr = [{
@@ -218,19 +194,21 @@ var arr = [{
 }];
 ```
 
-When `"arraysInArrays"` is set to `false`, the following patterns are considered problems:
+### arraysInArrays
+
+Examples of **incorrect** code for this rule with the `"always", { "arraysInArrays": false }` options:
 
 ```js
-/*eslint array-bracket-spacing: ["error", "always", { arraysInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
 var arr = [ [ 1, 2 ], 2, 3, 4 ];
 var arr = [ [ 1, 2 ], 2, [ 3, 4 ] ];
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always", { "arraysInArrays": false }` options:
 
 ```js
-/*eslint array-bracket-spacing: ["error", "always", { arraysInArrays: false }]*/
+/*eslint array-bracket-spacing: ["error", "always", { "arraysInArrays": false }]*/
 
 var arr = [[ 1, 2 ], 2, 3, 4 ];
 var arr = [[ 1, 2 ], 2, [ 3, 4 ]];

--- a/docs/rules/block-spacing.md
+++ b/docs/rules/block-spacing.md
@@ -1,37 +1,30 @@
-# Disallow or enforce spaces inside of single line blocks. (block-spacing)
+# Disallow or enforce spaces inside of single line blocks (block-spacing)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-This rule is for spacing style within single line blocks.
-
 ## Rule Details
 
-This rule is aimed to flag usage of spacing inside of blocks.
+This rule enforces consistent spacing inside single-line blocks.
 
 ## Options
 
-This rule has a option, its value is `"always"` or `"never"`.
+This rule has a string option:
 
-- `"always"` (by default) enforces one or more spaces.
-- `"never"` disallows space(s).
+* `"always"` (default) requires one or more spaces
+* `"never"` disallows spaces
 
-### "always"
+### always
 
-```json
-{
-  "block-spacing": ["error", "always"]
-}
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint block-spacing: "error"*/
+
 function foo() {return true;}
 if (foo) { bar = 0;}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint block-spacing: "error"*/
@@ -40,15 +33,9 @@ function foo() { return true; }
 if (foo) { bar = 0; }
 ```
 
-### "never"
+### never
 
-```json
-{
-  "block-spacing": ["error", "never"]
-}
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint block-spacing: ["error", "never"]*/
@@ -57,7 +44,7 @@ function foo() { return true; }
 if (foo) { bar = 0;}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint block-spacing: ["error", "never"]*/

--- a/docs/rules/brace-style.md
+++ b/docs/rules/brace-style.md
@@ -1,8 +1,8 @@
 # Require Brace Style (brace-style)
 
-Brace style is closely related to [indent style](http://en.wikipedia.org/wiki/Indent_style) in programming and describes the placement of curly braces relative to their control statement and body. There are probably a dozen, if not more, brace styles in the world.
+Brace style is closely related to [indent style](http://en.wikipedia.org/wiki/Indent_style) in programming and describes the placement of braces relative to their control statement and body. There are probably a dozen, if not more, brace styles in the world.
 
-The *one true brace style* is one of the most common brace styles in JavaScript, in which the opening curly brace of a block is placed on the same line as its corresponding statement or declaration. For example:
+The *one true brace style* is one of the most common brace styles in JavaScript, in which the opening brace of a block is placed on the same line as its corresponding statement or declaration. For example:
 
 ```js
 if (foo) {
@@ -12,7 +12,7 @@ if (foo) {
 }
 ```
 
-One common variant of one true brace style is called Stroustrup, in which the `else` statements in an `if-else` construct, as well as `catch` and `finally`, must be on its own line after the preceding closing brace, as in this example:
+One common variant of one true brace style is called Stroustrup, in which the `else` statements in an `if-else` construct, as well as `catch` and `finally`, must be on its own line after the preceding closing brace. For example:
 
 ```js
 if (foo) {
@@ -23,7 +23,7 @@ else {
 }
 ```
 
-Another style is called [Allman](https://en.wikipedia.org/wiki/Indent_style#Allman_style), in which all the braces are expected to be on their own lines without any extra indentation:
+Another style is called [Allman](https://en.wikipedia.org/wiki/Indent_style#Allman_style), in which all the braces are expected to be on their own lines without any extra indentation. For example:
 
 ```js
 if (foo)
@@ -40,27 +40,27 @@ While no style is considered better than the other, most developers agree that h
 
 ## Rule Details
 
-This rule is aimed at enforcing a particular brace style in JavaScript. As such, it warns whenever it sees a statement or declaration that does not adhere to the one true brace style.
+This rule enforces consistent brace style for blocks.
 
 ## Options
 
-The rule takes two options:
+This rule has a string option:
 
-1. A string which must be either `"1tbs"`, `"stroustrup"` or `"allman"`. The default is `"1tbs"`.
-2. An object that further controls the behaviour of this rule. Currently, the only available parameter is `allowSingleLine`, which indicates whether start and end braces may be on the same line.
+* `"1tbs"` (default) enforces one true brace style
+* `"stroustrup"` enforces Stroustrup style
+* `"allman"` enforces Allman style
 
-You can set the style in configuration like this:
+This rule has an object option for an exception:
 
-```json
-"brace-style": ["error", "stroustrup", { "allowSingleLine": true }]
-```
+* `"allowSingleLine": true` (default `false`) allows the opening and closing braces for a block to be on the *same* line
 
-### "1tbs"
+### 1tbs
 
-This is the default setting for this rule and enforces one true brace style. While using this setting, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"1tbs"` option:
 
 ```js
 /*eslint brace-style: "error"*/
+
 function foo()
 {
   return true;
@@ -87,7 +87,7 @@ else {
 }
 ```
 
-The following patterns use the one true brace style and are not considered problems:
+Examples of **correct** code for this rule with the default `"1tbs"` option:
 
 ```js
 /*eslint brace-style: "error"*/
@@ -117,7 +117,7 @@ if (foo) bar();
 else if (baz) boom();
 ```
 
-With one-line form enabled, the following is also valid:
+Examples of **correct** code for this rule with the `"1tbs", { "allowSingleLine": true }` options:
 
 ```js
 /*eslint brace-style: ["error", "1tbs", { "allowSingleLine": true }]*/
@@ -131,10 +131,9 @@ if (foo) { bar(); } else { baz(); }
 try { somethingRisky(); } catch(e) { handleError(); }
 ```
 
-### "stroustrup"
+### stroustrup
 
-
-This enforces Stroustrup style. While using this setting, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"stroustrup"` option:
 
 ```js
 /*eslint brace-style: ["error", "stroustrup"]*/
@@ -164,7 +163,7 @@ if (foo) {
 }
 ```
 
-The following patterns use the Stroustrup style and are not considered problems:
+Examples of **correct** code for this rule with the `"stroustrup"` option:
 
 ```js
 /*eslint brace-style: ["error", "stroustrup"]*/
@@ -196,7 +195,7 @@ if (foo) bar();
 else if (baz) boom();
 ```
 
-With one-line form enabled, the following is also valid:
+Examples of **correct** code for this rule with the `"stroustrup", { "allowSingleLine": true }` options:
 
 ```js
 /*eslint brace-style: ["error", "stroustrup", { "allowSingleLine": true }]*/
@@ -212,10 +211,9 @@ try { somethingRisky(); }
 catch(e) { handleError(); }
 ```
 
-### "allman"
+### allman
 
-
-This enforces Allman style. While using this setting, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"allman"` option:
 
 ```js
 /*eslint brace-style: ["error", "allman"]*/
@@ -243,7 +241,7 @@ if (foo) {
 }
 ```
 
-The following patterns use the Allman style and are not considered problems:
+Examples of **correct** code for this rule with the `"allman"` option:
 
 ```js
 /*eslint brace-style: ["error", "allman"]*/
@@ -281,7 +279,7 @@ if (foo) bar();
 else if (baz) boom();
 ```
 
-With one-line form enabled, the following is also valid:
+Examples of **correct** code for this rule with the `"allman", { "allowSingleLine": true }` options:
 
 ```js
 /*eslint brace-style: ["error", "allman", { "allowSingleLine": true }]*/

--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -1,6 +1,6 @@
 # Require Camelcase (camelcase)
 
-When it comes to naming variables, styleguides generally fall into one of two camps: camelcase (`variableName`) and underscores (`variable_name`). This rule focuses on using the camelcase approach. If your styleguide calls for camelcasing your variable names, then this rule is for you!
+When it comes to naming variables, style guides generally fall into one of two camps: camelcase (`variableName`) and underscores (`variable_name`). This rule focuses on using the camelcase approach. If your style guide calls for camelcasing your variable names, then this rule is for you!
 
 ## Rule Details
 
@@ -8,25 +8,18 @@ This rule looks for any underscores (`_`) located within the source code. It ign
 
 ## Options
 
-This rule accepts a single options argument with the following defaults:
+This rule has an object option:
 
-```json
-{
-    "rules": {
-        "camelcase": ["error", {"properties": "always"}]
-    }
-}
-```
+* `"properties": "always"` (default) enforces camelcase style for property names
+* `"properties": "never"` does not check property names
 
-`Properties` can have the following values:
+### always
 
-1. `always` is the default and checks all property names
-2. `never` does not check property names at all
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `{ "properties": "always" }` option:
 
 ```js
 /*eslint camelcase: "error"*/
+
 var my_favorite_color = "#112C85";
 
 function do_something() {
@@ -42,10 +35,11 @@ var obj = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "properties": "always" }` option:
 
 ```js
 /*eslint camelcase: "error"*/
+
 var myFavoriteColor   = "#112C85";
 var _myFavoriteColor  = "#112C85";
 var myFavoriteColor_  = "#112C85";
@@ -58,6 +52,9 @@ obj.do_something();
 var { category_id: category } = query;
 ```
 
+### never
+
+Examples of **correct** code for this rule with the `{ "properties": "never" }` option:
 
 ```js
 /*eslint camelcase: ["error", {properties: "never"}]*/

--- a/docs/rules/comma-spacing.md
+++ b/docs/rules/comma-spacing.md
@@ -11,27 +11,28 @@ var foo = 1 ,bar = 2;
 
 ## Rule Details
 
-This rule aims to enforce spacing around a comma. As such, it warns whenever it sees a missing or unwanted space in commas of variable declaration, object property, function parameter, sequence and array element.
+This rule enforces consistent spacing before and after commas in variable declarations, array literals, object literals, function parameters, and sequences.
 
+This rule does not apply in an `ArrayExpression` or `ArrayPattern` in either of the following cases:
+
+* adjacent null elements
+* an initial null element, to avoid conflicts with the [`array-bracket-spacing`](array-bracket-spacing.md) rule
 
 ## Options
 
-The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`. If `before` is `true`, space is enforced before commas and if it's `false`, space is disallowed before commas. If `after` is `true`, space is enforced after commas and if it's `false`, space is disallowed after commas. The default is `{"before": false, "after": true}`.
+This rule has an object option:
 
-```json
-    "comma-spacing": ["error", {"before": false, "after": true}]
-```
+* `"before": false` (default) disallows spaces before commas
+* `"before": true` requires one or more spaces before commas
+* `"after": true` (default) requires one or more spaces after commas
+* `"after": false` disallows spaces after commas
 
-The following examples show two primary usages of this option.
+### after
 
-### `{"before": false, "after": true}`
-
-This is the default option. It enforces spacing after commas and disallows spacing before commas.
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `{ "before": false, "after": true }` options:
 
 ```js
-/*eslint comma-spacing: ["error", {"before": false, "after": true}]*/
+/*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
 
 var foo = 1 ,bar = 2;
 var arr = [1 , 2];
@@ -42,14 +43,15 @@ function foo(a ,b){}
 a ,b
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "before": false, "after": true }` options:
 
 ```js
-/*eslint comma-spacing: ["error", {"before": false, "after": true}]*/
+/*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
 
 var foo = 1, bar = 2
     , baz = 3;
 var arr = [1, 2];
+var arr = [1,, 3]
 var obj = {"foo": "bar", "baz": "qur"};
 foo(a, b);
 new Foo(a, b);
@@ -57,14 +59,21 @@ function foo(a, b){}
 a, b
 ```
 
-### `{"before": true, "after": false}`
-
-This option enforces spacing before commas and disallows spacing after commas.
-
-The following patterns are considered problems:
+Example of **correct** code for this rule with initial null element for the default `{ "before": false, "after": true }` options:
 
 ```js
-/*eslint comma-spacing: ["error", {"before": true, "after": false}]*/
+/*eslint comma-spacing: ["error", { "before": false, "after": true }]*/
+/*eslint array-bracket-spacing: ["error", "always"]*/
+
+var arr = [ , 2, 3 ]
+```
+
+### before
+
+Examples of **incorrect** code for this rule with the `{ "before": true, "after": false }` options:
+
+```js
+/*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
 
 var foo = 1, bar = 2;
 var arr = [1 , 2];
@@ -74,14 +83,15 @@ function foo(a,b){}
 a, b
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "before": true, "after": false }` options:
 
 ```js
-/*eslint comma-spacing: ["error", {"before": true, "after": false}]*/
+/*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
 
 var foo = 1 ,bar = 2 ,
     baz = true;
 var arr = [1 ,2];
+var arr = [1 ,,3]
 var obj = {"foo": "bar" ,"baz": "qur"};
 foo(a ,b);
 new Foo(a ,b);
@@ -89,18 +99,14 @@ function foo(a ,b){}
 a ,b
 ```
 
-### Handling of `null` elements in `ArrayExpression` or `ArrayPattern`
-
-If you have a `null` element within of an `ArrayExpression` or `ArrayPattern` this rule will not validate the spacing before the respective comma.
-
-The following both examples are valid when the rule is configured with `{"before": false, "after": true}`.
+Examples of **correct** code for this rule with initial null element for the `{ "before": true, "after": false }` options:
 
 ```js
-var items = [, 2, 3 ]
-var items = [ , 2, 3 ]
-```
+/*eslint comma-spacing: ["error", { "before": true, "after": false }]*/
+/*eslint array-bracket-spacing: ["error", "never"]*/
 
-This behavior avoids conflicts with the [`array-bracket-spacing`](array-bracket-spacing.md) rule.
+var arr = [,2 ,3]
+```
 
 ## When Not To Use It
 

--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -8,23 +8,33 @@ In case linting is turned off, missing commas in variable declarations lead to l
 
 ## Rule Details
 
-This rule is aimed at enforcing a particular comma style in JavaScript. As such, it warns whenever it sees a variable declaration, object property and array element that does not adhere to a particular comma style. It doesn't support cases where there are line breaks before and after comma (lone commas) with in declarations, properties and elements. It also avoids single line declaration cases.
+This rule enforce consistent comma style in array literals, object literals, and variable declarations.
+
+This rule does not apply in either of the following cases:
+
+* comma preceded and followed by linebreak (lone comma)
+* single-line array literals, object literals, and variable declarations
 
 ## Options
 
-The rule takes an option, a string, which could be either `"last"` or `"first"`. The default is `"last"`.
+This rule has a string option:
 
-You can set the style in configuration like this:
+* `"last"` (default) requires a comma after and in the same line as an array element, object property, or variable declaration
+* `"first"` requires a comma before and in the same line as an array element, object property, or variable declaration
 
-```json
-"comma-style": ["error", "first"]
-```
+This rule can have an object option:
 
-### "last"
+* `"exceptions"` has properties whose names correspond to node types in the abstract syntax tree (AST) of JavaScript code:
 
-This is the default setting for this rule. This option requires that the comma be placed after and be in the same line as the variable declaration, object property and array element.
+    * `"ArrayExpression": true` ignores comma style in array literals
+    * `"ObjectExpression": true` ignores comma style in object literals
+    * `"VariableDeclaration": true` ignores comma style in variable declarations
 
-While using this setting, the following patterns are considered problems:
+A way to determine the node types as defined by [ESTree](https://github.com/estree/estree) is to use the [online demo](http://eslint.org/parser).
+
+### last
+
+Examples of **incorrect** code for this rule with the default `"last"` option:
 
 ```js
 /*eslint comma-style: ["error", "last"]*/
@@ -36,10 +46,8 @@ bar = 2;
 var foo = 1
   , bar = 2;
 
-
 var foo = ["apples"
            , "oranges"];
-
 
 function bar() {
     return {
@@ -47,10 +55,9 @@ function bar() {
         ,"b:": 2
     };
 }
-
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"last"` option:
 
 ```js
 /*eslint comma-style: ["error", "last"]*/
@@ -60,10 +67,8 @@ var foo = 1, bar = 2;
 var foo = 1,
     bar = 2;
 
-
 var foo = ["apples",
            "oranges"];
-
 
 function bar() {
     return {
@@ -71,14 +76,11 @@ function bar() {
         "b:": 2
     };
 }
-
 ```
 
-### "first"
+### first
 
-This option requires that the comma be placed before and be in the same line as the variable declaration, object property and array element.
-
-While using this setting, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"first"` option:
 
 ```js
 /*eslint comma-style: ["error", "first"]*/
@@ -86,10 +88,8 @@ While using this setting, the following patterns are considered problems:
 var foo = 1,
     bar = 2;
 
-
 var foo = ["apples",
            "oranges"];
-
 
 function bar() {
     return {
@@ -97,10 +97,9 @@ function bar() {
         "b:": 2
     };
 }
-
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"first"` option:
 
 ```js
 /*eslint comma-style: ["error", "first"]*/
@@ -110,10 +109,8 @@ var foo = 1, bar = 2;
 var foo = 1
     ,bar = 2;
 
-
 var foo = ["apples"
           ,"oranges"];
-
 
 function bar() {
     return {
@@ -121,34 +118,25 @@ function bar() {
         ,"b:": 2
     };
 }
-
 ```
 
-### Exceptions
+### exceptions
 
-Exceptions of the following nodes may be passed in order to tell ESLint to ignore nodes of certain types.
+An example use case is to enforce comma style *only* in var statements.
 
-```text
-ArrayExpression,
-ObjectExpression,
-VariableDeclaration
-```
-
-An example use case is if a user wanted to only enforce comma style in var statements.
-
-The following is considered a warning:
+Examples of **incorrect** code for this rule with sample `"first", { "exceptions": { … } }` options:
 
 ```js
-/*eslint comma-style: ["error", "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }]*/
+/*eslint comma-style: ["error", "first", { "exceptions": { "ArrayExpression": true, "ObjectExpression": true } }]*/
 
 var o = {},
     a = [];
 ```
 
-But the following would not be a warning:
+Examples of **correct** code for this rule with sample `"first", { "exceptions": { … } }` options:
 
 ```js
-/*eslint comma-style: ["error", "first", {exceptions: {ArrayExpression: true, ObjectExpression: true} }]*/
+/*eslint comma-style: ["error", "first", { "exceptions": { "ArrayExpression": true, "ObjectExpression": true } }]*/
 
 var o = {fst:1,
          snd: [1,

--- a/docs/rules/computed-property-spacing.md
+++ b/docs/rules/computed-property-spacing.md
@@ -1,4 +1,4 @@
-# Disallow or enforce spaces inside of computed properties. (computed-property-spacing)
+# Disallow or enforce spaces inside of computed properties (computed-property-spacing)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -8,39 +8,33 @@ or disallow spaces between computed properties in the following situations:
 ```js
 /*eslint-env es6*/
 
-// computed properties
 var obj = { prop: "value" };
 var a = "prop";
-var x = obj[a];
+var x = obj[a]; // computed property in object member expression
 
-// object literal computed properties (EcmaScript 6)
 var a = "prop";
-var obj = { [a]: "value" };
+var obj = {
+  [a]: "value" // computed property key in object literal (ECMAScript 6)
+};
 ```
 
 ## Rule Details
 
-This rule aims to maintain consistency around the spacing inside of computed properties.
+This rule enforces consistent spacing inside computed property brackets.
 
 It either requires or disallows spaces between the brackets and the values inside of them.
-Brackets that are separated from the adjacent value by a new line are exempt from this rule.
+This rule does not apply to brackets that are separated from the adjacent value by a newline.
 
 ## Options
 
-There are two main options for the rule:
+This rule has a string option:
 
-* `"always"` enforces a space inside of computed properties
-* `"never"` disallows spaces inside of computed properties (default)
+* `"never"` (default) disallows spaces inside computed property brackets
+* `"always"` requires one or more spaces inside computed property brackets
 
-Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+### never
 
-```json
-"computed-property-spacing": ["error", "never"]
-```
-
-### "never"
-
-When `"never"` is set, the following patterns will give a warning:
+Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "never"]*/
@@ -52,7 +46,7 @@ var x = {[ b ]: a}
 obj[foo[ bar ]]
 ```
 
-The following patterns are considered correct:
+Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "never"]*/
@@ -64,9 +58,9 @@ var x = {[b]: a}
 obj[foo[bar]]
 ```
 
-### "always"
+### always
 
-When `"always"` is used, the following patterns will give a warning:
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "always"]*/
@@ -81,7 +75,7 @@ obj[foo[ bar ]]
 var x = {[ b]: a}
 ```
 
-The following patterns are considered correct:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint computed-property-spacing: ["error", "always"]*/
@@ -91,7 +85,6 @@ obj[ foo ]
 obj[ 'foo' ]
 var x = {[ b ]: a}
 obj[ foo[ bar ] ]
-
 ```
 
 
@@ -101,7 +94,6 @@ You can turn this rule off if you are not concerned with the consistency of comp
 
 ## Related Rules
 
+* [array-bracket-spacing](array-bracket-spacing.md)
 * [comma-spacing](comma-spacing.md)
 * [space-in-parens](space-in-parens.md)
-* [computed-property-spacing](computed-property-spacing.md)
-* [space-in-brackets](space-in-brackets.md) (deprecated)

--- a/docs/rules/consistent-this.md
+++ b/docs/rules/consistent-this.md
@@ -14,26 +14,18 @@ There are many commonly used aliases for `this` such as `that`, `self` or `me`. 
 
 ## Rule Details
 
-This rule designates a variable as the chosen alias for `this`. It then enforces two things:
+This rule enforces two things about variables with the designated alias names for `this`:
 
-* if a variable with the designated name is declared or assigned to, it *must* explicitly be assigned the current execution context, i.e. `this`
-* if `this` is explicitly assigned to a variable, the name of that variable must be the designated one
+* If a variable with a designated name is declared, it *must* be either initialized (in the declaration) or assigned (in the same scope as the declaration) the value `this`.
+* If a variable is initialized or assigned the value `this`, the name of the variable *must* be a designated alias.
 
 ## Options
 
-This rule takes one option, a string, which is the designated `this` variable. The default is `that`.
+This rule has one or more string options:
 
-```json
-"consistent-this": ["error", "that"]
-```
+* designated alias names for `this` (default `"that"`)
 
-Additionally, you may configure extra aliases for cases where there are more than one supported alias for `this`.
-
-```js
-{ "consistent-this": [ "error", "self",  "vm" ] }
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"that"` option:
 
 ```js
 /*eslint consistent-this: ["error", "that"]*/
@@ -47,7 +39,7 @@ that = 42;
 self = this;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"that"` option:
 
 ```js
 /*eslint consistent-this: ["error", "that"]*/
@@ -63,7 +55,18 @@ that = this;
 foo.bar = this;
 ```
 
-A declaration of an alias does not need to assign `this` in the declaration, but it must perform an appropriate assignment in the same scope as the declaration. The following patterns are also considered okay:
+Examples of **incorrect** code for this rule with the default `"that"` option, if the variable is not initialized:
+
+```js
+/*eslint consistent-this: ["error", "that"]*/
+
+var that;
+function f() {
+    that = this;
+}
+```
+
+Examples of **correct** code for this rule with the default `"that"` option, if the variable is not initialized:
 
 ```js
 /*eslint consistent-this: ["error", "that"]*/
@@ -74,17 +77,6 @@ that = this;
 var foo, that;
 foo = 42;
 that = this;
-```
-
-But the following pattern is considered a warning:
-
-```js
-/*eslint consistent-this: ["error", "that"]*/
-
-var that;
-function f() {
-    that = this;
-}
 ```
 
 ## When Not To Use It

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -4,17 +4,18 @@
 
 Trailing newlines in non-empty files are a common UNIX idiom. Benefits of
 trailing newlines include the ability to concatenate or append to files as well
-as output files to the terminal without interfering with shell prompts. This
-rule enforces newlines for all non-empty programs.
+as output files to the terminal without interfering with shell prompts.
+
+## Rule Details
+
+This rule requires at least one newline at the end of non-empty files.
 
 Prior to v0.16.0 this rule also enforced that there was only a single line at
 the end of the file. If you still want this behaviour, consider enabling
 [no-multiple-empty-lines](no-multiple-empty-lines.md) with `maxEOF` and/or
 [no-trailing-spaces](no-trailing-spaces.md).
 
-## Rule Details
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint eol-last: "error"*/
@@ -24,7 +25,7 @@ function doSmth() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint eol-last: "error"*/
@@ -32,9 +33,12 @@ The following patterns are not considered problems:
 function doSmth() {
   var foo = 2;
 }
-// spaces here
+
 ```
 
 ## Options
 
-This rule may take one option which is either `unix` (LF) or `windows` (CRLF). When omitted `unix` is assumed.
+This rule has a string option:
+
+* `"unix"` (default) enforces line feed (LF) as newline
+* `"windows"` enforces carriage return line feed (CRLF) as newline

--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -1,6 +1,6 @@
 # Require Function Expressions to have a Name (func-names)
 
-A pattern that's becoming more common is to give function expressions names to aid in debugging, such as:
+A pattern that's becoming more common is to give function expressions names to aid in debugging. For example:
 
 ```js
 Foo.prototype.bar = function bar() {};
@@ -10,7 +10,7 @@ Adding the second `bar` in the above example is optional.  If you leave off the 
 
 ## Rule Details
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint func-names: "error"*/
@@ -22,7 +22,7 @@ Foo.prototype.bar = function() {};
 }())
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint func-names: "error"*/


### PR DESCRIPTION
The first 10 rules under **Stylistic Issues**

Something new in this smaller batch is first attempt at more consistency under **Options**. After some feedback, I will add to the guidelines.

@scriptdaemon If you have time, please critique the changed sentences and bulleted lists under **Options** (and anything else, of course). I applied some of what I am learning through the work you and alberto have done with rule descriptions.

Here are the changes beyond example sentences:
* array-bracket-spacing: delete period in heading; default option first in ul; delete json; delete obsolete sentence about first/last element; move built-in exception from Rule Detail to Options; move Exceptions up to Options
* block-spacing: delete period in heading; delete json; rewrite options
* brace-style: delete As such sentence in Rule Details; delete json; rewrite options
* camelcase: delete json; rewrite options; **please verify** that `"properties": "never"` is an exception option, therefore does not need examples of **incorrect** code
* comma-spacing: move does not apply from end to to Rule Details; delete json; rewrite options; move example with null elements from the end to the options
* comma-style: 2p to ul in Rule Details; delete json; rewrite options; delete empty lines at end of example code
* computed-property-spacing: delete period in heading; default value first; delete json; under Related Rules, delete self-link and replace space-in-brackets with array-bracket-spacing
* consistent-this: rewrite Rule Details; delete json; rewrite options; reorder auxiliary example incorrect/correct
* eol-last: move sentences from intro to Rule Details; rewrite options