### PR TITLE
Fix: newline-before-return handles return as first token (fixes #5816)

### DIFF
--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -62,13 +62,13 @@ module.exports = function(context) {
     /**
      * Returns the number of lines of comments that precede the node
      * @param {ASTNode} node - node to check for overlapping comments
-     * @param {token} tokenBefore - previous token to check for overlapping comments
+     * @param {number} lineNumTokenBefore - line number of previous token, to check for overlapping comments
      * @returns {number} Number of lines of comments that precede the node
      * @private
      */
-    function calcCommentLines(node, tokenBefore) {
-        var comments = sourceCode.getComments(node).leading;
-        var numLinesComments = 0;
+    function calcCommentLines(node, lineNumTokenBefore) {
+        var comments = sourceCode.getComments(node).leading,
+            numLinesComments = 0;
 
         if (!comments.length) {
             return numLinesComments;
@@ -82,7 +82,7 @@ module.exports = function(context) {
             }
 
             // avoid counting lines with inline comments twice
-            if (comment.loc.start.line === tokenBefore.loc.end.line) {
+            if (comment.loc.start.line === lineNumTokenBefore) {
                 numLinesComments--;
             }
 
@@ -101,10 +101,26 @@ module.exports = function(context) {
      * @private
      */
     function hasNewlineBefore(node) {
-        var tokenBefore = sourceCode.getTokenBefore(node);
-        var lineNumTokenBefore = tokenBefore.loc.end.line;
-        var lineNumNode = node.loc.start.line;
-        var commentLines = calcCommentLines(node, tokenBefore);
+        var tokenBefore = sourceCode.getTokenBefore(node),
+            lineNumNode = node.loc.start.line,
+            lineNumTokenBefore,
+            commentLines;
+
+        /**
+         * Global return (at the beginning of a script) is a special case.
+         * If there is no token before `return`, then we expect no line
+         * break before the return. Comments are allowed to occupy lines
+         * before the global return, just no blank lines.
+         * Setting lineNumTokenBefore to zero in that case results in the
+         * desired behavior.
+         */
+        if (tokenBefore) {
+            lineNumTokenBefore = tokenBefore.loc.end.line;
+        } else {
+            lineNumTokenBefore = 0;     // global return at beginning of script
+        }
+
+        commentLines = calcCommentLines(node, lineNumTokenBefore);
 
         return (lineNumNode - lineNumTokenBefore - commentLines) > 1;
     }

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -78,7 +78,27 @@ ruleTester.run("newline-before-return", rule, {
         "function a() {\nif (b) { //comment\nreturn;\n}\n\nreturn c;\n}",
         "function a() {\nif (b) { return; } //comment\n\nreturn c;\n}",
         "function a() {\nif (b) { return; } /*multi-line\ncomment*/\n\nreturn c;\n}",
-        "function a() {\nif (b) { return; }\n\n/*multi-line\ncomment*/ return c;\n}"
+        "function a() {\nif (b) { return; }\n\n/*multi-line\ncomment*/ return c;\n}",
+        {
+            code: "return;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } }
+        },
+        {
+            code: "var a;\n\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } }
+        },
+        {
+            code: "// comment\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } }
+        },
+        {
+            code: "/* comment */\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } }
+        },
+        {
+            code: "/* multi-line\ncomment */\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } }
+        }
     ],
 
     invalid: [
@@ -198,6 +218,34 @@ ruleTester.run("newline-before-return", rule, {
             errors: ["Expected newline before return statement."]
         }, {
             code: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ return c;\n}",
+            errors: ["Expected newline before return statement."]
+        }, {
+            code: "\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: ["Unexpected newline before return statement."]
+        }, {
+            code: "\n\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: ["Unexpected newline before return statement."]
+        }, {
+            code: "\n// comment\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: ["Unexpected newline before return statement."]
+        }, {
+            code: "\n/* comment */\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: ["Unexpected newline before return statement."]
+        }, {
+            code: "\n/* multi-line\ncomment */\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: ["Unexpected newline before return statement."]
+        }, {
+            code: "/* comment */\n\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: ["Unexpected newline before return statement."]
+        }, {
+            code: "var a;\nreturn;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
             errors: ["Expected newline before return statement."]
         }
     ]


### PR DESCRIPTION
Issue isn't accepted yet, but I wanted to put something together while it was still fresh in my mind.

My assumption is that there's no need to call this out in the rule documentation. Please let me know if I should.