### PR TITLE
Fix: Enable no-console rule in eslint-config-eslint (refs #5188)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -3,7 +3,7 @@
  * @author nzakas
  */
 /* global cat, cd, cp, echo, exec, exit, find, ls, mkdir, pwd, rm, target, test*/
-/* eslint no-use-before-define: 0*/
+/* eslint no-use-before-define: "off", no-console: "off" */
 "use strict";
 
 //------------------------------------------------------------------------------

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -5,6 +5,8 @@
  */
 "use strict";
 
+/* eslint no-console: "off" */
+
 /* istanbul ignore next */
 module.exports = {
 

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -102,7 +102,7 @@ function display(data) {
         return ALIGN[index](":", w + 1, "-");
     }).join("|"));
 
-    console.log(table.join("\n"));
+    console.log(table.join("\n"));      // eslint-disable-line no-console
 }
 
 /* istanbul ignore next */

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -32,7 +32,7 @@ rules:
     no-alert: "error"
     no-array-constructor: "error"
     no-caller: "error"
-    no-console: 0
+    no-console: "error"
     no-delete-var: "error"
     no-eval: "error"
     no-extend-native: "error"

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1851,13 +1851,15 @@ describe("CLIEngine", function() {
     });
 
     describe("isPathIgnored", function() {
+        var sandbox;
 
         beforeEach(function() {
-            sinon.stub(console, "info").returns(void 0);
+            sandbox = sinon.sandbox.create();
+            sandbox.stub(console, "info").returns(void 0);
         });
 
         afterEach(function() {
-            console.info.restore();
+            sandbox.restore();
         });
 
         it("should check if the given path is ignored", function() {

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -213,8 +213,8 @@ describe("configInitializer", function() {
 
         describe("auto", function() {
             var config,
-                origLog,
-                completeSpy = sinon.spy();
+                completeSpy = sinon.spy(),
+                sandbox;
 
             before(function() {
                 var patterns = [
@@ -232,23 +232,23 @@ describe("configInitializer", function() {
                     format: "JSON",
                     commonjs: false
                 };
-                origLog = console.log;
-                console.log = function() {}; // necessary to replace, because of progress bar
+
+                sandbox = sinon.sandbox.create();
+                sandbox.stub(console, "log"); // necessary to replace, because of progress bar
+
                 process.chdir(fixtureDir);
+
                 try {
                     config = init.processAnswers(answers);
                     process.chdir(originalDir);
                 } catch (err) {
 
-                    // if processAnswers crashes, we need to be sure to restore cwd and console.log
-                    console.log = origLog;
+                    // if processAnswers crashes, we need to be sure to restore cwd
                     process.chdir(originalDir);
                     throw err;
+                } finally {
+                    sandbox.restore();  // restore console.log()
                 }
-            });
-
-            beforeEach(function() {
-                console.log = origLog;
             });
 
             it("should create a config", function() {


### PR DESCRIPTION
Some assumptions I made:

1. Makefile.js can do whatever it wants with the console
1. lib/logging.js can do whatever it wants with the console
1. lib/timing.js can do whatever it wants with the console (BUT let me know if it should pull in lib/logging.js instead)
1. The remaining files (all of which were unit tests) can use sinon sandboxes to stub console methods and have them be reliably restored, which happens to skirt the rule

Let me know if anything seems fishy. Thanks!