### PR TITLE
Docs: Distinguish examples in rules under Stylistic Issues part 2

### DIFF
--- a/docs/rules/func-style.md
+++ b/docs/rules/func-style.md
@@ -1,6 +1,6 @@
-# Enforce Function Style (func-style)
+# enforce the consistent use of either `function` declarations or expressions (func-style)
 
-There are two ways of defining functions in JavaScript: function declarations and function expressions. Declarations have the `function` keyword first, followed by a name, followed by its arguments and the function body, such as:
+There are two ways of defining functions in JavaScript: `function` declarations and `function` expressions. Declarations contain the `function` keyword first, followed by a name and then its arguments and the function body, for example:
 
 ```js
 function doSomething() {
@@ -8,7 +8,7 @@ function doSomething() {
 }
 ```
 
-Equivalent function expressions begin with the `var` keyword, followed by a name, and then the function itself, such as:
+Equivalent function expressions begin with the `var` keyword, followed by a name and then the function itself, such as:
 
 ```js
 var doSomething = function() {
@@ -16,7 +16,7 @@ var doSomething = function() {
 };
 ```
 
-The primary difference between function declarations and function expressions is that declarations are *hoisted* to the top of the scope in which they are defined, which allows you to write code that uses the function before the declaration. For example:
+The primary difference between `function` declarations and `function expressions` is that declarations are *hoisted* to the top of the scope in which they are defined, which allows you to write code that uses the function before its declaration. For example:
 
 ```js
 doSomething();
@@ -26,9 +26,9 @@ function doSomething() {
 }
 ```
 
-Although this code might seem like an error, it actually works fine because JavaScript engines hoist the function declarations to the top of the scope. That means this code is treated as if the declaration came before the invocation.
+Although this code might seem like an error, it actually works fine because JavaScript engines hoist the `function` declarations to the top of the scope. That means this code is treated as if the declaration came before the invocation.
 
-For function expressions, you must define the function before it is used, otherwise it causes an error. Example:
+For `function` expressions, you must define the function before it is used, otherwise it causes an error. Example:
 
 ```js
 doSomething();  // error!
@@ -44,19 +44,22 @@ Due to these different behaviors, it is common to have guidelines as to which st
 
 ## Rule Details
 
-This rule is aimed at enforcing a particular type of function style throughout a JavaScript file, either declarations or expressions. You can specify which you prefer in the configuration.
+This rule enforces a particular type of `function` style throughout a JavaScript file, either declarations or expressions. You can specify which you prefer in the configuration.
 
 ## Options
 
-### "expression"
+This rule has a string option:
 
-This is the default configuration.  It reports an error when function declarations are used instead of function expressions.
+* `"expression"` (default) requires the use of function expressions instead of function declarations
+* `"declaration"` requires the use of function declarations instead of function expressions
 
-```json
-"func-style": ["error", "expression"]
-```
+This rule has an object option for an exception:
 
-The following patterns are considered problems:
+* `"allowArrowFunctions": true` (default `false`) allows the use of arrow functions
+
+### expression
+
+Examples of **incorrect** code for this rule with the default `"expression"` option:
 
 ```js
 /*eslint func-style: ["error", "expression"]*/
@@ -66,7 +69,7 @@ function foo() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"expression"` option:
 
 ```js
 /*eslint func-style: ["error", "expression"]*/
@@ -76,21 +79,9 @@ var foo = function() {
 };
 ```
 
-### "declaration"
+### declaration
 
-This reports an error if any function expressions are used where function declarations are expected. You can specify to use expressions instead:
-
-```json
-"func-style": ["error", "declaration"]
-```
-
-An additional option object can be added with a property `"allowArrowFunctions"`.  Setting this to `true` will allow arrow functions.
-
-```json
-"func-style": ["error", "declaration", { "allowArrowFunctions": true }]
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"declaration"` option:
 
 ```js
 /*eslint func-style: ["error", "declaration"]*/
@@ -98,15 +89,11 @@ The following patterns are considered problems:
 var foo = function() {
     // ...
 };
-```
-
-```js
-/*eslint func-style: ["error", "declaration"]*/
 
 var foo = () => {};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"declaration"` option:
 
 ```js
 /*eslint func-style: ["error", "declaration"]*/
@@ -121,12 +108,15 @@ SomeObject.foo = function() {
 };
 ```
 
+### allowSingleLine
+
+Examples of additional **correct** code for this rule with the `"declaration", { "allowSingleLine": true }` options:
+
 ```js
 /*eslint func-style: ["error", "declaration", { "allowArrowFunctions": true }]*/
 
 var foo = () => {};
 ```
-
 
 ## When Not To Use It
 

--- a/docs/rules/id-blacklist.md
+++ b/docs/rules/id-blacklist.md
@@ -1,41 +1,40 @@
-# Blacklist certain identifiers to prevent them being used (id-blacklist)
+# disallow specified identifiers (id-blacklist)
 
 > "There are only two hard things in Computer Science: cache invalidation and naming things." — Phil Karlton
 
-Bad names can lead to hard to decipher code. Using generic names, such as `data` don't infer much about the code and the values it receives. This rule allows you to configure a blacklist of bad identifier names, that you don't want to see in your code.
+Bad names can lead to hard-to-decipher code. Generic names, such as `data`, don't infer much about the code and the values it receives. This rule allows you to configure a blacklist of bad identifier names, that you don't want to see in your code.
 
 ## Rule Details
 
-This rule compares assignments and function definitions to a provided list of identifier names. If the identifier is present in the list, it will return an error.
+This rule disallows specified identifiers in assignments and `function` definitions.
 
 This rule will catch blacklisted identifiers that are:
 
 - variable declarations
 - function declarations
-- object properties
+- object properties assigned to during object creation
 
 It will not catch blacklisted identifiers that are:
 
 - function calls (so you can still use functions you do not have control over)
 - object properties (so you can still use objects you do not have control over)
 
-
 ## Options
 
-This rule needs a a set of identifier names to blacklist, like so:
+The rule takes one or more strings as options: the names of restricted identifiers.
+
+For example, to restrict the use of common generic identifiers:
 
 ```json
 {
-    "rules": {
-        "id-blacklist": ["error", "data", "err", "e", "cb", "callback"]
-    }
+    "id-blacklist": ["error", "data", "err", "e", "cb", "callback"]
 }
 ```
 
-For the rule in this example, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with sample `"data", "callback"` restricted identifiers:
 
 ```js
-/*eslint id-blacklist: ["error", "data", "err", "e", "cb", "callback"] */
+/*eslint id-blacklist: ["error", "data", "callback"] */
 
 var data = {...};
 
@@ -52,10 +51,10 @@ var itemSet = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with sample `"data", "callback"` restricted identifiers:
 
 ```js
-/*eslint id-blacklist: ["error", "data", "err", "e", "cb", "callback"] */
+/*eslint id-blacklist: ["error", "data", "callback"] */
 
 var encodingOptions = {...};
 
@@ -71,11 +70,11 @@ var itemSet = {
     entities: [...]
 };
 
-callback()  // all function calls are ignored
+callback(); // all function calls are ignored
 
-foo.callback() // all function calls are ignored
+foo.callback(); // all function calls are ignored
 
-foo.data // all property names that are not assignments are ignored
+foo.data; // all property names that are not assignments are ignored
 ```
 
 ## When Not To Use It

--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -1,148 +1,261 @@
-# Limit minimum and maximum length for identifiers (id-length)
+# enforce minimum and maximum identifier lengths (id-length)
 
-Very short identifier names like `e`, `x`, `_t` or very long ones like `hashGeneratorResultOutputContainerObject` usually make the code harder to read and potentially less maintainable. To prevent this, one may enforce a minimum and/or maximum identifier length. (usually min 2-chars)
+Very short identifier names like `e`, `x`, `_t` or very long ones like `hashGeneratorResultOutputContainerObject` can make code harder to read and potentially less maintainable. To prevent this, one may enforce a minimum and/or maximum identifier length.
 
 ```js
-// id-length: 1  // default is minimum 2-chars ({ min: 2})
-var x = 5; // too short
+var x = 5; // too short; difficult to understand its purpose without context
 ```
 
 ## Rule Details
 
-This rule is aimed at increasing code readability and maintainability by enforcing an identifier length convention. It will warn on any type of identifier which doesn't conform to length limits (upper and lower).
+This rule enforces a minimum and/or maximum identifier length convention.
 
-It allows the programmers to silently by-pass this check by using `"quoted"` property names or calculated property access to allow potential server-side data requirements.
+## Options
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default options:
 
 ```js
-/*eslint id-length: "error"*/     // default is minimum 2-chars ({ min: 2})
+/*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
 /*eslint-env es6*/
 
 var x = 5;
-
 obj.e = document.body;
-
 var foo = function (e) { };
-
 try {
     dangerousStuff();
 } catch (e) {
     // ignore as many do
 }
-
 var myObj = { a: 1 };
-
 (a) => { a * a };
-
-function foo(x = 0) { }
-
 class x { }
-
 class Foo { x() {} }
-
 function foo(...x) { }
-
-var { x} = {};
-
+var { x } = {};
 var { x: a} = {};
-
 var { a: [x]} = {};
-
-({ a: obj.x.y.z }) = {};
-
 ({ prop: obj.x }) = {};
 ```
 
-```
-import x from 'y';
-
-export var x = 0;
-```
-
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default options:
 
 ```js
-/*eslint id-length: "error"*/     // default is minimum 2-chars ({ min: 2})
+/*eslint id-length: "error"*/     // default is minimum 2-chars ({ "min": 2 })
 /*eslint-env es6*/
 
 var num = 5;
-
 function _f() { return 42; }
-
 function _func() { return 42; }
-
 obj.el = document.body;
-
 var foo = function (evt) { /* do stuff */ };
-
 try {
     dangerousStuff();
 } catch (error) {
     // ignore as many do
 }
-
 var myObj = { apple: 1 };
-
 (num) => { num * num };
-
 function foo(num = 0) { }
-
 class MyClass { }
-
 class Foo { method() {} }
-
 function foo(...args) { }
-
 var { prop } = {};
-
 var { prop: a } = {};
-
 var { prop: [x] } = {};
-
-({ prop: obj.x.y.something }) = {};
-
 ({ prop: obj.longName }) = {};
-
 var data = { "x": 1 };  // excused because of quotes
-
 data["y"] = 3;  // excused because of calculated property access
 ```
 
-```
-import something from "y";
+This rule has an shorthand integer option for the `"min"` object property.
 
-export var num = 0;
-```
-
-
-## Options
-
-The `id-length` rule has no required options and has 4 optional ones that needs to be passed in a single options object:
-
-* **min** *(default: 2)*: The minimum number of characters an identifier name should be, after it is stripped from it is prefixes and suffixes
-* **max** *(default: Infinity)*: The maximum number of characters an identifier name should be, after it is stripped from it is prefixes and suffixes
-* **properties** *(default: "always")*: If set to `"never"` does not check property names at all
-* **exceptions**: An array of identifier names that the rule should not apply to
-
-
-For example, to specify a minimum identifier length of 3, a maximum of 10, ignore property names and add `x` to exception list, use the following configuration:
-
-```json
-"id-length": ["error", {"min": 3, "max": 10, "properties": "never", "exceptions": ["x"]}]
-```
-
-The following patterns will not be considered problems
+Examples of **incorrect** code for this rule with a minimum of 4:
 
 ```js
-/*eslint id-length: ["error", {"properties": "never"}]*/
+/*eslint id-length: ["error", 4]*/
+/*eslint-env es6*/
+
+var val = 5;
+obj.e = document.body;
+function (e) { };
+try {
+    dangerousStuff();
+} catch (e) {
+    // ignore as many do
+}
+var myObj = { a: 1 };
+(val) => { val * val };
+class x { }
+class Foo { x() {} }
+function foo(...x) { }
+var { x } = {};
+var { x: a} = {};
+var { a: [x]} = {};
+({ prop: obj.x }) = {};
+```
+
+Examples of **correct** code for this rule with a minimum of 4:
+
+```js
+/*eslint id-length: ["error", 4]*/
+/*eslint-env es6*/
+
+var value = 5;
+function func() { return 42; }
+obj.element = document.body;
+var foo = function (event) { /* do stuff */ };
+try {
+    dangerousStuff();
+} catch (error) {
+    // ignore as many do
+}
+var myObj = { apple: 1 };
+(value) => { value * value };
+function foobar(value = 0) { }
+class MyClass { }
+class Foobar { method() {} }
+function foobar(...args) { }
+var { prop } = {};
+var { prop: a } = {};
+var { prop: [x] } = {};
+({ prop: obj.name }) = {};
+var data = { "x": 1 };  // excused because of quotes
+data["y"] = 3;  // excused because of calculated property access
+```
+
+This rule has an object option:
+
+* `"min"` (default: 2) enforces a minimum identifier length
+* `"max"` (default: Infinity) enforces a maximum identifier length
+* `"properties": always` (default) enforces identifier length convention for property names
+* `"properties": never` ignores identifier length convention for property names
+* `"exceptions"` allows an array of specified identifier names
+
+### min
+
+Examples of **incorrect** code for this rule with the `{ "min": 4 }` option:
+
+```js
+/*eslint id-length: ["error", { "min": 4 }]*/
+/*eslint-env es6*/
+
+var val = 5;
+obj.e = document.body;
+function (e) { };
+try {
+    dangerousStuff();
+} catch (e) {
+    // ignore as many do
+}
+var myObj = { a: 1 };
+(val) => { val * val };
+class x { }
+class Foo { x() {} }
+function foo(...x) { }
+var { x } = {};
+var { x: a} = {};
+var { a: [x]} = {};
+({ prop: obj.x }) = {};
+```
+
+Examples of **correct** code for this rule with the `{ "min": 4 }` option:
+
+```js
+/*eslint id-length: ["error", { "min": 4 }]*/
+/*eslint-env es6*/
+
+var value = 5;
+function func() { return 42; }
+obj.element = document.body;
+var foo = function (event) { /* do stuff */ };
+try {
+    dangerousStuff();
+} catch (error) {
+    // ignore as many do
+}
+var myObj = { apple: 1 };
+(value) => { value * value };
+function foobar(value = 0) { }
+class MyClass { }
+class Foobar { method() {} }
+function foobar(...args) { }
+var { prop } = {};
+var { prop: a } = {};
+var { prop: [x] } = {};
+({ prop: obj.name }) = {};
+var data = { "x": 1 };  // excused because of quotes
+data["y"] = 3;  // excused because of calculated property access
+```
+
+### max
+
+Examples of **incorrect** code for this rule with the `{ "max": 10 }` option:
+
+```js
+/*eslint id-length: ["error", { "max": "10" }]*/
+/*eslint-env es6*/
+
+var reallyLongVarName = 5;
+function reallyLongFuncName() { return 42; }
+obj.reallyLongPropName = document.body;
+var foo = function (reallyLongArgName) { /* do stuff */ };
+try {
+    dangerousStuff();
+} catch (reallyLongErrorName) {
+    // ignore as many do
+}
+(reallyLongArgName) => { return !reallyLongArgName; };
+```
+
+Examples of **correct** code for this rule with the `{ "max": 10 }` option:
+
+```js
+/*eslint id-length: ["error", { "max": "10" }]*/
+/*eslint-env es6*/
+
+var varName = 5;
+function funcName() { return 42; }
+obj.propName = document.body;
+var foo = function (arg) { /* do stuff */ };
+try {
+    dangerousStuff();
+} catch (error) {
+    // ignore as many do
+}
+(arg) => { return !arg; };
+```
+
+### properties
+
+Examples of **correct** code for this rule with the `{ "properties": "never" }` option:
+
+```js
+/*eslint id-length: ["error", { "properties": "never" }]*/
 /*eslint-env es6*/
 
 var myObj = { a: 1 };
-
 ({ a: obj.x.y.z }) = {};
+({ prop: obj.i }) = {};
+```
 
-({ prop: obj.x }) = {};
+### exceptions
+
+Examples of additional **correct** code for this rule with the `{ "exceptions": "x" }` option:
+
+```js
+/*eslint id-length: ["error", { "max": "10" }]*/
+/*eslint-env es6*/
+
+var x = 5;
+function x() { return 42; }
+obj.x = document.body;
+var foo = function (x) { /* do stuff */ };
+try {
+    dangerousStuff();
+} catch (x) {
+    // ignore as many do
+}
+(x) => { return x * x; };
 ```
 
 ## Related Rules

--- a/docs/rules/id-match.md
+++ b/docs/rules/id-match.md
@@ -1,82 +1,82 @@
-# Require IDs to match a pattern (id-match)
+# require identifiers to match a specified regular expression (id-match)
 
 > "There are only two hard things in Computer Science: cache invalidation and naming things." — Phil Karlton
 
 Naming things consistently in a project is an often underestimated aspect of code creation.
-When done right, it can save your team hours of unnecessary head scratching and misdirections.
+When done correctly, it can save your team hours of unnecessary head scratching and misdirections.
 This rule allows you to precisely define and enforce the variables and function names on your team should use.
 No more limiting yourself to camelCase, snake_case, PascalCase or oHungarianNotation. Id-match has all your needs covered!
 
 ## Rule Details
 
-This rule compares assignments and function definitions to a provided regular expression, giving you the maximum flexibility on the matter.
-It doesn't apply to function calls, so that you can still use functions or objects you do not have control over.
+This rule requires identifiers in assignments and `function` definitions to match a specified regular expression.
 
 ## Options
 
-This rule needs a text RegExp to operate with, and accepts an options map. Its signature is as follows:
+This rule has a string option for the specified regular expression.
+
+For example, to enforce a camelcase naming convention:
 
 ```json
 {
-    "rules": {
-        "id-match": ["error", "^[a-z]+([A-Z][a-z]+)*$", {"properties": false}]
-    }
+    "id-match": ["error", "^[a-z]+([A-Z][a-z]+)*$"]
 }
 ```
 
-`properties` can have the following values:
-
-1. `true` is the default and checks all property names
-2. `false` does not check property names at all (default)
-
-`onlyDeclarations` can have the following values:
-
-1. `true` validates only declaration of variables, functions and classes
-2. `false` validates all identifiers (default)
-
-For the rule in this example, which is simply camelcase, the following patterns are considered problems:
+Examples of **correct** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$"` option:
 
 ```js
-/*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$", {"properties": true}]*/
-
-var my_favorite_color = "#112C85";
-
-var _myFavoriteColor  = "#112C85";
-
-var myFavoriteColor_  = "#112C85";
-
-var MY_FAVORITE_COLOR = "#112C85";
-
-function do_something() {
-    // ...
-}
-
-obj.do_something = function() {
-    // ...
-};
-
-var obj = {
-    my_pref: 1
-};
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$", {"properties": false}]*/
+/*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$"]*/
 
 var myFavoriteColor   = "#112C85";
 var foo = bar.baz_boom;
 var foo = { qux: bar.baz_boom };
-
-obj.do_something();
-
-/*eslint id-match: ["error", "", {properties: false}]*/
+do_something();
 var obj = {
     my_pref: 1
 };
+```
 
-/*eslint id-match: [2, "^[a-z]+([A-Z][a-z]+)*$", {"onlyDeclarations": true}]*/
+Examples of **incorrect** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$"` option:
+
+```js
+/*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$"]*/
+
+var my_favorite_color = "#112C85";
+var _myFavoriteColor  = "#112C85";
+var myFavoriteColor_  = "#112C85";
+var MY_FAVORITE_COLOR = "#112C85";
+function do_something() {
+    // ...
+}
+obj.do_something = function() {
+    // ...
+};
+```
+
+This rule has an object option:
+
+* `"properties": true` requires object properties to match the specified regular expression
+* `"onlyDeclarations": true` requires only `var`, `function`, and `class` declarations to match the specified regular expression
+
+### properties
+
+Examples of **incorrect** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$", { "properties": true }` options:
+
+```js
+/*eslint id-match: ["error", "^[a-z]+([A-Z][a-z]+)*$", { "properties": true }]*/
+
+var obj = {
+    my_pref: 1
+};
+```
+
+### onlyDeclarations
+
+Examples of **correct** code for this rule with the `"^[a-z]+([A-Z][a-z]+)*$", { "onlyDeclarations": true }` options:
+
+```js
+/*eslint id-match: [2, "^[a-z]+([A-Z][a-z]+)*$", { "onlyDeclarations": true }]*/
 
 do_something(__dirname);
 ```

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -1,8 +1,6 @@
-# Validate Indentation (indent)
+# enforce consistent indentation (indent)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
-
-This option validates a specific tab width for your code in block statements.
 
 There are several common guidelines which require specific indentation of nested blocks and statements, like:
 
@@ -14,7 +12,7 @@ function hello(indentSize, type) {
 }
 ```
 
-This is the most common scenarios recommended in different style guides:
+These are the most common scenarios recommended in different style guides:
 
 * Two spaces, not longer and no tabs: Google, npm, Node.js, Idiomatic, Felix
 * Tabs: jQuery
@@ -22,18 +20,58 @@ This is the most common scenarios recommended in different style guides:
 
 ## Rule Details
 
-This rule is aimed to enforce consistent indentation style. The default style is `4 spaces`.
-
-It takes an option as the second parameter which can be `"tab"` for tab-based indentation or a positive number for space indentations.
+This rule enforces a consistent indentation style. The default style is `4 spaces`.
 
 ## Options
 
-The `indent` rule has two options:
+This rule has a mixed option:
 
-* Indentation style, positive number or `tab` (see rule details for examples)
-* Configuring optional validations, `Object`.
-    * `SwitchCase` - Level of switch cases indent, 0 by default.
-    * `VariableDeclarator` - Level of variable declaration indent, 1 by default. Can take an object to define separate rules for `var`, `let` and `const` declarations.
+For example, for 2-space indentation:
+
+```json
+{
+    "indent": ["error", 2]
+}
+```
+
+Or for tabbed indentation:
+
+```json
+{
+    "indent": ["error", "tab"]
+}
+```
+
+Examples of **incorrect** code for this rule with the default options:
+
+```js
+/*eslint indent: "error"*/
+
+if (a) {
+  b=c;
+  function foo(d) {
+    e=f;
+  }
+}
+```
+
+Examples of **correct** code for this rule with the default options:
+
+```js
+/*indent: "error"*/
+
+if (a) {
+    b=c;
+    function foo(d) {
+        e=f;
+    }
+}
+```
+
+This rule has an object option:
+
+* `"SwitchCase"` (default: 0) enforces indentation level for `switch` cases
+* `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -45,43 +83,9 @@ Level of indentation denotes the multiple of the indent specified. Example:
 * Indent of 2 spaces with SwitchCase set to 2 will indent `SwitchCase` with 4 space with respect to switch.
 * Indent of tabs with SwitchCase set to 2 will indent `SwitchCase` with 2 tabs with respect to switch.
 
+### tab
 
-2 space indentation with enabled switch cases indentation
-
-```json
- "indent": ["error", 2, {"SwitchCase": 1}]
-```
-
-4 space indention
-
-```json
-"indent": "error"
-```
-
-2 space indentation
-
-```json
-"indent": ["error", 2]
-```
-
-tabbed indentation
-
-```json
-"indent": ["error", "tab"]
-```
-
-The following patterns are considered problems:
-
-```js
-/*eslint indent: ["error", 2]*/
-
-if (a) {
-   b=c;
-function foo(d) {
-       e=f;
-}
-}
-```
+Examples of **incorrect** code for this rule with the `"tab"` option:
 
 ```js
 /*eslint indent: ["error", "tab"]*/
@@ -94,44 +98,7 @@ function foo(d) {
 }
 ```
 
-```js
-/*eslint indent: ["error", 2, {"VariableDeclarator": 1}]*/
-/*eslint-env es6*/
-
-var a,
-    b,
-    c;
-let a,
-    b,
-    c;
-const a = 1,
-    b = 2,
-    c = 3;
-```
-
-```js
-/*eslint indent: ["error", 2, {"SwitchCase": 1}]*/
-
-switch(a){
-case "a":
-    break;
-case "b":
-    break;
-}
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint indent: ["error", 2]*/
-
-if (a) {
-  b=c;
-  function foo(d) {
-    e=f;
-  }
-}
-```
+Examples of **correct** code for this rule with the `"tab"` option:
 
 ```js
 /*indent: ["error", "tab"]*/
@@ -144,8 +111,40 @@ if (a) {
 }
 ```
 
+### SwitchCase
+
+Examples of **incorrect** code for this rule with the `2, { "SwitchCase": 1 }` options:
+
 ```js
-/*eslint indent: ["error", 2, {"VariableDeclarator": 2}]*/
+/*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
+
+switch(a){
+case "a":
+    break;
+case "b":
+    break;
+}
+```
+
+Examples of **correct** code for this rule with the `2, { "SwitchCase": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "SwitchCase": 1 }]*/
+
+switch(a){
+  case "a":
+    break;
+  case "b":
+    break;
+}
+```
+
+### VariableDeclarator
+
+Examples of **incorrect** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
 /*eslint-env es6*/
 
 var a,
@@ -159,8 +158,44 @@ const a = 1,
     c = 3;
 ```
 
+Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 1 }` options:
+
 ```js
-/*eslint indent: ["error", 2, {"VariableDeclarator": { "var": 2, "let": 2, "const": 3}}]*/
+/*eslint indent: ["error", 2, { "VariableDeclarator": 1 }]*/
+/*eslint-env es6*/
+
+var a,
+  b,
+  c;
+let a,
+  b,
+  c;
+const a = 1,
+  b = 2,
+  c = 3;
+```
+
+Examples of **correct** code for this rule with the `2, { "VariableDeclarator": 2 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": 2 }]*/
+/*eslint-env es6*/
+
+var a,
+    b,
+    c;
+let a,
+    b,
+    c;
+const a = 1,
+    b = 2,
+    c = 3;
+```
+
+Examples of **correct** code for this rule with the `2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }` options:
+
+```js
+/*eslint indent: ["error", 2, { "VariableDeclarator": { "var": 2, "let": 2, "const": 3 } }]*/
 /*eslint-env es6*/
 
 var a,
@@ -173,18 +208,6 @@ const a = 1,
       b = 2,
       c = 3;
 ```
-
-```js
-/*eslint indent: ["error", 4, {"SwitchCase": 1}]*/
-
-switch(a){
-    case "a":
-        break;
-    case "b":
-        break;
-}
-```
-
 
 ## Compatibility
 


### PR DESCRIPTION
The second batch of (5) rules under Stylistic Issues.

The next batch will be bigger; I just didn't have as much time today as I had hoped. Depending on how this PR goes, I might just add the next 5-10 directly to this instead of a separate batch.

@pedrottimark There were a lot of differences in these rules from your latest updates, so could you give this a thorough look?

One concern before this gets merged: For options that don't have an explicit name, where should we put the code examples (apologies if this is answered in one of your issues / PRs)?

I found some more inconsistencies between some rules here and other rules, e.g. for the `id-match` rule, the `properties` object property option takes either `true` or `false`, but in other rules it takes `always` or `never`. This is outside of the scope of documentation updates, however, and would also be a breaking change, but perhaps something to keep in mind for the future.