### PR TITLE
Fix: Check that module.paths exists (fixes #5791)

### DIFF
--- a/lib/util/module-resolver.js
+++ b/lib/util/module-resolver.js
@@ -24,8 +24,11 @@ var DEFAULT_OPTIONS = {
      * module.paths is an array of paths to search for resolving things relative
      * to this file. Module.globalPaths contains all of the special Node.js
      * directories that can also be searched for modules.
+     *
+     * Need to check for existence of module.paths because Jest seems not to
+     * include it. See https://github.com/eslint/eslint/issues/5791.
      */
-    lookupPaths: module.paths.concat(Module.globalPaths)
+    lookupPaths: module.paths ? module.paths.concat(Module.globalPaths) : Module.globalPaths.concat()
 };
 
 /**


### PR DESCRIPTION
For some reason, Jest loads modules differently and `module.paths` isn't present. There's no good way to test because Node includes `module.paths` by default. Just including this workaround to help Jest users out.