### PR TITLE
Update: `commentPattern` option for `default-case` rule (fixes #5803)

### DIFF
--- a/docs/rules/default-case.md
+++ b/docs/rules/default-case.md
@@ -80,6 +80,35 @@ switch (a) {
 
 ```
 
+## Options
+
+This rule accepts a single options argument:
+
+* Set the `commentPattern` option to a regular expression string to change the default `^no default$` comment test pattern
+
+### commentPattern
+
+Examples of **correct** code for the `{ "commentPattern": "^skip\\sdefault" }` option:
+
+```js
+/*eslint default-case: ["error", { "commentPattern": "^skip\\sdefault" }]*/
+
+switch(a) {
+    case 1:
+        /* code */
+        break;
+
+    // skip default
+}
+
+switch(a) {
+    case 1:
+        /* code */
+        break;
+
+    // skip default case
+}
+```
 
 ## When Not To Use It
 

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -4,7 +4,7 @@
  */
 "use strict";
 
-var COMMENT_VALUE = "no default";
+var DEFAULT_COMMENT_PATTERN = /^no default$/;
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -18,10 +18,22 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [{
+            "type": "object",
+            "properties": {
+                "commentPattern": {
+                    "type": "string"
+                }
+            },
+            "additionalProperties": false
+        }]
     },
 
     create: function(context) {
+        var options = context.options[0] || {};
+        var commentPattern = options.commentPattern ?
+            new RegExp(options.commentPattern) :
+            DEFAULT_COMMENT_PATTERN;
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -70,7 +82,7 @@ module.exports = {
                         comment = last(comments);
                     }
 
-                    if (!comment || comment.value.trim() !== COMMENT_VALUE) {
+                    if (!comment || !commentPattern.test(comment.value.trim())) {
                         context.report(node, "Expected a default case.");
                     }
                 }

--- a/tests/lib/rules/default-case.js
+++ b/tests/lib/rules/default-case.js
@@ -29,7 +29,31 @@ ruleTester.run("default-case", rule, {
         "switch (a) { \n    case 1: a = 4; \n\n/* no default */\n }",
         "switch (a) { \n    case 1: a = 4; break; break; \n\n// no default\n }",
         "switch (a) { // no default\n }",
-        "switch (a) { }"
+        "switch (a) { }",
+        {
+            code: "switch (a) { case 1: break; default: break; }",
+            options: [{
+                commentPattern: "default case omitted"
+            }]
+        },
+        {
+            code: "switch (a) { case 1: break; \n // skip default case \n }",
+            options: [{
+                commentPattern: "^skip default"
+            }]
+        },
+        {
+            code: "switch (a) { case 1: break; \n /*\nTODO:\n throw error in default case\n*/ \n }",
+            options: [{
+                commentPattern: "default"
+            }]
+        },
+        {
+            code: "switch (a) { case 1: break; \n// \n }",
+            options: [{
+                commentPattern: ".?"
+            }]
+        }
     ],
 
     invalid: [
@@ -53,7 +77,36 @@ ruleTester.run("default-case", rule, {
                 message: "Expected a default case.",
                 type: "SwitchStatement"
             }]
+        },
+        {
+            code: "switch (a) { case 1: break; \n // no default \n }",
+            options: [{
+                commentPattern: "skipped default case"
+            }],
+            errors: [{
+                message: "Expected a default case.",
+                type: "SwitchStatement"
+            }]
+        },
+        {
+            code: "switch (a) {\ncase 1: break; \n// default omitted intentionally \n// TODO: add default case \n}",
+            options: [{
+                commentPattern: "default omitted"
+            }],
+            errors: [{
+                message: "Expected a default case.",
+                type: "SwitchStatement"
+            }]
+        },
+        {
+            code: "switch (a) {\ncase 1: break;\n}",
+            options: [{
+                commentPattern: ".?"
+            }],
+            errors: [{
+                message: "Expected a default case.",
+                type: "SwitchStatement"
+            }]
         }
-
     ]
 });


### PR DESCRIPTION
This PR adds the `commentPattern` option to `default-case` rule which may be a string or a regular expression string and which overrides the default comment pattern.
If no option is specified, the default comment pattern is used.
The strict comparison of a trimmed comment with the "no default" string is replaced by the `^no default$` regular expression test for consistency.