### PR TITLE
Update: Adds an avoid-quotes option for object-shorthand (fixes #3366)

### DIFF
--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -100,6 +100,37 @@ You can set the option in configuration like this:
 }
 ```
 
+While set to `"always"`, `"methods"`, or `"properties"`, shorthand syntax using string literal keys can be ignored using the optional parameter `"avoidQuotes"`. This will make it so longform syntax is preferred whenever the object key is a string literal. Note: The first parameter must be specified when using this optional parameter.
+
+```json
+{
+    "object-shorthand": ["error", "always", { "avoidQuotes": true }]
+}
+```
+
+Examples of **incorrect** code for this rule with the `"avoidQuotes"` option:
+
+```js
+/*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
+/*eslint-env es6*/
+
+var foo = {
+    "bar-baz"() {}
+};
+```
+
+Examples of **correct** code for this rule with the `"avoidQuotes"` option:
+
+```js
+/*eslint object-shorthand: ["error", "always", { "avoidQuotes": true }]*/
+/*eslint-env es6*/
+
+var foo = {
+    "bar-baz": function() {},
+    "qux": qux
+};
+```
+
 While set to `"always"` or `"methods"`, constructor functions can be ignored with the optional parameter `"ignoreConstructors"` enabled. Note: The first parameter must be specified when using this optional parameter.
 
 ```json

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -39,12 +39,34 @@ module.exports = {
                     type: "array",
                     items: [
                         {
+                            enum: ["always", "methods", "properties"]
+                        },
+                        {
+                            type: "object",
+                            properties: {
+                                avoidQuotes: {
+                                    type: "boolean"
+                                }
+                            },
+                            additionalProperties: false
+                        }
+                    ],
+                    minItems: 0,
+                    maxItems: 2
+                },
+                {
+                    type: "array",
+                    items: [
+                        {
                             enum: ["always", "methods"]
                         },
                         {
                             type: "object",
                             properties: {
                                 ignoreConstructors: {
+                                    type: "boolean"
+                                },
+                                avoidQuotes: {
                                     type: "boolean"
                                 }
                             },
@@ -66,6 +88,7 @@ module.exports = {
 
         var PARAMS = context.options[1] || {};
         var IGNORE_CONSTRUCTORS = PARAMS.ignoreConstructors;
+        var AVOID_QUOTES = PARAMS.avoidQuotes;
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -81,6 +104,15 @@ module.exports = {
             var firstChar = name.charAt(0);
 
             return firstChar === firstChar.toUpperCase();
+        }
+
+        /**
+          * Checks whether a node is a string literal.
+          * @param   {ASTNode} node - Any AST node.
+          * @returns {boolean} `true` if it is a string literal.
+          */
+        function isStringLiteral(node) {
+            return node.type === "Literal" && typeof node.value === "string";
         }
 
         //--------------------------------------------------------------------------
@@ -103,8 +135,13 @@ module.exports = {
                     context.report(node, "Expected longform " + type + " syntax.");
                 }
 
+                // {'xyz'() {}} should be written as {'xyz': function() {}}
+                if (AVOID_QUOTES && isStringLiteral(node.key) && isConciseProperty) {
+                    context.report(node, "Expected longform method syntax for string literal keys.");
+                }
+
                 // at this point if we're concise or if we're "never" we can leave
-                if (APPLY_NEVER || isConciseProperty) {
+                if (APPLY_NEVER || AVOID_QUOTES || isConciseProperty) {
                     return;
                 }
 

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -85,6 +85,11 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {ConstructorFunction: function(){}, a: b}", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
         { code: "var x = {notConstructorFunction: function(){}, b: c}", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
 
+        // avoidQuotes
+        { code: "var x = {'a': function(){}}", parserOptions: { ecmaVersion: 6 }, options: ["always", {avoidQuotes: true}] },
+        { code: "var x = {['a']: function(){}}", parserOptions: { ecmaVersion: 6 }, options: ["methods", {avoidQuotes: true}] },
+        { code: "var x = {'y': y}", parserOptions: { ecmaVersion: 6 }, options: ["properties", {avoidQuotes: true}] },
+
         // ignore object shorthand
         { code: "let {a, b} = o;", parserOptions: { ecmaVersion: 6 }, options: ["never"] }
     ],
@@ -119,6 +124,10 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {y, a: b, *x(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform property syntax.", type: "Property" }, { message: "Expected longform method syntax.", type: "Property" }], options: ["never"]},
         { code: "var x = {y: {x}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform property syntax.", type: "Property" }], options: ["never"]},
         { code: "var x = {ConstructorFunction(){}, a: b}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
-        { code: "var x = {notConstructorFunction(){}, b: c}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] }
+        { code: "var x = {notConstructorFunction(){}, b: c}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
+
+        // avoidQuotes
+        { code: "var x = {'a'(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax for string literal keys.", type: "Property" }], options: ["always", {avoidQuotes: true}] },
+        { code: "var x = {['a'](){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax for string literal keys.", type: "Property" }], options: ["methods", {avoidQuotes: true}] }
     ]
 });


### PR DESCRIPTION
This PR adds the `avoid-quotes` option discussed in #3366 to prevent the recommendation for object method shorthand in cases where 1) the key is a string literal, and 2) the key would be an invalid identifier if not stringified.

After going through this, I tend to feel that that is probably not the right approach, even though it solves the problem as stated in the PR. I thin kit would be better to have this new option for `object-shorthand` prevent warning on *any* stringified key, and have `quote-props` actually validate shorthand property keys (right now it just bails out early). Those two together would do a better job of specifying whether something is an "improperly" formatted key.

Thoughts?