### PR TITLE
Docs: Fix message for `inline-config` option

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -74,7 +74,7 @@ Miscellaneous:
   --debug                    Output debugging information
   -h, --help                 Show help
   -v, --version              Outputs the version number
-  --no-inline-config         Prevent comments from changing eslint rules -
+  --no-inline-config         Prevent comments from changing config or rules -
                              default: false
   --print-config             Print the configuration to be used
 ```

--- a/lib/options.js
+++ b/lib/options.js
@@ -213,7 +213,7 @@ module.exports = optionator({
             option: "inline-config",
             type: "Boolean",
             default: "true",
-            description: "Allow comments to change eslint config/rules"
+            description: "Prevent comments from changing config or rules"
         },
         {
             option: "print-config",


### PR DESCRIPTION
Since `inline-config` defaults to `true`, it's printed as `--no-default config` in `eslint -h`, and the description doesn't match the option.