### PR TITLE
Docs: Reduce length of paragraphs in rules index

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,12 +1,14 @@
 # Rules
 
-Rules in ESLint are divided into several categories to help you better understand their value. All rules are disabled by default. ESLint recommends some rules to catch common problems, and you can use these recommended rules by including `extends: "eslint:recommended"` in your configuration file. The rules that will be enabled when you inherit from `eslint:recommended` are indicated below as "(recommended)". For more information on how to configure rules and use `extends`, please see the [configuration documentation](../user-guide/configuring.md).
+Rules in ESLint are grouped by category to help you understand their purpose.
 
-Some rules are fixable using the `--fix` command line flag. Those rules are marked as "(fixable)" below. Currently these fixes are mostly limited only to whitespace fixes.
+No rules are enabled by default. The `"extends": "eslint:recommended"` property in a [configuration file](../user-guide/configuring#extending-configuration-files) enables rules that report common problems, which have a check mark (recommended) below.
+
+The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems (currently mostly whitespace) reported by rules which have a wrench (fixable) below.
 
 ## Possible Errors
 
-The following rules point out areas where you might have made mistakes.
+These rules relate to possible syntax or logic errors in JavaScript code:
 
 * [comma-dangle](comma-dangle.md): require or disallow trailing commas (recommended)
 * [no-cond-assign](no-cond-assign.md): disallow assignment operators in conditional expressions (recommended)
@@ -39,7 +41,7 @@ The following rules point out areas where you might have made mistakes.
 
 ## Best Practices
 
-These are rules designed to prevent you from making mistakes. They either prescribe a better way of doing something or help you avoid footguns.
+These rules relate to better ways of doing things to help you avoid problems:
 
 * [accessor-pairs](accessor-pairs.md): enforce getter and setter pairs in objects
 * [array-callback-return](array-callback-return.md): enforce `return` statements in callbacks of array methods
@@ -108,13 +110,13 @@ These are rules designed to prevent you from making mistakes. They either prescr
 
 ## Strict Mode
 
-These rules relate to using strict mode and strict mode directives.
+These rules relate to strict mode directives:
 
 * [strict](strict.md): require or disallow strict mode directives
 
 ## Variables
 
-These rules have to do with variable declarations.
+These rules relate to variable declarations:
 
 * [init-declarations](init-declarations.md): require or disallow initialization in `var` declarations
 * [no-catch-shadow](no-catch-shadow.md): disallow `catch` clause parameters from shadowing variables in the outer scope
@@ -131,7 +133,7 @@ These rules have to do with variable declarations.
 
 ## Node.js and CommonJS
 
-These rules are specific to JavaScript running on Node.js or using CommonJS in the browser.
+These rules relate to code running in Node.js, or in browsers with CommonJS:
 
 * [callback-return](callback-return.md): require `return` statements after callbacks
 * [global-require](global-require.md): require `require()` calls to be placed at top-level module scope
@@ -146,7 +148,7 @@ These rules are specific to JavaScript running on Node.js or using CommonJS in t
 
 ## Stylistic Issues
 
-These rules are purely matters of style and are quite subjective.
+These rules relate to style guidelines, and are therefore quite subjective:
 
 * [array-bracket-spacing](array-bracket-spacing.md): enforce consistent spacing inside array brackets (fixable)
 * [block-spacing](block-spacing.md): enforce consistent spacing inside single-line blocks (fixable)
@@ -220,7 +222,7 @@ These rules are purely matters of style and are quite subjective.
 
 ## ECMAScript 6
 
-These rules are only relevant to ES6 environments.
+These rules relate to ES6, also known as ES2015:
 
 * [arrow-body-style](arrow-body-style.md): require braces around arrow function bodies
 * [arrow-parens](arrow-parens.md): require parentheses around arrow function arguments
@@ -250,7 +252,7 @@ These rules are only relevant to ES6 environments.
 
 ## Removed
 
-These rules existed in a previous version of ESLint but have since been replaced by newer rules.
+These rules from older versions of ESLint have been replaced by newer rules:
 
 * [generator-star](generator-star.md): enforce consistent positioning of the `*` in generator functions (replaced by [generator-star-spacing](generator-star-spacing.md))
 * [global-strict](global-strict.md): require or disallow `"use strict"` in the global scope (replaced by [strict](strict.md))


### PR DESCRIPTION
Make each paragraph which directly follows a h1 or h2 heading fit in one line at 600px width, so the rules index page is more inviting and usable on tablets.

Less text also helps readers for whom English is not first language.

However, sentences which merely restate the preceding headings could be confusing or frustrating, so please push back it I cut too much or lost meaning while rewriting in parallel grammatical form.