### PR TITLE
Docs: Fix missing delimiter in README links

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,15 @@
 
 # ESLint
 
-[Website](http://eslint.org) | [Configuring](http://eslint.org/docs/user-guide/configuring) | [Rules](http://eslint.org/docs/rules/) | [Contributing](http://eslint.org/docs/developer-guide/contributing) | [Reporting Bugs](http://eslint.org/docs/developer-guide/contributing/reporting-bugs) | [Code of Conduct](https://jquery.org/conduct/) [Twitter](https://twitter.com/geteslint) | [Mailing List](https://groups.google.com/group/eslint) | [Chat Room](https://gitter.im/eslint/eslint)
+[Website](http://eslint.org) |
+[Configuring](http://eslint.org/docs/user-guide/configuring) |
+[Rules](http://eslint.org/docs/rules/) |
+[Contributing](http://eslint.org/docs/developer-guide/contributing) |
+[Reporting Bugs](http://eslint.org/docs/developer-guide/contributing/reporting-bugs) |
+[Code of Conduct](https://jquery.org/conduct/) |
+[Twitter](https://twitter.com/geteslint) |
+[Mailing List](https://groups.google.com/group/eslint) |
+[Chat Room](https://gitter.im/eslint/eslint)
 
 ESLint is a tool for identifying and reporting on patterns found in ECMAScript/JavaScript code. In many ways, it is similar to JSLint and JSHint with a few exceptions:
 


### PR DESCRIPTION
Also made the Markdown a little more organized via judicious use of line breaks.