### PR TITLE
New: Adding new key-space config (fixes #5613)

### DIFF
--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -12,16 +12,17 @@ This rule enforces consistent spacing between keys and values in object literal 
 
 This rule has an object option:
 
-* `"beforeColon": false` (default) disallows spaces between the key and the colon in object literals
-* `"beforeColon": true` requires at least one space between the key and the colon in object literals
-* `"afterColon": true` (default) requires at least one space between the colon and the value in object literals
-* `"afterColon": false` disallows spaces between the colon and the value in object literals
-* `"mode": strict` (default) enforces exactly one space before or after colons in object literals
-* `"mode": minimum` enforces one or more spaces before or after colons in object literals
-* `"align": "value"` enforces horizontal alignment of values in object literals
+* `"beforeColon": false` (default) disallows spaces between the key and the colon in object literals.
+* `"beforeColon": true` requires at least one space between the key and the colon in object literals.
+* `"afterColon": true` (default) requires at least one space between the colon and the value in object literals.
+* `"afterColon": false` disallows spaces between the colon and the value in object literals.
+* `"mode": strict` (default) enforces exactly one space before or after colons in object literals.
+* `"mode": minimum` enforces one or more spaces before or after colons in object literals.
+* `"align": "value"` enforces horizontal alignment of values in object literals.
 * `"align": "colon"` enforces horizontal alignment of both colons and values in object literals.
-* `"singleLine"` specifies a spacing style for single-line object literals
-* `"multiLine"` specifies a spacing style for multi-line object literals
+* `"align"` with an object value allows for fine-grained spacing when values are being aligned in object literals.
+* `"singleLine"` specifies a spacing style for single-line object literals.
+* `"multiLine"` specifies a spacing style for multi-line object literals.
 
 Please note that you can either use the top-level options or the grouped options (`singleLine` and `multiLine`) but not both.
 
@@ -181,6 +182,122 @@ call({
     foobar: 42,
     bat   : 2 * 2
 });
+```
+
+### align
+
+The `align` option can take additional configuration through the `beforeColon`, `afterColon`, `mode`, and `on` options.
+
+If `align` is defined as an object, but not all of the parameters are provided, undefined parameters will default to the following:
+
+```js
+// Defaults
+align: {
+    "beforeColon": false,
+    "afterColon": true,
+    "on": "colon",
+    "mode": "strict"
+}
+```
+
+Examples of **correct** code for this rule with sample `{ "align": { } }` options:
+
+```js
+/*eslint key-spacing: ["error", {
+    "align": {
+        "beforeColon": true,
+        "afterColon": true,
+        "on": "colon"
+    }
+}]*/
+
+var obj = {
+    "one"   : 1,
+    "seven" : 7
+}
+```
+
+```js
+/*eslint key-spacing: ["error", {
+    "align": {
+        "beforeColon": false,
+        "afterColon": false,
+        "on": "value"
+    }
+}]*/
+
+var obj = {
+    "one":  1,
+    "seven":7
+}
+```
+
+### align and multiLine
+
+The `multiLine` and `align` options can differ, which allows for fine-tuned control over the `key-spacing` of your files.  `align` will **not** inherit from `multiLine` if `align` is configured as an object.
+
+`multiLine` is used any time  an object literal spans multiple lines.  The `align` configuration is used when there is a group of properties in the the same object. For example:
+
+```javascript
+var myObj = {
+  key1: 1, // uses multiLine
+
+  key2: 2, // uses align (when defined)
+  key3: 3, // uses align (when defined)
+
+  key4: 4 // uses multiLine
+}
+
+```
+
+Examples of **incorrect** code for this rule with sample `{ "align": { }, "multiLine": { } }` options:
+
+```js
+/*eslint key-spacing: ["error", {
+    "multiLine": {
+        "beforeColon": false,
+        "afterColon":true
+    },
+    "align": {
+        "beforeColon": true,
+        "afterColon": true,
+        "on": "colon"
+    }
+}]*/
+
+var obj = {
+    "myObjectFunction": function() {
+        // Do something
+    },
+    "one"             : 1,
+    "seven"           : 7
+}
+```
+
+Examples of **correct** code for this rule with sample `{ "align": { }, "multiLine": { } }` options:
+
+```js
+/*eslint key-spacing: ["error", {
+    "multiLine": {
+        "beforeColon": false,
+        "afterColon": true
+
+    },
+    "align": {
+        "beforeColon": true,
+        "afterColon": true,
+        "on": "colon"
+    }
+}]*/
+
+var obj = {
+    "myObjectFunction": function() {
+        // Do something
+        //
+    }, // These are two separate groups, so no alignment between `myObjectFuction` and `one`
+    "one"   : 1,
+    "seven" : 7 // `one` and `seven` are in their own group, and therefore aligned
+}
 ```
 
 ### singleLine and multiLine

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -71,18 +71,14 @@ function isSingleLine(node) {
     return (node.loc.end.line === node.loc.start.line);
 }
 
-/** Sets option values from the configured options with defaults
+/**
+ * Initializes a single option property from the configuration with defaults for undefined values
  * @param {Object} toOptions Object to be initialized
  * @param {Object} fromOptions Object to be initialized from
  * @returns {Object} The object with correctly initialized options and values
  */
-function initOptions(toOptions, fromOptions) {
+function initOptionProperty(toOptions, fromOptions) {
     toOptions.mode = fromOptions.mode || "strict";
-
-    // Set align if exists -  multiLine case
-    if (typeof fromOptions.align !== "undefined") {
-        toOptions.align = fromOptions.align;
-    }
 
     // Set value of beforeColon
     if (typeof fromOptions.beforeColon !== "undefined") {
@@ -96,6 +92,55 @@ function initOptions(toOptions, fromOptions) {
         toOptions.afterColon = +fromOptions.afterColon;
     } else {
         toOptions.afterColon = 1;
+    }
+
+    // Set align if exists
+    if (typeof fromOptions.align !== "undefined") {
+        if (typeof fromOptions.align === "object") {
+            toOptions.align = fromOptions.align;
+        } else { // "string"
+            toOptions.align = {
+                on: fromOptions.align,
+                mode: toOptions.mode,
+                beforeColon: toOptions.beforeColon,
+                afterColon: toOptions.afterColon
+            };
+        }
+    }
+
+    return toOptions;
+}
+
+/**
+ * Initializes all the option values (singleLine, multiLine and align) from the configuration with defaults for undefined values
+ * @param {Object} toOptions Object to be initialized
+ * @param {Object} fromOptions Object to be initialized from
+ * @returns {Object} The object with correctly initialized options and values
+ */
+function initOptions(toOptions, fromOptions) {
+    if (typeof fromOptions.align === "object") {
+
+        // Initialize the alignment configuration
+        toOptions.align = initOptionProperty({}, fromOptions.align);
+        toOptions.align.on = fromOptions.align.on || "colon";
+        toOptions.align.mode = fromOptions.align.mode || "strict";
+
+        toOptions.multiLine = initOptionProperty({}, (fromOptions.multiLine || fromOptions));
+        toOptions.singleLine = initOptionProperty({}, (fromOptions.singleLine || fromOptions));
+
+    } else { // string or undefined
+        toOptions.multiLine = initOptionProperty({}, (fromOptions.multiLine || fromOptions));
+        toOptions.singleLine = initOptionProperty({}, (fromOptions.singleLine || fromOptions));
+
+        // If alignment options are defined in multiLine, pull them out into the general align configuration
+        if (toOptions.multiLine.align) {
+            toOptions.align = {
+                on: toOptions.multiLine.align.on,
+                mode: toOptions.multiLine.mode,
+                beforeColon: toOptions.multiLine.align.beforeColon,
+                afterColon: toOptions.multiLine.align.afterColon
+            };
+        }
     }
 
     return toOptions;
@@ -126,7 +171,29 @@ module.exports = {
                     type: "object",
                     properties: {
                         align: {
-                            enum: ["colon", "value"]
+                            anyOf: [
+                                {
+                                    enum: ["colon", "value"]
+                                },
+                                {
+                                    type: "object",
+                                    properties: {
+                                        mode: {
+                                            enum: ["strict", "minimum"]
+                                        },
+                                        on: {
+                                            enum: ["colon", "value"]
+                                        },
+                                        beforeColon: {
+                                            type: "boolean"
+                                        },
+                                        afterColon: {
+                                            type: "boolean"
+                                        }
+                                    },
+                                    additionalProperties: false
+                                }
+                            ]
                         },
                         mode: {
                             enum: ["strict", "minimum"]
@@ -162,10 +229,83 @@ module.exports = {
                             type: "object",
                             properties: {
                                 align: {
-                                    enum: ["colon", "value"]
+                                    anyOf: [
+                                        {
+                                            enum: ["colon", "value"]
+                                        },
+                                        {
+                                            type: "object",
+                                            properties: {
+                                                mode: {
+                                                    enum: ["strict", "minimum"]
+                                                },
+                                                on: {
+                                                    enum: ["colon", "value"]
+                                                },
+                                                beforeColon: {
+                                                    type: "boolean"
+                                                },
+                                                afterColon: {
+                                                    type: "boolean"
+                                                }
+                                            },
+                                            additionalProperties: false
+                                        }
+                                    ]
                                 },
                                 mode: {
                                     enum: ["strict", "minimum"]
+                                },
+                                beforeColon: {
+                                    type: "boolean"
+                                },
+                                afterColon: {
+                                    type: "boolean"
+                                }
+                            },
+                            additionalProperties: false
+                        }
+                    },
+                    additionalProperties: false
+                },
+                {
+                    type: "object",
+                    properties: {
+                        singleLine: {
+                            type: "object",
+                            properties: {
+                                mode: {
+                                    enum: ["strict", "minimum"]
+                                },
+                                beforeColon: {
+                                    type: "boolean"
+                                },
+                                afterColon: {
+                                    type: "boolean"
+                                }
+                            },
+                            additionalProperties: false
+                        },
+                        multiLine: {
+                            type: "object",
+                            properties: {
+                                beforeColon: {
+                                    type: "boolean"
+                                },
+                                afterColon: {
+                                    type: "boolean"
+                                }
+                            },
+                            additionalProperties: false
+                        },
+                        align: {
+                            type: "object",
+                            properties: {
+                                mode: {
+                                    enum: ["strict", "minimum"]
+                                },
+                                on: {
+                                    enum: ["colon", "value"]
                                 },
                                 beforeColon: {
                                     type: "boolean"
@@ -193,10 +333,11 @@ module.exports = {
          *     align: "colon" // Optional, or "value"
          * }
          */
-
         var options = context.options[0] || {},
-            multiLineOptions = initOptions({}, (options.multiLine || options)),
-            singleLineOptions = initOptions({}, (options.singleLine || options));
+            ruleOptions = initOptions({}, options),
+            multiLineOptions = ruleOptions.multiLine,
+            singleLineOptions = ruleOptions.singleLine,
+            alignmentOptions = ruleOptions.align || null;
 
         var sourceCode = context.getSourceCode();
 
@@ -397,11 +538,19 @@ module.exports = {
             var length = properties.length,
                 widths = properties.map(getKeyWidth), // Width of keys, including quotes
                 targetWidth = Math.max.apply(null, widths),
+                align = alignmentOptions.on, // "value" or "colon"
                 i, property, whitespace, width,
-                align = multiLineOptions.align,
-                beforeColon = multiLineOptions.beforeColon,
-                afterColon = multiLineOptions.afterColon,
-                mode = multiLineOptions.mode;
+                beforeColon, afterColon, mode;
+
+            if (alignmentOptions && length > 1) { // When aligning values within a group, use the alignment configuration.
+                beforeColon = alignmentOptions.beforeColon;
+                afterColon = alignmentOptions.afterColon;
+                mode = alignmentOptions.mode;
+            } else {
+                beforeColon = multiLineOptions.beforeColon;
+                afterColon = multiLineOptions.afterColon;
+                mode = alignmentOptions.mode;
+            }
 
             // Conditionally include one space before or after colon
             targetWidth += (align === "colon" ? beforeColon : afterColon);
@@ -466,7 +615,7 @@ module.exports = {
         // Public API
         //--------------------------------------------------------------------------
 
-        if (multiLineOptions.align) { // Verify vertical alignment
+        if (alignmentOptions) { // Verify vertical alignment
 
             return {
                 ObjectExpression: function(node) {

--- a/tests/lib/rules/key-spacing.js
+++ b/tests/lib/rules/key-spacing.js
@@ -507,6 +507,210 @@ ruleTester.run("key-spacing", rule, {
             align: "colon"
         }],
         parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    },
+
+    // https://github.com/eslint/eslint/issues/5613
+
+    { // if `align` is an object, but `on` is not declared, `on` defaults to `colon`
+        code: [
+            "({",
+            "    longName: 1,",
+            "    small   : 2,",
+            "    f       : function() {",
+            "    },",
+            "    xs :3",
+            "})"
+        ].join("\n"),
+        options: [{
+            align: {
+                afterColon: true
+            },
+            beforeColon: true,
+            afterColon: false
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    }, {
+        code: [
+            "({",
+            "    longName: 1,",
+            "    small:    2,",
+            "    f:        function() {",
+            "    },",
+            "    xs :3",
+            "})"
+        ].join("\n"),
+        options: [{
+            align: {
+                on: "value",
+                afterColon: true
+            },
+            beforeColon: true,
+            afterColon: false
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    }, {
+        code: [
+            "({",
+            "    longName : 1,",
+            "    small :    2,",
+            "    xs :       3",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                align: {
+                    on: "value",
+                    beforeColon: true,
+                    afterColon: true
+                }
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    }, {
+        code: [
+            "({",
+            "    longName :1,",
+            "    small    :2,",
+            "    xs       :3",
+            "})"
+        ].join("\n"),
+        options: [{
+            align: {
+                on: "colon",
+                beforeColon: true,
+                afterColon: false
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+        errors: []
+    }, {
+        code: [
+            "({",
+            "    longName: 1,",
+            "    small   : 2,",
+            "    xs      :        3",
+            "})"
+        ].join("\n"),
+        options: [{
+            align: {
+                on: "colon",
+                beforeColon: false,
+                afterColon: true,
+                mode: "minimum"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    }, {
+        code: [
+            "({",
+            "    longName: 1,",
+            "    small   : 2,",
+            "    xs      : 3",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                align: {
+                    on: "colon",
+                    beforeColon: false,
+                    afterColon: true
+                }
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    }, {
+        code: [
+            "({",
+            "    func: function() {",
+            "        var test = true;",
+            "    },",
+            "    longName : 1,",
+            "    small    : 2,",
+            "    xs       : 3,",
+            "    func2    : function() {",
+            "        var test2 = true;",
+            "    },",
+            "    internalGroup: {",
+            "        internal : true,",
+            "        ext      : false",
+            "    }",
+            "})"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                beforeColon: false,
+                afterColon: true
+            },
+            multiLine: {
+                beforeColon: false,
+                afterColon: true
+            },
+            align: {
+                on: "colon",
+                beforeColon: true,
+                afterColon: true
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    }, {
+        code: [
+            "({",
+            "    func: function() {",
+            "        var test = true;",
+            "    },",
+            "    longName: 1,",
+            "    small:    2,",
+            "    xs:       3,",
+            "    func2:    function() {",
+            "        var test2 = true;",
+            "    },",
+            "    final: 10",
+            "})"
+        ].join("\n"),
+        options: [{
+            singleLine: {
+                beforeColon: false,
+                afterColon: true
+            },
+            multiLine: {
+                align: {
+                    on: "value",
+                    beforeColon: false,
+                    afterColon: true
+                },
+                beforeColon: false,
+                afterColon: true
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
+    }, {
+        code: [
+            "({",
+            "    f:function() {",
+            "        var test = true;",
+            "    },",
+            "    stateName : 'NY',",
+            "    borough   : 'Brooklyn',",
+            "    zip       : 11201,",
+            "    f2        : function() {",
+            "        var test2 = true;",
+            "    },",
+            "    final:10",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                align: {
+                    on: "colon",
+                    beforeColon: true,
+                    afterColon: true,
+                    mode: "strict"
+                },
+                beforeColon: false,
+                afterColon: false
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }
     }],
 
     invalid: [{
@@ -1285,6 +1489,138 @@ ruleTester.run("key-spacing", rule, {
         errors: [
             { message: "Missing space before value for key 'a'.", line: 1, column: 6, type: "Identifier" },
             { message: "Extra space after key 'c'.", line: 1, column: 20, type: "Identifier" }
+        ]
+    },
+
+    // https://github.com/eslint/eslint/issues/5613
+    {
+        code: [
+            "({",
+            "    longName:1,",
+            "    small    :2,",
+            "    xs      : 3",
+            "})"
+        ].join("\n"),
+        output: [
+            "({",
+            "    longName : 1,",
+            "    small    : 2,",
+            "    xs       : 3",
+            "})"
+        ].join("\n"),
+        options: [{
+            align: {
+                on: "colon",
+                beforeColon: true,
+                afterColon: true,
+                mode: "strict"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+        errors: [
+            { message: "Missing space after key \'longName\'.", line: 2, column: 5, type: "Identifier" },
+            { message: "Missing space before value for key \'longName\'.", line: 2, column: 14, type: "Literal" },
+            { message: "Missing space before value for key \'small\'.", line: 3, column: 15, type: "Literal" },
+            { message: "Missing space after key \'xs\'.", line: 4, column: 5, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "({",
+            "    func:function() {",
+            "        var test = true;",
+            "    },",
+            "    longName: 1,",
+            "    small: 2,",
+            "    xs            : 3,",
+            "    func2    : function() {",
+            "        var test2 = true;",
+            "    },",
+            "    singleLine : 10",
+            "})"
+        ].join("\n"),
+        output: [
+            "({",
+            "    func: function() {",
+            "        var test = true;",
+            "    },",
+            "    longName : 1,",
+            "    small    : 2,",
+            "    xs       : 3,",
+            "    func2    : function() {",
+            "        var test2 = true;",
+            "    },",
+            "    singleLine: 10",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                beforeColon: false,
+                afterColon: true
+            },
+            align: {
+                on: "colon",
+                beforeColon: true,
+                afterColon: true,
+                mode: "strict"
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+        errors: [
+            { message: "Missing space before value for key \'func\'.", line: 2, column: 10, type: "FunctionExpression" },
+            { message: "Missing space after key \'longName\'.", line: 5, column: 5, type: "Identifier" },
+            { message: "Missing space after key \'small\'.", line: 6, column: 5, type: "Identifier" },
+            { message: "Extra space after key \'xs\'.", line: 7, column: 5, type: "Identifier" },
+            { message: "Extra space after key \'singleLine\'.", line: 11, column: 5, type: "Identifier" }
+        ]
+    }, {
+        code: [
+            "({",
+            "    func:function() {",
+            "        var test = false;",
+            "    },",
+            "    longName :1,",
+            "    small :2,",
+            "    xs            : 3,",
+            "    func2    : function() {",
+            "        var test2 = true;",
+            "    },",
+            "    singleLine : 10",
+            "})"
+        ].join("\n"),
+        output: [
+            "({",
+            "    func: function() {",
+            "        var test = false;",
+            "    },",
+            "    longName :1,",
+            "    small    :2,",
+            "    xs       :3,",
+            "    func2    :function() {",
+            "        var test2 = true;",
+            "    },",
+            "    singleLine: 10",
+            "})"
+        ].join("\n"),
+        options: [{
+            multiLine: {
+                beforeColon: false,
+                afterColon: true,
+                align: {
+                    on: "colon",
+                    beforeColon: true,
+                    afterColon: false,
+                    mode: "strict"
+                }
+            }
+        }],
+        parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+        errors: [
+            { message: "Missing space before value for key \'func\'.", line: 2, column: 10, type: "FunctionExpression" },
+            { message: "Missing space after key \'small\'.", line: 6, column: 5, type: "Identifier" },
+            { message: "Extra space after key \'xs\'.", line: 7, column: 5, type: "Identifier" },
+            { message: "Extra space before value for key \'xs\'.", line: 7, column: 21, type: "Literal" },
+            { message: "Extra space before value for key \'func2\'.", line: 8, column: 16, type: "FunctionExpression" },
+            { message: "Extra space after key \'singleLine\'.", line: 11, column: 5, type: "Identifier" }
         ]
     }]
 });


### PR DESCRIPTION
This configuration allows specifying how spacing should work when aligning values via a new `alignment` property.

Example Configuration using the new `alignment` property:

```json
"key-spacing": [2, {
    "singleLine": {
        "beforeColon": false,
        "afterColon": true
    },
    "multiLine": {
        "beforeColon": false,
        "afterColon": true,
        "align": "colon"
    },
    "align": {
        "beforeColon": true,
        "afterColon": true
    }
}]
```

The following alignment would throw no errors: 
```js
var obj = {
    _origin  : 0,
    _x       : 1,
    callback : function(cb) {
        cb();
    },
    a  : 1,
    bc : 2
    d  : function() {
        //...
    },
    o: {
        internal : true,
        int      : 1
    }
};
```


Tests were added showing that it should work with both `align: colon` and `align: value` .

------------------------------------------------------------

### Why

This allows eslint users (like myself) more granular control over the styling of their alignment.  I specifically chose to add a new configuration property to allow separate styling between `singleLine`, `multiLine` and `alignment` if the user so chooses.

The `alignment` options are initialized as null to maintain backwards compatibility and ensure that no hidden configurations are forced on the user without them realizing. 