### PR TITLE
Docs: Distinguish examples in rules under Stylistic Issues part 3

### DIFF
--- a/docs/rules/jsx-quotes.md
+++ b/docs/rules/jsx-quotes.md
@@ -1,4 +1,4 @@
-# Enforce JSX Quote Style (jsx-quotes)
+# enforce the consistent use of either double or single quotes in JSX attributes (jsx-quotes)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -19,13 +19,18 @@ If you want to have e.g. a double quote within a JSX attribute value, you have t
 
 ## Rule Details
 
-This rule takes one argument.
-If it is `"prefer-double"` then the rule enforces the usage of double quotes for all JSX attribute values which doesn’t contain a double quote.
-If `"prefer-single"` is configured then the rule enforces the usage of single quotes for all JSX attribute values which doesn’t contain a single quote.
+This rule enforces the consistent use of either double or single quotes in JSX attributes.
 
-The default is `"prefer-double"`.
+## Options
 
-The following patterns are considered problems when set to `"prefer-double"`:
+This rule has a string option:
+
+* `"prefer-double"` (default) enforces the use of double quotes for all JSX attribute values that don't contain a double quote.
+* `"prefer-single"` enforces the use of single quotes for all JSX attribute values that don’t contain a single quote.
+
+### prefer-double
+
+Examples of **incorrect** code for this rule with the default `"prefer-double"` option:
 
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
@@ -33,7 +38,7 @@ The following patterns are considered problems when set to `"prefer-double"`:
 <a b='c' />
 ```
 
-The following patterns are not considered problems when set to `"prefer-double"`:
+Examples of **correct** code for this rule with the default `"prefer-double"` option:
 
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-double"]*/
@@ -42,7 +47,9 @@ The following patterns are not considered problems when set to `"prefer-double"`
 <a b='"' />
 ```
 
-The following patterns are considered problems when set to `"prefer-single"`:
+### prefer-single
+
+Examples of **incorrect** code for this rule with the `"prefer-single"` option:
 
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-single"]*/
@@ -50,7 +57,7 @@ The following patterns are considered problems when set to `"prefer-single"`:
 <a b="c" />
 ```
 
-The following patterns are not considered problems when set to `"prefer-single"`:
+Examples of **correct** code for this rule with the `"prefer-single"` option:
 
 ```xml
 /*eslint jsx-quotes: ["error", "prefer-single"]*/

--- a/docs/rules/key-spacing.md
+++ b/docs/rules/key-spacing.md
@@ -1,90 +1,149 @@
-# Enforce Property Spacing (key-spacing)
+# enforce consistent spacing between keys and values in object literal properties (key-spacing)
 
-This rule enforces spacing around the colon in object literal properties. It can verify each property individually, or it can ensure vertical alignment of groups of properties in an object literal.
+This rule enforces spacing around the colon in object literal properties. It can verify each property individually, or it can ensure horizontal alignment of adjacent properties in an object literal.
 
 ## Rule Details
 
-This rule will warn when spacing in properties does not match the specified options. In the case of long lines, it is acceptable to add a new line wherever whitespace is allowed. There are three modes:
+This rule enforces consistent spacing between keys and values in object literal properties. In the case of long lines, it is acceptable to add a new line wherever whitespace is allowed.
 
 ## Options
 
-Use the `beforeColon`, `afterColon` and `mode` options to enforce having one space or zero spaces on each side, using `true` or `false`, respectively. The default is no whitespace between the key and the colon and one space between the colon and the value.
+This rule has an object option:
 
-`mode` option can be either `"strict"` or `"minimum"` and defaults to `"strict"`. In `strict` mode, it enforces exactly 1 space before or after the colon where as in `minimum` mode, it enforces at least 1 space but more are okay.
+* `"beforeColon": false` (default) disallows spaces between the key and the colon in object literals
+* `"beforeColon": true` requires at least one space between the key and the colon in object literals
+* `"afterColon": true` (default) requires at least one space between the colon and the value in object literals
+* `"afterColon": false` disallows spaces between the colon and the value in object literals
+* `"mode": strict` (default) enforces exactly one space before or after colons in object literals
+* `"mode": minimum` enforces one or more spaces before or after colons in object literals
+* `"align": "value"` enforces horizontal alignment of values in object literals
+* `"align": "colon"` enforces horizontal alignment of both colons and values in object literals.
+* `"singleLine"` specifies a spacing style for single-line object literals
+* `"multiLine"` specifies a spacing style for multi-line object literals
 
-The following patterns are considered valid:
+Please note that you can either use the top-level options or the grouped options (`singleLine` and `multiLine`) but not both.
+
+### beforeColon
+
+Examples of **incorrect** code for this rule with the default `{ "beforeColon": false }` option:
 
 ```js
-// DEFAULT
-/*eslint key-spacing: ["error", {"beforeColon": false, "afterColon": true}]*/
+/*eslint key-spacing: ["error", { "beforeColon": false }]*/
 
-var obj = { "foo": (42) };
-
-foo = { thisLineWouldBeTooLong:
-    soUseAnotherLine };
+var obj = { "foo" : 42 };
 ```
 
+Examples of **correct** code for this rule with the default `{ "beforeColon": false }` option:
+
 ```js
-/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": false}]*/
+/*eslint key-spacing: ["error", { "beforeColon": false }]*/
+
+var obj = { "foo": 42 };
+```
+
+Examples of **incorrect** code for this rule with the `{ "beforeColon": true }` option:
+
+```js
+/*eslint key-spacing: ["error", { "beforeColon": true }]*/
+
+var obj = { "foo": 42 };
+```
+
+Examples of **correct** code for this rule with the `{ "beforeColon": true }` option:
+
+```js
+/*eslint key-spacing: ["error", { "beforeColon": true }]*/
+
+var obj = { "foo" : 42 };
+```
+
+### afterColon
+
+Examples of **incorrect** code for this rule with the default `{ "afterColon": true }` option:
+
+```js
+/*eslint key-spacing: ["error", { "afterColon": true }]*/
+
+var obj = { "foo":42 };
+```
+
+Examples of **correct** code for this rule with the default `{ "afterColon": true }` option:
+
+```js
+/*eslint key-spacing: ["error", { "afterColon": true }]*/
+
+var obj = { "foo": 42 };
+```
+
+Examples of **incorrect** code for this rule with the `{ "afterColon": false }` option:
+
+```js
+/*eslint key-spacing: ["error", { "afterColon": false }]*/
+
+var obj = { "foo": 42 };
+```
+
+Examples of **correct** code for this rule with the `{ "afterColon": false }` option:
+
+```js
+/*eslint key-spacing: ["error", { "afterColon": false }]*/
+
+var obj = { "foo":42 };
+```
+
+### mode
+
+Examples of **incorrect** code for this rule with the default `{ "mode": "strict" }` option:
+
+```js
+/*eslint key-spacing: ["error", { "mode": "strict" }]*/
 
 call({
-    foobar :42,
-    bat :(2 * 2)
+    foobar: 42,
+    bat:    2 * 2
 });
 ```
 
+Examples of **correct** code for this rule with the default `{ "mode": "strict" }` option:
+
 ```js
-/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": false, "mode": "minimum"}]*/
+/*eslint key-spacing: ["error", { "mode": "strict" }]*/
 
 call({
-    foobar   :42,
-    bat :(2 * 2)
+    foobar: 42,
+    bat: 2 * 2
 });
 ```
 
-The following patterns are considered problems:
+Examples of **correct** code for this rule with the `{ "mode": "minimum" }` option:
 
 ```js
-/*eslint key-spacing: ["error", {"beforeColon": false, "afterColon": false}]*/
+/*eslint key-spacing: ["error", { "mode": "minimum" }]*/
 
-var obj = { foo: 42 };
-var bar = { baz :52 };
-
-foo = { thisLineWouldBeTooLong:
-    soUseAnotherLine };
+call({
+    foobar: 42,
+    bat:    2 * 2
+});
 ```
 
-```js
-/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": true}]*/
+### align
 
-function foo() {
-    return {
-        foobar: 42,
-        bat :"value"
-    };
-}
-```
-
-```js
-/*eslint key-spacing: ["error", {"beforeColon": true, "afterColon": true}]*/
-
-function foo() {
-    return {
-        foobar  : 42,
-        bat :  "value"
-    };
-}
-```
-
-### `"align": "value"`
-
-Use the `align` option to enforce vertical alignment of values in an object literal. This mode still respects `beforeColon` and `afterColon` where possible, but it will pad with spaces after the colon where necessary. Groups of properties separated by blank lines are considered distinct and can have different alignment than other groups. Single line object literals will not be checked for vertical alignment, but each property will still be checked for `beforeColon` and `afterColon`.
-
-The following patterns are considered valid:
+Examples of **incorrect** code for this rule with the `{ "align": "value" }` option:
 
 ```js
 /*eslint key-spacing: ["error", { "align": "value" }]*/
-// beforeColon and afterColon default to false and true, respectively
+
+var obj = {
+    a: value,
+    bcde:  42,
+    fg :   foo()
+};
+```
+
+Examples of **correct** code for this rule with the `{ "align": "value" }` option:
+
+```js
+/*eslint key-spacing: ["error", { "align": "value" }]*/
 
 var obj = {
     a:    value,
@@ -100,74 +159,34 @@ var obj = {
 var obj = { a: "foo", longPropertyName: "bar" };
 ```
 
+Examples of **incorrect** code for this rule with the `{ "align": "colon" }` option:
+
 ```js
-/*eslint key-spacing: ["error", { "align": "value", "beforeColon": true, "afterColon": false }]*/
+/*eslint key-spacing: ["error", { "align": "colon" }]*/
 
 call({
-    'a' :[],
-    b :  []
+    foobar: 42,
+    bat:    2 * 2
 });
 ```
 
-The following patterns are considered problems:
-
-```js
-/*eslint key-spacing: ["error", { "align": "value" }]*/
-
-var obj = {
-    a: value,
-    bcde:  42,
-    fg :   foo()
-};
-```
-
-### `"align": "colon"`
-
-The `align` option can also vertically align colons and values together. Whereas with `"value"` alignment, padding belongs right of the colon, with `"colon"` alignment, padding goes to the left of the colon. Except in the case of padding, it still respects `beforeColon` and `afterColon`. As with `"value"` alignment, groups of properties separated by blank lines are considered distinct and can have different alignment than other groups.
-
-The following patterns are considered valid:
+Examples of **correct** code for this rule with the `{ "align": "colon" }` option:
 
 ```js
 /*eslint key-spacing: ["error", { "align": "colon" }]*/
 
-var obj = {
-    foobar   : 42,
-    bat      : (2 * 2),
-    "default": fn(),
-
-    fn : function() {},
-    abc: value
-};
+call({
+    foobar: 42,
+    bat   : 2 * 2
+});
 ```
 
-```js
-/*eslint key-spacing: ["error", { "align": "colon", "beforeColon": true, "afterColon": false }]*/
+### singleLine and multiLine
 
-obj = {
-    first  :1,
-    second :2,
-    third  :3
-};
-```
-
-The following patterns are considered problems:
+Examples of **correct** code for this rule with sample `{ "singleLine": { }, "multiLine": { } }` options:
 
 ```js
-/*eslint key-spacing: ["error", { "align": "colon" }]*/
-
-var obj = {
-    one:   1,
-    "two": 2,
-    three:  3
-};
-```
-
-### Fine-grained control
-
-You can specify these options separately for single-line and multi-line configurations by organizing the options this way:
-
-```js
-"key-spacing": [2, {
+/*eslint "key-spacing": [2, {
     "singleLine": {
         "beforeColon": false,
         "afterColon": true
@@ -177,20 +196,13 @@ You can specify these options separately for single-line and multi-line configur
         "afterColon": true,
         "align": "colon"
     }
-}]
-```
-
-The following patterns are considered valid:
-
-```js
-var obj = {one: 1, "two": 2, three: 3}; /* valid due to `singleLine:{ beforeColon: false }`*/
+}]*/
+var obj = { one: 1, "two": 2, three: 3 };
 var obj2 = {
     "two" : 2,
     three : 3
 };
 ```
-
-Please note that you can either use the top-level options or the grouped options (`singleLine` and `multiLine`) but not both.
 
 ## When Not To Use It
 

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -1,4 +1,4 @@
-# Enforce spacing before and after keywords (keyword-spacing)
+# enforce consistent spacing before and after keywords (keyword-spacing)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -19,58 +19,38 @@ Of course, you could also have a style guide that disallows spaces around keywor
 
 ## Rule Details
 
-This rule will enforce consistency of spacing around keywords and keyword-like tokens: `as` (in module declarations), `break`, `case`, `catch`, `class`, `const`, `continue`, `debugger`, `default`, `delete`, `do`, `else`, `export`, `extends`, `finally`, `for`, `from` (in module declarations), `function`, `get` (of getters), `if`, `import`, `in`, `instanceof`, `let`, `new`, `of` (in for-of statements), `return`, `set` (of setters), `static`, `super`, `switch`, `this`, `throw`, `try`, `typeof`, `var`, `void`, `while`, `with`, and `yield`.
+This rule enforces consistent spacing around keywords and keyword-like tokens: `as` (in module declarations), `break`, `case`, `catch`, `class`, `const`, `continue`, `debugger`, `default`, `delete`, `do`, `else`, `export`, `extends`, `finally`, `for`, `from` (in module declarations), `function`, `get` (of getters), `if`, `import`, `in`, `instanceof`, `let`, `new`, `of` (in for-of statements), `return`, `set` (of setters), `static`, `super`, `switch`, `this`, `throw`, `try`, `typeof`, `var`, `void`, `while`, `with`, and `yield`. This rule is designed carefully not to conflict with other spacing rules: it does not apply to spacing where other rules report problems.
 
-The following patterns are considered problems:
+## Options
+
+This rule has an object option:
+
+* `"before": true` (default) requires at least one space before keywords
+* `"before": false` disallows spaces before keywords
+* `"after": true` (default) requires at least one space after keywords
+* `"after": false` disallows spaces after keywords
+* `"overrides"` allows overriding spacing style for specified keywords
+
+### before
+
+Examples of **incorrect** code for this rule with the default `{ "before": true }` option:
 
 ```js
-/*eslint keyword-spacing: "error"*/
-/*eslint-env es6*/
+/*eslint keyword-spacing: ["error", { "before": true }]*/
 
-if(foo){
+if (foo) {
     //...
 }else if (bar) {
     //...
-} else{
+}else {
     //...
 }
-
-try{
-    //...
-}catch(e) {
-    //...
-}
-
-switch (a) {
-    case+1:
-        break;
-}
-
-function foo() {
-    return[0, 1, 2];
-}
-
-for (let[a, b]of[foo, bar, baz]) {
-    //...
-}
-
-let obj = {
-    get[FOO]() {
-        //...
-    },
-    set[FOO](value) {
-        //...
-    }
-};
-
-import{foo}from"foo";
-import*as bar from "foo";
 ```
 
-The following patterns are considered not problems:
+Examples of **correct** code for this rule with the default `{ "before": true }` option:
 
 ```js
-/*eslint keyword-spacing: "error"*/
+/*eslint keyword-spacing: ["error", { "before": true }]*/
 /*eslint-env es6*/
 
 if (foo) {
@@ -81,58 +61,112 @@ if (foo) {
     //...
 }
 
-try {
-    //...
-} catch (e) {
-    //...
-}
-
-switch (a) {
-    case +1:
-        break;
-}
-
-function foo() {
-    return [0, 1, 2];
-}
-
-for (let [a, b] of [foo, bar, baz]) {
-    //...
-}
-
-let obj = {
-    get [FOO]() {
-        //...
-    },
-    set [FOO](value) {
-        //...
-    }
-};
-
-import {foo} from "foo";
-import * as bar from "foo";
-```
-
-This rule is designed carefully to not conflict with other spacing rules.
-Basically this rule ignores usage of spacing at places that other rules are catching.
-So the following patterns are considered not problems.
-
-```js
-/*eslint keyword-spacing: "error"*/
-/*eslint-env es6*/
-
-// not conflict with `array-bracket-spacing`
+// no conflict with `array-bracket-spacing`
 let a = [this];
 let b = [function() {}];
 
-// not conflict with `arrow-spacing`
-let a = () =>this.foo;
+// no conflict with `arrow-spacing`
+let a = ()=> this.foo;
 
-// not conflict with `block-spacing`
+// no conflict with `block-spacing`
 {function foo() {}}
 
-// not conflict with `comma-spacing`
+// no conflict with `comma-spacing`
 let a = [100,this.foo, this.bar];
+
+// not conflict with `computed-property-spacing`
+obj[this.foo] = 0;
+
+// no conflict with `generator-star-spacing`
+function *foo() {}
+
+// no conflict with `key-spacing`
+let obj = {
+    foo:function() {}
+};
+
+// no conflict with `object-curly-spacing`
+let obj = {foo: this};
+
+// no conflict with `semi-spacing`
+let a = this;function foo() {}
+
+// no conflict with `space-in-parens`
+(function () {})();
+
+// no conflict with `space-infix-ops`
+if ("foo"in {foo: 0}) {}
+if (10+this.foo<= this.bar) {}
+
+// no conflict with `jsx-curly-spacing`
+let a = <A foo={this.foo} bar={function(){}} />
+```
+
+Examples of **incorrect** code for this rule with the `{ "before": false }` option:
+
+```js
+/*eslint keyword-spacing: ["error", { "before": false }]*/
+
+if (foo) {
+    //...
+} else if (bar) {
+    //...
+} else {
+    //...
+}
+```
+
+Examples of **correct** code for this rule with the `{ "before": false }` option:
+
+```js
+/*eslint keyword-spacing: ["error", { "before": false }]*/
+
+if (foo) {
+    //...
+}else if (bar) {
+    //...
+}else {
+    //...
+}
+```
+
+### after
+
+Examples of **incorrect** code for this rule with the default `{ "after": true }` option:
+
+```js
+/*eslint keyword-spacing: ["error", { "after": true }]*/
+
+if(foo) {
+    //...
+} else if(bar) {
+    //...
+} else{
+    //...
+}
+```
+
+Examples of **correct** code for this rule with the default `{ "after": true }` option:
+
+```js
+/*eslint keyword-spacing: ["error", { "after": true }]*/
+
+if (foo) {
+    //...
+} else if (bar) {
+    //...
+} else {
+    //...
+}
+
+// not conflict with `array-bracket-spacing`
+let a = [this];
+
+// not conflict with `arrow-spacing`
+let a = ()=> this.foo;
+
+// not conflict with `comma-spacing`
+let a = [100, this.foo, this.bar];
 
 // not conflict with `computed-property-spacing`
 obj[this.foo] = 0;
@@ -159,149 +193,78 @@ let obj = {foo: this};
 let a = this;function foo() {}
 
 // not conflict with `space-before-function-paren`
-// not conflict with `space-in-parens`
-(function() {})();
+function() {}
 
-// not conflict with `space-infix-ops`
+// no conflict with `space-infix-ops`
 if ("foo"in{foo: 0}) {}
-if (10+this.foo <=this.bar) {}
+if (10+this.foo<= this.bar) {}
 
-// not conflict with `space-unary-ops`
+// no conflict with `space-unary-ops`
 function* foo(a) {
     return yield+a;
 }
 
-// not conflict with `yield-star-spacing`
+// no conflict with `yield-star-spacing`
 function* foo(a) {
     return yield* a;
 }
 
-// not conflict with `jsx-curly-spacing`
+// no conflict with `jsx-curly-spacing`
 let a = <A foo={this.foo} bar={function(){}} />
 ```
 
+Examples of **incorrect** code for this rule with the `{ "after": false }` option:
 
-## Options
+```js
+/*eslint keyword-spacing: ["error", { "after": false }]*/
 
-This rule has 3 options.
-
-```json
-{
-    "keyword-spacing": ["error", {"before": true, "after": true, "overrides": {}}]
+if (foo) {
+    //...
+} else if (bar) {
+    //...
+} else {
+    //...
 }
 ```
 
-- `"before"` (`boolean`, default is `true`) -
-  This option specifies usage of spacing before the keywords.
-  If `true` then the keywords must be preceded by at least one space.
-  Otherwise, no spaces will be allowed before the keywords (if possible).
-- `"after"` (`boolean`, default is `true`) -
-  This option specifies usage of spacing after the keywords.
-  If `true` then the keywords must be followed by at least one space.
-  Otherwise, no spaces will be allowed after the keywords (if possible).
-- `"overrides"` (`object`, default is `{}`) -
-  This option specifies overwriting usage of spacing for each keyword.
-  For Example:
-
-  ```json
-  {
-      "keyword-spacing": ["error", {"overrides": {
-          "if": {"after": false},
-          "for": {"after": false},
-          "while": {"after": false}
-      }}]
-  }
-  ```
-
-  In this case, no spaces will be allowed only after `if`, `for`, and `while`.
-
-The following patterns are considered problems when configured `{"before": false, "after": false}`:
+Examples of **correct** code for this rule with the `{ "after": false }` option:
 
 ```js
-/*eslint keyword-spacing: ["error", {before: false, after: false}]*/
-/*eslint-env es6*/
-
-if (foo){
-    //...
-} else if(bar) {
-    //...
-}else {
-    //...
-}
-
-try {
-    //...
-} catch (e) {
-    //...
-}
-
-switch(a) {
-    case +1:
-        break;
-}
-
-function foo() {
-    return [0, 1, 2];
-}
-
-for (let [a, b] of [foo, bar, baz]) {
-    //...
-}
-
-let obj = {
-    get [FOO]() {
-        //...
-    },
-    set [FOO](value) {
-        //...
-    }
-};
-
-import {foo} from "foo";
-import * as bar from"foo";
-```
-
-The following patterns are considered not problems when configured `{"before": false, "after": false}`:
-
-```js
-/*eslint keyword-spacing: ["error", {before: false, after: false}]*/
-/*eslint-env es6*/
+/*eslint keyword-spacing: ["error", { "after": false }]*/
 
 if(foo) {
     //...
-}else if(bar) {
+} else if(bar) {
     //...
-}else{
+} else{
+    //...
+}
+```
+
+### overrides
+
+Examples of **correct** code for this rule with the `{ "overrides": { "if": { "after": false }, "for": { "after": false }, "while": { "after": false } } }` option:
+
+```js
+/*eslint keyword-spacing: ["error", { "overrides": {
+  "if": { "after": false },
+  "for": { "after": false },
+  "while": { "after": false }
+} }]*/
+
+if(foo) {
+    //...
+} else if(bar) {
+    //...
+} else {
     //...
 }
 
-try{
-    //...
-}catch(e) {
-    //...
-}
+for(;;);
 
-switch(a) {
-    case+1:
-        break;
+while(true) {
+  //...
 }
-
-function foo() {
-    return[0, 1, 2];
-}
-
-for(let[a, b]of[foo, bar, baz]) {
-    //...
-}
-
-let obj = {
-    get[FOO]() {
-        //...
-    },
-    set[FOO](value) {
-        //...
-    }
-};
 ```
 
 ## When Not To Use It

--- a/docs/rules/linebreak-style.md
+++ b/docs/rules/linebreak-style.md
@@ -1,4 +1,4 @@
-# Enforce linebreak style (linebreak-style)
+# enforce consistent linebreak style (linebreak-style)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -8,19 +8,23 @@ different line endings are written by either of the mentioned (might especially 
 The linebreaks (new lines) used in windows operating system are usually _carriage returns_ (CR) followed by a _line feed_ (LF) making it a _carriage return line feed_ (CRLF)
 whereas Linux and Unix use a simple _line feed_ (LF). The corresponding _control sequences_ are `"\n"` (for LF) and `"\r\n"` for (CRLF).
 
-Many versioning systems (like git and subversion) can automatically ensure the correct ending. However to cover all contingencies you can activate this rule.
+Many versioning systems (like git and subversion) can automatically ensure the correct ending. However to cover all contingencies, you can activate this rule.
 
 ## Rule Details
 
-This rule aims to ensure having consistent line endings independent of operating system, VCS or editor used across your codebase.
+This rule enforces consistent line endings independent of operating system, VCS, or editor used across your codebase.
 
-The following patterns are considered problems:
+### Options
 
-```js
-/*eslint linebreak-style: "error"*/
+This rule has a string option:
 
-var a = 'a'; // \r\n
-```
+* `"unix"` (default) enforces the usage of Unix line endings: `\n` for LF.
+* `"windows"` enforces the usage of Windows line endings: `\r\n` for CRLF.
+
+
+### unix
+
+Examples of **incorrect** code for this rule with the default `"unix"` option:
 
 ```js
 /*eslint linebreak-style: ["error", "unix"]*/
@@ -29,13 +33,7 @@ var a = 'a'; // \r\n
 
 ```
 
-```js
-/*eslint linebreak-style: ["error", "windows"]*/
-
-var a = 'a';// \n
-```
-
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"unix"` option:
 
 ```js
 /*eslint linebreak-style: ["error", "unix"]*/
@@ -43,10 +41,22 @@ The following patterns are not considered problems:
 var a = 'a', // \n
     b = 'b'; // \n
 // \n
-function foo(params) {// \n
+function foo(params) { // \n
     // do stuff \n
 }// \n
 ```
+
+### windows
+
+Examples of **incorrect** code for this rule with the `"windows"` option:
+
+```js
+/*eslint linebreak-style: ["error", "windows"]*/
+
+var a = 'a'; // \n
+```
+
+Examples of **correct** code for this rule with the `"windows"` option:
 
 ```js
 /*eslint linebreak-style: ["error", "windows"]*/
@@ -58,10 +68,6 @@ function foo(params) { // \r\n
     // do stuff \r\n
 } // \r\n
 ```
-
-## Options
-
-This rule may take one option which is either `unix` (LF) or `windows` (CRLF). When omitted `unix` is assumed.
 
 ## When Not To Use It
 

--- a/docs/rules/lines-around-comment.md
+++ b/docs/rules/lines-around-comment.md
@@ -1,115 +1,41 @@
-# Enforce empty lines around comments (lines-around-comment)
+# require empty lines around comments (lines-around-comment)
 
 Many style guides require empty lines before or after comments. The primary goal
 of these rules is to make the comments easier to read and improve readability of the code.
 
 ## Rule Details
 
-This rule allows you to specify whether an empty line should be found
-before or after a comment. It can be enabled separately for both block (`/*`)
-and line (`//`) comments, and does not apply to comments that appear on the same
-line as code.
-
-
-By default an empty line is required above a block comment,
-such as in the following example:
-
-```js
-var x = 0;
-
-/**
- * The vertical position.
- */
-var y = 10;
-```
-
-The following would *not* pass the rule:
-
-```js
-var x = 0;
-/* the vertical position */
-var y = 10;
-```
-
-### Inline comments
-
-Inline comments are always excluded from the rule.
-
-The following would be acceptable:
-
-```js
-/*eslint lines-around-comment: "error"*/
-
-var x = 0;
-var y = 10; /* the vertical position */
-```
-
-Empty lines are also not required at the beginning or end of a file.
+This rule requires empty lines before and/or after comments. It can be enabled separately for both block (`/*`) and line (`//`) comments. This rule does not apply to comments that appear on the same line as code and does not require empty lines at the beginning or end of a file. Empty lines are also not required at the beginning or end of a file.
 
 ## Options
 
-This rule has 10 options.
+This rule has an object option:
 
-2 options for block comments:
+* `"beforeBlockComment": true` (default) requires an empty line before block comments
+* `"beforeBlockComment": false` disallows an empty line before block comments
+* `"afterBlockComment": true` requires an empty line after block comments
+* `"beforeLineComment": true` requires an empty line before line comments
+* `"afterLineComment": true` requires an empty line after line comments
+* `"allowBlockStart": true` allows comments to appear at the start of block statements
+* `"allowBlockEnd": true` allows comments to appear at the end of block statements
+* `"allowObjectStart": true` allows comments to appear at the start of object literals
+* `"allowObjectEnd": true` allows comments to appear at the end of object literals
+* `"allowArrayStart": true` allows comments to appear at the start of array literals
+* `"allowArrayEnd": true` allows comments to appear at the end of array literals
 
-* `beforeBlockComment` (enabled by default)
-* `afterBlockComment`
+### beforeBlockComment
 
-2 options for line comments:
-
-* `beforeLineComment`
-* `afterLineComment`
-
-6 options for exceptions:
-
-* `allowBlockStart`
-* `allowBlockEnd`
-* `allowObjectStart`
-* `allowObjectEnd`
-* `allowArrayStart`
-* `allowArrayEnd`
-
-Any combination of these rules may be applied at the same time.
-
-
-```json
-{
-    "lines-around-comment": ["error", { "beforeBlockComment": true, "beforeLineComment": true }]
-}
-```
-
-When set to `false` the option is simply ignored.
-
-
-### Block Comments
-
-Block comments are any comment that start with `/*` and need not extend to multiple lines.
-
-With both `beforeBlockComment` and `afterBlockComment` set to `true` the following code
-would not warn:
+Examples of **incorrect** code for this rule with the default `{ "beforeBlockComment": true }` option:
 
 ```js
-/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "afterBlockComment": true }]*/
-
-var night = "long";
-
-/* what a great and wonderful day */
-
-var day = "great"
-```
-
-This however would provide 2 warnings:
-
-```js
-/*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "afterBlockComment": true }]*/
+/*eslint lines-around-comment: ["error", { "beforeBlockComment": true }]*/
 
 var night = "long";
 /* what a great and wonderful day */
 var day = "great"
 ```
 
-With only `beforeBlockComment` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the default `{ "beforeBlockComment": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true }]*/
@@ -120,35 +46,44 @@ var night = "long";
 var day = "great"
 ```
 
-But this would cause 1 warning:
+### afterBlockComment
+
+Examples of **incorrect** code for this rule with the `{ "afterBlockComment": true }` option:
 
 ```js
-/*eslint lines-around-comment: ["error", { "beforeBlockComment": true }]*/
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true }]*/
 
 var night = "long";
+
 /* what a great and wonderful day */
 var day = "great"
 ```
 
-### Line Comments
-
-Line comments are any comments that start with `//`.
-
-With both `beforeLineComment` and `afterLineComment` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "afterBlockComment": true }` option:
 
 ```js
-/*eslint lines-around-comment: ["error", { "beforeLineComment": true, "afterLineComment": true }]*/
+/*eslint lines-around-comment: ["error", { "afterBlockComment": true }]*/
 
 var night = "long";
 
+/* what a great and wonderful day */
+
+var day = "great"
+```
+
+### beforeLineComment
+
+Examples of **incorrect** code for this rule with the `{ "beforeLineComment": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "beforeLineComment": true }]*/
+
+var night = "long";
 // what a great and wonderful day
-
 var day = "great"
 ```
 
-With only `beforeLineComment` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "beforeLineComment": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true }]*/
@@ -159,12 +94,32 @@ var night = "long";
 var day = "great"
 ```
 
-### `allowBlockStart`
+### afterLineComment
 
-When this option is set to `true`, it allows the comment to be present at the start of any block statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
+Examples of **incorrect** code for this rule with the `{ "afterLineComment": true }` option:
 
-With both `beforeLineComment` and `allowBlockStart` set to `true` the following code
-would not warn:
+```js
+/*eslint lines-around-comment: ["error", { "afterLineComment": true }]*/
+
+var night = "long";
+// what a great and wonderful day
+var day = "great"
+```
+
+Examples of **correct** code for this rule with the `{ "afterLineComment": true }` option:
+
+```js
+/*eslint lines-around-comment: ["error", { "afterLineComment": true }]*/
+
+var night = "long";
+// what a great and wonderful day
+
+var day = "great"
+```
+
+### allowBlockStart
+
+Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowBlockStart": true }` options:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowBlockStart": true }]*/
@@ -176,8 +131,7 @@ function foo(){
 }
 ```
 
-With both `beforeBlockComment` and `allowBlockStart` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowBlockStart": true }` options:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowBlockStart": true }]*/
@@ -189,12 +143,9 @@ function foo(){
 }
 ```
 
-### `allowBlockEnd`
+### allowBlockEnd
 
-When this option is set to `true`, it allows the comment to be present at the end of any block statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
-
-With both `afterLineComment` and `allowBlockEnd` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowBlockEnd": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowBlockEnd": true }]*/
@@ -206,8 +157,7 @@ function foo(){
 }
 ```
 
-With both `afterBlockComment` and `allowBlockEnd` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowBlockEnd": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowBlockEnd": true }]*/
@@ -220,12 +170,9 @@ function foo(){
 }
 ```
 
-### `allowObjectStart`
+### allowObjectStart
 
-When this option is set to `true`, it allows the comment to be present at the start of any object-like statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
-
-With both `beforeLineComment` and `allowObjectStart` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowObjectStart": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowObjectStart": true }]*/
@@ -246,8 +193,7 @@ const {
 } = {day: "great"};
 ```
 
-With both `beforeBlockComment` and `allowObjectStart` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowObjectStart": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowObjectStart": true }]*/
@@ -268,12 +214,9 @@ const {
 } = {day: "great"};
 ```
 
-### `allowObjectEnd`
+### allowObjectEnd
 
-When this option is set to `true`, it allows the comment to be present at the end of any object-like statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
-
-With both `afterLineComment` and `allowObjectEnd` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowObjectEnd": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowObjectEnd": true }]*/
@@ -294,8 +237,7 @@ const {
 } = {day: "great"};
 ```
 
-With both `afterBlockComment` and `allowObjectEnd` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowObjectEnd": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowObjectEnd": true }]*/
@@ -319,12 +261,9 @@ const {
 } = {day: "great"};
 ```
 
-### `allowArrayStart`
+### allowArrayStart
 
-When this option is set to `true`, it allows the comment to be present at the start of any array-like statement without any space above it. This option can be useful when combined with options `beforeLineComment` and `beforeBlockComment` only.
-
-With both `beforeLineComment` and `allowArrayStart` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "beforeLineComment": true, "allowArrayStart": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeLineComment": true, "allowArrayStart": true }]*/
@@ -341,8 +280,7 @@ const [
 ] = ["great", "not great"];
 ```
 
-With both `beforeBlockComment` and `allowArrayStart` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "beforeBlockComment": true, "allowArrayStart": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "beforeBlockComment": true, "allowArrayStart": true }]*/
@@ -359,12 +297,9 @@ const [
 ] = ["great", "not great"];
 ```
 
-### `allowArrayEnd`
+### allowArrayEnd
 
-When this option is set to `true`, it allows the comment to be present at the end of any array-like statement without any space below it. This option can be useful when combined with options `afterLineComment` and `afterBlockComment` only.
-
-With both `afterLineComment` and `allowArrayEnd` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "afterLineComment": true, "allowArrayEnd": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterLineComment": true, "allowArrayEnd": true }]*/
@@ -381,8 +316,7 @@ const [
 ] = ["great", "not great"];
 ```
 
-With both `afterBlockComment` and `allowArrayEnd` set to `true` the following code
-would not warn:
+Examples of **correct** code for this rule with the `{ "afterBlockComment": true, "allowArrayEnd": true }` option:
 
 ```js
 /*eslint lines-around-comment: ["error", { "afterBlockComment": true, "allowArrayEnd": true }]*/
@@ -403,11 +337,9 @@ const [
 
 ## When Not To Use It
 
-Many people enjoy a terser code style and don't mind comments bumping up against code. If you
-fall into that category this rule is not for you.
+Many people enjoy a terser code style and don't mind comments bumping up against code. If you fall into that category this rule is not for you.
 
 ## Related Rules
 
 * [space-before-blocks](space-before-blocks.md)
 * [spaced-comment](spaced-comment.md)
-* [spaced-line-comment](spaced-line-comment.md) (deprecated)

--- a/docs/rules/max-depth.md
+++ b/docs/rules/max-depth.md
@@ -1,67 +1,58 @@
-# Limit Maximum Depth (max-depth)
+# enforce a maximum depth that blocks can be nested (max-depth)
 
-The `max-depth` rule allows you to specify the maximum depth blocks can be nested.
-
-```js
-function foo() {
-  for (;;) { // Nested 1 deep.
-    if (true) { // Nested 2 deep.
-      if (true) { // Nested 3 deep.
-
-      }
-    }
-  }
-}
-```
+Many developers consider code difficult to read if blocks are nested beyond a certain depth.
 
 ## Rule Details
 
-This rule aims to reduce the complexity of your code by allowing you to configure the maximum depth blocks can be nested in a function. As such, it will warn when blocks are nested too deeply.
+This rule enforces a maximum depth that blocks can be nested to reduce code complexity.
 
 ## Options
 
-The default depth above which this rule will warn is `4`.  You can configure the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error with a maximum depth of 10:
+This rule has a number or object option:
 
-```json
-"max-depth": ["error", 10]
+* `"max"` (default `4`) enforces a maximum depth that blocks can be nested
 
-// or you can use an object property
+**Deprecated:** The object property `maximum` is deprecated; please use the object property `max` instead.
 
-"max-depth": ["error", {"max": 10}]
-```
+### max
 
-**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `{ "max": 4 }` option:
 
 ```js
-/*eslint max-depth: ["error", 2]*/
+/*eslint max-depth: ["error", 4]*/
+/*eslint-env es6*/
 
 function foo() {
-  for (;;) {
-    if (true) {
-      if (true) {
-
-      }
+    for (;;) { // Nested 1 deep
+        let val = () => (param) => { // Nested 2 deep
+            if (true) { // Nested 3 deep
+                if (true) { // Nested 4 deep
+                    if (true) { // Nested 5 deep
+                    }
+                }
+            }
+        };
     }
-  }
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "max": 4 }` option:
 
 ```js
-/*eslint max-depth: ["error", 2]*/
+/*eslint max-depth: ["error", 4]*/
+/*eslint-env es6*/
 
 function foo() {
-  for (;;) {
-    if (true) {
-
+    for (;;) { // Nested 1 deep
+        let val = () => (param) => { // Nested 2 deep
+           if (true) { // Nested 3 deep
+                if (true) { // Nested 4 deep
+                }
+            }
+        };
     }
-  }
 }
 ```
-
 
 ## Related Rules
 

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -1,71 +1,125 @@
-# Limit Maximum Length of Line (max-len)
+# enforce a maximum line length (max-len)
 
 Very long lines of code in any language can be difficult to read. In order to aid in readability and maintainability many coders have developed a convention to limit lines of code to X number of characters (traditionally 80 characters).
 
 ```js
-// max-len: ["error", 80, 4]; // maximum length of 80 characters
-var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" }; // too long
+var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" }; // very long
 ```
-
 
 ## Rule Details
 
-This rule is aimed at increasing code readability and maintainability by enforcing a line length convention. As such it will warn on lines that exceed the configured maximum.
+This rule enforces a maximum line length to increase code readability and maintainability.
 
 **Note:** This rule calculates the length of a line via code points, not characters. That means if you use a double-byte character in your code, it will count as 2 code points instead of 1, and 2 will be used to calculate line length. This is a technical limitation of JavaScript that is made easier with ES2015, and we will look to update this when ES2015 is available in Node.js.
 
-The following patterns are considered problems:
+## Options
+
+This rule has a number or object option:
+
+* `"code"` (default `80`) enforces a maximum line length
+* `"tabWidth"` (default `4`) specifies the character width for tab characters
+* `"comments"` enforces a maximum line length for comments; defaults to value of `code`
+* `"ignorePattern"` ignores lines matching a regular expression; can only match a single line and need to be double escaped when written in YAML or JSON
+* `"ignoreComments": true` ignores all trailing comments and comments on their own line
+* `"ignoreTrailingComments": true` ignores only trailing comments
+* `"ignoreUrls": true` ignores lines that contain a URL
+
+### code
+
+Examples of **incorrect** code for this rule with the default `{ "code": 80 }` option:
 
 ```js
-/*eslint max-len: ["error", 80, 4]*/ // maximum length of 80 characters
+/*eslint max-len: ["error", 80]*/
 
 var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficult": "to read" };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "code": 80 }` option:
 
 ```js
-/*eslint max-len: ["error", 80, 4]*/ // maximum length of 80 characters
+/*eslint max-len: ["error", 80]*/
 
 var foo = {
-    "bar": "This is a bar.",
-    "baz": {
-        "qux": "This is a qux"
-    },
-    "difficult": "to read"
+  "bar": "This is a bar.",
+  "baz": { "qux": "This is a qux" },
+  "easier": "to read"
 };
 ```
 
-## Options
+### tabWidth
 
-The `max-len` rule supports the following options:
+Examples of **incorrect** code for this rule with the default `{ "tabWidth": 4 }` option:
 
-`code`: The total number of characters allowed on each line of code. This character count includes indentation. Defaults to 80.
+```js
+/*eslint max-len: ["error", 80, 4]*/
 
-`comments`: The total number of characters allowed on a line of comments (e.g. no code on the line). If not specified, `code` is used for comment lines.
-
-`tabWidth`: The character count to use whenever a tab character is encountered. Defaults to 4.
-
-`ignoreComments`: Ignores all trailing comments and comments on their own line. For example, `function foo(/*string*/ bar) { /* ... */ }` isn't collapsed.
-
-`ignoreTrailingComments`: Only ignores comments that are trailing source.
-
-`ignoreUrls`: Ignores lines that contain a URL.
-
-`ignorePattern`: Ignores lines matching a regular express, such as `^\\s*var\\s.+=\\s*require\\s*\\(`. Be aware that regular expressions can only match a single line and need to be doubly escaped when written in YAML or JSON.
-
-Optionally, you may specify `code` and `tabWidth` as integers before the options object:
-
-```json
-"max-len": ["error", 80, 4, {"ignoreUrls": true}]
+\t  \t  var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" } };
 ```
 
-is equivalent to
+Examples of **correct** code for this rule with the default `{ "tabWidth": 4 }` option:
 
-```json
-"max-len": ["error", {"code": 80, "tabWidth": 4, "ignoreUrls": true}]
+```js
+/*eslint max-len: ["error", 80, 4]*/
+
+\t  \t  var foo = {
+\t  \t  \t  \t  "bar": "This is a bar.",
+\t  \t  \t  \t  "baz": { "qux": "This is a qux" }
+\t  \t  };
 ```
 
+### comments
+
+Examples of **incorrect** code for this rule with the `{ "comments": 65 }` option:
+
+```js
+/*eslint max-len: ["error", { "comments": 65 }]*/
+
+/**
+ * This is a comment that violates the maximum line length we have specified
+**/
+```
+
+### ignoreComments
+
+Examples of **correct** code for this rule with the `{ "ignoreComments": true }` option:
+
+```js
+/*eslint max-len: ["error", { "ignoreComments": true }]*/
+
+/**
+ * This is a really really really really really really really really really long comment
+**/
+```
+
+### ignoreTrailingComments
+
+Examples of **correct** code for this rule with the `{ "ignoreTrailingComments": true }` option:
+
+```js
+/*eslint max-len: ["error", { "ignoreTrailingComments": true }]*/
+
+var foo = 'bar'; // This is a really really really really really really really long comment
+```
+
+### ignoreUrls
+
+Examples of **correct** code for this rule with the `{ "ignoreUrls": true }` option:
+
+```js
+/*eslint max-len: ["error", { "ignoreUrls": true }]*/
+
+var url = 'https://www.example.com/really/really/really/really/really/really/really/long';
+```
+
+### ignorePattern
+
+Examples of **correct** code for this rule with the `{ "ignorePattern": true }` option:
+
+```js
+/*eslint max-len: ["error", { "ignorePattern": "^\\s*var\\s.+=\\s*require\\s*\\(/" }]*/
+
+var dep = require('really/really/really/really/really/really/really/really/long/module');
+```
 
 ## Related Rules
 

--- a/docs/rules/max-nested-callbacks.md
+++ b/docs/rules/max-nested-callbacks.md
@@ -1,4 +1,4 @@
-# Set Maximum Depth of Nested Callbacks (max-nested-callbacks)
+# enforce a maximum depth that callbacks can be nested (max-nested-callbacks)
 
 Many JavaScript libraries use the callback pattern to manage asynchronous operations. A program of any complexity will most likely need to manage several asynchronous operations at various levels of concurrency. A common pitfall that is easy to fall into is nesting callbacks, which makes code more difficult to read the deeper the callbacks are nested.
 
@@ -16,59 +16,55 @@ foo(function () {
 
 ## Rule Details
 
-This rule is aimed at increasing code clarity by discouraging deeply nesting callbacks. As such, it will warn when callbacks are nested deeper than the specified limit.
+This rule enforces a maximum depth that callbacks can be nested to increase code clarity.
 
 ## Options
 
-The default max depth for this rule is 10. You can define the depth as an option by using the second argument in your configuration. For example, this sets the rule as an error (code is 2) with a maximum depth of 3:
+This rule has a number or object option:
 
-```json
-"max-nested-callbacks": ["error", 3]
+* `"max"` (default `10`) enforces a maximum depth that callbacks can be nested
 
-// or you can use an object property
+**Deprecated:** The object property `maximum` is deprecated; please use the object property `max` instead.
 
-"max-nested-callbacks": ["error", {"max": 3}]
-```
+### max
 
-**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{ "max": 3 }` option:
 
 ```js
 /*eslint max-nested-callbacks: ["error", 3]*/
 
-foo(function () {
-    bar(function () {
-        baz(function() {
-            qux(function () {
-
+foo1(function() {
+    foo2(function() {
+        foo3(function() {
+            foo4(function() {
+                // Do something
             });
         });
     });
 });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "max": 3 }` option:
 
 ```js
 /*eslint max-nested-callbacks: ["error", 3]*/
 
-foo(handleFoo);
+foo1(handleFoo1);
 
-function handleFoo (){
-    bar(handleBar);
+function handleFoo1() {
+    foo2(handleFoo2);
 }
 
-function handleBar() {
-    baz(handleBaz);
+function handleFoo2() {
+    foo3(handleFoo3);
 }
 
-function handleBaz() {
-    qux(handleQux);
+function handleFoo3() {
+    foo4(handleFoo4);
 }
 
-function handleQux() {
-
+function handleFoo4() {
+    foo5();
 }
 ```
 

--- a/docs/rules/max-params.md
+++ b/docs/rules/max-params.md
@@ -1,4 +1,4 @@
-# Limit Maximum Number of Parameters (max-params)
+# enforce a maximum number of parameters in `function` definitions (max-params)
 
 Functions that take numerous parameters can be difficult to read and write because it requires the memorization of what each parameter is, its type, and the order they should appear in. As a result, many coders adhere to a convention that caps the number of parameters a function can take.
 
@@ -10,42 +10,47 @@ function foo (bar, baz, qux, qxx) { // four parameters, may be too many
 
 ## Rule Details
 
-This rule is aimed at making functions easier to read and write by capping the number of formal arguments a function can accept. As such it will warn when it encounters a function that accepts more than the configured maximum number of parameters.
+This rule enforces a maximum number of parameters allowed in function definitions.
 
-The following patterns are considered problems:
+## Options
+
+This rule has a number or object option:
+
+* `"max"` (default `3`) enforces a maximum number of parameters in function definitions
+
+**Deprecated:** The object property `maximum` is deprecated; please use the object property `max` instead.
+
+### max
+
+Examples of **incorrect** code for this rule with the default `{ "max": 3 }` option:
 
 ```js
 /*eslint max-params: ["error", 3]*/
+/*eslint-env es6*/
 
 function foo (bar, baz, qux, qxx) {
     doSomething();
 }
+
+let foo = (bar, baz, qux, qxx) => {
+    doSomething();
+};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "max": 4 }` option:
 
 ```js
 /*eslint max-params: ["error", 3]*/
+/*eslint-env es6*/
 
 function foo (bar, baz, qux) {
     doSomething();
 }
+
+let foo = (bar, baz, qux) => {
+    doSomething();
+};
 ```
-
-Optionally, you may specify a `max` object property:
-
-```json
-"max-params": ["error", 2]
-```
-
-is equivalent to
-
-```json
-"max-params": ["error", {"max": 2}]
-```
-
-**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
-
 
 ## Related Rules
 

--- a/docs/rules/max-statements.md
+++ b/docs/rules/max-statements.md
@@ -1,4 +1,4 @@
-# Limit Maximum Number of Statements (max-statements)
+# enforce a maximum number of statements allowed in `function` blocks (max-statements)
 
 The `max-statements` rule allows you to specify the maximum number of statements allowed in a function.
 
@@ -12,40 +12,96 @@ function foo() {
 
 ## Rule Details
 
-This rule allows you to configure the maximum number of statements allowed in a function.  The default is 10.
+This rule enforces a maximum number of statements allowed in function blocks.
 
 ## Options
 
-There is an additional optional argument to ignore top level functions.
+This rule has a number or object option:
 
-```json
-"max-statements": ["error", 10, {"ignoreTopLevelFunctions": true}]
+* `"max"` (default `10`) enforces a maximum number of statements allows in function blocks
 
-// or you can use an object property to set the maximum
+**Deprecated:** The object property `maximum` is deprecated; please use the object property `max` instead.
 
-"max-statements": ["error", {"max": 10}, {"ignoreTopLevelFunctions": true}]
-```
+This rule has an object option:
 
-**Deprecated:** the object property `maximum` is deprecated. Please use the property `max` instead.
+* `"ignoreTopLevelFunctions": true` ignores top-level functions
 
-The following patterns are considered problems:
+### max
+
+Examples of **incorrect** code for this rule with the default `{ "max": 10 }` option:
 
 ```js
-/*eslint max-statements: ["error", 2]*/  // Maximum of 2 statements.
-function foo() {
-  var bar = 1;
-  var baz = 2;
+/*eslint max-statements: ["error", 10]*/
+/*eslint-env es6*/
 
-  var qux = 3; // Too many.
+function foo() {
+  var foo1 = 1;
+  var foo2 = 2;
+  var foo3 = 3;
+  var foo4 = 4;
+  var foo5 = 5;
+  var foo6 = 6;
+  var foo7 = 7;
+  var foo8 = 8;
+  var foo9 = 9;
+  var foo10 = 10;
+
+  var foo11 = 11; // Too many.
 }
+
+let foo = () => {
+  var foo1 = 1;
+  var foo2 = 2;
+  var foo3 = 3;
+  var foo4 = 4;
+  var foo5 = 5;
+  var foo6 = 6;
+  var foo7 = 7;
+  var foo8 = 8;
+  var foo9 = 9;
+  var foo10 = 10;
+
+  var foo11 = 11; // Too many.
+};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "max": 10 }` option:
 
 ```js
-/*eslint max-statements: ["error", 2]*/  // Maximum of 2 statements.
+/*eslint max-statements: ["error", 10]*/
+/*eslint-env es6*/
+
 function foo() {
-  var bar = 1;
+  var foo1 = 1;
+  var foo2 = 2;
+  var foo3 = 3;
+  var foo4 = 4;
+  var foo5 = 5;
+  var foo6 = 6;
+  var foo7 = 7;
+  var foo8 = 8;
+  var foo9 = 9;
+  var foo10 = 10;
+  return function () {
+
+    // The number of statements in the inner function does not count toward the
+    // statement maximum.
+
+    return 42;
+  };
+}
+
+let foo = () => {
+  var foo1 = 1;
+  var foo2 = 2;
+  var foo3 = 3;
+  var foo4 = 4;
+  var foo5 = 5;
+  var foo6 = 6;
+  var foo7 = 7;
+  var foo8 = 8;
+  var foo9 = 9;
+  var foo10 = 10;
   return function () {
 
     // The number of statements in the inner function does not count toward the
@@ -56,14 +112,26 @@ function foo() {
 }
 ```
 
+### ignoreTopLevelFunctions
+
+Examples of additional **correct** code for this rule with the `{ "max": 10 }, { "ignoreTopLevelFunctions": true }` options:
+
 ```js
-/*eslint max-statements: ["error", 1, {ignoreTopLevelFunctions: true}]*/  // Maximum of 1 statement.
-(function() {
-  var bar = 1;
-  return function () {
-    return 42;
-  };
-})()
+/*eslint max-statements: ["error", 10, { "ignoreTopLevelFunctions": true }]*/
+
+function foo() {
+  var foo1 = 1;
+  var foo2 = 2;
+  var foo3 = 3;
+  var foo4 = 4;
+  var foo5 = 5;
+  var foo6 = 6;
+  var foo7 = 7;
+  var foo8 = 8;
+  var foo9 = 9;
+  var foo10 = 10;
+  var foo11 = 11;
+}
 ```
 
 ## Related Rules


### PR DESCRIPTION
Refactored and simplified a lot of examples to fit under the relevant options. Also removed one reference to a deprecated rule.

Where options have been deprecated, examples should no longer reference the deprecated option, nor should the option be listed among the available options. However, a note with the following format should be placed at the bottom of its respective option summary:

**Deprecated:** The object property `maximum` is deprecated; please use the object property `max` instead.