### PR TITLE
Update: Add options to ignore accessors in `require-jsdoc` (fixes #5891)

### DIFF
--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -26,7 +26,15 @@ This rule generates warnings for nodes that do not have JSDoc comments when they
 
 ## Options
 
-This rule accepts a `require` object with its properties as
+This rule has an object option:
+
+* `"require"` requires JSDoc comments for the specified nodes
+* `"ignoreGetters": true` ignores getters
+* `"ignoreSetters": true` ignores setters
+
+### require
+
+The `require` object accepts properties as:
 
 * `FunctionDeclaration` (default: `true`)
 * `ClassDeclaration` (default: `false`)
@@ -97,13 +105,53 @@ array.filter(function(item) {
 });
 
 /**
-* It returns 10
+* Test class
 */
 class Test{
     /**
     * returns the date
     */
     getDate(){}
+}
+```
+
+### ignoreGetters
+
+Examples of additional **correct** code for this rule with the `"ignoreGetters": true` option:
+
+```js
+/*eslint "require-jsdoc": ["error", {
+    "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true
+    },
+    "ignoreGetters": true
+}]*/
+/*eslint-env es6*/
+
+class Test {
+    get date() { return this._date; }
+}
+```
+
+### ignoreSetters
+
+Examples of additional **correct** code for this rule with the `"ignoreSetters": true` option:
+
+```js
+/*eslint "require-jsdoc": ["error", {
+    "require": {
+        "FunctionDeclaration": true,
+        "MethodDefinition": true,
+        "ClassDeclaration": true
+    },
+    "ignoreSetters": true
+}]*/
+/*eslint-env es6*/
+
+class Test {
+    set date(dt) { this._data = dt; }
 }
 ```
 

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -13,7 +13,11 @@ module.exports = function(context) {
         "MethodDefinition": false,
         "ClassDeclaration": false
     };
-    var options = lodash.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
+    var options = context.options[0] || {};
+    var includes = lodash.assign(DEFAULT_OPTIONS, options.require || {});
+
+    var ignoreGetters = options.ignoreGetters || false;
+    var ignoreSetters = options.ignoreSetters || false;
 
     /**
      * Report the error message
@@ -31,6 +35,16 @@ module.exports = function(context) {
      */
     function checkClassMethodJsDoc(node) {
         if (node.parent.type === "MethodDefinition") {
+            var kind = node.parent.kind;
+
+            if (ignoreGetters && kind === "get") {
+                return;
+            }
+
+            if (ignoreSetters && kind === "set") {
+                return;
+            }
+
             var jsdocComment = source.getJSDocComment(node);
 
             if (!jsdocComment) {
@@ -54,17 +68,17 @@ module.exports = function(context) {
 
     return {
         "FunctionDeclaration": function(node) {
-            if (options.FunctionDeclaration) {
+            if (includes.FunctionDeclaration) {
                 checkJsDoc(node);
             }
         },
         "FunctionExpression": function(node) {
-            if (options.MethodDefinition) {
+            if (includes.MethodDefinition) {
                 checkClassMethodJsDoc(node);
             }
         },
         "ClassDeclaration": function(node) {
-            if (options.ClassDeclaration) {
+            if (includes.ClassDeclaration) {
                 checkJsDoc(node);
             }
         }
@@ -89,6 +103,12 @@ module.exports.schema = [
                     }
                 },
                 "additionalProperties": false
+            },
+            "ignoreGetters": {
+                "type": "boolean"
+            },
+            "ignoreSetters": {
+                "type": "boolean"
             }
         },
         "additionalProperties": false

--- a/tests/lib/rules/require-jsdoc.js
+++ b/tests/lib/rules/require-jsdoc.js
@@ -165,6 +165,98 @@ ruleTester.run("require-jsdoc", rule, {
                     "ClassDeclaration": false
                 }
             }]
+        },
+        {
+            code:
+            "class A {\n" +
+            "    get member() {\n" +
+            "        return this.a;" +
+            "    }\n" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                "require": {
+                    "MethodDefinition": true
+                },
+                "ignoreGetters": true
+            }]
+        },
+        {
+            code:
+            "class A {\n" +
+            "    /**\n" +
+            "     * Description for setter.\n" +
+            "     * @param {object[]} xs - xs\n" +
+            "     */\n" +
+            "    set member(xs) {\n" +
+            "        this.a = xs;" +
+            "    }\n" +
+            "    get member() {\n" +
+            "        return this.a;" +
+            "    }\n" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                "require": {
+                    "MethodDefinition": true
+                },
+                "ignoreGetters": true
+            }]
+        },
+        {
+            code:
+            "class A {\n" +
+            "    set member(xs) {\n" +
+            "        this.a = xs;" +
+            "    }\n" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                "require": {
+                    "MethodDefinition": true
+                },
+                "ignoreSetters": true
+            }]
+        },
+        {
+            code:
+            "class A {\n" +
+            "    /**\n" +
+            "     * Description for getter.\n" +
+            "     */\n" +
+            "    get member() {\n" +
+            "        return this.a;" +
+            "    }\n" +
+            "    set member(xs) {\n" +
+            "        this.a = xs;" +
+            "    }\n" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                "require": {
+                    "MethodDefinition": true
+                },
+                "ignoreSetters": true
+            }]
+        },
+        {
+            code:
+            "class A {\n" +
+            "    get member() {\n" +
+            "        return this.a;" +
+            "    }\n" +
+            "    set member(xs) {\n" +
+            "        this.a = xs;" +
+            "    }\n" +
+            "}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{
+                "require": {
+                    "MethodDefinition": true
+                },
+                "ignoreGetters": true,
+                "ignoreSetters": true
+            }]
         }
     ],
 


### PR DESCRIPTION
Adds `ignoreGetters` and `ignoreSetters` options to `require-jsdoc`.

I'm up for discussion as to the implementation for this. I submitted a PR now since there was no feedback to the corresponding issue.

A possible alternative (and probably better, now that I think about it) implementation is to have an option to only require one JSDoc comment per pair, meaning if there exists only one or the other it would still require a JSDoc comment regardless of which one it is. Thoughts?

I didn't do a complete update to the rule doc to fit the latest guidelines since I haven't reached that batch of docs yet.