### PR TITLE
New: Add new rule `object-property-newline` (fixes #5667)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -173,6 +173,7 @@
         "newline-before-return": "off",
         "newline-per-chained-call": "off",
         "object-curly-spacing": ["off", "never"],
+        "object-property-newline": "off",
         "object-shorthand": "off",
         "one-var": "off",
         "one-var-declaration-per-line": "off",

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -200,6 +200,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 * [no-unneeded-ternary](no-unneeded-ternary.md): disallow ternary operators when simpler alternatives exist
 * [no-whitespace-before-property](no-whitespace-before-property.md): disallow whitespace before properties
 * [object-curly-spacing](object-curly-spacing.md): enforce consistent spacing inside braces (fixable)
+* [object-property-newline](object-property-newline.md): enforce placing object properties on separate lines
 * [one-var](one-var.md): enforce variables to be declared either together or separately in functions
 * [one-var-declaration-per-line](one-var-declaration-per-line.md): require or disallow newlines around `var` declarations
 * [operator-assignment](operator-assignment.md): require or disallow assignment operator shorthand where possible

--- a/docs/rules/object-property-newline.md
+++ b/docs/rules/object-property-newline.md
@@ -1,0 +1,89 @@
+# enforce placing object properties on separate lines (object-property-newline)
+
+While formatting preferences are very personal, a number of style guides require that object properties be placed on separate lines for better readability.
+
+Another argument in favor of this style is that it improves the readability of diffs when a property is changed:
+
+```diff
+// More readable
+ var obj = {
+     foo: "foo",
+-    bar: "bar",
++    bar: "bazz",
+     baz: "baz"
+ };
+```
+
+```diff
+// Less readable
+-var obj = { foo: "foo", bar: "bar", baz: "baz" };
++var obj = { foo: "foo", bar: "bazz", baz: "baz" };
+```
+
+## Rule Details
+
+This rule aims to maintain consistency of newlines between object properties.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint object-property-newline: "error"*/
+
+var obj = { foo: "foo", bar: "bar", baz: "baz" };
+
+var obj2 = {
+    foo: "foo", bar: "bar", baz: "baz"
+};
+
+var obj3 = {
+    foo: "foo", bar: "bar",
+    baz: "baz"
+};
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint object-property-newline: "error"*/
+
+var obj = {
+    foo: "foo",
+    bar: "bar",
+    baz: "baz"
+};
+```
+
+## Options
+
+This rule has an object option:
+
+* `"allowMultiplePropertiesPerLine"`: `true` allows all keys and values to be on the same line
+
+### allowMultiplePropertiesPerLine
+
+Examples of additional **correct** code for this rule with the `{ "allowMultiplePropertiesPerLine": true }` option:
+
+```js
+/*eslint object-property-newline: ["error", { "allowMultiplePropertiesPerLine": true }]*/
+
+var obj = { foo: "foo", bar: "bar", baz: "baz" };
+
+var obj2 = {
+    foo: "foo", bar: "bar", baz: "baz"
+};
+```
+
+## When Not To Use It
+
+You can turn this rule off if you are not concerned with the consistency of newlines between object properties.
+
+## Compatibility
+
+* **JSCS**: `requireObjectKeysOnNewLine`
+
+## Related Rules
+
+* [brace-style](brace-style.md)
+* [comma-dangle](comma-dangle.md)
+* [key-spacing](key-spacing.md)
+* [object-curly-spacing](object-curly-spacing.md)

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Rule to enforce placing object properties on separate lines.
+ * @author Vitor Balocco
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce placing object properties on separate lines",
+            category: "Stylistic Issues",
+            recommended: false
+        },
+
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    allowMultiplePropertiesPerLine: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
+    },
+
+    create: function(context) {
+        var allowSameLine = context.options[0] && Boolean(context.options[0].allowMultiplePropertiesPerLine);
+        var errorMessage = allowSameLine ?
+            "Object properties must go on a new line if they aren't all on the same line" :
+            "Object properties must go on a new line";
+
+        return {
+            ObjectExpression: function(node) {
+                var lastTokenOfPreviousValue, firstTokenOfCurrentKey;
+
+                if (allowSameLine) {
+                    if (node.properties.length > 1) {
+                        var firstToken = context.getFirstToken(node.properties[0].key);
+                        var lastToken = context.getLastToken(node.properties[node.properties.length - 1].value);
+
+                        if (firstToken.loc.end.line === lastToken.loc.start.line) {
+
+                            // All keys and values are on the same line
+                            return;
+                        }
+                    }
+                }
+
+                for (var i = 1; i < node.properties.length; i++) {
+                    lastTokenOfPreviousValue = context.getLastToken(node.properties[i - 1].value);
+                    firstTokenOfCurrentKey = context.getFirstToken(node.properties[i].key);
+
+                    if (lastTokenOfPreviousValue.loc.end.line === firstTokenOfCurrentKey.loc.start.line) {
+                        context.report({
+                            node: node,
+                            loc: firstTokenOfCurrentKey.loc.start,
+                            message: errorMessage
+                        });
+                    }
+                }
+            }
+        };
+    }
+};

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -1,0 +1,207 @@
+/**
+ * @fileoverview Rule to enforce placing object properties on separate lines.
+ * @author Vitor Balocco
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/object-property-newline"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run("object-property-newline", rule, {
+
+    valid: [
+
+        // default-case
+        { code: "var obj = {\nk1: 'val1',\nk2: 'val2',\nk3: 'val3',\nk4: 'val4'\n};" },
+        { code: "var obj = { k1: 'val1',\nk2: 'val2',\nk3: 'val3',\nk4: 'val4' };" },
+        { code: "var obj = { k1: 'val1' };" },
+        { code: "var obj = {\nk1: 'val1'\n};" },
+        { code: "var obj = {};" },
+        { code: "foo({ k1: 'val1',\nk2: 'val2' });" },
+        { code: "foo({\nk1: 'val1',\nk2: 'val2'\n});" },
+        { code: "foo({\na,\nb\n});", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo({\na,\nb,\n});", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo({\nbar() {},\nbaz\n});", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo({\n[bar]: 'baz',\nbaz \n})", parserOptions: { ecmaVersion: 6 } },
+
+        // allowMultiplePropertiesPerLine: true
+        { code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "var obj = {\nk1: 'val1', k2: 'val2', k3: 'val3'\n};", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "var obj = { k1: 'val1' };", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "var obj = {\nk1: 'val1'\n};", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "var obj = {};", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "foo({ k1: 'val1', k2: 'val2' });", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "foo({\nk1: 'val1', k2: 'val2'\n});", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "foo({ a, b });", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "foo({ bar() {}, baz });", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "foo({ [bar]: 'baz', baz })", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6 } }
+    ],
+
+    invalid: [
+
+        // default-case
+        {
+            code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };",
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 25
+                },
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 37
+                }
+            ]
+        },
+        {
+            code: "var obj = {\nk1: 'val1', k2: 'val2'\n};",
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "var obj = {\nk1: 'val1', k2: 'val2',\nk3: 'val3', k4: 'val4'\n};",
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 13
+                },
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "foo({ k1: 'val1', k2: 'val2' });",
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "foo({\nk1: 'val1', k2: 'val2'\n});",
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "foo({ a, b });",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 10
+                }
+            ]
+        },
+        {
+            code: "foo({\na, b\n});",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 4
+                }
+            ]
+        },
+        {
+            code: "foo({\nbar() {}, baz\n});",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 11
+                }
+            ]
+        },
+        {
+            code: "foo({\n[bar]: 'baz', baz\n})",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 15
+                }
+            ]
+        },
+        {
+            code: "var obj = {\na: {\nb: 1,\nc: 2\n}, d: 2\n};",
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 5,
+                    column: 4
+                }
+            ]
+        },
+
+        // allowMultiplePropertiesPerLine: true
+        {
+            code: "var obj = {\nk1: 'val1',\nk2: 'val2', k3: 'val3'\n};",
+            options: [{ allowMultiplePropertiesPerLine: true }],
+            errors: [
+                {
+                    message: "Object properties must go on a new line if they aren't all on the same line",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "var obj = {\nk1: 'val1',\nk2: 'val2', k3: 'val3'\n};",
+            options: [{ allowMultiplePropertiesPerLine: true }],
+            errors: [
+                {
+                    message: "Object properties must go on a new line if they aren't all on the same line",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 13
+                }
+            ]
+        }
+    ]
+});


### PR DESCRIPTION
Add a new rule `object-property-newline` that is a port from JSCS requireObjectKeysOnNewLine.