### PR TITLE
Update: Check indentation for multi-line chained properties (refs #1801)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -73,6 +73,7 @@ This rule has an object option:
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
 * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
+* `"MemberExpression"` (default: 1) enforces indentation level for multi-line property chains
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -83,6 +84,9 @@ Level of indentation denotes the multiple of the indent specified. Example:
 * Indent of 2 spaces with `SwitchCase` set to `0` will not indent `case` clauses with respect to `switch` statements.
 * Indent of 2 spaces with `SwitchCase` set to `2` will indent `case` clauses with 4 spaces with respect to `switch` statements.
 * Indent of tabs with `SwitchCase` set to `2` will indent `case` clauses with 2 tabs with respect to `switch` statements.
+* Indent of 2 spaces with `MemberExpression` set to `0` will indent the multi-line property chains with 0 spaces.
+* Indent of 2 spaces with `MemberExpression` set to `1` will indent the multi-line property chains with 2 spaces.
+* Indent of 2 spaces with `MemberExpression` set to `2` will indent the multi-line property chains with 4 spaces.
 
 ### tab
 
@@ -248,6 +252,28 @@ function foo(x) {
 if(y) {
    console.log('foo');
 }
+```
+
+### MemberExpression
+
+Examples of **incorrect** code for this rule with the `2, { "MemberExpression": 1 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
+
+foo
+.bar
+.baz()
+```
+
+Examples of **correct** code for this rule with the `2, { "MemberExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "MemberExpression": 1 }]*/
+
+foo
+  .bar
+  .baz();
 ```
 
 ## Compatibility

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -71,6 +71,10 @@ module.exports = {
                     outerIIFEBody: {
                         type: "integer",
                         minimum: 0
+                    },
+                    MemberExpression: {
+                        type: "integer",
+                        minimum: 0
                     }
                 },
                 additionalProperties: false
@@ -92,7 +96,8 @@ module.exports = {
                 let: DEFAULT_VARIABLE_INDENT,
                 const: DEFAULT_VARIABLE_INDENT
             },
-            outerIIFEBody: null
+            outerIIFEBody: null,
+            MemberExpression: 1
         };
 
         var sourceCode = context.getSourceCode();
@@ -124,6 +129,10 @@ module.exports = {
 
                 if (typeof opts.outerIIFEBody === "number") {
                     options.outerIIFEBody = opts.outerIIFEBody;
+                }
+
+                if (typeof opts.MemberExpression === "number") {
+                    options.MemberExpression = opts.MemberExpression;
                 }
             }
         }
@@ -797,6 +806,24 @@ module.exports = {
 
             ArrayExpression: function(node) {
                 checkIndentInArrayOrObjectBlock(node);
+            },
+
+            MemberExpression: function(node) {
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+
+                var propertyIndent = getNodeIndent(node) + indentSize * options.MemberExpression;
+
+                var checkNodes = [node.property];
+
+                var dot = context.getTokenBefore(node.property);
+
+                if (dot.type === "Punctuator" && dot.value === ".") {
+                    checkNodes.push(dot);
+                }
+
+                checkNodesIndent(checkNodes, propertyIndent);
             },
 
             SwitchStatement: function(node) {

--- a/tests/fixtures/rules/indent/indent-invalid-fixture-1.js
+++ b/tests/fixtures/rules/indent/indent-invalid-fixture-1.js
@@ -135,8 +135,8 @@ switch (a) {
 }
 
 a.b('hi')
-   .c(a.b()) // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
-   .d(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+   .c(a.b()) // <-
+   .d(); // <-
 
 if ( a ) {
   if ( b ) {

--- a/tests/fixtures/rules/indent/indent-valid-fixture-1.js
+++ b/tests/fixtures/rules/indent/indent-valid-fixture-1.js
@@ -135,8 +135,8 @@ switch (a) {
 }
 
 a.b('hi')
-   .c(a.b()) // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
-   .d(); // NO ERROR: DON'T VALIDATE MULTILINE STATEMENTS
+  .c(a.b()) // <-
+  .d(); // <-
 
 if ( a ) {
   if ( b ) {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -162,6 +162,21 @@ ruleTester.run("indent", rule, {
             code:
             "function test() {\n" +
             "    return client.signUp(email, PASSWORD, { preVerified: true })\n" +
+            "        .then(function (result) {\n" +
+            "            var x = 1;\n" +
+            "            var y = 1;\n" +
+            "        }, function(err){\n" +
+            "            var o = 1 - 2;\n" +
+            "            var y = 1 - 2;\n" +
+            "            return true;\n" +
+            "        })\n" +
+            "}",
+            options: [4]
+        },
+        {
+            code:
+            "function test() {\n" +
+            "    return client.signUp(email, PASSWORD, { preVerified: true })\n" +
             "    .then(function (result) {\n" +
             "        var x = 1;\n" +
             "        var y = 1;\n" +
@@ -171,8 +186,9 @@ ruleTester.run("indent", rule, {
             "        return true;\n" +
             "    });\n" +
             "}",
-            options: [4]
+            options: [4, {MemberExpression: 0}]
         },
+
         {
             code:
             "// hi",
@@ -946,6 +962,22 @@ ruleTester.run("indent", rule, {
                 "    return P.resolve({\n" +
                 "      type: 'POST'\n" +
                 "    })\n" +
+                "      .then(function () {\n" +
+                "        return true;\n" +
+                "      }, function () {\n" +
+                "        return false;\n" +
+                "      });\n" +
+                "  }\n" +
+                "};\n",
+            options: [2]
+        },
+        {
+            code:
+                "var obj = {\n" +
+                "  send: function () {\n" +
+                "    return P.resolve({\n" +
+                "      type: 'POST'\n" +
+                "    })\n" +
                 "    .then(function () {\n" +
                 "      return true;\n" +
                 "    }, function () {\n" +
@@ -953,7 +985,7 @@ ruleTester.run("indent", rule, {
                 "    });\n" +
                 "  }\n" +
                 "};\n",
-            options: [2]
+            options: [2, {MemberExpression: 0}]
         },
         {
             code:
@@ -1071,6 +1103,19 @@ ruleTester.run("indent", rule, {
             "            'ONE', 'TWO'\n" +
             "        ].forEach(command => { doSomething(); });\n" +
             "    });\n" +
+            "};",
+            parserOptions: { ecmaVersion: 6 },
+            options: [4, {MemberExpression: 0}]
+        },
+        {
+            code:
+            "const func = function (opts) {\n" +
+            "    return Promise.resolve()\n" +
+            "        .then(() => {\n" +
+            "            [\n" +
+            "                'ONE', 'TWO'\n" +
+            "            ].forEach(command => { doSomething(); });\n" +
+            "        });\n" +
             "};",
             parserOptions: { ecmaVersion: 6 },
             options: [4]
@@ -1296,6 +1341,41 @@ ruleTester.run("indent", rule, {
             "  console.log('hi');\n" +
             "}",
             options: [2, { outerIIFEBody: 0 }]
+        },
+        {
+            code:
+            "Buffer.length"
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .indexOf('a')\n" +
+            "    .toString()"
+        },
+        {
+            code:
+            "Buffer.\n" +
+            "    length"
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .foo\n" +
+            "    .bar"
+        },
+        {
+            code:
+            "Buffer\n" +
+            "\t.foo\n" +
+            "\t.bar",
+            options: ["tab"]
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .foo\n" +
+            "    .bar",
+            options: [2, {MemberExpression: 2}]
         }
     ],
     invalid: [
@@ -1368,6 +1448,8 @@ ruleTester.run("indent", rule, {
                 [120, 4, 6, "VariableDeclaration"],
                 [124, 4, 2, "BreakStatement"],
                 [134, 4, 6, "BreakStatement"],
+                [138, 2, 3, "Punctuator"],
+                [139, 2, 3, "Punctuator"],
                 [143, 4, 0, "ExpressionStatement"],
                 [151, 4, 6, "ExpressionStatement"],
                 [159, 4, 2, "ExpressionStatement"],
@@ -2280,6 +2362,57 @@ ruleTester.run("indent", rule, {
             "};",
             options: ["tab", { outerIIFEBody: 3 }],
             errors: expectedErrors("tab", [[3, 2, 4, "ReturnStatement"]])
+        },
+        {
+            code:
+            "Buffer\n" +
+            ".toString()",
+            output:
+            "Buffer\n" +
+            "    .toString()",
+            errors: expectedErrors([[2, 4, 0, "Punctuator"]])
+        },
+        {
+            code:
+            "Buffer\n" +
+            "    .indexOf('a')\n" +
+            ".toString()",
+            output:
+            "Buffer\n" +
+            "    .indexOf('a')\n" +
+            "    .toString()",
+            errors: expectedErrors([[3, 4, 0, "Punctuator"]])
+        },
+        {
+            code:
+            "Buffer.\n" +
+            "length",
+            output:
+            "Buffer.\n" +
+            "    length",
+            errors: expectedErrors([[2, 4, 0, "Identifier"]])
+        },
+        {
+            code:
+            "Buffer.\n" +
+            "\t\tlength",
+            output:
+            "Buffer.\n" +
+            "\tlength",
+            options: ["tab"],
+            errors: expectedErrors("tab", [[2, 1, 2, "Identifier"]])
+        },
+        {
+            code:
+            "Buffer\n" +
+            "  .foo\n" +
+            "  .bar",
+            output:
+            "Buffer\n" +
+            "    .foo\n" +
+            "    .bar",
+            options: [2, {MemberExpression: 2}],
+            errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 2, "Punctuator"]])
         }
     ]
 });


### PR DESCRIPTION
The end user can choose whether and how much to indent.

```js
foo()
.bar
.baz()
```

vs.

```js
foo()
  .bar
  .baz()
```

and so forth...