### PR TITLE
Fix: no-control-regex literal handling fixed. (fixes #5737)

### DIFF
--- a/docs/rules/no-control-regex.md
+++ b/docs/rules/no-control-regex.md
@@ -11,7 +11,7 @@ Examples of **incorrect** code for this rule:
 ```js
 /*eslint no-control-regex: "error"*/
 
-var pattern1 = /\\x1f/;
+var pattern1 = /\x1f/;
 var pattern2 = new RegExp("\x1f");
 ```
 
@@ -20,7 +20,7 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-control-regex: "error"*/
 
-var pattern1 = /\\x20/;
+var pattern1 = /\x20/;
 var pattern2 = new RegExp("\x20");
 ```
 

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -51,6 +51,31 @@ module.exports = {
             return null;
         }
 
+        /**
+         * Check if given regex string has control characters in it
+         * @param {String} regexStr regex as string to check
+         * @returns {Boolean} returns true if finds control characters on given string
+         * @private
+         */
+        function hasControlCharacters(regexStr) {
+
+            // check control characters, if RegExp object used
+            var hasControlChars = /[\x00-\x1f]/.test(regexStr); // eslint-disable-line no-control-regex
+
+            // check substr, if regex literal used
+            var subStrIndex = regexStr.search(/\\x[01][0-9a-f]/i);
+
+            if (!hasControlChars && subStrIndex > -1) {
+
+                // is it escaped, check backslash count
+                var possibleEscapeCharacters = regexStr.substr(0, subStrIndex).match(/\\+$/gi);
+
+                hasControlChars = possibleEscapeCharacters === null || !(possibleEscapeCharacters[0].length % 2);
+            }
+
+            return hasControlChars;
+        }
+
         return {
             Literal: function(node) {
                 var computedValue,
@@ -58,7 +83,8 @@ module.exports = {
 
                 if (regex) {
                     computedValue = regex.toString();
-                    if (/[\x00-\x1f]/.test(computedValue)) {
+
+                    if (hasControlCharacters(computedValue)) {
                         context.report(node, "Unexpected control character in regular expression.");
                     }
                 }

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -28,6 +28,7 @@ ruleTester.run("no-control-regex", rule, {
         "new (function foo(){})('\\x1f')"
     ],
     invalid: [
+        { code: "var regex = /\x1f/", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] },
         { code: "var regex = /\\\x1f/", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] },
         { code: "var regex = new RegExp('\\x1f')", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] },
         { code: "var regex = RegExp('\\x1f')", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] }


### PR DESCRIPTION
Regex'es defined with literal syntax were not handled as expected.
During the check we get the the regex from node and turn it to string,
then check if it contains control characters as in it. But
`regex.toString()` produces different outputs for literals and regexp
objects. Added another check, now it works as expected.

New check also interfered with the rule itself during `npm run lint`, I
had to use disable-line in the rule itself. I am not very proud of it.