### PR TITLE
New: Use process @abstract when processing @return (fixes #5941)

### DIFF
--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -131,6 +131,18 @@ class Foo {
         this.num1 = num1;
     }
 }
+
+// @returns allowed without return if used with @abstract
+class Foo {
+    /**
+     * @abstract
+     * @return {Number} num
+     */
+    abstractMethod () {
+        throw new Error('Not implemented');
+    }
+}
+
 ```
 
 ## Options

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -184,6 +184,7 @@ module.exports = function(context) {
             hasConstructor = false,
             isInterface = false,
             isOverride = false,
+            isAbstract = false,
             params = Object.create(null),
             jsdoc;
 
@@ -233,7 +234,7 @@ module.exports = function(context) {
                     case "returns":
                         hasReturns = true;
 
-                        if (!requireReturn && !functionData.returnPresent && (tag.type === null || !isValidReturnType(tag))) {
+                        if (!requireReturn && !functionData.returnPresent && (tag.type === null || !isValidReturnType(tag)) && !isAbstract) {
                             context.report(jsdocNode, "Unexpected @" + tag.title + " tag; function has no return statement.");
                         } else {
                             if (requireReturnType && !tag.type) {
@@ -255,6 +256,11 @@ module.exports = function(context) {
                     case "override":
                     case "inheritdoc":
                         isOverride = true;
+                        break;
+
+                    case "abstract":
+                    case "virtual":
+                        isAbstract = true;
                         break;
 
                     case "interface":

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -470,6 +470,48 @@ ruleTester.run("valid-jsdoc", rule, {
             parserOptions: {
                 ecmaVersion: 6
             }
+        },
+
+        // abstract
+        {
+            code:
+            "/**\n" +
+            "* Description\n" +
+            "* @abstract\n" +
+            "* @returns {Number} desc\n" +
+            "*/\n" +
+            "function foo(){ throw new Error('Not Implemented'); }",
+            options: [{ requireReturn: false }]
+        },
+        {
+            code:
+            "/**\n" +
+            "* Description\n" +
+            "* @virtual\n" +
+            "* @returns {Number} desc\n" +
+            "*/\n" +
+            "function foo(){ throw new Error('Not Implemented'); }",
+            options: [{ requireReturn: false }]
+        },
+        {
+            code:
+            "/**\n" +
+            "* Description\n" +
+            "* @abstract\n" +
+            "* @returns {Number} desc\n" +
+            "*/\n" +
+            "function foo(){ throw new Error('Not Implemented'); }",
+            options: [{ requireReturn: true }]
+        },
+        {
+            code:
+            "/**\n" +
+            "* Description\n" +
+            "* @abstract\n" +
+            "* @returns {Number} desc\n" +
+            "*/\n" +
+            "function foo(){}",
+            options: [{ requireReturn: true }]
         }
     ],
 


### PR DESCRIPTION
Allow @return(s) without return keyword in function when @abstract/virtual is present

My first ESLint PR, please be gentle 😛 