### PR TITLE
Fix: Add missing newlines to test cases (fixes #5947)

### DIFF
--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1123,7 +1123,7 @@ ruleTester.run("indent", rule, {
             code:
             "class Foo\n" +
             "  extends Bar {\n" +
-            "  baz() {}" +
+            "  baz() {}\n" +
             "}",
             parserOptions: { ecmaVersion: 6 },
             options: [2]
@@ -1132,7 +1132,7 @@ ruleTester.run("indent", rule, {
             code:
             "class Foo extends\n" +
             "  Bar {\n" +
-            "  baz() {}" +
+            "  baz() {}\n" +
             "}",
             parserOptions: { ecmaVersion: 6 },
             options: [2]


### PR DESCRIPTION
There are two test cases for the `indent` rule where it appears that
newlines were intended but not included. This change adds them.