### PR TITLE
Update: object-shorthand lints computed methods (fixes #5871)

### DIFF
--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -49,8 +49,9 @@ Each of the following properties would warn:
 /*eslint-env es6*/
 
 var foo = {
-    x: function() {},
-    y: function *() {},
+    w: function() {},
+    x: function *() {},
+    [y]: function() {},
     z: z
 };
 ```
@@ -62,8 +63,9 @@ In that case the expected syntax would have been:
 /*eslint-env es6*/
 
 var foo = {
-    x() {},
-    *y() {},
+    w() {},
+    *x() {},
+    [y]() {},
     z
 };
 ```

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -108,8 +108,13 @@ module.exports = {
                     return;
                 }
 
-                // getters, setters and computed properties are ignored
-                if (node.kind === "get" || node.kind === "set" || node.computed) {
+                // only computed methods can fail the following checks
+                if (!APPLY_TO_METHODS && node.computed) {
+                    return;
+                }
+
+                // getters and setters are ignored
+                if (node.kind === "get" || node.kind === "set") {
                     return;
                 }
 

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -65,6 +65,10 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {['y']: 'y'}", parserOptions: { ecmaVersion: 6 }, options: ["properties"] },
         { code: "var x = {['y']: y}", parserOptions: { ecmaVersion: 6 }, options: ["properties"] },
 
+        // object literal computed methods
+        { code: "var x = {[y]() {}}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
+        { code: "var x = {[y]: function x() {}}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
+
         // options
         { code: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
         { code: "var x = {x, y() {}, a:b}", parserOptions: { ecmaVersion: 6 }, options: ["methods"] },
@@ -99,11 +103,14 @@ ruleTester.run("object-shorthand", rule, {
         { code: "doSomething({'x': x})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
         { code: "doSomething({a: 'a', 'x': x})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
         { code: "doSomething({y: function() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "doSomething({[y]: function() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
+        { code: "doSomething({['y']: function() {}})", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }] },
 
         // options
         { code: "var x = {y: function() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
         { code: "var x = {x, y() {}, z: function() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
         { code: "var x = {ConstructorFunction: function(){}, a: b}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
+        { code: "var x = {[y]: function() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods"] },
         { code: "var x = {x: x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }], options: ["properties"] },
         { code: "var x = {a, b, c(){}, x: x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }], options: ["properties"] },
         { code: "var x = {y() {}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },


### PR DESCRIPTION
This PR makes it so that ESLint correctly warns on computed methods for the `object-shorthand` method. The rule will now warn for the following when `object-shorthand` is set to `methods` or `always`:

```js
var foo = {
  [bar]: function() {}
}
```

It continues not to warn in instances where the function is named, and never warns for anything related to computed properties.

I didn't see a sensible place for me to insert this update in the docs, but it's pretty minor so I wasn't sure it really warranted one anyways.