### PR TITLE
Docs: Organize meta and describe visitor in Working with Rules

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -1,12 +1,20 @@
 # Working with Rules
 
-Each ESLint rule has two files: a source file in the `lib/rules` directory and a test file in the `tests/lib/rules` directory. Both files should be named with the rule ID (i.e., `no-eval.js` for rule ID `no-eval`) The basic source code format for a rule is:
+Each rule in ESLint has two files named with its identifier (for example, `no-extra-semi`).
+
+* in the `lib/rules` directory: a source file (for example, `no-extra-semi.js`)
+* in the `tests/lib/rules` directory: a test file (for example, `no-extra-semi.js`)
+
+**Important:** If you submit a **core** rule to the ESLint repository, you **must** follow some conventions explained below.
+
+Here is the basic format of the source file for a rule:
 
 ```js
 /**
- * @fileoverview Rule to flag use of an empty block statement
+ * @fileoverview Rule to disallow unnecessary semicolons
  * @author Nicholas C. Zakas
  */
+
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -14,55 +22,51 @@ Each ESLint rule has two files: a source file in the `lib/rules` directory and a
 //------------------------------------------------------------------------------
 
 module.exports = function(context) {
-
     return {
-        // properties go here
+        // callback functions
     };
-
 };
 
-module.exports.schema = [
-    // JSON Schema for rule options goes here
-];
+module.exports.schema = []; // no options
 ```
-
-**Important:** Rule submissions will not be accepted unless they are in this format.
 
 ## Rule Basics
 
-Each rule is represented by a single object with several properties. The properties are equivalent to AST node types from [ESTree](https://github.com/estree/estree). For example, if your rule wants to know when an identifier is found in the AST, then add a method called "Identifier", such as:
+`schema` (array) specifies the [options](#options-schemas) so ESLint can prevent invalid [rule configurations](../user-guide/configuring#configuring-rules)
+
+`create` (function) returns an object with methods that ESLint calls to "visit" nodes while traversing the abstract syntax tree (AST as defined by [ESTree](https://github.com/estree/estree)) of JavaScript code:
+
+* if a key is a node type, ESLint calls that **visitor** function while going **down** the tree
+* if a key is a node type plus `:exit`, ESLint calls that **visitor** function while going **up** the tree
+* if a key is an event name, ESLint calls that **handler** function for [code path analysis](./code-path-analysis.md)
+
+A rule can use the current node and its surrounding tree to report or fix problems.
+
+Here are methods for the [array-callback-return](../rules/array-callback-return) rule:
 
 ```js
+function checkLastSegment (node) {
+    // report problem for function if last code path segment is reachable
+}
+
 module.exports = function(context) {
-
+    // declare the state of the rule
     return {
-
-        "Identifier": function(node) {
-            // do something with node
+        ReturnStatement: function(node) {
+            // at a ReturnStatement node while going down
+        },
+        // at a function expression node while going up:
+        "FunctionExpression:exit": checkLastSegment,
+        "ArrowFunctionExpression:exit": checkLastSegment,
+        onCodePathStart: function (codePath, node) {
+            // at the start of analyzing a code path
+        },
+        onCodePathEnd: function(codePath, node) {
+            // at the end of analyzing a code path
         }
     };
-
 };
 ```
-
-Each method that matches a node in the AST will be passed the corresponding node. You can then evaluate the node and it's surrounding tree to determine whether or not an issue needs reporting.
-
-By default, the method matching a node name is called during the traversal when the node is first encountered, on the way down the AST. You can also specify to visit the node on the other side of the traversal, as it comes back up the tree, by adding `:exit` to the end of the node type, such as:
-
-```js
-module.exports = function(context) {
-
-    return {
-
-        "Identifier:exit": function(node) {
-            // do something with node
-        }
-    };
-
-};
-```
-
-In this code, `"Identifier:exit"` is called on the way up the AST. This capability allows you to keep track as the traversal enters and exits specific parts of the AST.
 
 ## The Context Object
 


### PR DESCRIPTION
* bulleted list of rule files so it would be easy to add rule doc
* bulleted lists of meta properties (see #5417) and illustrated them in the first source file example
* use terms visit (verb) and visitor (noun) discussed in #5843 @jfmengels Can you please critique?
* use terms event and handler for code path analysis @mysticatea Can you please critique?
* illustrate visitors and handlers from `array-callback-return` in the second source file example