### PR TITLE
Fix: Clarify color option (fixes #5928)

### DIFF
--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -66,7 +66,7 @@ Handling warnings:
 Output:
   -o, --output-file path::String  Specify file to write report to
   -f, --format String        Use a specific output format - default: stylish
-  --no-color                 Disable color in piped output
+  --color, --no-color        Force enabling/disabling of color
 
 Miscellaneous:
   --init                     Run config initialization wizard - default: false
@@ -323,12 +323,13 @@ When specified, the given format is output to the console. If you'd like to save
 
 This saves the output into the `results.txt` file.
 
-#### `--no-color`
+#### `--color`, `--no-color`
 
-Disable color in piped output.
+This option forces the enabling/disabling of colorized output. You can use this to override the default behavior, which is to enable colorized output unless no TTY is detected, such as when when piping `eslint` through `cat` or `less`.
 
-Example:
+Examples:
 
+    eslint --color file.js | cat
     eslint --no-color file.js
 
 ### Miscellaneous

--- a/lib/options.js
+++ b/lib/options.js
@@ -173,8 +173,8 @@ module.exports = optionator({
         {
             option: "color",
             type: "Boolean",
-            default: "true",
-            description: "Disable color in piped output"
+            alias: "no-color",
+            description: "Force enabling/disabling of color"
         },
         {
             heading: "Miscellaneous"

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -190,10 +190,16 @@ describe("options", function() {
     });
 
     describe("--color", function() {
-        it("should return true for .color when passed", function() {
+        it("should return true for .color when passed --color", function() {
             var currentOptions = options.parse("--color");
 
             assert.isTrue(currentOptions.color);
+        });
+
+        it("should return false for .color when passed --no-color", function() {
+            var currentOptions = options.parse("--no-color");
+
+            assert.isFalse(currentOptions.color);
         });
     });
 


### PR DESCRIPTION
- Remove misleading default value of true; --color isn't actually passed through unless explicitly provided
- Display both --color and --no-color in help message and update verbiage accordingly