### PR TITLE
Do not swallow exceptions in CLIEngine.getFormatter

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -489,9 +489,7 @@ CLIEngine.getFormatter = function(format) {
         try {
             return require(formatterPath);
         } catch (ex) {
-            if (ex.code === "MODULE_NOT_FOUND" && ex.message.indexOf("'" + formatterPath + "'") !== -1) {
-                return null;
-            }
+            ex.message = "There was a problem loading formatter: " + formatterPath + "\nError: " + ex.message;
             throw ex;
         }
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -489,7 +489,10 @@ CLIEngine.getFormatter = function(format) {
         try {
             return require(formatterPath);
         } catch (ex) {
-            return null;
+            if (ex.code === "MODULE_NOT_FOUND" && ex.message.indexOf("'" + formatterPath + "'") !== -1) {
+                return null;
+            }
+            throw ex;
         }
 
     } else {

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -74,9 +74,10 @@ function printResults(engine, results, format, outputFile) {
         output,
         filePath;
 
-    formatter = engine.getFormatter(format);
-    if (!formatter) {
-        log.error("Could not find formatter '%s'.", format);
+    try {
+        formatter = engine.getFormatter(format);
+    } catch (e) {
+        log.error(e.message);
         return false;
     }
 

--- a/tests/fixtures/formatters/broken.js
+++ b/tests/fixtures/formatters/broken.js
@@ -1,0 +1,5 @@
+/*global module*/
+var nonExistantFormatter = require('this-module-does-not-exist');
+module.exports = function(results) {
+    return nonExistantFormatter(results);
+};

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1904,46 +1904,28 @@ describe("CLIEngine", function() {
 
         it("should return null when a customer formatter doesn't exist", function() {
             var engine = new CLIEngine(),
-                formatterPath = getFixturePath("formatters", "doesntexist.js"),
-                error = null;
+                formatterPath = getFixturePath("formatters", "doesntexist.js");
 
-            try {
+            assert.throws(function() {
                 engine.getFormatter(formatterPath);
-            } catch (e) {
-                error = e;
-            }
-
-            assert.instanceOf(error, Error);
-            assert.equal(error.message, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module '" + formatterPath + "'");
+            }, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module '" + formatterPath + "'");
         });
 
         it("should return null when a built-in formatter doesn't exist", function() {
-            var engine = new CLIEngine(),
-                error = null;
+            var engine = new CLIEngine();
 
-            try {
+            assert.throws(function() {
                 engine.getFormatter("special");
-            } catch (e) {
-                error = e;
-            }
-
-            assert.instanceOf(error, Error);
-            assert.equal(error.message, "There was a problem loading formatter: ./formatters/special\nError: Cannot find module './formatters/special'");
+            }, "There was a problem loading formatter: ./formatters/special\nError: Cannot find module './formatters/special'");
         });
 
         it("should throw if the required formatter exists but has an error", function() {
             var engine = new CLIEngine(),
-                formatterPath = getFixturePath("formatters", "broken.js")
-                error = null;
+                formatterPath = getFixturePath("formatters", "broken.js");
 
-            try {
+            assert.throws(function() {
                 engine.getFormatter(formatterPath);
-            } catch (e) {
-                error = e;
-            }
-
-            assert.instanceOf(error, Error);
-            assert.equal(error.message, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module 'this-module-does-not-exist'");
+            }, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module 'this-module-does-not-exist'");
         });
 
         it("should return null when a non-string formatter name is passed", function() {

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -451,10 +451,13 @@ describe("CLIEngine", function() {
             assert.equal(report.warningCount, 0);
             assert.equal(report.results[0].messages.length, 0);
             assert.equal(report.results[1].messages.length, 0);
+            assert.equal(report.results[2].messages.length, 0);
             assert.equal(report.results[0].errorCount, 0);
             assert.equal(report.results[0].warningCount, 0);
             assert.equal(report.results[1].errorCount, 0);
             assert.equal(report.results[1].warningCount, 0);
+            assert.equal(report.results[2].errorCount, 0);
+            assert.equal(report.results[2].warningCount, 0);
         });
 
         it("should process when file is given by not specifying extensions", function() {

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -446,7 +446,7 @@ describe("CLIEngine", function() {
 
             var report = engine.executeOnFiles([getFixturePath("formatters")]);
 
-            assert.equal(report.results.length, 2);
+            assert.equal(report.results.length, 3);
             assert.equal(report.errorCount, 0);
             assert.equal(report.warningCount, 0);
             assert.equal(report.results[0].messages.length, 0);
@@ -1911,6 +1911,20 @@ describe("CLIEngine", function() {
                 formatter = engine.getFormatter("special");
 
             assert.isNull(formatter);
+        });
+
+        it("should throw if the required formatter exists but has an error", function() {
+            var engine = new CLIEngine(),
+                error = null;
+
+            try {
+                engine.getFormatter(getFixturePath("formatters", "broken.js"));
+            } catch (e) {
+                error = e;
+            }
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.message, "Cannot find module 'this-module-does-not-exist'");
         });
 
         it("should return null when a non-string formatter name is passed", function() {

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1904,30 +1904,46 @@ describe("CLIEngine", function() {
 
         it("should return null when a customer formatter doesn't exist", function() {
             var engine = new CLIEngine(),
-                formatter = engine.getFormatter(getFixturePath("formatters", "doesntexist.js"));
-
-            assert.isNull(formatter);
-        });
-
-        it("should return null when a built-in formatter doesn't exist", function() {
-            var engine = new CLIEngine(),
-                formatter = engine.getFormatter("special");
-
-            assert.isNull(formatter);
-        });
-
-        it("should throw if the required formatter exists but has an error", function() {
-            var engine = new CLIEngine(),
+                formatterPath = getFixturePath("formatters", "doesntexist.js"),
                 error = null;
 
             try {
-                engine.getFormatter(getFixturePath("formatters", "broken.js"));
+                engine.getFormatter(formatterPath);
             } catch (e) {
                 error = e;
             }
 
             assert.instanceOf(error, Error);
-            assert.equal(error.message, "Cannot find module 'this-module-does-not-exist'");
+            assert.equal(error.message, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module '" + formatterPath + "'");
+        });
+
+        it("should return null when a built-in formatter doesn't exist", function() {
+            var engine = new CLIEngine(),
+                error = null;
+
+            try {
+                engine.getFormatter("special");
+            } catch (e) {
+                error = e;
+            }
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.message, "There was a problem loading formatter: ./formatters/special\nError: Cannot find module './formatters/special'");
+        });
+
+        it("should throw if the required formatter exists but has an error", function() {
+            var engine = new CLIEngine(),
+                formatterPath = getFixturePath("formatters", "broken.js")
+                error = null;
+
+            try {
+                engine.getFormatter(formatterPath);
+            } catch (e) {
+                error = e;
+            }
+
+            assert.instanceOf(error, Error);
+            assert.equal(error.message, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module 'this-module-does-not-exist'");
         });
 
         it("should return null when a non-string formatter name is passed", function() {


### PR DESCRIPTION
Fix for issue #5977 

If a formatter is broken, the exception telling you that it was broken would be swallowed by the catch block, and the error reporting would tell you that it could not find the formatter.

This fix means that any exception, that is not a result of the formatter module not being found, will be re-thrown.