### PR TITLE
Docs: Update CLA link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Before filing an issue, please be sure to read the guidelines for what you're re
 
 ## Contributing Code
 
-Please sign our [Contributor License Agreement](http://eslint.org/cla) and read over the [Pull Request Guidelines](http://eslint.org/docs/developer-guide/contributing/pull-requests).
+Please sign our [Contributor License Agreement](https://contribute.jquery.org/CLA/) and read over the [Pull Request Guidelines](http://eslint.org/docs/developer-guide/contributing/pull-requests).
 
 ## Full Documentation
 


### PR DESCRIPTION
Before submitting #5977 I had signed the old CLA from before joining the jQuery Foundation, as it was still referenced in the contribution guidelines file.

@IanVS made me aware of the move on gitter.

Related issue about removing the CLA from eslint.org: https://github.com/eslint/eslint.github.io/issues/254