### PR TITLE
Docs: mention parsing errors in strict mode (fixes #5485)

### DIFF
--- a/docs/rules/no-delete-var.md
+++ b/docs/rules/no-delete-var.md
@@ -1,10 +1,12 @@
-# Disallow Variables Deletion (no-delete-var)
+# disallow deleting variables (no-delete-var)
 
 The purpose of the `delete` operator is to remove a property from an object. Using the `delete` operator on a variable might lead to unexpected behavior.
 
 ## Rule Details
 
-This rule prevents the use of `delete` operator on variables.
+This rule disallows the use of the `delete` operator on variables.
+
+If ESLint parses code in strict mode, the parser (instead of this rule) reports the error.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-dupe-args.md
+++ b/docs/rules/no-dupe-args.md
@@ -1,11 +1,12 @@
 # disallow duplicate arguments in `function` definitions (no-dupe-args)
 
-In strict mode you will receive a `SyntaxError` if a function takes multiple arguments with the same name.
-Outside of strict mode duplicate arguments will mask the value of the first argument.
+If more than one parameter has the same name in a function definition, the last occurrence "shadows" the preceding occurrences. A duplicated name might be a typing error.
 
 ## Rule Details
 
-This rule disallows duplicate parameters in function definitions.
+This rule disallows duplicate parameter names in function declarations or expressions. It does not apply to arrow functions or class methods, because the parser reports the error.
+
+If ESLint parses code in strict mode, the parser (instead of this rule) reports the error.
 
 Examples of **incorrect** code for this rule:
 
@@ -13,11 +14,11 @@ Examples of **incorrect** code for this rule:
 /*eslint no-dupe-args: "error"*/
 
 function foo(a, b, a) {
-    console.log("which a is it?", a);
+    console.log("value of the second a:", a);
 }
 
 var bar = function (a, b, a) {
-    console.log("which a is it?", a);
+    console.log("value of the second a:", a);
 };
 ```
 
@@ -34,7 +35,3 @@ var bar = function (a, b, c) {
     console.log(a, b, c);
 };
 ```
-
-## When Not To Use It
-
-If your project uses strict mode this rule may not be needed as unique param names will be automatically enforced.

--- a/docs/rules/no-octal-escape.md
+++ b/docs/rules/no-octal-escape.md
@@ -1,6 +1,6 @@
-# Disallow Octal Escapes (no-octal-escape)
+# disallow octal escape sequences in string literals (no-octal-escape)
 
-As of version 5 of the ECMAScript specification, octal escape sequences are a deprecated feature and should not be used. It is recommended that Unicode escapes be used instead.
+As of the ECMAScript 5 specification, octal escape sequences in string literals are deprecated and should not be used. Unicode escape sequences should be used instead.
 
 ```js
 var foo = "Copyright \251";
@@ -8,7 +8,9 @@ var foo = "Copyright \251";
 
 ## Rule Details
 
-The rule is aimed at preventing the use of a deprecated JavaScript feature, the use of octal escape sequences. As such it will warn whenever an octal escape sequence is found in a string literal.
+This rule disallows octal escape sequences in string literals.
+
+If ESLint parses code in strict mode, the parser (instead of this rule) reports the error.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-octal.md
+++ b/docs/rules/no-octal.md
@@ -1,4 +1,4 @@
-# Disallow Octal Literals (no-octal)
+# disallow octal literals (no-octal)
 
 Octal literals are numerals that begin with a leading zero, such as:
 
@@ -6,13 +6,13 @@ Octal literals are numerals that begin with a leading zero, such as:
 var num = 071;      // 57
 ```
 
-The leading zero to identify an octal literal has been a source of confusion and error in JavaScript. ECMAScript 5 deprecates the use of octal numeric literals in JavaScript and octal literals cause syntax errors in strict mode.
-
-It's therefore recommended to avoid using octal literals in JavaScript code.
+Because the leading zero which identifies an octal literal has been a source of confusion and error in JavaScript code, ECMAScript 5 deprecates the use of octal numeric literals.
 
 ## Rule Details
 
-The rule is aimed at preventing the use of a deprecated JavaScript feature, the use of octal literals. As such it will warn whenever an octal literal is found.
+The rule disallows octal literals.
+
+If ESLint parses code in strict mode, the parser (instead of this rule) reports the error.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-with.md
+++ b/docs/rules/no-with.md
@@ -1,18 +1,30 @@
-# No with Statements (no-with)
+# disallow `with` statements (no-with)
 
-The `with` statement is potentially problematic because it adds members of an object to the current scope, making it impossible to tell what a variable inside the block actually refers to. Additionally, the `with` statement cannot be used in strict mode.
+The `with` statement is potentially problematic because it adds members of an object to the current scope, making it impossible to tell what a variable inside the block actually refers to.
 
 ## Rule Details
 
-This rule is aimed at eliminating `with` statements.
+This rule disallows `with` statements.
+
+If ESLint parses code in strict mode, the parser (instead of this rule) reports the error.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-with: "error"*/
-with (foo) {
-    // ...
+
+with (point) {
+    r = Math.sqrt(x * x + y * y); // is r a member of point?
 }
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint no-with: "error"*/
+/*eslint-env es6*/
+
+const r = ({x, y}) => Math.sqrt(x * x + y * y);
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
Wording changed from the possibilities discussed in the issue, as often happens while editing 😐

Additional changes include making the main heading and first sentence under Rule Details consistent with description in rules index.

Agree with the idea https://github.com/eslint/eslint/issues/5485#issuecomment-215253380 to make “strict mode” a hyperlink. Instead of to the `strict` rule, it will be to a not-yet-written section, possibly in Configuring ESLint, which describes all the things that cause ESLint to parse code in strict mode:

* `"use strict";` in code
* `parserOptions.sourceType = "module"` in config
* `parserOptions.ecmaFeatures.impliedStrict = true` in config

Any others?