### PR TITLE
Breaking: Count blockless else in max-statements-per-line (fixes #5926)

### DIFF
--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -99,6 +99,18 @@ module.exports = {
             enforceMaxStatementsPerLine(node.consequent);
         }
 
+        /**
+         * Check each line in both sides of an if statement
+         * @param {ASTNode} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function checkLinesInNonBlockElse(node) {
+            if (node.alternate && node.alternate.type !== "BlockStatement") {
+                enforceMaxStatementsPerLine([node.alternate]);
+            }
+        }
+
         //--------------------------------------------------------------------------
         // Public API
         //--------------------------------------------------------------------------
@@ -106,7 +118,8 @@ module.exports = {
         return {
             Program: checkLinesInBody,
             BlockStatement: checkLinesInBody,
-            SwitchCase: checkLinesInConsequent
+            SwitchCase: checkLinesInConsequent,
+            IfStatement: checkLinesInNonBlockElse
         };
 
     }

--- a/tests/lib/rules/max-statements-per-line.js
+++ b/tests/lib/rules/max-statements-per-line.js
@@ -74,6 +74,7 @@ ruleTester.run("max-statements-per-line", rule, {
         { code: "var bar = 1; var baz = 2;", errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
         { code: "var bar = 1; var baz = 2;", options: [{ max: 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
         { code: "if (condition) var bar = 1; if (condition) var baz = 2;", options: [{ max: 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
+        { code: "if (condition) var bar = 1; else var baz = 1;", options: [{ max: 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
         { code: "if (condition) { } if (condition) { }", options: [{ max: 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
         { code: "if (condition) { var bar = 1; } else { }", options: [{ max: 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },
         { code: "if (condition) { } else { var bar = 1; }", options: [{ max: 1 }], errors: [{ message: "This line has too many statements. Maximum allowed is 1." }] },


### PR DESCRIPTION
Previously `if (x) var y = 1; else var z = 1;` was allowed, now it isn't.