### PR TITLE
Fix: Avoid autoconfig crashes from inline comments (fixes #5992)

### DIFF
--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -310,7 +310,13 @@ Registry.prototype = {
                 var lintResults = eslint.verify(sourceCodes[filename], lintConfig);
 
                 lintResults.forEach(function(result) {
-                    lintedRegistry.rules[result.ruleId][ruleSetIdx].errorCount += 1;
+
+                    // It is possible that the error is from a configuration comment
+                    // in a linted file, in which case there may not be a config
+                    // set in this ruleSetIdx. (https://github.com/eslint/eslint/issues/5992)
+                    if (lintedRegistry.rules[result.ruleId][ruleSetIdx]) {
+                        lintedRegistry.rules[result.ruleId][ruleSetIdx].errorCount += 1;
+                    }
                 });
 
                 ruleSetIdx += 1;

--- a/tests/fixtures/autoconfig/source-with-comments.js
+++ b/tests/fixtures/autoconfig/source-with-comments.js
@@ -1,0 +1,5 @@
+/* eslint semi: [2, "never"] */
+
+var foo = 42;
+var baz = "baz";
+var bar = '"no-escape"';

--- a/tests/lib/config/autoconfig.js
+++ b/tests/lib/config/autoconfig.js
@@ -22,6 +22,7 @@ defaultOptions = lodash.assign({}, defaultOptions, {cwd: process.cwd()});
 //------------------------------------------------------------------------------
 
 var SOURCE_CODE_FIXTURE_FILENAME = "./tests/fixtures/autoconfig/source.js";
+var CONFIG_COMMENTS_FILENAME = "./tests/fixtures/autoconfig/source-with-comments.js";
 var SEVERITY = 2;
 
 //------------------------------------------------------------------------------
@@ -199,6 +200,21 @@ describe("autoconfig", function() {
                 assert.equal(registry.rules.semi[0].errorCount, 0);
                 assert.deepEqual(registry.rules.semi[2].config, [SEVERITY, "never"]);
                 assert.equal(registry.rules.semi[2].errorCount, 3);
+            });
+
+            it("should respect inline eslint config comments (and not crash when they make linting errors)", function() {
+                var config = {ignore: false};
+                var sourceCode = sourceCodeUtil.getSourceCodeOfFiles(CONFIG_COMMENTS_FILENAME, config);
+                var expectedRegistry = [
+                    { config: 2, specificity: 1, errorCount: 3 },
+                    { config: [ 2, "always" ], specificity: 2, errorCount: 3 },
+                    { config: [ 2, "never" ], specificity: 2, errorCount: 3 }
+                ];
+
+                registry = new autoconfig.Registry(rulesConfig);
+                registry = registry.lintSourceCode(sourceCode, defaultOptions);
+
+                assert.deepEqual(registry.rules.semi, expectedRegistry);
             });
         });
 


### PR DESCRIPTION
Autoconfig was crashing when pre-existing inline ESLint comments were resulting in linting errors.

Now, the config comments will still be applied (likely causing the rule to be unable to be configured), but the process will not crash.