### PR TITLE
Config example belongs in code block

### DIFF
--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -51,7 +51,9 @@ The rule takes one option, a string, which could be either `"always"` or `"as-ne
 
 You can set the option in configuration like this:
 
-"arrow-parens": [2, "always"]
+```json
+"arrow-parens": ["error", "always"]
+```
 
 ### "always"
 


### PR DESCRIPTION
If they're not, quotes are turned into smart quotes / non-ASCII things that are ~~impossible~~impractical to copy & paste.