### PR TITLE
Update: Define plugins in config using absolute paths (fixes #3458)

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 var debug = require("debug"),
+    isAbsolute = require("path-is-absolute"),
     Environments = require("./environments"),
     rules = require("../rules");
 
@@ -111,7 +112,11 @@ module.exports = {
 
         if (!plugins[pluginNameWithoutPrefix]) {
             try {
-                plugin = require(pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+                plugin = require(
+                    isAbsolute(pluginNameWithoutPrefix)
+                        ? pluginNameWithoutPrefix
+                        : (pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix)
+                );
             } catch (err) {
                 debug("Failed to load plugin eslint-plugin-" + pluginNameWithoutPrefix + ". Proceeding without it.");
                 err.message = "Failed to load plugin " + pluginName + ": " + err.message;


### PR DESCRIPTION
```javascript
// eslint-config-x/index.js
const xPluginPath = require.resolve('eslint-plugin-x')

module.exports = {
  // ...
  plugins: [
    xPluginPath,
  ],
  rules: {
    // ...
    [`${xPluginPath}/rule-name`]: 2,
    // ...
  },
  // ...
}
```