### PR TITLE
no-irregal-whitespace incorrectly reported error in a regular expression

### DIFF
--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -71,6 +71,19 @@ function thing() {
 function thing() {
   return 'test'; /*<NBSP>*/
 }
+
+function thing() {
+  // Description <NBSP>
+}
+
+function thing() {
+  return / <NBSP>regexp/;
+}
+
+/*eslint-env es6*/
+function thing() {
+  return `template  <NBSP>string`;
+}
 ```
 
 Examples of **correct** code for this rule:
@@ -99,14 +112,45 @@ Description<NBSP>: some descriptive text
 
 ## Options
 
-The `no-irregular-whitespace` rule has no required option and has one optional one that needs to be passed in a single options object:
+This rule has an object option for exceptions:
 
-* **skipComments** *(default: `false`)*: whether to ignore irregular whitespace within comments (`true`) or whether to check for them in there, too (`false`).
+* `"skipStrings": true` (default) allows any whitespace characters in string literals
+* `"skipComments": true` allows any whitespace characters in comments
+* `"skipRegExps": true` allows any whitespace characters in regular expression literals
+* `"skipTemplates": true` allows any whitespace characters in template literals
 
-For example, to specify that you want to skip checking for irregular whitespace within comments, use the following configuration:
+### skipComments
 
-```json
-"no-irregular-whitespace": ["error", { "skipComments": true }]
+Examples of additional **correct** code for this rule with the { "skipComments": true } option:
+
+```js
+/*eslint no-irregular-whitespace: ["error", { "skipComments": true }]*/
+function thing() {
+  // Description <NBSP>
+}
+```
+
+### skipRegExps
+
+Examples of additional **correct** code for this rule with the { "skipRegExps": true } option:
+
+```js
+/*eslint no-irregular-whitespace: ["error", { "skipRegExps": true }]*/
+function thing() {
+  return / <NBSP>regexp/;
+}
+```
+
+### skipTemplates
+
+Examples of additional **correct** code for this rule with the { "skipTemplates": true } option:
+
+```js
+/*eslint no-irregular-whitespace: ["error", { "skipTemplates": true }]*/
+/*eslint-env es6*/
+function thing() {
+  return `template  <NBSP>string`;
+}
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -24,6 +24,15 @@ module.exports = {
                 properties: {
                     skipComments: {
                         type: "boolean"
+                    },
+                    skipStrings: {
+                        type: "boolean"
+                    },
+                    skipTemplates: {
+                        type: "boolean"
+                    },
+                    skipRegExps: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -45,6 +54,9 @@ module.exports = {
         // Lookup the `skipComments` option, which defaults to `false`.
         var options = context.options[0] || {};
         var skipComments = !!options.skipComments;
+        var skipStrings = options.skipStrings !== false;
+        var skipRegExps = !!options.skipRegExps;
+        var skipTemplates = !!options.skipTemplates;
 
         /**
          * Removes errors that occur inside a string node
@@ -75,10 +87,27 @@ module.exports = {
          * @private
          */
         function removeInvalidNodeErrorsInIdentifierOrLiteral(node) {
-            if (typeof node.value === "string") {
+            var shouldCheckStrings = skipStrings && (typeof node.value === "string");
+            var shouldCheckRegExps = skipRegExps && (node.value instanceof RegExp);
+
+            if (shouldCheckStrings || shouldCheckRegExps) {
 
                 // If we have irregular characters remove them from the errors list
                 if (node.raw.match(irregularWhitespace) || node.raw.match(irregularLineTerminators)) {
+                    removeWhitespaceError(node);
+                }
+            }
+        }
+
+        /**
+         * Checks template string literal nodes for errors that we are choosing to ignore and calls the relevant methods to remove the errors
+         * @param {ASTNode} node to check for matching errors.
+         * @returns {void}
+         * @private
+         */
+        function removeInvalidNodeErrorsInTemplateLiteral(node) {
+            if (skipTemplates && (typeof node.value.raw === "string")) {
+                if (node.value.raw.match(irregularWhitespace) || node.value.raw.match(irregularLineTerminators)) {
                     removeWhitespaceError(node);
                 }
             }
@@ -186,6 +215,7 @@ module.exports = {
 
             Identifier: removeInvalidNodeErrorsInIdentifierOrLiteral,
             Literal: removeInvalidNodeErrorsInIdentifierOrLiteral,
+            TemplateElement: removeInvalidNodeErrorsInTemplateLiteral,
             LineComment: skipComments ? rememberCommentNode : noop,
             BlockComment: skipComments ? rememberCommentNode : noop,
             "Program:exit": function() {

--- a/tests/lib/rules/no-irregular-whitespace.js
+++ b/tests/lib/rules/no-irregular-whitespace.js
@@ -121,6 +121,48 @@ ruleTester.run("no-irregular-whitespace", rule, {
         { code: "/* \u202F */", options: [{ skipComments: true }] },
         { code: "/* \u205f */", options: [{ skipComments: true }] },
         { code: "/* \u3000 */", options: [{ skipComments: true }] },
+        { code: "/\u000B/", options: [{ skipRegExps: true }] },
+        { code: "/\u000C/", options: [{ skipRegExps: true }] },
+        { code: "/\u0085/", options: [{ skipRegExps: true }] },
+        { code: "/\u00A0/", options: [{ skipRegExps: true }] },
+        { code: "/\u180E/", options: [{ skipRegExps: true }] },
+        { code: "/\ufeff/", options: [{ skipRegExps: true }] },
+        { code: "/\u2000/", options: [{ skipRegExps: true }] },
+        { code: "/\u2001/", options: [{ skipRegExps: true }] },
+        { code: "/\u2002/", options: [{ skipRegExps: true }] },
+        { code: "/\u2003/", options: [{ skipRegExps: true }] },
+        { code: "/\u2004/", options: [{ skipRegExps: true }] },
+        { code: "/\u2005/", options: [{ skipRegExps: true }] },
+        { code: "/\u2006/", options: [{ skipRegExps: true }] },
+        { code: "/\u2007/", options: [{ skipRegExps: true }] },
+        { code: "/\u2008/", options: [{ skipRegExps: true }] },
+        { code: "/\u2009/", options: [{ skipRegExps: true }] },
+        { code: "/\u200A/", options: [{ skipRegExps: true }] },
+        { code: "/\u200B/", options: [{ skipRegExps: true }] },
+        { code: "/\u202F/", options: [{ skipRegExps: true }] },
+        { code: "/\u205f/", options: [{ skipRegExps: true }] },
+        { code: "/\u3000/", options: [{ skipRegExps: true }] },
+        { code: "`\u000B`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u000C`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u0085`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u00A0`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u180E`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\ufeff`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2000`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2001`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2002`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2003`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2004`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2005`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2006`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2007`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2008`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u2009`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u200A`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u200B`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u202F`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u205f`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
+        { code: "`\u3000`", options: [{ skipTemplates: true }], parserOptions: {ecmaVersion: 6} },
 
         // Unicode BOM.
         "\uFEFFconsole.log('hello BOM');"
@@ -426,6 +468,73 @@ ruleTester.run("no-irregular-whitespace", rule, {
         {
             code: "/* \u3000 */",
             errors: expectedCommentErrors
+        },
+        {
+            code: "var any = /\u3000/, other = /\u000B/;",
+            errors: [
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 12
+                },
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "var any = '\u3000', other = '\u000B';",
+            options: [{ skipStrings: false }],
+            errors: [
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 12
+                },
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "var any = `\u3000`, other = `\u000B`;",
+            options: [{ skipTemplates: false }],
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 12
+                },
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "`something ${\u3000 10} another thing`",
+            options: [{ skipTemplates: true }],
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                {
+                    message: "Irregular whitespace not allowed",
+                    type: "Program",
+                    line: 1,
+                    column: 14
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
### Problem:

`no-irregal-whitespace` ignores string literals correctly, but doen't regular expressions.  It is popular in Japan to include zenkaku-space (`\u3000`) in string literals or regular expressions.

### Solution:

Also check that the node is a regular expression in `removeInvalidNodeErrorsInIdentifierOrLiteral()`.  I also added test for this.

### Environment

- Node.js v5.6.0
- OS X 10.11.4