### PR TITLE
Docs: Fix a wrong examples' header of `prefer-arrow-callback`.

### DIFF
--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -57,7 +57,7 @@ foo(function bar() {});
 
 This is a `boolean` option and it is `true` by default. When set to `false`, this option allows the use of `this` without restriction and checks for dynamically assigned `this` values such as when using `Array.prototype.map` with a `context` argument. Normally, the rule will flag the use of `this` whenever a function does not use `bind()` to specify the value of `this` constantly.
 
-Examples of **correct** code for the `{ "allowUnboundThis": false }` option:
+Examples of **incorrect** code for the `{ "allowUnboundThis": false }` option:
 
 ```js
 /*eslint prefer-arrow-callback: ["error", { "allowUnboundThis": false }]*/


### PR DESCRIPTION
The document says **correct** examples, but those are incorrect examples.

![image](https://cloud.githubusercontent.com/assets/1937871/14936750/61f2b1c4-0f2f-11e6-99ce-7adbe6fb111b.png)
