### PR TITLE
Docs: Correct default for `one-var-declaration-per-line` (fixes #6017)

### DIFF
--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -24,8 +24,8 @@ This rule enforces a consistent coding style where newlines are required or disa
 
 This rule takes one option, a string, which can be:
 
-* `"always"` enforces a newline around each variable declaration (default)
-* `"initializations"` enforces a newline around a variable initialization
+* `"always"` enforces a newline around each variable declaration
+* `"initializations"` enforces a newline around each variable initialization (default)
 
 The following patterns are considered problems when set to `"always"`:
 


### PR DESCRIPTION
Updated docs to indicate the actual default. Fixed wording from `around a variable initialization` to `around each variable initialization`.