### PR TITLE
Fix: comma-style accounts for parens in array (fixes #6006)

### DIFF
--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -39,7 +39,6 @@ module.exports = {
     },
 
     create: function(context) {
-
         var style = context.options[0] || "last",
             exceptions = {},
             sourceCode = context.getSourceCode();
@@ -121,7 +120,13 @@ module.exports = {
                 items.forEach(function(item) {
                     var commaToken = item ? sourceCode.getTokenBefore(item) : previousItemToken,
                         currentItemToken = item ? sourceCode.getFirstToken(item) : sourceCode.getTokenAfter(commaToken),
-                        reportItem = item || currentItemToken;
+                        reportItem = item || currentItemToken,
+                        tokenBeforeComma = sourceCode.getTokenBefore(commaToken);
+
+                    // Check if previous token is wrapped in parentheses
+                    if (tokenBeforeComma && tokenBeforeComma.value === ")") {
+                        previousItemToken = tokenBeforeComma;
+                    }
 
                     /*
                      * This works by comparing three token locations:

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -37,6 +37,10 @@ ruleTester.run("comma-style", rule, {
         {code: "function foo(){var a=[1,\n 2]}"},
         {code: "function foo(){return {'a': 1,\n'b': 2}}"},
         {code: "var foo = \n1, \nbar = \n2;"},
+        {code: "var foo = [\n(bar),\nbaz\n];"},
+        {code: "var foo = [\n(bar\n),\nbaz\n];"},
+        {code: "var foo = [\n(\nbar\n),\nbaz\n];"},
+        {code: "var foo = [\n(bar\n)\n,baz\n];", options: ["first"]},
         {code: "var foo = \n1, \nbar = [1,\n2,\n3]"},
         {code: "var foo = ['apples'\n,'oranges'];", options: ["first"]},
         {code: "var foo = 1, bar = 2;", options: ["first"]},
@@ -226,6 +230,13 @@ ruleTester.run("comma-style", rule, {
             errors: [{
                 message: FIRST_MSG,
                 type: "Property"
+            }]
+        },
+        {
+            code: "var foo = [\n(bar\n)\n,\nbaz\n];",
+            errors: [{
+                message: BAD_LN_BRK_MSG,
+                type: "Identifier"
             }]
         }
     ]


### PR DESCRIPTION
Checks to see if the token right before the comma is a closing parens and uses that token if it is. ~~Also updated the calls on the context object to the current API.~~ Didn't realize @alberto was doing the same thing - his PR was merged today so I just rebased.