### PR TITLE
Fix: `no-return-assign` warning nested expressions (fixes #5913)

### DIFF
--- a/lib/rules/no-return-assign.js
+++ b/lib/rules/no-return-assign.js
@@ -8,14 +8,7 @@
 // Helpers
 //------------------------------------------------------------------------------
 
-/**
- * Checks whether or not a node is an `AssignmentExpression`.
- * @param {Node|null} node - A node to check.
- * @returns {boolean} Whether or not the node is an `AssignmentExpression`.
- */
-function isAssignment(node) {
-    return node && node.type === "AssignmentExpression";
-}
+var SENTINEL_TYPE = /^(?:[a-zA-Z]+?Statement|ArrowFunctionExpression|FunctionExpression|ClassExpression)$/;
 
 /**
  * Checks whether or not a node is enclosed in parentheses.
@@ -51,34 +44,33 @@ module.exports = {
 
     create: function(context) {
         var always = (context.options[0] || "except-parens") !== "except-parens";
-
         var sourceCode = context.getSourceCode();
 
-        /**
-         * Check whether return statement contains assignment
-         * @param {ASTNode} nodeToCheck node to check
-         * @param {ASTNode} nodeToReport node to report
-         * @param {string} message message to report
-         * @returns {void}
-         * @private
-         */
-        function checkForAssignInReturn(nodeToCheck, nodeToReport, message) {
-            if (isAssignment(nodeToCheck) && (always || !isEnclosedInParens(nodeToCheck, sourceCode))) {
-                context.report(nodeToReport, message);
-            }
-        }
-
         return {
-            ReturnStatement: function(node) {
-                var message = "Return statement should not contain assignment.";
+            AssignmentExpression: function(node) {
+                if (!always && isEnclosedInParens(node, sourceCode)) {
+                    return;
+                }
 
-                checkForAssignInReturn(node.argument, node, message);
-            },
-            ArrowFunctionExpression: function(node) {
-                if (node.body.type !== "BlockStatement") {
-                    var message = "Arrow function should not return assignment.";
+                var parent = node.parent;
 
-                    checkForAssignInReturn(node.body, node, message);
+                // Find ReturnStatement or ArrowFunctionExpression in ancestors.
+                while (parent && !SENTINEL_TYPE.test(parent.type)) {
+                    node = parent;
+                    parent = parent.parent;
+                }
+
+                // Reports.
+                if (parent && parent.type === "ReturnStatement") {
+                    context.report({
+                        node: parent,
+                        message: "Return statement should not contain assignment."
+                    });
+                } else if (parent && parent.type === "ArrowFunctionExpression" && parent.body === node) {
+                    context.report({
+                        node: parent,
+                        message: "Arrow function should not return assignment."
+                    });
                 }
             }
         };

--- a/tests/lib/rules/no-return-assign.js
+++ b/tests/lib/rules/no-return-assign.js
@@ -25,6 +25,7 @@ var ruleTester = new RuleTester();
 
 ruleTester.run("no-return-assign", rule, {
     valid: [
+        "var result = a * b;",
         "function x() { var result = a * b; return result; }",
         "function x() { return (result = a * b); }",
         {
@@ -37,6 +38,10 @@ ruleTester.run("no-return-assign", rule, {
         },
         {
             code: "function x() { var result = a * b; return result; }",
+            options: ["always"]
+        },
+        {
+            code: "function x() { return function y() { result = a * b }; }",
             options: ["always"]
         },
         {
@@ -86,6 +91,11 @@ ruleTester.run("no-return-assign", rule, {
         },
         {
             code: "function x() { return (result = a * b); };",
+            options: ["always"],
+            errors: [error]
+        },
+        {
+            code: "function x() { return result || (result = a * b); };",
             options: ["always"],
             errors: [error]
         }


### PR DESCRIPTION
Fixes #5913.

I modified the logic of this rule.
This will handle assignment expressions, then check their ancestor nodes.