### PR TITLE
Fix: throw when rule uses `fix` but `meta.fixable` not set (fixes #5970)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -962,8 +962,14 @@ module.exports = (function() {
             source: sourceCode.lines[location.line - 1] || ""
         };
 
-        // ensure there's range and text properties as well as metadata switch, otherwise it's not a valid fix
-        if (fix && Array.isArray(fix.range) && (typeof fix.text === "string") && (!meta || meta.fixable)) {
+        // ensure there's range and text properties, otherwise it's not a valid fix
+        if (fix && Array.isArray(fix.range) && (typeof fix.text === "string")) {
+
+            // If rule uses fix, has metadata, but has no metadata.fixable, we should throw
+            if (meta && !meta.fixable) {
+                throw new Error("Fixable rules should export a `meta.fixable` property.");
+            }
+
             problem.fix = fix;
         }
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -806,6 +806,31 @@ describe("eslint", function() {
             }, /Node must be an object$/);
         });
 
+        it("should throw an error if fix is passed but meta has no `fixable` property", function() {
+            var meta = {
+                docs: {},
+                schema: []
+            };
+
+            eslint.on("Program", function(node) {
+                eslint.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" }, meta);
+            });
+
+            assert.throws(function() {
+                eslint.verify("0", config, "", true);
+            }, /Fixable rules should export a `meta\.fixable` property.$/);
+        });
+
+        it("should not throw an error if fix is passed and no metadata is passed", function() {
+            eslint.on("Program", function(node) {
+                eslint.report("test-rule", 2, node, "hello world", [], { range: [1, 1], text: "" });
+            });
+
+            assert.doesNotThrow(function() {
+                eslint.verify("0", config, "", true);
+            });
+        });
+
         it("should correctly parse a message with object keys as numbers", function() {
             eslint.on("Program", function(node) {
                 eslint.report("test-rule", 2, node, "my message {{name}}{{0}}", {0: "!", name: "testing"});


### PR DESCRIPTION
Throw an error when a rule uses `fix` but has no `meta.fixable` property set. As discussed in #5970.