### PR TITLE
Docs: Clarify rule example in README since we allow string error levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ After running `eslint --init`, you'll have a `.eslintrc` file in your directory.
 }
 ```
 
-The names `"semi"` and `"quotes"` are the names of [rules](http://eslint.org/docs/rules) in ESLint. The number is the error level of the rule and can be one of the three values:
+The names `"semi"` and `"quotes"` are the names of [rules](http://eslint.org/docs/rules) in ESLint. The first value is the error level of the rule and can be one of these values:
 
 * `"off"` or `0` - turn the rule off
 * `"warn"` or `1` - turn the rule on as a warning (doesn't affect exit code)


### PR DESCRIPTION
Two changes:

* The value representing the error level may not be a number, so I just say "first value" here
* There are three error levels but six total representations of error levels, so I just changed "the three values" to "these values" when referring to the list of error codes.