### PR TITLE
Docs: Describe options in rules under Possible Errors part 2

### DIFF
--- a/docs/rules/no-empty-character-class.md
+++ b/docs/rules/no-empty-character-class.md
@@ -1,6 +1,6 @@
-# Disallow Empty Character Classes (no-empty-character-class)
+# disallow empty character classes in regular expressions (no-empty-character-class)
 
-Empty character classes in regular expressions do not match anything and can result in code that may not work as intended.
+Because empty character classes in regular expressions do not match anything, they might be typing mistakes.
 
 ```js
 var foo = /^abc[]/;
@@ -8,18 +8,15 @@ var foo = /^abc[]/;
 
 ## Rule Details
 
-This rule is aimed at highlighting possible typos and unexpected behavior in regular expressions which may arise from the use of empty character classes.
+This rule disallows empty character classes in regular expressions.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-empty-character-class: "error"*/
 
-var foo = /^abc[]/;
-
-/^abc[]/.test(foo);
-
-bar.match(/^abc[]/);
+/^abc[]/.test("abcdefg"); // false
+"abcdefg".match(/^abc[]/); // null
 ```
 
 Examples of **correct** code for this rule:
@@ -27,13 +24,21 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-empty-character-class: "error"*/
 
-var foo = /^abc/;
+/^abc/.test("abcdefg"); // true
+"abcdefg".match(/^abc/); // ["abc"]
 
-var foo = /^abc[a-z]/;
-
-var bar = new RegExp("^abc[]");
+/^abc[a-z]/.test("abcdefg"); // true
+"abcdefg".match(/^abc[a-z]/); // ["abcd"]
 ```
 
-## Related Rules
+## Known Limitations
 
-* [no-empty-class](no-empty-class.md) (removed)
+This rule does not report empty character classes in the string argument of calls to the `RegExp` constructor.
+
+Example of a *false negative* when this rule reports correct code:
+
+```js
+/*eslint no-empty-character-class: "error"*/
+
+var abcNeverMatches = new RegExp("^abc[]");
+```

--- a/docs/rules/no-ex-assign.md
+++ b/docs/rules/no-ex-assign.md
@@ -1,21 +1,11 @@
-# Disallow Assignment of the Exception Parameter (no-ex-assign)
+# disallow reassigning exceptions in `catch` clauses (no-ex-assign)
 
-When an error is caught using a `catch` block, it's possible to accidentally (or purposely) overwrite the reference to the error. Such as:
-
-```js
-try {
-    // code
-} catch (e) {
-    e = 10;
-}
-```
-
-This makes it impossible to track the error from that point on.
-
+If a `catch` clause in a `try` statement accidentally (or purposely) assigns another value to the exception parameter, it impossible to refer to the error from that point on.
+Since there is no `arguments` object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
 
 ## Rule Details
 
-This rule's purpose is to enforce convention. Assigning a value to the exception parameter wipes out all the valuable data contained therein and thus should be avoided. Since there is no `arguments` object to offer alternative access to this data, assignment of the parameter is absolutely destructive.
+This rule disallows reassigning exceptions in `catch` clauses.
 
 Examples of **incorrect** code for this rule:
 
@@ -37,7 +27,7 @@ Examples of **correct** code for this rule:
 try {
     // code
 } catch (e) {
-    var foo = 'bar';
+    var foo = 10;
 }
 ```
 

--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -1,4 +1,4 @@
-# Disallow Extra Boolean Casts (no-extra-boolean-cast)
+# disallow unnecessary boolean casts (no-extra-boolean-cast)
 
 In contexts such as an `if` statement's test where the result of the expression will already be coerced to a Boolean, casting to a Boolean via double negation (`!!`) or a `Boolean` call is unnecessary. For example, these `if` statements are equivalent:
 
@@ -18,7 +18,7 @@ if (foo) {
 
 ## Rule Details
 
-This rule aims to eliminate the use of Boolean casts in an already Boolean context.
+This rule disallows unnecessary boolean casts.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -1,26 +1,29 @@
-# Disallow Extra Parens (no-extra-parens)
+# disallow unnecessary parentheses (no-extra-parens)
 
-This rule restricts the use of parentheses to only where they are necessary. It may be restricted to report only function expressions.
+This rule restricts the use of parentheses to only where they are necessary.
 
 ## Rule Details
 
-A few cases of redundant parentheses are always allowed:
+This rule always ignores extra parentheses around the following:
 
-* RegExp literals: `(/abc/).test(var)` is always valid.
-* IIFEs: `var x = (function () {})();`, `((function foo() {return 1;})())` are always valid.
+* RegExp literals such as `(/abc/).test(var)` to avoid conflicts with the [wrap-regex](wrap-regex.md) rule
+* immediately-invokes function expressions (also known as IIFEs) such as `var x = (function () {})();` and `((function foo() {return 1;})())` to avoid conflicts with the [wrap-iife](wrap-iife.md) rule
 
 ## Options
 
-This rule takes 1 or 2 arguments. The first one is a string which must be one of the following:
+This rule has a string option:
 
-* `"all"` (default): it will report unnecessary parentheses around any expression.
-* `"functions"`: only function expressions will be checked for unnecessary parentheses.
+* `"all"` (default) disallows unnecessary parentheses around *any* expression
+* `"functions"` disallows unnecessary parentheses *only* around function expressions
 
-The second one is an object for more fine-grained configuration when the first option is `"all"`.
+This rule has an object option for exceptions to the `"all"` option:
+
+* `"conditionalAssign": false` allows extra parentheses around assignments in conditional test expressions
+* `"nestedBinaryExpressions": false` allows extra parentheses in nested binary expressions
 
 ### all
 
-Examples of **incorrect** code for the default `"all"` option:
+Examples of **incorrect** code for this rule with the default `"all"` option:
 
 ```js
 /*eslint no-extra-parens: "error"*/
@@ -34,7 +37,7 @@ typeof (a);
 (function(){} ? a() : b());
 ```
 
-Examples of **correct** code for the default `"all"` option:
+Examples of **correct** code for this rule with the default `"all"` option:
 
 ```js
 /*eslint no-extra-parens: "error"*/
@@ -50,9 +53,7 @@ Examples of **correct** code for the default `"all"` option:
 
 ### conditionalAssign
 
-When setting the first option as `"all"`, an additional option can be added to allow extra parens for assignment in conditional statements.
-
-Examples of **correct** code for the `"all"` and `{ "conditionalAssign": false }` options:
+Examples of **correct** code for this rule with the `"all"` and `{ "conditionalAssign": false }` options:
 
 ```js
 /*eslint no-extra-parens: ["error", "all", { "conditionalAssign": false }]*/
@@ -68,11 +69,11 @@ for (;(a = b););
 
 ### nestedBinaryExpressions
 
-When setting the first option as `"all"`, an additional option can be added to allow extra parens in nested binary expressions.
-
-Examples of **correct** for the `"all"` and `{ "nestedBinaryExpressions": false }` options:
+Examples of **correct** for this rule with the `"all"` and `{ "nestedBinaryExpressions": false }` options:
 
 ```js
+/*eslint no-extra-parens: ["error", "all", { "nestedBinaryExpressions": false }]*/
+
 x = a || (b && c);
 x = a + (b * c);
 x = (a * b) / c;
@@ -80,7 +81,7 @@ x = (a * b) / c;
 
 ### functions
 
-Examples of **incorrect** code for the `"functions"` option:
+Examples of **incorrect** code for this rule with the `"functions"` option:
 
 ```js
 /*eslint no-extra-parens: ["error", "functions"]*/
@@ -90,7 +91,7 @@ Examples of **incorrect** code for the `"functions"` option:
 var y = (function () {return 1;});
 ```
 
-Examples of **correct** code for the `"functions"` option:
+Examples of **correct** code for this rule with the `"functions"` option:
 
 ```js
 /*eslint no-extra-parens: ["error", "functions"]*/

--- a/docs/rules/no-extra-semi.md
+++ b/docs/rules/no-extra-semi.md
@@ -1,12 +1,12 @@
-# Disallow Extra Semicolons (no-extra-semi)
+# disallow unnecessary semicolons (no-extra-semi)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-JavaScript will more or less let you put semicolons after any statement without complaining. Typos and misunderstandings about where semicolons are required can lead to extra semicolons that are unnecessary.
+Typing mistakes and misunderstandings about where semicolons are required can lead to semicolons that are unnecessary. While not technically an error, extra semicolons can cause confusion when reading code.
 
 ## Rule Details
 
-This rule is aimed at eliminating extra unnecessary semicolons. While not technically an error, extra semicolons can be a source of confusion when reading code.
+This rule disallows unnecessary semicolons.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-func-assign.md
+++ b/docs/rules/no-func-assign.md
@@ -1,4 +1,4 @@
-# Disallow Function Assignment (no-func-assign)
+# disallow reassigning `function` declarations (no-func-assign)
 
 JavaScript functions can be written as a FunctionDeclaration `function foo() { ... }` or as a FunctionExpression `var foo = function() { ... };`. While a JavaScript interpreter might tolerate it, overwriting/reassigning a function written as a FunctionDeclaration is often indicative of a mistake or issue.
 
@@ -9,7 +9,7 @@ foo = bar;
 
 ## Rule Details
 
-This rule is aimed at flagging probable mistakes and issues in the form of overwriting a function that was written as a FunctionDeclaration. As such it will warn when this issue is encountered.
+This rule disallows reassigning `function` declarations.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-inner-declarations.md
+++ b/docs/rules/no-inner-declarations.md
@@ -1,4 +1,4 @@
-# Declarations in Program or Function Body (no-inner-declarations)
+# disallow `function` or `var` declarations in nested blocks (no-inner-declarations)
 
 In JavaScript, prior to ES6, a function declaration is only allowed in the first level of a program or the body of another function, though parsers sometimes [erroneously accept them elsewhere](https://code.google.com/p/esprima/issues/detail?id=422). This only applies to function declarations; named or anonymous function expressions can occur anywhere an expression is permitted.
 
@@ -60,17 +60,14 @@ This rule requires that function declarations and, optionally, variable declarat
 
 ## Options
 
-This rule takes a single option to specify whether it should check just function declarations or both function and variable declarations. The default is `"functions"`. Setting it to `"both"` will apply the same rules to both types of declarations.
+This rule has a string option:
 
-You can set the option in configuration like this:
-
-```json
-"no-inner-declarations": [2, "both"]
-```
+* `"functions"` (default) disallows `function` declarations in nested blocks
+* `"both"` disallows `function` and `var` declarations in nested blocks
 
 ### functions
 
-Examples of **incorrect** code for the default `"functions"` option:
+Examples of **incorrect** code for this rule with the default `"functions"` option:
 
 ```js
 /*eslint no-inner-declarations: "error"*/
@@ -86,7 +83,7 @@ function doSomethingElse() {
 }
 ```
 
-Examples of **correct** code for the default `"functions"` option:
+Examples of **correct** code for this rule with the default `"functions"` option:
 
 ```js
 /*eslint no-inner-declarations: "error"*/
@@ -109,7 +106,7 @@ if (test) {
 
 ### both
 
-Examples of **incorrect** code for the `"both"` option:
+Examples of **incorrect** code for this rule with the `"both"` option:
 
 ```js
 /*eslint no-inner-declarations: ["error", "both"]*/
@@ -125,7 +122,7 @@ function doAnotherThing() {
 }
 ```
 
-Examples of **correct** code for the `"both"` option:
+Examples of **correct** code for this rule with the `"both"` option:
 
 ```js
 /*eslint no-inner-declarations: "error"*/

--- a/docs/rules/no-invalid-regexp.md
+++ b/docs/rules/no-invalid-regexp.md
@@ -1,8 +1,10 @@
-# Disallow Invalid Regular Expressions (no-invalid-regexp)
+# disallow invalid regular expression strings in `RegExp` constructors (no-invalid-regexp)
 
-This rule validates string arguments passed to the `RegExp` constructor.
+An invalid pattern in a regular expression literal is a `SyntaxError` when the code is parsed, but an invalid string in `RegExp` constructors throws a `SyntaxError` only when the code is executed.
 
 ## Rule Details
+
+This rule disallows invalid regular expression strings in `RegExp` constructors.
 
 Examples of **incorrect** code for this rule:
 
@@ -30,25 +32,32 @@ this.RegExp('[')
 
 ## Environments
 
-ECMAScript 6 adds the "u" ([unicode](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode)) and "y" ([sticky](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky)) flags. You can enable these to be recognized as valid by setting the ECMAScript version to 6 in your [ESLint configuration](../user-guide/configuring).
+ECMAScript 6 adds the following flag arguments to the `RegExp` constructor:
 
+* `"u"` ([unicode](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.unicode))
+* `"y"` ([sticky](https://people.mozilla.org/~jorendorff/es6-draft.html#sec-get-regexp.prototype.sticky))
 
-## Options
+You can enable these to be recognized as valid by setting the ECMAScript version to 6 in your [ESLint configuration](../user-guide/configuring).
 
 If you want to allow additional constructor flags for any reason, you can specify them using an `allowConstructorFlags` option in `.eslintrc`. These flags will then be ignored by the rule regardless of the `ecmaVersion` setting.
 
-### `allowConstructorFlags`
+## Options
 
-This takes in an array of flags. With this option, the following patterns aren't considered problems:
+This rule has an object option for exceptions:
+
+* `"allowConstructorFlags"` is an array of flags
+
+### allowConstructorFlags
+
+Examples of **correct** code for this rule with the `{ "allowConstructorFlags": ["u", "y"] }` option:
 
 ```js
-/*eslint no-invalid-regexp: ["error", {"allowConstructorFlags": ["u", "y"]}]*/
+/*eslint no-invalid-regexp: ["error", { "allowConstructorFlags": ["u", "y"] }]*/
 
 new RegExp('.', 'y')
 
 new RegExp('.', 'yu')
 ```
-
 
 ## Further Reading
 

--- a/docs/rules/no-irregular-whitespace.md
+++ b/docs/rules/no-irregular-whitespace.md
@@ -1,4 +1,4 @@
-# No irregular whitespace (no-irregular-whitespace)
+# disallow irregular whitespace (no-irregular-whitespace)
 
 Invalid or irregular whitespace causes issues with ECMAScript 5 parsers and also makes code harder to debug in a similar nature to mixed tabs and spaces.
 
@@ -16,7 +16,7 @@ Known issues these spaces cause:
 
 This rule is aimed at catching invalid whitespace that is not a normal tab and space. Some of these characters may cause issues in modern browsers and others will be a debugging issue to spot.
 
-With this rule enabled the following characters will cause warnings outside of strings and comments:
+This rule disallows the following characters except where the options allow:
 
     \u000B - Line Tabulation (\v) - <VT>
     \u000C - Form Feed (\f) - <FF>
@@ -43,73 +43,6 @@ With this rule enabled the following characters will cause warnings outside of s
     \u205f - Medium Mathematical Space
     \u3000 - Ideographic Space
 
-Examples of **incorrect** code for this rule:
-
-```js
-/*eslint no-irregular-whitespace: "error"*/
-
-function thing() /*<NBSP>*/{
-  return 'test';
-}
-
-function thing( /*<NBSP>*/){
-  return 'test';
-}
-
-function thing /*<NBSP>*/(){
-  return 'test';
-}
-
-function thing᠎/*<MVS>*/(){
-  return 'test';
-}
-
-function thing() {
-  return 'test'; /*<ENSP>*/
-}
-
-function thing() {
-  return 'test'; /*<NBSP>*/
-}
-
-function thing() {
-  // Description <NBSP>
-}
-
-function thing() {
-  return / <NBSP>regexp/;
-}
-
-/*eslint-env es6*/
-function thing() {
-  return `template  <NBSP>string`;
-}
-```
-
-Examples of **correct** code for this rule:
-
-```js
-/*eslint no-irregular-whitespace: "error"*/
-
-function thing() {
-  return ' <NBSP>thing';
-}
-
-function thing() {
-  return '​<ZWSP>thing';
-}
-
-function thing() {
-  return 'th <NBSP>ing';
-}
-
-// Description<NBSP>: some descriptive text
-
-/*
-Description<NBSP>: some descriptive text
-*/
-```
-
 ## Options
 
 This rule has an object option for exceptions:
@@ -119,37 +52,111 @@ This rule has an object option for exceptions:
 * `"skipRegExps": true` allows any whitespace characters in regular expression literals
 * `"skipTemplates": true` allows any whitespace characters in template literals
 
+### skipStrings
+
+Examples of **incorrect** code for this rule with the default `{ "skipStrings": true }` option:
+
+```js
+/*eslint no-irregular-whitespace: "error"*/
+
+function thing() /*<NBSP>*/{
+    return 'test';
+}
+
+function thing( /*<NBSP>*/){
+    return 'test';
+}
+
+function thing /*<NBSP>*/(){
+    return 'test';
+}
+
+function thing᠎/*<MVS>*/(){
+    return 'test';
+}
+
+function thing() {
+    return 'test'; /*<ENSP>*/
+}
+
+function thing() {
+    return 'test'; /*<NBSP>*/
+}
+
+function thing() {
+    // Description <NBSP>: some descriptive text
+}
+
+/*
+Description <NBSP>: some descriptive text
+*/
+
+function thing() {
+    return / <NBSP>regexp/;
+}
+
+/*eslint-env es6*/
+function thing() {
+    return `template <NBSP>string`;
+}
+```
+
+Examples of **correct** code for this rule with the default `{ "skipStrings": true }` option:
+
+```js
+/*eslint no-irregular-whitespace: "error"*/
+
+function thing() {
+    return ' <NBSP>thing';
+}
+
+function thing() {
+    return '​<ZWSP>thing';
+}
+
+function thing() {
+    return 'th <NBSP>ing';
+}
+```
+
 ### skipComments
 
-Examples of additional **correct** code for this rule with the { "skipComments": true } option:
+Examples of additional **correct** code for this rule with the `{ "skipComments": true }` option:
 
 ```js
 /*eslint no-irregular-whitespace: ["error", { "skipComments": true }]*/
+
 function thing() {
-  // Description <NBSP>
+    // Description <NBSP>: some descriptive text
 }
+
+/*
+Description <NBSP>: some descriptive text
+*/
 ```
 
 ### skipRegExps
 
-Examples of additional **correct** code for this rule with the { "skipRegExps": true } option:
+Examples of additional **correct** code for this rule with the `{ "skipRegExps": true }` option:
 
 ```js
 /*eslint no-irregular-whitespace: ["error", { "skipRegExps": true }]*/
+
 function thing() {
-  return / <NBSP>regexp/;
+    return / <NBSP>regexp/;
 }
 ```
 
 ### skipTemplates
 
-Examples of additional **correct** code for this rule with the { "skipTemplates": true } option:
+Examples of additional **correct** code for this rule with the `{ "skipTemplates": true }` option:
 
 ```js
 /*eslint no-irregular-whitespace: ["error", { "skipTemplates": true }]*/
 /*eslint-env es6*/
+
 function thing() {
-  return `template  <NBSP>string`;
+    return `template <NBSP>string`;
 }
 ```
 

--- a/docs/rules/no-negated-in-lhs.md
+++ b/docs/rules/no-negated-in-lhs.md
@@ -1,38 +1,21 @@
-# Disallow negated left operand of `in` operator (no-negated-in-lhs)
+# disallow negating the left operand in `in` expressions (no-negated-in-lhs)
 
 ## Rule Details
 
-This rule is raised to highlight a potential error. Commonly, when a developer intends to write
+Just as developers might type `-a + b` when they mean `-(a + b)` for the negative of a sum, they might type `!key in object` by mistake when they almost certainly mean `!(key in object)` to test that a key is not in an object.
 
-```js
-if(!(a in b)) {
-    // do something
-}
-```
+## Rule Details
 
-they will instead write
-
-```js
-if(!a in b) {
-    // do something
-}
-```
-
-If one intended the original behaviour, the left operand should be explicitly coerced to a string like below.
-
-```js
-if(('' + !a) in b) {
-    // do something
-}
-```
+This rule disallows negating the left operand in `in` expressions.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-negated-in-lhs: "error"*/
 
-if(!a in b) {
-    // do something
+if(!key in object) {
+    // operator precedence makes it equivalent to (!key) in object
+    // and type conversion makes it equivalent to (key ? "false" : "true") in object
 }
 ```
 
@@ -41,19 +24,16 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-negated-in-lhs: "error"*/
 
-if(!(a in b)) {
-    // do something
+if(!(key in object)) {
+    // key is not in object
 }
 
-if(('' + !a) in b) {
-    // do something
+if(('' + !key) in object) {
+    // make operator precedence and type conversion explicit
+    // in a rare situation when that is the intended meaning
 }
 ```
 
 ## When Not To Use It
 
 Never.
-
-## Further Reading
-
-None.


### PR DESCRIPTION
The next 10 rules under **Possible Errors**

* Make description in h1 consistent with rules index page, not even the first word is capitalized. That is because will soon change the format to match the rules index page (that is, rule-id: rule description).
* Make first sentence under Rule Details consistent with description.
* Add “this rule with” to example sentences.
* Describe options according to patterns in guidelines.

Here are additional changes:
* no-empty-character-class: add Known Limitations; delete Related Rules link to removed rule
* no-ex-assign: make examples parallel
* no-extra-parens: add links to rules with potential conflicts which are ignored
* no-irregular-whitespace: move examples from Rule Details to Options; change indent from 2 to 4
* no-negated-in-lhs: rewrite introduction with analogy to incorrect numerical negation; remove Further Reading
