### PR TITLE
Fix: `no-sequences` false negative at arrow expressions (fixes #6082)

### DIFF
--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -31,7 +31,8 @@ module.exports = {
             IfStatement: "test",
             SwitchStatement: "discriminant",
             WhileStatement: "test",
-            WithStatement: "object"
+            WithStatement: "object",
+            ArrowFunctionExpression: "body"
 
             // Omitting CallExpression - commas are parsed as argument separators
             // Omitting NewExpression - commas are parsed as argument separators

--- a/tests/lib/rules/no-sequences.js
+++ b/tests/lib/rules/no-sequences.js
@@ -48,7 +48,8 @@ ruleTester.run("no-sequences", rule, {
         "if ((doSomething(), !!test));",
         "switch ((doSomething(), !!test)) {}",
         "while ((doSomething(), !!test));",
-        "with ((doSomething(), val)) {}"
+        "with ((doSomething(), val)) {}",
+        { code: "a => ((doSomething(), a))", env: {es6: true} }
     ],
 
     // Examples of code that should trigger the rule
@@ -59,6 +60,7 @@ ruleTester.run("no-sequences", rule, {
         { code: "if (doSomething(), !!test);", errors: errors(18) },
         { code: "switch (doSomething(), val) {}", errors: errors(22) },
         { code: "while (doSomething(), !!test);", errors: errors(21) },
-        { code: "with (doSomething(), val) {}", errors: errors(20) }
+        { code: "with (doSomething(), val) {}", errors: errors(20) },
+        { code: "a => (doSomething(), a)", env: {es6: true}, errors: errors(20)}
     ]
 });


### PR DESCRIPTION
Fixes #6082 