### PR TITLE
Docs: Improve showcase example in `one-var-declaration-per-line`

### DIFF
--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -3,7 +3,7 @@
 Some developers declare multiple var statements on the same line:
 
 ```js
-var foo, bar, baz = 0;
+var foo, bar, baz;
 ```
 
 Others prefer to declare one var per line.
@@ -11,7 +11,7 @@ Others prefer to declare one var per line.
 ```js
 var foo,
     bar,
-    baz = 0;
+    baz;
 ```
 
 This rule enforces a consistent style across the entire project.


### PR DESCRIPTION
The example made it appear like this rule can be used to enforce initializations in the same line as other vars, but it doesn't.