### PR TITLE
Build: Match rule id at beginning of heading (refs #5774)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -773,9 +773,13 @@ target.checkRuleFiles = function() {
          */
         function hasIdInTitle(id) {
             var docText = cat(docFilename);
-            var idInTitleRegExp = new RegExp("^# (.*?) \\(" + id + "\\)");
+            var idOldAtEndOfTitleRegExp = new RegExp("^# (.*?) \\(" + id + "\\)"); // original format
+            var idNewAtBeginningOfTitleRegExp = new RegExp("^# " + id + ": "); // new format is same as rules index
+            // 1. Added support for new format.
+            // 2. Will remove support for old format after all docs files have new format.
+            // 3. Will remove this check when the main heading is automatically generated from rule metadata.
 
-            return idInTitleRegExp.test(docText);
+            return idNewAtBeginningOfTitleRegExp.test(docText) || idOldAtEndOfTitleRegExp.test(docText);
         }
 
         // check for docs


### PR DESCRIPTION
Prerequisite to stage 1 described in https://github.com/eslint/eslint/issues/5774#issuecomment-216530450

During verification step of rule docs files, match the rule id in the main heading **either**

*   in original format: at the end, enclosed in parentheses

    require or disallow trailing commas (comma-dangle)
*   in new format: at the beginning, followed by a colon

    comma-dangle: require or disallow trailing commas

Short-term goal: After all rule docs files have been converted to the new format, its regexp pattern will be removed from the verification step.

Long-term goal: Instead of verification, the build process will automatically generated the heading from rule metadata, see https://github.com/eslint/eslint/issues/5774#issuecomment-216996951

EDIT: But must remember that **removed** rules might be an exception to our automation goal: probably not able to prepend to their doc the main heading, removed paragraph, nor fixable paragraph.