### PR TITLE
Fix: Exclude _ and $ from isES5Constructor (fixes #6085)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -57,7 +57,7 @@ function isModifyingReference(reference, index, references) {
 function isES5Constructor(node) {
     return (
         node.id &&
-        node.id.name[0] === node.id.name[0].toLocaleUpperCase()
+        node.id.name[0] !== node.id.name[0].toLocaleLowerCase()
     );
 }
 

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -113,6 +113,16 @@ ruleTester.run("consistent-return", rule, {
             ]
         },
         {
+            code: "function _foo() { if (a) return true; }",
+            errors: [
+                {
+                    message: "Expected to return a value at the end of this function.",
+                    type: "FunctionDeclaration",
+                    column: 10
+                }
+            ]
+        },
+        {
             code: "f(function foo() { if (a) return true; });",
             errors: [
                 {


### PR DESCRIPTION
As discussed in #6085, the previous case-matching code was overly liberal in matching these punctuation characters, which are not commonly used to begin constructor names.  In the case that they are used, such uses may be excluded from the relevant rules using inline configuration.

Fixes: #6085