### PR TITLE
Docs: Update headings of rules under Removed (refs #5774)

### DIFF
--- a/docs/rules/generator-star.md
+++ b/docs/rules/generator-star.md
@@ -1,6 +1,6 @@
-# Enforce the position of the * in generators (generator-star)
+# generator-star: enforce consistent spacing around the asterisk in generator functions
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [generator-star-spacing](generator-star-spacing.md) rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [generator-star-spacing](generator-star-spacing.md) rule.
 
 Generators are a new type of function in ECMAScript 6 that can return multiple values over time.
 These special functions are indicated by placing an `*` after the `function` keyword.

--- a/docs/rules/global-strict.md
+++ b/docs/rules/global-strict.md
@@ -1,6 +1,6 @@
-# Global Strict Mode (global-strict)
+# global-strict: require or disallow strict mode directives in the global scope
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [strict](strict.md) rule. `"global"` mode in the strict rule is most similar to this rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [strict](strict.md) rule. The `"global"` option in the new rule is most similar to the removed rule.
 
 Strict mode is enabled by using the following pragma in your code:
 

--- a/docs/rules/no-arrow-condition.md
+++ b/docs/rules/no-arrow-condition.md
@@ -1,6 +1,6 @@
-# Disallow arrow functions where a condition is expected (no-arrow-condition)
+# no-arrow-condition: disallow arrow functions where test conditions are expected
 
-**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by a combination of [no-confusing-arrow](no-confusing-arrow.md) and [no-constant-condition](no-constant-condition.md) rules.
+(removed) This rule was **removed** in ESLint v2.0 and **replaced** by a combination of the [no-confusing-arrow](no-confusing-arrow.md) and [no-constant-condition](no-constant-condition.md) rules.
 
 Arrow functions (`=>`) are similar in syntax to some comparison operators (`>`, `<`, `<=`, and `>=`). This rule warns against using the arrow function syntax in places where a condition is expected. Even if the arguments of the arrow function are wrapped with parens, this rule still warns about it.
 

--- a/docs/rules/no-comma-dangle.md
+++ b/docs/rules/no-comma-dangle.md
@@ -1,6 +1,6 @@
-# Disallow Dangling Commas (no-comma-dangle)
+# no-comma-dangle: disallow trailing commas in object and array literals
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [comma-dangle](comma-dangle.md) rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [comma-dangle](comma-dangle.md) rule.
 
 Trailing commas in object literals are valid according to the ECMAScript 5 (and ECMAScript 3!) spec, however IE8 (when not in IE8 document mode) and below will throw an error when it encounters trailing commas in JavaScript.
 

--- a/docs/rules/no-empty-class.md
+++ b/docs/rules/no-empty-class.md
@@ -1,6 +1,6 @@
-# Disallow Empty Character Classes (no-empty-class)
+# no-empty-class: disallow empty character classes in regular expressions
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [no-empty-character-class](no-empty-character-class.md) rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [no-empty-character-class](no-empty-character-class.md) rule.
 
 Empty character classes in regular expressions do not match anything and can result in code that may not work as intended.
 

--- a/docs/rules/no-empty-label.md
+++ b/docs/rules/no-empty-label.md
@@ -1,6 +1,6 @@
-# No empty labels (no-empty-label)
+# no-empty-label: disallow labels for anything other than loops and switches
 
-**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [no-labels](no-labels.md) rule.
+(removed) This rule was **removed** in ESLint v2.0 and **replaced** by the [no-labels](no-labels.md) rule.
 
 Labeled statements are only used in conjunction with labeled break and continue statements. ECMAScript has no goto statement.
 

--- a/docs/rules/no-extra-strict.md
+++ b/docs/rules/no-extra-strict.md
@@ -1,6 +1,6 @@
-# Disallow Unnecessary Strict Pragma (no-extra-strict)
+# no-extra-strict: disallow strict mode directives when already in strict mode
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [strict](strict.md) rule. Both `"global"` and `"function"` mode in the strict rule implement this rule's behavior.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [strict](strict.md) rule. The `"global"` or `"function"` options in the new rule are similar to the removed rule.
 
 The `"use strict";` directive applies to the scope in which it appears and all inner scopes contained within that scope. Therefore, using the `"use strict";` directive in one of these inner scopes is unnecessary.
 

--- a/docs/rules/no-reserved-keys.md
+++ b/docs/rules/no-reserved-keys.md
@@ -1,6 +1,6 @@
-# Disallow Use of Reserved Words as Keys (no-reserved-keys)
+# no-reserved-keys: disallow unquoted reserved words as property names in object literals
 
-**Replacement notice:** This rule was removed in ESLint v1.0 and replaced by the [quote-props](quote-props.md) rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [quote-props](quote-props.md) rule.
 
 ECMAScript 3 described as series of keywords and reserved words, such as `if` and `public`, that are used or intended to be used for a core language feature. The specification also indicated that these keywords and reserved words could not be used as object property names without being enclosed in strings. An error occurs in an ECMAScript 3 environment when you use a keyword or reserved word in an object literal. For example:
 

--- a/docs/rules/no-space-before-semi.md
+++ b/docs/rules/no-space-before-semi.md
@@ -1,6 +1,6 @@
-# Disallow Spaces Before Semicolon (no-space-before-semi)
+# no-space-before-semi: disallow spaces before semicolons
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [semi-spacing](semi-spacing.md) rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [semi-spacing](semi-spacing.md) rule.
 
 JavaScript allows for placing unnecessary spaces between an expression and the closing semicolon.
 

--- a/docs/rules/no-wrap-func.md
+++ b/docs/rules/no-wrap-func.md
@@ -1,6 +1,6 @@
-# Disallow Parens Around Functions (no-wrap-func)
+# no-wrap-func: disallow unnecessary parentheses around function expressions
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [no-extra-parens](no-extra-parens.md) rule, when configured in the `"functions"` mode.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [no-extra-parens](no-extra-parens.md) rule. The `"functions"` option in the new rule is equivalent to the removed rule.
 
 
 Although it's possible to wrap functions in parentheses, this can be confusing when the code also contains immediately-invoked function expressions (IIFEs) since parentheses are often used to make this distinction. For example:

--- a/docs/rules/space-after-function-name.md
+++ b/docs/rules/space-after-function-name.md
@@ -1,6 +1,6 @@
-# Require or disallow spaces following function names (space-after-function-name)
+# space-after-function-name: enforce consistent spacing after name in function definitions
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [space-before-function-paren](space-before-function-paren.md) rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [space-before-function-paren](space-before-function-paren.md) rule.
 
 Whitespace between a function name and its parameter list is optional.
 

--- a/docs/rules/space-after-keywords.md
+++ b/docs/rules/space-after-keywords.md
@@ -1,6 +1,6 @@
-# Require or disallow spaces following keywords (space-after-keywords)
+# space-after-keywords: enforce consistent spacing after keywords
 
-**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
+(removed) This rule was **removed** in ESLint v2.0 and replaced by the [keyword-spacing](keyword-spacing.md) rule.
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixed problems reported by this rule.
 

--- a/docs/rules/space-before-function-parentheses.md
+++ b/docs/rules/space-before-function-parentheses.md
@@ -1,6 +1,6 @@
-# Require or disallow spaces before function parentheses (space-before-function-parentheses)
+# space-before-function-parentheses: enforce consistent spacing before opening parenthesis in function definitions
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and has been renamed to [space-before-function-paren](space-before-function-paren.md) for consistency with other rules' names, which used "parens" instead of "parentheses". The new rule is identical in everything except name.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [space-before-function-paren](space-before-function-paren.md) rule. The name of the rule changed from "parentheses" to "paren" for consistency with the names of other rules.
 
 When formatting a function, whitespace is allowed between the function name or `function` keyword and the opening paren. Named functions also require a space between the `function` keyword and the function name, but anonymous functions require no whitespace. For example:
 

--- a/docs/rules/space-before-keywords.md
+++ b/docs/rules/space-before-keywords.md
@@ -1,6 +1,6 @@
-# Require or disallow spaces before keywords (space-before-keywords)
+# space-before-keywords: enforce consistent spacing before keywords
 
-**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
+(removed) This rule was **removed** in ESLint v2.0 and **replaced** by the [keyword-spacing](keyword-spacing.md) rule.
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixed problems reported by this rule.
 

--- a/docs/rules/space-in-brackets.md
+++ b/docs/rules/space-in-brackets.md
@@ -1,6 +1,6 @@
-# Disallow or enforce spaces inside of brackets. (space-in-brackets)
+# space-in-brackets: enforce consistent spacing inside braces of object literals and brackets of array literals
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [object-curly-spacing](object-curly-spacing.md), [computed-property-spacing](computed-property-spacing.md) and [array-bracket-spacing](array-bracket-spacing.md) rules.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [object-curly-spacing](object-curly-spacing.md) and [array-bracket-spacing](array-bracket-spacing.md) rules.
 
 While formatting preferences are very personal, a number of style guides require or disallow spaces between brackets:
 

--- a/docs/rules/space-return-throw-case.md
+++ b/docs/rules/space-return-throw-case.md
@@ -1,6 +1,6 @@
-# Require spaces following `return`, `throw`, and `case` (space-return-throw-case)
+# space-return-throw-case: require spaces after `return`, `throw`, and `case` keywords
 
-**Replacement notice**: This rule was removed in ESLint v2.0 and replaced by [keyword-spacing](keyword-spacing.md) rule.
+(removed) This rule was **removed** in ESLint v2.0 and **replaced** by the [keyword-spacing](keyword-spacing.md) rule.
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixed problems reported by this rule.
 

--- a/docs/rules/space-unary-word-ops.md
+++ b/docs/rules/space-unary-word-ops.md
@@ -1,6 +1,6 @@
-# Require spaces following unary word operators (space-unary-word-ops)
+# space-unary-word-ops: require spaces after unary word operators
 
-**Replacement notice**: This rule was removed and has been replaced by the [space-unary-ops](space-unary-ops.md) rule.
+(removed) This rule was **removed** in ESLint v0.10.0 and **replaced** by the [space-unary-ops](space-unary-ops.md) rule.
 
 Require spaces following unary word operators.
 

--- a/docs/rules/spaced-line-comment.md
+++ b/docs/rules/spaced-line-comment.md
@@ -1,6 +1,6 @@
-# Requires or disallows a whitespace (space or tab) beginning a single-line comment (spaced-line-comment)
+# spaced-line-comment: enforce consistent spacing after `//` in line comments
 
-**Replacement notice**: This rule was removed in ESLint v1.0 and replaced by the [spaced-comment](spaced-comment.md) rule.
+(removed) This rule was **removed** in ESLint v1.0 and **replaced** by the [spaced-comment](spaced-comment.md) rule.
 
 Some style guides require or disallow a whitespace immediately after the initial `//` of a line comment.
 Whitespace after the `//` makes it easier to read text in comments.


### PR DESCRIPTION
The rest of stage 1 described in https://github.com/eslint/eslint/issues/5774#issuecomment-216530450 which was dependent on #6089

For 18 removed rules:
    * Update the description in the main headings and move the rule identifier to the beginning (for similarity with the rules index).
    * Display the **X** glyphicon at the left of the removed/replaced sentences.
    * Make the sentences consistent in wording (they are already similar).

Extra change to space-in-brackets: deleted link to computed-property-spacing because it was not on the rules index and because lack of any mention of computed properties in the doc suggests that they were out of the scope of the removed rule
