### PR TITLE
Docs: Describe options in rules under Possible Errors part 3

### DIFF
--- a/docs/rules/no-obj-calls.md
+++ b/docs/rules/no-obj-calls.md
@@ -1,4 +1,4 @@
-# Disallow Global Object Function Calls (no-obj-calls)
+# disallow calling global object properties as functions (no-obj-calls)
 
 ECMAScript provides several global objects that are intended to be used as-is. Some of these objects look as if they could be constructors due their capitalization (such as `Math` and `JSON`) but will throw an error if you try to execute them as functions.
 
@@ -8,15 +8,15 @@ The [ECMAScript 5 specification](http://es5.github.io/#x15.8) makes it clear tha
 
 ## Rule Details
 
-This rule is aimed at preventing the accidental calling of global objects as functions.
+This rule disallows calling the `Math` and `JSON` objects as functions.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-obj-calls: "error"*/
 
-var x = Math();
-var y = JSON();
+var math = Math();
+var json = JSON();
 ```
 
 Examples of **correct** code for this rule:
@@ -24,8 +24,10 @@ Examples of **correct** code for this rule:
 ```js
 /*eslint no-obj-calls: "error"*/
 
-var x = math();
-var y = json();
+function area(r) {
+    return Math.PI * r * r;
+}
+var object = JSON.parse("{}");
 ```
 
 ## Further Reading

--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -1,4 +1,4 @@
-# Disallow Spaces in Regular Expressions (no-regex-spaces)
+# disallow multiple spaces in regular expression literals (no-regex-spaces)
 
 Regular expressions can be very complex and difficult to understand, which is why it's important to keep them as simple as possible in order to avoid mistakes. One of the more error-prone things you can do with a regular expression is to use more than one space, such as:
 
@@ -16,7 +16,7 @@ Now it is very clear that three spaces are expected to be matched.
 
 ## Rule Details
 
-This rule aims to eliminate errors due to multiple spaces inside of a regular expression. As such, it warns whenever more than one space in a row is found inside of a regular expression literal.
+This rule disallows multiple spaces in regular expression literals.
 
 Examples of **incorrect** code for this rule:
 
@@ -32,6 +32,16 @@ Examples of **correct** code for this rule:
 /*eslint no-regex-spaces: "error"*/
 
 var re = /foo {3}bar/;
+```
+
+## Known Limitations
+
+This rule does not report multiple spaces in the string argument of calls to the `RegExp` constructor.
+
+Example of a *false negative* when this rule reports correct code:
+
+```js
+/*eslint no-regex-spaces: "error"*/
 
 var re = new RegExp("foo   bar");
 ```

--- a/docs/rules/no-sparse-arrays.md
+++ b/docs/rules/no-sparse-arrays.md
@@ -1,4 +1,4 @@
-# Disallow Sparse Arrays (no-sparse-arrays)
+# disallow sparse arrays (no-sparse-arrays)
 
 Sparse arrays contain empty slots, most frequently due to multiple commas being used in an array literal, such as:
 
@@ -18,7 +18,7 @@ The confusion around sparse arrays defined in this manner is enough that it's re
 
 ## Rule Details
 
-This rule aims to eliminate sparse arrays that are defined by extra commas.
+This rule disallows sparse array literals which have "holes" where commas are not preceded by elements. It does not apply to a trailing comma following the last element.
 
 Examples of **incorrect** code for this rule:
 
@@ -37,7 +37,7 @@ Examples of **correct** code for this rule:
 var items = [];
 var items = new Array(23);
 
-// trailing comma is okay
+// trailing comma (after the last element) is not a problem
 var colors = [ "red", "blue", ];
 ```
 

--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -1,19 +1,19 @@
-# Avoid unexpected multiline expressions (no-unexpected-multiline)
+# disallow confusing multiline expressions (no-unexpected-multiline)
 
-Semicolons are optional in JavaScript, via a process called automatic semicolon insertion (ASI). See the documentation for [semi](./semi.md) for a fuller discussion of that feature.
+Semicolons are usually optional in JavaScript, because of automatic semicolon insertion (ASI). You can require or disallow semicolons with the [semi](./semi.md) rule.
 
-The rules for ASI are relatively straightforward: In short, as once described by Isaac Schlueter, a `\n` character always ends a statement (just like a semicolon) unless one of the following is true:
+The rules for ASI are relatively straightforward: As once described by Isaac Schlueter, a newline character character always ends a statement, just like a semicolon, **except** where one of the following is true:
 
 * The statement has an unclosed paren, array literal, or object literal or ends in some other way that is not a valid way to end a statement. (For instance, ending with `.` or `,`.)
 * The line is `--` or `++` (in which case it will decrement/increment the next token.)
 * It is a `for()`, `while()`, `do`, `if()`, or `else`, and there is no `{`
 * The next line starts with `[`, `(`, `+`, `*`, `/`, `-`, `,`, `.`, or some other binary operator that can only be found between two tokens in a single expression.
 
-This particular rule aims to spot scenarios where a newline looks like it is ending a statement, but is not.
+In the exceptions where a newline does **not** end a statement, a typing mistake to omit a semicolon causes two unrelated consecutive lines to be interpreted as one expression. Especially for a coding style without semicolons, readers might overlook the mistake. Although syntactically correct, the code might throw exceptions when it is executed.
 
 ## Rule Details
 
-This rule is aimed at ensuring that two unrelated consecutive lines are not accidentally interpreted as a single expression.
+This rule disallows confusing multiline expressions where a newline looks like it is ending a statement, but is not.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-unreachable.md
+++ b/docs/rules/no-unreachable.md
@@ -1,6 +1,6 @@
-# Disallow Unreachable Code (no-unreachable)
+# disallow unreachable code after `return`, `throw`, `continue`, and `break` statements (no-unreachable)
 
-A number of statements unconditionally exit a block of code. Any statements after that will not be executed and may be an error. The presence of unreachable code is usually a sign of a coding error.
+Because the `return`, `throw`, `break`, and `continue` statements unconditionally exit a block of code, any statements after them cannot be executed. Unreachable statements are usually a mistake.
 
 ```js
 function fn() {
@@ -12,7 +12,7 @@ function fn() {
 
 ## Rule Details
 
-This rule is aimed at detecting unreachable code. It produces an error when a statements exist after a `return`, `throw`, `break`, or `continue` statement.
+This rule disallows unreachable code after `return`, `throw`, `continue`, and `break` statements.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/no-unsafe-finally.md
+++ b/docs/rules/no-unsafe-finally.md
@@ -61,7 +61,7 @@ JavaScript suspends the control flow statements of `try` and `catch` blocks unti
 
 ## Rule Details
 
-This rule disallows `return`, `throw`, `break` and `continue` statements inside `finally` blocks. It allows indirect usages such as in `function` or `class` declarations / expressions etc.
+This rule disallows `return`, `throw`, `break`, and `continue` statements inside `finally` blocks. It allows indirect usages, such as in `function` or `class` definitions.
 
 Examples of **incorrect** code for this rule:
 

--- a/docs/rules/use-isnan.md
+++ b/docs/rules/use-isnan.md
@@ -1,10 +1,17 @@
-# Require isNaN() (use-isnan)
+# require calls to `isNaN()` when checking for `NaN` (use-isnan)
 
-In JavaScript, `NaN` is a special value of the `Number` type. It's used to represent any of the "not-a-number" values represented by the double-precision 64-bit format as specified by the IEEE Standard for Binary Floating-Point Arithmetic. `NaN` has the unique property of not being equal to anything, including itself. That is to say, that the condition `NaN !== NaN` evaluates to true.
+In JavaScript, `NaN` is a special value of the `Number` type. It's used to represent any of the "not-a-number" values represented by the double-precision 64-bit format as specified by the IEEE Standard for Binary Floating-Point Arithmetic.
+
+Because `NaN` is unique in JavaScript by not being equal to anything, including itself, the results of comparisons to `NaN` are confusing:
+
+* `NaN === NaN` or `NaN == NaN` evaluate to false
+* `NaN !== NaN` or `NaN != NaN` evaluate to true
+
+Therefore, use `Number.isNaN()` or global `isNaN()` functions to test whether a value is `NaN`.
 
 ## Rule Details
 
-This rule is aimed at eliminating potential errors as the result of comparing against the special value `NaN`.
+This rule disallows comparisons to 'NaN'.
 
 Examples of **incorrect** code for this rule:
 
@@ -29,7 +36,7 @@ if (isNaN(foo)) {
     // ...
 }
 
-if (isNaN(NaN)) {
+if (!isNaN(foo)) {
     // ...
 }
 ```

--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -1,10 +1,10 @@
-# Ensures that the results of typeof are compared against a valid string (valid-typeof)
+# enforce comparing `typeof` expressions against valid strings (valid-typeof)
 
-For a vast majority of use-cases, the only valid results of the `typeof` operator will be one of the following: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, `"function"` and `"symbol"`. When the result of a `typeof` operation is compared against a string that is not one of these strings, it is usually a typo. This rule ensures that when the result of a `typeof` operation is compared against a string, that string is in the aforementioned set.
+For a vast majority of use cases, the result of the `typeof` operator is one of the following string literals: `"undefined"`, `"object"`, `"boolean"`, `"number"`, `"string"`, `"function"` and `"symbol"`. It is usually a typing mistake to compare the result of a `typeof` operator to other string literals.
 
 ## Rule Details
 
-This rule aims to prevent errors from likely typos by ensuring that when the result of a `typeof` operation is compared against a string, that the string is a valid value.
+This rule enforces comparing `typeof` expressions to valid string literals.
 
 Examples of **incorrect** code for this rule:
 


### PR DESCRIPTION
The next 8 rules under **Possible Errors**

I am leaving valid-jsdoc for later because it has complicated changes to review and because there are open pull requests and issues which affect it.

* Make description in h1 consistent with rules index page, not even the first word is capitalized. That is because will soon change the format to match the rules index page (that is, rule-id: rule description).
* Make first sentence under Rule Details consistent with description.
* Add “this rule with” to example sentences.
* Describe options according to patterns in guidelines.

Here are additional changes:
* no-obj-calls: modify examples
* no-regex-spaces: move `RegExp` constructor example from correct code to false negative under Known Limitations
* use-isnan: modify second example of correct code to make it parallel with incorrect code