### PR TITLE
Build: Use split instead of slice/indexOf for commit check (fixes #6109)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -909,7 +909,7 @@ target.checkGitCommit = function() {
 
     // Only check non-release messages
     if (!semver.valid(commitMsgs[0]) && !/^Revert /.test(commitMsgs[0])) {
-        if (commitMsgs[0].slice(0, commitMsgs[0].indexOf("\n")).length > 72) {
+        if (commitMsgs[0].split(/\r?\n/)[0].length > 72) {
             echo(" - First line of commit message must not exceed 72 characters");
             failed = true;
         }

--- a/tests/templates/pr-create.md.ejs.js
+++ b/tests/templates/pr-create.md.ejs.js
@@ -92,7 +92,7 @@ describe("pr-create.md.ejs", function() {
                 commits: [
                     {
                         commit: {
-                            message: "Fix: abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz (fixes #124)"
+                            message: "Fix:56789012345678901234567890123456789012345678901234567890(fixes #9012)"
                         }
                     }
                 ]
@@ -100,6 +100,30 @@ describe("pr-create.md.ejs", function() {
         });
 
         assert.ok(result.indexOf("72 characters") > -1);
+        assert.ok(result.indexOf("require an issue") === -1);
+    });
+
+    it("should not mention commit message length when there's a multi-line message with first line not over 72 characters", function() {
+        var result = ejs.render(TEMPLATE_TEXT, {
+            payload: {
+                sender: {
+                    login: "nzakas"
+                },
+                commits: 1
+            },
+            meta: {
+                cla: true,
+                commits: [
+                    {
+                        commit: {
+                            message: "Fix:56789012345678901234567890123456789012345678901234567890(fixes #901)\r\n1234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890"
+                        }
+                    }
+                ]
+            }
+        });
+
+        assert.equal(result.trim(), "LGTM");
         assert.ok(result.indexOf("require an issue") === -1);
     });
 


### PR DESCRIPTION
#6109 `split(/\r?\n/)` always returns the first line of the commit if there's multiple lines or just one line.

Same logic as `templates/pr-create.md.ejs`:
```js
// get just the first line of the commit message
var log = meta.commits[0].commit.message.split(/\r?\n/g)[0];
```
https://github.com/eslint/eslint/blob/master/templates/pr-create.md.ejs#L23