### PR TITLE
Fix: Optimize no-irregular-whitespace for the common case (fixes #6116)

### DIFF
--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -7,6 +7,15 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Constants
+//------------------------------------------------------------------------------
+
+var ALL_IRREGULARS = /[\f\v\u0085\u00A0\ufeff\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000\u2028\u2029]/;
+var IRREGULAR_WHITESPACE = /[\f\v\u0085\u00A0\ufeff\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000]+/mg;
+var IRREGULAR_LINE_TERMINATORS = /[\u2028\u2029]/mg;
+var LINE_BREAK = /\r\n|\r|\n|\u2028|\u2029/g;
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -41,9 +50,6 @@ module.exports = {
     },
 
     create: function(context) {
-
-        var irregularWhitespace = /[\u0085\u00A0\ufeff\f\v\u00a0\u1680\u180e\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200a\u200b\u202f\u205f\u3000]+/mg,
-            irregularLineTerminators = /[\u2028\u2029]/mg;
 
         // Module store of errors that we have found
         var errors = [];
@@ -95,7 +101,7 @@ module.exports = {
             if (shouldCheckStrings || shouldCheckRegExps) {
 
                 // If we have irregular characters remove them from the errors list
-                if (node.raw.match(irregularWhitespace) || node.raw.match(irregularLineTerminators)) {
+                if (ALL_IRREGULARS.test(node.raw)) {
                     removeWhitespaceError(node);
                 }
             }
@@ -108,8 +114,8 @@ module.exports = {
          * @private
          */
         function removeInvalidNodeErrorsInTemplateLiteral(node) {
-            if (skipTemplates && (typeof node.value.raw === "string")) {
-                if (node.value.raw.match(irregularWhitespace) || node.value.raw.match(irregularLineTerminators)) {
+            if (typeof node.value.raw === "string") {
+                if (ALL_IRREGULARS.test(node.value.raw)) {
                     removeWhitespaceError(node);
                 }
             }
@@ -122,7 +128,7 @@ module.exports = {
          * @private
          */
         function removeInvalidNodeErrorsInComment(node) {
-            if (node.value.match(irregularWhitespace) || node.value.match(irregularLineTerminators)) {
+            if (ALL_IRREGULARS.test(node.value)) {
                 removeWhitespaceError(node);
             }
         }
@@ -141,7 +147,7 @@ module.exports = {
                     location,
                     match;
 
-                while ((match = irregularWhitespace.exec(sourceLine)) !== null) {
+                while ((match = IRREGULAR_WHITESPACE.exec(sourceLine)) !== null) {
                     location = {
                         line: lineNumber,
                         column: match.index
@@ -161,13 +167,13 @@ module.exports = {
         function checkForIrregularLineTerminators(node) {
             var source = sourceCode.getText(),
                 sourceLines = sourceCode.lines,
-                linebreaks = source.match(/\r\n|\r|\n|\u2028|\u2029/g),
+                linebreaks = source.match(LINE_BREAK),
                 lastLineIndex = -1,
                 lineIndex,
                 location,
                 match;
 
-            while ((match = irregularLineTerminators.exec(source)) !== null) {
+            while ((match = IRREGULAR_LINE_TERMINATORS.exec(source)) !== null) {
                 lineIndex = linebreaks.indexOf(match[0], lastLineIndex + 1) || 0;
 
                 location = {
@@ -197,8 +203,10 @@ module.exports = {
          */
         function noop() {}
 
-        return {
-            Program: function(node) {
+        var nodes = {};
+
+        if (ALL_IRREGULARS.test(sourceCode.getText())) {
+            nodes.Program = function(node) {
 
                 /*
                  * As we can easily fire warnings for all white space issues with
@@ -213,14 +221,14 @@ module.exports = {
 
                 checkForIrregularWhitespace(node);
                 checkForIrregularLineTerminators(node);
-            },
+            };
 
-            Identifier: removeInvalidNodeErrorsInIdentifierOrLiteral,
-            Literal: removeInvalidNodeErrorsInIdentifierOrLiteral,
-            TemplateElement: removeInvalidNodeErrorsInTemplateLiteral,
-            LineComment: skipComments ? rememberCommentNode : noop,
-            BlockComment: skipComments ? rememberCommentNode : noop,
-            "Program:exit": function() {
+            nodes.Identifier = removeInvalidNodeErrorsInIdentifierOrLiteral;
+            nodes.Literal = removeInvalidNodeErrorsInIdentifierOrLiteral;
+            nodes.TemplateElement = skipTemplates ? removeInvalidNodeErrorsInTemplateLiteral : noop;
+            nodes.LineComment = skipComments ? rememberCommentNode : noop;
+            nodes.BlockComment = skipComments ? rememberCommentNode : noop;
+            nodes["Program:exit"] = function() {
 
                 if (skipComments) {
 
@@ -232,7 +240,11 @@ module.exports = {
                 errors.forEach(function(error) {
                     context.report.apply(context, error);
                 });
-            }
-        };
+            };
+        } else {
+            nodes.Program = noop;
+        }
+
+        return nodes;
     }
 };


### PR DESCRIPTION
The bulk of the expense from running `no-irregular-whitespace` comes from visiting each `Identifier` - not the work performed while visiting, just the act of visiting.

This change optimizes the rule for the common case of not having any irregular whitespace. It's really cheap to test the entire source for the irregular characters before creating the visitors, and then only create them if there are any irregular characters. A few more changes include: creating the regexs only created once, and using `test` instead of `match` where possible, among others.

Before:

```
$ for i in {1..5}; do TIMING=1 ./bin/eslint.js --no-eslintrc --rule 'no-irregular-whitespace: 1' lib; done
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |   124.392 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |   104.545 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |   111.947 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |   115.883 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |   109.632 |   100.0%
```

After:

```
$ for i in {1..5}; do TIMING=1 ./bin/eslint.js --no-eslintrc --rule 'no-irregular-whitespace: 1' lib; done
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |     3.380 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |     3.083 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |     2.813 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |     2.931 |   100.0%
Rule                    | Time (ms) | Relative
:-----------------------|----------:|--------:
no-irregular-whitespace |     2.861 |   100.0%
```
