### PR TITLE
Add fix methods for arrow-parens rule

### DIFF
--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -41,17 +41,31 @@ module.exports = {
             // as-needed: x => x
             if (asNeeded && node.params.length === 1 && node.params[0].type === "Identifier") {
                 if (token.type === "Punctuator" && token.value === "(") {
-                    context.report(node, asNeededMessage);
+                    var after = sourceCode.getTokenAfter(node.params[0]); // value === ')'
+                    context.report({
+                        node: node,
+                        message: asNeededMessage,
+                        fix: function(fixer) {
+                            return fixer.replaceTextRange([token.start, after.end], node.params[0].name);
+                        }
+                    });
                 }
                 return;
             }
+
 
             if (token.type === "Identifier") {
                 var after = sourceCode.getTokenAfter(token);
 
                 // (x) => x
                 if (after.value !== ")") {
-                    context.report(node, message);
+                    context.report({
+                        node: node,
+                        message: message,
+                        fix: function(fixer) {
+                            return fixer.replaceText(token, '(' + token.value + ')');
+                        }
+                    });
                 }
             }
         }


### PR DESCRIPTION
I do think this needs more testing, but seems like it should be safe.