### PR TITLE
Fix: `no-loop-func` crashed (fixes #6130)

### DIFF
--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -73,7 +73,7 @@ function getContainingLoopNode(node) {
  * @returns {ASTNode} The most outer loop node.
  */
 function getTopLoopNode(node, excludedNode) {
-    var retv = null;
+    var retv = node;
     var border = excludedNode ? excludedNode.range[1] : 0;
 
     while (node && node.range[0] >= border) {

--- a/tests/lib/rules/no-loop-func.js
+++ b/tests/lib/rules/no-loop-func.js
@@ -107,6 +107,15 @@ ruleTester.run("no-loop-func", rule, {
                 "result.__default = 6;"
             ].join("\n"),
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: [
+                "while (true) {",
+                "    (function() { a; });",
+                "}",
+                "let a;"
+            ].join("\n"),
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
     invalid: [


### PR DESCRIPTION
Fixes #6130.

In `let` variable's cases, `getTopLoopNode` finds a loop node which directly contains the `let` declaration or exists after the `let` declaration. But, if there is not such loop node, `no-loop-func` had been crashing.