### PR TITLE
Fix: no-return-assign can run into a null pointer

### DIFF
--- a/lib/rules/no-return-assign.js
+++ b/lib/rules/no-return-assign.js
@@ -20,7 +20,7 @@ function isEnclosedInParens(node, sourceCode) {
     var prevToken = sourceCode.getTokenBefore(node);
     var nextToken = sourceCode.getTokenAfter(node);
 
-    return prevToken.value === "(" && nextToken.value === ")";
+    return prevToken && prevToken.value === "(" && nextToken && nextToken.value === ")";
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
The following line ended up throwing a type error.

```javascript
let countryData = countries.reduce((prev, curr) => (prev[curr.countryCode] = curr, prev), {})
```