### PR TITLE
Build: update npm script to use shx

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "browserify": "node Makefile.js browserify",
     "perf": "node Makefile.js perf",
     "profile": "beefy tests/bench/bench.js --open -- -t brfs -t ./tests/bench/xform-rules.js -r espree",
-    "coveralls": "cat ./coverage/lcov.info | coveralls",
+    "coveralls": "shx cat ./coverage/lcov.info | coveralls",
     "check-commit": "node Makefile.js checkGitCommit"
   },
   "files": [
@@ -95,6 +95,7 @@
     "proxyquire": ">=1.0.0 <1.7.5",
     "semver": "^5.0.3",
     "shelljs-nodecli": "~0.1.0",
+    "shx": "^0.1.2",
     "sinon": "^1.17.2",
     "temp": "^0.8.3",
     "through": "^2.3.6"


### PR DESCRIPTION
This updates your npm script to use [shx](https://github.com/shelljs/shx), which gives cross-platform unix commands from within `package.json`. Hope this helps out!

Cheers!