### PR TITLE
Fix: Null check no-extra-parens (Issue #6161)

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -143,7 +143,9 @@ module.exports = {
          * @private
          */
         function containsAssignment(node) {
-            if (node.type === "AssignmentExpression") {
+            if (!node) {
+                return false;
+            } else if (node.type === "AssignmentExpression") {
                 return true;
             } else if (node.type === "ConditionalExpression" &&
                     (node.consequent.type === "AssignmentExpression" || node.alternate.type === "AssignmentExpression")) {


### PR DESCRIPTION
Simple fix to one of the new issues. If a node is falsy, then it
definitely will NOT contain an assignment.