### PR TITLE
Fix: `valid-jsdoc` false positive at default parameters (fixes #6097)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -340,14 +340,14 @@ module.exports = {
 
                 if (node.params) {
                     node.params.forEach(function(param, i) {
-                        var name = param.name;
-
                         if (param.type === "AssignmentPattern") {
-                            name = param.left.name;
+                            param = param.left;
                         }
 
+                        var name = param.name;
+
                         // TODO(nzakas): Figure out logical things to do with destructured, default, rest params
-                        if (param.type === "Identifier" || param.type === "AssignmentPattern") {
+                        if (param.type === "Identifier") {
                             if (jsdocParams[i] && (name !== jsdocParams[i])) {
                                 context.report(jsdocNode, "Expected JSDoc for '{{name}}' but found '{{jsdocName}}'.", {
                                     name: name,

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -512,6 +512,34 @@ ruleTester.run("valid-jsdoc", rule, {
             "*/\n" +
             "function foo(){}",
             options: [{ requireReturn: true }]
+        },
+        {
+            code: [
+                "/**",
+                " * @param {string} a - a.",
+                " * @param {object} [obj] - obj.",
+                " * @param {string} obj.b - b.",
+                " * @param {string} obj.c - c.",
+                " * @returns {void}",
+                " */",
+                "function foo(a, {b, c} = {}) {",
+                "    // empty",
+                "}"
+            ].join("\n"),
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: [
+                "/**",
+                " * @param {string} a - a.",
+                " * @param {any[]} [list] - list.",
+                " * @returns {void}",
+                " */",
+                "function foo(a, [b, c] = []) {",
+                "    // empty",
+                "}"
+            ].join("\n"),
+            parserOptions: {ecmaVersion: 6}
         }
     ],
 


### PR DESCRIPTION
Fixes #6097.
