### PR TITLE
Breaking: use default for complexity in eslint:recommended (fixes #6021)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -138,7 +138,7 @@
         "comma-dangle": "error",
         "comma-spacing": "off",
         "comma-style": "off",
-        "complexity": ["off", 11],
+        "complexity": ["off"],
         "computed-property-spacing": "off",
         "consistent-return": "off",
         "consistent-this": "off",


### PR DESCRIPTION
Not exactly sure what the procedure is for things we want for v3.0, but figured this was an easy quick one to do. If you prefer I close this and re-open it later, let me know.