### PR TITLE
Fix: `max-statements-per-line` false positive by semi (fixes #6153)

### DIFF
--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -31,7 +31,8 @@ module.exports = {
 
     create: function(context) {
 
-        var options = context.options[0] || {},
+        var sourceCode = context.getSourceCode(),
+            options = context.options[0] || {},
             lastStatementLine = 0,
             numberOfStatementsOnThisLine = 0,
             maxStatementsPerLine = typeof options.max !== "undefined" ? options.max : 1;
@@ -51,6 +52,21 @@ module.exports = {
                 node,
                 "This line has too many statements. Maximum allowed is {{max}}.",
                 { max: maxStatementsPerLine });
+        }
+
+        /**
+         * Gets the actual last token of a given node.
+         *
+         * @param {ASTNode} node - A node to get. This is a node except EmptyStatement.
+         * @returns {Token} The actual last token.
+         */
+        function getActualLastToken(node) {
+            var lastToken = sourceCode.getLastToken(node);
+
+            if (lastToken.value === ";") {
+                lastToken = sourceCode.getTokenBefore(lastToken);
+            }
+            return lastToken;
         }
 
         /**
@@ -75,7 +91,7 @@ module.exports = {
                     ++numberOfStatementsOnThisLine;
                 } else {
                     numberOfStatementsOnThisLine = 1;
-                    lastStatementLine = currentStatement.loc.end.line;
+                    lastStatementLine = getActualLastToken(currentStatement).loc.end.line;
                 }
                 if (numberOfStatementsOnThisLine === maxStatementsPerLine + 1) {
                     report(currentStatement);

--- a/tests/lib/rules/max-statements-per-line.js
+++ b/tests/lib/rules/max-statements-per-line.js
@@ -68,7 +68,17 @@ ruleTester.run("max-statements-per-line", rule, {
         { code: "[bar => { a; }, baz => { b; }, qux => { c; }];", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
         { code: "foo(bar => { a; }, baz => { c; }, qux => { c; });", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
         { code: "({ bar: bar => { a; }, baz: baz => { c; }, qux: qux => { ; }});", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
-        { code: "(bar => { a; }) ? (baz => { b; }) : (qux => { c; });", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } }
+        { code: "(bar => { a; }) ? (baz => { b; }) : (qux => { c; });", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
+        {
+            code: [
+                "const name = 'ESLint'",
+                "",
+                ";(function foo() {",
+                "})()"
+            ].join("\n"),
+            options: [{max: 1}],
+            parserOptions: {ecmaVersion: 6}
+        }
     ],
     invalid: [
         { code: "{ }", options: [{ max: 0 }], errors: [{ message: "This line has too many statements. Maximum allowed is 0." }] },


### PR DESCRIPTION
Fixes #6153.

This PR makes this rule avoiding a use of semi-colons to check statements.