### PR TITLE
Fix: no-multiple-empty-lines BOF and EOF defaults (fixes #6179)

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -52,8 +52,8 @@ module.exports = {
 
         if (context.options.length) {
             max = context.options[0].max;
-            maxEOF = context.options[0].maxEOF;
-            maxBOF = context.options[0].maxBOF;
+            maxEOF = typeof context.options[0].maxEOF !== "undefined" ? context.options[0].maxEOF : max;
+            maxBOF = typeof context.options[0].maxBOF !== "undefined" ? context.options[0].maxBOF : max;
         }
 
         var sourceCode = context.getSourceCode();
@@ -122,11 +122,10 @@ module.exports = {
 
                 // Aggregate and count blank lines
                 if (firstNonBlankLine > maxBOF) {
-                    currentLocation = firstNonBlankLine - 1;
-
                     context.report(node, 0,
                             "Too many blank lines at the beginning of file. Max of " + maxBOF + " allowed.");
                 }
+                currentLocation = firstNonBlankLine - 1;
 
                 lastLocation = currentLocation;
                 currentLocation = trimmedLines.indexOf("", currentLocation + 1);

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -137,6 +137,14 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             code: "`\n\n\n\n\n`\n// valid 15\nvar a = 5;",
             options: [ { max: 0, maxBOF: 0 } ],
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "\n\n\n\n// valid 16\nvar a = 5;\n",
+            options: [ { max: 0, maxBOF: 4 } ]
+        },
+        {
+            code: "// valid 17\nvar a = 5;\n\n",
+            options: [ { max: 0, maxEOF: 1 } ]
         }
     ],
 
@@ -153,12 +161,12 @@ ruleTester.run("no-multiple-empty-lines", rule, {
         },
         {
             code: "// invalid 3\nvar a = 5;\n\n\n\n",
-            errors: [ getExpectedError(2) ],
+            errors: [ getExpectedErrorEOF(2) ],
             options: [ { max: 2 } ]
         },
         {
             code: "// invalid 4\nvar a = 5;\n \n \n \n",
-            errors: [ getExpectedError(2) ],
+            errors: [ getExpectedErrorEOF(2) ],
             options: [ { max: 2 } ]
         },
         {
@@ -183,7 +191,7 @@ ruleTester.run("no-multiple-empty-lines", rule, {
         },
         {
             code: "// invalid 9\nvar a=5;\n\n\n\n\n",
-            errors: [ getExpectedError(2) ],
+            errors: [ getExpectedErrorEOF(2) ],
             options: [ { max: 2 } ]
         },
         {


### PR DESCRIPTION
BOF and EOF variables now set as intended and BOF can be larger than max option