### PR TITLE
Fix: Remove default parser from CLIEngine options (fixes #6182)

### DIFF
--- a/conf/cli-options.js
+++ b/conf/cli-options.js
@@ -16,6 +16,7 @@ module.exports = {
     extensions: [".js"],
     ignore: true,
     ignorePath: null,
+    parser: "",     // must be empty
     cache: false,
 
     // in order to honor the cacheFile option if specified

--- a/conf/cli-options.js
+++ b/conf/cli-options.js
@@ -5,8 +5,6 @@
 
 "use strict";
 
-var DEFAULT_PARSER = require("../conf/eslint.json").parser;
-
 module.exports = {
     configFile: null,
     baseConfig: false,
@@ -18,8 +16,8 @@ module.exports = {
     extensions: [".js"],
     ignore: true,
     ignorePath: null,
-    parser: DEFAULT_PARSER,
     cache: false,
+
     // in order to honor the cacheFile option if specified
     // this option should not have a default value otherwise
     // it will always be used

--- a/tests/fixtures/configurations/parser/.eslintrc.json
+++ b/tests/fixtures/configurations/parser/.eslintrc.json
@@ -1,0 +1,7 @@
+{
+    "root": true,
+    "parser": "./custom.js",
+    "rules": {
+        "quotes": ["error", "double"]
+    }
+}

--- a/tests/fixtures/configurations/parser/custom.js
+++ b/tests/fixtures/configurations/parser/custom.js
@@ -1,0 +1,3 @@
+exports.parse = function() {
+    throw new Error("Boom!");
+};

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -274,6 +274,23 @@ describe("CLIEngine", function() {
 
         var engine;
 
+        it("should use correct parser when custom parser is specified", function() {
+
+            engine = new CLIEngine({
+                cwd: originalDir,
+                ignore: false
+            });
+
+            var filePath = path.resolve(__dirname, "../fixtures/configurations/parser/custom.js");
+            var report = engine.executeOnFiles([filePath]);
+
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].messages.length, 1);
+            assert.equal(report.results[0].messages[0].message, "Parsing error: Boom!");
+
+        });
+
+
         it("should report zero messages when given a config file and a valid file", function() {
 
             engine = new CLIEngine({

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -2,7 +2,7 @@
  * @fileoverview Tests for config object.
  * @author Seth McLaughlin
  */
-
+/* eslint no-undefined: "off" */
 "use strict";
 
 //------------------------------------------------------------------------------
@@ -289,6 +289,13 @@ describe("Config", function() {
             assert.equal(noUndef, 2);
         });
 
+        it("should contain the correct value for parser when a custom parser is specified", function() {
+            var configPath = path.resolve(__dirname, "../fixtures/configurations/parser/.eslintrc.json"),
+                configHelper = new Config({ cwd: process.cwd() }),
+                config = configHelper.getConfig(configPath);
+
+            assert.equal(config.parser, path.resolve(path.dirname(configPath), "./custom.js"));
+        });
 
         // Configuration hierarchy ---------------------------------------------
 
@@ -752,7 +759,7 @@ describe("Config", function() {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: void 0,
+                        parser: undefined,
                         rules: {
                             "home-folder-rule": 2
                         }
@@ -776,7 +783,7 @@ describe("Config", function() {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: void 0,
+                        parser: undefined,
                         rules: {
                             "project-level-rule": 2
                         }
@@ -801,7 +808,7 @@ describe("Config", function() {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: void 0,
+                        parser: undefined,
                         rules: {
                             quotes: [2, "double"]
                         }
@@ -825,7 +832,7 @@ describe("Config", function() {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: void 0,
+                        parser: undefined,
                         rules: {}
                     };
 
@@ -847,7 +854,7 @@ describe("Config", function() {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: void 0,
+                        parser: undefined,
                         rules: {}
                     };
 
@@ -868,7 +875,7 @@ describe("Config", function() {
                         parserOptions: {},
                         env: {},
                         globals: {},
-                        parser: void 0,
+                        parser: undefined,
                         rules: {
                             "project-level-rule": 2,
                             "subfolder-level-rule": 2


### PR DESCRIPTION
Not sure how to add tests for this, submitting because it's probably breaking badly for a lot of people.

I think it won't break anything if no parser is specified, since it is set by `lib/eslint.js`, but please review @eslint/eslint-team 