### PR TITLE
Lint unnecessary disabled reporting comments

### DIFF
--- a/conf/cli-options.js
+++ b/conf/cli-options.js
@@ -26,5 +26,6 @@ module.exports = {
     cacheLocation: "",
     cacheFile: ".eslintcache",
     fix: false,
-    allowInlineConfig: true
+    allowInlineConfig: true,
+    checkUnneededDisable: false
 };

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -190,10 +190,11 @@ function multipassFix(text, config, options) {
  * @param {string} filename An optional string representing the texts filename.
  * @param {boolean} fix Indicates if fixes should be processed.
  * @param {boolean} allowInlineConfig Allow/ignore comments that change config.
+ * @param {boolean} checkUnneededDisable Check for unneeded disable reporting comments.
  * @returns {Result} The results for linting on this text.
  * @private
  */
-function processText(text, configHelper, filename, fix, allowInlineConfig) {
+function processText(text, configHelper, filename, fix, allowInlineConfig, checkUnneededDisable) {
 
     // clear all existing settings for a new file
     eslint.reset();
@@ -237,7 +238,8 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
         parsedBlocks.forEach(function(block) {
             unprocessedMessages.push(eslint.verify(block, config, {
                 filename: filename,
-                allowInlineConfig: allowInlineConfig
+                allowInlineConfig: allowInlineConfig,
+                checkUnneededDisable: checkUnneededDisable
             }));
         });
 
@@ -250,13 +252,15 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
         if (fix) {
             fixedResult = multipassFix(text, config, {
                 filename: filename,
-                allowInlineConfig: allowInlineConfig
+                allowInlineConfig: allowInlineConfig,
+                checkUnneededDisable: checkUnneededDisable
             });
             messages = fixedResult.messages;
         } else {
             messages = eslint.verify(text, config, {
                 filename: filename,
-                allowInlineConfig: allowInlineConfig
+                allowInlineConfig: allowInlineConfig,
+                checkUnneededDisable: checkUnneededDisable
             });
         }
     }
@@ -289,7 +293,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
 function processFile(filename, configHelper, options) {
 
     var text = fs.readFileSync(path.resolve(filename), "utf8"),
-        result = processText(text, configHelper, filename, options.fix, options.allowInlineConfig);
+        result = processText(text, configHelper, filename, options.fix, options.allowInlineConfig, options.checkUnneededDisable);
 
     return result;
 
@@ -752,7 +756,7 @@ CLIEngine.prototype = {
 
             results.push(createIgnoreResult(filename, options.cwd));
         } else {
-            results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig));
+            results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig, options.checkUnneededDisable));
         }
 
         stats = calculateStatsPerRun(results);

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -56,7 +56,8 @@ function translateOptions(cliOptions) {
         cacheFile: cliOptions.cacheFile,
         cacheLocation: cliOptions.cacheLocation,
         fix: cliOptions.fix,
-        allowInlineConfig: cliOptions.inlineConfig
+        allowInlineConfig: cliOptions.inlineConfig,
+        checkUnneededDisable: cliOptions.checkUnneededDisable
     };
 }
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -216,25 +216,30 @@ function addDeclaredGlobals(program, globalScope, config) {
  * Add data to reporting configuration to disable reporting for list of rules
  * starting from start location
  * @param  {Object[]} reportingConfig Current reporting configuration
+ * @param  {Object} comment Node
  * @param  {Object} start Position to start
  * @param  {string[]} rulesToDisable List of rules
  * @returns {void}
  */
-function disableReporting(reportingConfig, start, rulesToDisable) {
+function disableReporting(reportingConfig, comment, start, rulesToDisable) {
 
     if (rulesToDisable.length) {
         rulesToDisable.forEach(function(rule) {
             reportingConfig.push({
                 start: start,
                 end: null,
-                rule: rule
+                rule: rule,
+                comment: comment,
+                used: 0
             });
         });
     } else {
         reportingConfig.push({
             start: start,
             end: null,
-            rule: null
+            rule: null,
+            comment: comment,
+            used: 0
         });
     }
 }
@@ -243,11 +248,12 @@ function disableReporting(reportingConfig, start, rulesToDisable) {
  * Add data to reporting configuration to enable reporting for list of rules
  * starting from start location
  * @param  {Object[]} reportingConfig Current reporting configuration
+ * @param  {Object} comment Node
  * @param  {Object} start Position to start
  * @param  {string[]} rulesToEnable List of rules
  * @returns {void}
  */
-function enableReporting(reportingConfig, start, rulesToEnable) {
+function enableReporting(reportingConfig, comment, start, rulesToEnable) {
     var i;
 
     if (rulesToEnable.length) {
@@ -322,11 +328,11 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
                         break;
 
                     case "eslint-disable":
-                        disableReporting(reportingConfig, comment.loc.start, Object.keys(parseListConfig(value)));
+                        disableReporting(reportingConfig, comment, comment.loc.start, Object.keys(parseListConfig(value)));
                         break;
 
                     case "eslint-enable":
-                        enableReporting(reportingConfig, comment.loc.start, Object.keys(parseListConfig(value)));
+                        enableReporting(reportingConfig, comment, comment.loc.start, Object.keys(parseListConfig(value)));
                         break;
 
                     case "eslint":
@@ -344,11 +350,11 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
                 }
             } else {        // comment.type === "Line"
                 if (match[1] === "eslint-disable-line") {
-                    disableReporting(reportingConfig, { line: comment.loc.start.line, column: 0 }, Object.keys(parseListConfig(value)));
-                    enableReporting(reportingConfig, comment.loc.end, Object.keys(parseListConfig(value)));
+                    disableReporting(reportingConfig, comment, { line: comment.loc.start.line, column: 0 }, Object.keys(parseListConfig(value)));
+                    enableReporting(reportingConfig, comment, comment.loc.end, Object.keys(parseListConfig(value)));
                 } else if (match[1] === "eslint-disable-next-line") {
-                    disableReporting(reportingConfig, comment.loc.start, Object.keys(parseListConfig(value)));
-                    enableReporting(reportingConfig, { line: comment.loc.start.line + 2 }, Object.keys(parseListConfig(value)));
+                    disableReporting(reportingConfig, comment, comment.loc.start, Object.keys(parseListConfig(value)));
+                    enableReporting(reportingConfig, comment, { line: comment.loc.start.line + 2 }, Object.keys(parseListConfig(value)));
                 }
             }
         }
@@ -383,6 +389,7 @@ function isDisabledByReportingConfig(reportingConfig, ruleId, location) {
         if ((!ignore.rule || ignore.rule === ruleId) &&
             (location.line > ignore.start.line || (location.line === ignore.start.line && location.column >= ignore.start.column)) &&
             (!ignore.end || (location.line < ignore.end.line || (location.line === ignore.end.line && location.column <= ignore.end.column)))) {
+            ignore.used++;
             return true;
         }
     }
@@ -707,12 +714,14 @@ module.exports = (function() {
             ecmaFeatures,
             ecmaVersion,
             allowInlineConfig,
+            checkUnneededDisable,
             text = (typeof textOrSourceCode === "string") ? textOrSourceCode : null;
 
         // evaluate arguments
         if (typeof filenameOrOptions === "object") {
             currentFilename = filenameOrOptions.filename;
             allowInlineConfig = filenameOrOptions.allowInlineConfig;
+            checkUnneededDisable = filenameOrOptions.checkUnneededDisable;
             saveState = filenameOrOptions.saveState;
         } else {
             currentFilename = filenameOrOptions;
@@ -887,6 +896,21 @@ module.exports = (function() {
                 },
                 leave: function(node) {
                     eventGenerator.leaveNode(node);
+                }
+            });
+        }
+
+        if (checkUnneededDisable) {
+            reportingConfig.forEach(function(reportConfig) {
+                if (reportConfig.used === 0) {
+                    messages.push({
+                        ruleId: null,
+                        severity: 2,
+                        source: reportConfig.comment.value,
+                        message: "unneeded eslint-disable " + reportConfig.rule + " comment",
+                        line: reportConfig.comment.loc.start.line,
+                        column: reportConfig.comment.loc.start.column
+                    });
                 }
             });
         }

--- a/lib/options.js
+++ b/lib/options.js
@@ -215,6 +215,12 @@ module.exports = optionator({
             description: "Prevent comments from changing config or rules"
         },
         {
+            option: "check-unneeded-disable",
+            type: "Boolean",
+            default: "false",
+            description: "Check for unneeded disable reporting comments"
+        },
+        {
             option: "print-config",
             type: "Boolean",
             description: "Print the configuration to be used"


### PR DESCRIPTION
ESLint configuration comments are handy for temporarily allowing an exception or hack. But sometimes the hack is fixed but the comment is still left in place.

A clever way to implement this would be with a eslint rule itself. However this is error prone. The most obvious thing is that disabling all rules in a file would then disable this meta rule.

Similar to `allowInlineConfig`, this probably means it needs to be implemented outside of the rule processing code path. I took a stab at plumbing a similar CLI flag to enable these checks.

If this is something that won't be accepted, would you at least consider publicly exposing the data on `reportConfig`? Theres really no way to access this without monkey patching `api.report`. `api.getReportingConfig()` would probably be enough for my needs.

Related https://github.com/eslint/eslint/issues/5659 https://github.com/sindresorhus/xo/issues/103 https://github.com/bbatsov/rubocop/issues/1865