### PR TITLE
Fix: `max-statements-per-line` false positive (fixes #6173, fixes #6153)

### DIFF
--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -31,87 +31,80 @@ module.exports = {
 
     create: function(context) {
 
-        var options = context.options[0] || {},
+        var sourceCode = context.getSourceCode(),
+            options = context.options[0] || {},
             lastStatementLine = 0,
             numberOfStatementsOnThisLine = 0,
-            maxStatementsPerLine = typeof options.max !== "undefined" ? options.max : 1;
+            maxStatementsPerLine = typeof options.max !== "undefined" ? options.max : 1,
+            message = "This line has too many statements. Maximum allowed is " + maxStatementsPerLine + ".";
 
         //--------------------------------------------------------------------------
         // Helpers
         //--------------------------------------------------------------------------
 
+        var SINGLE_CHILD_ALLOWED = /^(?:DoWhile|For|ForIn|ForOf|If|Labeled|While)Statement$/;
+
         /**
-         * Reports a node
-         * @param {ASTNode} node The node to report
-         * @returns {void}
-         * @private
+         * Gets the actual last token of a given node.
+         *
+         * @param {ASTNode} node - A node to get. This is a node except EmptyStatement.
+         * @returns {Token} The actual last token.
          */
-        function report(node) {
-            context.report(
-                node,
-                "This line has too many statements. Maximum allowed is {{max}}.",
-                { max: maxStatementsPerLine });
+        function getActualLastToken(node) {
+            var lastToken = sourceCode.getLastToken(node);
+
+            if (lastToken.value === ";") {
+                lastToken = sourceCode.getTokenBefore(lastToken);
+            }
+            return lastToken;
         }
 
         /**
-         * Enforce a maximum number of statements per line
-         * @param {ASTNode} nodes Array of nodes to evaluate
+         * Addresses a given node.
+         * It updates the state of this rule, then reports the node if the node violated this rule.
+         *
+         * @param {ASTNode} node - A node to check.
          * @returns {void}
-         * @private
          */
-        function enforceMaxStatementsPerLine(nodes) {
-            if (nodes.length < 1) {
+        function enterStatement(node) {
+            var line = node.loc.start.line;
+
+            // Skip to allow non-block statements if this is direct child of control statements.
+            // `if (a) foo();` is counted as 1.
+            // But `if (a) foo(); else foo();` should be counted as 2.
+            if (SINGLE_CHILD_ALLOWED.test(node.parent.type) &&
+                node.parent.alternate !== node
+            ) {
                 return;
             }
 
-            for (var i = 0, l = nodes.length; i < l; ++i) {
-                var currentStatement = nodes[i];
+            // Update state.
+            if (line === lastStatementLine) {
+                numberOfStatementsOnThisLine += 1;
+            } else {
+                numberOfStatementsOnThisLine = 1;
+                lastStatementLine = line;
+            }
 
-                if (currentStatement.type === "EmptyStatement") {
-                    continue;
-                }
-
-                if (currentStatement.loc.start.line === lastStatementLine) {
-                    ++numberOfStatementsOnThisLine;
-                } else {
-                    numberOfStatementsOnThisLine = 1;
-                    lastStatementLine = currentStatement.loc.end.line;
-                }
-                if (numberOfStatementsOnThisLine === maxStatementsPerLine + 1) {
-                    report(currentStatement);
-                }
+            // Reports if the node violated this rule.
+            if (numberOfStatementsOnThisLine === maxStatementsPerLine + 1) {
+                context.report({node: node, message: message});
             }
         }
 
         /**
-         * Check each line in the body of a node
-         * @param {ASTNode} node node to evaluate
+         * Updates the state of this rule with the end line of leaving node to check with the next statement.
+         *
+         * @param {ASTNode} node - A node to check.
          * @returns {void}
-         * @private
          */
-        function checkLinesInBody(node) {
-            enforceMaxStatementsPerLine(node.body);
-        }
+        function leaveStatement(node) {
+            var line = getActualLastToken(node).loc.end.line;
 
-        /**
-         * Check each line in the consequent of a switch case
-         * @param {ASTNode} node node to evaluate
-         * @returns {void}
-         * @private
-         */
-        function checkLinesInConsequent(node) {
-            enforceMaxStatementsPerLine(node.consequent);
-        }
-
-        /**
-         * Check each line in both sides of an if statement
-         * @param {ASTNode} node node to evaluate
-         * @returns {void}
-         * @private
-         */
-        function checkLinesInNonBlockElse(node) {
-            if (node.alternate && node.alternate.type !== "BlockStatement") {
-                enforceMaxStatementsPerLine([node.alternate]);
+            // Update state.
+            if (line !== lastStatementLine) {
+                numberOfStatementsOnThisLine = 1;
+                lastStatementLine = line;
             }
         }
 
@@ -120,11 +113,61 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            Program: checkLinesInBody,
-            BlockStatement: checkLinesInBody,
-            SwitchCase: checkLinesInConsequent,
-            IfStatement: checkLinesInNonBlockElse
-        };
+            BreakStatement: enterStatement,
+            ClassDeclaration: enterStatement,
+            ContinueStatement: enterStatement,
+            DebuggerStatement: enterStatement,
+            DoWhileStatement: enterStatement,
+            ExpressionStatement: enterStatement,
+            ForInStatement: enterStatement,
+            ForOfStatement: enterStatement,
+            ForStatement: enterStatement,
+            FunctionDeclaration: enterStatement,
+            IfStatement: enterStatement,
+            ImportDeclaration: enterStatement,
+            LabeledStatement: enterStatement,
+            ReturnStatement: enterStatement,
+            SwitchStatement: enterStatement,
+            ThrowStatement: enterStatement,
+            TryStatement: enterStatement,
+            VariableDeclaration: enterStatement,
+            WhileStatement: enterStatement,
+            WithStatement: enterStatement,
+            ExportNamedDeclaration: enterStatement,
+            ExportDefaultDeclaration: enterStatement,
+            ExportAllDeclaration: enterStatement,
 
+            "BreakStatement:exit": leaveStatement,
+            "ClassDeclaration:exit": leaveStatement,
+            "ContinueStatement:exit": leaveStatement,
+            "DebuggerStatement:exit": leaveStatement,
+            "DoWhileStatement:exit": leaveStatement,
+            "ExpressionStatement:exit": leaveStatement,
+            "ForInStatement:exit": leaveStatement,
+            "ForOfStatement:exit": leaveStatement,
+            "ForStatement:exit": leaveStatement,
+            "FunctionDeclaration:exit": leaveStatement,
+            "IfStatement:exit": leaveStatement,
+            "ImportDeclaration:exit": leaveStatement,
+            "LabeledStatement:exit": leaveStatement,
+            "ReturnStatement:exit": leaveStatement,
+            "SwitchStatement:exit": leaveStatement,
+            "ThrowStatement:exit": leaveStatement,
+            "TryStatement:exit": leaveStatement,
+            "VariableDeclaration:exit": leaveStatement,
+            "WhileStatement:exit": leaveStatement,
+            "WithStatement:exit": leaveStatement,
+            "ExportNamedDeclaration:exit": leaveStatement,
+            "ExportDefaultDeclaration:exit": leaveStatement,
+            "ExportAllDeclaration:exit": leaveStatement,
+
+            // For backward compatibility.
+            // Empty blocks should be warned if `{max: 0}` was given.
+            BlockStatement: function reportIfZero(node) {
+                if (maxStatementsPerLine === 0 && node.body.length === 0) {
+                    context.report({node: node, message: message});
+                }
+            }
+        };
     }
 };

--- a/tests/lib/rules/max-statements-per-line.js
+++ b/tests/lib/rules/max-statements-per-line.js
@@ -68,7 +68,25 @@ ruleTester.run("max-statements-per-line", rule, {
         { code: "[bar => { a; }, baz => { b; }, qux => { c; }];", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
         { code: "foo(bar => { a; }, baz => { c; }, qux => { c; });", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
         { code: "({ bar: bar => { a; }, baz: baz => { c; }, qux: qux => { ; }});", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
-        { code: "(bar => { a; }) ? (baz => { b; }) : (qux => { c; });", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } }
+        { code: "(bar => { a; }) ? (baz => { b; }) : (qux => { c; });", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 } },
+        {
+            code: [
+                "const name = 'ESLint'",
+                "",
+                ";(function foo() {",
+                "})()"
+            ].join("\n"),
+            options: [{max: 1}],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: [
+                "if (foo > 1)",
+                "    foo--;",
+                "else",
+                "    foo++;"
+            ].join("\n")
+        }
     ],
     invalid: [
         { code: "{ }", options: [{ max: 0 }], errors: [{ message: "This line has too many statements. Maximum allowed is 0." }] },
@@ -109,6 +127,7 @@ ruleTester.run("max-statements-per-line", rule, {
         { code: "bar => { a; }, baz => { b; }, qux => { c; }, quux => { d; };", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] },
         { code: "[bar => { a; }, baz => { b; }, qux => { c; }, quux => { d; }];", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] },
         { code: "foo(bar => { a; }, baz => { b; }, qux => { c; }, quux => { d; });", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] },
-        { code: "({ bar: bar => { a; }, baz: baz => { b; }, qux: qux => { c; }, quux: quux => { d; }});", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] }
+        { code: "({ bar: bar => { a; }, baz: baz => { b; }, qux: qux => { c; }, quux: quux => { d; }});", options: [{ max: 4 }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "This line has too many statements. Maximum allowed is 4." }] },
+        { code: "a; if (b) { c; d; }\nz;", options: [{ max: 2 }], errors: [{ message: "This line has too many statements. Maximum allowed is 2." }] }
     ]
 });


### PR DESCRIPTION
Fixes #6173, 
Fixes #6153.

I rewrote the traversal logic of this rule.
Before, it uses a `for` loop in BlockStatement handler.
After this PR, it uses ESLint's traversing. So this rule gets addressing nested nodes correctly.