### PR TITLE
Update: Add treatUndefinedAsUnspecified option (fixes #6026)

### DIFF
--- a/docs/rules/consistent-return.md
+++ b/docs/rules/consistent-return.md
@@ -1,12 +1,22 @@
-# Require Consistent Returns (consistent-return)
+# require `return` statements to either always or never specify values (consistent-return)
 
-One of the confusing aspects of JavaScript is that any function may or may not return a value at any point in time. When a function exits without any `return` statement executing, the function returns `undefined`. Similarly, calling `return` without specifying any value will cause the function to return `undefined`. Only when `return` is called with a value is there a change in the function's return value.
+Unlike statically-typed languages which enforce that a function returns a specified type of value, JavaScript allows different code paths in a function to return different types of values.
 
-Unlike statically-typed languages that will catch when a function doesn't return the type of data expected, JavaScript has no such checks, meaning that it's easy to make mistakes such as this:
+A confusing aspect of JavaScript is that a function returns `undefined` if any of the following are true:
+
+* it does not execute a `return` statement before it exits
+* it executes `return` which does not specify a value explicitly
+* it executes `return undefined`
+* it executes `return void` followed by an expression (for example, a function call)
+* it executes `return` followed by any other expression which evaluates to `undefined`
+
+If any code paths in a function return a value explicitly but some code path do not return a value explicitly, it might be a typing mistake, especially in a large function. In the following example:
+
+* a code path through the function returns a Boolean value `true`
+* another code path does not return a value explicitly, therefore returns `undefined` implicitly
 
 ```js
 function doSomething(condition) {
-
     if (condition) {
         return true;
     } else {
@@ -15,13 +25,9 @@ function doSomething(condition) {
 }
 ```
 
-Here, one branch of the function returns `true`, a Boolean value, while the other exits without specifying any value (and so returns `undefined`). This may be an indicator of a coding error, especially if this pattern is found in larger functions.
-
 ## Rule Details
 
-This rule is aimed at ensuring all `return` statements either specify a value or don't specify a value.
-
-It excludes constructors which, when invoked with the `new` operator, return the instantiated object if another object is not explicitly returned.  This rule treats a function as a constructor if its name starts with an uppercase letter.
+This rule requires `return` statements to either always or never specify values. This rule ignores function definitions where the name begins with an uppercase letter, because constructors (when invoked with the `new` operator) return the instantiated object implicitly if they do not return another object explicitly.
 
 Examples of **incorrect** code for this rule:
 
@@ -29,7 +35,6 @@ Examples of **incorrect** code for this rule:
 /*eslint consistent-return: "error"*/
 
 function doSomething(condition) {
-
     if (condition) {
         return true;
     } else {
@@ -38,16 +43,6 @@ function doSomething(condition) {
 }
 
 function doSomething(condition) {
-
-    if (condition) {
-        return;
-    } else {
-        return true;
-    }
-}
-
-function doSomething(condition) {
-
     if (condition) {
         return true;
     }
@@ -60,7 +55,6 @@ Examples of **correct** code for this rule:
 /*eslint consistent-return: "error"*/
 
 function doSomething(condition) {
-
     if (condition) {
         return true;
     } else {
@@ -74,6 +68,75 @@ function Foo() {
     }
 
     this.a = 0;
+}
+```
+
+## Options
+
+This rule has an object option:
+
+* `"treatUndefinedAsUnspecified": false` (default) always either specify values or return `undefined` implicitly only.
+* `"treatUndefinedAsUnspecified": true` always either specify values or return `undefined` explicitly or implicitly.
+
+### treatUndefinedAsUnspecified
+
+Examples of **incorrect** code for this rule with the default `{ "treatUndefinedAsUnspecified": false }` option:
+
+```js
+/*eslint consistent-return: ["error", { "treatUndefinedAsUnspecified": false }]*/
+
+function foo(callback) {
+    if (callback) {
+        return void callback();
+    }
+    // no return statement
+}
+
+function bar(condition) {
+    if (condition) {
+        return undefined;
+    }
+    // no return statement
+}
+```
+
+Examples of **incorrect** code for this rule with the `{ "treatUndefinedAsUnspecified": true }` option:
+
+```js
+/*eslint consistent-return: ["error", { "treatUndefinedAsUnspecified": true }]*/
+
+function foo(callback) {
+    if (callback) {
+        return void callback();
+    }
+    return true;
+}
+
+function bar(condition) {
+    if (condition) {
+        return undefined;
+    }
+    return true;
+}
+```
+
+Examples of **correct** code for this rule with the `{ "treatUndefinedAsUnspecified": true }` option:
+
+```js
+/*eslint consistent-return: ["error", { "treatUndefinedAsUnspecified": true }]*/
+
+function foo(callback) {
+    if (callback) {
+        return void callback();
+    }
+    // no return statement
+}
+
+function bar(condition) {
+    if (condition) {
+        return undefined;
+    }
+    // no return statement
 }
 ```
 

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -15,6 +15,16 @@ var astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 /**
+ * Checks whether or not a given node is an `Identifier` node which was named a given name.
+ * @param {ASTNode} node - A node to check.
+ * @param {string} name - An expected name of the node.
+ * @returns {boolean} `true` if the node is an `Identifier` node which was named as expected.
+ */
+function isIdentifier(node, name) {
+    return node.type === "Identifier" && node.name === name;
+}
+
+/**
  * Checks whether or not a given code path segment is unreachable.
  * @param {CodePathSegment} segment - A CodePathSegment to check.
  * @returns {boolean} `true` if the segment is unreachable.
@@ -35,10 +45,20 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [{
+            type: "object",
+            properties: {
+                treatUndefinedAsUnspecified: {
+                    type: "boolean"
+                }
+            },
+            additionalProperties: false
+        }]
     },
 
     create: function(context) {
+        var options = context.options[0] || {};
+        var treatUndefinedAsUnspecified = options.treatUndefinedAsUnspecified === true;
         var funcInfo = null;
 
         /**
@@ -115,7 +135,12 @@ module.exports = {
 
             // Reports a given return statement if it's inconsistent.
             ReturnStatement: function(node) {
-                var hasReturnValue = Boolean(node.argument);
+                var argument = node.argument;
+                var hasReturnValue = Boolean(argument);
+
+                if (treatUndefinedAsUnspecified && hasReturnValue) {
+                    hasReturnValue = !isIdentifier(argument, "undefined") && argument.operator !== "void";
+                }
 
                 if (!funcInfo.hasReturn) {
                     funcInfo.hasReturn = true;

--- a/tests/lib/rules/consistent-return.js
+++ b/tests/lib/rules/consistent-return.js
@@ -31,6 +31,12 @@ ruleTester.run("consistent-return", rule, {
         "function foo() { function bar() { return true; } return; }",
         "function foo() { function bar() { return; } return false; }",
         "function Foo() { if (!(this instanceof Foo)) return new Foo(); }",
+        { code: "function foo() { if (true) return; else return undefined; }", options: [{ treatUndefinedAsUnspecified: true }] },
+        { code: "function foo() { if (true) return; else return void 0; }", options: [{ treatUndefinedAsUnspecified: true }] },
+        { code: "function foo() { if (true) return undefined; else return; }", options: [{ treatUndefinedAsUnspecified: true }] },
+        { code: "function foo() { if (true) return undefined; else return void 0; }", options: [{ treatUndefinedAsUnspecified: true }] },
+        { code: "function foo() { if (true) return void 0; else return; }", options: [{ treatUndefinedAsUnspecified: true }] },
+        { code: "function foo() { if (true) return void 0; else return undefined; }", options: [{ treatUndefinedAsUnspecified: true }] },
         { code: "var x = () => {  return {}; };", parserOptions: { ecmaVersion: 6 } },
         { code: "if (true) { return 1; } return 0;", parserOptions: { ecmaVersion: 6, ecmaFeatures: { globalReturn: true } } }
     ],
@@ -139,6 +145,50 @@ ruleTester.run("consistent-return", rule, {
                     message: "Expected to return a value at the end of this function.",
                     type: "FunctionExpression",
                     column: 3
+                }
+            ]
+        },
+        {
+            code: "function foo() { if (true) return true; return undefined; }",
+            options: [{ treatUndefinedAsUnspecified: true }],
+            errors: [
+                {
+                    message: "Expected a return value.",
+                    type: "ReturnStatement",
+                    column: 41
+                }
+            ]
+        },
+        {
+            code: "function foo() { if (true) return true; return void 0; }",
+            options: [{ treatUndefinedAsUnspecified: true }],
+            errors: [
+                {
+                    message: "Expected a return value.",
+                    type: "ReturnStatement",
+                    column: 41
+                }
+            ]
+        },
+        {
+            code: "function foo() { if (true) return undefined; return true; }",
+            options: [{ treatUndefinedAsUnspecified: true }],
+            errors: [
+                {
+                    message: "Expected no return value.",
+                    type: "ReturnStatement",
+                    column: 46
+                }
+            ]
+        },
+        {
+            code: "function foo() { if (true) return void 0; return true; }",
+            options: [{ treatUndefinedAsUnspecified: true }],
+            errors: [
+                {
+                    message: "Expected no return value.",
+                    type: "ReturnStatement",
+                    column: 43
                 }
             ]
         },


### PR DESCRIPTION
Adds a new option to the `consistent-return` rule to treat `return undefined;` and `return void [...];` the same as `return;`