### PR TITLE
Docs: Add rule deprecation section to user guide (fixes #5845)

### DIFF
--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -22,6 +22,10 @@ There are a lot of command line flags for ESLint and this section explains what 
 
 Wondering if ESLint will work with your favorite editor or build system? This section has a list of all known integrations (submitted by their authors).
 
+## [Rule Deprecation](rule-deprecation)
+
+The ESLint team is committed to making upgrading as easy and painless as possible. This section outlines the guidelines the team has set in place for the deprecation of rules in future releases.
+
 ## [Migrating to 1.0.0](migrating-to-1.0.0)
 
 If you were using a version of ESLint prior to v1.0.0, this section helps you with the transition.

--- a/docs/user-guide/rule-deprecation.md
+++ b/docs/user-guide/rule-deprecation.md
@@ -1,0 +1,14 @@
+# Rule Deprecation
+
+Balancing the trade-offs of improving a tool and the frustration these changes can cause is a difficult task. One key area in which this affects our users is in the removal of rules.
+
+The ESLint team is committed to making upgrading as easy and painless as possible. To that end, the team has agreed upon some guidelines for deprecating rules in the future. The goal of these guidelines is to allow for improvements and changes to be made without breaking existing configurations.
+
+Until May 1, 2017, the team has committed to not remove any rules in any releases of ESLint; however, the team will deprecate rules as needed. When a rule is deprecated, it means that:
+
+* The rule will be marked as deprecated in all documentation.
+* The team will no longer do any work on the rule. This includes bug fixes, enhancements, and updates to the rule's documentation. Issues and pull requests related to the deprecated rule will not be accepted and will be closed automatically.
+
+After May 1, 2017, the team will revisit all deprecated rules and evaluate whether they should actually be removed or not. If the rule is removed at this time, users will have to adjust their configuration accordingly.
+
+We hope that by following these guidelines we will be able to continue improving and working to make ESLint the best tool it can be while causing as little disruption to our users as possible during the process.


### PR DESCRIPTION
Made a first pass at capturing this for the official docs. Thoughts @eslint/eslint-team?

Thoughts I had while writing it out:
* Should we be more specific about what "for the next year" means? i.e. include specific dates?
* I initially liked "Backwards Compatibility" better, but now I'm wonder if it should just cut to the chase and say "Deprecated Rules".