### PR TITLE
Fix: Incorrect object-property-newline behavior (fixes #6207)

### DIFF
--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -40,14 +40,14 @@ module.exports = {
 
         return {
             ObjectExpression: function(node) {
-                var lastTokenOfPreviousValue, firstTokenOfCurrentKey;
+                var lastTokenOfPreviousProperty, firstTokenOfCurrentProperty;
 
                 if (allowSameLine) {
                     if (node.properties.length > 1) {
-                        var firstToken = sourceCode.getFirstToken(node.properties[0].key);
-                        var lastToken = sourceCode.getLastToken(node.properties[node.properties.length - 1].value);
+                        var firstTokenOfFirstProperty = sourceCode.getFirstToken(node.properties[0]);
+                        var lastTokenOfLastProperty = sourceCode.getLastToken(node.properties[node.properties.length - 1]);
 
-                        if (firstToken.loc.end.line === lastToken.loc.start.line) {
+                        if (firstTokenOfFirstProperty.loc.end.line === lastTokenOfLastProperty.loc.start.line) {
 
                             // All keys and values are on the same line
                             return;
@@ -56,13 +56,13 @@ module.exports = {
                 }
 
                 for (var i = 1; i < node.properties.length; i++) {
-                    lastTokenOfPreviousValue = sourceCode.getLastToken(node.properties[i - 1].value);
-                    firstTokenOfCurrentKey = sourceCode.getFirstToken(node.properties[i].key);
+                    lastTokenOfPreviousProperty = sourceCode.getLastToken(node.properties[i - 1]);
+                    firstTokenOfCurrentProperty = sourceCode.getFirstToken(node.properties[i]);
 
-                    if (lastTokenOfPreviousValue.loc.end.line === firstTokenOfCurrentKey.loc.start.line) {
+                    if (lastTokenOfPreviousProperty.loc.end.line === firstTokenOfCurrentProperty.loc.start.line) {
                         context.report({
                             node: node,
-                            loc: firstTokenOfCurrentKey.loc.start,
+                            loc: firstTokenOfCurrentProperty.loc.start,
                             message: errorMessage
                         });
                     }

--- a/tests/lib/rules/object-property-newline.js
+++ b/tests/lib/rules/object-property-newline.js
@@ -28,12 +28,19 @@ ruleTester.run("object-property-newline", rule, {
         { code: "var obj = { k1: 'val1' };" },
         { code: "var obj = {\nk1: 'val1'\n};" },
         { code: "var obj = {};" },
+        { code: "var obj = {\n[bar]: 'baz',\nbaz\n};", parserOptions: { ecmaVersion: 6 } },
+        { code: "var obj = {\nk1: 'val1',\nk2: 'val2',\n...{}\n};", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "var obj = { k1: 'val1',\nk2: 'val2',\n...{} };", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "var obj = { ...{} };", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
         { code: "foo({ k1: 'val1',\nk2: 'val2' });" },
         { code: "foo({\nk1: 'val1',\nk2: 'val2'\n});" },
         { code: "foo({\na,\nb\n});", parserOptions: { ecmaVersion: 6 } },
         { code: "foo({\na,\nb,\n});", parserOptions: { ecmaVersion: 6 } },
         { code: "foo({\nbar() {},\nbaz\n});", parserOptions: { ecmaVersion: 6 } },
         { code: "foo({\n[bar]: 'baz',\nbaz \n})", parserOptions: { ecmaVersion: 6 } },
+        { code: "foo({\nk1: 'val1',\nk2: 'val2',\n...{}\n});", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "foo({ k1: 'val1',\nk2: 'val2',\n...{} });", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "foo({ ...{} });", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
 
         // allowMultiplePropertiesPerLine: true
         { code: "var obj = { k1: 'val1', k2: 'val2', k3: 'val3' };", options: [{ allowMultiplePropertiesPerLine: true }] },
@@ -41,11 +48,15 @@ ruleTester.run("object-property-newline", rule, {
         { code: "var obj = { k1: 'val1' };", options: [{ allowMultiplePropertiesPerLine: true }] },
         { code: "var obj = {\nk1: 'val1'\n};", options: [{ allowMultiplePropertiesPerLine: true }] },
         { code: "var obj = {};", options: [{ allowMultiplePropertiesPerLine: true }] },
+        { code: "var obj = { 'k1': 'val1', k2: 'val2', ...{} };", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "var obj = {\n'k1': 'val1', k2: 'val2', ...{}\n};", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
         { code: "foo({ k1: 'val1', k2: 'val2' });", options: [{ allowMultiplePropertiesPerLine: true }] },
         { code: "foo({\nk1: 'val1', k2: 'val2'\n});", options: [{ allowMultiplePropertiesPerLine: true }] },
         { code: "foo({ a, b });", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6 } },
         { code: "foo({ bar() {}, baz });", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6 } },
-        { code: "foo({ [bar]: 'baz', baz })", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6 } }
+        { code: "foo({ [bar]: 'baz', baz })", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6 } },
+        { code: "foo({ 'k1': 'val1', k2: 'val2', ...{} });", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } },
+        { code: "foo({\n'k1': 'val1', k2: 'val2', ...{}\n});", options: [{ allowMultiplePropertiesPerLine: true }], parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } } }
     ],
 
     invalid: [
@@ -92,6 +103,42 @@ ruleTester.run("object-property-newline", rule, {
                     message: "Object properties must go on a new line",
                     type: "ObjectExpression",
                     line: 3,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "var obj = { k1: 'val1', [\nk2]: 'val2' };",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "var obj = { k1: 'val1', ...{} };",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 25
+                }
+            ]
+        },
+        {
+            code: "var obj = {\nk1: 'val1', ...{}\n};",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
                     column: 13
                 }
             ]
@@ -167,6 +214,42 @@ ruleTester.run("object-property-newline", rule, {
             ]
         },
         {
+            code: "foo({ k1: 'val1', [\nk2]: 'val2' })",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "foo({ k1: 'val1', ...{} })",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 1,
+                    column: 19
+                }
+            ]
+        },
+        {
+            code: "foo({\nk1: 'val1', ...{}\n})",
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            errors: [
+                {
+                    message: "Object properties must go on a new line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 13
+                }
+            ]
+        },
+        {
             code: "var obj = {\na: {\nb: 1,\nc: 2\n}, d: 2\n};",
             errors: [
                 {
@@ -192,8 +275,74 @@ ruleTester.run("object-property-newline", rule, {
             ]
         },
         {
-            code: "var obj = {\nk1: 'val1',\nk2: 'val2', k3: 'val3'\n};",
+            code: "var obj = { [\nk1]: 'val1', k2: 'val2' };",
             options: [{ allowMultiplePropertiesPerLine: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line if they aren't all on the same line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 14
+                }
+            ]
+        },
+        {
+            code: "var obj = {\nk1: 'val1',\nk2: 'val2', ...{}\n};",
+            options: [{ allowMultiplePropertiesPerLine: true }],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            errors: [
+                {
+                    message: "Object properties must go on a new line if they aren't all on the same line",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "var obj = {\n...{},\nk1: 'val1', k2: 'val2'\n};",
+            options: [{ allowMultiplePropertiesPerLine: true }],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            errors: [
+                {
+                    message: "Object properties must go on a new line if they aren't all on the same line",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "foo({ [\nk1]: 'val1', k2: 'val2' })",
+            options: [{ allowMultiplePropertiesPerLine: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                {
+                    message: "Object properties must go on a new line if they aren't all on the same line",
+                    type: "ObjectExpression",
+                    line: 2,
+                    column: 14
+                }
+            ]
+        },
+        {
+            code: "foo({\nk1: 'val1',\nk2: 'val2', ...{}\n})",
+            options: [{ allowMultiplePropertiesPerLine: true }],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            errors: [
+                {
+                    message: "Object properties must go on a new line if they aren't all on the same line",
+                    type: "ObjectExpression",
+                    line: 3,
+                    column: 13
+                }
+            ]
+        },
+        {
+            code: "foo({\n...{},\nk1: 'val1', k2: 'val2'\n})",
+            options: [{ allowMultiplePropertiesPerLine: true }],
+            parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } },
             errors: [
                 {
                     message: "Object properties must go on a new line if they aren't all on the same line",


### PR DESCRIPTION
Syntax that wasn't handled correctly / caused errors to be thrown:
- computed keys spanning multiple lines
- experimental object spread