### PR TITLE
Fix: `vars-on-top` crashs at export declarations (fixes #6210)

### DIFF
--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -47,6 +47,23 @@ module.exports = {
         }
 
         /**
+         * Checks whether a given node is a variable declaration or not.
+         *
+         * @param {ASTNode} node - any node
+         * @returns {boolean} `true` if the node is a variable declaration.
+         */
+        function isVariableDeclaration(node) {
+            return (
+                node.type === "VariableDeclaration" ||
+                (
+                    node.type === "ExportNamedDeclaration" &&
+                    node.declaration &&
+                    node.declaration.type === "VariableDeclaration"
+                )
+            );
+        }
+
+        /**
          * Checks whether this variable is on top of the block body
          * @param {ASTNode} node - The node to check
          * @param {ASTNode[]} statements - collection of ASTNodes for the parent node block
@@ -64,9 +81,7 @@ module.exports = {
             }
 
             for (; i < l; ++i) {
-                if (statements[i].type !== "VariableDeclaration" &&
-                        (statements[i].type !== "ExportNamedDeclaration" ||
-                        statements[i].declaration.type !== "VariableDeclaration")) {
+                if (!isVariableDeclaration(statements[i])) {
                     return false;
                 }
                 if (statements[i] === node) {

--- a/tests/lib/rules/vars-on-top.js
+++ b/tests/lib/rules/vars-on-top.js
@@ -457,6 +457,40 @@ ruleTester.run("vars-on-top", rule, {
                 sourceType: "module"
             },
             errors: [{message: "All 'var' declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: [
+                "import {foo} from 'foo';",
+                "export {foo};",
+                "var test = 1;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            },
+            errors: [{message: "All 'var' declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: [
+                "export {foo} from 'foo';",
+                "var test = 1;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            },
+            errors: [{message: "All 'var' declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
+        },
+        {
+            code: [
+                "export * from 'foo';",
+                "var test = 1;"
+            ].join("\n"),
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            },
+            errors: [{message: "All 'var' declarations must be at the top of the function scope.", type: "VariableDeclaration"}]
         }
     ]
 });


### PR DESCRIPTION
Fixes #6210.

Just added a null check.
The declaration property is nullable by [spec](https://github.com/estree/estree/blob/master/es6.md#exportnameddeclaration)