### PR TITLE
New: `unicode-bom` rule to allow or disallow BOM (fixes #5502)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -207,6 +207,7 @@
         "spaced-comment": "off",
         "strict": "off",
         "template-curly-spacing": "off",
+        "unicode-bom": "off",
         "use-isnan": "error",
         "valid-jsdoc": "off",
         "valid-typeof": "error",

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -220,6 +220,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 * [space-infix-ops](space-infix-ops.md): require spacing around operators (fixable)
 * [space-unary-ops](space-unary-ops.md): enforce consistent spacing before or after unary operators (fixable)
 * [spaced-comment](spaced-comment.md): enforce consistent spacing after the `//` or `/*` in a comment (fixable)
+* [unicode-bom](unicode-bom.md): allow or disallow the Unicode BOM
 * [wrap-regex](wrap-regex.md): require parenthesis around regex literals
 
 ## ECMAScript 6

--- a/docs/rules/unicode-bom.md
+++ b/docs/rules/unicode-bom.md
@@ -1,0 +1,60 @@
+# Allow or disallow the Unicode Byte Order Mark (BOM) (unicode-bom)
+
+The Unicode Byte Order Mark (BOM) is used to specify whether code units are big
+endian or little endian. That is, whether the most significant or least
+significant bytes come first. UTF-8 does not require a BOM because byte ordering
+does not matter when characters are a single byte. Since UTF-8 is the dominant
+encoding of the web, we make `"never"` the default option.
+
+## Rule Details
+
+If the `"never"` option is used, this rule requires that the file does not begin
+with the unicode BOM character U+FEFF.
+
+## Options
+
+This rule has a string option:
+
+* `"always"` the unicode BOM is always allowed
+* `"never"` (default) the unicode BOM is never allowed
+
+### always
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```js
+/*eslint unicode-bom: "error"*/
+
+U+FEFF
+var abc;
+```
+
+```js
+/*eslint unicode-bom: "error"*/
+
+var abc;
+```
+
+### never
+
+Example of **correct** code for this rule with the default `"never"` option:
+
+```js
+/*eslint unicode-bom: ["error", "never"]*/
+
+var abc;
+```
+
+Example of **incorrect** code for this rule with the `"never"` option:
+
+```js
+/*eslint unicode-bom: ["error", "never"]*/
+
+U+FEFF
+var abc;
+```
+
+## When Not To Use It
+
+If your files are stored in UTF-16 or UTF-32, turn this rule off or use the
+"always" option.

--- a/lib/rules/unicode-bom.js
+++ b/lib/rules/unicode-bom.js
@@ -1,0 +1,52 @@
+/**
+ * @fileoverview Allow or disallow Unicode BOM
+ * @author ehjay <https://github.com/ehjay>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "allow or disallow Unicode BOM",
+            category: "Stylistic Issues",
+            recommended: false
+        },
+
+        schema: [
+            {
+                enum: ["always", "never"]
+            }
+        ]
+    },
+
+    create: function(context) {
+
+        //--------------------------------------------------------------------------
+        // Public
+        //--------------------------------------------------------------------------
+
+        return {
+
+            Program: function checkUnicodeBOM(node) {
+
+                var sourceCode = context.getSourceCode(),
+                    location = {column: 1, line: 1},
+                    allowBOM = context.options[0] || "never";
+
+                if (sourceCode.hasBOM && (allowBOM === "never")) {
+                    context.report({
+                        node: node,
+                        loc: location,
+                        message: "Found unicode BOM (Byte Order Mark)."
+                    });
+                }
+            }
+
+        };
+
+    }
+};

--- a/tests/lib/rules/unicode-bom.js
+++ b/tests/lib/rules/unicode-bom.js
@@ -1,0 +1,56 @@
+/**
+ * @fileoverview Check, that the Unicode BOM can be allowed and disallowed
+ * @author ehjay <https://github.com/ehjay>
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/rules/unicode-bom"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run("unicode-bom", rule, {
+
+    valid: [
+        {
+            code: "\uFEFF",
+            options: ["always"]
+        },
+        {
+            code: "\uFEFF var a = 123;",
+            options: ["always"]
+        },
+        {
+            code: "var a = 123; \uFEFF",
+            options: ["always"]
+        },
+        {
+            code: "var a = 123;",
+            options: ["never"]
+        },
+        {
+            code: "var a = 123; \uFEFF",
+            options: ["never"]
+        }
+    ],
+
+    invalid: [
+        {
+            code: "\uFEFF var a = 123;",
+            errors: [{ message: "Found unicode BOM (Byte Order Mark).", type: "Program" }]
+        },
+        {
+            code: "\uFEFF var a = 123;",
+            errors: [{ message: "Found unicode BOM (Byte Order Mark).", type: "Program" }],
+            options: ["never"]
+        }
+    ]
+});


### PR DESCRIPTION
Add a new rule that allows or disallows the Unicode Byte Order Mark (BOM) depending on the option chosen. References Github issue #5502