### PR TITLE
Fix: lost code in autofixing (refs #6233)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -154,6 +154,12 @@ function multipassFix(text, config, options) {
         debug("Generating fixed text for " + options.filename + " (pass " + passNumber + ")");
         fixedResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
 
+        // stop if there are any syntax errors.
+        // 'fixedResult.output' is a empty string.
+        if (messages.length === 1 && messages[0].fatal) {
+            break;
+        }
+
         // keep track if any fixes were ever applied - important for return value
         fixed = fixed || fixedResult.fixed;
 

--- a/tests/fixtures/rules/make-syntax-error-rule.js
+++ b/tests/fixtures/rules/make-syntax-error-rule.js
@@ -1,0 +1,14 @@
+module.exports = function(context) {
+    return {
+        Program: function(node) {
+            context.report({
+                node: node,
+                message: "ERROR",
+                fix: function(fixer) {
+                    return fixer.insertTextAfter(node, "this is a syntax error.");
+                }
+            });
+        }
+    };
+};
+module.exports.schema = [];


### PR DESCRIPTION
Refs #6233.

I added `break` statement into the multipass fixing loop.
This prevents deleting the text.

It would make `fixedResult` at least 1 time even if there is a syntax error from the first time.
