### PR TITLE
Fix: `comma-dangle` wrong autofix (fixes #6233)

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -143,13 +143,13 @@ module.exports = {
             }
 
             var sourceCode = context.getSourceCode(),
-                trailingToken;
-
-            // last item can be surrounded by parentheses for object and array literals
-            if (node.type === "ObjectExpression" || node.type === "ArrayExpression") {
-                trailingToken = sourceCode.getTokenBefore(sourceCode.getLastToken(node));
-            } else {
+                penultimateToken = lastItem,
                 trailingToken = sourceCode.getTokenAfter(lastItem);
+
+            // Skip close parentheses.
+            while (trailingToken.value === ")") {
+                penultimateToken = trailingToken;
+                trailingToken = sourceCode.getTokenAfter(trailingToken);
             }
 
             if (trailingToken.value !== ",") {
@@ -158,7 +158,7 @@ module.exports = {
                     loc: lastItem.loc.end,
                     message: MISSING_MESSAGE,
                     fix: function(fixer) {
-                        return fixer.insertTextAfter(lastItem, ",");
+                        return fixer.insertTextAfter(penultimateToken, ",");
                     }
                 });
             }

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -846,6 +846,26 @@ ruleTester.run("comma-dangle", rule, {
             parserOptions: { sourceType: "module" },
             options: ["always-multiline"],
             errors: [{message: "Missing trailing comma.", type: "ExportSpecifier"}]
+        },
+
+        // https://github.com/eslint/eslint/issues/6233
+        {
+            code: "var foo = {a: (1)}",
+            output: "var foo = {a: (1),}",
+            options: ["always"],
+            errors: [{message: "Missing trailing comma.", type: "Property"}]
+        },
+        {
+            code: "var foo = [(1)]",
+            output: "var foo = [(1),]",
+            options: ["always"],
+            errors: [{message: "Missing trailing comma.", type: "Literal"}]
+        },
+        {
+            code: "var foo = [\n1,\n(2)\n]",
+            output: "var foo = [\n1,\n(2),\n]",
+            options: ["always-multiline"],
+            errors: [{message: "Missing trailing comma.", type: "Literal"}]
         }
     ]
 });


### PR DESCRIPTION
Fixes #6233.

In an original way, it was a bit hard that it gets proper position to add a comma in a common logic since traversal direction is different (→/←) for each fork.