### PR TITLE
Update: arrow-parents.md to show appropriate output value of if statement

### DIFF
--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -117,7 +117,7 @@ if ((a) => b) {
 } else {
  console.log('falsey value returned');
 };
-// outputs 'falsey value returned'
+// outputs 'truthy value returned'
 ```
 
 The following is another example of this behavior:


### PR DESCRIPTION
Docs: The output value in the arrow-parens docs is wrong.  The arrow function reference is truthy, and it's not immediately invoked.  The output log is "truthy value returned".