### PR TITLE
New: Add `eslint:all` option (fixes #6240)

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,6 +1,5 @@
 /bin/**
 /build/**
-/conf/**
 /coverage/**
 /docs/**
 /jsdoc/**

--- a/Makefile.js
+++ b/Makefile.js
@@ -61,7 +61,7 @@ var NODE = "node ", // intentional extra space
 
     // Files
     MAKEFILE = "./Makefile.js",
-    JS_FILES = find("lib/").filter(fileType("js")).join(" "),
+    JS_FILES = find("lib/", "conf/").filter(fileType("js")).join(" "),
     JSON_FILES = find("conf/").filter(fileType("json")),
     MARKDOWN_FILES_ARRAY = find("docs/").concat(ls(".")).filter(fileType("md")),
     TEST_FILES = getTestFilePatterns(),

--- a/conf/eslint-all.js
+++ b/conf/eslint-all.js
@@ -1,0 +1,29 @@
+/**
+ * @fileoverview Config to enable all rules.
+ * @author Robert Fletcher
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var fs = require("fs"),
+    path = require("path");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+var ruleFiles = fs.readdirSync(path.resolve(__dirname, "../lib/rules"));
+var enabledRules = ruleFiles.reduce(function(result, filename) {
+    result[path.basename(filename, ".js")] = "error";
+    return result;
+}, {});
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = { rules: enabledRules };

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -369,6 +369,12 @@ function applyExtends(config, filePath, relativeTo) {
              * this lets us use the eslint.json file as the recommended rules
              */
             parentPath = path.resolve(__dirname, "../../conf/eslint.json");
+        } else if (parentPath === "eslint:all") {
+
+            /*
+             * Add an explicit substitution for eslint:all to conf/eslint-all.js
+             */
+            parentPath = path.resolve(__dirname, "../../conf/eslint-all.js");
         } else if (isFilePath(parentPath)) {
 
             /*

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -186,6 +186,21 @@ describe("ConfigFile", function() {
 
         });
 
+        it("should apply all rules when extends config includes 'eslint:all'", function() {
+
+            var configDeps = {
+                "../util/module-resolver": createStubModuleResolver({})
+            };
+            var StubbedConfigFile = proxyquire("../../../lib/config/config-file", configDeps);
+            var config = StubbedConfigFile.applyExtends({
+                extends: "eslint:all"
+            }, "/whatever");
+
+            assert.equal(config.rules.eqeqeq, "error");
+            assert.equal(config.rules.curly, "error");
+
+        });
+
         it("should throw an error when extends config is not found", function() {
 
             var configDeps = {


### PR DESCRIPTION
This adds a new option to allow a user to extend `eslint:all` in order
to enable all rules by default.