### PR TITLE
Build: Don't check commit count (fixes #5935)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ node_js:
     - "5"
     - "6"
 sudo: false
-script: "npm test && npm run check-commit && npm run docs"
+script: "npm test && npm run docs"
 after_success:
     - npm run coveralls
 addons:

--- a/templates/pr-create.md.ejs
+++ b/templates/pr-create.md.ejs
@@ -16,9 +16,7 @@ function needsIssueRef(log) {
 var problems = [];
 
 // Check for one commit per pull request
-if (payload.commits > 1) {
-    problems.push("We require one commit per pull request. Please [squash](https://egghead.io/lessons/javascript-how-to-squash-multiple-git-commits) your commits.");
-} else if (meta.commits) {
+if (meta.commits) {
     // get just the first line of the commit message
     var log = meta.commits[0].commit.message.split(/\r?\n/g)[0];
 

--- a/tests/templates/pr-create.md.ejs.js
+++ b/tests/templates/pr-create.md.ejs.js
@@ -40,21 +40,6 @@ describe("pr-create.md.ejs", function() {
         assert.equal(result.trim(), "LGTM");
     });
 
-    it("should mention squashing commits and welcome user by name when more than one commit is found", function() {
-        var result = ejs.render(TEMPLATE_TEXT, {
-            payload: {
-                sender: {
-                    login: "nzakas"
-                },
-                commits: 2
-            },
-            meta: {}
-        });
-
-        assert.ok(result.indexOf("@nzakas") > -1);
-        assert.ok(result.indexOf("squash") > -1);
-    });
-
     it("should mention commit message format when there's one commit and an invalid commit message is found", function() {
         var result = ejs.render(TEMPLATE_TEXT, {
             payload: {


### PR DESCRIPTION
This removes the commit count check from both Travis and the bot since we always squashing PRs now.

It still checks the first commit message to ensure it's the correct format.