### PR TITLE
Docs: Describe options in rules under Possible Errors part 4

### DIFF
--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -1,91 +1,73 @@
-# Validates JSDoc comments are syntactically correct (valid-jsdoc)
+# enforce valid JSDoc comments (valid-jsdoc)
 
-[JSDoc](http://usejsdoc.org) is a JavaScript API documentation generator. It uses specially-formatted comments inside of code to generate API documentation automatically. For example, this is what a JSDoc comment looks like for a function:
+[JSDoc](http://usejsdoc.org) generates application programming interface (API) documentation from specially-formatted comments in JavaScript code. For example, this is a JSDoc comment for a function:
 
 ```js
 /**
- * Adds two numbers together.
- * @param {int} num1 The first number.
- * @param {int} num2 The second number.
- * @returns {int} The sum of the two numbers.
+ * Add two numbers.
+ * @param {number} num1 The first number.
+ * @param {number} num2 The second number.
+ * @returns {number} The sum of the two numbers.
  */
-function sum(num1, num2) {
+function add(num1, num2) {
     return num1 + num2;
 }
 ```
 
-The JSDoc comments have a syntax all their own, and it is easy to mistakenly mistype a comment because comments aren't often checked for correctness in editors. Further, it's very easy for the function definition to get out of sync with the comments, making the comments a source of confusion and error.
+If comments are invalid because of typing mistakes, then documentation will be incomplete.
+
+If comments are inconsistent because they are not updated when function definitions are modified, then readers might become confused.
 
 ## Rule Details
 
-This rule aims to prevent invalid and incomplete JSDoc comments. It will warn when any of the following is true:
+This rule enforces valid and consistent JSDoc comments. It reports any of the following problems:
 
-* There is a JSDoc syntax error
-* A `@param` or `@returns` is used without a type specified
-* A `@param` or `@returns` is used without a description
-* A comment for a function is missing `@returns`
-* A parameter has no associated `@param` in the JSDoc comment
-* `@param`s are out of order with named arguments
+* missing parameter tag: `@arg`, `@argument`, or `@param`
+* inconsistent order of parameter names in a comment compared to the function or method
+* missing return tag: `@return` or `@returns`
+* missing parameter or return type
+* missing parameter or return description
+* syntax error
+
+This rule does not report missing JSDoc comments for classes, functions, or methods.
 
 Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint valid-jsdoc: "error"*/
 
-// missing type for @param and missing @returns
-/**                                 // 2 errors
- * A description
+// expected @param tag for parameter num1 but found num instead
+// missing @param tag for parameter num2
+// missing return type
+/**
+ * Add two numbers.
+ * @param {number} num The first number.
+ * @returns The sum of the two numbers.
+ */
+function add(num1, num2) {
+    return num1 + num2;
+}
+
+// missing brace
+// missing @returns tag
+/**
+ * @param {string name Whom to greet.
+ */
+function greet(name) {
+    console.log("Hello " + name);
+}
+
+// missing parameter type for num1
+// missing parameter description for num2
+/**
+ * Represents a sum.
+ * @constructor
  * @param num1 The first number.
+ * @param {number} num2
  */
-function foo(num1) {
-    // ...
-}
-
-// missing description for @param
-/**                                 //error Missing JSDoc parameter description for 'num1'.
- * A description
- * @param {int} num1
- * @returns {void}
- */
-function foo(num1) {
-    // ...
-}
-
-// no description for @returns
-/**                                 //error Missing JSDoc return description.
- * A description
- * @returns {int}
- */
-function foo() {
-    // ...
-}
-
-// no type for @returns
-/**                                 //error JSDoc syntax error.
- * A description
- * @returns Something awesome
- */
-function foo() {
-    // ...
-}
-
-// missing @param
-/**                                 //error Missing JSDoc for parameter 'a'.
- * A description
- * @returns {void}
- */
-function foo(a) {
-    // ...
-}
-
-// incorrect @param
-/**                                 //error Expected JSDoc for 'a' but found 'b'.
- * A description
- * @param {string} b Desc
- * @returns {void}
- */
-function foo(a) {
-    // ...
+function sum(num1, num2) {
+    this.num1 = num1;
+    this.num2 = num2;
 }
 ```
 
@@ -93,204 +75,285 @@ Examples of **correct** code for this rule:
 
 ```js
 /*eslint valid-jsdoc: "error"*/
+/*eslint-env es6*/
 
 /**
- * Adds two numbers together.
- * @param {int} num1 The first number.
- * @param {int} num2 The second number.
- * @returns {int} The sum of the two numbers.
+ * Add two numbers.
+ * @param {number} num1 The first number.
+ * @param {number} num2 The second number.
+ * @returns {number} The sum of the two numbers.
  */
-function foo(num1, num2) {
+function add(num1, num2) {
+    return num1 + num2;
+}
+
+// default options allow missing function description
+// return type `void` means the function has no `return` statement
+/**
+ * @param {string} name Whom to greet.
+ * @returns {void}
+ */
+function greet(name) {
+    console.log("Hello " + name);
+}
+
+// @constructor tag allows missing @returns tag
+/**
+ * Represents a sum.
+ * @constructor
+ * @param {number} num1 The first number.
+ * @param {number} num2 The second number.
+ */
+function sum(num1, num2) {
+    this.num1 = num1;
+    this.num2 = num2;
+}
+
+// class constructor allows missing @returns tag
+/**
+ * Represents a sum.
+ */
+class Sum {
+    /**
+     * @param {number} num1 The first number.
+     * @param {number} num2 The second number.
+     */
+    constructor(num1, num2) {
+        this.num1 = num1;
+        this.num2 = num2;
+    }
+}
+
+// @abstract tag allows @returns tag without `return` statement
+class Widget {
+    /**
+    * When the state changes, does it affect the rendered appearance?
+    * @abstract
+    * @param {Object} state The new state of the widget.
+    * @returns {boolean} Is current appearance inconsistent with new state?
+    */
+    mustRender (state) {
+        throw new Error("Widget subclass did not implement mustRender");
+    }
+}
+
+// @override tag allows missing @param and @returns tags
+class WonderfulWidget extends Widget {
+    /**
+     * @override
+     */
+    mustRender (state) {
+        return state !== this.state; // shallow comparison
+    }
+}
+```
+
+## Options
+
+This rule has an object option:
+
+* `"prefer"` enforces consistent documentation tags specified by an object whose properties mean instead of key use value (for example, `"return": "returns"` means instead of `@return` use `@returns`)
+* `"preferType"` enforces consistent type strings specified by an object whose properties mean instead of key use value (for example, `"object": "Object"` means instead of `object` use `Object`)
+* `"requireReturn"` requires a return tag:
+    * `true` (default) **even if** the function or method does not have a `return` statement (this option value does not apply to constructors)
+    * `false` **if and only if** the function or method has a `return` statement (this option value does apply to constructors)
+* `"requireReturnType": false` allows missing type in return tags
+* `"matchDescription"` specifies (as a string) a regular expression to match the description in each JSDoc comment (for example, `".+"` requires a description; this option does not apply to descriptions in parameter or return tags)
+* `"requireParamDescription": false` allows missing description in parameter tags
+* `"requireReturnDescription": false` allows missing description in return tags
+
+### prefer
+
+Examples of additional **incorrect** code for this rule with sample `"prefer": { "arg": "param", "argument": "param", "class": "constructor", "return": "returns", "virtual": "abstract" }` options:
+
+```js
+/*eslint valid-jsdoc: ["error", { "prefer": { "arg": "param", "argument": "param", "class": "constructor", "return": "returns", "virtual": "abstract" } }]*/
+/*eslint-env es6*/
+
+/**
+ * Add two numbers.
+ * @arg {int} num1 The first number.
+ * @arg {int} num2 The second number.
+ * @return {int} The sum of the two numbers.
+ */
+function add(num1, num2) {
     return num1 + num2;
 }
 
 /**
  * Represents a sum.
- * @param {int} num1 The first number.
- * @param {int} num2 The second number.
- * @constructor
+ * @class
+ * @argument {number} num1 The first number.
+ * @argument {number} num2 The second number.
  */
-function foo(num1, num2) { }
-
-// use of @override make @param and @returns optional
-/**
- * A description
- * @override
- */
-function foo(a) {
-    return a;
+function sum(num1, num2) {
+    this.num1 = num1;
+    this.num2 = num2;
 }
 
-// @returns is not required for a constructor
-class Foo {
+class Widget {
     /**
-    *
-    * @param {int} num1 The first number.
-    */
-    constructor(num1) {
-        this.num1 = num1;
-    }
-}
-
-// @returns allowed without return if used with @abstract
-class Foo {
-    /**
-     * @abstract
-     * @return {Number} num
+     * When the state changes, does it affect the rendered appearance?
+     * @virtual
+     * @argument {Object} state The new state of the widget.
+     * @return {boolean} Is current appearance inconsistent with new state?
      */
-    abstractMethod () {
-        throw new Error('Not implemented');
+    mustRender (state) {
+        throw new Error("Widget subclass did not implement mustRender");
     }
 }
-
-```
-
-## Options
-
-### prefer
-
-JSDoc offers a lot of tags with overlapping meaning. For example, both `@return` and `@returns` are acceptable for specifying the return value of a function. However, you may want to enforce a certain tag be used instead of others. You can specify your preferences regarding tag substitution by providing a mapping called `prefer` in the rule configuration. For example, to specify that `@returns` should be used instead of `@return`, you can use the following configuration:
-
-```json
-"valid-jsdoc": ["error", {
-    "prefer": {
-        "return": "returns"
-    }
-}]
-```
-
-With this configuration, ESLint will warn when it finds `@return` and recommend to replace it with `@returns`.
-
-### requireReturn
-
-By default ESLint requires you to document every function with a `@return` tag regardless of whether there is anything returned by the function. If instead you want to enforce that only functions with a `return` statement are documented with a `@return` tag, set the `requireReturn` option to `false`.  When `requireReturn` is `false`, every function documented with a `@return` tag must have a `return` statement, and every function with a `return` statement must have a `@return` tag.
-
-```json
-"valid-jsdoc": ["error", {
-    "requireReturn": false
-}]
-```
-
-### requireParamDescription
-
-By default ESLint requires you to specify a description for each `@param`. You can choose not to require descriptions for parameters by setting `requireParamDescription` to `false`.
-
-```json
-"valid-jsdoc": ["error", {
-    "requireParamDescription": false
-}]
-```
-
-### requireReturnDescription
-
-By default ESLint requires you to specify a description for each `@return`. You can choose not to require descriptions for `@return` by setting `requireReturnDescription` to `false`.
-
-```json
-"valid-jsdoc": ["error", {
-    "requireReturnDescription": false
-}]
-```
-
-### matchDescription
-
-Specify a regular expression to validate jsdoc comment block description against.
-
-```json
-"valid-jsdoc": ["error", {
-    "matchDescription": "^[A-Z][A-Za-z0-9\\s]*[.]$"
-}]
-```
-
-### requireReturnType
-
-By default ESLint requires you to specify `type` for `@return` tag for every documented function.
-
-```json
-"valid-jsdoc": ["error", {
-    "requireReturnType": false
-}]
 ```
 
 ### preferType
 
-It will validate all the types from jsdoc with the options setup by the user. Inside the options, key should be what the type you want to check and the value of it should be what the expected type should be. Note that we don't check for spelling mistakes with this option.
-In the example below, it will expect the "object" to start with an uppercase and all the "string" type to start with a lowercase.
+Examples of additional **incorrect** code for this rule with sample `"preferType": { "Boolean": "boolean", "Number": "number", "object": "Object", "String": "string" }` options:
 
-```json
-"valid-jsdoc": ["error", {
-    "preferType": {
-        "String": "string",
-        "object": "Object",
-        "test": "TesT"
+```js
+/*eslint valid-jsdoc: ["error", { "preferType": { "Boolean": "boolean", "Number": "number", "object": "Object", "String": "string" } }]*/
+/*eslint-env es6*/
+
+/**
+ * Add two numbers.
+ * @param {Number} num1 The first number.
+ * @param {Number} num2 The second number.
+ * @returns {Number} The sum of the two numbers.
+ */
+function add(num1, num2) {
+    return num1 + num2;
+}
+
+/**
+ * Output a greeting as a side effect.
+ * @param {String} name Whom to greet.
+ * @returns {void}
+ */
+function greet(name) {
+    console.log("Hello " + name);
+}
+
+class Widget {
+    /**
+     * When the state changes, does it affect the rendered appearance?
+     * @abstract
+     * @param {object} state The new state of the widget.
+     * @returns {Boolean} Is current appearance inconsistent with new state?
+     */
+    mustRender (state) {
+        throw new Error("Widget subclass did not implement mustRender");
     }
-}]
-```
-
-Examples of **incorrect** code for a sample of `"preferType"` options:
-
-```js
-/*eslint valid-jsdoc: ["error", { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
-
-/**
- * Adds two numbers together.
- * @param {String} param1 The first parameter.
- * @returns {object} The sum of the two numbers.
- */
-function foo(param1) {
-    return {a: param1};
-}
-
-/**
- * Adds two numbers together.
- * @param {Array<String>} param1 The first parameter.
- * @param {{1:test}} param2 The second parameter.
- * @returns {object} The sum of the two numbers.
- */
-function foo(param1, param2) {
-    return {a: param1};
-}
-
-/**
- * Adds two numbers together.
- * @param {String|int} param1 The first parameter.
- * @returns {object} The sum of the two numbers.
- */
-function foo(param1) {
-    return {a: param1};
 }
 ```
 
-Examples of **correct** code for a sample of `"preferType"` options:
+### requireReturn
+
+Examples of additional **incorrect** code for this rule with the `"requireReturn": false` option:
 
 ```js
-/*eslint valid-jsdoc: ["error", { "preferType": { "String": "string", "object": "Object", "test": "TesT" } }]*/
+/*eslint valid-jsdoc: ["error", { "requireReturn": false }]*/
 
+// unexpected @returns tag because function has no `return` statement
 /**
- * Adds two numbers together.
- * @param {string} param1 The first parameter.
- * @returns {Object} The sum of the two numbers.
+ * @param {string} name Whom to greet.
+ * @returns {string} The greeting.
  */
-function foo(param1) {
-    return {a: param1};
+function greet(name) {
+    console.log("Hello " + name);
 }
 
-/**
- * Adds two numbers together.
- * @param {Array<string>} param1 The first parameter.
- * @param {{1:TesT}} param2 The second parameter.
- * @returns {Object} The sum of the two numbers.
- */
-function foo(param1, param2) {
-    return {a: param1};
+// add @abstract tag to allow @returns tag without `return` statement
+class Widget {
+    /**
+     * When the state changes, does it affect the rendered appearance?
+     * @param {Object} state The new state of the widget.
+     * @returns {boolean} Is current appearance inconsistent with new state?
+     */
+    mustRender (state) {
+        throw new Error("Widget subclass did not implement mustRender");
+    }
 }
+```
+
+Example of additional **correct** code for this rule with the `"requireReturn": false` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "requireReturn": false }]*/
 
 /**
- * Adds two numbers together.
- * @param {string|int} param1 The first parameter.
- * @returns {Object} The sum of the two numbers.
+ * @param {string} name Whom to greet.
  */
-function foo(param1) {
-    return {a: param1};
+function greet(name) {
+    console.log("Hello " + name);
+}
+```
+
+### requireReturnType
+
+Example of additional **correct** code for this rule with the `"requireReturnType": false` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "requireReturnType": false }]*/
+
+/**
+ * Add two numbers.
+ * @param {number} num1 The first number.
+ * @param {number} num2 The second number.
+ * @returns The sum of the two numbers.
+ */
+function add(num1, num2) {
+    return num1 + num2;
+}
+```
+
+### matchDescription
+
+Example of additional **incorrect** code for this rule with a sample `"matchDescription": ".+"` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "matchDescription": ".+" }]*/
+
+// missing function description
+/**
+ * @param {string} name Whom to greet.
+ * @returns {void}
+ */
+function greet(name) {
+    console.log("Hello " + name);
+}
+```
+
+### requireParamDescription
+
+Example of additional **correct** code for this rule with the `"requireParamDescription": false` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "requireParamDescription": false }]*/
+
+/**
+ * Add two numbers.
+ * @param {int} num1
+ * @param {int} num2
+ * @returns {int} The sum of the two numbers.
+ */
+function add(num1, num2) {
+    return num1 + num2;
+}
+```
+
+### requireReturnDescription
+
+Example of additional **correct** code for this rule with the `"requireReturnDescription": false` option:
+
+```js
+/*eslint valid-jsdoc: ["error", { "requireReturnDescription": false }]*/
+
+/**
+ * Add two numbers.
+ * @param {number} num1 The first number.
+ * @param {number} num2 The second number.
+ * @returns {number}
+ */
+function add(num1, num2) {
+    return num1 + num2;
 }
 ```
 
@@ -301,3 +364,7 @@ If you aren't using JSDoc, then you can safely turn this rule off.
 ## Further Reading
 
 * [JSDoc](http://usejsdoc.org)
+
+## Related Rules
+
+* [require-jsdoc](require-jsdoc.md)


### PR DESCRIPTION
The last rule under **Possible Errors**

* Make description in h1 consistent with rules index page, not even the first word is capitalized. That is because will soon change the format to match the rules index page (that is, rule-id: rule description).
* Make first sentence under Rule Details consistent with description.
* Add “this rule with” to example sentences.
* Describe options according to patterns in guidelines.

**Hint**: The diff gets confusing after the bulleted list under Rule Details. At that point, you might click **View** and compare the markdown view to the Web site: http://eslint.org/docs/rules/valid-jsdoc

@nzakas EDIT can you verify that the rule details are clear, options list is correct, and examples are relevant, because I am just now learning JSDoc
@scriptdaemon your thoughts are welcome, especially on stretching the guidelines, as follows:

So far in new pattern, we describe options in bulleted lists and remove any redundant paragraphs between a level-3 heading for an option and the example code. I am open to your thoughts about including a paragraph of additional info following some of the option headings in this rule doc:
* because this doc has such long scrolling distance from the descriptions to the examples
* because there is some useful information that I cut because it did not fit into the bulleted list