### PR TITLE
Update: callback-return allows for object methods (fixes #4711)

### DIFF
--- a/docs/rules/callback-return.md
+++ b/docs/rules/callback-return.md
@@ -24,14 +24,16 @@ preceding a `return` statement. This rule decides what is a callback based on th
 
 ## Options
 
-The rule takes a single option, which is an array of possible callback names. The default callback names are `callback`, `cb`, `next`.
+The rule takes a single option - an array of possible callback names - which may include object methods. The default callback names are `callback`, `cb`, `next`.
+
+### Default callback names
 
 Examples of **incorrect** code for this rule with the default `["callback", "cb", "next"]` option:
 
 ```js
 /*eslint callback-return: "error"*/
 
-function foo() {
+function foo(err, callback) {
     if (err) {
         callback(err);
     }
@@ -44,11 +46,53 @@ Examples of **correct** code for this rule with the default `["callback", "cb", 
 ```js
 /*eslint callback-return: "error"*/
 
-function foo() {
+function foo(err, callback) {
     if (err) {
         return callback(err);
     }
     callback();
+}
+```
+
+### Supplied callback names
+
+Examples of **incorrect** code for this rule with the option `["done", "send.error", "send.success"]`:
+
+```js
+/*eslint callback-return: ["error", ["done", "send.error", "send.success"]]*/
+
+function foo(err, done) {
+    if (err) {
+        done(err);
+    }
+    done();
+}
+
+function bar(err, send) {
+    if (err) {
+        send.error(err);
+    }
+    send.success();
+}
+```
+
+Examples of **correct** code for this rule with the the option `["done", "send.error", "send.success"]`:
+
+```js
+/*eslint callback-return: ["error", ["done", "send.error", "send.success"]]*/
+
+function foo(err, done) {
+    if (err) {
+        return done(err);
+    }
+    done();
+}
+
+function bar(err, send) {
+    if (err) {
+        return send.error(err);
+    }
+    send.success();
 }
 ```
 
@@ -68,7 +112,7 @@ Example of a *false negative* when this rule reports correct code:
 ```js
 /*eslint callback-return: "error"*/
 
-function foo(callback) {
+function foo(err, callback) {
     if (err) {
         setTimeout(callback, 0); // this is bad, but WILL NOT warn
     }
@@ -85,7 +129,7 @@ Example of a *false negative* when this rule reports correct code:
 ```js
 /*eslint callback-return: "error"*/
 
-function foo(callback) {
+function foo(err, callback) {
     if (err) {
         process.nextTick(function() {
             return callback(); // this is bad, but WILL NOT warn
@@ -104,7 +148,7 @@ Example of a *false positive* when this rule reports incorrect code:
 ```js
 /*eslint callback-return: "error"*/
 
-function foo(callback) {
+function foo(err, callback) {
     if (err) {
         callback(err); // this is fine, but WILL warn
     } else {

--- a/tests/lib/rules/callback-return.js
+++ b/tests/lib/rules/callback-return.js
@@ -21,7 +21,7 @@ var ruleTester = new RuleTester();
 ruleTester.run("callback-return", rule, {
     valid: [
 
-        // callbacks inside of functions should  return
+        // callbacks inside of functions should return
         "function a(err) { if (err) return callback (err); }",
         "function a(err) { if (err) return callback (err); callback(); }",
         "function a(err) { if (err) { return callback (err); } callback(); }",
@@ -38,6 +38,7 @@ ruleTester.run("callback-return", rule, {
         "function x() { switch(x) { case 'a': return next(); } }",
         "function x() { for(x = 0; x < 10; x++) { return next(); } }",
         "function x() { while(x) { return next(); } }",
+        "function a(err) { if (err) { obj.method (err); } }",
 
         // callback() all you want outside of a function
         "callback()",
@@ -73,7 +74,7 @@ ruleTester.run("callback-return", rule, {
 
         // options (only warns with the correct callback name)
         {
-            code: "if (err) { callback(err) }",
+            code: "function a(err) { if (err) { callback(err) } }",
             options: [["cb"]]
         },
         {
@@ -83,6 +84,68 @@ ruleTester.run("callback-return", rule, {
         {
             code: "function a(err) { if (err) { return next(err) } else { callback(); } }",
             options: [["cb", "next"]]
+        },
+
+        // allow object methods (https://github.com/eslint/eslint/issues/4711)
+        {
+            code: "function a(err) { if (err) { return obj.method(err); } }",
+            options: [["obj.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { return obj.prop.method(err); } }",
+            options: [["obj.prop.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { return obj.prop.method(err); } otherObj.prop.method() }",
+            options: [["obj.prop.method", "otherObj.prop.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { callback(err); } }",
+            options: [["obj.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { otherObj.method(err); } }",
+            options: [["obj.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { //comment\nreturn obj.method(err); } }",
+            options: [["obj.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { /*comment*/return obj.method(err); } }",
+            options: [["obj.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { return obj.method(err); //comment\n } }",
+            options: [["obj.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { return obj.method(err); /*comment*/ } }",
+            options: [["obj.method"]]
+        },
+
+        // only warns if object of MemberExpression is an Identifier
+        {
+            code: "function a(err) { if (err) { obj().method(err); } }",
+            options: [["obj().method"]]
+        },
+        {
+            code: "function a(err) { if (err) { obj.prop().method(err); } }",
+            options: [["obj.prop().method"]]
+        },
+        {
+            code: "function a(err) { if (err) { obj().prop.method(err); } }",
+            options: [["obj().prop.method"]]
+        },
+
+        // does not warn if object of MemberExpression is invoked
+        {
+            code: "function a(err) { if (err) { obj().method(err); } }",
+            options: [["obj.method"]]
+        },
+        {
+            code: "function a(err) { if (err) { obj().method(err); } obj.method(); }",
+            options: [["obj.method"]]
         },
 
         //  known bad examples that we know we are ignoring
@@ -329,6 +392,90 @@ ruleTester.run("callback-return", rule, {
                     message: "Expected return with your callback function.",
                     line: 1,
                     column: 51,
+                    nodeType: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function a(err) { if (err) { obj.method(err); } }",
+            options: [["obj.method"]],
+            errors: [
+                {
+                    message: "Expected return with your callback function.",
+                    line: 1,
+                    column: 30,
+                    nodeType: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function a(err) { if (err) { obj.prop.method(err); } }",
+            options: [["obj.prop.method"]],
+            errors: [
+                {
+                    message: "Expected return with your callback function.",
+                    line: 1,
+                    column: 30,
+                    nodeType: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function a(err) { if (err) { obj.prop.method(err); } otherObj.prop.method() }",
+            options: [["obj.prop.method", "otherObj.prop.method"]],
+            errors: [
+                {
+                    message: "Expected return with your callback function.",
+                    line: 1,
+                    column: 30,
+                    nodeType: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function a(err) { if (err) { /*comment*/obj.method(err); } }",
+            options: [["obj.method"]],
+            errors: [
+                {
+                    message: "Expected return with your callback function.",
+                    line: 1,
+                    column: 41,
+                    nodeType: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function a(err) { if (err) { //comment\nobj.method(err); } }",
+            options: [["obj.method"]],
+            errors: [
+                {
+                    message: "Expected return with your callback function.",
+                    line: 2,
+                    column: 1,
+                    nodeType: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function a(err) { if (err) { obj.method(err); /*comment*/ } }",
+            options: [["obj.method"]],
+            errors: [
+                {
+                    message: "Expected return with your callback function.",
+                    line: 1,
+                    column: 30,
+                    nodeType: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "function a(err) { if (err) { obj.method(err); //comment\n } }",
+            options: [["obj.method"]],
+            errors: [
+                {
+                    message: "Expected return with your callback function.",
+                    line: 1,
+                    column: 30,
                     nodeType: "CallExpression"
                 }
             ]


### PR DESCRIPTION
~~The one caveat about solving this problem this way is that it must match exactly - i.e. `object().method` is not the same thing as `object.method`. This seems to me like a reasonable tradeoff to solve this issue right now, though maybe it could be made much smarter in the future.~~ Updated, no longer relevant.