### PR TITLE
Fix typo in `no-prototype-builtins` documentation

### DIFF
--- a/docs/rules/no-prototype-builtins.md
+++ b/docs/rules/no-prototype-builtins.md
@@ -9,7 +9,7 @@ This rule disallows calling some `Object.prototype` methods directly on object i
 Examples of **incorrect** code for this rule:
 
 ```js
-/*eslint no-prototype-built-ins: "error"*/
+/*eslint no-prototype-builtins: "error"*/
 
 var hasBarProperty = foo.hasOwnProperty("bar");
 
@@ -21,7 +21,7 @@ var barIsEnumerable = foo.propertyIsEnumerable("bar");
 Examples of **correct** code for this rule:
 
 ```js
-/*eslint no-prototype-built-ins: "error"*/
+/*eslint no-prototype-builtins: "error"*/
 
 var hasBarProperty = {}.hasOwnProperty.call(foo, "bar");
 


### PR DESCRIPTION
Fixes a minor typo in the `no-prototype-builtins` documentation. The rule name in the comments is incorrect.