### PR TITLE
Fix: no-useless-rename handles ExperimentalRestProperty (fixes #6284)

### DIFF
--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -92,7 +92,6 @@ module.exports = {
                  * if a rename is useless or not. If an ObjectPattern property
                  * lacks a key, it is likely an ExperimentalRestProperty and
                  * so there is no "renaming" occurring here.
-                 * TODO: Determine if SpreadProperty may cause problems later.
                  */
                 if (properties[i].computed || !properties[i].key) {
                     return;

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -87,7 +87,7 @@ module.exports = {
                     return;
                 }
 
-                if (properties[i].computed || properties[i].type === "ExperimentalRestProperty") {
+                if (properties[i].computed || !properties[i].key) {
                     return;
                 }
 

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -87,7 +87,7 @@ module.exports = {
                     return;
                 }
 
-                if (properties[i].computed) {
+                if (properties[i].computed || properties[i].type === "ExperimentalRestProperty") {
                     return;
                 }
 

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -87,6 +87,13 @@ module.exports = {
                     return;
                 }
 
+                /**
+                 * If an ObjectPattern property is computed, we have no idea
+                 * if a rename is useless or not. If an ObjectPattern property
+                 * lacks a key, it is likely an ExperimentalRestProperty and
+                 * so there is no "renaming" occurring here.
+                 * TODO: Determine if SpreadProperty may cause problems later.
+                 */
                 if (properties[i].computed || !properties[i].key) {
                     return;
                 }

--- a/tests/lib/rules/no-useless-rename.js
+++ b/tests/lib/rules/no-useless-rename.js
@@ -49,6 +49,27 @@ ruleTester.run("no-useless-rename", rule, {
         { code: "export {foo as bar, baz as qux};", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export {foo as bar} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
         { code: "export {foo as bar, baz as qux} from 'foo';", parserOptions: { ecmaVersion: 6, sourceType: "module" } },
+        {
+            code: "const {...stuff} = myObject;",
+            parserOptions: {
+                ecmaFeatures: { experimentalObjectRestSpread: true },
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const {foo, ...stuff} = myObject;",
+            parserOptions: {
+                ecmaFeatures: { experimentalObjectRestSpread: true },
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const {foo: bar, ...stuff} = myObject;",
+            parserOptions: {
+                ecmaFeatures: { experimentalObjectRestSpread: true },
+                ecmaVersion: 6
+            }
+        },
 
         // { ignoreDestructuring: true }
         {
@@ -236,6 +257,30 @@ ruleTester.run("no-useless-rename", rule, {
             code: "({foo: foo, bar: bar}) => {}",
             output: "({foo, bar}) => {}",
             parserOptions: { ecmaVersion: 6 },
+            errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
+        },
+        {
+            code: "const {foo: foo, ...stuff} = myObject;",
+            parserOptions: {
+                ecmaFeatures: { experimentalObjectRestSpread: true },
+                ecmaVersion: 6
+            },
+            errors: ["Destructuring assignment foo unnecessarily renamed."]
+        },
+        {
+            code: "const {foo: foo, bar: baz, ...stuff} = myObject;",
+            parserOptions: {
+                ecmaFeatures: { experimentalObjectRestSpread: true },
+                ecmaVersion: 6
+            },
+            errors: ["Destructuring assignment foo unnecessarily renamed."]
+        },
+        {
+            code: "const {foo: foo, bar: bar, ...stuff} = myObject;",
+            parserOptions: {
+                ecmaFeatures: { experimentalObjectRestSpread: true },
+                ecmaVersion: 6
+            },
             errors: ["Destructuring assignment foo unnecessarily renamed.", "Destructuring assignment bar unnecessarily renamed."]
         },
         {

--- a/tests/lib/rules/no-useless-rename.js
+++ b/tests/lib/rules/no-useless-rename.js
@@ -261,6 +261,7 @@ ruleTester.run("no-useless-rename", rule, {
         },
         {
             code: "const {foo: foo, ...stuff} = myObject;",
+            output: "const {foo, ...stuff} = myObject;",
             parserOptions: {
                 ecmaFeatures: { experimentalObjectRestSpread: true },
                 ecmaVersion: 6
@@ -269,6 +270,7 @@ ruleTester.run("no-useless-rename", rule, {
         },
         {
             code: "const {foo: foo, bar: baz, ...stuff} = myObject;",
+            output: "const {foo, bar: baz, ...stuff} = myObject;",
             parserOptions: {
                 ecmaFeatures: { experimentalObjectRestSpread: true },
                 ecmaVersion: 6
@@ -277,6 +279,7 @@ ruleTester.run("no-useless-rename", rule, {
         },
         {
             code: "const {foo: foo, bar: bar, ...stuff} = myObject;",
+            output: "const {foo, bar, ...stuff} = myObject;",
             parserOptions: {
                 ecmaFeatures: { experimentalObjectRestSpread: true },
                 ecmaVersion: 6


### PR DESCRIPTION
I had a couple of options here-- either compare the type explicitly, or just look for the absence of a `key` property. I went with the former to be safe, but I can certainly amend to the latter if people think that is better.

At this point I've only handled destructuring-- not sure yet if this is an issue in import or export. I'll investigate that and update this PR if needed. (EDIT: Seems those use a `*` token instead. In addition, that seems to be standard ES2015. So I assume we're good-- speak up if I missed something.)