### PR TITLE
Fix: `no-useless-rename` false positive in babel-eslint (fixes #6266)

### DIFF
--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -109,7 +109,7 @@ module.exports = {
             }
 
             if (node.imported.name === node.local.name &&
-                    node.imported !== node.local) {
+                    node.imported.range[0] !== node.local.range[0]) {
                 reportError(node, node.imported, node.local, "Import");
             }
         }
@@ -125,7 +125,7 @@ module.exports = {
             }
 
             if (node.local.name === node.exported.name &&
-                    node.local !== node.exported) {
+                    node.local.range[0] !== node.exported.range[0]) {
                 reportError(node, node.local, node.exported, "Export");
             }
 


### PR DESCRIPTION
Sorry, this one should fix it for real. I manually tested it using `babel-eslint`.