### PR TITLE
Fix: add warnIgnored flag to CLIEngine.executeOnText (fixes #6302)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -410,7 +410,7 @@ function getFormatterResults() {
             "    }",
             "};"
         ].join("\n"),
-        rawMessages = cli.executeOnText(codeString, "fullOfProblems.js");
+        rawMessages = cli.executeOnText(codeString, "fullOfProblems.js", true);
 
     return formatterFiles.reduce(function(data, filename) {
         var fileExt = path.extname(filename),

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -310,6 +310,8 @@ var report = cli.executeOnText("var foo = 'bar';", "foo.js");
 
 The `report` returned from `executeOnText()` is in the same format as from `executeOnFiles()`, but there is only ever one result in `report.results`.
 
+If a filename in the optional second parameter matches a file that is configured to be ignored, then this function returns no errors or warnings. To return a warning instead, call the method with true as the optional third parameter.
+
 ### addPlugin()
 
 Loads a plugin from configuration object with specified name. Name can include plugin prefix ("eslint-plugin-")

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -740,9 +740,10 @@ CLIEngine.prototype = {
      * Executes the current configuration on text.
      * @param {string} text A string of JavaScript code to lint.
      * @param {string} filename An optional string representing the texts filename.
+     * @param {boolean} warnIgnored Always warn when a file is ignored
      * @returns {Object} The results for the linting.
      */
-    executeOnText: function(text, filename) {
+    executeOnText: function(text, filename, warnIgnored) {
 
         var results = [],
             stats,
@@ -754,8 +755,7 @@ CLIEngine.prototype = {
         if (filename && !isAbsolute(filename)) {
             filename = path.resolve(options.cwd, filename);
         }
-        if (filename && ignoredPaths.contains(filename)) {
-
+        if (filename && warnIgnored && ignoredPaths.contains(filename)) {
             results.push(createIgnoreResult(filename, options.cwd));
         } else {
             results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig));

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -178,7 +178,7 @@ var cli = {
                 return 0;
             }
 
-            report = text ? engine.executeOnText(text, currentOptions.stdinFilename) : engine.executeOnFiles(files);
+            report = text ? engine.executeOnText(text, currentOptions.stdinFilename, true) : engine.executeOnFiles(files);
             if (currentOptions.fix) {
                 debug("Fix mode enabled - applying fixes");
                 CLIEngine.outputFixes(report);

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -148,13 +148,13 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].filePath, getFixturePath("test.js"));
         });
 
-        it("should return a warning when given a filename by --stdin-filename in excluded files list", function() {
+        it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is set", function() {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
             });
 
-            var report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
+            var report = engine.executeOnText("var bar = foo;", "fixtures/passing.js", true);
 
             assert.equal(report.results.length, 1);
             assert.equal(report.errorCount, 0);
@@ -165,6 +165,19 @@ describe("CLIEngine", function() {
             assert.isUndefined(report.results[0].messages[0].output);
             assert.equal(report.results[0].errorCount, 0);
             assert.equal(report.results[0].warningCount, 1);
+        });
+
+        it("should suppress excluded file warnings by default", function() {
+            engine = new CLIEngine({
+                ignorePath: getFixturePath(".eslintignore"),
+                cwd: getFixturePath("..")
+            });
+
+            var report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
+
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].errorCount, 0);
+            assert.equal(report.results[0].warningCount, 0);
         });
 
         it("should return a message when given a filename by --stdin-filename in excluded files list and ignore is off", function() {
@@ -338,7 +351,7 @@ describe("CLIEngine", function() {
                 ignore: false
             });
 
-            var report = engine.executeOnText("var bar = foo;", "node_modules/passing.js");
+            var report = engine.executeOnText("var bar = foo;", "node_modules/passing.js", true);
             var expectedMsg = "File ignored by default. Use \"--ignore-pattern \'!node_modules/*\'\" to override.";
 
             assert.equal(report.results.length, 1);
@@ -2158,7 +2171,7 @@ describe("CLIEngine", function() {
                 cwd: path.join(fixtureDir, "..")
             });
 
-            var report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
+            var report = engine.executeOnText("var bar = foo;", "fixtures/passing.js", true);
             var errorReport = CLIEngine.getErrorResults(report.results);
 
             assert.lengthOf(errorReport, 0);


### PR DESCRIPTION
added a warnIgnored parameter to executeOnText similar to the existing executeOnFile function.  the check is for an explicit `false` parameter so this doesn't break existing code