### PR TITLE
Docs: Code conventions improvements

### DIFF
--- a/docs/developer-guide/code-conventions.md
+++ b/docs/developer-guide/code-conventions.md
@@ -36,19 +36,7 @@ module.exports = {
 };
 ```
 
-The `@author` field gives you credit for having created the file. The `@copyright` field indicates that you are the copyright holder for the file.
-
-Your submission may touch other parts of the ESLint code that you did not write. In that case, you are welcome to add a copyright notice to the top of the file if you have done any amount of significant work on the file (we leave it up to you to decide what "significant" means - if you aren't sure, just ask). You should never change the `@author` field, but you can add another `@copyright` field on top of the existing ones, such as:
-
-```js
-/**
- * @fileoverview Description of the file
- * @author Author's Name
- * @copyright 2015 Your Name. All rights reserved.
- * @copyright 2014 Author's Name. All rights reserved.
- * See LICENSE file in root directory for full license.
- */
-```
+The `@author` field gives you credit for having created the file. There is no need to assert copyright on individual files.
 
 ## Indentation
 
@@ -655,37 +643,23 @@ Object properties follow the same naming conventions as variables. Object method
 
 ## Strict Mode
 
-Strict mode should be used only inside of functions and never globally.
+Strict mode should be used in all modules, specified below the file overview comment and above everything else:
 
-    // Bad: Global strict mode
+    // Bad: Strict mode in functions
+    function doSomething() {
+        "use strict";
+        
+        // code
+    }
+
+    // Good: Global strict mode
     "use strict";
-
+    
     function doSomething() {
-        // code
-    }
-
-    // Good
-    function doSomething() {
-        "use strict";
+        // no "use strict" here
 
         // code
     }
-
-If you want strict mode to apply to multiple functions without needing to write `"use strict"` multiple times, use immediate function invocation:
-
-    // Good
-    (function() {
-        "use strict";
-
-        function doSomething() {
-            // code
-        }
-
-        function doSomethingElse() {
-            // code
-        }
-
-    }());
 
 ## Assignments
 
@@ -933,7 +907,7 @@ Blank spaces should be used in the following circumstances:
 * A keyword followed by a parenthesis should be separated by a space.
 * A blank space should appear after commas in argument lists.
 * All binary operators except dot (`.`) should be separated from their operands by spaces. Blank spaces should never separate unary operators such as unary minus, increment (`++`), and decrement (`--`) from their operands.
-* The expressions in a `for` statement should be separated by blank spaces.
+* The expressions in a `for` statement should be separated by blank spaces. Blank spaces should only be used after semicolons, not before.
 
 ## Things to Avoid
 

--- a/docs/developer-guide/code-conventions.md
+++ b/docs/developer-guide/code-conventions.md
@@ -36,7 +36,7 @@ module.exports = {
 };
 ```
 
-The `@author` field gives you credit for having created the file. There is no need to assert copyright on individual files.
+The `@author` field gives you credit for having created the file.
 
 ## Indentation
 

--- a/docs/developer-guide/code-conventions.md
+++ b/docs/developer-guide/code-conventions.md
@@ -648,13 +648,22 @@ Strict mode should be used in all modules, specified below the file overview com
     // Bad: Strict mode in functions
     function doSomething() {
         "use strict";
-        
+
+        // code
+    }
+
+    // Bad: Strict mode in global scope and redundant strict mode directive in function
+    "use strict";       // This one is good
+
+    function doSomething() {
+        "use strict";   // This one is bad
+
         // code
     }
 
     // Good: Global strict mode
     "use strict";
-    
+
     function doSomething() {
         // no "use strict" here
 


### PR DESCRIPTION
Highlights:

* File overview section: Removed notes about copyright
* Strict mode: Rewrote guidelines to favor global "strict" mode
* Other tweaks: Fixed ambiguity about for statement spacing

## File Overview

I removed everything to do with copyright from that section. Now that we are in the jQuery foundation, we have decided to just use the "author" field and no copyright or license.

## Strict Mode

Our repository [enforces global "strict"](https://github.com/eslint/eslint/blob/89580a40557093184b5e164b7ef284670d47090b/packages/eslint-config-eslint/default.yml#L94), but the code conventions imply that we should have ["strict" mode in functions](https://github.com/eslint/eslint/blob/89580a40557093184b5e164b7ef284670d47090b/docs/developer-guide/code-conventions.md#strict-mode).

My assumption is that those conventions have more to do with non-module code, whereas NodeJS actually has an extra scope, global return, etc. and so it is safe to have "use strict" globally (and possibly better, since it means we don't have sections of files that are not strict).

## Other

Whitespace notes were slightly ambiguous about the spacing between elements of the for loop initialization. I added a note specifying that whitespace should only be after semicolons, not before.

(Apologies to @nzakas for creating a branch on the main repo-- I was using the GitHub editor and apparently did something wrong. Hopefully I'll figure it out before I do another GitHub doc change.)