### PR TITLE
Update: allow regular expressions for id-blacklist (fixes #6212)

### DIFF
--- a/docs/rules/id-blacklist.md
+++ b/docs/rules/id-blacklist.md
@@ -77,6 +77,24 @@ foo.callback(); // all function calls are ignored
 foo.data; // all property names that are not assignments are ignored
 ```
 
+You can also provide regular expressions in place of static identifier names. Your regular expressions will automatically be assumed to span from the start to the end of the identifier name, so you do not need to explicitly use the `^` or `$` control characters in your expressions.
+
+Examples of **incorrect** code for this rule with sample `"ref\\d*"` restricted identifiers:
+
+```js
+/*eslint id-blacklist: ["ref\\d"] */
+var ref = {...};
+var ref42 = [...];
+```
+
+Examples of **correct** code for this rule with the sample `"ref\\d*"` restricted identifiers:
+
+```js
+/*eslint id-blacklist: ["ref\\d"] */
+var myref = {...};
+var refs = [...];
+```
+
 ## When Not To Use It
 
 You can turn this rule off if you are happy for identifiers to be named freely.

--- a/lib/rules/id-blacklist.js
+++ b/lib/rules/id-blacklist.js
@@ -34,7 +34,7 @@ module.exports = {
         // Helpers
         //--------------------------------------------------------------------------
 
-        var blacklist = context.options;
+        var blacklistRegex = new RegExp("^(" + context.options.join("|") + ")$");
 
 
         /**
@@ -44,7 +44,7 @@ module.exports = {
          * @private
          */
         function isInvalid(name) {
-            return blacklist.indexOf(name) !== -1;
+            return blacklistRegex.test(name);
         }
 
         /**

--- a/tests/lib/rules/id-blacklist.js
+++ b/tests/lib/rules/id-blacklist.js
@@ -95,6 +95,14 @@ ruleTester.run("id-blacklist", rule, {
         {
             code: "foo.bar",
             options: ["bar"]
+        },
+        {
+            code: "foot",
+            options: ["foo\\d?"]
+        },
+        {
+            code: "foo2bar",
+            options: ["foo\\d+"]
         }
     ],
     invalid: [
@@ -294,6 +302,26 @@ ruleTester.run("id-blacklist", rule, {
             errors: [
                 {
                     message: "Identifier 'baz' is blacklisted",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "foo",
+            options: ["foo\\d?"],
+            errors: [
+                {
+                    message: "Identifier 'foo' is blacklisted",
+                    type: "Identifier"
+                }
+            ]
+        },
+        {
+            code: "foo234",
+            options: ["foo\\d+"],
+            errors: [
+                {
+                    message: "Identifier 'foo234' is blacklisted",
                     type: "Identifier"
                 }
             ]


### PR DESCRIPTION
This PR updates `id-blacklist` to accept regular expressions in addition to static ID names. This was a little awkward given that the only option the rule accepts is an array of strings. I considered three alternative ways to pass regular expressions without breaking existing users of the rule:
1. Add another option, probably an object with a `patterns` key that is an array of full regular expression strings to check for.
2. Pass regular expressions with static identifiers, but force them to be wrapped in `/`s. This would unambiguously indicate a regular expression, since identifiers can't start with `/`.
3. Pass regular expressions with static identifiers, without any indication that they are regular expressions. For this to work, the regular expressions have to be assumed to span the entire identifier name (that is, wrapped in `^...$`.

I went for number three with this PR because it was the simplest and definitely covers my original issue. I tried to find any prior art but couldn't spot any, so please let me know if I missed something that would clarify the way this should be done.

**Outcome**

You can now pass regular expressions in addition to static identifiers, and they will correctly blacklist offending IDs:

``` js
/* eslint id-blacklist: ["ref\\d?"] */

var ref = {...}; // flagged
var ref3 = {...}; // flagged
var reference = {...}; // not flagged
```
