### PR TITLE
Update: Add never option to arrow-body-style (fixes #6317)

### DIFF
--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -106,7 +106,7 @@ let foo = (retv, name) => {
 The following patterns are not considered problems:
 
 ```js
-/*eslint arrow-body-style: ["error", "as-needed"]*/
+/*eslint arrow-body-style: ["error", "never"]*/
 /*eslint-env es6*/
 
 let foo = () => 0;

--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -1,10 +1,10 @@
 # Require braces in arrow function body (arrow-body-style)
 
-Arrow functions can omit braces when there is a single statement in the body. This rule enforces the consistent use of braces in arrow functions.
+Arrow functions have two syntactic forms for their function bodies.  They may be defined with a *block* body (denoted by curly braces) `() => { ... }` or with a single expression `() => ...`, whose value is implicitly returned.
 
 ## Rule Details
 
-This rule can enforce the use of braces around arrow function body.
+This rule can enforce or disallow the use of braces around arrow function body.
 
 ## Options
 
@@ -12,6 +12,7 @@ The rule takes one option, a string, which can be:
 
 * `"always"` enforces braces around the function body
 * `"as-needed"` enforces no braces where they can be omitted (default)
+* `"never"` enforces no braces around the function body (constrains arrow functions to the role of returning an expression)
 
 ### "always"
 
@@ -83,4 +84,31 @@ let foo = () => { /* do nothing */ };
 let foo = () => {
     // do nothing.
 };
+```
+
+### "never"
+
+When the rule is set to `"never"` the following patterns are considered problems:
+
+```js
+/*eslint arrow-body-style: ["error", "never"]*/
+/*eslint-env es6*/
+
+let foo = () => {
+    return 0;
+};
+let foo = (retv, name) => {
+    retv[name] = true;
+    return retv;
+};
+```
+
+The following patterns are not considered problems:
+
+```js
+/*eslint arrow-body-style: ["error", "as-needed"]*/
+/*eslint-env es6*/
+
+let foo = () => 0;
+let foo = () => ({ foo: 0 });
 ```

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -18,7 +18,7 @@ module.exports = {
 
         schema: [
             {
-                enum: ["always", "as-needed"]
+                enum: ["always", "as-needed", "never"]
             }
         ]
     },
@@ -26,6 +26,7 @@ module.exports = {
     create: function(context) {
         var always = context.options[0] === "always";
         var asNeeded = !context.options[0] || context.options[0] === "as-needed";
+        var never = context.options[0] === "never";
 
         /**
          * Determines whether a arrow function body needs braces
@@ -36,18 +37,26 @@ module.exports = {
             var arrowBody = node.body;
 
             if (arrowBody.type === "BlockStatement") {
-                var blockBody = arrowBody.body;
-
-                if (blockBody.length !== 1) {
-                    return;
-                }
-
-                if (asNeeded && blockBody[0].type === "ReturnStatement") {
+                if (never) {
                     context.report({
                         node: node,
                         loc: arrowBody.loc.start,
                         message: "Unexpected block statement surrounding arrow body."
                     });
+                } else {
+                    var blockBody = arrowBody.body;
+
+                    if (blockBody.length !== 1) {
+                        return;
+                    }
+
+                    if (asNeeded && blockBody[0].type === "ReturnStatement") {
+                        context.report({
+                            node: node,
+                            loc: arrowBody.loc.start,
+                            message: "Unexpected block statement surrounding arrow body."
+                        });
+                    }
                 }
             } else {
                 if (always) {

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -30,7 +30,9 @@ ruleTester.run("arrow-body-style", rule, {
         { code: "var foo = () => { b = a };", parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = () => { bar: 1 };", parserOptions: { ecmaVersion: 6 } },
         { code: "var foo = () => { return 0; };", parserOptions: { ecmaVersion: 6 }, options: ["always"] },
-        { code: "var foo = () => { return bar(); };", parserOptions: { ecmaVersion: 6 }, options: ["always"] }
+        { code: "var foo = () => { return bar(); };", parserOptions: { ecmaVersion: 6 }, options: ["always"] },
+        { code: "var foo = () => 0;", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
+        { code: "var foo = () => ({ foo: 0 });", parserOptions: { ecmaVersion: 6 }, options: ["never"] }
     ],
     invalid: [
         {
@@ -63,6 +65,22 @@ ruleTester.run("arrow-body-style", rule, {
             options: ["as-needed"],
             errors: [
                 { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => {\nreturn 0;\n};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["never"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["never"],
+            errors: [
+                { line: 1, column: 27, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
             ]
         }
     ]


### PR DESCRIPTION
Arrow functions that return object literals can look very similar to arrow functions with brace bodies.  Some syntactic ambiguity can be avoided by disallowing block-style arrow functions in favour of ES5 function expressions.

**Outcome**

The following patterns are considered problems:
```
/*eslint arrow-body-style: ["error", "never"]*/
/*eslint-env es6*/

let foo = () => {
    return 0;
};

let foo = (retv, name) => {
    retv[name] = true;
    return retv;
};
```

The following patterns are not considered problems:
```
/*eslint arrow-body-style: ["error", "never"]*/
/*eslint-env es6*/

let foo = () => 0;

let foo = () => ({ key: 0 });
```