### PR TITLE
Docs: Remove reference to numeric configuration from About page (fixes #6309)

### DIFF
--- a/docs/about/index.md
+++ b/docs/about/index.md
@@ -25,7 +25,6 @@ Every rule:
 * Is standalone
 * Can be able to be turned off or on (nothing can be deemed "too important to turn off")
 * Can be set to be a warning or error individually
-* Is turned on by providing a non-zero number and off by providing zero
 
 Additionally:
 


### PR DESCRIPTION
EDIT: Ah crap, the commit summary is too long. Whoever reviews this, feel free to squash with a different message, or let me know if you want me to force-push to fix the message.