### PR TITLE
Docs: Add section about customizing RuleTester (fixes #6227)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -142,7 +142,7 @@ ruleTester.run("custom-plugin-rule", rule, {
 
 #### Customizing RuleTester
 
-RuleTester internally uses Mocha's `describe` and `it` methods when available to create tests for each valid and invalid case. If you use another test runner, you can override `RuleTester.describe` and `RuleTester.it` to make RuleTester compatible with it and have proper individual tests and feedback.
+To create tests for each valid and invalid case, RuleTester internally uses `describe` and `it` methods from the Mocha test framework when it is available. If you use another test framework, you can override `RuleTester.describe` and `RuleTester.it` to make RuleTester compatible with it and have proper individual tests and feedback.
 
 
 ## Share Plugins

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -142,7 +142,27 @@ ruleTester.run("custom-plugin-rule", rule, {
 
 #### Customizing RuleTester
 
-To create tests for each valid and invalid case, RuleTester internally uses `describe` and `it` methods from the Mocha test framework when it is available. If you use another test framework, you can override `RuleTester.describe` and `RuleTester.it` to make RuleTester compatible with it and have proper individual tests and feedback.
+To create tests for each valid and invalid case, `RuleTester` internally uses `describe` and `it` methods from the Mocha test framework when it is available. If you use another test framework, you can override `RuleTester.describe` and `RuleTester.it` to make `RuleTester` compatible with it and have proper individual tests and feedback.
+
+Example:
+
+```js
+"use strict";
+
+var RuleTester = require("eslint").RuleTester;
+var test = require("my-test-runner");
+
+RuleTester.describe = function(text, method) {
+    RuleTester.it.title = text;
+    return method.apply(this);
+};
+
+RuleTester.it = function(text, method) {
+    test(RuleTester.it.title + ": " + text, method);
+};
+
+// then use RuleTester as documented
+```
 
 
 ## Share Plugins

--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -140,6 +140,11 @@ ruleTester.run("custom-plugin-rule", rule, {
 });
 ```
 
+#### Customizing RuleTester
+
+RuleTester internally uses Mocha's `describe` and `it` methods when available to create tests for each valid and invalid case. If you use another test runner, you can override `RuleTester.describe` and `RuleTester.it` to make RuleTester compatible with it and have proper individual tests and feedback.
+
+
 ## Share Plugins
 
 In order to make your plugin available to the community you have to publish it on npm.


### PR DESCRIPTION
Following the discussion we had in (#6227), I'm adding a section about how to customize RuleTester to work with different test runners like AVA. Didn't go into too much detail, as I figure you'll probably need to go and read the code anyway. At least people will now know that it's possible.

Let me know if you have suggestions on how to improve this.

(PS: If you found this by searching for AVA, I wrote the following package to allow RuleTester to be used with AVA https://github.com/jfmengels/eslint-ava-rule-tester)