### PR TITLE
Docs: Clarified how plugin rules look in plugin configs (fixes #6346)

### DIFF
--- a/docs/developer-guide/working-with-plugins.md
+++ b/docs/developer-guide/working-with-plugins.md
@@ -92,13 +92,15 @@ configs: {
     myConfig: {
         env: ["browser"],
         rules: {
-            semi: 2
+            semi: 2,
+            "myPlugin/my-rule": 2,
+            "eslint-plugin-myPlugin/another-rule": 2
         }
     }
 }
 ```
 
-**Note:** Please note that configuration will not automatically attach your rules and you have to specify your plugin name and any rules you want to enable that are part of the plugin. See [Configuring Plugins](../user-guide/configuring#configuring-plugins)
+**Note:** Please note that configuration will not automatically attach your rules and you have to specify your plugin name and any rules you want to enable that are part of the plugin. Any plugin rules must be prefixed with the short or long plugin name. See [Configuring Plugins](../user-guide/configuring#configuring-plugins)
 
 ### Peer Dependency
 


### PR DESCRIPTION
I included an example of a short-form plugin rule configuration and a long-form plugin rule configuration-- let me know if that seems excessive.