### PR TITLE
Update: Added "allowAfterSuper" property to rule "no-underscore-dangle"

### DIFF
--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -32,6 +32,14 @@ Array of variable names that are permitted to be used with underscore. If provid
 
 This option allows usage of dangled variables as members of `this`.
 
+### `allowAfterSuper`
+
+```json
+"no-underscore-dangle": ["error", { "allowAfterSuper": true }]
+```
+
+Same as the "allowAfterThis" option, but for the ES2015 'super' keyword.
+
 The following patterns are considered problems:
 
 ```js
@@ -66,6 +74,13 @@ foo._bar();
 
 var a = this.foo_;
 this._bar();
+```
+
+```js
+/*eslint no-underscore-dangle: ["error", { "allowAfterSuper": true }]*/
+
+var a = super.foo_;
+super._bar();
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -44,7 +44,7 @@ module.exports = {
         var options = context.options[0] || {};
         var ALLOWED_VARIABLES = options.allow ? options.allow : [];
         var allowAfterThis = typeof options.allowAfterThis !== "undefined" ? options.allowAfterThis : false;
-		var allowAfterSuper = typeof options.allowAfterSuper !== "undefined" ? options.allowAfterSuper : false;
+        var allowAfterSuper = typeof options.allowAfterSuper !== "undefined" ? options.allowAfterSuper : false;
 
         //-------------------------------------------------------------------------
         // Helpers
@@ -136,11 +136,11 @@ module.exports = {
         function checkForTrailingUnderscoreInMemberExpression(node) {
             var identifier = node.property.name,
                 isMemberOfThis = node.object.type === "ThisExpression",
-				isMemberOfSuper = node.object.type === "Super";
+                isMemberOfSuper = node.object.type === "Super";
 
             if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) &&
                 !(isMemberOfThis && allowAfterThis) &&
-				!(isMemberOfSuper && allowAfterSuper) &&
+                !(isMemberOfSuper && allowAfterSuper) &&
                 !isSpecialCaseIdentifierForMemberExpression(identifier) && !isAllowed(identifier)) {
                 context.report(node, "Unexpected dangling '_' in '" + identifier + "'.");
             }

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -29,6 +29,9 @@ module.exports = {
                     },
                     allowAfterThis: {
                         type: "boolean"
+                    },
+                    allowAfterSuper: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -41,6 +44,7 @@ module.exports = {
         var options = context.options[0] || {};
         var ALLOWED_VARIABLES = options.allow ? options.allow : [];
         var allowAfterThis = typeof options.allowAfterThis !== "undefined" ? options.allowAfterThis : false;
+		var allowAfterSuper = typeof options.allowAfterSuper !== "undefined" ? options.allowAfterSuper : false;
 
         //-------------------------------------------------------------------------
         // Helpers
@@ -131,10 +135,12 @@ module.exports = {
          */
         function checkForTrailingUnderscoreInMemberExpression(node) {
             var identifier = node.property.name,
-                isMemberOfThis = node.object.type === "ThisExpression";
+                isMemberOfThis = node.object.type === "ThisExpression",
+				isMemberOfSuper = node.object.type === "Super";
 
             if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) &&
                 !(isMemberOfThis && allowAfterThis) &&
+				!(isMemberOfSuper && allowAfterSuper) &&
                 !isSpecialCaseIdentifierForMemberExpression(identifier) && !isAllowed(identifier)) {
                 context.report(node, "Unexpected dangling '_' in '" + identifier + "'.");
             }

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -71,7 +71,7 @@ rules:
     no-undef: "error"
     no-undef-init: "error"
     no-undefined: "error"
-    no-underscore-dangle: ["error", {allowAfterThis: true}]
+    no-underscore-dangle: ["error", {allowAfterThis: true, allowAfterSuper: true}]
     no-unmodified-loop-condition: "error"
     no-unused-expressions: "error"
     no-unused-vars: ["error", {vars: "all", args: "after-used"}]


### PR DESCRIPTION
Functionally the same as the "allowAfterThis" property, but for the ES2015 'super' keyword