### PR TITLE
Docs: Fix broken links in no-mixed-operators

### DIFF
--- a/docs/rules/no-mixed-operators.md
+++ b/docs/rules/no-mixed-operators.md
@@ -13,8 +13,8 @@ var foo = a && (b || c || d);  /*GOOD*/
 
 This rule checks `BinaryExpression` and `LogicalExpression`.
 
-This rule may conflict with [no-extra-parens] rule.
-If you use both this and [no-extra-parens] rule together, you need to use the `nestedBinaryExpressions` option of [no-extra-parens] rule.
+This rule may conflict with [no-extra-parens](no-extra-parens.md) rule.
+If you use both this and [no-extra-parens](no-extra-parens.md) rule together, you need to use the `nestedBinaryExpressions` option of [no-extra-parens](no-extra-parens.md) rule.
 
 Examples of **incorrect** code for this rule:
 
@@ -133,6 +133,4 @@ If you don't want to be notified about mixed operators, then it's safe to disabl
 
 ## Related Rules
 
-* [no-extra-parens]
-
-[no-extra-parens]: no-extra-parens.md
+* [no-extra-parens](no-extra-parens.md)


### PR DESCRIPTION
There are a few broken links in the documentation for the [no-mixed-operators](http://eslint.org/docs/rules/no-mixed-operators) rule on the eslint.org website. All of the links for `no-extra-parens` are incorrectly pointing at a non-existent `.md` file. 

The links work correctly from within github; they're only broken on the website. I'm assuming this is because the website generator can't handle reference links being used instead of inline links. If my assumption is correct, then this PR should fix it :D