### PR TITLE
Docs: Fix wrong link in object-curly-newline

### DIFF
--- a/docs/rules/object-curly-newline.md
+++ b/docs/rules/object-curly-newline.md
@@ -472,7 +472,7 @@ If you don't want to enforce consistent line breaks inside braces, then it's saf
 
 ## Related Rules
 
-* [comma-spacing](key-spacing.md)
+* [comma-spacing](comma-spacing.md)
 * [key-spacing](key-spacing.md)
 * [object-curly-spacing](object-curly-spacing.md)
 * [object-property-newline](object-property-newline.md)


### PR DESCRIPTION
A "Related Rules" link pointed to the wrong rule.