### PR TITLE
Fix: add test for a syntax error (fixes #6013)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "doctrine": "^1.2.2",
     "es6-map": "^0.1.3",
     "escope": "^3.6.0",
-    "espree": "3.1.4",
+    "espree": "^3.1.6",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",
     "file-entry-cache": "^1.1.1",

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -3685,6 +3685,13 @@ describe("eslint", function() {
             eslint.verify("var { a='a' } = {};", { parserOptions: { ecmaVersion: 6 }});
         });
 
+        it("should report syntax error when a keyword exists in object property shorthand", function() {
+            var messages = eslint.verify("let a = {this}", { parserOptions: { ecmaVersion: 6 }});
+
+            assert.equal(messages.length, 1);
+            assert.equal(messages[0].fatal, true);
+        });
+
         it("should not rewrite env setting in core (https://github.com/eslint/eslint/issues/4814)", function() {
 
             // This test focuses on the instance of https://github.com/eslint/eslint/blob/v2.0.0-alpha-2/conf/environments.js#L26-L28


### PR DESCRIPTION
Fixes #6013.

This syntax error came to be raised since Acorn 3.2.0. This syntax error prevents a false positive of `no-undef` rule.

RuleTester fails always on syntax errors, so I added this test into `tests/lib/eslint.js`.