### PR TITLE
Update: Implement IndentOuterIIFE option for indent rule (fixes #6259)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -72,7 +72,7 @@ This rule has an object option:
 
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
-* `"IndentOuterIIFE"` (default: true) when false enforces no indentation level increase for file-level IIFEs.
+* `"outerIIFEBody"` (default: true) when false enforces no indentation level increase for file-level IIFEs.
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -210,12 +210,12 @@ const a = 1,
       c = 3;
 ```
 
-### IndentOuterIIFE
+### outerIIFEBody
 
-Examples of **incorrect** code for this rule with the options `2, { "IndentOuterIIFE": 0 }`:
+Examples of **incorrect** code for this rule with the options `2, { "outerIIFEBody": 0 }`:
 
 ```js
-/*eslint indent: ["error", 2, { "IndentOuterIIFE": 0 }]*/
+/*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
 
 (function() {
 
@@ -231,10 +231,10 @@ console.log('foo');
 }
 ```
 
-Examples of **correct** code for this rule with the options `2, {"IndentOuterIIFE": 0}`:
+Examples of **correct** code for this rule with the options `2, {"outerIIFEBody": 0}`:
 
 ```js
-/*eslint indent: ["error", 2, { "IndentOuterIIFE": 0 }]*/
+/*eslint indent: ["error", 2, { "outerIIFEBody": 0 }]*/
 
 (function() {
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -212,10 +212,10 @@ const a = 1,
 
 ### IndentOuterIIFE
 
-Examples of **incorrect** code for this rule with the options `2, { "IndentOuterIIFE": false }`:
+Examples of **incorrect** code for this rule with the options `2, { "IndentOuterIIFE": 0 }`:
 
 ```js
-/*eslint indent: ["error", 2, { "IndentOuterIIFE": false }]*/
+/*eslint indent: ["error", 2, { "IndentOuterIIFE": 0 }]*/
 
 (function() {
 
@@ -231,10 +231,10 @@ console.log('foo');
 }
 ```
 
-Examples of **correct** code for this rule with the options `2, {"IndentOuterIIFE": false}`:
+Examples of **correct** code for this rule with the options `2, {"IndentOuterIIFE": 0}`:
 
 ```js
-/*eslint indent: ["error", 2, { "IndentOuterIIFE": false }]*/
+/*eslint indent: ["error", 2, { "IndentOuterIIFE": 0 }]*/
 
 (function() {
 

--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -72,6 +72,7 @@ This rule has an object option:
 
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
+* `"IndentOuterIIFE"` (default: true) when false enforces no indentation level increase for file-level IIFEs.
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -207,6 +208,46 @@ let a,
 const a = 1,
       b = 2,
       c = 3;
+```
+
+### IndentOuterIIFE
+
+Examples of **incorrect** code for this rule with the options `2, { "IndentOuterIIFE": false }`:
+
+```js
+/*eslint indent: ["error", 2, { "IndentOuterIIFE": false }]*/
+
+(function() {
+
+  function foo(x) {
+    return x + 1;
+  }
+
+})();
+
+
+if(y) {
+console.log('foo');
+}
+```
+
+Examples of **correct** code for this rule with the options `2, {"IndentOuterIIFE": false}`:
+
+```js
+/*eslint indent: ["error", 2, { "IndentOuterIIFE": false }]*/
+
+(function() {
+
+function foo(x) {
+  return x + 1;
+}
+
+})();
+
+
+if(y) {
+   console.log('foo');
+}
 ```
 
 ## Compatibility

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -68,7 +68,7 @@ module.exports = {
                             }
                         ]
                     },
-                    IndentOuterIIFE: {
+                    outerIIFEBody: {
                         type: "integer",
                         minimum: 0
                     }
@@ -92,7 +92,7 @@ module.exports = {
                 let: DEFAULT_VARIABLE_INDENT,
                 const: DEFAULT_VARIABLE_INDENT
             },
-            IndentOuterIIFE: null
+            outerIIFEBody: null
         };
 
         var sourceCode = context.getSourceCode();
@@ -122,8 +122,8 @@ module.exports = {
                     lodash.assign(options.VariableDeclarator, variableDeclaratorRules);
                 }
 
-                if (typeof opts.IndentOuterIIFE === "number") {
-                    options.IndentOuterIIFE = opts.IndentOuterIIFE;
+                if (typeof opts.outerIIFEBody === "number") {
+                    options.outerIIFEBody = opts.outerIIFEBody;
                 }
             }
         }
@@ -433,8 +433,8 @@ module.exports = {
             // is the outer closure function and that option is enabled.
             var functionOffset = indentSize;
 
-            if (options.IndentOuterIIFE !== null && isOuterClosure(calleeNode.parent)) {
-                functionOffset = options.IndentOuterIIFE;
+            if (options.outerIIFEBody !== null && isOuterClosure(calleeNode.parent)) {
+                functionOffset = options.outerIIFEBody;
             }
             indent += functionOffset;
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -67,6 +67,9 @@ module.exports = {
                                 }
                             }
                         ]
+                    },
+                    IndentOuterIIFE: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -87,7 +90,8 @@ module.exports = {
                 var: DEFAULT_VARIABLE_INDENT,
                 let: DEFAULT_VARIABLE_INDENT,
                 const: DEFAULT_VARIABLE_INDENT
-            }
+            },
+            IndentOuterIIFE: true
         };
 
         var sourceCode = context.getSourceCode();
@@ -115,6 +119,10 @@ module.exports = {
                     };
                 } else if (typeof variableDeclaratorRules === "object") {
                     lodash.assign(options.VariableDeclarator, variableDeclaratorRules);
+                }
+
+                if (typeof opts.IndentOuterIIFE !== "undefined") {
+                    options.IndentOuterIIFE = opts.IndentOuterIIFE;
                 }
             }
         }
@@ -208,7 +216,7 @@ module.exports = {
         }
 
         /**
-         * Get node indent
+         * Get the actual indent of node
          * @param {ASTNode|Token} node Node to examine
          * @param {boolean} [byLastLine=false] get indent of node's last line
          * @param {boolean} [excludeCommas=false] skip comma on start of line
@@ -358,6 +366,17 @@ module.exports = {
             return false;
         }
 
+		/**
+         * Check to see if the node is a file level IIFE
+         * @param {ASTNode} node node to check
+         * @returns {boolean} True if the node is the outer IIFE
+         */
+        function isOuterClosure(node) {
+            return node && node.type === "CallExpression" &&
+                node.parent && node.parent.type === "ExpressionStatement" &&
+                node.parent.parent && node.parent.parent.type === "Program";
+        }
+
         /**
          * Check indent for function block content
          * @param {ASTNode} node node to examine
@@ -409,8 +428,14 @@ module.exports = {
                 }
             }
 
-            // function body indent should be indent + indent size
-            indent += indentSize;
+            // function body indent should be indent + indent size, unless this
+            // is the outer closure function and that option is enabled.
+            var functionOffset = indentSize;
+
+            if (!options.IndentOuterIIFE && isOuterClosure(calleeNode.parent)) {
+                functionOffset = 0;
+            }
+            indent += functionOffset;
 
             // check if the node is inside a variable
             var parentVarNode = getVariableDeclaratorNode(node);
@@ -423,7 +448,7 @@ module.exports = {
                 checkNodesIndent(node.body, indent);
             }
 
-            checkLastNodeLineIndent(node, indent - indentSize);
+            checkLastNodeLineIndent(node, indent - functionOffset);
         }
 
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -69,7 +69,8 @@ module.exports = {
                         ]
                     },
                     IndentOuterIIFE: {
-                        type: "boolean"
+                        type: "integer",
+                        minimum: 0
                     }
                 },
                 additionalProperties: false
@@ -91,7 +92,7 @@ module.exports = {
                 let: DEFAULT_VARIABLE_INDENT,
                 const: DEFAULT_VARIABLE_INDENT
             },
-            IndentOuterIIFE: true
+            IndentOuterIIFE: null
         };
 
         var sourceCode = context.getSourceCode();
@@ -121,7 +122,7 @@ module.exports = {
                     lodash.assign(options.VariableDeclarator, variableDeclaratorRules);
                 }
 
-                if (typeof opts.IndentOuterIIFE !== "undefined") {
+                if (typeof opts.IndentOuterIIFE === "number") {
                     options.IndentOuterIIFE = opts.IndentOuterIIFE;
                 }
             }
@@ -432,8 +433,8 @@ module.exports = {
             // is the outer closure function and that option is enabled.
             var functionOffset = indentSize;
 
-            if (!options.IndentOuterIIFE && isOuterClosure(calleeNode.parent)) {
-                functionOffset = 0;
+            if (options.IndentOuterIIFE !== null && isOuterClosure(calleeNode.parent)) {
+                functionOffset = options.IndentOuterIIFE;
             }
             indent += functionOffset;
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -372,7 +372,7 @@ module.exports = {
          * @param {ASTNode} node node to check
          * @returns {boolean} True if the node is the outer IIFE
          */
-        function isOuterClosure(node) {
+        function isOuterIIFE(node) {
             return node && node.type === "CallExpression" &&
                 node.parent && node.parent.type === "ExpressionStatement" &&
                 node.parent.parent && node.parent.parent.type === "Program";
@@ -430,10 +430,10 @@ module.exports = {
             }
 
             // function body indent should be indent + indent size, unless this
-            // is the outer closure function and that option is enabled.
+            // is the outer IIFE and that option is enabled.
             var functionOffset = indentSize;
 
-            if (options.outerIIFEBody !== null && isOuterClosure(calleeNode.parent)) {
+            if (options.outerIIFEBody !== null && isOuterIIFE(calleeNode.parent)) {
                 functionOffset = options.outerIIFEBody;
             }
             indent += functionOffset;

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -2118,6 +2118,34 @@ ruleTester.run("indent", rule, {
             "}\n",
             options: [4],
             errors: expectedErrors([[4, 4, 2, "Keyword"]])
+        },
+        {
+            code:
+            "(function(){\n" +
+            "  function foo(x) {\n" +
+            "    return x + 1;\n" +
+            "  }\n" +
+            "})();",
+            options: [2, { outerIIFEBody: 0 }],
+            errors: expectedErrors([[2, 0, 2, "FunctionDeclaration"]])
+        },
+        {
+            code:
+            "(function(){\n" +
+            "    function foo(x) {\n" +
+            "        return x + 1;\n" +
+            "    }\n" +
+            "})();",
+            options: [4, { outerIIFEBody: 2 }],
+            errors: expectedErrors([[2, 2, 4, "FunctionDeclaration"]])
+        },
+        {
+            code:
+            "if(data) {\n" +
+            "console.log('hi');\n" +
+            "}",
+            options: [2, { outerIIFEBody: 0 }],
+            errors: expectedErrors([[2, 2, 0, "ExpressionStatement"]])
         }
     ]
 });

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1136,6 +1136,69 @@ ruleTester.run("indent", rule, {
             "}",
             parserOptions: { ecmaVersion: 6 },
             options: [2]
+        },
+        {
+            code:
+            "(function(){\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})();",
+            options: [2, { IndentOuterIIFE: false }]
+        },
+        {
+            code:
+            "(function(x, y){\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})(1, 2);",
+            options: [2, { IndentOuterIIFE: false }]
+        },
+        {
+            code:
+            "(function(){\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "}());",
+            options: [2, { IndentOuterIIFE: false }]
+        },
+        {
+            code:
+            "var out = function(){\n" +
+            "  function fooVar(x) {\n" +
+            "    return x + 1;\n" +
+            "  }\n" +
+            "};",
+            options: [2, { IndentOuterIIFE: false }]
+        },
+        {
+            code:
+            "(() => {\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})();",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2, { IndentOuterIIFE: false }]
+        },
+        {
+            code:
+            ";(() => {\n" +
+            "function foo(x) {\n" +
+            "  return x + 1;\n" +
+            "}\n" +
+            "})();",
+            parserOptions: { ecmaVersion: 6 },
+            options: [2, { IndentOuterIIFE: false }]
+        },
+        {
+            code:
+            "if(data) {\n" +
+            "  console.log('hi');\n" +
+            "}",
+            options: [2, { IndentOuterIIFE: false }]
         }
     ],
     invalid: [

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1144,7 +1144,16 @@ ruleTester.run("indent", rule, {
             "  return x + 1;\n" +
             "}\n" +
             "})();",
-            options: [2, { IndentOuterIIFE: false }]
+            options: [2, { IndentOuterIIFE: 0 }]
+        },
+        {
+            code:
+            "(function(){\n" +
+            "  function foo(x) {\n" +
+            "      return x + 1;\n" +
+            "  }\n" +
+            "})();",
+            options: [4, { IndentOuterIIFE: 2 }]
         },
         {
             code:
@@ -1153,7 +1162,7 @@ ruleTester.run("indent", rule, {
             "  return x + 1;\n" +
             "}\n" +
             "})(1, 2);",
-            options: [2, { IndentOuterIIFE: false }]
+            options: [2, { IndentOuterIIFE: 0 }]
         },
         {
             code:
@@ -1162,7 +1171,7 @@ ruleTester.run("indent", rule, {
             "  return x + 1;\n" +
             "}\n" +
             "}());",
-            options: [2, { IndentOuterIIFE: false }]
+            options: [2, { IndentOuterIIFE: 0 }]
         },
         {
             code:
@@ -1171,7 +1180,7 @@ ruleTester.run("indent", rule, {
             "    return x + 1;\n" +
             "  }\n" +
             "};",
-            options: [2, { IndentOuterIIFE: false }]
+            options: [2, { IndentOuterIIFE: 0 }]
         },
         {
             code:
@@ -1181,7 +1190,7 @@ ruleTester.run("indent", rule, {
             "}\n" +
             "})();",
             parserOptions: { ecmaVersion: 6 },
-            options: [2, { IndentOuterIIFE: false }]
+            options: [2, { IndentOuterIIFE: 0 }]
         },
         {
             code:
@@ -1191,14 +1200,14 @@ ruleTester.run("indent", rule, {
             "}\n" +
             "})();",
             parserOptions: { ecmaVersion: 6 },
-            options: [2, { IndentOuterIIFE: false }]
+            options: [2, { IndentOuterIIFE: 0 }]
         },
         {
             code:
             "if(data) {\n" +
             "  console.log('hi');\n" +
             "}",
-            options: [2, { IndentOuterIIFE: false }]
+            options: [2, { IndentOuterIIFE: 0 }]
         }
     ],
     invalid: [

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1144,7 +1144,7 @@ ruleTester.run("indent", rule, {
             "  return x + 1;\n" +
             "}\n" +
             "})();",
-            options: [2, { IndentOuterIIFE: 0 }]
+            options: [2, { outerIIFEBody: 0 }]
         },
         {
             code:
@@ -1153,7 +1153,7 @@ ruleTester.run("indent", rule, {
             "      return x + 1;\n" +
             "  }\n" +
             "})();",
-            options: [4, { IndentOuterIIFE: 2 }]
+            options: [4, { outerIIFEBody: 2 }]
         },
         {
             code:
@@ -1162,7 +1162,7 @@ ruleTester.run("indent", rule, {
             "  return x + 1;\n" +
             "}\n" +
             "})(1, 2);",
-            options: [2, { IndentOuterIIFE: 0 }]
+            options: [2, { outerIIFEBody: 0 }]
         },
         {
             code:
@@ -1171,7 +1171,7 @@ ruleTester.run("indent", rule, {
             "  return x + 1;\n" +
             "}\n" +
             "}());",
-            options: [2, { IndentOuterIIFE: 0 }]
+            options: [2, { outerIIFEBody: 0 }]
         },
         {
             code:
@@ -1180,7 +1180,7 @@ ruleTester.run("indent", rule, {
             "    return x + 1;\n" +
             "  }\n" +
             "};",
-            options: [2, { IndentOuterIIFE: 0 }]
+            options: [2, { outerIIFEBody: 0 }]
         },
         {
             code:
@@ -1190,7 +1190,7 @@ ruleTester.run("indent", rule, {
             "}\n" +
             "})();",
             parserOptions: { ecmaVersion: 6 },
-            options: [2, { IndentOuterIIFE: 0 }]
+            options: [2, { outerIIFEBody: 0 }]
         },
         {
             code:
@@ -1200,14 +1200,14 @@ ruleTester.run("indent", rule, {
             "}\n" +
             "})();",
             parserOptions: { ecmaVersion: 6 },
-            options: [2, { IndentOuterIIFE: 0 }]
+            options: [2, { outerIIFEBody: 0 }]
         },
         {
             code:
             "if(data) {\n" +
             "  console.log('hi');\n" +
             "}",
-            options: [2, { IndentOuterIIFE: 0 }]
+            options: [2, { outerIIFEBody: 0 }]
         }
     ],
     invalid: [


### PR DESCRIPTION
Partly fixes #6259. I've only added support for IIFEs and not for the other forms of full-file closures described [here](https://contribute.jquery.org/style-guide/js/#full-file-closures) because I don't know much about the other forms.

Some questions for people who know a bit more about eslint:

* Do I need to add anything to the `indent-valid-fixture-1.js` or `indent-invalid-fixture-1.js` test files?
* Any thoughts on the option name?
* There are some [crazy ways](http://stackoverflow.com/a/23925102/874671) of writing IIFEs, should we support them all?