### PR TITLE
Update: Add autofix for `padded-blocks` (fixes #6320)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -210,7 +210,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 * [one-var-declaration-per-line](one-var-declaration-per-line.md): require or disallow newlines around `var` declarations
 * [operator-assignment](operator-assignment.md): require or disallow assignment operator shorthand where possible
 * [operator-linebreak](operator-linebreak.md): enforce consistent linebreak style for operators
-* [padded-blocks](padded-blocks.md): require or disallow padding within blocks
+* [padded-blocks](padded-blocks.md): require or disallow padding within blocks (fixable)
 * [quote-props](quote-props.md): require quotes around object literal property names
 * [quotes](quotes.md): enforce the consistent use of either backticks, double, or single quotes (fixable)
 * [require-jsdoc](require-jsdoc.md): require JSDoc comments

--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -1,5 +1,7 @@
 # Enforce padding within blocks (padded-blocks)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Some style guides require block statements to start and end with blank lines. The goal is
 to improve readability by visually separating the block content and the surrounding code.
 

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -17,6 +17,8 @@ module.exports = {
             recommended: false
         },
 
+        fixable: "whitespace",
+
         schema: [
             {
                 oneOf: [
@@ -164,6 +166,9 @@ module.exports = {
                     context.report({
                         node: node,
                         loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
+                        fix: function(fixer) {
+                            return fixer.insertTextAfter(openBrace, "\n");
+                        },
                         message: ALWAYS_MESSAGE
                     });
                 }
@@ -171,23 +176,36 @@ module.exports = {
                     context.report({
                         node: node,
                         loc: {line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
+                        fix: function(fixer) {
+                            return fixer.insertTextBefore(closeBrace, "\n");
+                        },
                         message: ALWAYS_MESSAGE
                     });
                 }
             } else {
                 if (blockHasTopPadding) {
+                    var nextToken = sourceCode.getTokenOrCommentAfter(openBrace);
+
                     context.report({
                         node: node,
                         loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
+                        fix: function(fixer) {
+                            return fixer.replaceTextRange([openBrace.end, nextToken.start], "\n");
+                        },
                         message: NEVER_MESSAGE
                     });
                 }
 
                 if (blockHasBottomPadding) {
+                    var previousToken = sourceCode.getTokenOrCommentBefore(closeBrace);
+
                     context.report({
                         node: node,
                         loc: {line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
-                        message: NEVER_MESSAGE
+                        message: NEVER_MESSAGE,
+                        fix: function(fixer) {
+                            return fixer.replaceTextRange([previousToken.end, closeBrace.start], "\n");
+                        }
                     });
                 }
             }

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -76,6 +76,7 @@ ruleTester.run("padded-blocks", rule, {
     invalid: [
         {
             code: "{\n//comment\na();\n\n}",
+            output: "{\n\n//comment\na();\n\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -86,6 +87,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\na();\n//comment\n}",
+            output: "{\n\na();\n//comment\n\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -96,6 +98,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\na()\n//comment\n}",
+            output: "{\n\na()\n//comment\n\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -106,6 +109,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\na();\n\n}",
+            output: "{\n\na();\n\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -115,6 +119,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\na();\n}",
+            output: "{\n\na();\n\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -124,6 +129,21 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\na();\n}",
+            output: "{\n\na();\n\n}",
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE,
+                    line: 1
+                },
+                {
+                    message: ALWAYS_MESSAGE,
+                    line: 3
+                }
+            ]
+        },
+        {
+            code: "{\r\na();\r\n}",
+            output: "{\n\r\na();\r\n\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -137,6 +157,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\na();}",
+            output: "{\n\na();\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -150,6 +171,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{a();\n}",
+            output: "{\na();\n\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -163,6 +185,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{a();\n}",
+            output: "{\na();\n\n}",
             options: [{blocks: "always"}],
             errors: [
                 {
@@ -177,6 +200,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "switch (a) {\ncase 0: foo();\ncase 1: bar();\n}",
+            output: "switch (a) {\n\ncase 0: foo();\ncase 1: bar();\n\n}",
             options: [{switches: "always"}],
             errors: [
                 {
@@ -193,6 +217,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "switch (a) {\n//comment\ncase 0: foo();//comment\n}",
+            output: "switch (a) {\n\n//comment\ncase 0: foo();//comment\n\n}",
             options: [{switches: "always"}],
             errors: [
                 {
@@ -209,6 +234,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "class A {\nconstructor(){}\n}",
+            output: "class A {\n\nconstructor(){}\n\n}",
             parserOptions: { ecmaVersion: 6 },
             options: [{classes: "always"}],
             errors: [
@@ -226,6 +252,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{a();}",
+            output: "{\na();\n}",
             errors: [
                 {
                     message: ALWAYS_MESSAGE,
@@ -239,6 +266,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\na()\n//comment\n\n}",
+            output: "{\na()\n//comment\n}",
             options: ["never"],
             errors: [
                 {
@@ -249,6 +277,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\na();\n\n}",
+            output: "{\na();\n}",
             options: ["never"],
             errors: [
                 {
@@ -262,7 +291,23 @@ ruleTester.run("padded-blocks", rule, {
             ]
         },
         {
-            code: "{\n\n\na();\n\n\n}",
+            code: "{\r\n\r\na();\r\n\r\n}",
+            output: "{\na();\n}",
+            options: ["never"],
+            errors: [
+                {
+                    message: NEVER_MESSAGE,
+                    line: 1
+                },
+                {
+                    message: NEVER_MESSAGE,
+                    line: 5
+                }
+            ]
+        },
+        {
+            code: "{\n\n\n  a();\n\n\n}",
+            output: "{\na();\n}",
             options: ["never"],
             errors: [
                 {
@@ -277,6 +322,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\na();\n}",
+            output: "{\na();\n}",
             options: ["never"],
             errors: [
                 {
@@ -287,6 +333,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\na();\n\n}",
+            output: "{\na();\n}",
             options: ["never"],
             errors: [
                 {
@@ -297,6 +344,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n// comment\nif (\n// comment\n a) {}\n\n}",
+            output: "{\n\n// comment\nif (\n// comment\n a) {}\n\n}",
             options: ["always"],
             errors: [
                 {
@@ -308,6 +356,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\n// comment\nif (\n// comment\n a) {}\n}",
+            output: "{\n// comment\nif (\n// comment\n a) {}\n}",
             options: ["never"],
             errors: [
                 {
@@ -319,6 +368,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\n// comment\nif (\n// comment\n a) {}\n}",
+            output: "{\n// comment\nif (\n// comment\n a) {}\n}",
             options: [{blocks: "never"}],
             errors: [
                 {
@@ -330,6 +380,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "switch (a) {\n\ncase 0: foo();\n}",
+            output: "switch (a) {\ncase 0: foo();\n}",
             options: [{switches: "never"}],
             errors: [
                 {
@@ -341,6 +392,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "switch (a) {\ncase 0: foo();\n\n  }",
+            output: "switch (a) {\ncase 0: foo();\n}",
             options: [{switches: "never"}],
             errors: [
                 {
@@ -352,6 +404,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "class A {\n\nconstructor(){\n\nfoo();\n\n}\n\n}",
+            output: "class A {\nconstructor(){\n\nfoo();\n\n}\n}",
             parserOptions: { ecmaVersion: 6 },
             options: [{classes: "never"}],
             errors: [
@@ -367,6 +420,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "class A {\n\nconstructor(){\n\nfoo();\n\n}\n\n}",
+            output: "class A {\nconstructor(){\nfoo();\n}\n}",
             parserOptions: { ecmaVersion: 6 },
             options: [{blocks: "never", classes: "never"}],
             errors: [


### PR DESCRIPTION
Note this doesn't deal with differences in linebreaks or keeping correct indentation, since it seems there is consensus in leaving that to subsequent fix passes.