### PR TITLE
Fix: `object-curly-newline` multiline with comments (fixes #6381)

### DIFF
--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -128,8 +128,8 @@ module.exports = {
             var options = normalizedOptions[node.type];
             var openBrace = sourceCode.getFirstToken(node);
             var closeBrace = sourceCode.getLastToken(node);
-            var first = sourceCode.getTokenAfter(openBrace);
-            var last = sourceCode.getTokenBefore(closeBrace);
+            var first = sourceCode.getTokenOrCommentAfter(openBrace);
+            var last = sourceCode.getTokenOrCommentBefore(closeBrace);
             var needsLinebreaks = (
                 node.properties.length >= options.minProperties ||
                 (
@@ -138,6 +138,17 @@ module.exports = {
                     first.loc.start.line !== last.loc.end.line
                 )
             );
+
+            /*
+             * Use tokens or comments to check multiline or not.
+             * But use only tokens to check whether line breaks are needed.
+             * This allows:
+             *     var obj = { // eslint-disable-line foo
+             *         a: 1
+             *     }
+             */
+            first = sourceCode.getTokenAfter(openBrace);
+            last = sourceCode.getTokenBefore(closeBrace);
 
             if (needsLinebreaks) {
                 if (astUtils.isTokenOnSameLine(openBrace, first)) {

--- a/tests/lib/rules/object-curly-newline.js
+++ b/tests/lib/rules/object-curly-newline.js
@@ -138,6 +138,23 @@ ruleTester.run("object-curly-newline", rule, {
             ].join("\n"),
             options: [{multiline: true}]
         },
+        {
+            code: [
+                "var obj = {",
+                "    // comment",
+                "    a: 1",
+                "};"
+            ].join("\n"),
+            options: [{multiline: true}]
+        },
+        {
+            code: [
+                "var obj = { // comment",
+                "    a: 1",
+                "};"
+            ].join("\n"),
+            options: [{multiline: true}]
+        },
 
         // "minProperties" ----------------------------------------------------------
         {


### PR DESCRIPTION
Fixes #6381.

I modified the rule to use comments also to check whether an object literal is multiline or not.