### PR TITLE
Docs: Delete empty table of links from Code Path Analysis

### DIFF
--- a/docs/developer-guide/code-path-analysis.md
+++ b/docs/developer-guide/code-path-analysis.md
@@ -1,8 +1,5 @@
 # Code Path Analysis Details
 
-| [Objects](#objects) | [Events](#events) | [Usage Examples](#usage-examples) | [Code Path Examples](#code-path-examples) |
-|:-------------------:|:-----------------:|:---------------------------------:|:-----------------------------------------:|
-
 ESLint's rules can use code paths.
 The code path is execution routes of programs.
 It forks/joins at such as `if` statements.

--- a/docs/developer-guide/code-path-analysis/README.md
+++ b/docs/developer-guide/code-path-analysis/README.md
@@ -1,8 +1,5 @@
 # Code Path Analysis Details
 
-| [Objects](#objects) | [Events](#events) | [Usage Examples](#usage-examples) | [Code Path Examples](#code-path-examples) |
-|:-------------------:|:-----------------:|:---------------------------------:|:-----------------------------------------:|
-
 ESLint's rules can use code paths.
 The code path is execution routes of programs.
 It forks/joins at such as `if` statements.


### PR DESCRIPTION
Maybe was for a different markdown-to-HTML converter to produce a page TOC?

Looks like we have a duplicate doc to sort out too.