### PR TITLE
Docs: Add gitter chat link to Reporting Bugs

### DIFF
--- a/docs/developer-guide/contributing/reporting-bugs.md
+++ b/docs/developer-guide/contributing/reporting-bugs.md
@@ -15,4 +15,4 @@ In addition, if you're reporting a bug with a rule, be sure to include:
 
 Please include as much detail as possible to help us properly address your issue. If we need to triage issues and constantly ask people for more detail, that's time taken away from actually fixing issues. Help us be as efficient as possible by including a lot of detail in your issues.
 
-**Note:** If you just have a question that won't necessarily result in a change to ESLint, such as asking how something works or how to contribute, please use the [mailing list](https://groups.google.com/group/eslint) instead of filing an issue.
+**Note:** If you just have a question that won't necessarily result in a change to ESLint, such as asking how something works or how to contribute, please use the [mailing list](https://groups.google.com/group/eslint) or [chat](https://gitter.im/eslint/eslint) instead of filing an issue.


### PR DESCRIPTION
A gitter chat link was added to the same paragraph in Change Requests https://github.com/eslint/eslint.github.io/pull/217