### PR TITLE
Fix: false negative of `object-shorthand` (fixes #6429)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -131,43 +131,8 @@ module.exports = {
                     return;
                 }
 
-                // if we're "never" and concise we should warn now
-                if (APPLY_NEVER && isConciseProperty) {
-                    type = node.method ? "method" : "property";
-                    context.report({
-                        node: node,
-                        message: "Expected longform " + type + " syntax.",
-                        fix: function(fixer) {
-                            if (node.method) {
-                                if (node.value.generator) {
-                                    return fixer.replaceTextRange([node.range[0], node.key.range[1]], node.key.name + ": function*");
-                                }
-
-                                return fixer.insertTextAfter(node.key, ": function");
-                            }
-
-                            return fixer.insertTextAfter(node.key, ": " + node.key.name);
-                        }
-                    });
-                }
-
-                // {'xyz'() {}} should be written as {'xyz': function() {}}
-                if (AVOID_QUOTES && isStringLiteral(node.key) && isConciseProperty) {
-                    context.report({
-                        node: node,
-                        message: "Expected longform method syntax for string literal keys.",
-                        fix: function(fixer) {
-                            if (node.computed) {
-                                return fixer.insertTextAfterRange([node.key.range[0], node.key.range[1] + 1], ": function");
-                            }
-
-                            return fixer.insertTextAfter(node.key, ": function");
-                        }
-                    });
-                }
-
-                // at this point if we're concise or if we're "never" we can leave
-                if (APPLY_NEVER || AVOID_QUOTES || isConciseProperty) {
+                // getters and setters are ignored
+                if (node.kind === "get" || node.kind === "set") {
                     return;
                 }
 
@@ -176,13 +141,55 @@ module.exports = {
                     return;
                 }
 
-                // getters and setters are ignored
-                if (node.kind === "get" || node.kind === "set") {
+                //--------------------------------------------------------------
+                // Checks for property/method shorthand.
+                if (isConciseProperty) {
+
+                    // if we're "never" and concise we should warn now
+                    if (APPLY_NEVER) {
+                        type = node.method ? "method" : "property";
+                        context.report({
+                            node: node,
+                            message: "Expected longform " + type + " syntax.",
+                            fix: function(fixer) {
+                                if (node.method) {
+                                    if (node.value.generator) {
+                                        return fixer.replaceTextRange([node.range[0], node.key.range[1]], node.key.name + ": function*");
+                                    }
+
+                                    return fixer.insertTextAfter(node.key, ": function");
+                                }
+
+                                return fixer.insertTextAfter(node.key, ": " + node.key.name);
+                            }
+                        });
+                    }
+
+                    // {'xyz'() {}} should be written as {'xyz': function() {}}
+                    if (AVOID_QUOTES && isStringLiteral(node.key)) {
+                        context.report({
+                            node: node,
+                            message: "Expected longform method syntax for string literal keys.",
+                            fix: function(fixer) {
+                                if (node.computed) {
+                                    return fixer.insertTextAfterRange([node.key.range[0], node.key.range[1] + 1], ": function");
+                                }
+
+                                return fixer.insertTextAfter(node.key, ": function");
+                            }
+                        });
+                    }
+
                     return;
                 }
 
+                //--------------------------------------------------------------
+                // Checks for longform properties.
                 if (node.value.type === "FunctionExpression" && !node.value.id && APPLY_TO_METHODS) {
                     if (IGNORE_CONSTRUCTORS && isConstructor(node.key.name)) {
+                        return;
+                    }
+                    if (AVOID_QUOTES && isStringLiteral(node.key)) {
                         return;
                     }
 
@@ -231,6 +238,9 @@ module.exports = {
                         }
                     });
                 } else if (node.value.type === "Identifier" && node.key.type === "Literal" && node.key.value === node.value.name && APPLY_TO_PROPS) {
+                    if (AVOID_QUOTES) {
+                        return;
+                    }
 
                     // {"x": x} should be written as {x}
                     context.report({

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -136,6 +136,9 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {notConstructorFunction(){}, b: c}", output: "var x = {notConstructorFunction: function(){}, b: c}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
 
         // // avoidQuotes
+        { code: "var x = {a: a}", output: "var x = {a}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }], options: ["always", {avoidQuotes: true}] },
+        { code: "var x = {a: function(){}}", output: "var x = {a(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods", {avoidQuotes: true}] },
+        { code: "var x = {[a]: function(){}}", output: "var x = {[a](){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected method shorthand.", type: "Property" }], options: ["methods", {avoidQuotes: true}] },
         { code: "var x = {'a'(){}}", output: "var x = {'a': function(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax for string literal keys.", type: "Property" }], options: ["always", {avoidQuotes: true}] },
         { code: "var x = {['a'](){}}", output: "var x = {['a']: function(){}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax for string literal keys.", type: "Property" }], options: ["methods", {avoidQuotes: true}] }
     ]


### PR DESCRIPTION
Fixes #6429.

I refactored the logic flow. The new flow has 3 parts.

1. Check whether it should be ignored always or not.
2. Check for concise properties.
3. Check for longform properties.

Then I fixed it for #6429.