### PR TITLE
Chore: `no-control-regex`: Remove seemingly unnecessary logic.

### DIFF
--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -62,17 +62,6 @@ module.exports = {
             // check control characters, if RegExp object used
             var hasControlChars = /[\x00-\x1f]/.test(regexStr); // eslint-disable-line no-control-regex
 
-            // check substr, if regex literal used
-            var subStrIndex = regexStr.search(/\\x[01][0-9a-f]/i);
-
-            if (!hasControlChars && subStrIndex > -1) {
-
-                // is it escaped, check backslash count
-                var possibleEscapeCharacters = regexStr.substr(0, subStrIndex).match(/\\+$/gi);
-
-                hasControlChars = possibleEscapeCharacters === null || !(possibleEscapeCharacters[0].length % 2);
-            }
-
             return hasControlChars;
         }
 


### PR DESCRIPTION
While investigating a fix for #6293, I discovered that the test in https://github.com/eslint/eslint/commit/141b77841e1c086d2f1b73e767d2fe3be4590a17 continues to pass even without this code.

Either this code should be deleted, or tests should be added that necessitate its existence. I'm not sure which, but it seemed like the former was correct.

/cc @efegurkan