### PR TITLE
Docs: Quoted "classes" option key (fixes #6440)

### DIFF
--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -21,7 +21,7 @@ then all blocks should never have any preceding space. If different spacing is d
 blocks, keyword blocks and classes, an optional configuration object can be passed as the rule argument to
 configure the cases separately.
 
-( e.g. `{ "functions": "never", "keywords": "always", classes: "always" }` )
+( e.g. `{ "functions": "never", "keywords": "always", "classes": "always" }` )
 
 The default is `"always"`.
 
@@ -116,10 +116,10 @@ class Foo{
 }
 ```
 
-The following patterns are considered problems when configured `{ "functions": "never", "keywords": "always", classes: "never" }`:
+The following patterns are considered problems when configured `{ "functions": "never", "keywords": "always", "classes": "never" }`:
 
 ```js
-/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
 /*eslint-env es6*/
 
 function a() {}
@@ -132,10 +132,10 @@ class Foo{
 ```
 
 
-The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "always", classes: "never" }`:
+The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "always", "classes": "never" }`:
 
 ```js
-/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
 /*eslint-env es6*/
 
 for (;;) {
@@ -151,10 +151,10 @@ class Foo {
 }
 ```
 
-The following patterns are considered problems when configured `{ "functions": "always", "keywords": "never", classes: "never" }`:
+The following patterns are considered problems when configured `{ "functions": "always", "keywords": "never", "classes": "never" }`:
 
 ```js
-/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
 /*eslint-env es6*/
 
 function a(){}
@@ -167,10 +167,10 @@ class Foo {
 ```
 
 
-The following patterns are not considered problems when configured `{ "functions": "always", "keywords": "never", classes: "never" }`:
+The following patterns are not considered problems when configured `{ "functions": "always", "keywords": "never", "classes": "never" }`:
 
 ```js
-/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", classes: "never" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
 /*eslint-env es6*/
 
 if (a){
@@ -184,10 +184,10 @@ class Foo{
 }
 ```
 
-The following patterns are considered problems when configured `{ "functions": "never", "keywords": "never", classes: "always" }`:
+The following patterns are considered problems when configured `{ "functions": "never", "keywords": "never", "classes": "always" }`:
 
 ```js
-/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", classes: "always" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/
 /*eslint-env es6*/
 
 class Foo{
@@ -196,10 +196,10 @@ class Foo{
 ```
 
 
-The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "never", classes: "always" }`:
+The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "never", "classes": "always" }`:
 
 ```js
-/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", classes: "always" }]*/
+/*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/
 /*eslint-env es6*/
 
 class Foo {


### PR DESCRIPTION
Made `classes` key consistent with all other option keys which are quoted..