### PR TITLE
Update padded-blocks to include padding outside blocks

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -9,10 +9,25 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+var choiceType = {
+    enum: ["always", "never"]
+};
+
+var insideOptions = {
+    type: "object",
+    properties: {
+        blocks: choiceType,
+        switches: choiceType,
+        classes: choiceType
+    },
+    additionalProperties: false,
+    minProperties: 1
+};
+
 module.exports = {
     meta: {
         docs: {
-            description: "require or disallow padding within blocks",
+            description: "require or disallow padding within and outside blocks",
             category: "Stylistic Issues",
             recommended: false
         },
@@ -22,20 +37,15 @@ module.exports = {
         schema: [
             {
                 oneOf: [
-                    {
-                        enum: ["always", "never"]
-                    },
+                    choiceType,
+                    insideOptions,
                     {
                         type: "object",
                         properties: {
-                            blocks: {
-                                enum: ["always", "never"]
-                            },
-                            switches: {
-                                enum: ["always", "never"]
-                            },
-                            classes: {
-                                enum: ["always", "never"]
+                            above: choiceType,
+                            below: choiceType,
+                            inside: {
+                                oneOf: [choiceType, insideOptions]
                             }
                         },
                         additionalProperties: false,
@@ -47,25 +57,51 @@ module.exports = {
     },
 
     create: function(context) {
-        var options = {};
+        var options = { inside: {} };
         var config = context.options[0] || "always";
 
         if (typeof config === "string") {
-            options.blocks = config === "always";
-        } else {
+            options.inside.blocks = config === "always";
+        } else if (config.hasOwnProperty("blocks") ||
+            config.hasOwnProperty("switches") ||
+            config.hasOwnProperty("classes")) {
+
             if (config.hasOwnProperty("blocks")) {
-                options.blocks = config.blocks === "always";
+                options.inside.blocks = config.blocks === "always";
             }
             if (config.hasOwnProperty("switches")) {
-                options.switches = config.switches === "always";
+                options.inside.switches = config.switches === "always";
             }
             if (config.hasOwnProperty("classes")) {
-                options.classes = config.classes === "always";
+                options.inside.classes = config.classes === "always";
+            }
+        } else {
+            var inside = config.inside;
+
+            if (inside) {
+                if (inside.hasOwnProperty("switches")) {
+                    options.inside.switches = inside.switches === "always";
+                }
+                if (inside.hasOwnProperty("switches")) {
+                    options.inside.switches = inside.switches === "always";
+                }
+                if (inside.hasOwnProperty("classes")) {
+                    options.inside.classes = inside.classes === "always";
+                }
+            } else {
+
+                // To maintain backwards compatibility, we enable block
+                // checking if no inside options are explicitly set:
+                config.inside.blocks = true;
+            }
+
+            if (config.hasOwnProperty("above")) {
+                options.above = config.above === "always";
+            }
+            if (config.hasOwnProperty("below")) {
+                options.below = config.below === "always";
             }
         }
-
-        var ALWAYS_MESSAGE = "Block must be padded by blank lines.",
-            NEVER_MESSAGE = "Block must not be padded by blank lines.";
 
         var sourceCode = context.getSourceCode();
 
@@ -131,18 +167,19 @@ module.exports = {
         }
 
         /**
-         * Checks if a node should be padded, according to the rule config.
+         * Checks if a node should be padded on the inside,
+         * according to the rule config.
          * @param {ASTNode} node The AST node to check.
          * @returns {boolean} True if the node should be padded, false otherwise.
          */
-        function requirePaddingFor(node) {
+        function requireInsidePaddingFor(node) {
             switch (node.type) {
                 case "BlockStatement":
-                    return options.blocks;
+                    return options.inside.blocks;
                 case "SwitchStatement":
-                    return options.switches;
+                    return options.inside.switches;
                 case "ClassBody":
-                    return options.classes;
+                    return options.inside.classes;
 
                 /* istanbul ignore next */
                 default:
@@ -155,13 +192,15 @@ module.exports = {
          * @param {ASTNode} node The AST node of a BlockStatement.
          * @returns {void} undefined.
          */
-        function checkPadding(node) {
+        function checkInsidePadding(node) {
             var openBrace = getOpenBrace(node),
                 closeBrace = sourceCode.getLastToken(node),
                 blockHasTopPadding = isTokenTopPadded(openBrace),
-                blockHasBottomPadding = isTokenBottomPadded(closeBrace);
+                blockHasBottomPadding = isTokenBottomPadded(closeBrace),
+                ALWAYS_MESSAGE = "Block must be padded by blank lines on the inside.",
+                NEVER_MESSAGE = "Block must not be padded by blank lines on the inside.";
 
-            if (requirePaddingFor(node)) {
+            if (requireInsidePaddingFor(node)) {
                 if (!blockHasTopPadding) {
                     context.report({
                         node: node,
@@ -211,32 +250,141 @@ module.exports = {
             }
         }
 
-        var rule = {};
+        /**
+         * Finds the node that "dominates" the given BlockStatement node.
+         * Example:
+         * Here we're interested in the node corresponding to the VariableDeclaration:
+         * var a = function() {}
+         *
+         * Here we're interested in the IfStatement node:
+         * if (a) {}
+         * @param  {ASTNode} node The ASTNode we're finding the parent for
+         * @returns {ASTNode} node
+         */
+        function findBlockStartNode(node) {
+            var parent = node.parent,
+                types = [
+                    "SwitchStatement",
+                    "ClassBody",
+                    "BlockStatement",
+                    "Program"
+                ];
 
-        if (options.hasOwnProperty("switches")) {
+            return types.indexOf(parent.type) === -1 ? findBlockStartNode(parent) : node;
+        }
+
+        /**
+         * Checks if the given node is padded on the outside, if required.
+         * @param {ASTNode} node AST node
+         * @returns {void} undefined.
+         */
+        function checkOutsidePadding(node) {
+            var ALWAYS_MESSAGE = "Block must be padded by blank lines on the outside.",
+                NEVER_MESSAGE = "Block must not be padded by blank lines on the outside.",
+                startNode = findBlockStartNode(node),
+                firstToken = sourceCode.getFirstToken(startNode),
+                closeBrace = sourceCode.getLastToken(node),
+                tokenBefore = sourceCode.getTokenOrCommentBefore(firstToken),
+                tokenAfter = sourceCode.getTokenOrCommentAfter(closeBrace),
+                checkAbove = options.hasOwnProperty("above"),
+                checkBelow = options.hasOwnProperty("below"),
+                blockHasAbovePadding,
+                blockHasBelowPadding;
+
+            // Ignore if this is the first block in a program or another block:
+            if (checkAbove && tokenBefore && tokenBefore.value !== "{") {
+                blockHasAbovePadding = isTokenBottomPadded(firstToken);
+                if (options.above && !blockHasAbovePadding) {
+                    context.report({
+                        node: node,
+                        loc: { line: firstToken.loc.start.line, column: firstToken.loc.start.column },
+
+                        // If there's a block below and we're checking it later,
+                        // skip the fix for now:
+                        fix: (tokenBefore.value !== "}" || !checkBelow) && function(fixer) {
+                            return fixer.insertTextBefore(startNode, "\n");
+                        },
+                        message: ALWAYS_MESSAGE
+                    });
+                } else if (!options.above && blockHasAbovePadding) {
+                    context.report({
+                        node: node,
+                        loc: { line: firstToken.loc.start.line, column: firstToken.loc.start.column },
+                        fix: (tokenBefore.value !== "}" || !checkBelow) && function(fixer) {
+                            return fixer.replaceTextRange([tokenBefore.end, startNode.start], "\n");
+                        },
+                        message: NEVER_MESSAGE
+                    });
+                }
+            }
+
+            // Ignore if this is the final block in a program or another block:
+            if (checkBelow && tokenAfter && tokenAfter.value !== "}") {
+                blockHasBelowPadding = isTokenTopPadded(closeBrace);
+                if (options.below && !blockHasBelowPadding) {
+                    context.report({
+                        node: node,
+                        loc: {line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
+                        fix: function(fixer) {
+                            return fixer.insertTextAfter(closeBrace, "\n");
+                        },
+                        message: ALWAYS_MESSAGE
+                    });
+                } else if (!options.below && blockHasBelowPadding) {
+                    context.report({
+                        node: node,
+                        loc: {line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
+                        fix: function(fixer) {
+                            return fixer.replaceTextRange([closeBrace.end, tokenAfter.start], "\n");
+                        },
+                        message: NEVER_MESSAGE
+                    });
+                }
+            }
+        }
+
+        var rule = {};
+        var checkOutside = options.hasOwnProperty("above") || options.hasOwnProperty("below");
+
+        if (options.inside.hasOwnProperty("switches") || checkOutside) {
             rule.SwitchStatement = function(node) {
+                if (checkOutside) {
+                    checkOutsidePadding(node);
+                }
                 if (node.cases.length === 0) {
                     return;
                 }
-                checkPadding(node);
+                if (options.inside.hasOwnProperty("switches")) {
+                    checkInsidePadding(node);
+                }
             };
         }
 
-        if (options.hasOwnProperty("blocks")) {
+        if (options.inside.hasOwnProperty("blocks") || checkOutside) {
             rule.BlockStatement = function(node) {
+                if (checkOutside) {
+                    checkOutsidePadding(node);
+                }
                 if (node.body.length === 0) {
                     return;
                 }
-                checkPadding(node);
+                if (options.inside.hasOwnProperty("blocks")) {
+                    checkInsidePadding(node);
+                }
             };
         }
 
-        if (options.hasOwnProperty("classes")) {
+        if (options.inside.hasOwnProperty("classes") || checkOutside) {
             rule.ClassBody = function(node) {
+                if (checkOutside) {
+                    checkOutsidePadding(node);
+                }
                 if (node.body.length === 0) {
                     return;
                 }
-                checkPadding(node);
+                if (options.inside.hasOwnProperty("classes")) {
+                    checkInsidePadding(node);
+                }
             };
         }
 

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -17,8 +17,10 @@ var rule = require("../../../lib/rules/padded-blocks"),
 //------------------------------------------------------------------------------
 
 var ruleTester = new RuleTester(),
-    ALWAYS_MESSAGE = "Block must be padded by blank lines.",
-    NEVER_MESSAGE = "Block must not be padded by blank lines.";
+    ALWAYS_MESSAGE_INSIDE = "Block must be padded by blank lines on the inside.",
+    ALWAYS_MESSAGE_OUTSIDE = "Block must be padded by blank lines on the outside.",
+    NEVER_MESSAGE_INSIDE = "Block must not be padded by blank lines on the inside.",
+    NEVER_MESSAGE_OUTSIDE = "Block must not be padded by blank lines on the outside.";
 
 ruleTester.run("padded-blocks", rule, {
     valid: [
@@ -71,7 +73,91 @@ ruleTester.run("padded-blocks", rule, {
         {code: "{\n// comment\nif (\n// comment\n a) {}\n }", options: ["never"] },
         {code: "{\n// comment\nif (\n// comment\n a) {}\n }", options: [{blocks: "never"}] },
         {code: "switch (a) {\ncase 0: foo();\n}", options: [{switches: "never"}]},
-        {code: "class A{\nfoo(){}\n}", parserOptions: { ecmaVersion: 6 }, options: [{classes: "never"}]}
+        {code: "class A{\nfoo(){}\n}", parserOptions: { ecmaVersion: 6 }, options: [{classes: "never"}]},
+
+        // above/below:
+        {
+            code: "{}\n\n{\na();\n}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+        {
+            code: "{}\n\nif (a) {\nb();\n}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+        {
+            code: "if (c) {}\n\nif (a) {\nb();\n}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+        {
+            code: "if (c) {}\nif (a) {\nb();\n}",
+            options: [{ inside: "never", above: "never", below: "never" }]
+        },
+
+        {
+            code: "{\na();\n}\n\n{}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+        {
+            code: "{\nb();\n}\n\nif(b) {}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+        {
+            code: "var a = 5;\n\n{\nb();\n}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+        {
+            code: "if (a) {\nb();\n}\n{}",
+            options: [{ inside: "never", above: "never", below: "never" }]
+        },
+        {
+            code: "if (a) {\nb();\n}\nif (a) {}",
+            options: [{ inside: "never", above: "never", below: "never" }]
+        },
+        {
+            code: "var a = 5;\n\nclass A {\nconstructor(){}\n}\nvar b = 3;",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ inside: "never", above: "always", below: "never" }]
+        },
+        {
+            code: "var a = 5;\n\nswitch (a) {\ncase 1: break;\n}\nvar b = 3;",
+            options: [{ inside: "never", above: "always", below: "never" }]
+        },
+        {
+            code: "var a = 5;\n\nswitch (a) {\n\ncase 1: break;\n\n}\nvar b = 3;",
+            options: [{ inside: { switches: "always" }, above: "always", below: "never" }]
+        },
+
+        // Inside should have presedence, by ignoring first and final nested blocks:
+        {
+            code: "class A{\nfoo(){\na();\n}\n\nb() { c(); }\n}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+        {
+            code: "{\nif (b) { c(); }\n\na();\n}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+
+        // The padding for SwitchCase blocks should be before the case itself:
+        {
+            code: "switch (a) {\ncase 1: break;\n\ncase 2: { c(); }\n}",
+            options: [{ inside: "never", above: "always", below: "always" }]
+        },
+
+        // Do nothing if outside options aren't explicitly set:
+        {code: "{}\n{\na();\n}\n\n{}", options: [{ inside: "never" }]},
+
+        // above/below classes and switches:
+        {
+            code: "var a = 5;\n\nclass A {}\nvar b = 3;",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ inside: "never", above: "always", below: "never" }]
+        },
+        {
+            code: "var a = 5;\n\nswitch (a) {}\nvar b = 3;",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ inside: "never", above: "always", below: "never" }]
+        }
     ],
     invalid: [
         {
@@ -79,7 +165,7 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\n//comment\na();\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1,
                     column: 1
                 }
@@ -90,7 +176,7 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\na();\n//comment\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 5,
                     column: 1
                 }
@@ -101,7 +187,7 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\na()\n//comment\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 5,
                     column: 1
                 }
@@ -112,7 +198,7 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\na();\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 }
             ]
@@ -122,7 +208,7 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\na();\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 4
                 }
             ]
@@ -132,11 +218,11 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\na();\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 3
                 }
             ]
@@ -146,11 +232,11 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\r\na();\r\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 3
                 }
             ]
@@ -160,11 +246,11 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\n\na();\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 2
                 }
             ]
@@ -174,11 +260,11 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\na();\n\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 2
                 }
             ]
@@ -189,11 +275,11 @@ ruleTester.run("padded-blocks", rule, {
             options: [{blocks: "always"}],
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 2
                 }
             ]
@@ -204,12 +290,12 @@ ruleTester.run("padded-blocks", rule, {
             options: [{switches: "always"}],
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1,
                     column: 12
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 4,
                     column: 1
                 }
@@ -221,12 +307,12 @@ ruleTester.run("padded-blocks", rule, {
             options: [{switches: "always"}],
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1,
                     column: 12
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 4,
                     column: 1
                 }
@@ -239,12 +325,12 @@ ruleTester.run("padded-blocks", rule, {
             options: [{classes: "always"}],
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1,
                     column: 9
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 3,
                     column: 1
                 }
@@ -255,11 +341,11 @@ ruleTester.run("padded-blocks", rule, {
             output: "{\na();\n}",
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1
                 }
             ]
@@ -270,7 +356,7 @@ ruleTester.run("padded-blocks", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 5
                 }
             ]
@@ -281,11 +367,11 @@ ruleTester.run("padded-blocks", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 5
                 }
             ]
@@ -296,11 +382,11 @@ ruleTester.run("padded-blocks", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 5
                 }
             ]
@@ -311,11 +397,11 @@ ruleTester.run("padded-blocks", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 7
                 }
             ]
@@ -326,7 +412,7 @@ ruleTester.run("padded-blocks", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1
                 }
             ]
@@ -337,7 +423,7 @@ ruleTester.run("padded-blocks", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 4
                 }
             ]
@@ -348,7 +434,7 @@ ruleTester.run("padded-blocks", rule, {
             options: ["always"],
             errors: [
                 {
-                    message: ALWAYS_MESSAGE,
+                    message: ALWAYS_MESSAGE_INSIDE,
                     line: 1,
                     column: 1
                 }
@@ -360,7 +446,7 @@ ruleTester.run("padded-blocks", rule, {
             options: ["never"],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1,
                     column: 1
                 }
@@ -372,7 +458,7 @@ ruleTester.run("padded-blocks", rule, {
             options: [{blocks: "never"}],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1,
                     column: 1
                 }
@@ -384,7 +470,7 @@ ruleTester.run("padded-blocks", rule, {
             options: [{switches: "never"}],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1,
                     column: 12
                 }
@@ -396,7 +482,7 @@ ruleTester.run("padded-blocks", rule, {
             options: [{switches: "never"}],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 4,
                     column: 3
                 }
@@ -409,11 +495,11 @@ ruleTester.run("padded-blocks", rule, {
             options: [{classes: "never"}],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 9
                 }
             ]
@@ -425,20 +511,208 @@ ruleTester.run("padded-blocks", rule, {
             options: [{blocks: "never", classes: "never"}],
             errors: [
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 1
                 },
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 3
                 },
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 7
                 },
                 {
-                    message: NEVER_MESSAGE,
+                    message: NEVER_MESSAGE_INSIDE,
                     line: 9
+                }
+            ]
+        },
+
+        // Outside:
+        {
+            code: "switch (a) {\ncase 1: break;\ncase 2: { c(); }\n}",
+            output: "switch (a) {\ncase 1: break;\n\ncase 2: { c(); }\n}",
+            options: [{ inside: "never", above: "always", below: "always" }],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 3
+                }
+            ]
+        },
+
+        // Empty blocks should still be checked:
+        {
+            code: "if (a) {}\nc();",
+            output: "if (a) {}\n\nc();",
+            options: [{ inside: "never", above: "always", below: "always" }],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 1
+                }
+            ]
+        },
+        {
+            code: "if (a) {}\n\n//test\n\n{}",
+            output: "if (a) {}\n//test\n{}",
+            options: [{ inside: "never", above: "never", below: "never" }],
+            errors: [
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 1
+                },
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 5
+                }
+            ]
+        },
+        {
+            code: "if (a) {}\n//test\n{}",
+            output: "if (a) {}\n\n//test\n\n{}",
+            options: [{ inside: "never", above: "always", below: "always" }],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 1
+                },
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 3
+                }
+            ]
+        },
+        {
+            code: "if (a) {}\n\n{}",
+            output: "if (a) {}\n{}",
+            options: [{ inside: "never", above: "never", below: "never" }],
+            errors: [
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 1
+                },
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 3
+                }
+            ]
+        },
+        {
+            code: "if (a) {}\n{}",
+            output: "if (a) {}\n\n{}",
+            options: [{ inside: "never", above: "always", below: "always" }],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 1
+                },
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 2
+                }
+            ]
+        },
+        {
+            code: "if (a) {\nc();\n}\n\nvar b = 3;",
+            output: "if (a) {\nc();\n}\nvar b = 3;",
+            options: [{ inside: "never", above: "never", below: "never" }],
+            errors: [
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 3
+                }
+            ]
+        },
+        {
+            code: "var c = 3;\n\nif (a) {\nc();\n}\n\nvar b = 3;",
+            output: "var c = 3;\nif (a) {\nc();\n}\n\nvar b = 3;",
+            options: [{ inside: "never", above: "never" }],
+            errors: [
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 3
+                }
+            ]
+        },
+        {
+            code: "var e = 123;\nvar a = function() {\nc();\n}\nvar b = 3;",
+            output: "var e = 123;\n\nvar a = function() {\nc();\n}\n\nvar b = 3;",
+            options: [{ inside: "never", above: "always", below: "always" }],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 2
+                },
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 4
+                }
+            ]
+        },
+        {
+            code: "class A {\nconstructor(){}\nb() {}\n\nc() {}\n}",
+            output: "class A {\nconstructor(){}\nb() {}\nc() {}\n}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{inside: "never", above: "never", below: "never"}],
+            errors: [
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 3
+                },
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 5
+                }
+            ]
+        },
+        {
+            code: "class A {\nconstructor(){}\nb() {}\n\nc() {}\n}",
+            output: "class A {\nconstructor(){}\n\nb() {}\n\nc() {}\n}",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{inside: "never", above: "always", below: "always"}],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 2
+                },
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 3
+                }
+            ]
+        },
+
+        // above/below classes and switches:
+        {
+            code: "var a = 5;\nclass A {\nconstructor(){}\n}\n\nvar b = 3;",
+            output: "var a = 5;\n\nclass A {\nconstructor(){}\n}\nvar b = 3;",
+            parserOptions: { ecmaVersion: 6 },
+            options: [{ inside: "never", above: "always", below: "never" }],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 2
+                },
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 4
+                }
+            ]
+        },
+        {
+            code: "var a = 5;\nswitch (a) {\ncase 1: break;\n}\n\nvar b = 3;",
+            output: "var a = 5;\n\nswitch (a) {\ncase 1: break;\n}\nvar b = 3;",
+            options: [{ inside: "never", above: "always", below: "never" }],
+            errors: [
+                {
+                    message: ALWAYS_MESSAGE_OUTSIDE,
+                    line: 2
+                },
+                {
+                    message: NEVER_MESSAGE_OUTSIDE,
+                    line: 4
                 }
             ]
         }


### PR DESCRIPTION
## What/why

This allows ESLint to enforce newline padding above and below blocks, classes and switches.

See #3092 for original discussion.
The issue isn't accepted yet, but I thought I'd open a PR to show one example of how this could be implemented.
## Examples

``` js
// Turns this:
function a() {

}
function b() {

}

// Into this:
function a() {

}

function b() {

}


// Valid with above: "never" and below: "always":
var a = 5;
var b = function() {

};

var c = 3;


// Valid with above: "never", invalid with above: "always":
var a = "cat";
class B {
  constructor() {}
}
var b = 5; // Valid with below: "never", invalid with below: "always"
```
## How

Currently this extends `padded-blocks` in a backwards compatible manner by adding the two options `above` and `below`. The existing rule options are then moved to `inside`. 
### Valid options

``` js
// Old (still works):
"always"
"never"
{ "blocks": "always", "switches": "never", "classes": "never" }

// New:
{ "inside": "always" }
{ "inside": { "blocks": "always" }, "above": "always" }
{ "inside": "always", "above": "always", "below": "never" }
```

I.e. no outside padding is checked without explicitly setting `above` or `below`.
## Alternatives
#### Allow toggling based on type (classes, switches and blocks)

Unlike the options for padding on the inside of blocks, `above` and `below` only support the options `"always"` and `"never"`. 
This could of course be added, but I think the extra complexity makes less sense here than it does with inside padding.
#### Merge always/never into `outside`

This was my original implementation, but I think the extra configurability makes sense here - as there's probably a decent amount of people that would want this to be valid:

``` js
var a = 5;
var b = function() {

};
```
#### Move this into its own rule

Either by having one rule for all the functionality added here, or by splitting it up into multiple small rules for different block types.
## Overlap

This overlaps with #5950, which is a really clean implementation that targets class methods. These are still blocks though, so they're picked up by the functionality implemented in this PR.
This could be "solved" by splitting up this rule into multiple ones, or by ignoring class methods and having both.
## Other

Blocks inside switch cases are currently linted as follows:

``` js
// Valid with above: "always":
switch (a) {
  case 1: {
  }

  case 2: {
    let b = 5;
    break;
  }
}
```

Instead of:

``` js
switch (a) {
  case 1: {
  }

  case 2: 

  {
    let b = 5;
    break;
  }
}
```

Also, as the above examples show, outside padding is not checked for the first and last block in another block. This is to prevent overlap with the existing inside padding check.
## TODO
- [ ] Update documentation
- [ ] Add more test cases and structure the existing ones a bit better
