### PR TITLE
Docs: Consistent example headings & text (refs #5446)

### DIFF
--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -91,7 +91,7 @@ let foo = () => ({ bar: 0 });
 
 #### requireReturnForObjectLiteral
 
-> This option is only applicable when used in conjunction with the `"as-needed"` option.
+This option is only applicable when used in conjunction with the `"as-needed"` option.
 
 Examples of **incorrect** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:
 

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -18,11 +18,18 @@ This rule normalize style of spacing before/after an arrow function's arrow(`=>`
 
 This rule takes an object argument with `before` and `after` properties, each with a Boolean value.
 
+## Options
+
 The default configuration is `{ "before": true, "after": true }`.
 
 `true` means there should be **one or more spaces** and `false` means **no spaces**.
 
-The following patterns are considered problems if `{ "before": true, "after": true }`.
+## Examples
+
+### before: true, after: true
+
+Examples of **incorrect** code for this rule with the default `{ "before": true, "after": true }` option:
+
 
 ```js
 /*eslint arrow-spacing: "error"*/
@@ -38,7 +45,7 @@ a=> a;
 () =>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": true, "after": true }`.
+Examples of **correct** code for this rule with the default `{ "before": true, "after": true }` option:
 
 ```js
 /*eslint arrow-spacing: "error"*/
@@ -50,7 +57,9 @@ a => a;
 () => {'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": false, "after": false }`.
+### before: false, after: false
+
+Examples of **correct** code for this rule with the `{ "before": false, "after": false }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
@@ -62,7 +71,9 @@ a=>a;
 ()=>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": true, "after": false }`.
+### before: true, after: false
+
+Examples of **correct** code for this rule with the `{ "before": true, "after": false }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": true, "after": false }]*/
@@ -74,7 +85,9 @@ a =>a;
 () =>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": false, "after": true }`.
+## before: false, after: true
+
+Examples of **correct** code for this rule with the `{ "before": false, "after": true }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -10,7 +10,9 @@ This rule checks whether or not there is a valid `super()` call.
 
 This rule is aimed to flag invalid/missing `super()` calls.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/
@@ -38,7 +40,7 @@ class A extends null {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -15,7 +15,9 @@ But the modification is a mistake in most cases.
 
 This rule is aimed to flag modifying variables of class declarations.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/
@@ -56,7 +58,7 @@ let A = class A {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/


### PR DESCRIPTION
1. Ensure each doc has "Examples" heading, and that each
option-specific example pair also has a suitable heading.

2. Ensure text above examples is consistent as per #5446