### PR TITLE
Fix: Keep indentation when fixing `padded-blocks` "never" (fixes #6454)

### DIFF
--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -190,7 +190,7 @@ module.exports = {
                         node: node,
                         loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
                         fix: function(fixer) {
-                            return fixer.replaceTextRange([openBrace.end, nextToken.start], "\n");
+                            return fixer.replaceTextRange([openBrace.end, nextToken.start - nextToken.loc.start.column], "\n");
                         },
                         message: NEVER_MESSAGE
                     });
@@ -204,7 +204,7 @@ module.exports = {
                         loc: {line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
                         message: NEVER_MESSAGE,
                         fix: function(fixer) {
-                            return fixer.replaceTextRange([previousToken.end, closeBrace.start], "\n");
+                            return fixer.replaceTextRange([previousToken.end, closeBrace.start - closeBrace.loc.start.column], "\n");
                         }
                     });
                 }

--- a/tests/lib/rules/padded-blocks.js
+++ b/tests/lib/rules/padded-blocks.js
@@ -307,7 +307,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "{\n\n\n  a();\n\n\n}",
-            output: "{\na();\n}",
+            output: "{\n  a();\n}",
             options: ["never"],
             errors: [
                 {
@@ -332,8 +332,30 @@ ruleTester.run("padded-blocks", rule, {
             ]
         },
         {
+            code: "{\n\n\ta();\n}",
+            output: "{\n\ta();\n}",
+            options: ["never"],
+            errors: [
+                {
+                    message: NEVER_MESSAGE,
+                    line: 1
+                }
+            ]
+        },
+        {
             code: "{\na();\n\n}",
             output: "{\na();\n}",
+            options: ["never"],
+            errors: [
+                {
+                    message: NEVER_MESSAGE,
+                    line: 4
+                }
+            ]
+        },
+        {
+            code: "  {\n    a();\n\n  }",
+            output: "  {\n    a();\n  }",
             options: ["never"],
             errors: [
                 {
@@ -392,7 +414,7 @@ ruleTester.run("padded-blocks", rule, {
         },
         {
             code: "switch (a) {\ncase 0: foo();\n\n  }",
-            output: "switch (a) {\ncase 0: foo();\n}",
+            output: "switch (a) {\ncase 0: foo();\n  }",
             options: [{switches: "never"}],
             errors: [
                 {


### PR DESCRIPTION
For #6454, keep the leading spaces/tabs instead of deleting up to the `nextToken`. Fixes/adds tests.