### PR TITLE
Fix: wrong baseDir (fixes #6450)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -495,7 +495,6 @@ function resolve(filePath, relativeTo) {
 function load(filePath, applyEnvironments, relativeTo) {
     var resolvedPath = resolve(filePath, relativeTo),
         dirname = path.dirname(resolvedPath.filePath),
-        basedir = getBaseDir(dirname),
         lookupPath = getLookupPath(dirname),
         config = loadConfigFile(resolvedPath);
 
@@ -514,7 +513,7 @@ function load(filePath, applyEnvironments, relativeTo) {
         // include full path of parser if present
         if (config.parser) {
             if (isFilePath(config.parser)) {
-                config.parser = path.resolve(basedir || "", config.parser);
+                config.parser = path.resolve(dirname || "", config.parser);
             } else {
                 config.parser = resolver.resolve(config.parser, lookupPath);
             }
@@ -528,7 +527,7 @@ function load(filePath, applyEnvironments, relativeTo) {
          * a "parent". Load the referenced file and merge the configuration recursively.
          */
         if (config.extends) {
-            config = applyExtends(config, filePath, basedir);
+            config = applyExtends(config, filePath, dirname);
         }
 
         if (config.env && applyEnvironments) {

--- a/tests/fixtures/config-file/extends-chain-2/parser.eslintrc.json
+++ b/tests/fixtures/config-file/extends-chain-2/parser.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "parser": "./parser.js"
+}

--- a/tests/fixtures/config-file/extends-chain-2/relative.eslintrc.json
+++ b/tests/fixtures/config-file/extends-chain-2/relative.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "./node_modules/eslint-config-a/index.js"
+}

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -17,6 +17,7 @@ var assert = require("chai").assert,
     yaml = require("js-yaml"),
     userHome = require("user-home"),
     proxyquire = require("proxyquire"),
+    shell = require("shelljs"),
     environments = require("../../../conf/environments"),
     ConfigFile = require("../../../lib/config/config-file");
 
@@ -654,6 +655,78 @@ describe("ConfigFile", function() {
                     a: 2,       // from node_modules/eslint-config-a/index.js
                     relative: 2 // from node_modules/eslint-config-a/relative.js
                 }
+            });
+        });
+
+        it("should load information from `extends` chain in .eslintrc with relative path.", function() {
+            var config = ConfigFile.load(getFixturePath("extends-chain-2/relative.eslintrc.json"));
+
+            assert.deepEqual(config, {
+                env: {},
+                extends: "./node_modules/eslint-config-a/index.js",
+                globals: {},
+                parserOptions: {},
+                rules: {
+                    a: 2,       // from node_modules/eslint-config-a/index.js
+                    relative: 2 // from node_modules/eslint-config-a/relative.js
+                }
+            });
+        });
+
+        it("should load information from `parser` in .eslintrc with relative path.", function() {
+            var config = ConfigFile.load(getFixturePath("extends-chain-2/parser.eslintrc.json"));
+            var parserPath = getFixturePath("extends-chain-2/parser.js");
+
+            assert.deepEqual(config, {
+                env: {},
+                globals: {},
+                parser: parserPath,
+                parserOptions: {},
+                rules: {}
+            });
+        });
+
+        describe("even if it's in another directory,", function() {
+            var fixturePath = "";
+
+            before(function() {
+                var tempDir = temp.mkdirSync("eslint-test-chain");
+                var chain2 = getFixturePath("extends-chain-2");
+
+                fixturePath = path.join(tempDir, "extends-chain-2");
+                shell.cp("-r", chain2, fixturePath);
+            });
+
+            after(function() {
+                temp.cleanupSync();
+            });
+
+            it("should load information from `extends` chain in .eslintrc with relative path.", function() {
+                var config = ConfigFile.load(path.join(fixturePath, "relative.eslintrc.json"));
+
+                assert.deepEqual(config, {
+                    env: {},
+                    extends: "./node_modules/eslint-config-a/index.js",
+                    globals: {},
+                    parserOptions: {},
+                    rules: {
+                        a: 2,       // from node_modules/eslint-config-a/index.js
+                        relative: 2 // from node_modules/eslint-config-a/relative.js
+                    }
+                });
+            });
+
+            it("should load information from `parser` in .eslintrc with relative path.", function() {
+                var config = ConfigFile.load(path.join(fixturePath, "parser.eslintrc.json"));
+                var parserPath = path.join(fixturePath, "parser.js");
+
+                assert.deepEqual(config, {
+                    env: {},
+                    globals: {},
+                    parser: parserPath,
+                    parserOptions: {},
+                    rules: {}
+                });
             });
         });
 


### PR DESCRIPTION
Fixes #6450 

I'm not sure this fix is correct or not. I want to get any insights about `getBaseDir`.

And actually, this new test does not make sense. The test succeeds as well before this fix. The issue's error seems to be appeared only if eslint is installed to another package. I'm not sure how to write tests for this fix...