### PR TITLE
New: Allow conditional rules in eslint based on the environment

### DIFF
--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -89,6 +89,28 @@ module.exports = {
     applyEnvironments: function(config) {
         if (config.env && typeof config.env === "object") {
             debug("Apply environment settings to config");
+            var re = /^env:(\w+)\//;
+
+            var disallowedRules = Object.keys(config.rules).filter(function(rule) {
+                var match = re.exec(rule);
+
+                if (match) {
+                    var env = match[1];
+
+                    if (env.length && !(env in config.env)) {
+                        return true;
+                    }
+                }
+                return false;
+            });
+
+            disallowedRules.forEach(function(rule) {
+                debug("Removing conditional rule " + rule);
+                delete config.rules[rule];
+            });
+
+
+
             return this.merge(this.createEnvironmentConfig(config.env), config);
         }
 


### PR DESCRIPTION
This is a proposal to allow conditional rules that only apply when an
environment is set. The example case is to have a rule like
"env:dev/no-console": ["off"] which would disable the no-console rule
when you call eslint --env dev. This would allow for easy flexibility
to have different rules for different environments.


** THIS IS A WORK IN PROGRESS **
Right now it is to show the idea to see if folks think it has merit. I can pull the code out into a separate function, add tests etc. if this feature is accepted :-)

The associated issue is https://github.com/eslint/eslint/issues/6460