### PR TITLE
Fix: `strict` rule reports a syntax error for ES2016 (fixes #6405)

### DIFF
--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -38,8 +38,6 @@ In the **CommonJS** module system, a hidden function wraps each module and limit
 
 In **ECMAScript** modules, which always have strict mode semantics, the directives are unnecessary.
 
-Since **ECMAScript 2016**, `"use strict"` directive in a function with non-simple parameter list is a syntax error. This rule disallows such `"use strict"` directives. See also the examples of [function option](#function)
-
 ## Rule Details
 
 This rule requires or disallows strict mode directives.
@@ -48,6 +46,8 @@ This rule disallows strict mode directives, no matter which option is specified,
 
 * `"sourceType": "module"` that is, files are **ECMAScript** modules
 * `"impliedStrict": true` property in the `ecmaFeatures` object
+
+This rule disallows strict mode directives, no matter which option is specified, in functions with non-simple parameter lists (for example, parameter lists with default parameter values) because that is a syntax error in **ECMAScript 2016** and later. See the examples of the [function](#function) option.
 
 ## Options
 
@@ -129,10 +129,6 @@ function foo() {
 
 function foo() {
 }
-```
-
-```js
-/*eslint strict: ["error", "function"]*/
 
 (function() {
     function bar() {

--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -38,6 +38,8 @@ In the **CommonJS** module system, a hidden function wraps each module and limit
 
 In **ECMAScript** modules, which always have strict mode semantics, the directives are unnecessary.
 
+Since **ECMAScript 2016**, `"use strict"` directive in a function with non-simple parameter list is a syntax error. This rule disallows such `"use strict"` directives. See also the examples of [function option](#function)
+
 ## Rule Details
 
 This rule requires or disallows strict mode directives.
@@ -139,6 +141,22 @@ function foo() {
 }());
 ```
 
+```js
+/*eslint strict: ["error", "function"]*/
+/*eslint-env es6*/
+
+// Illegal "use strict" directive in function with non-simple parameter list.
+// This is a syntax error since ES2016.
+function foo(a = 1) {
+    "use strict";
+}
+
+// We cannot write "use strict" directive in this function.
+// So we have to wrap this function with a function with "use strict" directive.
+function foo(a = 1) {
+}
+```
+
 Examples of **correct** code for this rule with the `"function"` option:
 
 ```js
@@ -150,8 +168,19 @@ function foo() {
 
 (function() {
     "use strict";
+
     function bar() {
     }
+
+    function baz(a = 1) {
+    }
+}());
+
+var foo = (function() {
+    "use strict";
+
+    return function foo(a = 1) {
+    };
 }());
 ```
 

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -67,6 +67,11 @@ ruleTester.run("strict", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: ["function"]
         },
+        {
+            code: "(function() { 'use strict'; function foo(a = 0) { } }())",
+            parserOptions: {ecmaVersion: 6},
+            options: ["function"]
+        },
 
 
         // "safe" mode corresponds to "global" if ecmaFeatures.globalReturn is true, otherwise "function"
@@ -433,6 +438,80 @@ ruleTester.run("strict", rule, {
                 { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" },
                 { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" }
             ]
+        },
+
+        // Reports deprecated syntax: https://github.com/eslint/eslint/issues/6405
+        {
+            code: "function foo(a = 0) { 'use strict' }",
+            parserOptions: {ecmaVersion: 6},
+            options: [],
+            errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
+        },
+        {
+            code: "(function() { 'use strict'; function foo(a = 0) { 'use strict' } }())",
+            parserOptions: {ecmaVersion: 6},
+            options: [],
+            errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
+        },
+        {
+            code: "function foo(a = 0) { 'use strict' }",
+            parserOptions: {ecmaVersion: 6, ecmaFeatures: {globalReturn: true}},
+            options: [],
+            errors: [
+                "Use the global form of 'use strict'.",
+                "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."
+            ]
+        },
+        {
+            code: "'use strict'; function foo(a = 0) { 'use strict' }",
+            parserOptions: {ecmaVersion: 6, ecmaFeatures: {globalReturn: true}},
+            options: [],
+            errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
+        },
+        {
+            code: "function foo(a = 0) { 'use strict' }",
+            parserOptions: {ecmaVersion: 6},
+            options: ["never"],
+            errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
+        },
+        {
+            code: "function foo(a = 0) { 'use strict' }",
+            parserOptions: {ecmaVersion: 6},
+            options: ["global"],
+            errors: [
+                "Use the global form of 'use strict'.",
+                "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."
+            ]
+        },
+        {
+            code: "'use strict'; function foo(a = 0) { 'use strict' }",
+            parserOptions: {ecmaVersion: 6},
+            options: ["global"],
+            errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
+        },
+        {
+            code: "function foo(a = 0) { 'use strict' }",
+            parserOptions: {ecmaVersion: 6},
+            options: ["function"],
+            errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
+        },
+        {
+            code: "(function() { 'use strict'; function foo(a = 0) { 'use strict' } }())",
+            parserOptions: {ecmaVersion: 6},
+            options: ["function"],
+            errors: ["'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."]
+        },
+        {
+            code: "function foo(a = 0) { }",
+            parserOptions: {ecmaVersion: 6},
+            options: ["function"],
+            errors: ["Wrap this function in a function with 'use strict' directive."]
+        },
+        {
+            code: "(function() { function foo(a = 0) { } }())",
+            parserOptions: {ecmaVersion: 6},
+            options: ["function"],
+            errors: ["Use the function form of 'use strict'."]
         }
 
     ]


### PR DESCRIPTION
Fixes #6405.

I didn't remove warnings for functions with a non-simple parameter list as I followed https://github.com/eslint/eslint/issues/6377#issuecomment-226193450

- `function foo(a = 0) { 'use strict' }` is always warned: "'use strict' directive inside a function with non-simple parameter list throws a syntax error since ES2016."
- `function foo(a = 0) { }` is warned under `function` option: "Wrap this function in a function with 'use strict' directive."