### PR TITLE
Remove dead code in excuteOnFiles

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -585,7 +585,6 @@ CLIEngine.prototype = {
      */
     executeOnFiles: function(patterns) {
         var results = [],
-            processed = {},
             options = this.options,
             fileCache = this._fileCache,
             configHelper = new Config(options),
@@ -656,13 +655,6 @@ CLIEngine.prototype = {
                     debug("Skipping file since hasn't changed: " + filename);
 
                     /*
-                     * Adding the filename to the processed hashmap
-                     * so the reporting is not affected (showing a warning about .eslintignore being used
-                     * when it is not really used)
-                     */
-                    processed[filename] = true;
-
-                    /*
                      * Add the the cached results (always will be 0 error and
                      * 0 warnings). We should not cache results for files that
                      * failed, in order to guarantee that next execution will
@@ -676,8 +668,6 @@ CLIEngine.prototype = {
             }
 
             debug("Processing " + filename);
-
-            processed[filename] = true;
 
             var res = processFile(filename, configHelper, options);
 


### PR DESCRIPTION
The "processed" identifier is not read from anywhere within executeOnFiles. All tests pass after removing it.