### PR TITLE
Fix: Ensure config extends reads from the right spot (fixes #5450)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -377,18 +377,35 @@ function applyExtends(config, filePath, relativeTo) {
             parentPath = path.resolve(__dirname, "../../conf/eslint-all.js");
         } else if (isFilePath(parentPath)) {
 
+            debug("parentPath before:" + parentPath);
+
             /*
              * If the `extends` path is relative, use the directory of the current configuration
              * file as the reference point. Otherwise, use as-is.
              */
-            parentPath = (!isAbsolutePath(parentPath) ?
-                path.join(relativeTo || path.dirname(filePath), parentPath) :
-                parentPath
-            );
+            if (!isAbsolutePath(parentPath)) {
+                var dirname = path.dirname(filePath);
+
+                /*
+                 * Special case: if filePath is a package name (such as "foo" for eslint-config-foo)
+                 * then dirname will end up as just ".". When you pass "." into path.join(), it is
+                 * treated differently so if parentPath is "./foo.js" it becomes "foo.js". When that
+                 * happens, the rest of the logic breaks because "foo.js" looks like a package name.
+                 * So, we have to just not do the join in that situation. See:
+                 * https://github.com/eslint/eslint/issues/6450
+                 * https://github.com/eslint/eslint/issues/6358
+                 */
+                if (dirname !== ".") {
+                    parentPath = path.join(dirname, parentPath);
+                }
+
+            }
+
+            debug("parentPath after:" + parentPath);
         }
 
         try {
-            debug("Loading " + parentPath);
+            debug("Loading " + parentPath + " relative to " + relativeTo);
             return ConfigOps.merge(load(parentPath, false, relativeTo), previousValue);
         } catch (e) {
 
@@ -460,10 +477,15 @@ function normalizePackageName(name, prefix) {
  * @private
  */
 function resolve(filePath, relativeTo) {
+    debug("resolve(): " + filePath + "," + relativeTo);
+
     if (isFilePath(filePath)) {
+        debug("Path to resolve is a file path:" + filePath);
         return { filePath: path.resolve(relativeTo || "", filePath) };
     } else {
         var normalizedPackageName;
+
+        debug("filePath " + filePath + " is not a filepath, must be a package name");
 
         if (filePath.indexOf("plugin:") === 0) {
             var packagePath = filePath.substr(7, filePath.lastIndexOf("/") - 7);
@@ -493,6 +515,9 @@ function resolve(filePath, relativeTo) {
  * @private
  */
 function load(filePath, applyEnvironments, relativeTo) {
+
+    debug("load(): " + filePath + ", " + relativeTo);
+
     var resolvedPath = resolve(filePath, relativeTo),
         dirname = path.dirname(resolvedPath.filePath),
         basedir = getBaseDir(dirname),

--- a/tests/fixtures/config-file/extends-chain-2/relative.eslintrc.json
+++ b/tests/fixtures/config-file/extends-chain-2/relative.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    "extends": "./node_modules/eslint-config-a/index.js"
+}

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -642,12 +642,27 @@ describe("ConfigFile", function() {
             });
         });
 
-        it("should load information from `extends` chain with relative path.", function() {
+        it("should load information from `extends` chain in .eslintrc with relative path.", function() {
             var config = ConfigFile.load(getFixturePath("extends-chain-2/.eslintrc.json"));
 
             assert.deepEqual(config, {
                 env: {},
                 extends: "a",
+                globals: {},
+                parserOptions: {},
+                rules: {
+                    a: 2,       // from node_modules/eslint-config-a/index.js
+                    relative: 2 // from node_modules/eslint-config-a/relative.js
+                }
+            });
+        });
+
+        it("should load information from `extends` chain in non-.eslintrc file with relative path.", function() {
+            var config = ConfigFile.load(getFixturePath("extends-chain-2/relative.eslintrc.json"));
+
+            assert.deepEqual(config, {
+                env: {},
+                extends: "./node_modules/eslint-config-a/index.js",
                 globals: {},
                 parserOptions: {},
                 rules: {


### PR DESCRIPTION
I believe this should fix all of the issues with config `extends`. I don't have the energy to figure out a unit test for #6450, but I manually tested on a local copy of Jest (which had reported the problem) and it works. I also verified that https://github.com/eslint/eslint/issues/6358 is fixed by this as well.

If someone can figure out a good unit test, I'd appreciate it. (I'm guessing we probably just need to pass in something as `relativeTo`, I just don't have the extra energy to experiment.)