### PR TITLE
Docs: Fix typo in max-params examples

### DIFF
--- a/docs/rules/max-params.md
+++ b/docs/rules/max-params.md
@@ -37,7 +37,7 @@ let foo = (bar, baz, qux, qxx) => {
 };
 ```
 
-Examples of **correct** code for this rule with the default `{ "max": 4 }` option:
+Examples of **correct** code for this rule with the default `{ "max": 3 }` option:
 
 ```js
 /*eslint max-params: ["error", 3]*/


### PR DESCRIPTION
Original meaning inferred from earlier statements in the file, the header for the immediate example, and the code for the rule itself (on line 49). The docs described the default value as `4`, but the actual default value is `3`.