### PR TITLE
Docs: Consistent example headings & text bat2 #5446

### DIFF
--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -20,7 +20,9 @@ The second one is an object for more fine-grained configuration when the first o
 "arrow-body-style": ["error", "always"]
 ```
 
-When the rule is set to `"always"` the following patterns are considered problems:
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "always"]*/
@@ -28,7 +30,7 @@ When the rule is set to `"always"` the following patterns are considered problem
 let foo = () => 0;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 let foo = () => {
@@ -40,9 +42,9 @@ let foo = (retv, name) => {
 };
 ```
 
-### "as-needed"
+### as-needed
 
-When the rule is set to `"as-needed"` the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"as-needed"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed"]*/
@@ -61,7 +63,7 @@ let foo = () => {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"as-needed"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed"]*/
@@ -89,7 +91,9 @@ let foo = () => ({ bar: 0 });
 
 #### requireReturnForObjectLiteral
 
-When the rule is set to `"as-needed", { requireReturnForObjectLiteral: true }` the following patterns are considered problems:
+> This option is only applicalble when used in conjunction with the `"as-needed"` option.
+
+Examples of **incorrect** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed", { requireReturnForObjectLiteral: true }]*/
@@ -98,7 +102,7 @@ let foo = () => ({});
 let foo = () => ({ bar: 0 });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "requireReturnForObjectLiteral": true }` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "as-needed", { requireReturnForObjectLiteral: true }]*/
@@ -110,7 +114,7 @@ let foo = () => { return { bar: 0 }; };
 
 ### "never"
 
-When the rule is set to `"never"` the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "never"]*/
@@ -125,7 +129,7 @@ let foo = (retv, name) => {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint arrow-body-style: ["error", "never"]*/

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -57,7 +57,7 @@ You can set the option in configuration like this:
 
 ### "always"
 
-When the rule is set to `"always"` the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "always"]*/
@@ -71,7 +71,7 @@ a.then(foo => a);
 a(foo => { if (true) {}; });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "always"]*/
@@ -87,7 +87,7 @@ a.then((foo) => { if (true) {}; });
 
 #### If Statements
 
-One benefits of this option is that it prevents the incorrect use of arrow functions in conditionals:
+One of benefits of this option is that it prevents the incorrect use of arrow functions in conditionals:
 
 ```js
 /*eslint-env es6*/
@@ -104,6 +104,7 @@ if (a => b) {
 ```
 
 The contents of the `if` statement is an arrow function, not a comparison.
+
 If the arrow function is intentional, it should be wrapped in parens to remove ambiguity.
 
 ```js
@@ -141,10 +142,9 @@ var a = 1, b = 2, c = 3, d = 4;
 var f = (a) => b ? c: d;
 ```
 
-
 ### "as-needed"
 
-When the rule is set to `"as-needed"` the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"as-needed"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "as-needed"]*/
@@ -158,7 +158,7 @@ a.then((foo) => a);
 a((foo) => { if (true) {}; });
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"as-needed"` option:
 
 ```js
 /*eslint arrow-parens: ["error", "as-needed"]*/

--- a/docs/rules/arrow-spacing.md
+++ b/docs/rules/arrow-spacing.md
@@ -22,7 +22,10 @@ The default configuration is `{ "before": true, "after": true }`.
 
 `true` means there should be **one or more spaces** and `false` means **no spaces**.
 
-The following patterns are considered problems if `{ "before": true, "after": true }`.
+### both true
+
+Examples of **incorrect** code for this rule with the default `{ "before": true, "after": true }` option:
+
 
 ```js
 /*eslint arrow-spacing: "error"*/
@@ -38,7 +41,7 @@ a=> a;
 () =>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": true, "after": true }`.
+Examples of **correct** code for this rule with the default `{ "before": true, "after": true }` option:
 
 ```js
 /*eslint arrow-spacing: "error"*/
@@ -50,7 +53,9 @@ a => a;
 () => {'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": false, "after": false }`.
+### both false
+
+Examples of **correct** code for this rule with the `{ "before": false, "after": false }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": false }]*/
@@ -62,7 +67,9 @@ a=>a;
 ()=>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": true, "after": false }`.
+### before: true, after: false
+
+Examples of **correct** code for this rule with the `{ "before": true, "after": false }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": true, "after": false }]*/
@@ -74,7 +81,9 @@ a =>a;
 () =>{'\n'};
 ```
 
-The following patterns are not considered problems if `{ "before": false, "after": true }`.
+## before: false, after: true
+
+Examples of **correct** code for this rule with the `{ "before": false, "after": true }` option:
 
 ```js
 /*eslint arrow-spacing: ["error", { "before": false, "after": true }]*/

--- a/docs/rules/constructor-super.md
+++ b/docs/rules/constructor-super.md
@@ -10,7 +10,9 @@ This rule checks whether or not there is a valid `super()` call.
 
 This rule is aimed to flag invalid/missing `super()` calls.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/
@@ -38,7 +40,7 @@ class A extends null {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint constructor-super: "error"*/

--- a/docs/rules/generator-star-spacing.md
+++ b/docs/rules/generator-star-spacing.md
@@ -71,7 +71,11 @@ And the option has shorthand as a string keyword:
 "generator-star-spacing": ["error", "after"]
 ```
 
-When using `{"before": true, "after": false}` this placement will be enforced:
+## Examples
+
+### before
+
+Examples of **correct** code for this rule with the `"before"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": true, "after": false}]*/
@@ -84,7 +88,9 @@ var anonymous = function *() {};
 var shorthand = { *generator() {} };
 ```
 
-When using `{"before": false, "after": true}` this placement will be enforced:
+### after
+
+Examples of **correct** code for this rule with the `"after"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": false, "after": true}]*/
@@ -97,7 +103,9 @@ var anonymous = function* () {};
 var shorthand = { * generator() {} };
 ```
 
-When using `{"before": true, "after": true}` this placement will be enforced:
+### both
+
+Examples of **correct** code for this rule with the `"both"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": true, "after": true}]*/
@@ -110,7 +118,9 @@ var anonymous = function * () {};
 var shorthand = { * generator() {} };
 ```
 
-When using `{"before": false, "after": false}` this placement will be enforced:
+### neither
+
+Examples of **correct** code for this rule with the `"neither"` option:
 
 ```js
 /*eslint generator-star-spacing: ["error", {"before": false, "after": false}]*/

--- a/docs/rules/no-class-assign.md
+++ b/docs/rules/no-class-assign.md
@@ -15,7 +15,9 @@ But the modification is a mistake in most cases.
 
 This rule is aimed to flag modifying variables of class declarations.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/
@@ -56,7 +58,7 @@ let A = class A {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-class-assign: "error"*/

--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -19,7 +19,9 @@ foo.bar(); // goodbye
 
 This rule is aimed to flag the use of duplicate names in class members.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-dupe-class-members: "error"*/
@@ -41,7 +43,7 @@ class Foo {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-dupe-class-members: "error"*/

--- a/docs/rules/no-new-symbol.md
+++ b/docs/rules/no-new-symbol.md
@@ -12,7 +12,9 @@ This throws a `TypeError` exception.
 
 This rule is aimed at preventing the accidental calling of `Symbol` with the `new` operator.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-new-symbol: "error"*/
@@ -21,7 +23,7 @@ The following patterns are considered problems:
 var foo = new Symbol('foo');
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new-symbol: "error"*/

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -28,7 +28,9 @@ To restrict the use of all Node.js core imports (via https://github.com/nodejs/n
     ],
 ```
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -42,7 +44,7 @@ import fs from 'fs';
 import cluster from ' cluster ';
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -8,7 +8,9 @@ This rule checks `this`/`super` keywords in constructors, then reports those tha
 
 This rule is aimed to flag `this`/`super` keywords before `super()` callings.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-this-before-super: "error"*/
@@ -42,7 +44,7 @@ class A extends B {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-this-before-super: "error"*/

--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -16,6 +16,8 @@ var foo = {"a": "b"};
 
 This rule disallows unnecessary usage of computed property keys.
 
+## Examples
+
 Examples of **incorrect** code for this rule:
 
 ```js

--- a/docs/rules/no-useless-constructor.md
+++ b/docs/rules/no-useless-constructor.md
@@ -19,7 +19,9 @@ class A extends B {
 
 This rule flags class constructors that can be safely removed without changing how the class works.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-constructor: "error"*/
@@ -37,7 +39,7 @@ class A extends B {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-useless-constructor: "error"*/

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -21,7 +21,9 @@ console.log("We have " + count + " people and " + sandwiches.length + " sandwich
 
 This rule is aimed at discouraging the use of `var` and encouraging the use of `const` or `let` instead.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-var: "error"*/
@@ -30,7 +32,7 @@ var x = "y";
 var CONFIG = {};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-var: "error"*/


### PR DESCRIPTION
Main focus of these commits:

1. Ensure consistent headings in Examples section

2. Ensure valid code fence captions to get stylised code blocks

Other issues in the existing docs were largely overlooked and will be dealt with in future updates.

@pedrottimark Can you check if this has worked as expected?