### PR TITLE
Docs: Consistent example headings & text pt2 #5446

### DIFF
--- a/docs/rules/no-dupe-class-members.md
+++ b/docs/rules/no-dupe-class-members.md
@@ -19,7 +19,9 @@ foo.bar(); // goodbye
 
 This rule is aimed to flag the use of duplicate names in class members.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-dupe-class-members: "error"*/
@@ -41,7 +43,7 @@ class Foo {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-dupe-class-members: "error"*/

--- a/docs/rules/no-new-symbol.md
+++ b/docs/rules/no-new-symbol.md
@@ -12,7 +12,9 @@ This throws a `TypeError` exception.
 
 This rule is aimed at preventing the accidental calling of `Symbol` with the `new` operator.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-new-symbol: "error"*/
@@ -21,7 +23,7 @@ The following patterns are considered problems:
 var foo = new Symbol('foo');
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-new-symbol: "error"*/

--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -28,7 +28,9 @@ To restrict the use of all Node.js core imports (via https://github.com/nodejs/n
     ],
 ```
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/
@@ -42,7 +44,7 @@ import fs from 'fs';
 import cluster from ' cluster ';
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-restricted-imports: ["error", "fs"]*/

--- a/docs/rules/no-this-before-super.md
+++ b/docs/rules/no-this-before-super.md
@@ -8,7 +8,9 @@ This rule checks `this`/`super` keywords in constructors, then reports those tha
 
 This rule is aimed to flag `this`/`super` keywords before `super()` callings.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-this-before-super: "error"*/
@@ -42,7 +44,7 @@ class A extends B {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-this-before-super: "error"*/

--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -16,6 +16,8 @@ var foo = {"a": "b"};
 
 This rule disallows unnecessary usage of computed property keys.
 
+## Examples
+
 Examples of **incorrect** code for this rule:
 
 ```js

--- a/docs/rules/no-useless-constructor.md
+++ b/docs/rules/no-useless-constructor.md
@@ -19,7 +19,9 @@ class A extends B {
 
 This rule flags class constructors that can be safely removed without changing how the class works.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-useless-constructor: "error"*/
@@ -37,7 +39,7 @@ class A extends B {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-useless-constructor: "error"*/

--- a/docs/rules/no-var.md
+++ b/docs/rules/no-var.md
@@ -21,7 +21,9 @@ console.log("We have " + count + " people and " + sandwiches.length + " sandwich
 
 This rule is aimed at discouraging the use of `var` and encouraging the use of `const` or `let` instead.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint no-var: "error"*/
@@ -30,7 +32,7 @@ var x = "y";
 var CONFIG = {};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint no-var: "error"*/


### PR DESCRIPTION
This PR replaces #6487.

1. Ensure each doc has "Examples" heading, and that each
    option-specific example pair also has a suitable heading.

2. Ensure text above examples is consistent as per #5446

This PR does not attempt to address issues other than
those stated above; such issues will be dealt with on
subsequent sweeps of the docs detailed in #6444..

Note: Skipped no-duplicate-imports due to #6455, will
come back to that one at later date.