### PR TITLE
Docs: Consistent example headings & text pt3 (refs #5446)

### DIFF
--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -252,6 +252,7 @@ Examples of **correct** code for this rule when used without exceptions:
 
 Reflect.getOwnPropertyNames({})
 ```
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["getOwnPropertyNames"] }` option:
 
 ```js
@@ -280,6 +281,7 @@ Examples of **correct** code for this rule when used without exceptions:
 
 Reflect.preventExtensions({})
 ```
+
 Examples of **correct** code for this rule with the `{ "exceptions": ["preventExtensions"] }` option:
 
 ```js

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -31,7 +31,7 @@ These can be combined as much as you like. To make all methods exceptions (there
 
 ### Reflect.apply
 
-> Deprecates `Function.prototype.apply()` and `Function.prototype.call()`
+Deprecates `Function.prototype.apply()` and `Function.prototype.call()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -90,7 +90,7 @@ obj.foo.call(other, arg);
 
 ### Reflect.defineProperty
 
-> Deprecates `Object.defineProperty()`
+Deprecates `Object.defineProperty()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -119,7 +119,7 @@ Reflect.defineProperty({}, 'foo', {value: 1})
 
 ### Reflect.getOwnPropertyDescriptor
 
-> Deprecates `Object.getOwnPropertyDescriptor()`
+Deprecates `Object.getOwnPropertyDescriptor()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -148,7 +148,7 @@ Reflect.getOwnPropertyDescriptor({}, 'foo')
 
 ### Reflect.getPrototypeOf
 
-> Deprecates `Object.getPrototypeOf()`
+Deprecates `Object.getPrototypeOf()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -177,7 +177,7 @@ Reflect.getPrototypeOf({}, 'foo')
 
 ### Reflect.setPrototypeOf
 
-> Deprecates `Object.setPrototypeOf()`
+Deprecates `Object.setPrototypeOf()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -206,7 +206,7 @@ Reflect.setPrototypeOf({}, Object.prototype)
 
 ### Reflect.isExtensible
 
-> Deprecates `Object.isExtensible`
+Deprecates `Object.isExtensible`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -235,7 +235,7 @@ Reflect.isExtensible({})
 
 ### Reflect.getOwnPropertyNames
 
-> Deprecates `Object.getOwnPropertyNames()`
+Deprecates `Object.getOwnPropertyNames()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -264,7 +264,7 @@ Reflect.getOwnPropertyNames({})
 
 ### Reflect.preventExtensions
 
-> Deprecates `Object.preventExtensions()`
+Deprecates `Object.preventExtensions()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -293,7 +293,7 @@ Reflect.preventExtensions({})
 
 ### Reflect.deleteProperty
 
-> Deprecates the `delete` keyword
+Deprecates the `delete` keyword
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -312,7 +312,7 @@ delete bar; // deleting variable
 Reflect.deleteProperty(foo, 'bar');
 ```
 
-> Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md)
+Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md)
 
 Examples of **correct** code for this rule with the `{ "exceptions": ["delete"] }` option:
 

--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -18,20 +18,22 @@ The prefer-reflect rule will flag usage of any older method, suggesting to inste
 ### Exceptions
 
 ```
-"prefer-reflect": [<enabled>, { exceptions: [<...exceptions>] }]
+"prefer-reflect": [<enabled>, { "exceptions": [<...exceptions>] }]
 ```
 
 The `exceptions` option allows you to pass an array of methods names you'd like to continue to use in the old style.
 
-For example if you wish to use all Reflect methods, except for `Function.prototype.apply` then your config would look like `prefer-reflect: [2, { exceptions: ["apply"] }]`.
+For example if you wish to use all Reflect methods, except for `Function.prototype.apply` then your config would look like `prefer-reflect: [2, { "exceptions": ["apply"] }]`.
 
-If you want to use Reflect methods, but keep using the `delete` keyword, then your config would look like `prefer-reflect: [2, { exceptions: ["delete"] }]`.
+If you want to use Reflect methods, but keep using the `delete` keyword, then your config would look like `prefer-reflect: [2, { "exceptions": ["delete"] }]`.
 
-These can be combined as much as you like. To make all methods exceptions (thereby rendering this rule useless), use `prefer-reflect: [2, { exceptions: ["apply", "call", "defineProperty", "getOwnPropertyDescriptor", "getPrototypeOf", "setPrototypeOf", "isExtensible", "getOwnPropertyNames", "preventExtensions", "delete"] }]`
+These can be combined as much as you like. To make all methods exceptions (thereby rendering this rule useless), use `prefer-reflect: [2, { "exceptions": ["apply", "call", "defineProperty", "getOwnPropertyDescriptor", "getPrototypeOf", "setPrototypeOf", "isExtensible", "getOwnPropertyNames", "preventExtensions", "delete"] }]`
 
-### Reflect.apply (Function.prototype.apply/Function.prototype.call)
+### Reflect.apply
 
-The following patterns are considered problems:
+> Deprecates `Function.prototype.apply()` and `Function.prototype.call()`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -47,7 +49,7 @@ obj.foo.call(obj, arg);
 obj.foo.call(other, arg);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -62,35 +64,35 @@ Reflect.apply(obj.foo, obj, [arg]);
 Reflect.apply(obj.foo, other, [arg]);
 ```
 
-```js
-/*eslint prefer-reflect: ["error", { exceptions: ["apply"] }]*/
+Examples of **correct** code for this rule with the `{ "exceptions": ["apply"] }` option:
 
+```js
+/*eslint prefer-reflect: ["error", { "exceptions": ["apply"] }]*/
+
+// in addition to Reflect.apply(...):
 foo.apply(undefined, args);
 foo.apply(null, args);
 obj.foo.apply(obj, args);
 obj.foo.apply(other, args);
-Reflect.apply(undefined, args);
-Reflect.apply(null, args);
-Reflect.apply(obj.foo, obj, args);
-Reflect.apply(obj.foo, other, args);
 ```
 
-```js
-/*eslint prefer-reflect: ["error", { exceptions: ["call"] }]*/
+Examples of **correct** code for this rule with the `{ "exceptions": ["call"] }` option:
 
+```js
+/*eslint prefer-reflect: ["error", { "exceptions": ["call"] }]*/
+
+// in addition to Reflect.apply(...):
 foo.call(undefined, arg);
 foo.call(null, arg);
 obj.foo.call(obj, arg);
 obj.foo.call(other, arg);
-Reflect.apply(undefined, [arg]);
-Reflect.apply(null, [arg]);
-Reflect.apply(obj.foo, obj, [arg]);
-Reflect.apply(obj.foo, other, [arg]);
 ```
 
-### Reflect.defineProperty (Object.defineProperty)
+### Reflect.defineProperty
 
-The following patterns are considered problems:
+> Deprecates `Object.defineProperty()`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -98,7 +100,7 @@ The following patterns are considered problems:
 Object.defineProperty({}, 'foo', {value: 1})
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -106,16 +108,20 @@ The following patterns are not considered problems:
 Reflect.defineProperty({}, 'foo', {value: 1})
 ```
 
+Examples of **correct** code for this rule with the `{ "exceptions": ["defineProperty"] }` option:
+
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["defineProperty"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["defineProperty"] }]*/
 
 Object.defineProperty({}, 'foo', {value: 1})
 Reflect.defineProperty({}, 'foo', {value: 1})
 ```
 
-### Reflect.getOwnPropertyDescriptor (Object.getOwnPropertyDescriptor)
+### Reflect.getOwnPropertyDescriptor
 
-The following patterns are considered problems:
+> Deprecates `Object.getOwnPropertyDescriptor()`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -123,7 +129,7 @@ The following patterns are considered problems:
 Object.getOwnPropertyDescriptor({}, 'foo')
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -131,18 +137,20 @@ The following patterns are not considered problems:
 Reflect.getOwnPropertyDescriptor({}, 'foo')
 ```
 
-__config:__ `prefer-reflect: ["error", { exceptions: ["getOwnPropertyDescriptor"] }]`
+Examples of **correct** code for this rule with the `{ "exceptions": ["getOwnPropertyDescriptor"] }` option:
 
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["getOwnPropertyDescriptor"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["getOwnPropertyDescriptor"] }]*/
 
 Object.getOwnPropertyDescriptor({}, 'foo')
 Reflect.getOwnPropertyDescriptor({}, 'foo')
 ```
 
-### Reflect.getPrototypeOf (Object.getPrototypeOf)
+### Reflect.getPrototypeOf
 
-The following patterns are considered problems:
+> Deprecates `Object.getPrototypeOf()`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -150,7 +158,7 @@ The following patterns are considered problems:
 Object.getPrototypeOf({}, 'foo')
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -158,16 +166,20 @@ The following patterns are not considered problems:
 Reflect.getPrototypeOf({}, 'foo')
 ```
 
+Examples of **correct** code for this rule with the `{ "exceptions": ["getPrototypeOf"] }` option:
+
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["getPrototypeOf"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["getPrototypeOf"] }]*/
 
 Object.getPrototypeOf({}, 'foo')
 Reflect.getPrototypeOf({}, 'foo')
 ```
 
-### Reflect.setPrototypeOf (Object.setPrototypeOf)
+### Reflect.setPrototypeOf
 
-The following patterns are considered problems:
+> Deprecates `Object.setPrototypeOf()`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -175,7 +187,7 @@ The following patterns are considered problems:
 Object.setPrototypeOf({}, Object.prototype)
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -183,18 +195,20 @@ The following patterns are not considered problems:
 Reflect.setPrototypeOf({}, Object.prototype)
 ```
 
-__config:__ `prefer-reflect: ["error", { exceptions: ["setPrototypeOf"] }]`
+Examples of **correct** code for this rule with the `{ "exceptions": ["setPrototypeOf"] }` option:
 
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["setPrototypeOf"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["setPrototypeOf"] }]*/
 
 Object.setPrototypeOf({}, Object.prototype)
 Reflect.setPrototypeOf({}, Object.prototype)
 ```
 
-### Reflect.isExtensible (Object.isExtensible)
+### Reflect.isExtensible
 
-The following patterns are considered problems:
+> Deprecates `Object.isExtensible`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -202,7 +216,7 @@ The following patterns are considered problems:
 Object.isExtensible({})
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -210,16 +224,20 @@ The following patterns are not considered problems:
 Reflect.isExtensible({})
 ```
 
+Examples of **correct** code for this rule with the `{ "exceptions": ["isExtensible"] }` option:
+
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["isExtensible"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["isExtensible"] }]*/
 
 Object.isExtensible({})
 Reflect.isExtensible({})
 ```
 
-### Reflect.getOwnPropertyNames (Object.getOwnPropertyNames)
+### Reflect.getOwnPropertyNames
 
-The following patterns are considered problems:
+> Deprecates `Object.getOwnPropertyNames()`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -227,24 +245,27 @@ The following patterns are considered problems:
 Object.getOwnPropertyNames({})
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
 
 Reflect.getOwnPropertyNames({})
 ```
+Examples of **correct** code for this rule with the `{ "exceptions": ["getOwnPropertyNames"] }` option:
 
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["getOwnPropertyNames"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["getOwnPropertyNames"] }]*/
 
 Object.getOwnPropertyNames({})
 Reflect.getOwnPropertyNames({})
 ```
 
-### Reflect.preventExtensions (Object.preventExtensions)
+### Reflect.preventExtensions
 
-The following patterns are considered problems:
+> Deprecates `Object.preventExtensions()`
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
@@ -252,50 +273,54 @@ The following patterns are considered problems:
 Object.preventExtensions({})
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
 
 Reflect.preventExtensions({})
 ```
+Examples of **correct** code for this rule with the `{ "exceptions": ["preventExtensions"] }` option:
 
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["preventExtensions"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["preventExtensions"] }]*/
 
 Object.preventExtensions({})
 Reflect.preventExtensions({})
 ```
 
-### Reflect.deleteProperty (The `delete` keyword)
+### Reflect.deleteProperty
 
-The following patterns are considered problems:
+> Deprecates the `delete` keyword
+
+Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
 
-delete foo.bar;
+delete foo.bar; // deleting object property
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
 
-delete bar; // Does not reference an object, just a var
+delete bar; // deleting variable
 Reflect.deleteProperty(foo, 'bar');
 ```
 
-(Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md))
+> Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md)
+
+Examples of **correct** code for this rule with the `{ "exceptions": ["delete"] }` option:
 
 ```js
-/*eslint prefer-reflect: ["error", { exceptions: ["delete"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["delete"] }]*/
 
 delete bar
 delete foo.bar
 Reflect.deleteProperty(foo, 'bar');
 ```
-
 
 ## When Not To Use It
 


### PR DESCRIPTION
Just a single doc in this batch due to variance in changes:

Headings were already present, however they were
over-complicated; I separated out the old (ES3/5) feature
from the heading and put it in a block quote to distinguish
it from the new (Reflect API) feature.

As per previous batches, ensured text above examples is
consistent as per #5446

This PR did not focus on issues other than those stated
above; such issues will be dealt with on subsequent
sweeps of the docs detailed in #6444.