### PR TITLE
Docs: Consistent example headings & text pt4 (refs #5446)

### DIFF
--- a/docs/rules/prefer-rest-params.md
+++ b/docs/rules/prefer-rest-params.md
@@ -9,7 +9,9 @@ We can use that feature for variadic functions instead of the `arguments` variab
 
 This rule is aimed to flag usage of `arguments` variables.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 function foo() {
@@ -22,7 +24,7 @@ function foo(action) {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 function foo(...args) {

--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -18,9 +18,11 @@ Math.max(...args);
 
 ## Rule Details
 
-This rule is aimed to flag usage of `Function.prototype.apply()` that can be replaced with the spread operator.
+This rule is aimed to flag usage of `Function.prototype.apply()` in situations where the spread operator could be used instead.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint prefer-spread: "error"*/
@@ -32,7 +34,7 @@ foo.apply(null, args);
 obj.foo.apply(obj, args);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint prefer-spread: "error"*/
@@ -51,8 +53,7 @@ obj.foo.apply(obj, [1, 2, 3]);
 
 Known limitations:
 
-This rule analyzes code statically to check whether or not the `this` argument is changed.
-So if the `this` argument is computed in a dynamic expression, this rule cannot detect a violation.
+This rule analyzes code statically to check whether or not the `this` argument is changed. So, if the `this` argument is computed in a dynamic expression, this rule cannot detect a violation.
 
 ```js
 /*eslint prefer-spread: "error"*/

--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -16,7 +16,9 @@ var str = `Hello, ${name}!`;
 
 This rule is aimed to flag usage of `+` operators with strings.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint prefer-template: "error"*/
@@ -25,7 +27,7 @@ var str = "Hello, " + name + "!";
 var str = "Time: " + (12 * 60 * 60 * 1000);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint prefer-template: "error"*/
@@ -47,4 +49,5 @@ In ES2015 (ES6) or later, if you don't want to be notified about string concaten
 
 ## Related Rules
 
+* [no-useless-concat](no-useless-concat.md)
 * [quotes](quotes.md)

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -1,10 +1,12 @@
 # Disallow generator functions that do not have `yield` (require-yield)
 
-This rule generates warnings for generator functions that do not have the `yield` keyword.
-
 ## Rule Details
 
-The following patterns are considered problems:
+This rule generates warnings for generator functions that do not have the `yield` keyword.
+
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint require-yield: "error"*/
@@ -15,7 +17,7 @@ function* foo() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint require-yield: "error"*/

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -27,15 +27,35 @@ When declaring multiple imports, a sorted list of import declarations make it ea
 
 This rule checks all import declarations and verifies that all imports are first sorted by the used member syntax and then alphabetically by the first member or alias name.
 
-The sort order of import declarations based on the member syntax can be configured via the `memberSyntaxSortOrder` option.
-The default member syntax sort order is:
+## Options
 
-- `none` - import module without exported bindings.
-- `all` - import all members provided by exported bindings.
-- `multiple` - import multiple members.
-- `single` - import single member.
+This rule accepts an object with its properties as
 
-The following example shows correct sorted import declarations:
+* `ignoreCase` (default: `false`)
+* `ignoreMemberSort` (default: `false`)
+* `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`); all 4 items must be present in the array, but you can change the order:
+	* `none` = import module without exported bindings.
+	* `all` = import all members provided by exported bindings.
+	* `multiple` = import multiple members.
+	* `single` = import single member.
+
+Default option settings are:
+
+```json
+{
+    "sort-imports": ["error", {
+        "ignoreCase": false,
+        "ignoreMemberSort": false,
+        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
+    }]
+}
+```
+
+## Examples
+
+### Default settings
+
+Examples of **correct** code for this rule when using default options:
 
 ```js
 /*eslint sort-imports: "error"*/
@@ -46,9 +66,23 @@ import {alpha, beta} from 'alpha.js';
 import {delta, gamma} from 'delta.js';
 import a from 'baz.js';
 import b from 'qux.js';
+
+/*eslint sort-imports: "error"*/
+import a from 'foo.js';
+import b from 'bar.js';
+import c from 'baz.js';
+
+/*eslint sort-imports: "error"*/
+import 'foo.js'
+import * from 'bar.js';
+import {a, b} from 'baz.js';
+import c from 'qux.js';
+
+/*eslint sort-imports: "error"*/
+import {a, b, c} from 'foo.js'
 ```
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule when using default options:
 
 ```js
 /*eslint sort-imports: "error"*/
@@ -75,50 +109,11 @@ import * as b from 'bar.js';
 import {b, a, c} from 'foo.js'
 ```
 
-The following patterns are not considered problems:
-
-```js
-/*eslint sort-imports: "error"*/
-import a from 'foo.js';
-import b from 'bar.js';
-import c from 'baz.js';
-
-/*eslint sort-imports: "error"*/
-import 'foo.js'
-import * from 'bar.js';
-import {a, b} from 'baz.js';
-import c from 'qux.js';
-
-/*eslint sort-imports: "error"*/
-import {a, b, c} from 'foo.js'
-```
-
-
-## Options
-
-This rule accepts an object with its properties as
-
-- `ignoreCase` (default: `false`)
-- `ignoreMemberSort` (default: `false`)
-- `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`)
-
-Default option settings are
-
-```json
-{
-    "sort-imports": ["error", {
-        "ignoreCase": false,
-        "ignoreMemberSort": false,
-        "memberSyntaxSortOrder": ["none", "all", "multiple", "single"]
-    }]
-}
-```
-
 ### `ignoreCase`
 
 When `true` the rule ignores the case-sensitivity of the imports local name.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{ "ignoreCase": true }` option:
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreCase": true }]*/
@@ -127,7 +122,7 @@ import B from 'foo.js';
 import a from 'bar.js';
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "ignoreCase": true }` option:
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreCase": true }]*/
@@ -143,14 +138,14 @@ Default is `false`.
 
 Ignores the member sorting within a `multiple` member import declaration.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `{ "ignoreMemberSort": false }` option:
 
 ```js
-/*eslint sort-imports: "error"*/
+/*eslint sort-imports: ["error", { "ignoreMemberSort": false }]*/
 import {b, a, c} from 'foo.js'
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "ignoreMemberSort": true }` option:
 
 ```js
 /*eslint sort-imports: ["error", { "ignoreMemberSort": true }]*/
@@ -161,16 +156,16 @@ Default is `false`.
 
 ### `memberSyntaxSortOrder`
 
-The member syntax sort order can be configured with this option. There are four different styles and the default member syntax sort order is:
+There are four different styles and the default member syntax sort order is:
 
 - `none` - import module without exported bindings.
 - `all` - import all members provided by exported bindings.
 - `multiple` - import multiple members.
 - `single` - import single member.
 
-Use this option if you want a different sort order. Every style must be defined in the sort order (There shall be four items in the array).
+All four options must be specified in the array, but you can customise their order.
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `{ "memberSyntaxSortOrder": ["none", "all", "multiple", "single"] }` option:
 
 ```js
 /*eslint sort-imports: "error"*/
@@ -178,14 +173,18 @@ import a from 'foo.js';
 import * as b from 'bar.js';
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "memberSyntaxSortOrder": ['single', 'all', 'multiple', 'none'] }` option:
 
 ```js
 /*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['single', 'all', 'multiple', 'none'] }]*/
 
 import a from 'foo.js';
 import * as b from 'bar.js';
+```
 
+Examples of **correct** code for this rule with the `{ "memberSyntaxSortOrder": ['all', 'single', 'multiple', 'none'] }` option:
+
+```
 /*eslint sort-imports: ["error", { "memberSyntaxSortOrder": ['all', 'single', 'multiple', 'none'] }]*/
 
 import * as foo from 'foo.js';

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -34,10 +34,10 @@ This rule accepts an object with its properties as
 * `ignoreCase` (default: `false`)
 * `ignoreMemberSort` (default: `false`)
 * `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`); all 4 items must be present in the array, but you can change the order:
-	* `none` = import module without exported bindings.
-	* `all` = import all members provided by exported bindings.
-	* `multiple` = import multiple members.
-	* `single` = import single member.
+  * `none` = import module without exported bindings.
+  * `all` = import all members provided by exported bindings.
+  * `multiple` = import multiple members.
+  * `single` = import single member.
 
 Default option settings are:
 
@@ -158,10 +158,10 @@ Default is `false`.
 
 There are four different styles and the default member syntax sort order is:
 
-- `none` - import module without exported bindings.
-- `all` - import all members provided by exported bindings.
-- `multiple` - import multiple members.
-- `single` - import single member.
+* `none` - import module without exported bindings.
+* `all` - import all members provided by exported bindings.
+* `multiple` - import multiple members.
+* `single` - import single member.
 
 All four options must be specified in the array, but you can customise their order.
 

--- a/docs/rules/sort-imports.md
+++ b/docs/rules/sort-imports.md
@@ -34,10 +34,10 @@ This rule accepts an object with its properties as
 * `ignoreCase` (default: `false`)
 * `ignoreMemberSort` (default: `false`)
 * `memberSyntaxSortOrder` (default: `["none", "all", "multiple", "single"]`); all 4 items must be present in the array, but you can change the order:
-  * `none` = import module without exported bindings.
-  * `all` = import all members provided by exported bindings.
-  * `multiple` = import multiple members.
-  * `single` = import single member.
+    * `none` = import module without exported bindings.
+    * `all` = import all members provided by exported bindings.
+    * `multiple` = import multiple members.
+    * `single` = import single member.
 
 Default option settings are:
 

--- a/docs/rules/template-curly-spacing.md
+++ b/docs/rules/template-curly-spacing.md
@@ -3,7 +3,8 @@
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
 We can embed expressions in template strings with using a pair of `${` and `}`.
-This rule can force usage of spacing inside of the curly brace pair according to style guides.
+
+This rule can force usage of spacing _within_ the curly brace pair according to style guides.
 
 ```js
 let hello = `hello, ${people.name}!`;
@@ -26,7 +27,11 @@ This rule has one option which has either `"never"` or `"always"` as value.
 * `"never"` (by default) - Disallows spaces inside of the curly brace pair.
 * `"always"` - Requires one or more spaces inside of the curly brace pair.
 
-The following patterns are considered problems when configured `"never"`:
+## Examples
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint template-curly-spacing: "error"*/
@@ -37,18 +42,7 @@ The following patterns are considered problems when configured `"never"`:
 `hello, ${ people.name }!`;
 ```
 
-The following patterns are considered problems when configured `"always"`:
-
-```js
-/*eslint template-curly-spacing: ["error", "always"]*/
-
-`hello, ${ people.name}!`;
-`hello, ${people.name }!`;
-
-`hello, ${people.name}!`;
-```
-
-The following patterns are not considered problems when configured `"never"`:
+Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint template-curly-spacing: "error"*/
@@ -60,7 +54,20 @@ The following patterns are not considered problems when configured `"never"`:
 }!`;
 ```
 
-The following patterns are not considered problems when configured `"always"`:
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```js
+/*eslint template-curly-spacing: ["error", "always"]*/
+
+`hello, ${ people.name}!`;
+`hello, ${people.name }!`;
+
+`hello, ${people.name}!`;
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint template-curly-spacing: ["error", "always"]*/

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -6,6 +6,11 @@
 
 This rule enforces spacing around the `*` in `yield*` expressions.
 
+To use this rule you either need to [use the `es6` environment](../user-guide/configuring.md#specifying-environments) or
+[set `ecmaVersion` to `6` in `parserOptions`](../user-guide/configuring.md#specifying-parser-options).
+
+## Options
+
 The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`.
 
 * `before` enforces spacing between the `yield` and the `*`.
@@ -31,7 +36,11 @@ The option also has a string shorthand:
 "yield-star-spacing": ["error", "after"]
 ```
 
-When using `"after"` this spacing will be enforced:
+## Examples
+
+### after
+
+Examples of **correct** code for this rule with the default `"after"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "after"]*/
@@ -42,7 +51,9 @@ function* generator() {
 }
 ```
 
-When using `"before"` this spacing will be enforced:
+### before
+
+Examples of **correct** code for this rule with the `"before"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "before"]*/
@@ -53,7 +64,9 @@ function *generator() {
 }
 ```
 
-When using `"both"` this spacing will be enforced:
+### both
+
+Examples of **correct** code for this rule with the `"both"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "both"]*/
@@ -64,7 +77,9 @@ function * generator() {
 }
 ```
 
-When using `"neither"` this spacing will be enforced:
+### neither
+
+Examples of **correct** code for this rule with the `"neither"` option:
 
 ```js
 /*eslint yield-star-spacing: ["error", "neither"]*/
@@ -74,9 +89,6 @@ function*generator() {
   yield*other();
 }
 ```
-
-To use this rule you either need to [use the `es6` environment](../user-guide/configuring.md#specifying-environments) or
-[set `ecmaVersion` to `6` in `parserOptions`](../user-guide/configuring.md#specifying-parser-options).
 
 ## When Not To Use It
 


### PR DESCRIPTION
Final batch of es6 docs for this sweep!

1. Ensure each doc has "Examples" heading, and that each
option-specific example pair also has a suitable heading.

2. Ensure text above examples is consistent as per #5446

This PR does not attempt to address issues other than
those stated above; such issues will be dealt with on
subsequent sweeps of the docs detailed in #6444..