### PR TITLE
Update: Add fixer for arrow-parens (fixes #4766)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -231,7 +231,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 These rules relate to ES6, also known as ES2015:
 
 * [arrow-body-style](arrow-body-style.md): require braces around arrow function bodies
-* [arrow-parens](arrow-parens.md): require parentheses around arrow function arguments
+* [arrow-parens](arrow-parens.md): require parentheses around arrow function arguments (fixable)
 * [arrow-spacing](arrow-spacing.md): enforce consistent spacing before and after the arrow in arrow functions (fixable)
 * [constructor-super](constructor-super.md): require `super()` calls in constructors (recommended)
 * [generator-star-spacing](generator-star-spacing.md): enforce consistent spacing around `*` operators in generator functions (fixable)

--- a/docs/rules/arrow-parens.md
+++ b/docs/rules/arrow-parens.md
@@ -1,5 +1,7 @@
 # Require parens in arrow function arguments (arrow-parens)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Arrow functions can omit parentheses when they have exactly one parameter. In all other cases the parameter(s) must
 be wrapped in parentheses. This rule enforces the consistent use of parentheses in arrow functions.
 

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -16,6 +16,8 @@ module.exports = {
             recommended: false
         },
 
+        fixable: "code",
+
         schema: [
             {
                 enum: ["always", "as-needed"]
@@ -41,7 +43,19 @@ module.exports = {
             // as-needed: x => x
             if (asNeeded && node.params.length === 1 && node.params[0].type === "Identifier") {
                 if (token.type === "Punctuator" && token.value === "(") {
-                    context.report(node, asNeededMessage);
+                    context.report({
+                        node: node,
+                        message: asNeededMessage,
+                        fix: function(fixer) {
+                            var paramToken = context.getTokenAfter(token);
+                            var closingParenToken = context.getTokenAfter(paramToken);
+
+                            return fixer.replaceTextRange([
+                                token.range[0],
+                                closingParenToken.range[1]
+                            ], paramToken.value);
+                        }
+                    });
                 }
                 return;
             }
@@ -51,7 +65,13 @@ module.exports = {
 
                 // (x) => x
                 if (after.value !== ")") {
-                    context.report(node, message);
+                    context.report({
+                        node: node,
+                        message: message,
+                        fix: function(fixer) {
+                            return fixer.replaceText(token, "(" + token.value + ")");
+                        }
+                    });
                 }
             }
         }

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -44,6 +44,7 @@ var type = "ArrowFunctionExpression";
 var invalid = [
     {
         code: "a => {}",
+        output: "(a) => {}",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -54,6 +55,7 @@ var invalid = [
     },
     {
         code: "a => a",
+        output: "(a) => a",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -64,6 +66,7 @@ var invalid = [
     },
     {
         code: "a => {\n}",
+        output: "(a) => {\n}",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -74,6 +77,7 @@ var invalid = [
     },
     {
         code: "a.then(foo => {});",
+        output: "a.then((foo) => {});",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -84,6 +88,7 @@ var invalid = [
     },
     {
         code: "a.then(foo => a);",
+        output: "a.then((foo) => a);",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -94,6 +99,7 @@ var invalid = [
     },
     {
         code: "a(foo => { if (true) {}; });",
+        output: "a((foo) => { if (true) {}; });",
         parserOptions: { ecmaVersion: 6 },
         errors: [{
             line: 1,
@@ -106,6 +112,7 @@ var invalid = [
     // as-needed
     {
         code: "(a) => a",
+        output: "a => a",
         options: ["as-needed"],
         parserOptions: { ecmaVersion: 6 },
         errors: [{
@@ -117,6 +124,7 @@ var invalid = [
     },
     {
         code: "(b) => b",
+        output: "b => b",
         options: ["as-needed"],
         parserOptions: { ecmaVersion: 6 },
         errors: [{


### PR DESCRIPTION
This PR adds auto fix for arrow-parens rule. It removes the params as-needed and adds them when set to always.