### PR TITLE
New: Add ignorePropertiesFor to no-param-reassign

### DIFF
--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -22,7 +22,13 @@ module.exports = {
             {
                 type: "object",
                 properties: {
-                    props: { type: "boolean" }
+                    props: { type: "boolean" },
+                    ignorePropertiesFor: {
+                        type: "array",
+                        items: {
+                            type: "string"
+                        }
+                    }
                 },
                 additionalProperties: false
             }
@@ -31,6 +37,7 @@ module.exports = {
 
     create(context) {
         const props = context.options[0] && Boolean(context.options[0].props);
+        const ignorePropertiesFor = context.options[0] && context.options[0].ignorePropertiesFor || [];
 
         /**
          * Checks whether or not the reference modifies properties of its variable.
@@ -105,6 +112,11 @@ module.exports = {
                     context.report({ node: identifier, message: "Assignment to function parameter '{{name}}'.", data: { name: identifier.name } });
                 } else if (props && isModifyingProp(reference)) {
                     context.report({ node: identifier, message: "Assignment to property of function parameter '{{name}}'.", data: { name: identifier.name } });
+                } else if (props && isModifyingProp(reference) && ignorePropertiesFor.indexOf(identifier.name) === -1) {
+                    context.report(
+                        identifier,
+                        "Assignment to property of function parameter '{{name}}'.",
+                        { name: identifier.name });
                 }
             }
         }

--- a/tests/lib/rules/no-param-reassign.js
+++ b/tests/lib/rules/no-param-reassign.js
@@ -30,7 +30,11 @@ ruleTester.run("no-param-reassign", rule, {
         { code: "function foo(a) { [a.b] = []; }", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(a) { bar(a.b).c = 0; }", options: [{ props: true }] },
         { code: "function foo(a) { data[a.b] = 0; }", options: [{ props: true }] },
-        { code: "function foo(a) { +a.b; }", options: [{ props: true }] }
+        { code: "function foo(a) { +a.b; }", options: [{ props: true }] },
+        { code: "function foo($scope) { $scope.valid = true; }", options: [{ignorePropertiesFor: ["$scope"]}] },
+        { code: "function foo($scope) { $scope.valid = true; }", options: [{props: false, ignorePropertiesFor: ["$scope"]}] },
+        { code: "function foo($scope) { $scope.valid = true; }", options: [{props: true, ignorePropertiesFor: ["$scope"]}] },
+        { code: "function foo($scope) { $scope.valid = true; }", options: [{props: false}] }
     ],
 
     invalid: [
@@ -71,6 +75,26 @@ ruleTester.run("no-param-reassign", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: [{ props: true }],
             errors: [{ message: "Assignment to property of function parameter 'bar'." }]
+        },
+        {
+            code: "function foo($scope) { $scope = true; }",
+            options: [{ignorePropertiesFor: ["$scope"]}],
+            errors: [{ message: "Assignment to function parameter '$scope'." }]
+        },
+        {
+            code: "function foo($scope) { $scope = true; }",
+            options: [{props: false, ignorePropertiesFor: ["$scope"]}],
+            errors: [{ message: "Assignment to function parameter '$scope'." }]
+        },
+        {
+            code: "function foo($scope) { $scope = true; }",
+            options: [{props: true, ignorePropertiesFor: ["$scope"]}],
+            errors: [{ message: "Assignment to function parameter '$scope'." }]
+        },
+        {
+            code: "function foo($scope) { $scope.invalid = true; }",
+            options: [{props: true}],
+            errors: [{ message: "Assignment to property of function parameter '$scope'." }]
         }
     ]
 });


### PR DESCRIPTION
This helps keeping the rule on and strict when using angular
where you frequently see

``` js
app.controller('MyCtrl', function($scope) {
  $scope.something = true;
});
```

(fixes #6505)
