### PR TITLE
Docs: Add "Proposing a Rule Change" link to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ Before filing an issue, please be sure to read the guidelines for what you're re
 
 * [Bug Report](http://eslint.org/docs/developer-guide/contributing/reporting-bugs)
 * [Propose a New Rule](http://eslint.org/docs/developer-guide/contributing/new-rules)
+* [Proposing a Rule Change](http://eslint.org/docs/developer-guide/contributing/rule-changes)
 * [Request a Change](http://eslint.org/docs/developer-guide/contributing/changes)
 
 ## Contributing Code


### PR DESCRIPTION
This gets CONTRIBUTING.md and README.md in sync in terms of providing guidance for different types of issues.