### PR TITLE
Docs: Consistent example heading and caption (Refs #5446)

### DIFF
--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -13,19 +13,23 @@ if (a) {
 }
 ```
 
-Since it's good to have a consistent code style, you should either always write
-padded blocks or never do it.
+Since it's good to have a consistent code style, you should either always write padded blocks or never do it.
 
 ## Rule Details
 
 This rule enforces consistent padding within blocks.
 
+## Options
+
 This rule takes one argument, which can be an string or an object. If it is `"always"` (the default) then block statements must start **and** end with a blank line. If `"never"`, then block statements should neither start nor end with a blank line. By default, this rule ignores padding in switch statements and classes.
 
 If you want to enforce padding within switches and classes, a configuration object can be passed as the rule argument to configure the cases separately ( e.g. `{ "blocks": "always", "switches": "always", "classes": "always" }` ).
 
+## Examples
 
-The following patterns are considered problems when set to `"always"`:
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint padded-blocks: ["error", "always"]*/
@@ -58,7 +62,7 @@ if (a) {
 }
 ```
 
-The following patterns are not considered problems when set to `"always"`:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint padded-blocks: ["error", "always"]*/
@@ -84,7 +88,9 @@ if (a) {
 }
 ```
 
-The following patterns are considered problems when set to `"never"`:
+### never
+
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint padded-blocks: ["error", "never"]*/
@@ -113,7 +119,7 @@ if (a) {
 }
 ```
 
-The following patterns are not considered problems when set to `"never"`:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint padded-blocks: ["error", "never"]*/
@@ -128,7 +134,9 @@ if (a)
 }
 ```
 
-The following patterns are considered problems when configured `{ "switches": "always" }`:
+### switches
+
+Examples of **incorrect** code for this rule with the `{ "switches": "always" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "switches": "always" }]*/
@@ -138,7 +146,7 @@ switch (a) {
 }
 ```
 
-The following patterns are not considered problems when configured `{ "switches": "always" }`:
+Examples of **correct** code for this rule with the `{ "switches": "always" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "switches": "always" }]*/
@@ -154,7 +162,7 @@ if (a) {
 }
 ```
 
-The following patterns are considered problems when configured `{ "switches": "never" }`:
+Examples of **incorrect** code for this rule with the `{ "switches": "never" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "switches": "never" }]*/
@@ -166,7 +174,7 @@ switch (a) {
 }
 ```
 
-The following patterns are not considered problems when configured `{ "switches": "never" }`:
+Examples of **correct** code for this rule with the `{ "switches": "never" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "switches": "never" }]*/
@@ -182,7 +190,9 @@ if (a) {
 }
 ```
 
-The following patterns are considered problems when configured `{ "classes": "always" }`:
+### classes
+
+Examples of **incorrect** code for this rule with the `{ "classes": "always" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "classes": "always" }]*/
@@ -193,7 +203,7 @@ class  A {
 }
 ```
 
-The following patterns are not considered problems when configured `{ "classes": "always" }`:
+Examples of **correct** code for this rule with the `{ "classes": "always" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "classes": "always" }]*/
@@ -206,7 +216,7 @@ class  A {
 }
 ```
 
-The following patterns are considered problems when configured `{ "classes": "never" }`:
+Examples of **incorrect** code for this rule with the `{ "classes": "never" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "classes": "never" }]*/
@@ -219,7 +229,7 @@ class  A {
 }
 ```
 
-The following patterns are not considered problems when configured `{ "classes": "never" }`:
+Examples of **correct** code for this rule with the `{ "classes": "never" }` option:
 
 ```js
 /*eslint padded-blocks: ["error", { "classes": "never" }]*/

--- a/docs/rules/space-before-blocks.md
+++ b/docs/rules/space-before-blocks.md
@@ -17,17 +17,17 @@ This rule will enforce consistency of spacing before blocks. It is only applied 
 ## Options
 
 This rule takes one argument. If it is `"always"` then blocks must always have at least one preceding space. If `"never"`
-then all blocks should never have any preceding space. If different spacing is desired for function
-blocks, keyword blocks and classes, an optional configuration object can be passed as the rule argument to
-configure the cases separately.
+then all blocks should never have any preceding space.
+
+If different spacing is desired for function blocks, keyword blocks and classes, an optional configuration object can be passed as the rule argument to configure the cases separately.
 
 ( e.g. `{ "functions": "never", "keywords": "always", "classes": "always" }` )
 
 The default is `"always"`.
 
-### "always"
+### always
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-blocks: "error"*/
@@ -49,7 +49,7 @@ class Foo{
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-blocks: "error"*/
@@ -74,9 +74,9 @@ for (;;) {
 try {} catch(a) {}
 ```
 
-### "never"
+### never
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-blocks: ["error", "never"]*/
@@ -94,7 +94,7 @@ for (;;) {
 try {} catch(a) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-blocks: ["error", "never"]*/
@@ -116,7 +116,43 @@ class Foo{
 }
 ```
 
-The following patterns are considered problems when configured `{ "functions": "never", "keywords": "always", "classes": "never" }`:
+### functions
+
+Examples of **incorrect** code for this rule with the `{ "functions": "always", "keywords": "never", "classes": "never" }` option:
+
+```js
+/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
+/*eslint-env es6*/
+
+function a(){}
+
+try {} catch(a) {}
+
+class Foo {
+  constructor(){}
+}
+```
+
+Examples of **correct** code for this rule with the `{ "functions": "always", "keywords": "never", "classes": "never" }` option:
+
+```js
+/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
+/*eslint-env es6*/
+
+if (a){
+  b();
+}
+
+var a = function() {}
+
+class Foo{
+  constructor() {}
+}
+```
+
+### keywords
+
+Examples of **incorrect** code for this rule with the `{ "functions": "never", "keywords": "always", "classes": "never" }` option:
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
@@ -131,8 +167,7 @@ class Foo{
 }
 ```
 
-
-The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "always", "classes": "never" }`:
+Examples of **correct** code for this rule with the `{ "functions": "never", "keywords": "always", "classes": "never" }` option:
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "always", "classes": "never" }]*/
@@ -151,40 +186,9 @@ class Foo {
 }
 ```
 
-The following patterns are considered problems when configured `{ "functions": "always", "keywords": "never", "classes": "never" }`:
+### classes
 
-```js
-/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
-/*eslint-env es6*/
-
-function a(){}
-
-try {} catch(a) {}
-
-class Foo {
-  constructor(){}
-}
-```
-
-
-The following patterns are not considered problems when configured `{ "functions": "always", "keywords": "never", "classes": "never" }`:
-
-```js
-/*eslint space-before-blocks: ["error", { "functions": "always", "keywords": "never", "classes": "never" }]*/
-/*eslint-env es6*/
-
-if (a){
-  b();
-}
-
-var a = function() {}
-
-class Foo{
-  constructor() {}
-}
-```
-
-The following patterns are considered problems when configured `{ "functions": "never", "keywords": "never", "classes": "always" }`:
+Examples of **incorrect** code for this rule with the `{ "functions": "never", "keywords": "never", "classes": "always" }` option:
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/
@@ -195,8 +199,7 @@ class Foo{
 }
 ```
 
-
-The following patterns are not considered problems when configured `{ "functions": "never", "keywords": "never", "classes": "always" }`:
+Examples of **correct** code for this rule with the `{ "functions": "never", "keywords": "never", "classes": "always" }` option:
 
 ```js
 /*eslint space-before-blocks: ["error", { "functions": "never", "keywords": "never", "classes": "always" }]*/

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -5,13 +5,9 @@
 When formatting a function, whitespace is allowed between the function name or `function` keyword and the opening paren. Named functions also require a space between the `function` keyword and the function name, but anonymous functions require no whitespace. For example:
 
 ```js
-function withoutSpace(x) {
-    // ...
-}
+function withoutSpace(x) {};
 
-function withSpace (x) {
-    // ...
-}
+function withSpace (x) {};
 
 var anonymousWithoutSpace = function() {};
 
@@ -26,303 +22,224 @@ This rule aims to enforce consistent spacing before function parentheses and as 
 
 ## Options
 
-This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`). In this case, you can use "ignore" to only apply the rule to one type of function (e. g. `{"anonymous": "ignore", "named": "never"}` will warn on spaces for named functions, but will not warn on anonymous functions one way or the other).
+This rule can have either a simple string argument or an object literal (if more granular control is required).
+
+The string argument can either be:
+
+* `"always"` _(default)_ - all functions, named and anonymous, must have space before function parentheses.
+* `"never"` - all functions, named and anonymous, must not have space before function parentheses.
+
+If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`). In this case, you can use `"ignore"` to only apply the rule to one type of function (e. g. `{"anonymous": "ignore", "named": "never"}` will warn on spaces for named functions, but will not warn on anonymous functions one way or the other).
 
 The default configuration is `"always"`.
 
-### "always"
+## Examples
 
-The following patterns are considered problems:
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-function-paren: "error"*/
 /*eslint-env es6*/
 
-function foo() {
-    // ...
-}
+function foo() {};
 
-var bar = function() {
-    // ...
-};
+var bar = function() {};
 
-var bar = function foo() {
-    // ...
-};
+var bar = function foo() {};
 
 class Foo {
-    constructor() {
-        // ...
-    }
+    constructor() {}
 }
 
 var foo = {
-    bar() {
-        // ...
-    }
+    bar() {}
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-function-paren: "error"*/
 /*eslint-env es6*/
 
-function foo () {
-    // ...
-}
+function foo () {};
 
-var bar = function () {
-    // ...
-};
+var bar = function () {};
 
-var bar = function foo () {
-    // ...
-};
+var bar = function foo () {};
 
 class Foo {
-    constructor () {
-        // ...
-    }
+    constructor () {}
 }
 
 var foo = {
-    bar () {
-        // ...
-    }
+    bar () {}
 };
 ```
 
 ### "never"
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
 /*eslint-env es6*/
 
-function foo () {
-    // ...
-}
+function foo () {};
 
-var bar = function () {
-    // ...
-};
+var bar = function () {};
 
-var bar = function foo () {
-    // ...
-};
+var bar = function foo () {};
 
 class Foo {
-    constructor () {
-        // ...
-    }
+    constructor () {}
 }
 
 var foo = {
-    bar () {
-        // ...
-    }
+    bar () {}
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
 /*eslint-env es6*/
 
-function foo() {
-    // ...
-}
+function foo() {};
 
-var bar = function() {
-    // ...
-};
+var bar = function() {};
 
-var bar = function foo() {
-    // ...
-};
+var bar = function foo() {};
 
 class Foo {
-    constructor() {
-        // ...
-    }
+    constructor() {}
 }
 
 var foo = {
-    bar() {
-        // ...
-    }
+    bar() {}
 };
 ```
 
-### `{"anonymous": "always", "named": "never"}`
+### anonymous: always, named: never
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "always", "named": "never" }]*/
 /*eslint-env es6*/
 
-function foo () {
-    // ...
-}
+function foo () {};
 
-var bar = function() {
-    // ...
-};
+var bar = function() {};
 
 class Foo {
-    constructor () {
-        // ...
-    }
+    constructor () {}
 }
 
 var foo = {
-    bar () {
-        // ...
-    }
+    bar () {}
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "always", "named": "never" }]*/
 /*eslint-env es6*/
 
-function foo() {
-    // ...
-}
+function foo() {};
 
-var bar = function () {
-    // ...
-};
+var bar = function () {};
 
 class Foo {
-    constructor() {
-        // ...
-    }
+    constructor() {}
 }
 
 var foo = {
-    bar() {
-        // ...
-    }
+    bar() {}
 };
 ```
 
-### `{"anonymous": "never", "named": "always"}`
+### anonymous: never, named: always
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
 /*eslint-env es6*/
 
-function foo() {
-    // ...
-}
+function foo() {};
 
-var bar = function () {
-    // ...
-};
+var bar = function () {};
 
 class Foo {
-    constructor() {
-        // ...
-    }
+    constructor() {}
 }
 
 var foo = {
-    bar() {
-        // ...
-    }
+    bar() {}
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
 /*eslint-env es6*/
 
-function foo () {
-    // ...
-}
+function foo () {};
 
-var bar = function() {
-    // ...
-};
+var bar = function() {};
 
 class Foo {
-    constructor () {
-        // ...
-    }
+    constructor () {}
 }
 
 var foo = {
-    bar () {
-        // ...
-    }
+    bar () {}
 };
 ```
 
-### `{"anonymous": "ignore", "named": "always"}`
+### anonymous: ignore, named: always
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
 /*eslint-env es6*/
 
-function foo() {
-    // ...
-}
+function foo() {};
 
 class Foo {
-    constructor() {
-        // ...
-    }
+    constructor() {}
 }
 
 var foo = {
-    bar() {
-        // ...
-    }
+    bar() {}
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
 /*eslint-env es6*/
 
-var bar = function() {
-    // ...
-};
+var bar = function() {};
 
-var bar = function () {
-    // ...
-};
+var bar = function () {};
 
-function foo () {
-    // ...
-}
+function foo () {};
 
 class Foo {
-    constructor () {
-        // ...
-    }
+    constructor () {}
 }
 
 var foo = {
-    bar () {
-        // ...
-    }
+    bar () {}
 };
 ```
 

--- a/docs/rules/space-in-parens.md
+++ b/docs/rules/space-in-parens.md
@@ -8,6 +8,8 @@ Some style guides require or disallow spaces inside of parentheses:
 foo( 'bar' );
 var x = ( 1 + 2 ) * 3;
 
+// or
+
 foo('bar');
 var x = (1 + 2) * 3;
 ```
@@ -18,48 +20,20 @@ This rule will enforce consistency of spacing directly inside of parentheses, by
 
 ## Options
 
-There are two options for this rule:
+There are two basic options for this rule:
 
 * `"always"` enforces a space inside of parentheses
 * `"never"` enforces zero spaces inside of parentheses (default)
 
-Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+In addition to the basic options, an object literal may be used as a third array item to specify exceptions, with the key `"exceptions"` and an array as the value. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing, then any "exception" will *disallow* spacing. Conversely, if `"never"` is set to disallow spacing, then any "exception" will *enforce* spacing.
 
-```json
-"space-in-parens": ["error", "always"]
-```
+The following exceptions are available: `["{}", "[]", "()", "empty"]`. The `"empty"` exception concerns empty parentheses, and works the same way as the other exceptions, inverting the first option.
 
-### "always"
+## Examples
 
-When `"always"` is set, the following patterns are considered problems:
+### never
 
-```js
-/*eslint space-in-parens: ["error", "always"]*/
-
-foo( 'bar');
-foo('bar' );
-foo('bar');
-
-var foo = (1 + 2) * 3;
-(function () { return 'bar'; }());
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint space-in-parens: ["error", "always"]*/
-
-foo();
-
-foo( 'bar' );
-
-var foo = ( 1 + 2 ) * 3;
-( function () { return 'bar'; }() );
-```
-
-### "never"
-
-When `"never"` is used, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never"]*/
@@ -72,7 +46,7 @@ var foo = ( 1 + 2 ) * 3;
 ( function () { return 'bar'; }() );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint space-in-parens: ["error", "never"]*/
@@ -85,13 +59,37 @@ var foo = (1 + 2) * 3;
 (function () { return 'bar'; }());
 ```
 
-### Exceptions
+### always
 
-An object literal may be used as a third array item to specify exceptions, with the key `"exceptions"` and an array as the value. These exceptions work in the context of the first option. That is, if `"always"` is set to enforce spacing, then any "exception" will *disallow* spacing. Conversely, if `"never"` is set to disallow spacing, then any "exception" will *enforce* spacing.
+Examples of **incorrect** code for this rule with the `"always"` option:
 
-The following exceptions are available: `["{}", "[]", "()", "empty"]`.
+```js
+/*eslint space-in-parens: ["error", "always"]*/
 
-For example, given `"space-in-parens": ["error", "always", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
+foo( 'bar');
+foo('bar' );
+foo('bar');
+
+var foo = (1 + 2) * 3;
+(function () { return 'bar'; }());
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```js
+/*eslint space-in-parens: ["error", "always"]*/
+
+foo();
+
+foo( 'bar' );
+
+var foo = ( 1 + 2 ) * 3;
+( function () { return 'bar'; }() );
+```
+
+### exceptions: curly braces
+
+Examples of **incorrect** code for this rule when the `"always"` option is combined with an exception of `"{}"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
@@ -100,7 +98,7 @@ foo( {bar: 'baz'} );
 foo( 1, {bar: 'baz'} );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"always"` option is combined with an exception of `"{}"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}"] }]*/
@@ -109,7 +107,7 @@ foo({bar: 'baz'});
 foo( 1, {bar: 'baz'});
 ```
 
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["{}"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule when the `"never"` option is combined with an exception of `"{}"`:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
@@ -118,7 +116,7 @@ foo({bar: 'baz'});
 foo(1, {bar: 'baz'});
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"never"` option is combined with an exception of `"{}"`:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["{}"] }]*/
@@ -127,7 +125,9 @@ foo( {bar: 'baz'} );
 foo(1, {bar: 'baz'} );
 ```
 
-Given `"space-in-parens": ["error", "always", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
+### exceptions: square brackets
+
+Examples of **incorrect** code for this rule when the `"always"` option is combined with an exception of `"[]"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
@@ -136,7 +136,7 @@ foo( [bar, baz] );
 foo( [bar, baz], 1 );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"always"` option is combined with an exception of `"[]"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["[]"] }]*/
@@ -145,7 +145,7 @@ foo([bar, baz]);
 foo([bar, baz], 1 );
 ```
 
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["[]"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule when the `"never"` option is combined with an exception of `"[]"`:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
@@ -154,7 +154,7 @@ foo([bar, baz]);
 foo([bar, baz], 1);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"never"` option is combined with an exception of `"[]"`:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["[]"] }]*/
@@ -163,7 +163,9 @@ foo( [bar, baz] );
 foo( [bar, baz], 1);
 ```
 
-Given `"space-in-parens": ["error", "always", { "exceptions": ["()"] }]`, the following patterns are considered problems:
+### exceptions: parentheses
+
+Examples of **incorrect** code for this rule when the `"always"` option is combined with an exception of `"()"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
@@ -172,7 +174,7 @@ foo( ( 1 + 2 ) );
 foo( ( 1 + 2 ), 1 );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"always"` option is combined with an exception of `"()"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["()"] }]*/
@@ -181,7 +183,7 @@ foo(( 1 + 2 ));
 foo(( 1 + 2 ), 1 );
 ```
 
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["()"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule when the `"never"` option is combined with an exception of `"()"`:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
@@ -190,7 +192,7 @@ foo((1 + 2));
 foo((1 + 2), 1);
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"never"` option is combined with an exception of `"()"`:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["()"] }]*/
@@ -199,9 +201,9 @@ foo( (1 + 2) );
 foo( (1 + 2), 1);
 ```
 
-The `"empty"` exception concerns empty parentheses, and works the same way as the other exceptions, inverting the first option.
+### exceptions: empty
 
-For example, given `"space-in-parens": ["error", "always", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule when the `"always"` option is combined with an exception of `"empty"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
@@ -209,7 +211,7 @@ For example, given `"space-in-parens": ["error", "always", { "exceptions": ["emp
 foo( );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"always"` option is combined with an exception of `"empty"`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["empty"] }]*/
@@ -217,7 +219,8 @@ The following patterns are not considered problems:
 foo();
 ```
 
-Or, given `"space-in-parens": ["error", "never", { "exceptions": ["empty"] }]`, the following patterns are considered problems:
+Examples of **incorrect** code for this rule when the `"never"` option is combined with an exception of `"empty"`:
+
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
@@ -225,7 +228,7 @@ Or, given `"space-in-parens": ["error", "never", { "exceptions": ["empty"] }]`, 
 foo();
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"never"` option is combined with an exception of `"empty"`:
 
 ```js
 /*eslint space-in-parens: ["error", "never", { "exceptions": ["empty"] }]*/
@@ -233,7 +236,11 @@ The following patterns are not considered problems:
 foo( );
 ```
 
-You can include multiple entries in the `"exceptions"` array. For example, given `"space-in-parens": ["error", "always", { "exceptions": ["{}", "[]"] }]`, the following patterns are considered problems:
+### exceptions: multiple
+
+You can include multiple entries in the `"exceptions"` array.
+
+Examples of **incorrect** code for this rule when the `"always"` option is combined with an exceptions `["{}", "[]"]`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/
@@ -243,7 +250,7 @@ baz( 1, [1,2] );
 foo( {bar: 'baz'}, [1, 2] );
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when the `"always"` option is combined with an exceptions `["{}", "[]"]`:
 
 ```js
 /*eslint space-in-parens: ["error", "always", { "exceptions": ["{}", "[]"] }]*/

--- a/docs/rules/space-infix-ops.md
+++ b/docs/rules/space-infix-ops.md
@@ -11,32 +11,30 @@ var sum = 1 + 2;
 The proponents of these extra spaces believe it make the code easier to read and can more easily highlight potential errors, such as:
 
 ```js
-var sum = i+++2;
+var sum = i+++2; // `i++ +2` or `i + ++2` or `i++ + 2`?
 ```
 
 While this is valid JavaScript syntax, it is hard to determine what the author intended.
 
 ## Rule Details
 
-This rule is aimed at ensuring there are spaces around infix operators.
+This rule ensures there are spaces around infix operators to improve code readability and highlight potential errors.
 
 ## Options
 
 This rule accepts a single options argument with the following defaults:
 
 ```json
-"space-infix-ops": ["error", {"int32Hint": false}]
+"space-infix-ops": [ "error", { "int32Hint": false } ]
 ```
 
-### `int32Hint`
+Setting the `int32Hint` option to `true` enables use of the patern `a|0` without space, a common pattern used to force a number to a signed 32-bit integer.
 
-Set the `int32Hint` option to `true` (default is `false`) to allow write `a|0` without space.
+## Examples
 
-```js
-var foo = bar|0; // `foo` is forced to be signed 32 bit integer
-```
+### defaults
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule when using default settings:
 
 ```js
 /*eslint space-infix-ops: "error"*/
@@ -50,6 +48,8 @@ a +b
 
 a?b:c
 
+let x = y|0
+
 const a={b:1};
 
 var {a=0}=bar;
@@ -57,7 +57,7 @@ var {a=0}=bar;
 function foo(a=0) { }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when using default settings:
 
 ```js
 /*eslint space-infix-ops: "error"*/
@@ -69,9 +69,19 @@ a       + b
 
 a ? b : c
 
+let x = y | 0
+
 const a = {b:1};
 
 var {a = 0} = bar;
 
 function foo(a = 0) { }
+```
+
+### int32Hint
+
+Examples of **correct** code for this rule with the `{ "int32Hint": true }` option:
+
+```js
+var x = y|0;
 ```

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -6,7 +6,7 @@ Some styleguides require or disallow spaces before or after unary operators. Thi
 
 ## Rule Details
 
-This rule enforces consistency regarding the spaces after `words` unary operators and after/before `nonwords` unary operators.
+This rule enforces consistency regarding the spaces after `words` unary operators and after/before `non-words` unary operators.
 
 Examples of unary `words` operators:
 
@@ -27,7 +27,7 @@ typeof {} // object
 void 0 // undefined
 ```
 
-Examples of unary `nonwords` operators:
+Examples of unary `non-words` operators:
 
 ```js
 if ([1,2,3].indexOf(1) !== -1) {};
@@ -43,25 +43,27 @@ This rule has three options:
 
 * `words` - applies to unary word operators such as: `new`, `delete`, `typeof`, `void`, `yield`
 * `nonwords` - applies to unary operators such as: `-`, `+`, `--`, `++`, `!`, `!!`
-* `overrides` - specifies overwriting usage of spacing for each
-  operator, word or non word. This is empty by default, but can be used
-  to enforce or disallow spacing around operators. For example:
+* `overrides` - specifies overwriting usage of spacing for each operator, word or non-word. This is empty by default, but can be used to enforce or disallow spacing around operators. For example:
 
 ```js
-    "space-unary-ops": [
-        2, {
-          "words": true,
-          "nonwords": false,
-          "overrides": {
-            "new": false,
-            "++": true
-          }
-    }]
+"space-unary-ops": [
+    2, {
+      "words": true,
+      "nonwords": false,
+      "overrides": {
+        "new": false,
+        "++": true
+      }
+}]
 ```
 
 In this case, spacing will be disallowed after a `new` operator and required before/after a `++` operator.
 
-Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are considered problems:
+## Examples
+
+### defaults
+
+Examples of **incorrect** code for this rule with the default `{ "words": true, "nonwords": false }` options:
 
 ```js
 /*eslint space-unary-ops: "error"*/
@@ -92,30 +94,25 @@ function *foo() {
 }
 ```
 
-Given the default values `words`: `true`, `nonwords`: `false`, the following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{ "words": true, "nonwords": false }` options:
 
 ```js
 /*eslint space-unary-ops: "error"*/
 
-// Word unary operator "delete" is followed by a whitespace.
+// Word unary operators followed by a whitespace.
 delete foo.bar;
 
-// Word unary operator "new" is followed by a whitespace.
 new Foo;
 
-// Word unary operator "void" is followed by a whitespace.
 void 0;
 
-// Unary operator "++" is not followed by whitespace.
+// Non-word unary operators not followed by whitespace.
 ++foo;
 
-// Unary operator "--" is not preceded by whitespace.
 foo--;
 
-// Unary operator "-" is not followed by whitespace.
 -foo;
 
-// Unary operator "+" is not followed by whitespace.
 +"3";
 ```
 

--- a/docs/rules/spaced-comment.md
+++ b/docs/rules/spaced-comment.md
@@ -58,7 +58,7 @@ You can also define separate exceptions and markers for block and line comments:
 
 ### always
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint spaced-comment: ["error", "always"]*/
@@ -68,7 +68,7 @@ The following patterns are considered problems:
 /*This is a comment with no whitespace at the beginning */
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /* eslint spaced-comment: ["error", "always"] */
@@ -96,7 +96,7 @@ This comment has a newline
 
 ### never
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
@@ -108,7 +108,7 @@ The following patterns are considered problems:
 /* \nThis is a comment with a whitespace at the beginning */
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint spaced-comment: ["error", "never"]*/
@@ -126,7 +126,7 @@ The following patterns are not considered problems:
 
 ### exceptions
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule when using various custom exceptions:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["-"] } }] */
@@ -134,25 +134,22 @@ The following patterns are considered problems:
 //--------------
 // Comment block
 //--------------
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-", "+"] }] */
 
 //------++++++++
 // Comment block
 //------++++++++
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-", "+"] }] */
 
 /*------++++++++*/
 /* Comment block */
 /*------++++++++*/
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "line": { "exceptions": ["-+"] } }] */
 
 /*-+-+-+-+-+-+-+*/
@@ -160,7 +157,7 @@ The following patterns are considered problems:
 /*-+-+-+-+-+-+-+*/
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when using various custom exceptions:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-"] }] */
@@ -168,25 +165,22 @@ The following patterns are not considered problems:
 //--------------
 // Comment block
 //--------------
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "line": { "exceptions": ["-"] } }] */
 
 //--------------
 // Comment block
 //--------------
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["*"] }] */
 
 /****************
  * Comment block
  ****************/
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "exceptions": ["-+"] }] */
 
 //-+-+-+-+-+-+-+
@@ -196,9 +190,8 @@ The following patterns are not considered problems:
 /*-+-+-+-+-+-+-+*/
 // Comment block
 /*-+-+-+-+-+-+-+*/
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "block": { "exceptions": ["-+"] } }] */
 
 /*-+-+-+-+-+-+-+*/
@@ -208,7 +201,7 @@ The following patterns are not considered problems:
 
 ### markers
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule if `"markers"` is set as `"/"`:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */
@@ -216,25 +209,23 @@ The following patterns are considered problems:
 ///This is a comment with a marker but without whitespace
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule when using various custom markers:
 
 ```js
 /* eslint spaced-comment: ["error", "always", { "markers": ["/"] }] */
 
 /// This is a comment with a marker
-```
 
-```js
-/*eslint spaced-comment: ["error", "never", { "markers": ["!<"] }]*/
+
+/* eslint spaced-comment: ["error", "never", { "markers": ["!<"] }]*/
 
 //!<This is a line comment with a marker
 
 /*!<this is a block comment with a marker
 subsequent lines are ignored
 */
-```
 
-```js
+
 /* eslint spaced-comment: ["error", "always", { "markers": ["global"] }] */
 
 /*global ABC*/

--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -12,7 +12,9 @@ function a() {
 
 This is used to disambiguate the slash operator and facilitates more readable code.
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint wrap-regex: "error"*/
@@ -22,7 +24,7 @@ function a() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule:
 
 ```js
 /*eslint wrap-regex: "error"*/


### PR DESCRIPTION
Primary objectives of this commit:

1. Consistent example headings
2. Consistent captions above code fences
3. Where possible, consolidate options in to Options section