### PR TITLE
chore(docs): fix max-lines samples (fixes #6516)

### DIFF
--- a/docs/rules/max-lines.md
+++ b/docs/rules/max-lines.md
@@ -67,7 +67,7 @@ var a, b, c;
 Examples of **incorrect** code for this rule with the `{ "skipBlankLines": true }` option:
 
 ```js
-/*eslint max-lines: ["error", 2, {"skipBlankLines": true}]*/
+/*eslint max-lines: ["error", {"max": 2, "skipBlankLines": true}]*/
 
 var a,
     b,
@@ -77,7 +77,7 @@ var a,
 Examples of **correct** code for this rule with the `{ "skipBlankLines": true }` option:
 
 ```js
-/*eslint max-lines: ["error", 2, {"skipBlankLines": true}]*/
+/*eslint max-lines: ["error", {"max": 2, "skipBlankLines": true}]*/
 
 var a,
     b, c;
@@ -88,7 +88,7 @@ var a,
 Examples of **incorrect** code for this rule with the `{ "skipComments": true }` option:
 
 ```js
-/*eslint max-lines: ["error", 2, {"skipComments": true}]*/
+/*eslint max-lines: ["error", {"max": 2, "skipComments": true}]*/
 // a comment
 var a,
     b,
@@ -98,7 +98,7 @@ var a,
 Examples of **correct** code for this rule with the `{ "skipComments": true }` option:
 
 ```js
-/*eslint max-lines: ["error", 2, {"skipComments": true}]*/
+/*eslint max-lines: ["error", {"max": 2, "skipComments": true}]*/
 // a comment
 var a,
     b, c;


### PR DESCRIPTION
Current docs contains invalid samples of `max-lines` rules configuration:
`eslint max-lines: ["error", 2, {"skipComments": true}]`
should be
`eslint max-lines: ["error", {"max":2, "skipComments": true}]`