### PR TITLE
Docs: Consistent example headings & text pt6 (refs #5446)

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -49,6 +49,7 @@ Examples of **incorrect** code for this rule with the default `"double"` option:
 var single = 'single';
 var unescaped = 'a string containing "double" quotes';
 ```
+
 Examples of **correct** code for this rule with the default `"double"` option:
 
 ```js

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -9,7 +9,7 @@ JavaScript allows you to define strings in one of three ways: double quotes, sin
 
 var double = "double";
 var single = 'single';
-var backtick = `backtick`;    // ES6 only
+var backtick = `backtick`; // ES6 only
 ```
 
 Each of these lines creates a string and, in some cases, can be used interchangeably. The choice of how to define strings in a codebase is a stylistic one outside of template literals (which allow embedded of expressions to be interpreted).
@@ -19,6 +19,8 @@ Many codebases require strings to be defined in a consistent manner.
 ## Rule Details
 
 This rule is aimed at ensuring consistency of string quotes and as such will report a problem when an inconsistent style is found.
+
+## Options
 
 The rule configuration takes up to two options:
 
@@ -35,9 +37,11 @@ Configuration looks like this:
 [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}]
 ```
 
-**Deprecation notice**: The `avoid-escape` option is a deprecated syntax and you should use the object form instead.
+> **Deprecation notice**: The `avoid-escape` option is a deprecated syntax and you should use the object form instead.
 
-The following patterns are considered problems:
+### double
+
+Examples of **incorrect** code for this rule with the default `"double"` option:
 
 ```js
 /*eslint quotes: ["error", "double"]*/
@@ -45,6 +49,51 @@ The following patterns are considered problems:
 var single = 'single';
 var unescaped = 'a string containing "double" quotes';
 ```
+Examples of **correct** code for this rule with the default `"double"` option:
+
+```js
+/*eslint quotes: ["error", "double"]*/
+/*eslint-env es6*/
+
+var double = "double";
+
+var backtick = `back${x}tick`; // allowed due to substitution
+var backtick = `back\ntick`;  // allowed due to newline
+var backtick = tag`backtick`; // allowed due to tag
+```
+
+#### double, allowTemlpateLiterals
+
+Examples of **correct** code for this rule with the `"double"` option combined with `{"allowTemplateLiterals": true}`:
+
+```js
+/*eslint quotes: ["error", "double", {"allowTemplateLiterals": true}]*/
+
+var backtick = `backtick`;
+```
+
+#### double, avoidEscape
+
+Examples of **incorrect** code for this rule with the `"double"` option combined with `{"avoidEscape": true}`:
+
+```js
+/*eslint quotes: ["error", "double", {"avoidEscape": true}]*/
+
+var single = 'single';
+var backtick = `backtick`;
+```
+
+Examples of **correct** code for this rule with the `"double"` option combined with `{"avoidEscape": true}`:
+
+```js
+/*eslint quotes: ["error", "double", {"avoidEscape": true}]*/
+
+var single = 'a string containing "double" quotes';
+```
+
+### single
+
+Examples of **incorrect** code for this rule with the `"single"` option:
 
 ```js
 /*eslint quotes: ["error", "single"]*/
@@ -53,19 +102,49 @@ var double = "double";
 var unescaped = "a string containing 'single' quotes";
 ```
 
+Examples of **correct** code for this rule with the `"single"` option:
+
 ```js
-/*eslint quotes: ["error", "double", {"avoidEscape": true}]*/
+/*eslint quotes: ["error", "single"]*/
+/*eslint-env es6*/
 
 var single = 'single';
-var single = `single`;
+
+// backticks are allowed as per earlier example
 ```
+
+#### single, allowTemplateLiterals
+
+Examples of **correct** code for this rule with the `"single"` option combined with `{"allowTemplateLiterals": true}`:
+
+```js
+/*eslint quotes: ["error", "single", {"allowTemplateLiterals": true}]*/
+
+var backtick = `backtick`;
+```
+
+#### single, avoidEscape
+
+Examples of **incorrect** code for this rule with the `"single"` option combined with `{"avoidEscape": true}`:
 
 ```js
 /*eslint quotes: ["error", "single", {"avoidEscape": true}]*/
 
 var double = "double";
-var double = `double`;
+var backtick = `backtick`;
 ```
+
+Examples of **correct** code for this rule with the `"single"` option combined with `{"avoidEscape": true}`:
+
+```js
+/*eslint quotes: ["error", "single", {"avoidEscape": true}]*/
+
+var double = "a string containing 'single' quotes";
+```
+
+### backtick
+
+Examples of **incorrect** code for this rule with the `"backtick"` option:
 
 ```js
 /*eslint quotes: ["error", "backtick"]*/
@@ -75,57 +154,7 @@ var double = "double";
 var unescaped = 'a string containing `backticks`';
 ```
 
-```js
-/*eslint quotes: ["error", "backtick", {"avoidEscape": true}]*/
-
-var single = 'single';
-var double = "double";
-```
-
-The following patterns are not considered problems:
-
-```js
-/*eslint quotes: ["error", "double"]*/
-/*eslint-env es6*/
-
-var double = "double";
-var backtick = `back\ntick`;  // backticks are allowed due to newline
-var backtick = tag`backtick`; // backticks are allowed due to tag
-```
-
-```js
-/*eslint quotes: ["error", "single"]*/
-/*eslint-env es6*/
-
-var single = 'single';
-var backtick = `back${x}tick`; // backticks are allowed due to substitution
-```
-
-```js
-/*eslint quotes: ["error", "double", {"avoidEscape": true}]*/
-
-var single = 'a string containing "double" quotes';
-```
-
-```js
-/*eslint quotes: ["error", "single", {"avoidEscape": true}]*/
-
-var double = "a string containing 'single' quotes";
-```
-
-```js
-/*eslint quotes: ["error", "double", {"allowTemplateLiterals": true}]*/
-
-var single = 'single';
-var single = `single`;
-```
-
-```js
-/*eslint quotes: ["error", "single", {"allowTemplateLiterals": true}]*/
-
-var double = "double";
-var double = `double`;
-```
+Examples of **correct** code for this rule with the `"backtick"` option:
 
 ```js
 /*eslint quotes: ["error", "backtick"]*/
@@ -133,6 +162,19 @@ var double = `double`;
 
 var backtick = `backtick`;
 ```
+
+#### backtick, avoidEscape
+
+Examples of **incorrect** code for this rule with the `"backtick"` option combined with `{"avoidEscape": true}`:
+
+```js
+/*eslint quotes: ["error", "backtick", {"avoidEscape": true}]*/
+
+var single = 'single';
+var double = "double";
+```
+
+Examples of **correct** code for this rule with the `"backtick"` option combined with `{"avoidEscape": true}`:
 
 ```js
 /*eslint quotes: ["error", "backtick", {"avoidEscape": true}]*/

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -46,7 +46,9 @@ Default option settings are
 }
 ```
 
-The following patterns are considered problems:
+## Examples
+
+Examples of **incorrect** code for this rule if all options are set to `true`:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -66,7 +68,7 @@ class Test{
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule if all options are set to `true`:
 
 ```js
 /*eslint "require-jsdoc": ["error", {

--- a/docs/rules/semi-spacing.md
+++ b/docs/rules/semi-spacing.md
@@ -37,11 +37,11 @@ The default is `{"before": false, "after": true}`.
     "semi-spacing": ["error", {"before": false, "after": true}]
 ```
 
-### `{"before": false, "after": true}`
+## examples
 
-This is the default option. It enforces spacing after semicolons and disallows spacing before semicolons.
+### after
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `{"before": false, "after": true}` option:
 
 ```js
 /*eslint semi-spacing: "error"*/
@@ -54,7 +54,7 @@ for (i = 0 ; i < 10 ; i++) {}
 for (i = 0;i < 10;i++) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `{"before": false, "after": true}` option:
 
 ```js
 /*eslint semi-spacing: "error"*/
@@ -69,11 +69,9 @@ if (true) {;}
 ;foo();
 ```
 
-### `{"before": true, "after": false}`
+### before
 
-This option enforces spacing before semicolons and disallows spacing after semicolons.
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"before": true, "after": false}` option:
 
 ```js
 /*eslint semi-spacing: ["error", { "before": true, "after": false }]*/
@@ -86,7 +84,7 @@ for (i = 0;i < 10;i++) {}
 for (i = 0; i < 10; i++) {}
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"before": true, "after": false}` option:
 
 ```js
 /*eslint semi-spacing: ["error", { "before": true, "after": false }]*/

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -61,19 +61,27 @@ This rule is aimed at ensuring consistent use of semicolons. You can decide whet
 
 ## Options
 
-The rule takes one or two options. The first one is a string, which could be `"always"` or `"never"`. The default is `"always"`. The second one is an object for more fine-grained configuration when the first option is `"always"`.
-
-You can set the option in configuration like this:
-
-### "always"
-
-By using the default option, semicolons must be used any place where they are valid.
+The rule takes one or two options. The first one is a string, which could be `"always"` or `"never"`. The default is `"always"`.
 
 ```json
-semi: ["error", "always"]
+semi: [ "error", "always" ]
 ```
 
-The following patterns are considered problems:
+> Note: In `"never"` mode, semicolons are still allowed to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`.
+
+The second one is an object for more fine-grained configuration when the first option is `"always"`. Currently it has one option:
+
+```json
+{ "omitLastInOneLineBlock": true }
+```
+
+When setting the first option as "always", an additional option can be added to omit the last semicolon in a one-line block, that is, a block in which its braces (and therefore the content of the block) are in the same line.
+
+## Examples
+
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint semi: "error"*/
@@ -85,7 +93,7 @@ object.method = function() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint semi: "error"*/
@@ -97,15 +105,11 @@ object.method = function() {
 };
 ```
 
-#### Fine-grained control
+#### omitLastInOneLineBlock
 
-When setting the first option as "always", an additional option can be added to omit the last semicolon in a one-line block, that is, a block in which its braces (and therefore the content of the block) are in the same line:
+> The `"omitLastInOneLineBlock"` option is only takes effect when using the `"always"` option.
 
-```json
-semi: ["error", "always", { "omitLastInOneLineBlock": true}]
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{ "omitLastInOneLineBlock": true}` option:
 
 ```js
 /*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
@@ -117,7 +121,7 @@ if (foo) {
 if (foo) { bar(); }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "omitLastInOneLineBlock": true}` option:
 
 ```js
 /*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
@@ -127,15 +131,9 @@ if (foo) { bar() }
 if (foo) { bar(); baz() }
 ```
 
-### "never"
+### never
 
-If you want to enforce that semicolons are never used, switch the configuration to:
-
-```json
-semi: [2, "never"]
-```
-
-Then, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint semi: ["error", "never"]*/
@@ -147,7 +145,7 @@ object.method = function() {
 };
 ```
 
-And the following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint semi: ["error", "never"]*/
@@ -159,7 +157,11 @@ object.method = function() {
 }
 ```
 
-Even in `"never"` mode, semicolons are still allowed to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`:
+#### disambiguation
+
+Even in `"never"` mode, semicolons are still allowed to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`.
+
+Examples of **correct** code for this rule with the `"never"` option in scenarios where semicolons are required for disambiguation:
 
 ```js
 /*eslint semi: ["error", "never"]*/

--- a/docs/rules/sort-vars.md
+++ b/docs/rules/sort-vars.md
@@ -5,9 +5,24 @@ When declaring multiple variables within the same block, some developers prefer 
 ## Rule Details
 
 This rule checks all variable declaration blocks and verifies that all variables are sorted alphabetically.
+
+## Options
+
+This rule, when enabled, always enforces sorted variables (there is no `"always"` or `"never"` option unlike most other rules).
+
+There is, however, an option to toggle case sensitivity:
+
+```
+"sort-vars": [ "error", { "ignoreCase": true }]
+```
+
 The default configuration of the rule is case-sensitive.
 
-The following patterns are considered problems:
+## Examples
+
+### default options
+
+Examples of **incorrect** code for this rule with the default options:
 
 ```js
 /*eslint sort-vars: "error"*/
@@ -19,7 +34,7 @@ var a, B, c;
 var a, A;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default options:
 
 ```js
 /*eslint sort-vars: "error"*/
@@ -31,36 +46,12 @@ var _b = 20;
 
 var A, a;
 
-var B, a, c;
+var B, a, c; // uppercase before lowercase
 ```
 
-Alphabetical list is maintained starting from the first variable and excluding any that are considered problems. So the following code will produce two problems:
+### ignoreCase: true
 
-```js
-/*eslint sort-vars: "error"*/
-
-var c, d, a, b;
-```
-
-But this one, will only produce one:
-
-```js
-/*eslint sort-vars: "error"*/
-
-var c, d, a, e;
-```
-
-## Options
-
-```
-"sort-vars": [<enabled>, { "ignoreCase": <boolean> }]
-```
-
-### `ignoreCase`
-
-When `true` the rule ignores the case-sensitivity of the variables order.
-
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "ignoreCase": true }`:
 
 ```js
 /*eslint sort-vars: ["error", { "ignoreCase": true }]*/
@@ -68,6 +59,28 @@ The following patterns are not considered problems:
 var a, A;
 
 var a, B, c;
+```
+
+## Notes
+
+If a variable is not in alphabetical order it will be flagged without altering the expected order for the next variable.
+
+For example, the following list will generate two errors:
+
+```js
+/*eslint sort-vars: "error"*/
+
+var c, d, a, b;
+//        ^  ^ errors at `a` and `b`
+```
+
+While this list will only produce one:
+
+```js
+/*eslint sort-vars: "error"*/
+
+var c, d, a, e;
+//        ^ error at `a`
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
1. Ensure each doc has "Examples" heading, and that each
option-specific example pair also has a suitable heading.

2. Ensure text above examples is consistent as per #5446