### PR TITLE
Docs: yield-star-spacing cleanup & refactor

### DIFF
--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -86,6 +86,10 @@ function*generator() {
 }
 ```
 
+## Related Rules
+
+* [generator-star-spacing](generator-star-spacing) - Enforce spacing around the * in generator functions
+
 ## When Not To Use It
 
 If your project will not be using generators or you are not concerned with spacing consistency, you do not need this rule.

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -11,30 +11,26 @@ To use this rule you either need to [use the `es6` environment](../user-guide/co
 
 ## Options
 
-The rule takes one option, an object, which has two keys `before` and `after` having boolean values `true` or `false`.
+```
+yield-star-spacing: [ <level>, <behavior> ]
 
-* `before` enforces spacing between the `yield` and the `*`.
-  If `true`, a space is required, otherwise spaces are disallowed.
-
-* `after` enforces spacing between the `*` and the argument.
-  If it is `true`, a space is required, otherwise spaces are disallowed.
-
-The default is `{"before": false, "after": true}`.
-
-```json
-"yield-star-spacing": ["error", {"before": true, "after": false}]
+yield-star-spacing: [ <level>, { <option>: <val>, ... } ]
 ```
 
-The option also has a string shorthand:
+* __<level>:__
+    * **`"off"`** _(default)_ - ignore violations
+    * `"warn"` - violations generate warnings
+    * `"error"` - violations generate errors (exit code `1`)
+* __<behavior>:__ _shortform - settings string_
+    * [**`"after"`**](#after) _(default)_ ⟶ `{"before": false, "after": true}`
+    * [`"before"`](#before) ⟶ `{"before": true, "after": false}`
+    * [`"both"`](#both) ⟶ `{"before": true, "after": true}`
+    * [`"neither"`](#neither) ⟶ `{"before": false, "after": false}`
+* __<option>:__ _longform - settings object_
+    * `"before"` - spacing between `yeild` and `*`? `true` or `false` _(default)_
+    * `"after"` - spacing between `*` and expression? `true` _(default)_ or `false`
 
-* `{"before": false, "after": true}` → `"after"`
-* `{"before": true, "after": false}` → `"before"`
-* `{"before": true, "after": true}` → `"both"`
-* `{"before": false, "after": false}` → `"neither"`
-
-```json
-"yield-star-spacing": ["error", "after"]
-```
+See [Configuring Rules](../user-guide/configuring#configuring-rules) for more details.
 
 ## Examples
 

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -4,9 +4,9 @@
 
 ## Rule Details
 
-This rule enforces spacing around the `*` in `yield*` statements.
+Enforce a spacing policy for the `*` in `yield*` statements.
 
-It does not affect `*` spacing in `function*` declarations.
+Does not affect `function*` declarations.
 
 To use this rule you either need to [use the `es6` environment](../user-guide/configuring.md#specifying-environments) or
 [set `ecmaVersion` to `6` in `parserOptions`](../user-guide/configuring.md#specifying-parser-options).
@@ -19,16 +19,16 @@ yield-star-spacing: [ <level>, <behavior> ]
 yield-star-spacing: [ <level>, { <option>: <val>, ... } ]
 ```
 
-* __<level>:__
-    * **`"off"`** _(default)_ - ignore violations
-    * `"warn"` - violations generate warnings
-    * `"error"` - violations generate errors (exit code `1`)
-* __<behavior>:__ _shortform - settings string_
+* __level:__ (Number|String)
+    * `0` or **`"off"`** _(default)_ - ignore violations
+    * `1` or `"warn"` - violations generate warnings
+    * `2` or `"error"` - violations generate errors (exit code `1`)
+* __behavior:__  (String)
     * [**`"after"`**](#after) _(default)_ ⟶ `{"before": false, "after": true}`
     * [`"before"`](#before) ⟶ `{"before": true, "after": false}`
     * [`"both"`](#both) ⟶ `{"before": true, "after": true}`
     * [`"neither"`](#neither) ⟶ `{"before": false, "after": false}`
-* __<option>:__ _longform - settings object_
+* __option:__ (Object)
     * `"before"` - spacing between `yeild` and `*`? `true` or `false` _(default)_
     * `"after"` - spacing between `*` and expression? `true` _(default)_ or `false`
 
@@ -99,4 +99,4 @@ If your project will not be using generators or you are not concerned with spaci
 ## Further Reading
 
 * [Understanding ES6: Generators](https://leanpub.com/understandinges6/read/#leanpub-auto-generators)
-* [yield* operator)](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/yield*)
+* [yield* operator](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/yield*)

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -93,3 +93,4 @@ If your project will not be using generators or you are not concerned with spaci
 ## Further Reading
 
 * [Understanding ES6: Generators](https://leanpub.com/understandinges6/read/#leanpub-auto-generators)
+* [yield* operator)](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Operators/yield*)

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -1,10 +1,10 @@
-# Enforce spacing around the `*` in `yield*` expressions (yield-star-spacing)
+# Enforce spacing around the `*` in `yield*` statements (yield-star-spacing)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
 ## Rule Details
 
-This rule enforces spacing around the `*` in `yield*` expressions.
+This rule enforces spacing around the `*` in `yield*` statements.
 
 It does not affect `*` spacing in `function*` declarations.
 

--- a/docs/rules/yield-star-spacing.md
+++ b/docs/rules/yield-star-spacing.md
@@ -6,6 +6,8 @@
 
 This rule enforces spacing around the `*` in `yield*` expressions.
 
+It does not affect `*` spacing in `function*` declarations.
+
 To use this rule you either need to [use the `es6` environment](../user-guide/configuring.md#specifying-environments) or
 [set `ecmaVersion` to `6` in `parserOptions`](../user-guide/configuring.md#specifying-parser-options).
 
@@ -55,7 +57,7 @@ Examples of **correct** code for this rule with the `"before"` option:
 /*eslint yield-star-spacing: ["error", "before"]*/
 /*eslint-env es6*/
 
-function *generator() {
+function* generator() {
   yield *other();
 }
 ```
@@ -68,7 +70,7 @@ Examples of **correct** code for this rule with the `"both"` option:
 /*eslint yield-star-spacing: ["error", "both"]*/
 /*eslint-env es6*/
 
-function * generator() {
+function* generator() {
   yield * other();
 }
 ```
@@ -81,7 +83,7 @@ Examples of **correct** code for this rule with the `"neither"` option:
 /*eslint yield-star-spacing: ["error", "neither"]*/
 /*eslint-env es6*/
 
-function*generator() {
+function* generator() {
   yield*other();
 }
 ```


### PR DESCRIPTION
1. Options: Updated layout to better illustrate variadic options
2. Further Reading: Link to MDN page for `yeild*`
3. Related Rules: generator-star-spacing
4. Clarification: This rule doesn't affect `function*` declarations
5. Clarification: This rule affects `yield*` statements, not their expressions
6. General clean up, remove typos, etc.