### PR TITLE
Breaking: Error thrown/printed if no config found (fixes #5987)

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -93,9 +93,9 @@ function getPersonalConfig() {
 /**
  * Determine if rules were explicitly passed in as options.
  * @param {Object} options The options used to create our configuration.
- * @returns {bool} True if rules were passed in as options, false otherwise.
+ * @returns {boolean} True if rules were passed in as options, false otherwise.
  */
-function optionsHaveRules(options) {
+function hasRules(options) {
     return options.rules && Object.keys(options.rules).length > 0;
 }
 
@@ -155,27 +155,26 @@ function getLocalConfig(thisConfig, directory) {
         /*
          * - Is there a personal config in the user's home directory? If so,
          *   merge that with the passed-in config.
-         * - Otherwise, throw an exception.
+         * - Otherwise, if no rules were manually passed in, throw and error.
+         * - Note: This function is not called if useEslintrc is false.
          */
         personalConfig = getPersonalConfig();
 
         if (personalConfig) {
             config = ConfigOps.merge(config, personalConfig);
+        } else if (!hasRules(thisConfig.options)) {
+
+            // No config file, no manual configuration, and no rules, so error.
+            var noConfigError = new Error("No ESLint configuration found.");
+
+            noConfigError.messageTemplate = "no-config-found";
+            noConfigError.messageData = {
+                directory: directory,
+                filesExamined: localConfigFiles
+            };
+
+            throw noConfigError;
         }
-    }
-
-    if (!found && !thisConfig.useSpecificConfig && !personalConfig && !optionsHaveRules(thisConfig.options)) {
-
-        // No config file, and no manual configuration, so error.
-        var noConfigError = new Error("No ESLint configuration found.");
-
-        noConfigError.messageTemplate = "no-config-found";
-        noConfigError.messageData = {
-            directory: directory,
-            filesExamined: localConfigFiles
-        };
-
-        throw noConfigError;
     }
 
     return config;

--- a/lib/config.js
+++ b/lib/config.js
@@ -145,7 +145,7 @@ function getLocalConfig(thisConfig, directory) {
         return config;
     } else {
 
-        /**
+        /*
          * - Is there a personal config in the user's home directory? If so,
          *   merge that with the passed-in config.
          * - Otherwise, throw an exception.

--- a/lib/config.js
+++ b/lib/config.js
@@ -91,6 +91,15 @@ function getPersonalConfig() {
 }
 
 /**
+ * Determine if rules were explicitly passed in as options.
+ * @param {Object} options The options used to create our configuration.
+ * @returns {bool} True if rules were passed in as options, false otherwise.
+ */
+function optionsHaveRules(options) {
+    return options.rules && Object.keys(options.rules).length > 0;
+}
+
+/**
  * Get a local config object.
  * @param {Object} thisConfig A Config object.
  * @param {string} directory The directory to start looking in for a local config file.
@@ -141,9 +150,7 @@ function getLocalConfig(thisConfig, directory) {
         config = ConfigOps.merge(localConfig, config);
     }
 
-    if (found || thisConfig.useSpecificConfig) {
-        return config;
-    } else {
+    if (!found && !thisConfig.useSpecificConfig) {
 
         /*
          * - Is there a personal config in the user's home directory? If so,
@@ -153,25 +160,25 @@ function getLocalConfig(thisConfig, directory) {
         personalConfig = getPersonalConfig();
 
         if (personalConfig) {
-            return ConfigOps.merge(config, personalConfig);
-        } else if (thisConfig.options.rules && Object.keys(thisConfig.options.rules).length > 0) {
-
-            // Return config if there is no config file, but rules were passed explicitly.
-            return ConfigOps.merge(config, {});
-        } else {
-
-            // No config file, and no manual configuration, so error.
-            var noConfigError = new Error("No ESLint configuration found.");
-
-            noConfigError.messageTemplate = "no-config-found";
-            noConfigError.messageData = {
-                directory: directory,
-                filesExamined: localConfigFiles
-            };
-
-            throw noConfigError;
+            config = ConfigOps.merge(config, personalConfig);
         }
     }
+
+    if (!found && !thisConfig.useSpecificConfig && !personalConfig && !optionsHaveRules(thisConfig.options)) {
+
+        // No config file, and no manual configuration, so error.
+        var noConfigError = new Error("No ESLint configuration found.");
+
+        noConfigError.messageTemplate = "no-config-found";
+        noConfigError.messageData = {
+            directory: directory,
+            filesExamined: localConfigFiles
+        };
+
+        throw noConfigError;
+    }
+
+    return config;
 }
 
 //------------------------------------------------------------------------------

--- a/lib/config.js
+++ b/lib/config.js
@@ -71,7 +71,7 @@ function loadConfig(configToLoad) {
 
 /**
  * Get personal config object from ~/.eslintrc.
- * @returns {Object} the personal config object (empty object if there is no personal config)
+ * @returns {Object} the personal config object (null if there is no personal config)
  * @private
  */
 function getPersonalConfig() {
@@ -87,7 +87,7 @@ function getPersonalConfig() {
         }
     }
 
-    return config || {};
+    return config || null;
 }
 
 /**
@@ -105,7 +105,8 @@ function getLocalConfig(thisConfig, directory) {
         localConfigFiles = thisConfig.findLocalConfigFiles(directory),
         numFiles = localConfigFiles.length,
         rootPath,
-        projectConfigPath = ConfigFile.getFilenameForDirectory(thisConfig.options.cwd);
+        projectConfigPath = ConfigFile.getFilenameForDirectory(thisConfig.options.cwd),
+        personalConfig;
 
     for (i = 0; i < numFiles; i++) {
 
@@ -140,8 +141,31 @@ function getLocalConfig(thisConfig, directory) {
         config = ConfigOps.merge(localConfig, config);
     }
 
-    // Use the personal config file if there are no other local config files found.
-    return found || thisConfig.useSpecificConfig ? config : ConfigOps.merge(config, getPersonalConfig());
+    if (found || thisConfig.useSpecificConfig) {
+        return config;
+    } else {
+
+        /**
+         * - Is there a personal config in the user's home directory? If so,
+         *   merge that with the passed-in config.
+         * - Otherwise, throw an exception.
+         */
+        personalConfig = getPersonalConfig();
+
+        if (personalConfig) {
+            return ConfigOps.merge(config, personalConfig);
+        } else {
+            var noConfigError = new Error("No ESLint configuration found.");
+
+            noConfigError.messageTemplate = "no-config-found";
+            noConfigError.messageData = {
+                directory: directory,
+                filesExamined: localConfigFiles
+            };
+
+            throw noConfigError;
+        }
+    }
 }
 
 //------------------------------------------------------------------------------

--- a/lib/config.js
+++ b/lib/config.js
@@ -154,7 +154,13 @@ function getLocalConfig(thisConfig, directory) {
 
         if (personalConfig) {
             return ConfigOps.merge(config, personalConfig);
+        } else if (thisConfig.options.rules && Object.keys(thisConfig.options.rules).length > 0) {
+
+            // Return config if there is no config file, but rules were passed explicitly.
+            return ConfigOps.merge(config, {});
         } else {
+
+            // No config file, and no manual configuration, so error.
             var noConfigError = new Error("No ESLint configuration found.");
 
             noConfigError.messageTemplate = "no-config-found";

--- a/messages/no-config-found.txt
+++ b/messages/no-config-found.txt
@@ -2,6 +2,6 @@ ESLint couldn't find a configuration file. To set up a configuration file for th
 
     eslint --init
 
-We looked for configuration files in <%= directory =%> and its ancestors.
+ESLint looked for configuration files in <%= directory %> and its ancestors.
 
 If you think you already have a configuration file or if you need more help, please stop by the ESLint chat room: https://gitter.im/eslint/eslint

--- a/messages/no-config-found.txt
+++ b/messages/no-config-found.txt
@@ -1,21 +1,7 @@
-We couldn't find a valid configuration file for this linting run.
-
-This is the directory we were trying to lint: <%= directory %>
-
-<% if (filesExamined && filesExamined.length) { %>These are the configuration files we examined:
-
-<% filesExamined.forEach(function(file) { %>- <%= file %>
-<% }); %>
-None of these configuration files resulted in a valid configuration. Please
-check each file and look for a potential JSON/YAML syntax error. For JavaScript
-configuration files, please make sure that their configuration is exported by
-assigning to module.exports. Alternatively, you can create a new configuration
-file by running this command from your project root:
+ESLint couldn't find a configuration file. To set up a configuration file for this project, please run:
 
     eslint --init
-<% } else { %>No potential configuration files were found. If you have not created a
-configuration file, run this command from your project root to get started:
 
-    eslint --init
-<% } %>
-If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.
+We looked for configuration files in <%= directory =%> and its ancestors.
+
+If you think you already have a configuration file or if you need more help, please stop by the ESLint chat room: https://gitter.im/eslint/eslint

--- a/messages/no-config-found.txt
+++ b/messages/no-config-found.txt
@@ -1,0 +1,21 @@
+We couldn't find a valid configuration file for this linting run.
+
+This is the directory we were trying to lint: <%= directory %>
+
+<% if (filesExamined && filesExamined.length) { %>These are the configuration files we examined:
+
+<% filesExamined.forEach(function(file) { %>- <%= file %>
+<% }); %>
+None of these configuration files resulted in a valid configuration. Please
+check each file and look for a potential JSON/YAML syntax error. For JavaScript
+configuration files, please make sure that their configuration is exported by
+assigning to module.exports. Alternatively, you can create a new configuration
+file by running this command from your project root:
+
+    eslint --init
+<% } else { %>No potential configuration files were found. If you have not created a
+configuration file, run this command from your project root to get started:
+
+    eslint --init
+<% } %>
+If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.

--- a/tests/fixtures/source-code-util/.eslintrc.json
+++ b/tests/fixtures/source-code-util/.eslintrc.json
@@ -1,0 +1,3 @@
+{
+    // This file is only to ensure no error is thrown due to lack of config.
+}

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -251,13 +251,15 @@ describe("Config", function() {
             assert.equal(config.rules["no-new"], 1);
         });
 
-        it("should return a default config when an invalid path is given", function() {
+        it("should throw an error when an invalid path is given", function() {
             var configPath = path.resolve(__dirname, "..", "fixtures", "configurations", "foobaz", ".eslintrc");
             var configHelper = new Config({cwd: process.cwd()});
 
             sandbox.stub(fs, "readdirSync").throws(new Error());
 
-            assert.isObject(configHelper.getConfig(configPath));
+            assert.throws(function() {
+                configHelper.getConfig(configPath);
+            }, "No ESLint configuration found.");
         });
 
         it("should throw error when a configuration file doesn't exist", function() {
@@ -904,7 +906,7 @@ describe("Config", function() {
                 assert.deepEqual(actual, expected);
             });
 
-            it("should have an empty config if no local config and no personal config was found", function() {
+            it("should throw an error if no local config and no personal config was found", function() {
                 var projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -914,20 +916,14 @@ describe("Config", function() {
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
 
-                var config = new StubbedConfig({ cwd: process.cwd() }),
-                    actual = config.getConfig(filePath),
-                    expected = {
-                        parserOptions: {},
-                        env: {},
-                        globals: {},
-                        parser: undefined,
-                        rules: {}
-                    };
+                var config = new StubbedConfig({ cwd: process.cwd() });
 
-                assert.deepEqual(actual, expected);
+                assert.throws(function() {
+                    config.getConfig(filePath);
+                }, "No ESLint configuration found");
             });
 
-            it("should have an empty config if no local config was found and ~/package.json contains no eslintConfig section", function() {
+            it("should throw an error if no local config was found and ~/package.json contains no eslintConfig section", function() {
                 var projectPath = getFakeFixturePath("personal-config", "project-without-config"),
                     homePath = getFakeFixturePath("personal-config", "home-folder-with-packagejson"),
                     filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
@@ -937,17 +933,11 @@ describe("Config", function() {
                 mockPersonalConfigFileSystem();
                 mockCWDResponse(projectPath);
 
-                var config = new StubbedConfig({ cwd: process.cwd() }),
-                    actual = config.getConfig(filePath),
-                    expected = {
-                        parserOptions: {},
-                        env: {},
-                        globals: {},
-                        parser: undefined,
-                        rules: {}
-                    };
+                var configHelper = new StubbedConfig({ cwd: process.cwd() });
 
-                assert.deepEqual(actual, expected);
+                assert.throws(function() {
+                    configHelper.getConfig(filePath);
+                }, "No ESLint configuration found");
             });
 
             it("should still load the project config if the current working directory is the same as the home folder", function() {

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -106,7 +106,7 @@ describe("Config", function() {
     /**
      * Mocks the current CWD path
      * @param {string} fakeCWDPath - fake CWD path
-     * @returns {undefined}
+     * @returns {void}
      * @private
      */
     function mockCWDResponse(fakeCWDPath) {

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -940,6 +940,46 @@ describe("Config", function() {
                 }, "No ESLint configuration found");
             });
 
+            it("should not throw an error if no local config and no personal config was found but useEslintrc is false", function() {
+                var projectPath = getFakeFixturePath("personal-config", "project-without-config"),
+                    homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
+                    filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
+
+                var StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+
+                mockPersonalConfigFileSystem();
+                mockCWDResponse(projectPath);
+
+                var config = new StubbedConfig({
+                    cwd: process.cwd(),
+                    useEslintrc: false
+                });
+
+                assert.doesNotThrow(function() {
+                    config.getConfig(filePath);
+                }, "No ESLint configuration found");
+            });
+
+            it("should not throw an error if no local config and no personal config was found but rules are specified", function() {
+                var projectPath = getFakeFixturePath("personal-config", "project-without-config"),
+                    homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
+                    filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
+
+                var StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+
+                mockPersonalConfigFileSystem();
+                mockCWDResponse(projectPath);
+
+                var config = new StubbedConfig({
+                    cwd: process.cwd(),
+                    rules: { quotes: [2, "single"] }
+                });
+
+                assert.doesNotThrow(function() {
+                    config.getConfig(filePath);
+                }, "No ESLint configuration found");
+            });
+
             it("should still load the project config if the current working directory is the same as the home folder", function() {
                 var projectPath = getFakeFixturePath("personal-config", "project-with-config"),
                     filePath = getFakeFixturePath("personal-config", "project-with-config", "subfolder", "foo.js");


### PR DESCRIPTION
Pulled in @IanVS' commit and added a few of my own to reorganize things a bit. I'm *fairly* sure this is ready, but let me know if I can organize things better (or if I should revert some of my last commits).

Organization stuff:
* Created new sub-describe in tests for cases where local and personal config does not exist (throws unless no-eslintrc or unless there is at least one rule key/value pair)
* Tried to make lib/config.js getLocalConfig() have fewer exit points. At the end is an if statement setting up the throw condition, and immediately after that is an unconditional return.

Thanks in advance for any feedback.

Ping @IanVS, @nzakas