### PR TITLE
Chore: Update index and `meta` for `"eslint:recommended"` (refs #6403)

### DIFF
--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -10,7 +10,6 @@ The `--fix` option on the [command line](../user-guide/command-line-interface#fi
 
 These rules relate to possible syntax or logic errors in JavaScript code:
 
-* [comma-dangle](comma-dangle.md): require or disallow trailing commas (fixable)
 * [no-cond-assign](no-cond-assign.md): disallow assignment operators in conditional expressions (recommended)
 * [no-console](no-console.md): disallow the use of `console` (recommended)
 * [no-constant-condition](no-constant-condition.md): disallow constant expressions in conditions (recommended)
@@ -156,6 +155,7 @@ These rules relate to style guidelines, and are therefore quite subjective:
 * [block-spacing](block-spacing.md): enforce consistent spacing inside single-line blocks (fixable)
 * [brace-style](brace-style.md): enforce consistent brace style for blocks
 * [camelcase](camelcase.md): enforce camelcase naming convention
+* [comma-dangle](comma-dangle.md): require or disallow trailing commas (fixable)
 * [comma-spacing](comma-spacing.md): enforce consistent spacing before and after commas (fixable)
 * [comma-style](comma-style.md): enforce consistent comma style
 * [computed-property-spacing](computed-property-spacing.md): enforce consistent spacing inside computed property brackets (fixable)

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -31,8 +31,8 @@ module.exports = {
     meta: {
         docs: {
             description: "require or disallow trailing commas",
-            category: "Possible Errors",
-            recommended: true
+            category: "Stylistic Issues",
+            recommended: false
         },
 
         fixable: "code",

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -14,7 +14,7 @@ module.exports = {
         docs: {
             description: "disallow assignments to native objects or read-only global variables",
             category: "Best Practices",
-            recommended: false
+            recommended: true
         },
 
         schema: [

--- a/lib/rules/no-unsafe-finally.js
+++ b/lib/rules/no-unsafe-finally.js
@@ -23,7 +23,7 @@ module.exports = {
         docs: {
             description: "disallow control flow statements in `finally` blocks",
             category: "Possible Errors",
-            recommended: false
+            recommended: true
         }
     },
     create: function(context) {


### PR DESCRIPTION
Because `comma-dangle` is removed from `"eslint:recommended"` in ESLint 3.0.0:
* Move from Possible Errors to Stylistic Issues in the rules index
* Change `recommended` from `true` to `false` in rule `meta` data

Because `no-native-reassign` and `no-unsafe-finally` are added to `"eslint:recommended"`
* Change `recommended` from `false` to `true` in rule `meta` data
