### PR TITLE
Fix: false negative of `max-len` (fixes #6564)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -162,7 +162,7 @@ module.exports = {
 
             return comment &&
                 (start.line < lineNumber || (start.line === lineNumber && isFirstTokenOnLine)) &&
-                (end.line > lineNumber || end.column === line.length);
+                (end.line > lineNumber || (end.line === lineNumber && end.column === line.length));
         }
 
         /**

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -394,6 +394,21 @@ ruleTester.run("max-len", rule, {
                     column: 1
                 }
             ]
+        },
+
+        // check comments with the same length as non-comments - https://github.com/eslint/eslint/issues/6564
+        {
+            code: "// This commented line has precisely 51 characters.\n" +
+                  "var x = 'This line also has exactly 51 characters';",
+            options: [20, { ignoreComments: true }],
+            errors: [
+                {
+                    message: "Line 2 exceeds the maximum line length of 20.",
+                    type: "Program",
+                    line: 2,
+                    column: 1
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
Fixes #6564.

This corrects a bug in the `isFullLineComment` helper function, which was incorrectly identifying non-commented lines of code as full-line comments if they were preceded by a commented line of the same length.