### PR TITLE
Docs: rules\id-length ###exceptions typos (fixes #6397)

### DIFF
--- a/docs/rules/id-length.md
+++ b/docs/rules/id-length.md
@@ -240,10 +240,10 @@ var myObj = { a: 1 };
 
 ### exceptions
 
-Examples of additional **correct** code for this rule with the `{ "exceptions": "x" }` option:
+Examples of additional **correct** code for this rule with the `{ "exceptions": ["x"] }` option:
 
 ```js
-/*eslint id-length: ["error", { "max": "10" }]*/
+/*eslint id-length: ["error", { "exceptions": ["x"] }]*/
 /*eslint-env es6*/
 
 var x = 5;


### PR DESCRIPTION
Changed 2 typos:
exceptions accepts array,
was max property instead of exception property.