### PR TITLE
Fix: Make outerIIFEBody work correctly (fixes #6585)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -369,18 +369,23 @@ module.exports = {
 
 		/**
          * Check to see if the node is a file level IIFE
-         * @param {ASTNode} node node to check
+         * @param {ASTNode} node The function node to check.
          * @returns {boolean} True if the node is the outer IIFE
          */
         function isOuterIIFE(node) {
-            return node && node.type === "CallExpression" &&
-                node.parent && node.parent.type === "ExpressionStatement" &&
-                node.parent.parent && node.parent.parent.type === "Program";
+            var parent = node.parent;
+
+            return (
+                parent.type === "CallExpression" &&
+                parent.callee === node &&
+                parent.parent.type === "ExpressionStatement" &&
+                parent.parent.parent && parent.parent.parent.type === "Program"
+            );
         }
 
         /**
          * Check indent for function block content
-         * @param {ASTNode} node node to examine
+         * @param {ASTNode} node A BlockStatement node that is inside of a function.
          * @returns {void}
          */
         function checkIndentInFunctionBlock(node) {
@@ -433,8 +438,8 @@ module.exports = {
             // is the outer IIFE and that option is enabled.
             var functionOffset = indentSize;
 
-            if (options.outerIIFEBody !== null && isOuterIIFE(calleeNode.parent)) {
-                functionOffset = options.outerIIFEBody;
+            if (options.outerIIFEBody !== null && isOuterIIFE(calleeNode)) {
+                functionOffset = options.outerIIFEBody * indentSize;
             }
             indent += functionOffset;
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1139,6 +1139,14 @@ ruleTester.run("indent", rule, {
         },
         {
             code:
+            "fs.readdirSync(path.join(__dirname, '../rules')).forEach(name => {\n" +
+            "  files[name] = foo;\n" +
+            "});",
+            options: [2, { outerIIFEBody: 0 }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code:
             "(function(){\n" +
             "function foo(x) {\n" +
             "  return x + 1;\n" +
@@ -1149,9 +1157,9 @@ ruleTester.run("indent", rule, {
         {
             code:
             "(function(){\n" +
-            "  function foo(x) {\n" +
-            "      return x + 1;\n" +
-            "  }\n" +
+            "        function foo(x) {\n" +
+            "            return x + 1;\n" +
+            "        }\n" +
             "})();",
             options: [4, { outerIIFEBody: 2 }]
         },
@@ -2137,7 +2145,7 @@ ruleTester.run("indent", rule, {
             "    }\n" +
             "})();",
             options: [4, { outerIIFEBody: 2 }],
-            errors: expectedErrors([[2, 2, 4, "FunctionDeclaration"]])
+            errors: expectedErrors([[2, 8, 4, "FunctionDeclaration"]])
         },
         {
             code:


### PR DESCRIPTION
This should make the `outerIIFEBody` option work as intended:

1. Make sure the indent is a multiplier, not a set number of spaces.
2. Fix false positive top-level IIFE detection.