### PR TITLE
New: exposes rule metadata to the Node API (fixes #6582)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -105,6 +105,16 @@ The `verify()` method returns an array of objects containing information about t
     fix: {
         range: [1, 15],
         text: ";"
+    },
+    meta: {
+        docs: {
+            description: "disallow unnecessary semicolons",
+            category: "Possible Errors",
+            recommended: true,
+            uri: "http://eslint.org/docs/rules/semi"
+        },
+        fixable: "code",
+        schema: [] // no options
     }
 }
 ```
@@ -120,6 +130,7 @@ The information available for each linting message is:
 * `severity` - either 1 or 2, depending on your configuration.
 * `source` - the line of code where the problem is (or empty string if it can't be found).
 * `fix` - an object describing the fix for the problem (this property is omitted if no fix is available).
+* `meta` - metadata from the rule definition
 
 You can also get an instance of the `SourceCode` object used inside of `linter` by using the `getSourceCode()` method:
 

--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -28,7 +28,8 @@ module.exports = {
         docs: {
             description: "disallow unnecessary semicolons",
             category: "Possible Errors",
-            recommended: true
+            recommended: true,
+            uri: "http://eslint.org/docs/rules/semi"
         },
         fixable: "code",
         schema: [] // no options
@@ -52,6 +53,7 @@ The source file for a rule exports an object with the following properties.
     * `description` (string) provides the short description of the rule in the [rules index](../rules/)
     * `category` (string) specifies the heading under which the rule is listed in the [rules index](../rules/)
     * `recommended` (boolean) is whether the `"extends": "eslint:recommended"` property in a [configuration file](../user-guide/configuring#extending-configuration-files) enables the rule
+    * `uri` (string) URI pointing to the documentation for the rule
 
     In a custom rule or plugin, you can omit `docs` or include any properties that you need in it.
 

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -455,8 +455,10 @@ function prepareConfig(config) {
         globals: ConfigOps.merge({}, config.globals),
         env: ConfigOps.merge({}, config.env || {}),
         settings: ConfigOps.merge({}, config.settings || {}),
-        parserOptions: ConfigOps.merge(parserOptions, config.parserOptions || {})
+        parserOptions: ConfigOps.merge(parserOptions, config.parserOptions || {}),
+        meta: ConfigOps.merge({}, config.meta || {})
     };
+
 
     if (preparedConfig.parserOptions.sourceType === "module") {
         if (!preparedConfig.parserOptions.ecmaFeatures) {
@@ -980,6 +982,10 @@ module.exports = (function() {
             nodeType: node && node.type,
             source: sourceCode.lines[location.line - 1] || ""
         };
+
+        if (meta) {
+            problem.meta = meta;
+        }
 
         // ensure there's range and text properties, otherwise it's not a valid fix
         if (fix && Array.isArray(fix.range) && (typeof fix.text === "string")) {

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -256,7 +256,25 @@ describe("CLIEngine", function() {
                                 line: 1,
                                 column: 11,
                                 nodeType: "Identifier",
-                                source: "var bar = foo"
+                                source: "var bar = foo",
+                                meta: {
+                                    docs: {
+                                        category: "Variables",
+                                        description: "disallow the use of undeclared variables unless mentioned in `/*global */` comments",
+                                        recommended: true
+                                    },
+                                    schema: [
+                                        {
+                                            additionalProperties: false,
+                                            properties: {
+                                                typeof: {
+                                                    type: "boolean"
+                                                }
+                                            },
+                                            type: "object"
+                                        }
+                                    ]
+                                }
                             }
                         ],
                         errorCount: 1,
@@ -1042,6 +1060,7 @@ describe("CLIEngine", function() {
 
         describe("Fix Mode", function() {
 
+
             it("should return fixed text on multiple files when in fix mode", function() {
 
                 /**
@@ -1097,7 +1116,23 @@ describe("CLIEngine", function() {
                                     nodeType: "BinaryExpression",
                                     ruleId: "eqeqeq",
                                     severity: 2,
-                                    source: "if (msg == \"hi\") {"
+                                    source: "if (msg == \"hi\") {",
+                                    meta: {
+                                        docs: {
+                                            category: "Best Practices",
+                                            description: "require the use of `===` and `!==`",
+                                            recommended: false
+                                        },
+                                        schema: [
+                                            {
+                                                enum: [
+                                                    "always",
+                                                    "smart",
+                                                    "allow-null"
+                                                ]
+                                            }
+                                        ]
+                                    }
                                 }
                             ],
                             errorCount: 1,
@@ -1114,7 +1149,25 @@ describe("CLIEngine", function() {
                                     nodeType: "Identifier",
                                     ruleId: "no-undef",
                                     severity: 2,
-                                    source: "var msg = \"hi\" + foo;"
+                                    source: "var msg = \"hi\" + foo;",
+                                    meta: {
+                                        docs: {
+                                            category: "Variables",
+                                            description: "disallow the use of undeclared variables unless mentioned in `/*global */` comments",
+                                            recommended: true
+                                        },
+                                        schema: [
+                                            {
+                                                additionalProperties: false,
+                                                properties: {
+                                                    typeof: {
+                                                        type: "boolean"
+                                                    }
+                                                },
+                                                type: "object"
+                                            }
+                                        ]
+                                    }
                                 }
                             ],
                             errorCount: 1,

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -1723,6 +1723,39 @@ describe("eslint", function() {
         });
     });
 
+    describe("When a URI is provided for the rule documentation", function() {
+        var RULE_URI = "http://path.to/docs/rules/test-doc-rule";
+
+        eslint.defineRule("test-plugin/test-doc-rule", {
+            meta: {
+                docs: {
+                    uri: RULE_URI
+                }
+            },
+            create: function(context) {
+                return {
+                    Literal: function(node) {
+                        if (node.value === "trigger violation") {
+                            context.report(node, "Reporting violation.");
+                        }
+                    }
+                };
+            }
+        });
+
+        it("should report the URI", function() {
+            var config = {
+                rules: {"test-plugin/test-doc-rule": 2}
+            };
+            var code = "var a = \"trigger violation\";";
+
+            eslint.reset();
+            var messages = eslint.verify(code, config, filename, false);
+
+            assert.equal(messages[0].meta.docs.uri, RULE_URI);
+        });
+    });
+
     describe("when evaluating code with comments to enable rules", function() {
 
         it("should report a violation", function() {


### PR DESCRIPTION
So that CLI clients such as [AtomLinter/linter-eslint](https://github.com/AtomLinter/linter-eslint) can find the documentation for a rule at `meta.docs.uri`. 

There may be additional benefits to exposing a rule's metadata through the API, but that was the impetus. 