### PR TITLE
Chore: remove path-is-absolute in favor of the built-in (fixes #6598)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -20,7 +20,6 @@ var fs = require("fs"),
 
     lodash = require("lodash"),
     debug = require("debug"),
-    isAbsolute = require("path-is-absolute"),
 
     rules = require("./rules"),
     eslint = require("./eslint"),
@@ -740,7 +739,7 @@ CLIEngine.prototype = {
             ignoredPaths = new IgnoredPaths(options);
 
         // resolve filename based on options.cwd (for reporting, ignoredPaths also resolves)
-        if (filename && !isAbsolute(filename)) {
+        if (filename && !path.isAbsolute(filename)) {
             filename = path.resolve(options.cwd, filename);
         }
         if (filename && warnIgnored && ignoredPaths.contains(filename)) {

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -23,7 +23,6 @@ var debug = require("debug"),
     stripBom = require("strip-bom"),
     stripComments = require("strip-json-comments"),
     stringify = require("json-stable-stringify"),
-    isAbsolutePath = require("path-is-absolute"),
     defaultOptions = require("../../conf/eslint.json"),
     requireUncached = require("require-uncached");
 
@@ -81,7 +80,7 @@ function readFile(filePath) {
  * @private
  */
 function isFilePath(filePath) {
-    return isAbsolutePath(filePath) || !/\w|@/.test(filePath.charAt(0));
+    return path.isAbsolute(filePath) || !/\w|@/.test(filePath.charAt(0));
 }
 
 /**
@@ -382,7 +381,7 @@ function applyExtends(config, filePath, relativeTo) {
              * If the `extends` path is relative, use the directory of the current configuration
              * file as the reference point. Otherwise, use as-is.
              */
-            parentPath = (!isAbsolutePath(parentPath) ?
+            parentPath = (!path.isAbsolute(parentPath) ?
                 path.join(relativeTo || path.dirname(filePath), parentPath) :
                 parentPath
             );

--- a/lib/util/path-util.js
+++ b/lib/util/path-util.js
@@ -8,8 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var path = require("path"),
-    isAbsolute = require("path-is-absolute");
+var path = require("path");
 
 //------------------------------------------------------------------------------
 // Private
@@ -51,11 +50,11 @@ function convertPathToPosix(filepath) {
 function getRelativePath(filepath, baseDir) {
     var relativePath;
 
-    if (!isAbsolute(filepath)) {
+    if (!path.isAbsolute(filepath)) {
         filepath = path.resolve(filepath);
     }
     if (baseDir) {
-        if (!isAbsolute(baseDir)) {
+        if (!path.isAbsolute(baseDir)) {
             throw new Error("baseDir should be an absolute path");
         }
         relativePath = path.relative(baseDir, filepath);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.0",
     "optionator": "^0.8.1",
-    "path-is-absolute": "^1.0.0",
     "path-is-inside": "^1.0.1",
     "pluralize": "^1.2.1",
     "progress": "^1.1.8",


### PR DESCRIPTION
Fixes #6598.
