### PR TITLE
Chore: add internal rule that validates meta property (fixes #6383)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ versions.json
 .eslintcache
 .cache
 /packages/**/node_modules
+.vscode/setting.json
+.sublimelinterrc

--- a/Makefile.js
+++ b/Makefile.js
@@ -57,7 +57,7 @@ var NODE = "node ", // intentional extra space
 
     // Utilities - intentional extra space at the end of each string
     MOCHA = NODE_MODULES + "mocha/bin/_mocha ",
-    ESLINT = NODE + " bin/eslint.js ",
+    ESLINT = NODE + " bin/eslint.js --rulesdir lib/internal-rules/ ",
 
     // Files
     MAKEFILE = "./Makefile.js",

--- a/lib/internal-rules/internal-no-invalid-meta.js
+++ b/lib/internal-rules/internal-no-invalid-meta.js
@@ -1,0 +1,212 @@
+/**
+ * @fileoverview Internal rule to prevent missing or invalid meta property in core rules.
+ * @author Vitor Balocco
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the property of the Object node passed in that has the name specified.
+ *
+ * @param {string} property Name of the property to return.
+ * @param {ASTNode} node The ObjectExpression node.
+ * @returns {ASTNode} The Property node or null if not found.
+ */
+function getPropertyFromObject(property, node) {
+    var properties = node.properties;
+
+    for (var i = 0; i < properties.length; i++) {
+        if (properties[i].key.name === property) {
+            return properties[i];
+        }
+    }
+
+    return null;
+}
+
+/**
+ * Extracts the `meta` property from the ObjectExpression that all rules export.
+ *
+ * @param {ASTNode} exportsNode ObjectExpression node that the rule exports.
+ * @returns {ASTNode} The `meta` Property node or null if not found.
+ */
+function getMetaPropertyFromExportsNode(exportsNode) {
+    return getPropertyFromObject("meta", exportsNode);
+}
+
+/**
+ * Whether this `meta` ObjectExpression has a `docs` property defined or not.
+ *
+ * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
+ * @returns {boolean} `true` if a `docs` property exists.
+ */
+function hasMetaDocs(metaPropertyNode) {
+    return Boolean(getPropertyFromObject("docs", metaPropertyNode.value));
+}
+
+/**
+ * Whether this `meta` ObjectExpression has a `docs.description` property defined or not.
+ *
+ * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
+ * @returns {boolean} `true` if a `docs.description` property exists.
+ */
+function hasMetaDocsDescription(metaPropertyNode) {
+    var metaDocs = getPropertyFromObject("docs", metaPropertyNode.value);
+
+    return metaDocs && getPropertyFromObject("description", metaDocs.value);
+}
+
+/**
+ * Whether this `meta` ObjectExpression has a `docs.category` property defined or not.
+ *
+ * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
+ * @returns {boolean} `true` if a `docs.category` property exists.
+ */
+function hasMetaDocsCategory(metaPropertyNode) {
+    var metaDocs = getPropertyFromObject("docs", metaPropertyNode.value);
+
+    return metaDocs && getPropertyFromObject("category", metaDocs.value);
+}
+
+/**
+ * Whether this `meta` ObjectExpression has a `docs.recommended` property defined or not.
+ *
+ * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
+ * @returns {boolean} `true` if a `docs.recommended` property exists.
+ */
+function hasMetaDocsRecommended(metaPropertyNode) {
+    var metaDocs = getPropertyFromObject("docs", metaPropertyNode.value);
+
+    return metaDocs && getPropertyFromObject("recommended", metaDocs.value);
+}
+
+/**
+ * Whether this `meta` ObjectExpression has a `schema` property defined or not.
+ *
+ * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
+ * @returns {boolean} `true` if a `schema` property exists.
+ */
+function hasMetaSchema(metaPropertyNode) {
+    return getPropertyFromObject("schema", metaPropertyNode.value);
+}
+
+/**
+ * Whether this `meta` ObjectExpression has a `fixable` property defined or not.
+ *
+ * @param {ASTNode} metaPropertyNode The `meta` ObjectExpression for this rule.
+ * @returns {boolean} `true` if a `fixable` property exists.
+ */
+function hasMetaFixable(metaPropertyNode) {
+    return getPropertyFromObject("fixable", metaPropertyNode.value);
+}
+
+/**
+ * Checks the validity of the meta definition of this rule and reports any errors found.
+ *
+ * @param {RuleContext} context The ESLint rule context.
+ * @param {ASTNode} exportsNode ObjectExpression node that the rule exports.
+ * @param {boolean} ruleIsFixable whether the rule is fixable or not.
+ * @returns {void}
+ */
+function checkMetaValidity(context, exportsNode, ruleIsFixable) {
+    var metaProperty = getMetaPropertyFromExportsNode(exportsNode);
+
+    if (!metaProperty) {
+        context.report(exportsNode, "Rule is missing a meta property.");
+        return;
+    }
+
+    if (!hasMetaDocs(metaProperty)) {
+        context.report(metaProperty, "Rule is missing a meta.docs property.");
+        return;
+    }
+
+    if (!hasMetaDocsDescription(metaProperty)) {
+        context.report(metaProperty, "Rule is missing a meta.docs.description property.");
+        return;
+    }
+
+    if (!hasMetaDocsCategory(metaProperty)) {
+        context.report(metaProperty, "Rule is missing a meta.docs.category property.");
+        return;
+    }
+
+    if (!hasMetaDocsRecommended(metaProperty)) {
+        context.report(metaProperty, "Rule is missing a meta.docs.recommended property.");
+        return;
+    }
+
+    if (!hasMetaSchema(metaProperty)) {
+        context.report(metaProperty, "Rule is missing a meta.schema property.");
+        return;
+    }
+
+    if (ruleIsFixable && !hasMetaFixable(metaProperty)) {
+        context.report(metaProperty, "Rule is fixable, but is missing a meta.fixable property.");
+        return;
+    }
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "enforce correct use of `meta` property in core rules",
+            category: "Internal",
+            recommended: false
+        },
+
+        schema: []
+    },
+
+    create: function(context) {
+        var metaExportsValue;
+        var ruleIsFixable = false;
+
+        return {
+            AssignmentExpression: function(node) {
+                if (node.left &&
+                    node.right &&
+                    node.left.type === "MemberExpression" &&
+                    node.left.object.name === "module" &&
+                    node.left.property.name === "exports") {
+
+                    metaExportsValue = node.right;
+                }
+            },
+
+            CallExpression: function(node) {
+
+                // If the rule has a call for `context.report` and a property `fix`
+                // is being passed in, then we consider that the rule is fixable.
+                //
+                // Note that we only look for context.report() calls in the new
+                // style (with single MessageDescriptor argument), because only
+                // calls in the new style can specify a fix.
+                if (node.callee.type === "MemberExpression" &&
+                    node.callee.object.type === "Identifier" &&
+                    node.callee.object.name === "context" &&
+                    node.callee.property.type === "Identifier" &&
+                    node.callee.property.name === "report" &&
+                    node.arguments.length === 1 &&
+                    node.arguments[0].type === "ObjectExpression") {
+
+                    if (getPropertyFromObject("fix", node.arguments[0])) {
+                        ruleIsFixable = true;
+                    }
+                }
+            },
+
+            "Program:exit": function() {
+                checkMetaValidity(context, metaExportsValue, ruleIsFixable);
+            }
+        };
+    }
+};

--- a/lib/rules/.eslintrc.yml
+++ b/lib/rules/.eslintrc.yml
@@ -1,0 +1,2 @@
+rules:
+    internal-no-invalid-meta: "error"

--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -14,7 +14,9 @@ module.exports = {
             description: "disallow calling some `Object.prototype` methods directly on objects",
             category: "Possible Errors",
             recommended: false
-        }
+        },
+
+        schema: []
     },
 
     create: function(context) {

--- a/lib/rules/no-unsafe-finally.js
+++ b/lib/rules/no-unsafe-finally.js
@@ -24,7 +24,9 @@ module.exports = {
             description: "disallow control flow statements in `finally` blocks",
             category: "Possible Errors",
             recommended: true
-        }
+        },
+
+        schema: []
     },
     create: function(context) {
 

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -16,7 +16,9 @@ module.exports = {
             description: "disallow unnecessary computed property keys in object literals",
             category: "ECMAScript 6",
             recommended: false
-        }
+        },
+
+        schema: []
     },
     create: function(context) {
         var sourceCode = context.getSourceCode();

--- a/tests/lib/internal-rules/internal-no-valid-meta.js
+++ b/tests/lib/internal-rules/internal-no-valid-meta.js
@@ -1,0 +1,263 @@
+/**
+ * @fileoverview Tests for internal no-valid-meta rule.
+ * @author Vitor Balocco
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require("../../../lib/internal-rules/internal-no-invalid-meta"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+var ruleTester = new RuleTester();
+
+ruleTester.run("internal-no-invalid-meta", rule, {
+    valid: [
+
+        // context.report() call with no fix
+        [
+            "module.exports = {",
+            "    meta: {",
+            "        docs: {",
+            "            description: 'some rule',",
+            "            category: 'Internal',",
+            "            recommended: false",
+            "        },",
+            "        schema: []",
+            "    },",
+
+            "    create: function(context) {",
+            "        return {",
+            "            Program: function(node) {",
+            "                context.report({",
+            "                    node: node",
+            "                });",
+            "            }",
+            "        };",
+            "    }",
+            "};"
+        ].join("\n"),
+
+        // context.report() call in old style
+        [
+            "module.exports = {",
+            "    meta: {",
+            "        docs: {",
+            "            description: 'some rule',",
+            "            category: 'Internal',",
+            "            recommended: false",
+            "        },",
+            "        schema: []",
+            "    },",
+
+            "    create: function(context) {",
+            "        return {",
+            "            Program: function(node) {",
+            "                context.report(node, 'Getter is not present');",
+            "            }",
+            "        };",
+            "    }",
+            "};"
+        ].join("\n"),
+
+        // context.report() call with a fix property
+        [
+            "module.exports = {",
+            "    meta: {",
+            "        docs: {",
+            "            description: 'some rule',",
+            "            category: 'Internal',",
+            "            recommended: false",
+            "        },",
+            "        schema: [],",
+            "        fixable: 'whitespace'",
+            "    },",
+
+            "    create: function(context) {",
+            "        return {",
+            "            Program: function(node) {",
+            "                context.report({",
+            "                    node: node,",
+            "                    fix: function(fixer) {",
+            "                        return fixer.insertTextAfter(node, ' ');",
+            "                    }",
+            "                });",
+            "            }",
+            "        };",
+            "    }",
+            "};"
+        ].join("\n")
+    ],
+    invalid: [
+        {
+            code: [
+                "module.exports = {",
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {}",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta property.",
+                line: 1,
+                column: 18
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
+                "    meta: {",
+                "        schema: []",
+                "    },",
+
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {}",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta.docs property.",
+                line: 2,
+                column: 5
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
+                "    meta: {",
+                "        docs: {",
+                "            category: 'Internal',",
+                "            recommended: false",
+                "        },",
+                "        schema: []",
+                "    },",
+
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {}",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta.docs.description property.",
+                line: 2,
+                column: 5
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
+                "    meta: {",
+                "        docs: {",
+                "            description: 'some rule',",
+                "            recommended: false",
+                "        },",
+                "        schema: []",
+                "    },",
+
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {}",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta.docs.category property.",
+                line: 2,
+                column: 5
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
+                "    meta: {",
+                "        docs: {",
+                "            description: 'some rule',",
+                "            category: 'Internal'",
+                "        },",
+                "        schema: []",
+                "    },",
+
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {}",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta.docs.recommended property.",
+                line: 2,
+                column: 5
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
+                "    meta: {",
+                "        docs: {",
+                "            description: 'some rule',",
+                "            category: 'Internal',",
+                "            recommended: false",
+                "        }",
+                "    },",
+
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {}",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is missing a meta.schema property.",
+                line: 2,
+                column: 5
+            }]
+        },
+        {
+            code: [
+                "module.exports = {",
+                "    meta: {",
+                "        docs: {",
+                "            description: 'some rule',",
+                "            category: 'Internal',",
+                "            recommended: false",
+                "        },",
+                "        schema: []",
+                "    },",
+                "    create: function(context) {",
+                "        return {",
+                "            Program: function(node) {",
+                "                context.report({",
+                "                    node: node,",
+                "                    fix: function(fixer) {",
+                "                        return fixer.insertTextAfter(node, ' ');",
+                "                    }",
+                "                });",
+                "            }",
+                "        };",
+                "    }",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule is fixable, but is missing a meta.fixable property.",
+                line: 2,
+                column: 5
+            }]
+        }
+    ]
+});


### PR DESCRIPTION
Add a custom rule to verify that all core rules have the correct `meta` property format.
As discussed in #6383 this is just an internal custom rule for now and not a plugin.

I modified the Makefile's lint task so it find our "internal rules" directory. Feedback welcome on a better folder name.