### PR TITLE
Docs: Removed non-existing resource

### DIFF
--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -179,7 +179,6 @@ If you do not want to enforce semicolon usage (or omission) in any particular wa
 
 * [An Open Letter to JavaScript Leaders Regarding Semicolons](http://blog.izs.me/post/2353458699/an-open-letter-to-javascript-leaders-regarding)
 * [JavaScript Semicolon Insertion](http://inimino.org/~inimino/blog/javascript_semicolons)
-* [Understanding Automatic Semicolon Insertion in JavaScript](http://jamesallardice.com/understanding-automatic-semi-colon-insertion-in-javascript/)
 
 ## Related Rules
 


### PR DESCRIPTION
Hello :wave:,

I found out that the last resource of the [semi rule](http://eslint.org/docs/rules/semi.html) documentation page doesn't exist anymore. I couldn't find any backup of it online either, so I think it's good to remove it from the documentation?

Since this is about the docs, and not eslint itself, I haven't filled out the issue template. Sorry if that was wrong.