### PR TITLE
Fix: Remove  reference from 3.0.0 migration guide (refs #6605)

### DIFF
--- a/docs/user-guide/migrating-to-3.0.0.md
+++ b/docs/user-guide/migrating-to-3.0.0.md
@@ -13,9 +13,8 @@ With ESLint v3.0.0, we are dropping support for Node.js versions prior to 4. Nod
 ESLint v3.0.0 now requires that you use a configuration to run. A configuration can be any of the following:
 
 1. A `.eslintrc.js`, `.eslintrc.json`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc` file either in your project or home directory.
-2. Configuration options passed on the command line using `--rule`
-3. A configuration file passed on the command line using `-c`.
-4. A configuration passed to `CLIEngine` with the `useSpecificConfig` option.
+2. Configuration options passed on the command line using `--rule` (or to CLIEngine using `rules`).
+3. A configuration file passed on the command line using `-c` (or to CLIEngine using `configFile`).
 
 If ESLint can't find a configuration, then it will throw an error and ask you to provide one.
 


### PR DESCRIPTION
**What issue does this pull request address?**

ESLint 3.0.0 migration guide, in section "Requiring Configuration to Run", mentions a `useSpecificConfig` option which is not part of the public API. The correct option is `configFile` (already mentioned).

**What changes did you make? (Give an overview)**

I removed the incorrect text. I also decided to augment the remaining text with info on how to pass in configuration files (or equivalent) via CLIEngine as well as CLI.

**Is there anything you'd like reviewers to focus on?**

Let me know if the extra text is too much.

NOTE: There is also an issue where `baseConfig` is not sufficient to suppress the No Config error message. This pull request intentionally does *not* address that problem. When I fix that issue (in a separate pull request), I will update the Migration Guide in the same commit to reflect that `baseConfig` is a valid method of including configuration.