### PR TITLE
Fix: Remove  reference from 3.0.0 migration guide (refs #6605)

### DIFF
--- a/docs/user-guide/migrating-to-3.0.0.md
+++ b/docs/user-guide/migrating-to-3.0.0.md
@@ -13,9 +13,8 @@ With ESLint v3.0.0, we are dropping support for Node.js versions prior to 4. Nod
 ESLint v3.0.0 now requires that you use a configuration to run. A configuration can be any of the following:
 
 1. A `.eslintrc.js`, `.eslintrc.json`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc` file either in your project or home directory.
-2. Configuration options passed on the command line using `--rule`
-3. A configuration file passed on the command line using `-c`.
-4. A configuration passed to `CLIEngine` with the `useSpecificConfig` option.
+2. Configuration options passed on the command line using `--rule` (or to CLIEngine using `rules`).
+3. A configuration file passed on the command line using `-c` (or to CLIEngine using `configFile`).
 
 If ESLint can't find a configuration, then it will throw an error and ask you to provide one.
 


### PR DESCRIPTION
**What issue does this pull request address?**

CLIEngine now throws an exception (claiming no configuration was provided/could be found) if a user uses the `baseConfig` option in a project without an eslintrc file. Since the spirit of the intended 3.0.0 change was to throw if there wasn't a configuration (as opposed to a configuration file), we need to support `baseConfig` as an alternative means of providing a configuration.

**What changes did you make? (Give an overview)**

lib/config.js will now check for `baseConfig` being specified in options before throwing a No Configuration Found exception.

**Is there anything you'd like reviewers to focus on?**

I'm assuming here that an empty config (`baseConfig: {}`) still counts as explicitly specifying a configuration (even if it is empty). Please let me know if this is a bad assumption.