### PR TITLE
Fix: Do not throw exception if baseConfig is provided (fixes #6605)

### DIFF
--- a/docs/user-guide/migrating-to-3.0.0.md
+++ b/docs/user-guide/migrating-to-3.0.0.md
@@ -15,6 +15,7 @@ ESLint v3.0.0 now requires that you use a configuration to run. A configuration 
 1. A `.eslintrc.js`, `.eslintrc.json`, `.eslintrc.yml`, `.eslintrc.yaml`, or `.eslintrc` file either in your project or home directory.
 2. Configuration options passed on the command line using `--rule` (or to CLIEngine using `rules`).
 3. A configuration file passed on the command line using `-c` (or to CLIEngine using `configFile`).
+4. A base configuration is provided to CLIEngine using the `baseConfig` option.
 
 If ESLint can't find a configuration, then it will throw an error and ask you to provide one.
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -162,7 +162,7 @@ function getLocalConfig(thisConfig, directory) {
 
         if (personalConfig) {
             config = ConfigOps.merge(config, personalConfig);
-        } else if (!hasRules(thisConfig.options)) {
+        } else if (!hasRules(thisConfig.options) && !thisConfig.options.baseConfig) {
 
             // No config file, no manual configuration, and no rules, so error.
             var noConfigError = new Error("No ESLint configuration found.");

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -1043,6 +1043,26 @@ describe("Config", function() {
                     config.getConfig(filePath);
                 }, "No ESLint configuration found");
             });
+
+            it("should not throw an error if no local config and no personal config was found but baseConfig is specified", function() {
+                var projectPath = getFakeFixturePath("personal-config", "project-without-config"),
+                    homePath = getFakeFixturePath("personal-config", "folder-does-not-exist"),
+                    filePath = getFakeFixturePath("personal-config", "project-without-config", "foo.js");
+
+                var StubbedConfig = proxyquire("../../lib/config", { "user-home": homePath });
+
+                mockPersonalConfigFileSystem();
+                mockCWDResponse(projectPath);
+
+                var config = new StubbedConfig({
+                    cwd: process.cwd(),
+                    baseConfig: {}
+                });
+
+                assert.doesNotThrow(function() {
+                    config.getConfig(filePath);
+                }, "No ESLint configuration found");
+            });
         });
     });
 


### PR DESCRIPTION
**What issue does this pull request address?**

When using CLIEngine, specifying baseConfig was not enough to prevent a No Config Found exception from being thrown. This change will ensure that no exception is thrown if baseConfig is provided to CLIEngine.

**What changes did you make? (Give an overview)**

Check if baseConfig is present in lib/config.js before throwing an exception, plus test, plus change to migration guide.

**Is there anything you'd like reviewers to focus on?**

Not 100% sure if baseConfig should be checked for at least one key, like "rules" is. Assumption is that baseConfig is null/undefined by default, and so an empty object still represents a conscious user decision to provide a config (even if empty). If this is a bad assumption, let me know.