### PR TITLE
Fix: Warning behavior for executeOnText (fixes #6611)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -742,8 +742,11 @@ CLIEngine.prototype = {
         if (filename && !path.isAbsolute(filename)) {
             filename = path.resolve(options.cwd, filename);
         }
-        if (filename && warnIgnored && ignoredPaths.contains(filename)) {
-            results.push(createIgnoreResult(filename, options.cwd));
+
+        if (filename && ignoredPaths.contains(filename)) {
+            if (warnIgnored) {
+                results.push(createIgnoreResult(filename, options.cwd));
+            }
         } else {
             results.push(processText(text, configHelper, filename, options.fix, options.allowInlineConfig));
         }

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -148,7 +148,7 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].filePath, getFixturePath("test.js"));
         });
 
-        it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is set", function() {
+        it("should return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is true", function() {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
                 cwd: getFixturePath("..")
@@ -167,6 +167,19 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].warningCount, 1);
         });
 
+        it("should not return a warning when given a filename by --stdin-filename in excluded files list if warnIgnored is false", function() {
+            engine = new CLIEngine({
+                ignorePath: getFixturePath(".eslintignore"),
+                cwd: getFixturePath("..")
+            });
+
+            // intentional parsing error
+            var report = engine.executeOnText("va r bar = foo;", "fixtures/passing.js", false);
+
+            // should not report anything because the file is ignored
+            assert.equal(report.results.length, 0);
+        });
+
         it("should suppress excluded file warnings by default", function() {
             engine = new CLIEngine({
                 ignorePath: getFixturePath(".eslintignore"),
@@ -175,9 +188,8 @@ describe("CLIEngine", function() {
 
             var report = engine.executeOnText("var bar = foo;", "fixtures/passing.js");
 
-            assert.equal(report.results.length, 1);
-            assert.equal(report.results[0].errorCount, 0);
-            assert.equal(report.results[0].warningCount, 0);
+            // should not report anything because there are no errors
+            assert.equal(report.results.length, 0);
         });
 
         it("should return a message when given a filename by --stdin-filename in excluded files list and ignore is off", function() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6611

**What changes did you make? (Give an overview)**

Previously, `executeOnText()` would lint an ignored file if `warnIgnored` was `false`. I changed it so that it always ignores files that should be ignored and only outputs a warning when `warnIgnored` is `true`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.