### PR TITLE
Fix: Install required eslint plugin for "standard" guide (fixes #6656)

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -278,7 +278,7 @@ function getConfigForStyleGuide(guide) {
     var guides = {
         google: {extends: "google"},
         airbnb: {extends: "airbnb", plugins: ["react"]},
-        standard: {extends: "standard", plugins: ["standard"]}
+        standard: {extends: "standard", plugins: ["standard", "promise"]}
     };
 
     if (!guides[guide]) {

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -195,7 +195,7 @@ describe("configInitializer", function() {
             it("should support the standard style guide", function() {
                 var config = init.getConfigForStyleGuide("standard");
 
-                assert.deepEqual(config, {extends: "standard", installedESLint: true, plugins: ["standard"]});
+                assert.deepEqual(config, {extends: "standard", installedESLint: true, plugins: ["standard", "promise"]});
             });
 
             it("should throw when encountering an unsupported style guide", function() {


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6656 

**What changes did you make? (Give an overview)**

`eslint-config-standard` peer depends on `eslint-plugin-promise`, so
let's install that for users.

**Is there anything you'd like reviewers to focus on?**

Nothing. Just so you know, you guys are awesome 👍 