### PR TITLE
Docs: fix incorrect example being mark as correct

### DIFF
--- a/docs/rules/prefer-template.md
+++ b/docs/rules/prefer-template.md
@@ -18,7 +18,7 @@ This rule is aimed to flag usage of `+` operators with strings.
 
 ## Examples
 
-Examples of **correct** code for this rule:
+Examples of **incorrect** code for this rule:
 
 ```js
 /*eslint prefer-template: "error"*/


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
An example in prefer-template was marked as correct when it's indeed is incorrect.

**What changes did you make? (Give an overview)**
Changed the word.

**Is there anything you'd like reviewers to focus on?**
Nope.