### PR TITLE
Update: Added 'allowSuper' option to no-underscore-dangle rule (fixes #6355)

### DIFF
--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -41,7 +41,7 @@ This rule has an object option:
 
 * `"allow"` allows specified identifiers to have dangling underscores
 * `"allowAfterThis": false` (default) disallows dangling underscores in members of the `this` object
-* `"allowAfterThis": true` allows dangling underscores in members of the `this` object
+* `"allowAfterSuper": false` (default) disallows dangling underscores in members of the `super` object
 
 ### allow
 
@@ -63,6 +63,17 @@ Examples of **correct** code for this rule with the `{ "allowAfterThis": true }`
 
 var a = this.foo_;
 this._bar();
+```
+
+### allowAfterSuper
+
+Examples of **correct** code for this rule with the `{ "allowAfterSuper": true }` option:
+
+```js
+/*eslint no-underscore-dangle: ["error", { "allowAfterSuper": true }]*/
+
+var a = super.foo_;
+super._bar();
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -29,6 +29,9 @@ module.exports = {
                     },
                     allowAfterThis: {
                         type: "boolean"
+                    },
+                    allowAfterSuper: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -41,6 +44,7 @@ module.exports = {
         var options = context.options[0] || {};
         var ALLOWED_VARIABLES = options.allow ? options.allow : [];
         var allowAfterThis = typeof options.allowAfterThis !== "undefined" ? options.allowAfterThis : false;
+        var allowAfterSuper = typeof options.allowAfterSuper !== "undefined" ? options.allowAfterSuper : false;
 
         //-------------------------------------------------------------------------
         // Helpers
@@ -131,10 +135,12 @@ module.exports = {
          */
         function checkForTrailingUnderscoreInMemberExpression(node) {
             var identifier = node.property.name,
-                isMemberOfThis = node.object.type === "ThisExpression";
+                isMemberOfThis = node.object.type === "ThisExpression",
+                isMemberOfSuper = node.object.type === "Super";
 
             if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) &&
                 !(isMemberOfThis && allowAfterThis) &&
+                !(isMemberOfSuper && allowAfterSuper) &&
                 !isSpecialCaseIdentifierForMemberExpression(identifier) && !isAllowed(identifier)) {
                 context.report(node, "Unexpected dangling '_' in '" + identifier + "'.");
             }

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -32,7 +32,7 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "foo._bar;", options: [{ allow: ["_bar"] }]},
         { code: "function _foo() {}", options: [{ allow: ["_foo"] }]},
         { code: "this._bar;", options: [{allowAfterThis: true}]},
-        { code: "super._bar;", options: [{allowAfterSuper: true}]}
+        { code: "class foo { constructor() { super._bar; } }", parserOptions: { ecmaVersion: 6 }, options: [{allowAfterSuper: true}]}
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ message: "Unexpected dangling '_' in '_foo'.", type: "VariableDeclarator"}] },
@@ -42,6 +42,6 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "var __proto__ = 1;", errors: [{ message: "Unexpected dangling '_' in '__proto__'.", type: "VariableDeclarator"}] },
         { code: "foo._bar;", errors: [{ message: "Unexpected dangling '_' in '_bar'.", type: "MemberExpression"}] },
         { code: "this._prop;", errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] },
-        { code: "super._prop;", errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] }
+        { code: "class foo { constructor() { super._prop; } }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] }
     ]
 });

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -31,7 +31,8 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "var __proto__ = 1;", options: [{ allow: ["__proto__"] }]},
         { code: "foo._bar;", options: [{ allow: ["_bar"] }]},
         { code: "function _foo() {}", options: [{ allow: ["_foo"] }]},
-        { code: "this._bar;", options: [{allowAfterThis: true}]}
+        { code: "this._bar;", options: [{allowAfterThis: true}]},
+        { code: "super._bar;", options: [{allowAfterSuper: true}]}
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ message: "Unexpected dangling '_' in '_foo'.", type: "VariableDeclarator"}] },
@@ -40,6 +41,7 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "function foo_() {}", errors: [{ message: "Unexpected dangling '_' in 'foo_'.", type: "FunctionDeclaration"}] },
         { code: "var __proto__ = 1;", errors: [{ message: "Unexpected dangling '_' in '__proto__'.", type: "VariableDeclarator"}] },
         { code: "foo._bar;", errors: [{ message: "Unexpected dangling '_' in '_bar'.", type: "MemberExpression"}] },
-        { code: "this._prop;", errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] }
+        { code: "this._prop;", errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] },
+        { code: "super._prop;", errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] }
     ]
 });

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -42,6 +42,7 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "var __proto__ = 1;", errors: [{ message: "Unexpected dangling '_' in '__proto__'.", type: "VariableDeclarator"}] },
         { code: "foo._bar;", errors: [{ message: "Unexpected dangling '_' in '_bar'.", type: "MemberExpression"}] },
         { code: "this._prop;", errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] },
-        { code: "class foo { constructor() { super._prop; } }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] }
+        { code: "class foo { constructor() { super._prop; } }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] },
+		{ code: "class foo { constructor() { this._prop; } }", options: [{allowAfterSuper: true}], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression"}] }
     ]
 });


### PR DESCRIPTION
Previous PR got confused with a merge and so I recreated it here. See #6355 

Update: Same as the "allowAfterThis" option, but for the ES2015 'super' keyword. fixes #6355