### PR TITLE
Docs: fix typos,wrong path,backticks

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -206,11 +206,11 @@ Some rules require options in order to function correctly. These options appear 
 
 ```json
 {
-    "quotes": [2, "double"]
+    "quotes": ["error", "double"]
 }
 ```
 
-The `quotes` rule in this example has one option, `"double"` (the `2` is the error level). You can retrieve the options for a rule by using `context.options`, which is an array containing every configured option for the rule. In this case, `context.options[0]` would contain `"double"`:
+The `quotes` rule in this example has one option, `"double"` (the `error` is the error level). You can retrieve the options for a rule by using `context.options`, which is an array containing every configured option for the rule. In this case, `context.options[0]` would contain `"double"`:
 
 ```js
 module.exports = {

--- a/docs/rules/newline-after-var.md
+++ b/docs/rules/newline-after-var.md
@@ -87,7 +87,7 @@ console.log(greet, name);
 
 ### never
 
-Examples of **incorrect** code for this rule with the default `"never"` option:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint newline-after-var: ["error", "never"]*/

--- a/docs/rules/newline-before-return.md
+++ b/docs/rules/newline-before-return.md
@@ -1,6 +1,6 @@
 # require an empty line before `return` statements (newline-before-return)
 
-There is no hardfast rule about whether empty lines should precede `return` statements in JavaScript. However, clearly delineating where a function is returning can greatly increase the readability and clarity of the code. For example:
+There is no hard and fast rule about whether empty lines should precede `return` statements in JavaScript. However, clearly delineating where a function is returning can greatly increase the readability and clarity of the code. For example:
 
 ```js
 function foo(bar) {

--- a/docs/rules/no-labels.md
+++ b/docs/rules/no-labels.md
@@ -87,7 +87,7 @@ However, this way is ultra rare, not well-known, so this would be confusing deve
 
 ### allowLoop
 
-Examples of **correct** code for the { "allowLoop": true } option:
+Examples of **correct** code for the `{ "allowLoop": true }` option:
 
 ```js
 /*eslint no-labels: ["error", { "allowLoop": true }]*/
@@ -100,7 +100,7 @@ label:
 
 ### allowSwitch
 
-Examples of **correct** code for the { "allowSwitch": true } option:
+Examples of **correct** code for the `{ "allowSwitch": true }` option:
 
 ```js
 /*eslint no-labels: ["error", { "allowSwitch": true }]*/

--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -48,7 +48,7 @@ var dutyFreePrice = 100,
 An array of numbers to ignore. It's set to `[]` by default.
 If provided, it must be an `Array`.
 
-Examples of **correct** code for the sample { "ignore": [1] } option:
+Examples of **correct** code for the sample `{ "ignore": [1] }` option:
 
 ```js
 /*eslint no-magic-numbers: ["error", { "ignore": [1] }]*/
@@ -61,7 +61,7 @@ var dataLast = data.length && data[data.length - 1];
 
 A boolean to specify if numbers used as array indexes are considered okay. `false` by default.
 
-Examples of **correct** code for the { "ignoreArrayIndexes": true } option:
+Examples of **correct** code for the `{ "ignoreArrayIndexes": true }` option:
 
 ```js
 /*eslint no-magic-numbers: ["error", { "ignoreArrayIndexes": true }]*/
@@ -74,7 +74,7 @@ var dataLast = data[2];
 
 A boolean to specify if we should check for the const keyword in variable declaration of numbers. `false` by default.
 
-Examples of **incorrect** code for the { "enforceConst": true } option:
+Examples of **incorrect** code for the `{ "enforceConst": true }` option:
 
 ```js
 /*eslint no-magic-numbers: ["error", { "enforceConst": true }]*/
@@ -89,7 +89,7 @@ var dutyFreePrice = 100,
 
 A boolean to specify if we should detect numbers when setting object properties for example. `false` by default.
 
-Examples of **incorrect** code for the { "detectObjects": true } option:
+Examples of **incorrect** code for the `{ "detectObjects": true }` option:
 
 ```js
 /*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/
@@ -102,7 +102,7 @@ var dutyFreePrice = 100,
     finalPrice = dutyFreePrice + (dutyFreePrice * magic.tax);
 ```
 
-Examples of **correct** code for the { "detectObjects": true } option:
+Examples of **correct** code for the `{ "detectObjects": true }` option:
 
 ```js
 /*eslint no-magic-numbers: ["error", { "detectObjects": true }]*/

--- a/docs/rules/no-undefined.md
+++ b/docs/rules/no-undefined.md
@@ -76,8 +76,8 @@ If you want to allow the use of `undefined` in your code, then you can safely tu
 
 ## Further Reading
 
-* [undefined - JavaScript | MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)
-* [Understanding JavaScript’s ‘undefined’ | JavaScript, JavaScript...](http://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/)
+* [undefined - JavaScript \| MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/undefined)
+* [Understanding JavaScript’s ‘undefined’ \| JavaScript, JavaScript...](http://javascriptweblog.wordpress.com/2010/08/16/understanding-undefined-and-preventing-referenceerrors/)
 * [ECMA262 edition 5.1 &sect;15.1.1.3: undefined](https://es5.github.io/#x15.1.1.3)
 
 ## Related Rules

--- a/docs/rules/space-unary-ops.md
+++ b/docs/rules/space-unary-ops.md
@@ -2,7 +2,7 @@
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
-Some styleguides require or disallow spaces before or after unary operators. This is mainly a stylistic issue, however, some JavaScript expressions can be written without spacing which makes it harder to read and maintain.
+Some style guides require or disallow spaces before or after unary operators. This is mainly a stylistic issue, however, some JavaScript expressions can be written without spacing which makes it harder to read and maintain.
 
 ## Rule Details
 


### PR DESCRIPTION
**What issue does this pull request address?**

docs fixed

**What changes did you make? (Give an overview)**

fix typos,wrong path,backticks. 

for example: in the rule [no-undefined](http://eslint.org/docs/rules/no-undefined)

![image](https://cloud.githubusercontent.com/assets/3702904/16801924/26a3c082-4930-11e6-9cee-fc9e0fe8b31d.png)

**Is there anything you'd like reviewers to focus on?**

no
