### PR TITLE
Docs: Add another pre-commit hook to integrations

### DIFF
--- a/docs/user-guide/integrations.md
+++ b/docs/user-guide/integrations.md
@@ -36,6 +36,7 @@
 ## Source Control
 
 * [Git Precommit Hook](https://coderwall.com/p/zq8jlq)
+* [Git pre-commit hook that only lints staged changes](https://gist.github.com/dahjelle/8ddedf0aebd488208a9a7c829f19b9e8)
 * [overcommit Git hook manager](https://github.com/brigade/overcommit)
 
 ## Testing


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
Documentation update.

**What changes did you make? (Give an overview)**
Added another integration link.

**Is there anything you'd like reviewers to focus on?**

--

No problem if you don't accept changes of this nature; I noticed the existing linked pre-commit hook linted the on-disk contents of a staged file rather than just the staged changes. My script only lints the staged changes.