### PR TITLE
Fix: Allow named recursive functions (fixes #6616)

### DIFF
--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -17,7 +17,7 @@ This rule can enforce or disallow the use of named function expressions.
 This rule has a string option:
 
 * `"always"` (default) requires function expressions to have a name
-* `"never"` disallows named function expressions
+* `"never"` disallows named function expressions, except in recursive functions, where a name is needed
 
 
 Examples of **incorrect** code for this rule with the default `"always"` option:

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -5,6 +5,15 @@
 
 "use strict";
 
+/**
+ * Checks whether or not a given variable is a function name.
+ * @param {escope.Variable} variable - A variable to check.
+ * @returns {boolean} `true` if the variable is a function name.
+ */
+function isFunctionName(variable) {
+    return variable && variable.defs[0].type === "FunctionName";
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -45,7 +54,14 @@ module.exports = {
         }
 
         return {
-            FunctionExpression: function(node) {
+            "FunctionExpression:exit": function(node) {
+
+                // Skip recursive functions.
+                var nameVar = context.getDeclaredVariables(node)[0];
+
+                if (isFunctionName(nameVar) && nameVar.references.length > 0) {
+                    return;
+                }
 
                 var name = node.id && node.id.name;
 

--- a/tests/lib/rules/func-names.js
+++ b/tests/lib/rules/func-names.js
@@ -51,6 +51,10 @@ ruleTester.run("func-names", rule, {
             options: ["never"]
         },
         {
+            code: "var a = function foo() { foo(); };",
+            options: ["never"]
+        },
+        {
             code: "var foo = {bar: function() {}};",
             options: ["never"]
         },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6616 `func-names` `never` option prevented having recursive functions.

**What changes did you make? (Give an overview)**
Skipped recursing functions.

**Is there anything you'd like reviewers to focus on?**
`isFunctionName` is duplicated in a few other places. Should we move to a utils file? Where?