### PR TITLE
Fix incorrect exitCode when eslint is called with --stdin

### DIFF
--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -11,8 +11,7 @@
 // Helpers
 //------------------------------------------------------------------------------
 
-var exitCode = 0,
-    useStdIn = (process.argv.indexOf("--stdin") > -1),
+var useStdIn = (process.argv.indexOf("--stdin") > -1),
     init = (process.argv.indexOf("--init") > -1),
     debug = (process.argv.indexOf("--debug") > -1);
 
@@ -55,26 +54,24 @@ process.on("uncaughtException", function(err){
 if (useStdIn) {
     process.stdin.pipe(concat({ encoding: "string" }, function(text) {
         try {
-            exitCode = cli.execute(process.argv, text);
+            process.exitCode = cli.execute(process.argv, text);
         } catch (ex) {
             console.error(ex.message);
             console.error(ex.stack);
-            exitCode = 1;
+            process.exitCode = 1;
         }
     }));
 } else if (init) {
     var configInit = require("../lib/config/config-initializer");
     configInit.initializeConfig(function(err) {
         if (err) {
-            exitCode = 1;
+            process.exitCode = 1;
             console.error(err.message);
             console.error(err.stack);
         } else {
-            exitCode = 0;
+            process.exitCode = 0;
         }
     });
 } else {
-    exitCode = cli.execute(process.argv);
+    process.exitCode = cli.execute(process.argv);
 }
-
-process.exitCode = exitCode;


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6677 

**What changes did you make? (Give an overview)**
I removed the exitCode variable and made each block set process.exitCode directly.

**Is there anything you'd like reviewers to focus on?**
Confirm the exitCode is set correctly by running

    echo var a | eslint --stdin --rule no-var:error --no-eslintrc --no-ignore && echo good!

<codegood</code> should **not** get echoed after this patch is applied.

Previously exitCode was set at the end of bin/eslint.js but the callback
executed for --stdin was asynchronous.
The asynchronous callback was setting exitCode after process.exitCode
had already been assigned.

This removes the exitCode variable and just gets each block to set
process.exitCode directly.