### PR TITLE
Chore: Remove fixable key from multiline-ternary metadata (fixes #6683)

### DIFF
--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -18,7 +18,6 @@ module.exports = {
             category: "Stylistic Issues",
             recommended: false
         },
-        fixable: "whitespace",
         schema: []
     },
 


### PR DESCRIPTION
3rd time's a charm!

<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
I forgot to remove the fixable key from multiline-ternary's metadata when we decided to not autofix for the rule. This should be removed. Sorry for the oversight!

**What changes did you make? (Give an overview)**
Remove the key

**Is there anything you'd like reviewers to focus on?**
N/A
