### PR TITLE
Fix: `balanced` false positive in `spaced-comment` (fixes #6689)

### DIFF
--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -342,7 +342,7 @@ module.exports = {
                     }
                 }
 
-                if (balanced && !endMatch) {
+                if (balanced && type === "block" && !endMatch) {
                     reportEnd(node, "Expected space or tab before '*/' in comment");
                 }
             } else {
@@ -354,7 +354,7 @@ module.exports = {
                     }
                 }
 
-                if (endMatch && balanced) {
+                if (balanced && type === "block" && endMatch) {
                     reportEnd(node, "Unexpected space or tab before '*/' in comment", endMatch);
                 }
             }

--- a/tests/lib/rules/spaced-comment.js
+++ b/tests/lib/rules/spaced-comment.js
@@ -171,6 +171,14 @@ ruleTester.run("spaced-comment", rule, {
             code: "//\n",
             options: ["always"]
         },
+        {
+            code: "// space only at start; valid since balanced doesn't apply to line comments",
+            options: ["always", { block: { balanced: true }}]
+        },
+        {
+            code: "//space only at end; valid since balanced doesn't apply to line comments ",
+            options: ["never", { block: { balanced: true }}]
+        },
 
         // block comments
         {


### PR DESCRIPTION
**What issue does this pull request address?**

- The issue is that the `balanced` option in the `spaced-comment` rule is incorrectly being applied to line comments instead of only block comments
- Fixes #6689

**What changes did you make? (Give an overview)**

- Two small changes that cause only block comments to report `balanced` errors
- Two tests that fail prior to changes and pass afterward

**Is there anything you'd like reviewers to focus on?**

My stunning good looks