### PR TITLE
Fix: `eslint:all` causes regression in 3.1.0 (fixes #6687)

### DIFF
--- a/conf/eslint-all.js
+++ b/conf/eslint-all.js
@@ -18,7 +18,9 @@ var fs = require("fs"),
 
 var ruleFiles = fs.readdirSync(path.resolve(__dirname, "../lib/rules"));
 var enabledRules = ruleFiles.reduce(function(result, filename) {
-    result[path.basename(filename, ".js")] = "error";
+    if (path.extname(filename) === ".js") {
+        result[path.basename(filename, ".js")] = "error";
+    }
     return result;
 }, {});
 

--- a/tests/conf/eslint-all.js
+++ b/tests/conf/eslint-all.js
@@ -1,0 +1,41 @@
+/**
+ * @fileoverview Tests for eslint-all.
+ * @author Alberto Rodríguez
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var assert = require("chai").assert,
+    eslintAll = require("../../conf/eslint-all"),
+    rules = eslintAll.rules;
+
+describe("eslint-all", function() {
+    it("should only include rules", function() {
+        var ruleNames = Object.keys(rules);
+
+        assert.notInclude(ruleNames, ".eslintrc.yml");
+
+    });
+
+    it("should return all rules", function() {
+        var ruleNames = Object.keys(rules);
+        var count = ruleNames.length;
+        var someRule = "yoda";
+
+        assert.include(ruleNames, someRule);
+        assert.isAbove(count, 200);
+    });
+
+    it("should configure all rules as errors", function() {
+        var ruleNames = Object.keys(rules);
+        var nonErrorRules = ruleNames.filter(function (ruleName) {
+            return rules[ruleName] !== "error";
+        });
+
+        assert.equal(nonErrorRules.length, 0);
+    });
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6687 

**What changes did you make? (Give an overview)**
Filter files by `.js` extension

**Is there anything you'd like reviewers to focus on?**
No.


This replaces #6685 since the fix wasn't correct, and we might want to include this in a patch release tomorrow.
