### PR TITLE
Docs: Clarify Closure type hint expectation (fixes #5231)

### DIFF
--- a/docs/rules/valid-jsdoc.md
+++ b/docs/rules/valid-jsdoc.md
@@ -31,6 +31,8 @@ This rule enforces valid and consistent JSDoc comments. It reports any of the fo
 
 This rule does not report missing JSDoc comments for classes, functions, or methods.
 
+**Note:** This rule does not support all of the Google Closure documentation tool's use cases. As such, some code such as `(/**number*/ n => n * 2);` will be flagged as missing appropriate function JSDoc comments even though `/**number*/` is intended to be a type hint and not a documentation block for the function. We don't recommend using this rule if you use type hints in this way.
+
 Examples of **incorrect** code for this rule:
 
 ```js


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#5231

**What changes did you make? (Give an overview)**

Added a note explaining that Google Closure-style type hints don't work as expected with `valid-jsdoc`.

**Is there anything you'd like reviewers to focus on?**

Verify that the description is clear.