### PR TITLE
Fix: `no-use-before-define` false negative on for-in/of (fixes #6699)

### DIFF
--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -10,6 +10,7 @@
 //------------------------------------------------------------------------------
 
 var SENTINEL_TYPE = /^(?:(?:Function|Class)(?:Declaration|Expression)|ArrowFunctionExpression|CatchClause|ImportDeclaration|ExportNamedDeclaration)$/;
+var FOR_IN_OF_TYPE = /^For(?:In|Of)Statement$/;
 
 /**
  * Parses a given value as options.
@@ -87,6 +88,14 @@ function isInRange(node, location) {
 /**
  * Checks whether or not a given reference is inside of the initializers of a given variable.
  *
+ * This returns `true` in the following cases:
+ *
+ *     var a = a
+ *     var [a = a] = list
+ *     var {a = a} = obj
+ *     for (var a in a) {}
+ *     for (var a of a) {}
+ *
  * @param {Variable} variable - A variable to check.
  * @param {Reference} reference - A reference to check.
  * @returns {boolean} `true` if the reference is inside of the initializers.
@@ -102,6 +111,11 @@ function isInInitializer(variable, reference) {
     while (node) {
         if (node.type === "VariableDeclarator") {
             if (isInRange(node.init, location)) {
+                return true;
+            }
+            if (FOR_IN_OF_TYPE.test(node.parent.parent.type) &&
+                isInRange(node.parent.parent.right, location)
+            ) {
                 return true;
             }
             break;

--- a/tests/lib/rules/no-use-before-define.js
+++ b/tests/lib/rules/no-use-before-define.js
@@ -33,6 +33,8 @@ ruleTester.run("no-use-before-define", rule, {
         { code: "var [a = 0, b = a] = {};", parserOptions: { ecmaVersion: 6 } },
         "function foo() { foo(); }",
         "var foo = function() { foo(); };",
+        { code: "var a; for (a in a) {}" },
+        { code: "var a; for (a of a) {}", parserOptions: { ecmaVersion: 6 } },
 
         // Block-level bindings
         { code: "\"use strict\"; a(); { function a() {} }", parserOptions: { ecmaVersion: 6 } },
@@ -87,6 +89,8 @@ ruleTester.run("no-use-before-define", rule, {
         { code: "var {b = a, a} = {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined", type: "Identifier"}] },
         { code: "var [b = a, a] = {};", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined", type: "Identifier"}] },
         { code: "var {a = 0} = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined", type: "Identifier"}] },
-        { code: "var [a = 0] = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined", type: "Identifier"}] }
+        { code: "var [a = 0] = a;", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined", type: "Identifier"}] },
+        { code: "for (var a in a) {}", errors: [{ message: "'a' was used before it was defined", type: "Identifier"}] },
+        { code: "for (var a of a) {}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "'a' was used before it was defined", type: "Identifier"}] },
     ]
 });


### PR DESCRIPTION
Fixes #6699.

This PR makes the rule handling `ForInStatement.right` and `ForOfStatement.right` as the initializer of variables.