### PR TITLE
	Update: add `props` option to `no-self-assign` rule (fixes #6718)

### DIFF
--- a/docs/rules/no-self-assign.md
+++ b/docs/rules/no-self-assign.md
@@ -41,6 +41,52 @@ let foo = foo;
 [foo = 1] = [foo];
 ```
 
+## Options
+
+This rule has the option to check properties as well.
+
+```json
+{
+    "no-self-assign": ["error", {"props": false}]
+}
+```
+
+- `props` - if this is `true`, `no-self-assign` rule warns self-assignments of properties. Default is `false`.
+
+### props
+
+Examples of **incorrect** code for the `{ "props": true }` option:
+
+```js
+/*eslint no-self-assign: [error, {props: true}]*/
+
+// self-assignments with properties.
+obj.a = obj.a;
+obj.a.b = obj.a.b;
+obj["a"] = obj["a"];
+obj[a] = obj[a];
+```
+
+Examples of **correct** code for the `{ "props": true }` option:
+
+```js
+/*eslint no-self-assign: [error, {props: true}]*/
+
+// non-self-assignments with properties.
+obj.a = obj.b;
+obj.a.b = obj.c.b;
+obj.a.b = obj.a.c;
+obj[a] = obj["a"]
+
+// This ignores if there is a function call.
+obj.a().b = obj.a().b
+a().b = a().b
+
+// Known limitation: this does not support computed properties except single literal or single identifier.
+obj[a + b] = obj[a + b];
+obj["a" + "b"] = obj["a" + "b"];
+```
+
 ## When Not To Use It
 
 If you don't want to notify about self assignments, then it's safe to disable this rule.

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -584,5 +584,74 @@ module.exports = {
      */
     isFunction: function(node) {
         return Boolean(node && anyFunctionPattern.test(node.type));
+    },
+
+    /**
+     * Gets the property name of a given node.
+     * The node can be a MemberExpression, a Property, or a MethodDefinition.
+     *
+     * If the name is dynamic, this returns `null`.
+     *
+     * For examples:
+     *
+     *     a.b           // => "b"
+     *     a["b"]        // => "b"
+     *     a['b']        // => "b"
+     *     a[`b`]        // => "b"
+     *     a[100]        // => "100"
+     *     a[b]          // => null
+     *     a["a" + "b"]  // => null
+     *     a[tag`b`]     // => null
+     *     a[`${b}`]     // => null
+     *
+     *     let a = {b: 1}            // => "b"
+     *     let a = {["b"]: 1}        // => "b"
+     *     let a = {['b']: 1}        // => "b"
+     *     let a = {[`b`]: 1}        // => "b"
+     *     let a = {[100]: 1}        // => "100"
+     *     let a = {[b]: 1}          // => null
+     *     let a = {["a" + "b"]: 1}  // => null
+     *     let a = {[tag`b`]: 1}     // => null
+     *     let a = {[`${b}`]: 1}     // => null
+     *
+     * @param {ASTNode} node - The node to get.
+     * @returns {string|null} The property name if static. Otherwise, null.
+     */
+    getStaticPropertyName(node) {
+        let prop;
+
+        switch (node && node.type) {
+            case "Property":
+            case "MethodDefinition":
+                prop = node.key;
+                break;
+
+            case "MemberExpression":
+                prop = node.property;
+                break;
+
+            // no default
+        }
+
+        switch (prop && prop.type) {
+            case "Literal":
+                return String(prop.value);
+
+            case "TemplateLiteral":
+                if (prop.expressions.length === 0 && prop.quasis.length === 1) {
+                    return prop.quasis[0].value.cooked;
+                }
+                break;
+
+            case "Identifier":
+                if (!node.computed) {
+                    return prop.name;
+                }
+                break;
+
+            // no default
+        }
+
+        return null;
     }
 };

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -46,38 +46,6 @@ function getLocation(node, sourceCode) {
 }
 
 /**
- * Gets the name of a given node if the node is a Identifier node.
- *
- * @param {ASTNode} node - A node to get.
- * @returns {string} The name of the node, or an empty string.
- */
-function getIdentifierName(node) {
-    return node.type === "Identifier" ? node.name : "";
-}
-
-/**
- * Gets the value of a given node if the node is a Literal node or a
- * TemplateLiteral node.
- *
- * @param {ASTNode} node - A node to get.
- * @returns {string} The value of the node, or an empty string.
- */
-function getConstantStringValue(node) {
-    switch (node.type) {
-        case "Literal":
-            return String(node.value);
-
-        case "TemplateLiteral":
-            return node.expressions.length === 0
-                ? node.quasis[0].value.cooked
-                : "";
-
-        default:
-            return "";
-    }
-}
-
-/**
  * Checks a given node is a MemberExpression node which has the specified name's
  * property.
  *
@@ -88,9 +56,7 @@ function getConstantStringValue(node) {
 function isTargetMethod(node) {
     return (
         node.type === "MemberExpression" &&
-        TARGET_METHODS.test(
-            (node.computed ? getConstantStringValue : getIdentifierName)(node.property)
-        )
+        TARGET_METHODS.test(astUtils.getStaticPropertyName(node) || "")
     );
 }
 

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const getPropertyName = require("../ast-utils").getStaticPropertyName;
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
@@ -26,22 +32,6 @@ function isProhibitedIdentifier(name) {
  */
 function report(context, node, identifierName) {
     context.report(node, "Unexpected {{name}}.", { name: identifierName });
-}
-
-/**
- * Returns the property name of a MemberExpression.
- * @param {ASTNode} memberExpressionNode The MemberExpression node.
- * @returns {string|null} Returns the property name if available, null else.
- */
-function getPropertyName(memberExpressionNode) {
-    if (memberExpressionNode.computed) {
-        if (memberExpressionNode.property.type === "Literal") {
-            return memberExpressionNode.property.value;
-        }
-    } else {
-        return memberExpressionNode.property.name;
-    }
-    return null;
 }
 
 /**

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -5,6 +5,12 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const getPropertyName = require("../ast-utils").getStaticPropertyName;
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -35,31 +41,6 @@ module.exports = {
                 message: "The function binding is unnecessary.",
                 loc: node.parent.property.loc.start
             });
-        }
-
-        /**
-         * Gets the property name of a given node.
-         * If the property name is dynamic, this returns an empty string.
-         *
-         * @param {ASTNode} node - A node to check. This is a MemberExpression.
-         * @returns {string} The property name of the node.
-         */
-        function getPropertyName(node) {
-            if (node.computed) {
-                switch (node.property.type) {
-                    case "Literal":
-                        return String(node.property.value);
-                    case "TemplateLiteral":
-                        if (node.property.expressions.length === 0) {
-                            return node.property.quasis[0].value.cooked;
-                        }
-
-                        // fallthrough
-                    default:
-                        return false;
-                }
-            }
-            return node.property.name;
         }
 
         /**

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -6,8 +6,65 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
+
+const SPACES = /\s+/g;
+
+/**
+ * Checks whether the property of 2 given member expression nodes are the same
+ * property or not.
+ *
+ * @param {ASTNode} left - A member expression node to check.
+ * @param {ASTNode} right - Another member expression node to check.
+ * @returns {boolean} `true` if the member expressions have the same property.
+ */
+function isSameProperty(left, right) {
+    if (left.property.type === "Identifier" &&
+        left.property.type === right.property.type &&
+        left.property.name === right.property.name &&
+        left.computed === right.computed
+    ) {
+        return true;
+    }
+
+    const lname = astUtils.getStaticPropertyName(left);
+    const rname = astUtils.getStaticPropertyName(right);
+
+    return lname !== null && lname === rname;
+}
+
+/**
+ * Checks whether 2 given member expression nodes are the reference to the same
+ * property or not.
+ *
+ * @param {ASTNode} left - A member expression node to check.
+ * @param {ASTNode} right - Another member expression node to check.
+ * @returns {boolean} `true` if the member expressions are the reference to the
+ *  same property or not.
+ */
+function isSameMember(left, right) {
+    if (!isSameProperty(left, right)) {
+        return false;
+    }
+
+    const lobj = left.object;
+    const robj = right.object;
+
+    if (lobj.type !== robj.type) {
+        return false;
+    }
+    if (lobj.type === "MemberExpression") {
+        return isSameMember(lobj, robj);
+    }
+    return lobj.type === "Identifier" && lobj.name === robj.name;
+}
 
 /**
  * Traverses 2 Pattern nodes in parallel, then reports self-assignments.
@@ -16,12 +73,11 @@
  *      a Property.
  * @param {ASTNode|null} right - A right node to traverse. This is a Pattern or
  *      a Property.
+ * @param {boolean} props - The flag to check member expressions as well.
  * @param {Function} report - A callback function to report.
  * @returns {void}
  */
-function eachSelfAssignment(left, right, report) {
-    let i, j;
-
+function eachSelfAssignment(left, right, props, report) {
     if (!left || !right) {
 
         // do nothing
@@ -37,10 +93,10 @@ function eachSelfAssignment(left, right, report) {
     ) {
         const end = Math.min(left.elements.length, right.elements.length);
 
-        for (i = 0; i < end; ++i) {
+        for (let i = 0; i < end; ++i) {
             const rightElement = right.elements[i];
 
-            eachSelfAssignment(left.elements[i], rightElement, report);
+            eachSelfAssignment(left.elements[i], rightElement, props, report);
 
             // After a spread element, those indices are unknown.
             if (rightElement && rightElement.type === "SpreadElement") {
@@ -51,7 +107,7 @@ function eachSelfAssignment(left, right, report) {
         left.type === "RestElement" &&
         right.type === "SpreadElement"
     ) {
-        eachSelfAssignment(left.argument, right.argument, report);
+        eachSelfAssignment(left.argument, right.argument, props, report);
     } else if (
         left.type === "ObjectPattern" &&
         right.type === "ObjectExpression" &&
@@ -62,18 +118,19 @@ function eachSelfAssignment(left, right, report) {
         // It's possible to overwrite properties followed by it.
         let startJ = 0;
 
-        for (i = right.properties.length - 1; i >= 0; --i) {
+        for (let i = right.properties.length - 1; i >= 0; --i) {
             if (right.properties[i].type === "ExperimentalSpreadProperty") {
                 startJ = i + 1;
                 break;
             }
         }
 
-        for (i = 0; i < left.properties.length; ++i) {
-            for (j = startJ; j < right.properties.length; ++j) {
+        for (let i = 0; i < left.properties.length; ++i) {
+            for (let j = startJ; j < right.properties.length; ++j) {
                 eachSelfAssignment(
                     left.properties[i],
                     right.properties[j],
+                    props,
                     report
                 );
             }
@@ -87,7 +144,14 @@ function eachSelfAssignment(left, right, report) {
         !right.method &&
         left.key.name === right.key.name
     ) {
-        eachSelfAssignment(left.value, right.value, report);
+        eachSelfAssignment(left.value, right.value, props, report);
+    } else if (
+        props &&
+        left.type === "MemberExpression" &&
+        right.type === "MemberExpression" &&
+        isSameMember(left, right)
+    ) {
+        report(right);
     }
 }
 
@@ -103,10 +167,23 @@ module.exports = {
             recommended: true
         },
 
-        schema: []
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    props: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create: function(context) {
+        const sourceCode = context.getSourceCode();
+        const options = context.options[0];
+        const props = Boolean(options && options.props);
 
         /**
          * Reports a given node as self assignments.
@@ -118,14 +195,16 @@ module.exports = {
             context.report({
                 node: node,
                 message: "'{{name}}' is assigned to itself.",
-                data: node
+                data: {
+                    name: sourceCode.getText(node).replace(SPACES, "")
+                }
             });
         }
 
         return {
             AssignmentExpression: function(node) {
                 if (node.operator === "=") {
-                    eachSelfAssignment(node.left, node.right, report);
+                    eachSelfAssignment(node.left, node.right, props, report);
                 }
             }
         };

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -421,4 +421,149 @@ describe("ast-utils", function() {
             assert(!astUtils.isLoop(ast.body[1]));
         });
     });
+
+    describe("getStaticPropertyName", function() {
+        it("should return 'b' for `a.b`", function() {
+            const ast = espree.parse("a.b");
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return 'b' for `a['b']`", function() {
+            const ast = espree.parse("a['b']");
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return 'b' for `a[`b`]`", function() {
+            const ast = espree.parse("a[`b`]", {ecmaVersion: 6});
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return '100' for `a[100]`", function() {
+            const ast = espree.parse("a[100]");
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "100");
+        });
+
+        it("should return null for `a[b]`", function() {
+            const ast = espree.parse("a[b]");
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return null for `a['a' + 'b']`", function() {
+            const ast = espree.parse("a['a' + 'b']");
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return null for `a[tag`b`]`", function() {
+            const ast = espree.parse("a[tag`b`]", {ecmaVersion: 6});
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return null for `a[`${b}`]`", function() {
+            const ast = espree.parse("a[`${b}`]", {ecmaVersion: 6});
+            const node = ast.body[0].expression;
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return 'b' for `b: 1`", function() {
+            const ast = espree.parse("({b: 1})");
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return 'b' for `b() {}`", function() {
+            const ast = espree.parse("({b() {}})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return 'b' for `get b() {}`", function() {
+            const ast = espree.parse("({get b() {}})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return 'b' for `['b']: 1`", function() {
+            const ast = espree.parse("({['b']: 1})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return 'b' for `['b']() {}`", function() {
+            const ast = espree.parse("({['b']() {}})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return 'b' for `[`b`]: 1`", function() {
+            const ast = espree.parse("({[`b`]: 1})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "b");
+        });
+
+        it("should return '100' for` [100]: 1`", function() {
+            const ast = espree.parse("({[100]: 1})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), "100");
+        });
+
+        it("should return null for `[b]: 1`", function() {
+            const ast = espree.parse("({[b]: 1})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return null for `['a' + 'b']: 1`", function() {
+            const ast = espree.parse("({['a' + 'b']: 1})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return null for `[tag`b`]: 1`", function() {
+            const ast = espree.parse("({[tag`b`]: 1})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return null for `[`${b}`]: 1`", function() {
+            const ast = espree.parse("({[`${b}`]: 1})", {ecmaVersion: 6});
+            const node = ast.body[0].expression.properties[0];
+
+            assert.strictEqual(astUtils.getStaticPropertyName(node), null);
+        });
+
+        it("should return null for non member expressions", function() {
+            const ast = espree.parse("foo()");
+
+            assert.strictEqual(astUtils.getStaticPropertyName(ast.body[0].expression), null);
+            assert.strictEqual(astUtils.getStaticPropertyName(ast.body[0]), null);
+            assert.strictEqual(astUtils.getStaticPropertyName(ast.body), null);
+            assert.strictEqual(astUtils.getStaticPropertyName(ast), null);
+            assert.strictEqual(astUtils.getStaticPropertyName(null), null);
+        });
+    });
 });

--- a/tests/lib/rules/no-self-assign.js
+++ b/tests/lib/rules/no-self-assign.js
@@ -39,7 +39,19 @@ ruleTester.run("no-self-assign", rule, {
         {code: "({a} = {a: b})", parserOptions: {ecmaVersion: 6}},
         {code: "({a} = {a() {}})", parserOptions: {ecmaVersion: 6}},
         {code: "({a} = {[a]: a})", parserOptions: {ecmaVersion: 6}},
-        {code: "({a, ...b} = {a, ...b})", parserOptions: {ecmaVersion: 6, ecmaFeatures: {experimentalObjectRestSpread: true}}}
+        {code: "({a, ...b} = {a, ...b})", parserOptions: {ecmaVersion: 6, ecmaFeatures: {experimentalObjectRestSpread: true}}},
+        {code: "a.b = a.c", options: [{props: true}]},
+        {code: "a.b = c.b", options: [{props: true}]},
+        {code: "a.b = a[b]", options: [{props: true}]},
+        {code: "a[b] = a.b", options: [{props: true}]},
+        {code: "a.b().c = a.b().c", options: [{props: true}]},
+        {code: "b().c = b().c", options: [{props: true}]},
+        {code: "a[b + 1] = a[b + 1]", options: [{props: true}]},  // it ignores non-simple computed properties.
+        {code: "a.b = a.b"},
+        {code: "a.b.c = a.b.c"},
+        {code: "a[b] = a[b]"},
+        {code: "a['b'] = a['b']"},
+        {code: "a[\n    'b'\n] = a[\n    'b'\n]"},
     ],
     invalid: [
         {code: "a = a", errors: ["'a' is assigned to itself."]},
@@ -55,6 +67,11 @@ ruleTester.run("no-self-assign", rule, {
         {code: "({a, b} = {b, a})", parserOptions: {ecmaVersion: 6}, errors: ["'b' is assigned to itself.", "'a' is assigned to itself."]},
         {code: "({a, b} = {c, a})", parserOptions: {ecmaVersion: 6}, errors: ["'a' is assigned to itself."]},
         {code: "({a: {b}, c: [d]} = {a: {b}, c: [d]})", parserOptions: {ecmaVersion: 6}, errors: ["'b' is assigned to itself.", "'d' is assigned to itself."]},
-        {code: "({a, b} = {a, ...x, b})", parserOptions: {ecmaVersion: 6, ecmaFeatures: {experimentalObjectRestSpread: true}}, errors: ["'b' is assigned to itself."]}
+        {code: "({a, b} = {a, ...x, b})", parserOptions: {ecmaVersion: 6, ecmaFeatures: {experimentalObjectRestSpread: true}}, errors: ["'b' is assigned to itself."]},
+        {code: "a.b = a.b", options: [{props: true}], errors: ["'a.b' is assigned to itself."]},
+        {code: "a.b.c = a.b.c", options: [{props: true}], errors: ["'a.b.c' is assigned to itself."]},
+        {code: "a[b] = a[b]", options: [{props: true}], errors: ["'a[b]' is assigned to itself."]},
+        {code: "a['b'] = a['b']", options: [{props: true}], errors: ["'a['b']' is assigned to itself."]},
+        {code: "a[\n    'b'\n] = a[\n    'b'\n]", options: [{props: true}], errors: ["'a['b']' is assigned to itself."]},
     ]
 });


### PR DESCRIPTION
Fixes #6718.

This PR fixes `no-self-assign` rule to warn properties.

Also, there is a few refactoring (those commits are separated.). I added a function to get the property name of a MemberExpression node (e.g. `a.b` and `a["b"]`) into `ast-utils.js` because this logic is used in multiple places.