### PR TITLE
Ensure that space-infix-ops doesn't fail for Flow type annotations

### DIFF
--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -106,6 +106,10 @@ module.exports = {
          * @private
          */
         function checkBinary(node) {
+            if (node.left.typeAnnotation) {
+                return;
+            }
+
             var nonSpacedNode = getFirstNonSpacedToken(node.left, node.right);
 
             if (nonSpacedNode) {

--- a/tests/fixtures/parsers/flow-stub-parser.js
+++ b/tests/fixtures/parsers/flow-stub-parser.js
@@ -1,0 +1,391 @@
+
+exports.parse = function() {
+    return {
+      "type": "Program",
+      "loc": {
+        "source": null,
+        "start": {
+          "line": 1,
+          "column": 0
+        },
+        "end": {
+          "line": 1,
+          "column": 31
+        }
+      },
+      "range": [
+        0,
+        31
+      ],
+      "body": [
+        {
+          "type": "FunctionDeclaration",
+          "loc": {
+            "source": null,
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 31
+            }
+          },
+          "range": [
+            0,
+            31
+          ],
+          "id": {
+            "type": "Identifier",
+            "loc": {
+              "source": null,
+              "start": {
+                "line": 1,
+                "column": 9
+              },
+              "end": {
+                "line": 1,
+                "column": 12
+              }
+            },
+            "range": [
+              9,
+              12
+            ],
+            "name": "foo",
+            "typeAnnotation": null,
+            "optional": false
+          },
+          "params": [
+            {
+              "type": "Identifier",
+              "loc": {
+                "source": null,
+                "start": {
+                  "line": 1,
+                  "column": 13
+                },
+                "end": {
+                  "line": 1,
+                  "column": 22
+                }
+              },
+              "range": [
+                13,
+                22
+              ],
+              "name": "a",
+              "typeAnnotation": {
+                "type": "TypeAnnotation",
+                "loc": {
+                  "source": null,
+                  "start": {
+                    "line": 1,
+                    "column": 14
+                  },
+                  "end": {
+                    "line": 1,
+                    "column": 22
+                  }
+                },
+                "range": [
+                  14,
+                  22
+                ],
+                "typeAnnotation": {
+                  "type": "NumberTypeAnnotation",
+                  "loc": {
+                    "source": null,
+                    "start": {
+                      "line": 1,
+                      "column": 16
+                    },
+                    "end": {
+                      "line": 1,
+                      "column": 22
+                    }
+                  },
+                  "range": [
+                    16,
+                    22
+                  ]
+                }
+              },
+              "optional": false
+            }
+          ],
+          "defaults": [
+            {
+              "type": "Literal",
+              "loc": {
+                "source": null,
+                "start": {
+                  "line": 1,
+                  "column": 25
+                },
+                "end": {
+                  "line": 1,
+                  "column": 26
+                }
+              },
+              "range": [
+                25,
+                26
+              ],
+              "value": 0,
+              "raw": "0"
+            }
+          ],
+          "rest": null,
+          "body": {
+            "type": "BlockStatement",
+            "loc": {
+              "source": null,
+              "start": {
+                "line": 1,
+                "column": 28
+              },
+              "end": {
+                "line": 1,
+                "column": 31
+              }
+            },
+            "range": [
+              28,
+              31
+            ],
+            "body": []
+          },
+          "async": false,
+          "generator": false,
+          "expression": false,
+          "returnType": null,
+          "typeParameters": null
+        }
+      ],
+      "comments": [],
+      "errors": [],
+    "tokens": [
+        {
+          "type": "Keyword",
+          "value": "function",
+          "start": 0,
+          "end": 8,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 0
+            },
+            "end": {
+              "line": 1,
+              "column": 8
+            }
+          },
+          "range": [
+            0,
+            8
+          ]
+        },
+        {
+          "type": "Identifier",
+          "value": "foo",
+          "start": 9,
+          "end": 12,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 9
+            },
+            "end": {
+              "line": 1,
+              "column": 12
+            }
+          },
+          "range": [
+            9,
+            12
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "(",
+          "start": 12,
+          "end": 13,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 12
+            },
+            "end": {
+              "line": 1,
+              "column": 13
+            }
+          },
+          "range": [
+            12,
+            13
+          ]
+        },
+        {
+          "type": "Identifier",
+          "value": "a",
+          "start": 13,
+          "end": 14,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 13
+            },
+            "end": {
+              "line": 1,
+              "column": 14
+            }
+          },
+          "range": [
+            13,
+            14
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": ":",
+          "start": 15,
+          "end": 16,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 15
+            },
+            "end": {
+              "line": 1,
+              "column": 16
+            }
+          },
+          "range": [
+            15,
+            16
+          ]
+        },
+        {
+          "type": "Identifier",
+          "value": "string",
+          "start": 16,
+          "end": 22,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 16
+            },
+            "end": {
+              "line": 1,
+              "column": 22
+            }
+          },
+          "range": [
+            16,
+            22
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "=",
+          "start": 24,
+          "end": 25,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 24
+            },
+            "end": {
+              "line": 1,
+              "column": 25
+            }
+          },
+          "range": [
+            24,
+            25
+          ]
+        },
+        {
+          "type": "Numeric",
+          "value": "0",
+          "start": 26,
+          "end": 27,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 26
+            },
+            "end": {
+              "line": 1,
+              "column": 27
+            }
+          },
+          "range": [
+            26,
+            27
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": ")",
+          "start": 27,
+          "end": 28,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 27
+            },
+            "end": {
+              "line": 1,
+              "column": 28
+            }
+          },
+          "range": [
+            27,
+            28
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "{",
+          "start": 29,
+          "end": 30,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 29
+            },
+            "end": {
+              "line": 1,
+              "column": 30
+            }
+          },
+          "range": [
+            29,
+            30
+          ]
+        },
+        {
+          "type": "Punctuator",
+          "value": "}",
+          "start": 31,
+          "end": 32,
+          "loc": {
+            "start": {
+              "line": 1,
+              "column": 31
+            },
+            "end": {
+              "line": 1,
+              "column": 32
+            }
+          },
+          "range": [
+            31,
+            32
+          ]
+        }
+      ]
+    };
+};

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -9,7 +9,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-var rule = require("../../../lib/rules/space-infix-ops"),
+var path = require("path"),
+    rule = require("../../../lib/rules/space-infix-ops"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 var ruleTester = new RuleTester();
@@ -29,7 +30,7 @@ ruleTester.run("space-infix-ops", rule, {
         { code: "const my_object = {key: 'value'};", parserOptions: { ecmaVersion: 6 } },
         { code: "var {a = 0} = bar;", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(a = 0) { }", parserOptions: { ecmaVersion: 6 } },
-        { code: "function foo(a: number = 0) { }", parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo(a: number = 0) { }", parser: path.resolve(__dirname, "../../fixtures/parsers/flow-stub-parser.js"), parserOptions: { ecmaVersion: 6 } },
         { code: "a ** b", parserOptions: { ecmaVersion: 7 } },
         { code: "a|0", options: [{ int32Hint: true }] },
         { code: "a |0", options: [{ int32Hint: true }] }

--- a/tests/lib/rules/space-infix-ops.js
+++ b/tests/lib/rules/space-infix-ops.js
@@ -29,6 +29,7 @@ ruleTester.run("space-infix-ops", rule, {
         { code: "const my_object = {key: 'value'};", parserOptions: { ecmaVersion: 6 } },
         { code: "var {a = 0} = bar;", parserOptions: { ecmaVersion: 6 } },
         { code: "function foo(a = 0) { }", parserOptions: { ecmaVersion: 6 } },
+        { code: "function foo(a: number = 0) { }", parserOptions: { ecmaVersion: 6 } },
         { code: "a ** b", parserOptions: { ecmaVersion: 7 } },
         { code: "a|0", options: [{ int32Hint: true }] },
         { code: "a |0", options: [{ int32Hint: true }] }


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#5211 (continues work of #6519)

**What changes did you make? (Give an overview)**

Created a custom stub parser to test that type annotations will no longer trigger `space-infix-ops`. 

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.