### PR TITLE
Update: merge warnings of consecutive unreachable nodes (fixes #6583)

### DIFF
--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -26,6 +26,75 @@ function isUnreachable(segment) {
     return !segment.reachable;
 }
 
+/**
+ * The class to distinguish consecutive unreachable statements.
+ */
+class ConsecutiveRange {
+    constructor(sourceCode) {
+        this.sourceCode = sourceCode;
+        this.startNode = null;
+        this.endNode = null;
+    }
+
+    /**
+     * The location object of this range.
+     * @type {Object}
+     */
+    get location() {
+        return {
+            start: this.startNode.loc.start,
+            end: this.endNode.loc.end
+        };
+    }
+
+    /**
+     * `true` if this range is empty.
+     * @type {boolean}
+     */
+    get isEmpty() {
+        return !(this.startNode && this.endNode);
+    }
+
+    /**
+     * Checks whether the given node is inside of this range.
+     * @param {ASTNode|Token} node - The node to check.
+     * @returns {boolean} `true` if the node is inside of this range.
+     */
+    contains(node) {
+        return (
+            node.range[0] >= this.startNode.range[0] &&
+            node.range[1] <= this.endNode.range[1]
+        );
+    }
+
+    /**
+     * Checks whether the given node is consecutive to this range.
+     * @param {ASTNode} node - The node to check.
+     * @returns {boolean} `true` if the node is consecutive to this range.
+     */
+    isConsecutive(node) {
+        return this.contains(this.sourceCode.getTokenBefore(node));
+    }
+
+    /**
+     * Merges the given node to this range.
+     * @param {ASTNode} node - The node to merge.
+     * @returns {void}
+     */
+    merge(node) {
+        this.endNode = node;
+    }
+
+    /**
+     * Resets this range by the given node or null.
+     * @param {ASTNode|null} node - The node to reset, or null.
+     * @returns {void}
+     */
+    reset(node) {
+        this.startNode = this.endNode = node;
+    }
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -44,15 +113,50 @@ module.exports = {
     create: function(context) {
         var currentCodePath = null;
 
+        const range = new ConsecutiveRange(context.getSourceCode());
+
         /**
          * Reports a given node if it's unreachable.
          * @param {ASTNode} node - A statement node to report.
          * @returns {void}
          */
         function reportIfUnreachable(node) {
-            if (currentCodePath.currentSegments.every(isUnreachable)) {
-                context.report({message: "Unreachable code.", node: node});
+            let nextNode = null;
+
+            if (node && currentCodePath.currentSegments.every(isUnreachable)) {
+
+                // Store this statement to distinguish consecutive statements.
+                if (range.isEmpty) {
+                    range.reset(node);
+                    return;
+                }
+
+                // Skip if this statement is inside of the current range.
+                if (range.contains(node)) {
+                    return;
+                }
+
+                // Merge if this statement is consecutive to the current range.
+                if (range.isConsecutive(node)) {
+                    range.merge(node);
+                    return;
+                }
+
+                nextNode = node;
             }
+
+            // Report the current range since this statement is reachable or is
+            // not consecutive to the current range.
+            if (!range.isEmpty) {
+                context.report({
+                    message: "Unreachable code.",
+                    loc: range.location,
+                    node: range.startNode
+                });
+            }
+
+            // Update the current range.
+            range.reset(nextNode);
         }
 
         return {
@@ -96,7 +200,11 @@ module.exports = {
             WithStatement: reportIfUnreachable,
             ExportNamedDeclaration: reportIfUnreachable,
             ExportDefaultDeclaration: reportIfUnreachable,
-            ExportAllDeclaration: reportIfUnreachable
+            ExportAllDeclaration: reportIfUnreachable,
+
+            "Program:exit": function() {
+                reportIfUnreachable();
+            }
         };
     }
 };


### PR DESCRIPTION
Fixes #6583.

This PR makes `no-unreachable` rule merging the warnings of consecutive unreachable statements.

I used ES Classes and Template Literals in this PR.