### PR TITLE
Fix: sort-imports: single import of multiple style as "multiple" type (fixes #6736)

### DIFF
--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -67,6 +67,11 @@ module.exports = {
             } else if (node.specifiers[0].type === "ImportNamespaceSpecifier") {
                 return "all";
             } else if (node.specifiers.length === 1) {
+
+                // Multiple import with only one value.
+                if (node.specifiers[0].imported) {
+                    return "multiple";
+                }
                 return "single";
             } else {
                 return "multiple";

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -147,6 +147,26 @@ ruleTester.run("sort-imports", rule, {
             parserOptions: parserOptions
         },
 
+        // https://github.com/eslint/eslint/issues/6736
+        {
+            code:
+                "import foo from 'bar.js';\n" +
+                "import {a} from 'foo.js';",
+            parserOptions: parserOptions,
+            options: [{
+                memberSyntaxSortOrder: [ "none", "single", "all", "multiple" ]
+            }]
+        },
+        {
+            code:
+                "import foo from 'bar.js';\n" +
+                "import {a,b} from 'foo.js';",
+            parserOptions: parserOptions,
+            options: [{
+                memberSyntaxSortOrder: [ "none", "single", "all", "multiple" ]
+            }]
+        },
+
         // https://github.com/eslint/eslint/issues/5130
         {
             code:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6736

**What changes did you make? (Give an overview)**
The rule uses `node.specifiers.length` to determine if an import is of type `multiple` or `single`. The bug is that imports of `multiple`-style with a single import (`import { a } from 'foo';`) are incorrectly treated as `single`. I fixed this edge case.
