### PR TITLE
Docs: Add plugin example to disabling with comments guide (fixes #6742)

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -415,6 +415,12 @@ alert('foo'); // eslint-disable-line no-alert, quotes, semi
 alert('foo');
 ```
 
+All of the above methods also work for plugin rules. For example, to disable `eslint-plugin-example`'s `rule-name` rule, combine the plugin's name (`example`) and the rule's name (`rule-name`) into `example/rule-name`:
+
+```js
+foo(); // eslint-disable-line example/rule-name
+```
+
 **Note:** Comments that disable warnings for a portion of a file tell ESLint not to report rule violations for the disabled code. ESLint still parses the entire file, however, so disabled code still needs to be syntactically valid JavaScript.
 
 ## Adding Shared Settings


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6742 - The issue was initially closed as working as designed, then reopened as a documentation bug because we didn't include anything about disabling plugin rules in the "Disabling Rules with Inline Comments" section of the configuring guide.

**What changes did you make? (Give an overview)**

I added an example showing how to disable a plugin rule with an inline comment.

**Is there anything you'd like reviewers to focus on?**

Is the example too specific? Elsewhere we just use `plugin1/rule1` as the example.
