### PR TITLE
Docs: Add options to func-names config comments

### DIFF
--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -19,11 +19,12 @@ This rule has a string option:
 * `"always"` (default) requires function expressions to have a name
 * `"never"` disallows named function expressions, except in recursive functions, where a name is needed
 
+### always
 
 Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
-/*eslint func-names: "error"*/
+/*eslint func-names: ["error", "always"]*/
 
 Foo.prototype.bar = function() {};
 
@@ -35,7 +36,7 @@ Foo.prototype.bar = function() {};
 Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
-/*eslint func-names: "error"*/
+/*eslint func-names: ["error", "always"]*/
 
 Foo.prototype.bar = function bar() {};
 
@@ -44,10 +45,12 @@ Foo.prototype.bar = function bar() {};
 }())
 ```
 
+### never
+
 Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
-/*eslint func-names: "error"*/
+/*eslint func-names: ["error", "never"]*/
 
 Foo.prototype.bar = function bar() {};
 
@@ -59,7 +62,7 @@ Foo.prototype.bar = function bar() {};
 Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
-/*eslint func-names: "error"*/
+/*eslint func-names: ["error", "never"]*/
 
 Foo.prototype.bar = function() {};
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

*This is a docs PR, so no issue filed.* The `func-names` examples were missing the `"always"` and `"never"` mode options from the config comments in their examples.

**What changes did you make? (Give an overview)**

I added the `"always"` and `"never"` mode options to the config comments in the examples.

**Is there anything you'd like reviewers to focus on?**

When there is a default option (in this case `"always"`), do we want to specify it explicitly in the examples (`/*eslint func-names: ["error", "always"]*/`) or leave the default implicit (`/*eslint func-names: "error"*/`)? I followed the [comma-style docs](http://eslint.org/docs/rules/comma-style) here and made the `"always"` examples explicit.