### PR TITLE
New: func-call-spacing rule (fixes #6080)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -154,6 +154,7 @@
         "dot-notation": "off",
         "eol-last": "off",
         "eqeqeq": "off",
+        "func-call-spacing": "off",
         "func-names": "off",
         "func-style": "off",
         "generator-star-spacing": "off",

--- a/docs/rules/func-call-spacing.md
+++ b/docs/rules/func-call-spacing.md
@@ -1,0 +1,107 @@
+# require or disallow spacing between `function` identifiers and their invocations (func-call-spacing)
+
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
+When calling a function, developers may insert optional whitespace between the function's name and the parentheses that invoke it. The following pairs of function calls are equivalent:
+
+```js
+alert('Hello');
+alert ('Hello');
+
+console.log(42);
+console.log (42);
+
+new Date();
+new Date ();
+```
+
+## Rule Details
+
+This rule requires or disallows spaces between the function name and the opening parenthesis that calls it.
+
+## options
+
+This rule has a string option:
+
+- `"never"` (default) disallows space between the function name and the opening parenthesis.
+- `"always"` requires space between the function name and the opening parenthesis.
+
+Further, in `"always"` mode, a second object option is available that contains a single boolean `allowNewlines` property.
+
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
+
+```js
+/*eslint func-call-spacing: ["error", "never"]*/
+
+fn ();
+
+fn
+();
+```
+
+Examples of **correct** code for this rule with the default `"never"` option:
+
+```js
+/*eslint func-call-spacing: ["error", "never"]*/
+
+fn();
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
+
+```js
+/*eslint func-call-spacing: ["error", "always"]*/
+
+fn();
+
+fn
+();
+```
+
+Examples of **correct** code for this rule with the `"always"` option:
+
+```js
+/*eslint func-call-spacing: ["error", "always"]*/
+
+fn ();
+```
+
+#### allowNewlines
+
+By default, `"always"` does not allow newlines. To permit newlines when in `"always"` mode, set the `allowNewlines` option to `true`. Newlines are never required.
+
+Examples of **incorrect** code for this rule with `allowNewlines` option enabled:
+
+```js
+/*eslint func-call-spacing: ["error", "always", { "allowNewlines": true }]*/
+
+fn();
+```
+
+Examples of **correct** code for this rule with the `allowNewlines` option enabled:
+
+```js
+/*eslint func-call-spacing: ["error", "always", { "allowNewlines": true }]*/
+
+fn (); // Newlines are never required.
+
+fn
+();
+```
+
+## When Not To Use It
+
+This rule can safely be turned off if your project does not care about enforcing a consistent style for spacing within function calls.
+
+## Related Rules
+
+- [no-spaced-func](no-spaced-func.md) (deprecated)
+
+## Compatibility
+
+- **JSCS**: [disallowSpacesInCallExpression](http://jscs.info/rule/disallowSpacesInCallExpression)
+- **JSCS**: [requireSpacesInCallExpression](http://jscs.info/rule/requireSpacesInCallExpression)

--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -179,7 +179,7 @@ let obj = {
     foo:function() {}
 };
 
-// not conflict with `no-spaced-func`
+// not conflict with `func-call-spacing`
 class A {
     constructor() {
         super();

--- a/docs/rules/no-spaced-func.md
+++ b/docs/rules/no-spaced-func.md
@@ -1,5 +1,7 @@
 # disallow spacing between `function` identifiers and their applications (no-spaced-func)
 
+This rule was **deprecated** in ESLint v3.3.0 and replaced by the [func-call-spacing](func-call-spacing.md) rule.
+
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
 While it's possible to have whitespace between the name of a function and the parentheses that execute it, such patterns tend to look more like errors.

--- a/docs/rules/no-unexpected-multiline.md
+++ b/docs/rules/no-unexpected-multiline.md
@@ -66,6 +66,6 @@ Note that the patterns considered problems are **not** flagged by the [semi](sem
 
 ## Related Rules
 
+* [func-call-spacing](func-call-spacing.md)
 * [semi](semi.md)
-* [no-spaced-func](no-spaced-func.md)
 * [space-unary-ops](space-unary-ops.md)

--- a/lib/rules/func-call-spacing.js
+++ b/lib/rules/func-call-spacing.js
@@ -1,0 +1,153 @@
+/**
+ * @fileoverview Rule to control spacing within function calls
+ * @author Matt DuVall <http://www.mattduvall.com>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require or disallow spacing between `function` identifiers and their invocations",
+            category: "Stylistic Issues",
+            recommended: false
+        },
+
+        fixable: "whitespace",
+        schema: {
+            anyOf: [
+                {
+                    type: "array",
+                    items: [
+                        {
+                            enum: ["never"]
+                        }
+                    ],
+                    minItems: 0,
+                    maxItems: 1
+                },
+                {
+                    type: "array",
+                    items: [
+                        {
+                            enum: ["always"]
+                        },
+                        {
+                            type: "object",
+                            properties: {
+                                allowNewlines: {
+                                    type: "boolean"
+                                }
+                            },
+                            additionalProperties: false
+                        }
+                    ],
+                    minItems: 0,
+                    maxItems: 2
+                }
+            ]
+        }
+    },
+
+    create: function(context) {
+
+        const never = context.options[0] !== "always";
+        const allowNewlines = !never && context.options[1] && context.options[1].allowNewlines;
+        const sourceCode = context.getSourceCode();
+        const text = sourceCode.getText();
+
+        /**
+         * Check if open space is present in a function name
+         * @param {ASTNode} node node to evaluate
+         * @returns {void}
+         * @private
+         */
+        function checkSpacing(node) {
+            const lastCalleeToken = sourceCode.getLastToken(node.callee);
+            let prevToken = lastCalleeToken;
+            let parenToken = sourceCode.getTokenAfter(lastCalleeToken);
+
+            // advances to an open parenthesis.
+            while (
+                parenToken &&
+                parenToken.range[1] < node.range[1] &&
+                parenToken.value !== "("
+            ) {
+                prevToken = parenToken;
+                parenToken = sourceCode.getTokenAfter(parenToken);
+            }
+
+            // Parens in NewExpression are optional
+            if (!(parenToken && parenToken.range[1] < node.range[1])) {
+                return;
+            }
+
+            const hasWhitespace = sourceCode.isSpaceBetweenTokens(prevToken, parenToken);
+            const hasNewline = hasWhitespace &&
+                /\n/.test(text.slice(prevToken.range[1], parenToken.range[0]).replace(/\/\*.*?\*\//g, ""));
+
+            /*
+             * never allowNewlines hasWhitespace hasNewline message
+             * F     F             F             F          Missing space between function name and paren.
+             * F     F             F             T          (Invalid `!hasWhitespace && hasNewline`)
+             * F     F             T             T          Unexpected newline between function name and paren.
+             * F     F             T             F          (OK)
+             * F     T             T             F          (OK)
+             * F     T             T             T          (OK)
+             * F     T             F             T          (Invalid `!hasWhitespace && hasNewline`)
+             * F     T             F             F          Missing space between function name and paren.
+             * T     T             F             F          (Invalid `never && allowNewlines`)
+             * T     T             F             T          (Invalid `!hasWhitespace && hasNewline`)
+             * T     T             T             T          (Invalid `never && allowNewlines`)
+             * T     T             T             F          (Invalid `never && allowNewlines`)
+             * T     F             T             F          Unexpected space between function name and paren.
+             * T     F             T             T          Unexpected space between function name and paren.
+             * T     F             F             T          (Invalid `!hasWhitespace && hasNewline`)
+             * T     F             F             F          (OK)
+             *
+             * T                   T                        Unexpected space between function name and paren.
+             * F                   F                        Missing space between function name and paren.
+             * F     F                           T          Unexpected newline between function name and paren.
+             */
+
+            if (never && hasWhitespace) {
+                context.report({
+                    node: node,
+                    loc: lastCalleeToken.loc.start,
+                    message: "Unexpected space between function name and paren.",
+                    fix: function(fixer) {
+                        return fixer.removeRange([prevToken.range[1], parenToken.range[0]]);
+                    }
+                });
+            } else if (!never && !hasWhitespace) {
+                context.report({
+                    node: node,
+                    loc: lastCalleeToken.loc.start,
+                    message: "Missing space between function name and paren.",
+                    fix: function(fixer) {
+                        return fixer.insertTextBefore(parenToken, " ");
+                    }
+                });
+            } else if (!never && !allowNewlines && hasNewline) {
+                context.report({
+                    node: node,
+                    loc: lastCalleeToken.loc.start,
+                    message: "Unexpected newline between function name and paren.",
+                    fix: function(fixer) {
+                        return fixer.replaceTextRange([prevToken.range[1], parenToken.range[0]], " ");
+                    }
+                });
+            }
+        }
+
+        return {
+            CallExpression: checkSpacing,
+            NewExpression: checkSpacing
+        };
+
+    }
+};

--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Rule to check that spaced function application
  * @author Matt DuVall <http://www.mattduvall.com>
+ * @deprecated in ESLint v3.3.0
  */
 
 "use strict";
@@ -12,10 +13,13 @@
 module.exports = {
     meta: {
         docs: {
-            description: "disallow spacing between `function` identifiers and their applications",
+            description: "disallow spacing between `function` identifiers and their applications (deprecated)",
             category: "Stylistic Issues",
-            recommended: false
+            recommended: false,
+            replacedBy: ["func-call-spacing"]
         },
+
+        deprecated: true,
 
         fixable: "whitespace",
         schema: []

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -19,6 +19,7 @@ rules:
     dot-notation: ["error", { allowKeywords: true }]
     eol-last: "error"
     eqeqeq: "error"
+    func-call-spacing: "error"
     func-style: ["error", "declaration"]
     generator-star-spacing: "error"
     guard-for-in: "error"
@@ -72,7 +73,6 @@ rules:
     no-sequences: "error"
     no-shadow: "error"
     no-shadow-restricted-names: "error"
-    no-spaced-func: "error"
     no-tabs: "error"
     no-trailing-spaces: "error"
     no-undef: "error"

--- a/tests/lib/rules/func-call-spacing.js
+++ b/tests/lib/rules/func-call-spacing.js
@@ -1,0 +1,518 @@
+/**
+ * @fileoverview Tests for func-call-spacing rule.
+ * @author Matt DuVall <http://www.mattduvall.com>
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/func-call-spacing"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("func-call-spacing", rule, {
+    valid: [
+
+        // default ("never")
+        "f();",
+        "f(a, b);",
+        "f.b();",
+        "f.b().c();",
+        "f()()",
+        "(function() {}())",
+        "var f = new Foo()",
+        "var f = new Foo",
+        "f( (0) )",
+        "( f )( 0 )",
+        "( (f) )( (0) )",
+        "( f()() )(0)",
+        "(function(){ if (foo) { bar(); } }());",
+        "f(0, (1))",
+        "describe/**/('foo', function () {});",
+        "new (foo())",
+
+        // "never"
+        {
+            code: "f();",
+            options: ["never"]
+        },
+        {
+            code: "f(a, b);",
+            options: ["never"]
+        },
+        {
+            code: "f.b();",
+            options: ["never"]
+        },
+        {
+            code: "f.b().c();",
+            options: ["never"]
+        },
+        {
+            code: "f()()",
+            options: ["never"]
+        },
+        {
+            code: "(function() {}())",
+            options: ["never"]
+        },
+        {
+            code: "var f = new Foo()",
+            options: ["never"]
+        },
+        {
+            code: "var f = new Foo",
+            options: ["never"]
+        },
+        {
+            code: "f( (0) )",
+            options: ["never"]
+        },
+        {
+            code: "( f )( 0 )",
+            options: ["never"]
+        },
+        {
+            code: "( (f) )( (0) )",
+            options: ["never"]
+        },
+        {
+            code: "( f()() )(0)",
+            options: ["never"]
+        },
+        {
+            code: "(function(){ if (foo) { bar(); } }());",
+            options: ["never"]
+        },
+        {
+            code: "f(0, (1))",
+            options: ["never"]
+        },
+        {
+            code: "describe/**/('foo', function () {});",
+            options: ["never"]
+        },
+        {
+            code: "new (foo())",
+            options: ["never"]
+        },
+
+        // "always"
+        {
+            code: "f ();",
+            options: ["always"]
+        },
+        {
+            code: "f (a, b);",
+            options: ["always"]
+        },
+        {
+            code: "f.b ();",
+            options: ["always"]
+        },
+        {
+            code: "f.b ().c ();",
+            options: ["always"]
+        },
+        {
+            code: "f () ()",
+            options: ["always"]
+        },
+        {
+            code: "(function() {} ())",
+            options: ["always"]
+        },
+        {
+            code: "var f = new Foo ()",
+            options: ["always"]
+        },
+        {
+            code: "var f = new Foo",
+            options: ["always"]
+        },
+        {
+            code: "f ( (0) )",
+            options: ["always"]
+        },
+        {
+            code: "f (0) (1)",
+            options: ["always"]
+        },
+        {
+            code: "(f) (0)",
+            options: ["always"]
+        },
+        {
+            code: "f ();\n t   ();",
+            options: ["always"]
+        },
+
+        // "always", "allowNewlines": true
+        {
+            code: "f\n();",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f.b \n ();",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f\n() ().b \n()\n ()",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "var f = new Foo\n();",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f// comment\n()",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f // comment\n ()",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f// comment\n()",
+            options: ["always", { allowNewlines: true }]
+        },
+        {
+            code: "f\n/*\n*/\n()",
+            options: ["always", { allowNewlines: true }]
+        }
+    ],
+    invalid: [
+
+        // default ("never")
+        {
+            code: "f ();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f();"
+        },
+        {
+            code: "f (a, b);",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f(a, b);"
+        },
+        {
+            code: "f\n();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f();"
+        },
+        {
+            code: "f.b ();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b();"
+        },
+        {
+            code: "f.b().c ();",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 7 }],
+            output: "f.b().c();"
+        },
+        {
+            code: "f() ()",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f()()"
+        },
+        {
+            code: "(function() {} ())",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "(function() {}())"
+        },
+        {
+            code: "var f = new Foo ()",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "NewExpression" }],
+            output: "var f = new Foo()"
+        },
+        {
+            code: "f ( (0) )",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f( (0) )"
+        },
+        {
+            code: "f(0) (1)",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f(0)(1)"
+        },
+        {
+            code: "(f) (0)",
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "(f)(0)"
+        },
+        {
+            code: "f ();\n t   ();",
+            errors: [
+                { message: "Unexpected space between function name and paren.", type: "CallExpression" },
+                { message: "Unexpected space between function name and paren.", type: "CallExpression" }
+            ],
+            output: "f();\n t();"
+        },
+
+        // "never"
+        {
+            code: "f ();",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f();"
+        },
+        {
+            code: "f (a, b);",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f(a, b);"
+        },
+        {
+            code: "f\n();",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f();"
+        },
+        {
+            code: "f.b ();",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b();"
+        },
+        {
+            code: "f.b().c ();",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression", column: 7 }],
+            output: "f.b().c();"
+        },
+        {
+            code: "f() ()",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f()()"
+        },
+        {
+            code: "(function() {} ())",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "(function() {}())"
+        },
+        {
+            code: "var f = new Foo ()",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "NewExpression" }],
+            output: "var f = new Foo()"
+        },
+        {
+            code: "f ( (0) )",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f( (0) )"
+        },
+        {
+            code: "f(0) (1)",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "f(0)(1)"
+        },
+        {
+            code: "(f) (0)",
+            options: ["never"],
+            errors: [{ message: "Unexpected space between function name and paren.", type: "CallExpression" }],
+            output: "(f)(0)"
+        },
+        {
+            code: "f ();\n t   ();",
+            options: ["never"],
+            errors: [
+                { message: "Unexpected space between function name and paren.", type: "CallExpression" },
+                { message: "Unexpected space between function name and paren.", type: "CallExpression" }
+            ],
+            output: "f();\n t();"
+        },
+
+        // "always"
+        {
+            code: "f();",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f ();"
+        },
+        {
+            code: "f\n();",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }],
+            output: "f ();"
+        },
+        {
+            code: "f(a, b);",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f (a, b);"
+        },
+        {
+            code: "f\n(a, b);",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }],
+            output: "f (a, b);"
+        },
+        {
+            code: "f.b();",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b ();"
+        },
+        {
+            code: "f.b\n();",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b ();"
+        },
+        {
+            code: "f.b().c ();",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b ().c ();"
+        },
+        {
+            code: "f.b\n().c ();",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b ().c ();"
+        },
+        {
+            code: "f() ()",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f () ()"
+        },
+        {
+            code: "f\n() ()",
+            options: ["always"],
+            errors: [{ message: "Unexpected newline between function name and paren.", type: "CallExpression" }],
+            output: "f () ()"
+        },
+        {
+            code: "f\n()()",
+            options: ["always"],
+            errors: [
+                { message: "Unexpected newline between function name and paren.", type: "CallExpression" },
+                { message: "Missing space between function name and paren.", type: "CallExpression" }
+            ],
+            output: "f () ()"
+        },
+        {
+            code: "(function() {}())",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "(function() {} ())"
+        },
+        {
+            code: "var f = new Foo()",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "NewExpression" }],
+            output: "var f = new Foo ()"
+        },
+        {
+            code: "f( (0) )",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f ( (0) )"
+        },
+        {
+            code: "f(0) (1)",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f (0) (1)"
+        },
+        {
+            code: "(f)(0)",
+            options: ["always"],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "(f) (0)"
+        },
+        {
+            code: "f();\n t();",
+            options: ["always"],
+            errors: [
+                { message: "Missing space between function name and paren.", type: "CallExpression" },
+                { message: "Missing space between function name and paren.", type: "CallExpression" }
+            ],
+            output: "f ();\n t ();"
+        },
+
+        // "always", "allowNewlines": true
+        {
+            code: "f();",
+            options: ["always", { allowNewlines: true }],
+            errors: [
+                { message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f ();"
+        },
+        {
+            code: "f(a, b);",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f (a, b);"
+        },
+        {
+            code: "f.b();",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b ();"
+        },
+        {
+            code: "f.b().c ();",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression", column: 3 }],
+            output: "f.b ().c ();"
+        },
+        {
+            code: "f() ()",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f () ()"
+        },
+        {
+            code: "(function() {}())",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "(function() {} ())"
+        },
+        {
+            code: "var f = new Foo()",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "NewExpression" }],
+            output: "var f = new Foo ()"
+        },
+        {
+            code: "f( (0) )",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f ( (0) )"
+        },
+        {
+            code: "f(0) (1)",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "f (0) (1)"
+        },
+        {
+            code: "(f)(0)",
+            options: ["always", { allowNewlines: true }],
+            errors: [{ message: "Missing space between function name and paren.", type: "CallExpression" }],
+            output: "(f) (0)"
+        },
+        {
+            code: "f();\n t();",
+            options: ["always", { allowNewlines: true }],
+            errors: [
+                { message: "Missing space between function name and paren.", type: "CallExpression" },
+                { message: "Missing space between function name and paren.", type: "CallExpression" }
+            ],
+            output: "f ();\n t ();"
+        }
+    ]
+});

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -819,7 +819,7 @@ ruleTester.run("keyword-spacing", rule, {
         {code: "class A { a() { ({a:super }) } }", parserOptions: {ecmaVersion: 6}},
         {code: "class A { a() { ({a: super }) } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
 
-        // not conflict with `no-spaced-func`
+        // not conflict with `func-call-spacing`
         {code: "class A { constructor() { super(); } }", parserOptions: {ecmaVersion: 6}},
         {code: "class A { constructor() { super (); } }", options: [NEITHER], parserOptions: {ecmaVersion: 6}},
 

--- a/tests/lib/rules/no-spaced-func.js
+++ b/tests/lib/rules/no-spaced-func.js
@@ -1,6 +1,7 @@
 /**
  * @fileoverview Tests for no-spaced-func rule.
  * @author Matt DuVall <http://www.mattduvall.com>
+ * @deprecated in ESLint v3.3.0
  */
 
 "use strict";


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6080 - support [requireSpacesInCallExpression](http://jscs.info/rule/requireSpacesInCallExpression) and [disallowSpacesInCallExpression](http://jscs.info/rule/disallowSpacesInCallExpression) by replacing the `no-spaced-func` rule with a new `func-call-spacing` rule having `"never"` (default) or `"always"` modes.

**What changes did you make? (Give an overview)**

Copied the `no-spaced-func` rule, named the new rule `func-call-spacing`, and added support for `"never"` and `"always"` options.

**Is there anything you'd like reviewers to focus on?**

1. I haven't touched `no-spaced-func`. What's the proper way to indicate that it's deprecated in favor of `func-call-spacing`?
2. For compatibility with JSCS `requireSpacesInCallExpression`, `"always"` permits newlines within calls.