### PR TITLE
Chore: Updated no-control-regex tests to cover all cases (fixes #6438)

### DIFF
--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -21,6 +21,7 @@ var ruleTester = new RuleTester();
 ruleTester.run("no-control-regex", rule, {
     valid: [
         "var regex = /x1f/",
+        "var regex =" + /\\x1f/,
         "var regex = new RegExp('x1f')",
         "var regex = RegExp('x1f')",
         "new RegExp('[')",
@@ -28,8 +29,8 @@ ruleTester.run("no-control-regex", rule, {
         "new (function foo(){})('\\x1f')"
     ],
     invalid: [
-        { code: "var regex = /\x1f/", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] },
-        { code: "var regex = /\\\x1f/", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] },
+        { code: "var regex = " + /\x1f/, errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: "var regex = " + /\\\x1f/, errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] }, // eslint-disable-line no-control-regex
         { code: "var regex = new RegExp('\\x1f')", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] },
         { code: "var regex = RegExp('\\x1f')", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] }
     ]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6438 

**What changes did you make? (Give an overview)**
toString prints out different outputs for /\x01/ and "/\x01/". Because
of that behavior, no-control-regex rule was broken before(fixed on 141b778).

During the fix for #5737 I added a test to cover the case I wrote for fix. Which
was also passing when the fix was not there. The test was on a string
literal unfortunately which was not covering the test case where regex
is written on a literal (like /\x01/). Changed the tests to make sure it
covers the literal regex's as expected.

**Is there anything you'd like reviewers to focus on?**

