### PR TITLE
Update: make `eslint:all` excluding deprecated rules (fixes #6734)

### DIFF
--- a/conf/eslint-all.js
+++ b/conf/eslint-all.js
@@ -9,17 +9,16 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-let fs = require("fs"),
-    path = require("path");
+const load = require("../lib/load-rules"),
+    rules = require("../lib/rules");
 
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
 
-let ruleFiles = fs.readdirSync(path.resolve(__dirname, "../lib/rules"));
-let enabledRules = ruleFiles.reduce(function(result, filename) {
-    if (path.extname(filename) === ".js") {
-        result[path.basename(filename, ".js")] = "error";
+const enabledRules = Object.keys(load()).reduce((result, ruleId) => {
+    if (!rules.get(ruleId).meta.deprecated) {
+        result[ruleId] = "error";
     }
     return result;
 }, {});


### PR DESCRIPTION
Fixes #6734.

Also, I changed the way which enumerates core rules to a use of existing `loadRules` function.