### PR TITLE
Revert "Build: Remove support for Node v5 (fixes #6743)"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
     - "4"
+    - "5"
     - "6"
 sudo: false
 script: "npm test && npm run docs"


### PR DESCRIPTION
Reverts eslint/eslint#6744

This was merged a bit too hastily. We can't drop support for Node 5 without a major release. 