### PR TITLE
Docs: Distinguish examples in rules under Stylistic Issues part 7

### DIFF
--- a/docs/rules/object-curly-spacing.md
+++ b/docs/rules/object-curly-spacing.md
@@ -1,4 +1,4 @@
-# Disallow or enforce spaces inside of curly braces in objects. (object-curly-spacing)
+# enforce consistent spacing inside braces (object-curly-spacing)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -22,28 +22,27 @@ export { foo };
 
 ## Rule Details
 
-This rule aims to maintain consistency around the spacing inside of object literals. It also
-applies to EcmaScript 6 destructured assignment and import/export specifiers.
-
-It either requires or disallows spaces between those braces and the values inside of them.
-Braces that are separated from the adjacent value by a new line are exempt from this rule.
+This rule enforce consistent spacing inside braces of object literals, destructuring assignments, and import/export specifiers.
 
 ## Options
 
-There are two main options for the rule:
+This rule has two options, a string option and an object option.
 
-* `"always"` enforces a space inside of curly braces
-* `"never"` disallows spaces inside of curly braces (default)
+String option:
 
-Depending on your coding conventions, you can choose either option by specifying it in your configuration:
+* `"never"` (default) disallows spacing inside of braces
+* `"always"` requires spacing inside of braces (except `{}`)
 
-```json
-"object-curly-spacing": ["error", "always"]
-```
+Object option:
 
-### "never"
+* `"arraysInObjects": true` requires spacing inside of braces of objects beginning and/or ending with an array element (applies when the first option is set to `never`)
+* `"arraysInObjects": false` disallows spacing inside of braces of objects beginning and/or ending with an array element (applies when the first option is set to `always`)
+* `"objectsInObjects": true` requires spacing inside of braces of objects beginning and/or ending with an object element (applies when the first option is set to `never`)
+* `"objectsInObjects": false` disallows spacing inside of braces of objects beginning and/or ending with an object element (applies when the first option is set to `always`)
 
-When `"never"` is set, the following patterns are considered problems:
+### never
+
+Examples of **incorrect** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint object-curly-spacing: ["error", "never"]*/
@@ -56,7 +55,7 @@ var {x } = y;
 import { foo } from 'bar';
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"never"` option:
 
 ```js
 /*eslint object-curly-spacing: ["error", "never"]*/
@@ -75,9 +74,9 @@ var {x} = y;
 import {foo} from 'bar';
 ```
 
-### "always"
+### always
 
-When `"always"` is used, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint object-curly-spacing: ["error", "always"]*/
@@ -94,7 +93,7 @@ var {x} = y;
 import {foo } from 'bar';
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint object-curly-spacing: ["error", "always"]*/
@@ -109,62 +108,43 @@ var { x } = y;
 import { foo } from 'bar';
 ```
 
-Note that `{}` is always exempt from spacing requirements with this rule.
+#### arraysInObjects
 
-### Exceptions
-
-There are two exceptions you can apply to this rule: `objectsInObjects` and
-`arraysInObjects`. Their values can be set to either `true` or `false` as part
-of an object literal set as the 3rd argument for the rule.
-
-These exceptions work in the context of the first option.
-That is, if `"always"` is set to enforce spacing and an exception is set to `false`,
-it will disallow spacing for cases matching the exception. Likewise,
-if `"never"` is set to disallow spacing and an exception is set to `true`,
-it will enforce spacing for cases matching the exception.
-
-You can add exceptions like so:
-
-```json
-"object-curly-spacing": ["error", "always", {
-  "objectsInObjects": false,
-  "arraysInObjects": false
-}]
-```
-
-#### `objectsInObjects`
-
-In the case of the `"always"` option, set `objectsInObjects` exception to `false` to
-enforce the following syntax (notice the `}}` at the end):
+Examples of additional **correct** code for this rule with the `"never", { "arraysInObjects": true }` options:
 
 ```js
-var obj = { "foo": { "baz": 1, "bar": 2 }};
+/*eslint object-curly-spacing: ["error", "never", { "arraysInObjects": true }]*/
+
+var obj = {"foo": [ 1, 2 ] };
+var obj = {"foo": [ "baz", "bar" ] };
 ```
 
-In the case of the `"never"` option, set `objectsInObjects` exception to `true` to enforce
-the following style (with a space between the `}` at the end:
-
+Examples of additional **correct** code for this rule with the `"always", { "arraysInObjects": false }` options:
 
 ```js
-var obj = {"foo": {"baz": 1, "bar": 2} };
-```
+/*eslint object-curly-spacing: ["error", "always", { "arraysInObjects": false }]*/
 
-#### `arraysInObjects`
-
-In the case of the `"always"` option, set `arraysInObjects` exception to `false` to
-enforce the following syntax (notice the `]}` at the end):
-
-```js
 var obj = { "foo": [ 1, 2 ]};
 var obj = { "foo": [ "baz", "bar" ]};
 ```
 
-In the case of the `"never"` option, set `arraysInObjects` exception to `true` to enforce
-the following style (with a space between the `]` and  `}` at the end:
+
+#### objectsInObjects
+
+Examples of additional **correct** code for this rule with the `"never", { "objectsInObjects": true }` options:
 
 ```js
-var obj = {"foo": [ 1, 2 ] };
-var obj = {"foo": [ "baz", "bar" ] };
+/*eslint object-curly-spacing: ["error", "never", { "objectsInObjects": true }]*/
+
+var obj = {"foo": {"baz": 1, "bar": 2} };
+```
+
+Examples of additional **correct** code for this rule with the `"always", { "objectsInObjects": false }` options:
+
+```js
+/*eslint object-curly-spacing: ["error", "always", { "objectsInObjects": false }]*/
+
+var obj = { "foo": { "baz": 1, "bar": 2 }};
 ```
 
 ## When Not To Use It
@@ -175,4 +155,3 @@ You can turn this rule off if you are not concerned with the consistency of spac
 
 * [comma-spacing](comma-spacing.md)
 * [space-in-parens](space-in-parens.md)
-* [space-in-brackets](space-in-brackets.md) (deprecated)

--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -1,4 +1,4 @@
-# Require or disallow an newline around variable declarations (one-var-declaration-per-line)
+# require or disallow newlines around `var` declarations (one-var-declaration-per-line)
 
 Some developers declare multiple var statements on the same line:
 
@@ -14,20 +14,51 @@ var foo,
     baz;
 ```
 
-This rule enforces a consistent style across the entire project.
+Keeping to one of these styles across a project's codebase can help with maintaining code consistency.
 
 ## Rule Details
 
-This rule enforces a consistent coding style where newlines are required or disallowed after each var declaration or just when there is a variable initialization. It ignores var declarations inside for loop conditionals.
+This rule enforces a consistent newlines around variable declarations. This rule ignores variable declarations inside `for` loop conditionals.
 
 ## Options
 
-This rule takes one option, a string, which can be:
+This rule has a single string option:
 
-* `"always"` enforces a newline around each variable declaration
-* `"initializations"` enforces a newline around each variable initialization (default)
+* `"initializations"` (default) enforces a newline around variable initializations
+* `"always"` enforces a newline around variable declarations
 
-The following patterns are considered problems when set to `"always"`:
+### initializations
+
+Examples of **incorrect** code for this rule with the default `"initializations"` option:
+
+```js
+/*eslint one-var-declaration-per-line: ["error", "initializations"]*/
+/*eslint-env es6*/
+
+var a, b, c = 0;
+
+let a,
+    b = 0, c;
+```
+
+Examples of **correct** code for this rule with the default `"initializations"` option:
+
+```js
+/*eslint one-var-declaration-per-line: ["error", "initializations"]*/
+/*eslint-env es6*/
+
+var a, b;
+
+let a,
+    b;
+
+let a,
+    b = 0;
+```
+
+### always
+
+Examples of **incorrect** code for this rule with the `"always"` option:
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "always"]*/
@@ -40,40 +71,13 @@ let a, b = 0;
 const a = 0, b = 0;
 ```
 
-The following patterns are not considered problems when set to `"always"`:
+Examples of **correct** code for this rule with the `"always"` option:
 
 ```js
 /*eslint one-var-declaration-per-line: ["error", "always"]*/
 /*eslint-env es6*/
 
 var a,
-    b;
-
-let a,
-    b = 0;
-```
-
-The following patterns are considered problems when set to `"initializations"`:
-
-```js
-/*eslint one-var-declaration-per-line: ["error", "initializations"]*/
-/*eslint-env es6*/
-
-var a, b, c = 0;
-
-let a,
-    b = 0, c;
-```
-
-The following patterns are not considered problems when set to `"initializations"`:
-
-```js
-/*eslint one-var-declaration-per-line: ["error", "initializations"]*/
-/*eslint-env es6*/
-
-var a, b;
-
-let a,
     b;
 
 let a,

--- a/docs/rules/one-var.md
+++ b/docs/rules/one-var.md
@@ -1,4 +1,4 @@
-# Require or Disallow One Variable Declaration per Scope (one-var)
+# enforce variables to be declared either together or separately in functions (one-var)
 
 Variables can be declared at any point in JavaScript code using `var`, `let`, or `const`. There are many styles and preferences related to the declaration of variables, and one of those is deciding on how many variable declarations should be allowed in a single function.
 
@@ -26,59 +26,36 @@ The single-declaration school of thought is based in pre-ECMAScript 6 behaviors,
 
 ## Rule Details
 
-This rule is aimed at enforcing the use of either one variable declaration or multiple declarations per function (for `var`) or block (for `let` and `const`) scope. As such, it will warn when it encounters an unexpected number of variable declarations.
+This rule enforces variables to be declared either together or separately per function ( for `var`) or block (for `let` and `const`) scope.
 
 ## Options
 
-There are two ways to configure this rule. The first is by using one string specified as `"always"` (the default) to enforce one variable declaration per scope or `"never"` to enforce multiple variable declarations per scope.  If you declare variables in your code with `let` and `const`, then `"always"` and `"never"` will apply to the block scope for those declarations, not the function scope.
+This rule has one option, which can be a string option or an object option.
 
-The second way to configure this rule is with an object. The keys are any of:
+String option:
 
-* `var`
-* `let`
-* `const`
+* `"always"` (default) requires one variable declaration per scope
+* `"never"` requires multiple variable declarations per scope
 
-or:
+Object option:
 
-* `uninitialized`
-* `initialized`
+* `"var": "always"` requires one `var` declaration per function
+* `"var": "never"` requires multiple `var` declarations per function
+* `"let": "always"` requires one `let` declaration per block
+* `"let": "never"` requires multiple `let` declarations per block
+* `"const": "always"` requires one `const` declaration per block
+* `"const": "never"` requires multiple `const` declarations per block
 
-and the values are either `"always"` or `"never"`. This allows you to set behavior differently for each type of declaration, or whether variables are initialized during declaration.
+Alternate object option:
 
-You can configure the rule as follows:
+* `"initialized": "always"` requires one variable declaration for initialized variables per scope
+* `"initialized": "never"` requires multiple variable declarations for initialized variables per scope
+* `"uninitialized": "always"` requires one variable declaration for uninitialized variables per scope
+* `"uninitialized": "never"` requires multiple variable declarations for uninitialized variables per scope
 
-(default) Exactly one variable declaration per type per function (var) or block (let or const)
+### always
 
-```json
-"one-var": [2, "always"]
-```
-
-Exactly one declarator per declaration per function (var) or block (let or const)
-
-```json
-"one-var": ["error", "never"]
-```
-
-Configure each declaration type individually. Defaults to `"always"` if key not present.
-
-```json
-"one-var": ["error", {
-    "var": "always", // Exactly one var declaration per function
-    "let": "always", // Exactly one let declaration per block
-    "const": "never" // Exactly one declarator per const declaration per block
-}]
-```
-
-Configure uninitialized and initialized seperately. Defaults to `"always"` if key not present.
-
-```json
-"one-var": [2, {
-    "uninitialized": "always", // Exactly one declaration for uninitialized variables per function (var) or block (let or const)
-    "initialized": "never" // Exactly one declarator per initialized variable declaration per function (var) or block (let or const)
-}]
-```
-
-When configured with `"always"` as the first option (the default), the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint one-var: ["error", "always"]*/
@@ -107,7 +84,7 @@ function foo() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint one-var: ["error", "always"]*/
@@ -145,7 +122,9 @@ function foo(){
 }
 ```
 
-When configured with `"never"` as the first option, the following patterns are considered problems:
+### never
+
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint one-var: ["error", "never"]*/
@@ -173,7 +152,7 @@ function foo(){
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint one-var: ["error", "never"]*/
@@ -201,11 +180,30 @@ function foo() {
 }
 ```
 
-When configured with an object as the first option, you can individually control how `var`, `let`, and `const` are handled, or alternatively how `uninitialized` and `initialized` variables are handled (which if used will override `var`, `let`, and `const`).
+### var, let, and const
 
-**Note:** A variable declared in a for-in or for-of loop will not be flagged with the option `{ uninitialized: "always" }`, as this value is determined by the loop.
+Examples of **incorrect** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
 
-The following patterns are not considered problems:
+```js
+/*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
+/*eslint-env es6*/
+
+function foo() {
+    var bar;
+    var baz;
+    let qux,
+        norf;
+}
+
+function foo() {
+    const bar = 1,
+          baz = 2;
+    let qux,
+        norf;
+}
+```
+
+Examples of **correct** code for this rule with the `{ var: "always", let: "never", const: "never" }` option:
 
 ```js
 /*eslint one-var: ["error", { var: "always", let: "never", const: "never" }]*/
@@ -226,42 +224,96 @@ function foo() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **incorrect** code for this rule with the `{ var: "never" }` option:
 
 ```js
-/*eslint one-var: ["error", { uninitialized: "always", initialized: "never" }]*/
+/*eslint one-var: ["error", { var: "never" }]*/
+/*eslint-env es6*/
+
+function foo() {
+    var bar,
+        baz;
+}
+```
+
+Examples of **correct** code for this rule with the `{ var: "never" }` option:
+
+```js
+/*eslint one-var: ["error", { var: "never" }]*/
+/*eslint-env es6*/
+
+function foo() {
+    var bar,
+        baz;
+    const bar = 1; // `const` and `let` declarations are ignored if they are not specified
+    const baz = 2;
+    let qux;
+    let norf;
+}
+```
+
+
+### initialized and uninitialized
+
+Examples of **incorrect** code for this rule with the `{ "initialized": "always", "uninitialized": "never" }` option:
+
+```js
+/*eslint one-var: ["error", { "initialized": "always", "uninitialized": "never" }]*/
+/*eslint-env es6*/
 
 function foo() {
     var a, b, c;
     var foo = true;
     var bar = false;
 }
+```
 
-let x, y;
+Examples of **correct** code for this rule with the `{ "initialized": "always", "uninitialized": "never" }` option:
+
+```js
+/*eslint one-var: ["error", { "initialized": "always", "uninitialized": "never" }]*/
+
+function foo() {
+    var a;
+    var b;
+    var c;
+    var foo = true,
+        bar = false;
+}
+
 for (let z of foo) {
     doSomething(z);
 }
 
-let x, y, z;
+let z;
 for (z of foo) {
     doSomething(z);
 }
 ```
 
-If you are configuring the rule with an object, by default, if you didn't specify declaration type it will not be checked. So the following pattern is not considered a warning when options are set to: `{ var: "always", let: "always" }`
+Examples of **incorrect** code for this rule with the `{ "initialized": "never" }` option:
 
 ```js
-/*eslint one-var: ["error", { var: "always", let: "always" }]*/
+/*eslint one-var: ["error", { "initialized": "never" }]*/
 /*eslint-env es6*/
 
 function foo() {
-    var a, b;
-    const foo = true;
-    const bar = true;
-    let c, d;
+    var foo = true,
+        bar = false;
 }
 ```
 
+Examples of **correct** code for this rule with the `{ "initialized": never" }` option:
+
+```js
+/*eslint one-var: ["error", { initialized: never" }]*/
+
+function foo() {
+    var foo = true;
+    var bar = false;
+    var a, b, c; // Uninitialized variables are ignored
+}
+```
 
 ## Compatibility
 

--- a/docs/rules/operator-assignment.md
+++ b/docs/rules/operator-assignment.md
@@ -1,4 +1,4 @@
-# Operator Assignment Shorthand (operator-assignment)
+# require or disallow assignment operator shorthand where possible (operator-assignment)
 
 JavaScript provides shorthand operators that combine variable assignment and some simple mathematical operations. For example, `x = x + 4` can be shortened to `x += 4`. The supported shorthand forms are as follows:
 
@@ -20,19 +20,29 @@ JavaScript provides shorthand operators that combine variable assignment and som
 
 ## Rule Details
 
-This rule enforces use of the shorthand assignment operators by requiring them where possible or prohibiting them entirely.
+This rule requires or disallows assignment operator shorthand where possible.
 
 ## Options
 
-This rule has two options: `always` and `never`. The default is `always`.
+This rule has a single string option:
 
-### "always"
+* `"always"` (default)  requires assignment operator shorthand where possible
+* `"never"` disallows assignment operator shorthand
 
-`"operator-assignment": ["error", "always"]`
+### always
 
-This mode enforces use of operator assignment shorthand where possible.
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
-The following are examples of valid patterns:
+```js
+/*eslint operator-assignment: ["error", "always"]*/
+
+x = x + y;
+x = y * x;
+x[0] = x[0] / y;
+x.y = x.y << z;
+```
+
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint operator-assignment: ["error", "always"]*/
@@ -46,39 +56,24 @@ x[foo()] = x[foo()] % 2;
 x = y + x; // `+` is not always commutative (e.g. x = "abc")
 ```
 
-The following patterns are considered problems and should be replaced by their shorthand equivalents:
+### never
 
-```js
-/*eslint operator-assignment: ["error", "always"]*/
-
-x = x + y;
-x = y * x;
-x[0] = x[0] / y;
-x.y = x.y << z;
-```
-
-### "never"
-
-`"operator-assignment": ["error", "never"]`
-
-This mode warns on any use of operator assignment shorthand.
-
-The following are examples of valid patterns:
-
-```js
-/*eslint operator-assignment: ["error", "never"]*/
-
-x = x + y;
-x.y = x.y / a.b;
-```
-
-The following patterns are considered problems and should be written out fully without the shorthand assignments:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint operator-assignment: ["error", "never"]*/
 
 x *= y;
 x ^= (y + z) / foo();
+```
+
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+/*eslint operator-assignment: ["error", "never"]*/
+
+x = x + y;
+x.y = x.y / a.b;
 ```
 
 ## When Not To Use It

--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -1,4 +1,4 @@
-# Operator Linebreak (operator-linebreak)
+# enforce consistent linebreak style for operators (operator-linebreak)
 
 When a statement is too long to fit on a single line, line breaks are generally inserted next to the operators separating expressions. The first style coming to mind would be to place the operator at the end of the line, following the english punctuation rules.
 
@@ -18,25 +18,25 @@ var fullHeight = borderTop
 
 ## Rule Details
 
-The `operator-linebreak` rule is aimed at enforcing a particular operator line break style. As such, it warns whenever it sees a binary operator or assignment that does not adhere to a particular style: either placing linebreaks after or before the operators.
+This rule enforces a consistent linebreak style for operators.
 
 ## Options
 
-The rule takes two options, a string, which can be `"after"`, `"before"` or `"none"` where the default is `"after"` and an object for more fine-grained configuration.
+This rule has one option, which can be a string option or an object option.
 
-You can set the style in configuration like this:
+String option:
 
-```json
-"operator-linebreak": ["error", "before", { "overrides": { "?": "after" } }]
-```
+* `"after"` (default) requires linebreaks to be placed after the operator (except for the ternary operator characters `?` and `:`)
+* `"before"` requires linebreaks to be placed before the operator
+* `"none"` disallows linebreaks on either side of the operator
 
-The default configuration is to enforce line breaks _after_ the operator except for the ternary operator `?` and `:` following that.
+Object option:
 
-### "after"
+* `"overrides"` overrides the global setting for specified operators
 
-This is the default setting for this rule. This option requires the line break to be placed after the operator.
+### after
 
-While using this setting, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/
@@ -60,7 +60,7 @@ answer = everything
   : foo;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/
@@ -82,11 +82,9 @@ answer = everything ?
   foo;
 ```
 
-### "before"
+### before
 
-This option requires the line break to be placed before the operator.
-
-While using this setting, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"before"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "before"]*/
@@ -106,7 +104,7 @@ answer = everything ?
   foo;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"before"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "before"]*/
@@ -128,11 +126,9 @@ answer = everything
   : foo;
 ```
 
-### "none"
+### none
 
-This option disallows line breaks on either side of the operator.
-
-While using this setting, the following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"none"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "none"]*/
@@ -160,7 +156,7 @@ answer = everything ?
   foo;
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"none"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "none"]*/
@@ -175,24 +171,21 @@ if (someCondition || otherCondition) {
 answer = everything ? 42 : foo;
 ```
 
-### Fine-grained control
+### overrides
 
-The rule allows you to have even finer-grained control over individual operators by specifying an `overrides` dictionary:
-
-```json
-"operator-linebreak": ["error", "before", { "overrides": { "?": "after", "+=": "none" } }]
-```
-
-This would override the global setting for that specific operator.
-
-#### "ignore" override
-
-This option is only supported using overrides and ignores line breaks on either side of the operator.
-
-While using this setting, the following patterns are not considered problems:
+Examples of additional **correct** code for this rule with the `{ "overrides": { +=": "before" } }` option:
 
 ```js
-/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "ignore", ":": "ignore"} }]*/
+/*eslint operator-linebreak: ["error", "after", { "overrides": { +=": "before" } }]*/
+
+var thing
+  += 'thing';
+```
+
+Examples of additional **correct** code for this rule with the `{ "overrides": { "?": "ignore", ":": "ignore" } }` option:
+
+```js
+/*eslint operator-linebreak: ["error", "after", { "overrides": { "?": "ignore", ":": "ignore" } }]*/
 
 answer = everything ?
   42

--- a/docs/rules/padded-blocks.md
+++ b/docs/rules/padded-blocks.md
@@ -1,4 +1,4 @@
-# Enforce padding within blocks (padded-blocks)
+# require or disallow padding within blocks (padded-blocks)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -18,15 +18,26 @@ padded blocks or never do it.
 
 ## Rule Details
 
-This rule enforces consistent padding within blocks.
+This rule enforces consistent empty line padding within blocks.
 
-This rule takes one argument, which can be an string or an object. If it is `"always"` (the default) then block statements must start **and** end with a blank line. If `"never"`, then block statements should neither start nor end with a blank line. By default, this rule ignores padding in switch statements and classes.
+## Options
 
-If you want to enforce padding within switches and classes, a configuration object can be passed as the rule argument to configure the cases separately ( e.g. `{ "blocks": "always", "switches": "always", "classes": "always" }` ).
+This rule has one option, which can be a string option or an object option.
+
+String option:
+
+* `"always"` (default) requires empty lines at the beginning and ending of block statements (except `switch` statements and classes)
+* `"never"` disallows empty lines at the beginning and ending of block statements
+
+Object option:
+
+* `"blocks"` require or disallow padding within block statements
+* `"classes"` require or disallow padding within classes
+* `"switches"` require or disallow padding within `switch` statements
 
 ### always
 
-Examples of **incorrect** code for this rule with the `"always"` option:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint padded-blocks: ["error", "always"]*/
@@ -59,7 +70,7 @@ if (a) {
 }
 ```
 
-Examples of **correct** code for this rule with the `"always"` option:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint padded-blocks: ["error", "always"]*/
@@ -142,6 +153,28 @@ if (a) {
     b();
 }
 
+if (a) { b(); }
+
+if (a)
+{
+    b();
+}
+
+if (a) {
+
+    b();
+}
+
+if (a) {
+    b();
+
+}
+
+if (a) {
+    // comment
+    b();
+
+}
 ```
 
 Examples of **correct** code for this rule with the `{ "blocks": "always" }` option:
@@ -155,6 +188,19 @@ if (a) {
 
 }
 
+if (a)
+{
+
+    b();
+
+}
+
+if (a) {
+
+    // comment
+    b();
+
+}
 ```
 
 Examples of **incorrect** code for this rule with the `{ "blocks": "never" }` option:
@@ -168,6 +214,22 @@ if (a) {
 
 }
 
+if (a)
+{
+
+    b();
+
+}
+
+if (a) {
+
+    b();
+}
+
+if (a) {
+    b();
+
+}
 ```
 
 Examples of **correct** code for this rule with the `{ "blocks": "never" }` option:
@@ -179,6 +241,60 @@ if (a) {
     b();
 }
 
+if (a)
+{
+    b();
+}
+```
+
+### classes
+
+Examples of **incorrect** code for this rule with the `{ "classes": "always" }` option:
+
+```js
+/*eslint padded-blocks: ["error", { "classes": "always" }]*/
+
+class  A {
+    constructor(){
+    }
+}
+```
+
+Examples of **correct** code for this rule with the `{ "classes": "always" }` option:
+
+```js
+/*eslint padded-blocks: ["error", { "classes": "always" }]*/
+
+class  A {
+
+    constructor(){
+    }
+
+}
+```
+
+Examples of **incorrect** code for this rule with the `{ "classes": "never" }` option:
+
+```js
+/*eslint padded-blocks: ["error", { "classes": "never" }]*/
+
+class  A {
+
+    constructor(){
+    }
+
+}
+```
+
+Examples of **correct** code for this rule with the `{ "classes": "never" }` option:
+
+```js
+/*eslint padded-blocks: ["error", { "classes": "never" }]*/
+
+class  A {
+    constructor(){
+    }
+}
 ```
 
 ### switches
@@ -234,56 +350,6 @@ if (a) {
 
     b();
 
-}
-```
-
-### classes
-
-Examples of **incorrect** code for this rule with the `{ "classes": "always" }` option:
-
-```js
-/*eslint padded-blocks: ["error", { "classes": "always" }]*/
-
-class  A {
-    constructor(){
-    }
-}
-```
-
-Examples of **correct** code for this rule with the `{ "classes": "always" }` option:
-
-```js
-/*eslint padded-blocks: ["error", { "classes": "always" }]*/
-
-class  A {
-
-    constructor(){
-    }
-
-}
-```
-
-Examples of **incorrect** code for this rule with the `{ "classes": "never" }` option:
-
-```js
-/*eslint padded-blocks: ["error", { "classes": "never" }]*/
-
-class  A {
-
-    constructor(){
-    }
-
-}
-```
-
-Examples of **correct** code for this rule with the `{ "classes": "never" }` option:
-
-```js
-/*eslint padded-blocks: ["error", { "classes": "never" }]*/
-
-class  A {
-    constructor(){
-    }
 }
 ```
 

--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -1,4 +1,4 @@
-# Quoting Style for Property Names (quote-props)
+# require quotes around object literal property names (quote-props)
 
 Object literal property names can be defined in two ways: using literals or using strings. For example, these two objects are equivalent:
 
@@ -32,51 +32,29 @@ This may look alright at first sight, but this code in fact throws a syntax erro
 
 ## Rule Details
 
-This rule aims to enforce use of quotes in property names and as such will flag any properties that don't use quotes (default behavior).
+This rule requires quotes around object literal property names.
 
 ## Options
 
-There are four behaviors for this rule: `"always"` (default), `"as-needed"`, `"consistent"` and `"consistent-as-needed"`. You can define these options in your configuration as:
+This rule has two options, a string option and an object option.
 
-```json
-{
-    "quote-props": ["error", "as-needed"]
-}
-```
+String option:
 
-### "always"
+* `"always"` (default) requires quotes around all object literal property names
+* `"as-needed"` disallows quotes around object literal property names that are not strictly required
+* `"consistent"` enforces a consistent quote style requires quotes around object literal property names
+* `"consistent-as-needed"` requires quotes around all object literal property names if any name strictly requires quotes, otherwise disallows quotes around object property names
 
-When configured with `"always"` as the first option (the default), quoting for all properties will be enforced. Some believe that ensuring property names in object literals are always wrapped in quotes is generally a good idea, since [depending on the property name you may need to quote them anyway](https://mathiasbynens.be/notes/javascript-properties). Consider this example:
+Object option:
 
-```js
-var object = {
-    foo: "bar",
-    baz: 42,
-    "qux-lorem": true
-};
-```
+* `"keywords": true` requires quotes around language keywords used as object property names (only applies when using `as-needed` or `consistent-as-needed`)
+* `"unnecessary": true` (default) disallows quotes around object literal property names that are not strictly required (only applies when using `as-needed`)
+* `"unnecessary": false` allows quotes around object literal property names that are not strictly required (only applies when using `as-needed`)
+* `"numbers": true` requires quotes around numbers used as object property names (only applies when using `as-needed`)
 
-Here, the properties `foo` and `baz` are not wrapped in quotes, but `qux-lorem` is, because it doesn’t work without the quotes. This is rather inconsistent. Instead, you may prefer to quote names of all properties:
+### always
 
-```js
-var object = {
-    "foo": "bar",
-    "baz": 42,
-    "qux-lorem": true
-};
-```
-
-or, if you prefer single quotes:
-
-```js
-var object = {
-    'foo': 'bar',
-    'baz': 42,
-    'qux-lorem': true
-};
-```
-
-When configured with `"always"` as the first option (the default), quoting for all properties will be enforced. The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint quote-props: ["error", "always"]*/
@@ -88,7 +66,7 @@ var object = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint quote-props: ["error", "always"]*/
@@ -113,9 +91,9 @@ var object3 = {
 };
 ```
 
-### "as-needed"
+### as-needed
 
-When configured with `"as-needed"` as the first option, quotes will be enforced when they are strictly required, and unnecessary quotes will cause warnings. The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"as-needed"` option:
 
 ```js
 /*eslint quote-props: ["error", "as-needed"]*/
@@ -128,7 +106,7 @@ var object = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"as-needed"` option:
 
 ```js
 /*eslint quote-props: ["error", "as-needed"]*/
@@ -155,73 +133,9 @@ var object3 = {
 };
 ```
 
-When the `"as-needed"` mode is selected, an additional `keywords` option can be provided. This flag indicates whether language keywords should be quoted as properties. By default it is set to `false`.
+### consistent
 
-```json
-{
-    "quote-props": ["error", "as-needed", { "keywords": true }]
-}
-```
-
-When `keywords` is set to `true`, the following patterns become problems:
-
-```js
-/*eslint quote-props: ["error", "as-needed", { "keywords": true }]*/
-
-var x = {
-    while: 1,
-    volatile: "foo"
-};
-```
-
-Another modifier for this rule is the `unnecessary` option which defaults to `true`. Setting this to `false` will prevent the rule from complaining about unnecessarily quoted properties. This comes in handy when you _only_ care about quoting keywords.
-
-```json
-{
-    "quote-props": ["error", "as-needed", { "keywords": true, "unnecessary": false }]
-}
-```
-
-When `unnecessary` is set to `false`, the following patterns _stop_ being problems:
-
-```js
-/*eslint quote-props: ["error", "as-needed", { "keywords": true, "unnecessary": false }]*/
-
-var x = {
-    "while": 1,
-    "foo": "bar"  // Would normally have caused a warning
-};
-```
-
-A `numbers` flag, with default value `false`, can also be used as a modifier for the `"as-needed"` mode. When it is set to `true`, numeric literals should always be quoted.
-
-```json
-{
-    "quote-props": ["error", "as-needed", {"numbers": true}]
-}
-```
-
-When `numbers` is set to `true`, the following patterns become problems:
-
-```js
-/*eslint quote-props: ["error", "as-needed", { "numbers": true }]*/
-
-var x = {
-    100: 1
-}
-```
-
-and the following patterns _stop_ being problems:
-
-```js
-var x = {
-    "100": 1
-}
-```
-
-### "consistent"
-
-When configured with `"consistent"`, the patterns below are considered problems. Basically `"consistent"` means all or no properties are expected to be quoted, in other words quoting style can't be mixed within an object. Please note the latter situation (no quotation at all) isn't always possible as some property names require quoting.
+Examples of **incorrect** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint quote-props: ["error", "consistent"]*/
@@ -238,7 +152,7 @@ var object2 = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"consistent"` option:
 
 ```js
 /*eslint quote-props: ["error", "consistent"]*/
@@ -260,9 +174,9 @@ var object3 = {
 };
 ```
 
-### "consistent-as-needed"
+### consistent-as-needed
 
-When configured with `"consistent-as-needed"`, the behavior is similar to `"consistent"` with one difference. Namely, properties' quoting should be consistent (as in `"consistent"`) but whenever all quotes are redundant a warning is raised. In other words if at least one property name has to be quoted (like `qux-lorem`) then all property names must be quoted, otherwise no properties can be quoted. The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"consistent-as-needed"` option:
 
 ```js
 /*eslint quote-props: ["error", "consistent-as-needed"]*/
@@ -279,7 +193,7 @@ var object2 = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"consistent-as-needed"` option:
 
 ```js
 /*eslint quote-props: ["error", "consistent-as-needed"]*/
@@ -296,23 +210,53 @@ var object2 = {
 };
 ```
 
-When the `"consistent-as-needed"` mode is selected, an additional `keywords` option can be provided. This flag indicates whether language keywords can be used unquoted as properties. By default it is set to `false`.
+### keywords
 
-```json
-{
-    "quote-props": ["error", "consistent-as-needed", { "keywords": true }]
-}
-```
-
-When `keywords` is set to `true`, the following patterns are considered problems:
+Examples of additional **incorrect** code for this rule with the `"as-needed", { "keywords": true }` options:
 
 ```js
-/*eslint quote-props: ["error", "consistent-as-needed", { "keywords": true }]*/
+/*eslint quote-props: ["error", "as-needed", { "keywords": true }]*/
 
 var x = {
     while: 1,
     volatile: "foo"
 };
+```
+
+Examples of additional **incorrect** code for this rule with the `"consistent-as-needed", { "keywords": true }` options:
+
+```js
+/*eslint quote-props: ["error", "consistent-as-needed", { "keywords": true }]*/
+
+var x = {
+    "prop": 1,
+    "bar": "foo"
+};
+```
+
+### unnecessary
+
+Examples of additional **correct** code for this rule with the `"as-needed", { "unnecessary": false }` options:
+
+```js
+/*eslint quote-props: ["error", "as-needed", { "keywords": true, "unnecessary": false }]*/
+
+var x = {
+    "while": 1,
+    "foo": "bar"  // Would normally have caused a warning
+};
+```
+
+### numbers
+
+Examples of additional **incorrect** code for this rule with the `"as-needed", { "numbers": true }` options:
+
+```js
+/*eslint quote-props: ["error", "as-needed", { "numbers": true }]*/
+
+var x = {
+    100: 1
+}
 ```
 
 ## When Not To Use It

--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -1,4 +1,4 @@
-# Enforce Quote Style (quotes)
+# enforce the consistent use of either backticks, double, or single quotes (quotes)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -18,26 +18,28 @@ Many codebases require strings to be defined in a consistent manner.
 
 ## Rule Details
 
-This rule is aimed at ensuring consistency of string quotes and as such will report a problem when an inconsistent style is found.
+This rule enforces the consistent use of either backticks, double, or single quotes.
 
-The rule configuration takes up to two options:
+## Options
 
-1. The first option is `"double"`, `"single"` or `"backtick"` for double-quotes, single-quotes or backticks respectively. The default is `"double"`.
-1. The second option takes two options:
-    1. `"avoidEscape"`: When using `"avoidEscape"`, this rule will not report a problem when a string is using single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise. For example, if you specify `"double"` and `"avoidEscape"`, the string `'He said, "hi!"'` is not considered a problem because using double quotes for that string would require escaping the double quotes inside of the string. This option is off by default.
-    1. `"allowTemplateLiterals"`: when using `"allowTemplateLiterals"`, this rule will not report a problem when a string is using backticks and option one is either `"double"` or `"single"`.
+This rule has two options, a string option and an object option.
 
-When using `"single"` or `"double"`, template literals that don't contain a substitution, don't contain a line break and aren't tagged templates, are flagged as problems, even with the `"avoidEscape"` option. However they are not problems when `"allowTemplateLiterals"` is used.
+String option:
 
-Configuration looks like this:
+* `"double"` (default) requires the use of double quotes wherever possible
+* `"single"` requires the use of single quotes wherever possible
+* `"backtick"` requires the use of backticks wherever possible
 
-```js
-[2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}]
-```
+Object option:
 
-**Deprecation notice**: The `avoid-escape` option is a deprecated syntax and you should use the object form instead.
+* `"avoidEscape": true` allows strings to use single-quotes or double-quotes so long as the string contains a quote that would have to be escaped otherwise
+* `"allowTemplateLiterals": true` allows strings to use backticks
 
-The following patterns are considered problems:
+**Deprecated**: The object property `avoid-escape` is deprecated; please use the object property `avoidEscape` instead.
+
+### double
+
+Examples of **incorrect** code for this rule with the default `"double"` option:
 
 ```js
 /*eslint quotes: ["error", "double"]*/
@@ -46,43 +48,7 @@ var single = 'single';
 var unescaped = 'a string containing "double" quotes';
 ```
 
-```js
-/*eslint quotes: ["error", "single"]*/
-
-var double = "double";
-var unescaped = "a string containing 'single' quotes";
-```
-
-```js
-/*eslint quotes: ["error", "double", {"avoidEscape": true}]*/
-
-var single = 'single';
-var single = `single`;
-```
-
-```js
-/*eslint quotes: ["error", "single", {"avoidEscape": true}]*/
-
-var double = "double";
-var double = `double`;
-```
-
-```js
-/*eslint quotes: ["error", "backtick"]*/
-
-var single = 'single';
-var double = "double";
-var unescaped = 'a string containing `backticks`';
-```
-
-```js
-/*eslint quotes: ["error", "backtick", {"avoidEscape": true}]*/
-
-var single = 'single';
-var double = "double";
-```
-
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"double"` option:
 
 ```js
 /*eslint quotes: ["error", "double"]*/
@@ -93,6 +59,19 @@ var backtick = `back\ntick`;  // backticks are allowed due to newline
 var backtick = tag`backtick`; // backticks are allowed due to tag
 ```
 
+### single
+
+Examples of **incorrect** code for this rule with the `"single"` option:
+
+```js
+/*eslint quotes: ["error", "single"]*/
+
+var double = "double";
+var unescaped = "a string containing 'single' quotes";
+```
+
+Examples of **correct** code for this rule with the `"single"` option:
+
 ```js
 /*eslint quotes: ["error", "single"]*/
 /*eslint-env es6*/
@@ -101,31 +80,19 @@ var single = 'single';
 var backtick = `back${x}tick`; // backticks are allowed due to substitution
 ```
 
-```js
-/*eslint quotes: ["error", "double", {"avoidEscape": true}]*/
+### backticks
 
-var single = 'a string containing "double" quotes';
-```
+Examples of **incorrect** code for this rule with the `"backtick"` option:
 
 ```js
-/*eslint quotes: ["error", "single", {"avoidEscape": true}]*/
-
-var double = "a string containing 'single' quotes";
-```
-
-```js
-/*eslint quotes: ["error", "double", {"allowTemplateLiterals": true}]*/
+/*eslint quotes: ["error", "backtick"]*/
 
 var single = 'single';
-var single = `single`;
-```
-
-```js
-/*eslint quotes: ["error", "single", {"allowTemplateLiterals": true}]*/
-
 var double = "double";
-var double = `double`;
+var unescaped = 'a string containing `backticks`';
 ```
+
+Examples of **correct** code for this rule with the `"backtick"` option:
 
 ```js
 /*eslint quotes: ["error", "backtick"]*/
@@ -134,10 +101,50 @@ var double = `double`;
 var backtick = `backtick`;
 ```
 
+### avoidEscape
+
+Examples of additional **correct** code for this rule with the `"double", { "avoidEscape": true }` options:
+
 ```js
-/*eslint quotes: ["error", "backtick", {"avoidEscape": true}]*/
+/*eslint quotes: ["error", "double", { "avoidEscape": true }]*/
+
+var single = 'a string containing "double" quotes';
+```
+
+Examples of additional **correct** code for this rule with the `"single", { "avoidEscape": true }` options:
+
+```js
+/*eslint quotes: ["error", "single", { "avoidEscape": true }]*/
+
+var double = "a string containing 'single' quotes";
+```
+
+Examples of additional **correct** code for this rule with the `"backtick", { "avoidEscape": true }` options:
+
+```js
+/*eslint quotes: ["error", "backtick", { "avoidEscape": true }]*/
 
 var double = "a string containing `backtick` quotes"
+```
+
+### allowTemplateLiterals
+
+Examples of additional **correct** code for this rule with the `"double", { "allowTemplateLiterals": true }` options:
+
+```js
+/*eslint quotes: ["error", "double", { "allowTemplateLiterals": true }]*/
+
+var single = 'single';
+var single = `single`;
+```
+
+Examples of additional **correct** code for this rule with the `"single", { "allowTemplateLiterals": true }` options:
+
+```js
+/*eslint quotes: ["error", "single", { "allowTemplateLiterals": true }]*/
+
+var double = "double";
+var double = `double`;
 ```
 
 ## When Not To Use It

--- a/docs/rules/require-jsdoc.md
+++ b/docs/rules/require-jsdoc.md
@@ -1,4 +1,4 @@
-# Require JSDoc comment (require-jsdoc)
+# require JSDoc comments (require-jsdoc)
 
 [JSDoc](http://usejsdoc.org) is a JavaScript API documentation generator. It uses specially-formatted comments inside of code to generate API documentation automatically. For example, this is what a JSDoc comment looks like for a function:
 
@@ -18,21 +18,19 @@ Some style guides require JSDoc comments for all functions as a way of explainin
 
 ## Rule Details
 
-This rule generates warnings for nodes that do not have JSDoc comments when they should. Supported nodes:
+This rule requires JSDoc comments for specified nodes. Supported nodes:
 
-* `FunctionDeclaration`
-* `ClassDeclaration`
-* `MethodDefinition`
+* `"FunctionDeclaration"`
+* `"ClassDeclaration"`
+* `"MethodDefinition"`
 
 ## Options
 
-This rule accepts a `require` object with its properties as
+This rule has a single object option:
 
-* `FunctionDeclaration` (default: `true`)
-* `ClassDeclaration` (default: `false`)
-* `MethodDefinition` (default: `false`)
+* `"require"` requires JSDoc comments for the specified nodes
 
-Default option settings are
+Default option settings are:
 
 ```json
 {
@@ -46,7 +44,9 @@ Default option settings are
 }
 ```
 
-The following patterns are considered problems:
+### require
+
+Examples of **incorrect** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true } }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -66,7 +66,7 @@ class Test{
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{ "require": { "FunctionDeclaration": true, "MethodDefinition": true, "ClassDeclaration": true } }` option:
 
 ```js
 /*eslint "require-jsdoc": ["error", {
@@ -78,15 +78,15 @@ The following patterns are not considered problems:
 }]*/
 
 /**
-* It returns 10
-*/
+ * It returns 10
+ */
 function foo() {
     return 10;
 }
 
 /**
-* It returns 10
-*/
+ * It returns 10
+ */
 var foo = function() {
     return 10;
 }
@@ -97,8 +97,8 @@ array.filter(function(item) {
 });
 
 /**
-* It returns 10
-*/
+ * It returns 10
+ */
 class Test{
     /**
     * returns the date

--- a/docs/rules/semi.md
+++ b/docs/rules/semi.md
@@ -1,4 +1,4 @@
-# Enforce or Disallow Semicolons (semi)
+# require or disallow semicolons instead of ASI (semi)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -57,26 +57,27 @@ Although ASI allows for more freedom over your coding style, it can also make yo
 
 ## Rule Details
 
-This rule is aimed at ensuring consistent use of semicolons. You can decide whether or not to require semicolons at the end of statements.
+This rule enforces consistent use of semicolons.
 
 ## Options
 
-The rule takes one or two options. The first one is a string, which could be `"always"` or `"never"`. The default is `"always"`. The second one is an object for more fine-grained configuration when the first option is `"always"`.
+This rule has two options, a string option and an object option.
 
-You can set the option in configuration like this:
+String option:
 
-### "always"
+* `"always"` (default) requires semicolons at the end of statements
+* `"never"` disallows semicolons as the end of statements (except to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`)
 
-By using the default option, semicolons must be used any place where they are valid.
+Object option:
 
-```json
-semi: ["error", "always"]
-```
+* `"omitLastInOneLineBlock": true` ignores the last semicolon in a block in which its braces (and therefore the content of the block) are in the same line
 
-The following patterns are considered problems:
+### always
+
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
-/*eslint semi: "error"*/
+/*eslint semi: ["error", "always"]*/
 
 var name = "ESLint"
 
@@ -85,7 +86,7 @@ object.method = function() {
 }
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint semi: "error"*/
@@ -97,27 +98,41 @@ object.method = function() {
 };
 ```
 
-#### Fine-grained control
+### never
 
-When setting the first option as "always", an additional option can be added to omit the last semicolon in a one-line block, that is, a block in which its braces (and therefore the content of the block) are in the same line:
-
-```json
-semi: ["error", "always", { "omitLastInOneLineBlock": true}]
-```
-
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
-/*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
+/*eslint semi: ["error", "never"]*/
 
-if (foo) {
-    bar()
-}
+var name = "ESLint";
 
-if (foo) { bar(); }
+object.method = function() {
+    // ...
+};
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
+
+```js
+/*eslint semi: ["error", "never"]*/
+
+var name = "ESLint"
+
+object.method = function() {
+    // ...
+}
+
+var name = "ESLint"
+
+;(function() {
+    // ...
+})()
+```
+
+#### omitLastInOneLineBlock
+
+Examples of additional **incorrect** code for this rule with the `"always", { "omitLastInOneLineBlock": true }` options:
 
 ```js
 /*eslint semi: ["error", "always", { "omitLastInOneLineBlock": true}] */
@@ -125,50 +140,6 @@ The following patterns are not considered problems:
 if (foo) { bar() }
 
 if (foo) { bar(); baz() }
-```
-
-### "never"
-
-If you want to enforce that semicolons are never used, switch the configuration to:
-
-```json
-semi: [2, "never"]
-```
-
-Then, the following patterns are considered problems:
-
-```js
-/*eslint semi: ["error", "never"]*/
-
-var name = "ESLint";
-
-object.method = function() {
-    // ...
-};
-```
-
-And the following patterns are not considered problems:
-
-```js
-/*eslint semi: ["error", "never"]*/
-
-var name = "ESLint"
-
-object.method = function() {
-    // ...
-}
-```
-
-Even in `"never"` mode, semicolons are still allowed to disambiguate statements beginning with `[`, `(`, `/`, `+`, or `-`:
-
-```js
-/*eslint semi: ["error", "never"]*/
-
-var name = "ESLint"
-
-;(function() {
-    // ...
-})()
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
**What issue does this pull request address?**

Documentation update.

**What changes did you make? (Give an overview)**

Documentation update.

**Is there anything you'd like reviewers to focus on?**

* `one-var`
    * Combined the object properties for each object option. Willing to reconsider if desired.
    * Added language for using one of three different options
* `quote-props`
    * Do we have special language for object options that only apply based on choices of previous options? My only concern with this rule, I believe.

@pedrottimark Got another batch for ya.