### PR TITLE
Update: make `max-lines` report the actual number of lines (fixes #6766)

### DIFF
--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -139,7 +139,11 @@ module.exports = {
                 if (lines.length > max) {
                     context.report({
                         loc: { line: 1, column: 0 },
-                        message: "File must be at most " + max + " lines long."
+                        message: "File must be at most {{max}} lines long. It's {{actual}} lines long.",
+                        data: {
+                            max,
+                            actual: lines.length,
+                        }
                     });
                 }
             }

--- a/tests/lib/rules/max-lines.js
+++ b/tests/lib/rules/max-lines.js
@@ -21,11 +21,13 @@ const ruleTester = new RuleTester();
 
 /**
  * Returns the error message with the specified max number of lines
- * @param {number} lines Maximum number of lines
+ * @param {number} limitLines Maximum number of lines
+ * @param {number} actualLines Actual number of lines
  * @returns {string} error message
  */
-function errorMessage(lines) {
-    return "File must be at most " + lines + " lines long.";
+function errorMessage(limitLines, actualLines) {
+    return "File must be at most " + limitLines + " lines long. It's "
+        + actualLines + " lines long.";
 }
 
 ruleTester.run("max-lines", rule, {
@@ -88,17 +90,17 @@ ruleTester.run("max-lines", rule, {
         {
             code: "var xyz;\nvar xyz;\nvar xyz;",
             options: [2],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 3)}]
         },
         {
             code: "/* a multiline comment\n that goes to many lines*/\nvar xy;\nvar xy;",
             options: [2],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 4)}]
         },
         {
             code: "//a single line comment\nvar xy;\nvar xy;",
             options: [2],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 3)}]
         },
         {
             code: [
@@ -109,7 +111,7 @@ ruleTester.run("max-lines", rule, {
                 "var y;"
             ].join("\n"),
             options: [{max: 2} ],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 5)}]
         },
         {
             code: [
@@ -123,7 +125,7 @@ ruleTester.run("max-lines", rule, {
                 " long comment*/"
             ].join("\n"),
             options: [{max: 2, skipComments: true } ],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 4)}]
         },
         {
             code: [
@@ -132,7 +134,7 @@ ruleTester.run("max-lines", rule, {
                 "var z;"
             ].join("\n"),
             options: [{max: 2, skipComments: true} ],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 3)}]
         },
         {
             code: [
@@ -142,7 +144,7 @@ ruleTester.run("max-lines", rule, {
                 "var z;"
             ].join("\n"),
             options: [{max: 2, skipComments: true} ],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 3)}]
         },
         {
             code: [
@@ -156,7 +158,7 @@ ruleTester.run("max-lines", rule, {
                 " long comment*/"
             ].join("\n"),
             options: [{max: 2, skipBlankLines: true } ],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 6)}]
         },
         {
             code: [
@@ -170,7 +172,7 @@ ruleTester.run("max-lines", rule, {
                 " long comment*/"
             ].join("\n"),
             options: [{max: 2, skipComments: true } ],
-            errors: [{message: errorMessage(2)}]
+            errors: [{message: errorMessage(2, 4)}]
         }
     ]
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
It makes `max-lines` report the actual number of lines along with the limit.


**What changes did you make? (Give an overview)**
I altered the report message and updated `max-lines` test suite.


**Is there anything you'd like reviewers to focus on?**
Report output. May it be better?

Instead of reporting only that `max` value has been exceeded
it now also reports how many lines there is in the file.