### PR TITLE
Fix inconsistent spacing inside block comment

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -113,7 +113,7 @@ Environments can be specified inside of a file, in configuration files or using 
 To specify environments using a comment inside of your JavaScript file, use the following format:
 
 ```js
-/*eslint-env node, mocha */
+/* eslint-env node, mocha */
 ```
 
 This enables Node.js and Mocha environments.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
Doc-only pull request, no accepted issue

**What changes did you make? (Give an overview)**
Other block comments in this file follow the pattern of a space after the opening `/*` and before the closing `*/`; this one was spaced inconsistently so I modified it to match the spacing shown on the others.


**Is there anything you'd like reviewers to focus on?**
Nope, should be a quick one.
