### PR TITLE
Fix: Improves perf of globbing by inheriting glob.GlobSync (fixes #6710)

### DIFF
--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -10,7 +10,7 @@
 
 const fs = require("fs"),
     path = require("path"),
-    glob = require("glob"),
+    GlobSync = require("./glob"),
     shell = require("shelljs"),
 
     pathUtil = require("./path-util"),
@@ -113,9 +113,9 @@ function listFilesToProcess(globPatterns, options) {
     const ignoredPaths = new IgnoredPaths(options);
     const globOptions = {
         nodir: true,
-        cwd,
-        ignore: ignoredPaths.getIgnoredFoldersGlobPatterns()
+        cwd
     };
+    const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
 
     /**
      * Executes the linter on a file defined by the `filename`. Skips
@@ -162,7 +162,7 @@ function listFilesToProcess(globPatterns, options) {
         if (shell.test("-f", file)) {
             addFile(fs.realpathSync(file), !shell.test("-d", file));
         } else {
-            glob.sync(pattern, globOptions).forEach(function(globMatch) {
+            new GlobSync(pattern, globOptions, shouldIgnore).found.forEach(function(globMatch) {
                 addFile(path.resolve(cwd, globMatch), false);
             });
         }

--- a/lib/util/glob.js
+++ b/lib/util/glob.js
@@ -1,0 +1,63 @@
+/**
+ * @fileoverview An inherited `glob.GlobSync` to support .gitignore patterns.
+ * @author Kael Zhang
+ */
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const Sync = require("glob").GlobSync,
+    util = require("util");
+
+//------------------------------------------------------------------------------
+// Private
+//------------------------------------------------------------------------------
+
+const IGNORE = typeof Symbol === "function" ? Symbol("ignore") : "_shouldIgnore";
+
+/**
+ * Subclass of `glob.GlobSync`
+ * @param {string}     pattern      Pattern to be matched.
+ * @param {Object}     options      `options` for `glob`
+ * @param {function()} shouldIgnore Method to check whether a directory should be ignored.
+ * @constructor
+ */
+function GlobSync(pattern, options, shouldIgnore) {
+
+    /**
+     * We don't put this thing to argument `options` to avoid
+     * further problems, such as `options` validation.
+     *
+     * Use `Symbol` as much as possible to avoid confliction.
+     */
+    this[IGNORE] = shouldIgnore;
+
+    Sync.call(this, pattern, options);
+}
+
+util.inherits(GlobSync, Sync);
+
+/* eslint no-underscore-dangle: ["error", { "allow": ["_readdir", "_mark"] }] */
+
+GlobSync.prototype._readdir = function(abs, inGlobStar) {
+
+    /**
+     * `options.nodir` makes `options.mark` as `true`.
+     * Mark `abs` first
+     * to make sure `"node_modules"` will be ignored immediately with ignore pattern `"node_modules/"`.
+
+     * There is a built-in cache about marked `File.Stat` in `glob`, so that we could not worry about the extra invocation of `this._mark()`
+     */
+    const marked = this._mark(abs);
+
+    if (this[IGNORE](marked)) {
+        return null;
+    }
+
+    return Sync.prototype._readdir.call(this, abs, inGlobStar);
+};
+
+
+module.exports = GlobSync;

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "file-entry-cache": "^1.3.1",
     "glob": "^7.0.3",
     "globals": "^9.2.0",
-    "ignore": "^3.1.2",
+    "ignore": "^3.1.5",
     "imurmurhash": "^0.1.4",
     "inquirer": "^0.12.0",
     "is-my-json-valid": "^2.10.0",

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -529,50 +529,93 @@ describe("IgnoredPaths", function() {
 
     });
 
-    describe("getIgnoredFoldersGlobPatterns", function() {
-        it("should return default ignores glob dir patterns when there is no eslintignore file", function() {
-            const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath("no-ignore-file") });
+    describe("getIgnoredFoldersGlobChecker", function() {
 
-            const expected = ["node_modules/**", "bower_components/**"];
-            const actual = ignoredPaths.getIgnoredFoldersGlobPatterns();
+        /**
+         * Creates a function to resolve the given relative path according to the `cwd`
+         * @param {path} cwd The cwd of `ignorePaths`
+         * @returns {function()} the function described above.
+         */
+        function createResolve(cwd) {
+            return function(relative) {
+                return path.join(cwd, relative);
+            };
+        }
 
-            assert.sameMembers(actual, expected);
+        it("should ignore default folders when there is no eslintignore file", function() {
+            const cwd = getFixturePath("no-ignore-file");
+            const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: cwd });
+
+            const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
+            const resolve = createResolve(cwd);
+
+            assert.isTrue(shouldIgnore(resolve("node_modules/a")));
+            assert.isTrue(shouldIgnore(resolve("node_modules/a/b")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
+            assert.isFalse(shouldIgnore(resolve(".hidden")));
         });
 
-        it("should return default glob dir patterns when there is an ignore file without unignored defaults", function() {
-            const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignore"), cwd: getFixturePath() });
+        it("should ignore default folders there is an ignore file without unignored defaults", function() {
+            const cwd = getFixturePath();
+            const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignore"), cwd: cwd });
 
-            const expected = ["node_modules/**", "bower_components/**"];
-            const actual = ignoredPaths.getIgnoredFoldersGlobPatterns();
+            const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
+            const resolve = createResolve(cwd);
 
-            assert.sameMembers(actual, expected);
+            assert.isTrue(shouldIgnore(resolve("node_modules/a")));
+            assert.isTrue(shouldIgnore(resolve("node_modules/a/b")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
+            assert.isFalse(shouldIgnore(resolve(".hidden")));
         });
 
-        it("should not return dirs with unignored defaults in ignore file", function() {
-            const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults"), cwd: getFixturePath() });
+        it("should not ignore things which are re-included in ignore file", function() {
+            const cwd = getFixturePath();
+            const ignoredPaths = new IgnoredPaths({ ignore: true, ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults"), cwd: cwd });
 
-            const actual = ignoredPaths.getIgnoredFoldersGlobPatterns();
+            const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
+            const resolve = createResolve(cwd);
 
-            assert.notInclude(actual, "node_modules/**");
-            assert.notInclude(actual, "bower_components/**");
+            assert.isTrue(shouldIgnore(resolve("node_modules/a")));
+            assert.isTrue(shouldIgnore(resolve("node_modules/a/b")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
+            assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isFalse(shouldIgnore(resolve("node_modules/package")));
+            assert.isFalse(shouldIgnore(resolve("bower_components/package")));
         });
 
-        it("should return dirs with unignored defaults in ignore file when ignore option is disabled", function() {
-            const ignoredPaths = new IgnoredPaths({ ignore: false, ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults"), cwd: getFixturePath() });
+        it("should ignore files which we try to re-include in ignore file when ignore option is disabled", function() {
+            const cwd = getFixturePath();
+            const ignoredPaths = new IgnoredPaths({ ignore: false, ignorePath: getFixturePath(".eslintignoreWithUnignoredDefaults"), cwd: cwd });
 
-            const expected = ["node_modules/**", "bower_components/**"];
-            const actual = ignoredPaths.getIgnoredFoldersGlobPatterns();
+            const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
+            const resolve = createResolve(cwd);
 
-            assert.includeMembers(actual, expected);
+            assert.isTrue(shouldIgnore(resolve("node_modules/a")));
+            assert.isTrue(shouldIgnore(resolve("node_modules/a/b")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
+            assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isTrue(shouldIgnore(resolve("node_modules/package")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/package")));
         });
 
-        it("should not return dirs unignored by ignorePattern", function() {
-            const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath("no-ignore-file"), ignorePattern: "!/node_modules/package" });
+        it("should not ignore dirs which are re-included by ignorePattern", function() {
+            const cwd = getFixturePath("no-ignore-file");
+            const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: cwd, ignorePattern: "!/node_modules/package" });
 
-            const actual = ignoredPaths.getIgnoredFoldersGlobPatterns();
+            const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();
+            const resolve = createResolve(cwd);
 
-            assert.notInclude(actual, "node_modules/**");
-            assert.include(actual, "bower_components/**");
+            assert.isTrue(shouldIgnore(resolve("node_modules/a")));
+            assert.isTrue(shouldIgnore(resolve("node_modules/a/b")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/a/b")));
+            assert.isFalse(shouldIgnore(resolve(".hidden")));
+            assert.isFalse(shouldIgnore(resolve("node_modules/package")));
+            assert.isTrue(shouldIgnore(resolve("bower_components/package")));
         });
     });
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
As #6710 discussed, I create a subclass of `glob.GlobSync` to skip certain glob process according to .gitignore rules.

**What changes did you make? (Give an overview)**
- inherits `glob.GlobSync` and overrides `_readdir`, special thanks to the good idea of @mysticatea. But there are several detail things we should aware of, see the inline comments of the commit.
- change `ignoredPaths.getIgnoredFoldersGlobPatterns()` -> `ignoredPaths.getIgnoredFoldersGlobChecker()`, and now it will return a function.

**Is there anything you'd like reviewers to focus on?**
Do I need to create a specific test cases file for `lib/glob.js`? Or just testing it with `glob-util.js` is ok? I did create a test file, because I thought there was much duplication with `tests/lib/glob-util.js`

If it is necessary, I will add one.