### PR TITLE
Build: Fix site generation (fixes #6791)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -663,11 +663,14 @@ target.gensite = function(prereleaseVersion) {
                 }
                 text += "* [Documentation source](" + docsUrl + baseName + ")\n";
             }
+
+            // 9. Update content of the file with changes
+            text.to(filename.replace("README.md", "index.md"));
         }
     });
     JSON.stringify(versions).to("./versions.json");
 
-    // 10. Copy temorary directory to site's docs folder
+    // 10. Copy temporary directory to site's docs folder
     let outputDir = DOCS_DIR;
 
     if (prereleaseVersion) {


### PR DESCRIPTION
**What issue does this pull request address?**

#6791

**What changes did you make? (Give an overview)**

https://github.com/eslint/eslint/pull/6658 mistakenly removed a line that output the frontmatter into the Jekyll pages which resulted in 404s on eslint.org. This PR simply adds that line back in.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.