### PR TITLE
Fix: ignore MemberExpression in VariableDeclarators (fixes #6795)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -73,7 +73,7 @@ This rule has an object option:
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
 * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
-* `"MemberExpression"` (default: 1) enforces indentation level for multi-line property chains
+* `"MemberExpression"` (default: 1) enforces indentation level for multi-line property chains (except in variable declarations and assignments)
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -274,6 +274,10 @@ Examples of **correct** code for this rule with the `2, { "MemberExpression": 1 
 foo
   .bar
   .baz();
+
+// Any indentation is permitted in variable declarations and assignments.
+var bip = aardvark.badger
+                  .coyote;
 ```
 
 ## Compatibility

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -332,19 +332,40 @@ module.exports = {
         }
 
         /**
+         * Returns a parent node of given node based on a specified type
+         * if not present then return null
+         * @param {ASTNode} node node to examine
+         * @param {string} type type that is being looked for
+         * @returns {ASTNode|void} if found then node otherwise null
+         */
+        function getParentNodeByType(node, type) {
+            let parent = node.parent;
+
+            while (parent.type !== type && parent.type !== "Program") {
+                parent = parent.parent;
+            }
+
+            return parent.type === type ? parent : null;
+        }
+
+        /**
          * Returns the VariableDeclarator based on the current node
          * if not present then return null
          * @param {ASTNode} node node to examine
          * @returns {ASTNode|void} if found then node otherwise null
          */
         function getVariableDeclaratorNode(node) {
-            let parent = node.parent;
+            return getParentNodeByType(node, "VariableDeclarator");
+        }
 
-            while (parent.type !== "VariableDeclarator" && parent.type !== "Program") {
-                parent = parent.parent;
-            }
-
-            return parent.type === "VariableDeclarator" ? parent : null;
+        /**
+         * Returns the ExpressionStatement based on the current node
+         * if not present then return null
+         * @param {ASTNode} node node to examine
+         * @returns {ASTNode|void} if found then node otherwise null
+         */
+        function getAssignmentExpressionNode(node) {
+            return getParentNodeByType(node, "AssignmentExpression");
         }
 
         /**
@@ -810,6 +831,18 @@ module.exports = {
 
             MemberExpression: function(node) {
                 if (isSingleLineNode(node)) {
+                    return;
+                }
+
+                // The typical layout of variable declarations and assignments
+                // alter the expectation of correct indentation. Skip them.
+                // TODO: Add appropriate configuration options for variable
+                // declarations and assignments.
+                if (getVariableDeclaratorNode(node)) {
+                    return;
+                }
+
+                if (getAssignmentExpressionNode(node)) {
                     return;
                 }
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1376,6 +1376,18 @@ ruleTester.run("indent", rule, {
             "    .foo\n" +
             "    .bar",
             options: [2, {MemberExpression: 2}]
+        },
+        {
+            code:
+            "var foo = bar.baz()\n" +
+            "            .bip();",
+            options: [4, {MemberExpression: 1}]
+        },
+        {
+            code:
+            "foo = bar.baz()\n" +
+            "        .bip();",
+            options: [4, {MemberExpression: 1}]
         }
     ],
     invalid: [


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6795 

**What changes did you make? (Give an overview)**

The `MemberExpression` checking in the `indent` rule (which checks indentation on chained properties that span multiple lines) will provide surprising results in variable declarations.

A user *might* expect:

```javascript
var foo = bar.baz()
            .bip();
```

But the current rule expects this:

```javascript
var foo = bar.baz()
  .bip();
```

This change causes the rule to ignore `MemberExpression` if it is inside a `VariableDeclarator`. I propose this as a quick fix. Subsequently, it may be worthwhile to allow more granular configuration to control this situation. (For example, it may be good to allow the user to choose from disabling the checks entirely, enforcing the rule as it currently is, enforcing the indentation from the parent object, or enforcing alignment of the `Punctuator`.)

**Is there anything you'd like reviewers to focus on?**

Chained properties on objects will typically not be indented as the rule
expects in variable declarations. For now, ignore variable declarations
(as was done in the previous version of ESLint, where all chained
properties were ignored) and possibly revisit later to offer users
opportunity to enforce alignment and/or sensible indentation.