### PR TITLE
Fix: Make MemberExpression option opt-in (fixes #6797)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -73,7 +73,7 @@ This rule has an object option:
 * `"SwitchCase"` (default: 0) enforces indentation level for `case` clauses in `switch` statements
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
 * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
-* `"MemberExpression"` (default: 1) enforces indentation level for multi-line property chains
+* `"MemberExpression"` (off by default) enforces indentation level for multi-line property chains
 
 Level of indentation denotes the multiple of the indent specified. Example:
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -96,8 +96,7 @@ module.exports = {
                 let: DEFAULT_VARIABLE_INDENT,
                 const: DEFAULT_VARIABLE_INDENT
             },
-            outerIIFEBody: null,
-            MemberExpression: 1
+            outerIIFEBody: null
         };
 
         let sourceCode = context.getSourceCode();
@@ -809,6 +808,10 @@ module.exports = {
             },
 
             MemberExpression: function(node) {
+                if (typeof options.MemberExpression === "undefined") {
+                    return;
+                }
+
                 if (isSingleLineNode(node)) {
                     return;
                 }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1344,31 +1344,35 @@ ruleTester.run("indent", rule, {
         },
         {
             code:
-            "Buffer.length"
+            "Buffer.length",
+            options: [4, { MemberExpression: 1 }]
         },
         {
             code:
             "Buffer\n" +
             "    .indexOf('a')\n" +
-            "    .toString()"
+            "    .toString()",
+            options: [4, { MemberExpression: 1 }]
         },
         {
             code:
             "Buffer.\n" +
-            "    length"
+            "    length",
+            options: [4, { MemberExpression: 1 }]
         },
         {
             code:
             "Buffer\n" +
             "    .foo\n" +
-            "    .bar"
+            "    .bar",
+            options: [4, { MemberExpression: 1 }]
         },
         {
             code:
             "Buffer\n" +
             "\t.foo\n" +
             "\t.bar",
-            options: ["tab"]
+            options: ["tab", { MemberExpression: 1 }]
         },
         {
             code:
@@ -1376,6 +1380,15 @@ ruleTester.run("indent", rule, {
             "    .foo\n" +
             "    .bar",
             options: [2, {MemberExpression: 2}]
+        },
+        {
+            code:
+            "MemberExpression\n" +
+            ".is" +
+            "  .off" +
+            "    .by" +
+            " .default();",
+            options: [4]
         }
     ],
     invalid: [
@@ -1428,7 +1441,7 @@ ruleTester.run("indent", rule, {
         {
             code: fixture,
             output: fixedFixture,
-            options: [2, {SwitchCase: 1}],
+            options: [2, {SwitchCase: 1, MemberExpression: 1}],
             errors: expectedErrors([
                 [5, 2, 4, "VariableDeclaration"],
                 [10, 4, 6, "BlockStatement"],
@@ -2370,6 +2383,7 @@ ruleTester.run("indent", rule, {
             output:
             "Buffer\n" +
             "    .toString()",
+            options: [4, { MemberExpression: 1 }],
             errors: expectedErrors([[2, 4, 0, "Punctuator"]])
         },
         {
@@ -2381,6 +2395,7 @@ ruleTester.run("indent", rule, {
             "Buffer\n" +
             "    .indexOf('a')\n" +
             "    .toString()",
+            options: [4, { MemberExpression: 1 }],
             errors: expectedErrors([[3, 4, 0, "Punctuator"]])
         },
         {
@@ -2390,6 +2405,7 @@ ruleTester.run("indent", rule, {
             output:
             "Buffer.\n" +
             "    length",
+            options: [4, { MemberExpression: 1 }],
             errors: expectedErrors([[2, 4, 0, "Identifier"]])
         },
         {
@@ -2399,7 +2415,7 @@ ruleTester.run("indent", rule, {
             output:
             "Buffer.\n" +
             "\tlength",
-            options: ["tab"],
+            options: ["tab", { MemberExpression: 1 }],
             errors: expectedErrors("tab", [[2, 1, 2, "Identifier"]])
         },
         {
@@ -2411,7 +2427,7 @@ ruleTester.run("indent", rule, {
             "Buffer\n" +
             "    .foo\n" +
             "    .bar",
-            options: [2, {MemberExpression: 2}],
+            options: [2, { MemberExpression: 2 }],
             errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 2, "Punctuator"]])
         }
     ]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

https://github.com/eslint/eslint/issues/6797

**What changes did you make? (Give an overview)**

Turn `MemberExpression` option of the `indent` rule to be off by default.

**Is there anything you'd like reviewers to focus on?**

The `MemberExpression` option should be opt-in as it is a breaking
change.