### PR TITLE
Docs: Update JSCS status in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,7 +184,10 @@ Yes. Since we are solving the same problems, ESLint and JSCS teams have decided 
 
 ### So, should I stop using JSCS and start using ESLint?
 
-Not yet. We are still working to smooth the transition. You can see our progress [here](https://github.com/eslint/eslint/milestones/JSCS%20Compatibility). We’ll announce when all of the changes necessary to support JSCS users in ESLint are complete and will start encouraging JSCS users to switch to ESLint at that time. Meanwhile, we recommend you to upgrade to JSCS 3.0 and provide feedback to the team.
+Maybe, depending on how much you need it. [JSCS has reached end of life](http://eslint.org/blog/2016/07/jscs-end-of-life), but if it is working for you then there is no reason to move yet. We are still working to smooth the transition. You can see our progress [here](https://github.com/eslint/eslint/milestones/JSCS%20Compatibility). We’ll announce when all of the changes necessary to support JSCS users in ESLint are complete and will start encouraging JSCS users to switch to ESLint at that time.
+
+If you are having issues with JSCS, you can try to move to ESLint. We are focusing our time and energy on JSCS compatibility issues.
+
 
 ### Is ESLint just linting or does it also check style?
 


### PR DESCRIPTION
Since JSCS has reached end of life and JSCS recommends people with issues to use ESLint, we should do the same here.

