### PR TITLE
Docs: clarify minor releases and suggest using `~ to version

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ ESLint follows [semantic versioning](http://semver.org). However, due to the nat
     * An existing formatter is removed.
     * Part of the public API is removed or changed in an incompatible way.
 
+Because our policy allows a minor release to result in reporting more errors, it can be seen as a "breaking change". Thus if you don't want an update to ESLint to break your lint build, we recommend you you `~` in `package.json` e.g. `"eslint": "~3.1.0"` in order to only get patch changes.
+
 ## Frequently Asked Questions
 
 ### How is ESLint different from JSHint?

--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ ESLint follows [semantic versioning](http://semver.org). However, due to the nat
     * An existing formatter is removed.
     * Part of the public API is removed or changed in an incompatible way.
 
-Because our policy allows a minor release to result in reporting more errors, it can be seen as a "breaking change". Thus if you don't want an update to ESLint to break your lint build, we recommend you you `~` in `package.json` e.g. `"eslint": "~3.1.0"` in order to only get patch changes.
+According to our policy, any minor update may report more errors than the previous release (ex: from a bug fix). As such, we recommend using the tilde (`~`) in `package.json` e.g. `"eslint": "~3.1.0"` to guarantee the results of your builds.
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
**What issue does this pull request address?**

https://github.com/eslint/eslint/issues/6795#issuecomment-236325346

> I don't think anyone is suggesting the default be 0 or 1 just that any default was set. But according to the policy that will happen. I think we just need to signal that if you don't want a "breaking change / breaking lint build" (in terms of other projects) you should be using ~ in package.json for ESLint since it can be surprising.

> @hzoo that's a good point. Want to put together a PR for the readme with that suggestion?

**What changes did you make? (Give an overview)**

A docs change to the readme to suggest using ~ so users don't get unexpected changes.

--

Wording can be changed, maybe mention what I said about it being surprising otherwise.

aside: another thing I thought of was when doing minor updates that cause more fixes that we point that out either in the changelog, the summary, or commit message. Then users have more of an idea of what will be breaking (and in those cases we can also explain if theres an easy migration to fix (an autofix for it)