### PR TITLE
Chore: Enable object-shorthand rule (refs #6407)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -399,8 +399,8 @@ function lintMarkdown(files) {
             MD041: false  // First line in file should be a top level header
         },
         result = markdownlint.sync({
-            files: files,
-            config: config
+            files,
+            config
         }),
         resultString = result.toString(),
         returnCode = resultString ? 1 : 0;

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -204,23 +204,23 @@ module.exports = {
      * @returns {boolean} Whether or not the tokens are on the same line.
      * @public
      */
-    isTokenOnSameLine: function(left, right) {
+    isTokenOnSameLine(left, right) {
         return left.loc.end.line === right.loc.start.line;
     },
 
-    isNullOrUndefined: isNullOrUndefined,
-    isCallee: isCallee,
-    isES5Constructor: isES5Constructor,
-    getUpperFunction: getUpperFunction,
-    isArrayFromMethod: isArrayFromMethod,
-    isParenthesised: isParenthesised,
+    isNullOrUndefined,
+    isCallee,
+    isES5Constructor,
+    getUpperFunction,
+    isArrayFromMethod,
+    isParenthesised,
 
     /**
      * Checks whether or not a given node is a string literal.
      * @param {ASTNode} node - A node to check.
      * @returns {boolean} `true` if the node is a string literal.
      */
-    isStringLiteral: function(node) {
+    isStringLiteral(node) {
         return (
             (node.type === "Literal" && typeof node.value === "string") ||
             node.type === "TemplateLiteral"
@@ -241,7 +241,7 @@ module.exports = {
      * @param {ASTNode} node - A node to check.
      * @returns {boolean} `true` if the node is breakable.
      */
-    isBreakableStatement: function(node) {
+    isBreakableStatement(node) {
         return breakableTypePattern.test(node.type);
     },
 
@@ -251,7 +251,7 @@ module.exports = {
      * @param {ASTNode} node - A node to get.
      * @returns {string|null} The label or `null`.
      */
-    getLabel: function(node) {
+    getLabel(node) {
         if (node.parent.type === "LabeledStatement") {
             return node.parent.label.name;
         }
@@ -264,7 +264,7 @@ module.exports = {
      * @returns {Reference[]} An array of only references which are non initializer and writable.
      * @public
      */
-    getModifyingReferences: function(references) {
+    getModifyingReferences(references) {
         return references.filter(isModifyingReference);
     },
 
@@ -275,7 +275,7 @@ module.exports = {
      * @returns {boolean} True if the text is surrounded by the character, false if not.
      * @private
      */
-    isSurroundedBy: function(val, character) {
+    isSurroundedBy(val, character) {
         return val[0] === character && val[val.length - 1] === character;
     },
 
@@ -284,7 +284,7 @@ module.exports = {
      * @param {LineComment|BlockComment} node The node to be checked
      * @returns {boolean} `true` if the node is an ESLint directive comment
      */
-    isDirectiveComment: function(node) {
+    isDirectiveComment(node) {
         let comment = node.value.trim();
 
         return (
@@ -317,7 +317,7 @@ module.exports = {
      * @param {string} name - A variable name to find.
      * @returns {escope.Variable|null} A found variable or `null`.
      */
-    getVariableByName: function(initScope, name) {
+    getVariableByName(initScope, name) {
         let scope = initScope;
 
         while (scope) {
@@ -354,7 +354,7 @@ module.exports = {
      * @param {SourceCode} sourceCode - A SourceCode instance to get comments.
      * @returns {boolean} The function node is the default `this` binding.
      */
-    isDefaultThisBinding: function(node, sourceCode) {
+    isDefaultThisBinding(node, sourceCode) {
         if (isES5Constructor(node) || hasJSDocThisTag(node, sourceCode)) {
             return false;
         }
@@ -470,7 +470,7 @@ module.exports = {
      * @returns {int} precedence level
      * @private
      */
-    getPrecedence: function(node) {
+    getPrecedence(node) {
         switch (node.type) {
             case "SequenceExpression":
                 return 0;
@@ -568,7 +568,7 @@ module.exports = {
      * @param {ASTNode|null} node - A node to check.
      * @returns {boolean} `true` if the node is a loop node.
      */
-    isLoop: function(node) {
+    isLoop(node) {
         return Boolean(node && anyLoopPattern.test(node.type));
     },
 
@@ -583,7 +583,7 @@ module.exports = {
      * @param {ASTNode|null} node - A node to check.
      * @returns {boolean} `true` if the node is a function node.
      */
-    isFunction: function(node) {
+    isFunction(node) {
         return Boolean(node && anyFunctionPattern.test(node.type));
     }
 };

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -250,8 +250,8 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
 
         parsedBlocks.forEach(function(block) {
             unprocessedMessages.push(eslint.verify(block, config, {
-                filename: filename,
-                allowInlineConfig: allowInlineConfig
+                filename,
+                allowInlineConfig
             }));
         });
 
@@ -263,14 +263,14 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
 
         if (fix) {
             fixedResult = multipassFix(text, config, {
-                filename: filename,
-                allowInlineConfig: allowInlineConfig
+                filename,
+                allowInlineConfig
             });
             messages = fixedResult.messages;
         } else {
             messages = eslint.verify(text, config, {
-                filename: filename,
-                allowInlineConfig: allowInlineConfig
+                filename,
+                allowInlineConfig
             });
         }
     }
@@ -279,7 +279,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
 
     let result = {
         filePath: filename,
-        messages: messages,
+        messages,
         errorCount: stats.errorCount,
         warningCount: stats.warningCount
     };
@@ -338,7 +338,7 @@ function createIgnoreResult(filePath, baseDir) {
             {
                 fatal: false,
                 severity: 1,
-                message: message
+                message
             }
         ],
         errorCount: 0,
@@ -568,7 +568,7 @@ CLIEngine.prototype = {
      * @param {Object} pluginobject Plugin configuration object.
      * @returns {void}
      */
-    addPlugin: function(name, pluginobject) {
+    addPlugin(name, pluginobject) {
         Plugins.define(name, pluginobject);
     },
 
@@ -578,7 +578,7 @@ CLIEngine.prototype = {
      * @param {string[]} patterns The file patterns passed on the command line.
      * @returns {string[]} The equivalent glob patterns.
      */
-    resolveFileGlobPatterns: function(patterns) {
+    resolveFileGlobPatterns(patterns) {
         return globUtil.resolveFileGlobPatterns(patterns, this.options);
     },
 
@@ -587,7 +587,7 @@ CLIEngine.prototype = {
      * @param {string[]} patterns An array of file and directory names.
      * @returns {Object} The results for all files that were linted.
      */
-    executeOnFiles: function(patterns) {
+    executeOnFiles(patterns) {
         let results = [],
             options = this.options,
             fileCache = this._fileCache,
@@ -727,7 +727,7 @@ CLIEngine.prototype = {
         debug("Linting complete in: " + (Date.now() - startTime) + "ms");
 
         return {
-            results: results,
+            results,
             errorCount: stats.errorCount,
             warningCount: stats.warningCount
         };
@@ -740,7 +740,7 @@ CLIEngine.prototype = {
      * @param {boolean} warnIgnored Always warn when a file is ignored
      * @returns {Object} The results for the linting.
      */
-    executeOnText: function(text, filename, warnIgnored) {
+    executeOnText(text, filename, warnIgnored) {
 
         let results = [],
             stats,
@@ -764,7 +764,7 @@ CLIEngine.prototype = {
         stats = calculateStatsPerRun(results);
 
         return {
-            results: results,
+            results,
             errorCount: stats.errorCount,
             warningCount: stats.warningCount
         };
@@ -777,7 +777,7 @@ CLIEngine.prototype = {
      * @param {string} filePath The path of the file to retrieve a config object for.
      * @returns {Object} A configuration object for the file.
      */
-    getConfigForFile: function(filePath) {
+    getConfigForFile(filePath) {
         let configHelper = new Config(this.options);
 
         return configHelper.getConfig(filePath);
@@ -788,7 +788,7 @@ CLIEngine.prototype = {
      * @param {string} filePath The path of the file to check.
      * @returns {boolean} Whether or not the given path is ignored.
      */
-    isPathIgnored: function(filePath) {
+    isPathIgnored(filePath) {
         let ignoredPaths;
         let resolvedPath = path.resolve(this.options.cwd, filePath);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -124,7 +124,7 @@ let cli = {
      * @param {string} [text] The text to lint (used for TTY).
      * @returns {int} The exit code for the operation.
      */
-    execute: function(args, text) {
+    execute(args, text) {
 
         let currentOptions,
             files,

--- a/lib/code-path-analysis/code-path-analyzer.js
+++ b/lib/code-path-analysis/code-path-analyzer.js
@@ -592,7 +592,7 @@ CodePathAnalyzer.prototype = {
      * @param {ASTNode} node - A node which is entering.
      * @returns {void}
      */
-    enterNode: function(node) {
+    enterNode(node) {
         this.currentNode = node;
 
         // Updates the code path due to node's position in its parent node.
@@ -617,7 +617,7 @@ CodePathAnalyzer.prototype = {
      * @param {ASTNode} node - A node which is leaving.
      * @returns {void}
      */
-    leaveNode: function(node) {
+    leaveNode(node) {
         this.currentNode = node;
 
         // Updates the code path.
@@ -641,7 +641,7 @@ CodePathAnalyzer.prototype = {
      * @param {CodePathSegment} toSegment - A segment of next.
      * @returns {void}
      */
-    onLooped: function(fromSegment, toSegment) {
+    onLooped(fromSegment, toSegment) {
         if (fromSegment.reachable && toSegment.reachable) {
             debug.dump("onCodePathSegmentLoop " + fromSegment.id + " -> " + toSegment.id);
             this.emitter.emit(

--- a/lib/code-path-analysis/code-path-segment.js
+++ b/lib/code-path-analysis/code-path-segment.js
@@ -138,7 +138,7 @@ CodePathSegment.prototype = {
      * @param {CodePathSegment} segment - A previous segment to check.
      * @returns {boolean} `true` if the segment is coming from the end of a loop.
      */
-    isLoopedPrevSegment: function(segment) {
+    isLoopedPrevSegment(segment) {
         return this.internal.loopedPrevSegments.indexOf(segment) !== -1;
     }
 };

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -278,7 +278,7 @@ CodePathState.prototype = {
      *   "finally" block.
      * @returns {ForkContext} The created context.
      */
-    pushForkContext: function(forkLeavingPath) {
+    pushForkContext(forkLeavingPath) {
         this.forkContext = ForkContext.newEmpty(
             this.forkContext,
             forkLeavingPath
@@ -291,7 +291,7 @@ CodePathState.prototype = {
      * Pops and merges the last forking context.
      * @returns {ForkContext} The last context.
      */
-    popForkContext: function() {
+    popForkContext() {
         let lastContext = this.forkContext;
 
         this.forkContext = lastContext.upper;
@@ -304,7 +304,7 @@ CodePathState.prototype = {
      * Creates a new path.
      * @returns {void}
      */
-    forkPath: function() {
+    forkPath() {
         this.forkContext.add(this.parentForkContext.makeNext(-1, -1));
     },
 
@@ -314,7 +314,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    forkBypassPath: function() {
+    forkBypassPath() {
         this.forkContext.add(this.parentForkContext.head);
     },
 
@@ -353,11 +353,11 @@ CodePathState.prototype = {
      *   paths between `true` and `false`.
      * @returns {void}
      */
-    pushChoiceContext: function(kind, isForkingAsResult) {
+    pushChoiceContext(kind, isForkingAsResult) {
         this.choiceContext = {
             upper: this.choiceContext,
-            kind: kind,
-            isForkingAsResult: isForkingAsResult,
+            kind,
+            isForkingAsResult,
             trueForkContext: ForkContext.newEmpty(this.forkContext),
             falseForkContext: ForkContext.newEmpty(this.forkContext),
             processed: false
@@ -369,7 +369,7 @@ CodePathState.prototype = {
      *
      * @returns {ChoiceContext} The popped context.
      */
-    popChoiceContext: function() {
+    popChoiceContext() {
         let context = this.choiceContext;
 
         this.choiceContext = context.upper;
@@ -457,7 +457,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeLogicalRight: function() {
+    makeLogicalRight() {
         let context = this.choiceContext;
         let forkContext = this.forkContext;
 
@@ -501,7 +501,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeIfConsequent: function() {
+    makeIfConsequent() {
         let context = this.choiceContext;
         let forkContext = this.forkContext;
 
@@ -528,7 +528,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeIfAlternate: function() {
+    makeIfAlternate() {
         let context = this.choiceContext;
         let forkContext = this.forkContext;
 
@@ -558,10 +558,10 @@ CodePathState.prototype = {
      * @param {string|null} label - The label text.
      * @returns {void}
      */
-    pushSwitchContext: function(hasCase, label) {
+    pushSwitchContext(hasCase, label) {
         this.switchContext = {
             upper: this.switchContext,
-            hasCase: hasCase,
+            hasCase,
             defaultSegments: null,
             defaultBodySegments: null,
             foundDefault: false,
@@ -582,7 +582,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    popSwitchContext: function() {
+    popSwitchContext() {
         let context = this.switchContext;
 
         this.switchContext = context.upper;
@@ -658,7 +658,7 @@ CodePathState.prototype = {
      * @param {boolean} isDefault - `true` if the body is the default case.
      * @returns {void}
      */
-    makeSwitchCaseBody: function(isEmpty, isDefault) {
+    makeSwitchCaseBody(isEmpty, isDefault) {
         let context = this.switchContext;
 
         if (!context.hasCase) {
@@ -709,11 +709,11 @@ CodePathState.prototype = {
      *   `finally` block.
      * @returns {void}
      */
-    pushTryContext: function(hasFinalizer) {
+    pushTryContext(hasFinalizer) {
         this.tryContext = {
             upper: this.tryContext,
             position: "try",
-            hasFinalizer: hasFinalizer,
+            hasFinalizer,
 
             returnedForkContext: hasFinalizer
                 ? ForkContext.newEmpty(this.forkContext)
@@ -730,7 +730,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    popTryContext: function() {
+    popTryContext() {
         let context = this.tryContext;
 
         this.tryContext = context.upper;
@@ -784,7 +784,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeCatchBlock: function() {
+    makeCatchBlock() {
         let context = this.tryContext;
         let forkContext = this.forkContext;
         let thrown = context.thrownForkContext;
@@ -813,7 +813,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeFinallyBlock: function() {
+    makeFinallyBlock() {
         let context = this.tryContext;
         let forkContext = this.forkContext;
         let returned = context.returnedForkContext;
@@ -871,7 +871,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeFirstThrowablePathInTryBlock: function() {
+    makeFirstThrowablePathInTryBlock() {
         let forkContext = this.forkContext;
 
         if (!forkContext.reachable) {
@@ -904,7 +904,7 @@ CodePathState.prototype = {
      * @param {string|null} label - A label of the node which was triggered.
      * @returns {void}
      */
-    pushLoopContext: function(type, label) {
+    pushLoopContext(type, label) {
         let forkContext = this.forkContext;
         let breakContext = this.pushBreakContext(true, label);
 
@@ -913,8 +913,8 @@ CodePathState.prototype = {
                 this.pushChoiceContext("loop", false);
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     test: void 0,
                     continueDestSegments: null,
                     brokenForkContext: breakContext.brokenForkContext
@@ -925,8 +925,8 @@ CodePathState.prototype = {
                 this.pushChoiceContext("loop", false);
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     test: void 0,
                     entrySegments: null,
                     continueForkContext: ForkContext.newEmpty(forkContext),
@@ -938,8 +938,8 @@ CodePathState.prototype = {
                 this.pushChoiceContext("loop", false);
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     test: void 0,
                     endOfInitSegments: null,
                     testSegments: null,
@@ -955,8 +955,8 @@ CodePathState.prototype = {
             case "ForOfStatement":
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     prevSegments: null,
                     leftSegments: null,
                     endOfLeftSegments: null,
@@ -976,7 +976,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    popLoopContext: function() {
+    popLoopContext() {
         let context = this.loopContext;
 
         this.loopContext = context.upper;
@@ -1047,7 +1047,7 @@ CodePathState.prototype = {
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
-    makeWhileTest: function(test) {
+    makeWhileTest(test) {
         let context = this.loopContext;
         let forkContext = this.forkContext;
         let testSegments = forkContext.makeNext(0, -1);
@@ -1063,7 +1063,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeWhileBody: function() {
+    makeWhileBody() {
         let context = this.loopContext;
         let choiceContext = this.choiceContext;
         let forkContext = this.forkContext;
@@ -1085,7 +1085,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeDoWhileBody: function() {
+    makeDoWhileBody() {
         let context = this.loopContext;
         let forkContext = this.forkContext;
         let bodySegments = forkContext.makeNext(-1, -1);
@@ -1101,7 +1101,7 @@ CodePathState.prototype = {
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
-    makeDoWhileTest: function(test) {
+    makeDoWhileTest(test) {
         let context = this.loopContext;
         let forkContext = this.forkContext;
 
@@ -1122,7 +1122,7 @@ CodePathState.prototype = {
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
-    makeForTest: function(test) {
+    makeForTest(test) {
         let context = this.loopContext;
         let forkContext = this.forkContext;
         let endOfInitSegments = forkContext.head;
@@ -1140,7 +1140,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForUpdate: function() {
+    makeForUpdate() {
         let context = this.loopContext;
         let choiceContext = this.choiceContext;
         let forkContext = this.forkContext;
@@ -1167,7 +1167,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForBody: function() {
+    makeForBody() {
         let context = this.loopContext;
         let choiceContext = this.choiceContext;
         let forkContext = this.forkContext;
@@ -1219,7 +1219,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForInOfLeft: function() {
+    makeForInOfLeft() {
         let context = this.loopContext;
         let forkContext = this.forkContext;
         let leftSegments = forkContext.makeDisconnected(-1, -1);
@@ -1236,7 +1236,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForInOfRight: function() {
+    makeForInOfRight() {
         let context = this.loopContext;
         let forkContext = this.forkContext;
         let temp = ForkContext.newEmpty(forkContext);
@@ -1255,7 +1255,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForInOfBody: function() {
+    makeForInOfBody() {
         let context = this.loopContext;
         let forkContext = this.forkContext;
         let temp = ForkContext.newEmpty(forkContext);
@@ -1283,11 +1283,11 @@ CodePathState.prototype = {
      * @param {string|null} label - The label of this context.
      * @returns {Object} The new context.
      */
-    pushBreakContext: function(breakable, label) {
+    pushBreakContext(breakable, label) {
         this.breakContext = {
             upper: this.breakContext,
-            breakable: breakable,
-            label: label,
+            breakable,
+            label,
             brokenForkContext: ForkContext.newEmpty(this.forkContext)
         };
         return this.breakContext;
@@ -1298,7 +1298,7 @@ CodePathState.prototype = {
      *
      * @returns {Object} The removed context.
      */
-    popBreakContext: function() {
+    popBreakContext() {
         let context = this.breakContext;
         let forkContext = this.forkContext;
 
@@ -1326,7 +1326,7 @@ CodePathState.prototype = {
      * @param {string} label - A label of the break statement.
      * @returns {void}
      */
-    makeBreak: function(label) {
+    makeBreak(label) {
         let forkContext = this.forkContext;
 
         if (!forkContext.reachable) {
@@ -1352,7 +1352,7 @@ CodePathState.prototype = {
      * @param {string} label - A label of the continue statement.
      * @returns {void}
      */
-    makeContinue: function(label) {
+    makeContinue(label) {
         let forkContext = this.forkContext;
 
         if (!forkContext.reachable) {
@@ -1387,7 +1387,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeReturn: function() {
+    makeReturn() {
         let forkContext = this.forkContext;
 
         if (forkContext.reachable) {
@@ -1404,7 +1404,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeThrow: function() {
+    makeThrow() {
         let forkContext = this.forkContext;
 
         if (forkContext.reachable) {
@@ -1417,7 +1417,7 @@ CodePathState.prototype = {
      * Makes the final path.
      * @returns {void}
      */
-    makeFinal: function() {
+    makeFinal() {
         let segments = this.currentSegments;
 
         if (segments.length > 0 && segments[0].reachable) {

--- a/lib/code-path-analysis/code-path.js
+++ b/lib/code-path-analysis/code-path.js
@@ -123,7 +123,7 @@ CodePath.prototype = {
      * @param {Function} callback - A callback function.
      * @returns {void}
      */
-    traverseSegments: function(options, callback) {
+    traverseSegments(options, callback) {
         if (typeof options === "function") {
             callback = options;
             options = null;
@@ -142,14 +142,14 @@ CodePath.prototype = {
         let skippedSegment = null;
         let broken = false;
         let controller = {
-            skip: function() {
+            skip() {
                 if (stack.length <= 1) {
                     broken = true;
                 } else {
                     skippedSegment = stack[stack.length - 2][0];
                 }
             },
-            break: function() {
+            break() {
                 broken = true;
             }
         };

--- a/lib/code-path-analysis/debug-helpers.js
+++ b/lib/code-path-analysis/debug-helpers.js
@@ -143,7 +143,7 @@ module.exports = {
      * @param {Object} traceMap - Optional. A map to check whether or not segments had been done.
      * @returns {string} A DOT code of the code path.
      */
-    makeDotArrows: function(codePath, traceMap) {
+    makeDotArrows(codePath, traceMap) {
         let stack = [[codePath.initialSegment, 0]];
         let done = traceMap || Object.create(null);
         let lastId = codePath.initialSegment.id;

--- a/lib/code-path-analysis/fork-context.js
+++ b/lib/code-path-analysis/fork-context.js
@@ -150,7 +150,7 @@ ForkContext.prototype = {
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
-    makeNext: function(begin, end) {
+    makeNext(begin, end) {
         return makeSegments(this, begin, end, CodePathSegment.newNext);
     },
 
@@ -162,7 +162,7 @@ ForkContext.prototype = {
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
-    makeUnreachable: function(begin, end) {
+    makeUnreachable(begin, end) {
         return makeSegments(this, begin, end, CodePathSegment.newUnreachable);
     },
 
@@ -175,7 +175,7 @@ ForkContext.prototype = {
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
-    makeDisconnected: function(begin, end) {
+    makeDisconnected(begin, end) {
         return makeSegments(this, begin, end, CodePathSegment.newDisconnected);
     },
 
@@ -186,7 +186,7 @@ ForkContext.prototype = {
      * @param {CodePathSegment[]} segments - Segments to add.
      * @returns {void}
      */
-    add: function(segments) {
+    add(segments) {
         assert(segments.length >= this.count, segments.length + " >= " + this.count);
 
         this.segmentsList.push(mergeExtraSegments(this, segments));
@@ -199,7 +199,7 @@ ForkContext.prototype = {
      * @param {CodePathSegment[]} segments - Segments to add.
      * @returns {void}
      */
-    replaceHead: function(segments) {
+    replaceHead(segments) {
         assert(segments.length >= this.count, segments.length + " >= " + this.count);
 
         this.segmentsList.splice(-1, 1, mergeExtraSegments(this, segments));
@@ -211,7 +211,7 @@ ForkContext.prototype = {
      * @param {ForkContext} context - A fork context to add.
      * @returns {void}
      */
-    addAll: function(context) {
+    addAll(context) {
         assert(context.count === this.count);
 
         let source = context.segmentsList;
@@ -226,7 +226,7 @@ ForkContext.prototype = {
      *
      * @returns {void}
      */
-    clear: function() {
+    clear() {
         this.segmentsList = [];
     }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -169,7 +169,7 @@ function getLocalConfig(thisConfig, directory) {
 
             noConfigError.messageTemplate = "no-config-found";
             noConfigError.messageData = {
-                directory: directory,
+                directory,
                 filesExamined: localConfigFiles
             };
 

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -53,7 +53,7 @@ function makeRegistryItems(rulesConfig) {
     return Object.keys(rulesConfig).reduce(function(accumulator, ruleId) {
         accumulator[ruleId] = rulesConfig[ruleId].map(function(config) {
             return {
-                config: config,
+                config,
                 specificity: config.length || 1,
                 errorCount: void 0
             };
@@ -88,7 +88,7 @@ Registry.prototype = {
      *
      * @returns {void}
      */
-    populateFromCoreRules: function() {
+    populateFromCoreRules() {
         let rulesConfig = configRule.createCoreRuleConfigs();
 
         this.rules = makeRegistryItems(rulesConfig);
@@ -108,7 +108,7 @@ Registry.prototype = {
      * @param   {Object}   registry The autoconfig registry
      * @returns {Object[]}          "rules" configurations to use for linting
      */
-    buildRuleSets: function() {
+    buildRuleSets() {
         let idx = 0,
             ruleIds = Object.keys(this.rules),
             ruleSets = [];
@@ -169,7 +169,7 @@ Registry.prototype = {
      *
      * @returns {void}
      */
-    stripFailingConfigs: function() {
+    stripFailingConfigs() {
         let ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
@@ -194,7 +194,7 @@ Registry.prototype = {
      *
      * @returns {void}
      */
-    stripExtraConfigs: function() {
+    stripExtraConfigs() {
         let ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
@@ -215,7 +215,7 @@ Registry.prototype = {
      *
      * @returns {Registry}  A registry of failing rules.
      */
-    getFailingRulesRegistry: function() {
+    getFailingRulesRegistry() {
         let ruleIds = Object.keys(this.rules),
             failingRegistry = new Registry();
 
@@ -238,7 +238,7 @@ Registry.prototype = {
      *
      * @returns {Object} An eslint config with rules section populated
      */
-    createConfig: function() {
+    createConfig() {
         let ruleIds = Object.keys(this.rules),
             config = {rules: {}};
 
@@ -257,7 +257,7 @@ Registry.prototype = {
      * @param   {number} specificity Only keep configs with this specificity
      * @returns {Registry}           A registry of rules
      */
-    filterBySpecificity: function(specificity) {
+    filterBySpecificity(specificity) {
         let ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
@@ -279,7 +279,7 @@ Registry.prototype = {
      * @param   {progressCallback} [cb] Optional callback for reporting execution status
      * @returns {Registry}              New registry with errorCount populated
      */
-    lintSourceCode: function(sourceCodes, config, cb) {
+    lintSourceCode(sourceCodes, config, cb) {
         let totalFilesLinting,
             lintConfig,
             ruleSets,
@@ -367,6 +367,6 @@ function extendFromRecommended(config) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    Registry: Registry,
-    extendFromRecommended: extendFromRecommended
+    Registry,
+    extendFromRecommended
 };

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -472,12 +472,12 @@ function resolve(filePath, relativeTo) {
             normalizedPackageName = normalizePackageName(packagePath, "eslint-plugin");
             debug("Attempting to resolve " + normalizedPackageName);
             filePath = resolver.resolve(normalizedPackageName, getLookupPath(relativeTo));
-            return { filePath: filePath, configName: configName };
+            return { filePath, configName };
         } else {
             normalizedPackageName = normalizePackageName(filePath, "eslint-config");
             debug("Attempting to resolve " + normalizedPackageName);
             filePath = resolver.resolve(normalizedPackageName, getLookupPath(relativeTo));
-            return { filePath: filePath };
+            return { filePath };
         }
     }
 
@@ -547,14 +547,14 @@ function load(filePath, applyEnvironments, relativeTo) {
 
 module.exports = {
 
-    getBaseDir: getBaseDir,
-    getLookupPath: getLookupPath,
-    load: load,
-    resolve: resolve,
-    write: write,
-    applyExtends: applyExtends,
-    normalizePackageName: normalizePackageName,
-    CONFIG_FILES: CONFIG_FILES,
+    getBaseDir,
+    getLookupPath,
+    load,
+    resolve,
+    write,
+    applyExtends,
+    normalizePackageName,
+    CONFIG_FILES,
 
     /**
      * Retrieves the configuration filename for a given directory. It loops over all
@@ -563,7 +563,7 @@ module.exports = {
      * @returns {?string} The filename of the configuration file for the directory
      *      or null if there is no configuration file in the directory.
      */
-    getFilenameForDirectory: function(directory) {
+    getFilenameForDirectory(directory) {
 
         let filename;
 

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -316,7 +316,7 @@ function promptUser(callback) {
             name: "styleguide",
             message: "Which style guide do you want to follow?",
             choices: [{name: "Google", value: "google"}, {name: "AirBnB", value: "airbnb"}, {name: "Standard", value: "standard"}],
-            when: function(answers) {
+            when(answers) {
                 answers.packageJsonExists = npmUtil.checkPackageJson();
                 return answers.source === "guide" && answers.packageJsonExists;
             }
@@ -325,10 +325,10 @@ function promptUser(callback) {
             type: "input",
             name: "patterns",
             message: "Which file(s), path(s), or glob(s) should be examined?",
-            when: function(answers) {
+            when(answers) {
                 return (answers.source === "auto");
             },
-            validate: function(input) {
+            validate(input) {
                 if (input.trim().length === 0 && input.trim() !== ",") {
                     return "You must tell us what code to examine. Try again.";
                 }
@@ -341,7 +341,7 @@ function promptUser(callback) {
             message: "What format do you want your config file to be in?",
             default: "JavaScript",
             choices: ["JavaScript", "YAML", "JSON"],
-            when: function(answers) {
+            when(answers) {
                 return ((answers.source === "guide" && answers.packageJsonExists) || answers.source === "auto");
             }
         }
@@ -377,7 +377,7 @@ function promptUser(callback) {
                 name: "modules",
                 message: "Are you using ES6 modules?",
                 default: false,
-                when: function(answers) {
+                when(answers) {
                     return answers.es6 === true;
                 }
             },
@@ -393,7 +393,7 @@ function promptUser(callback) {
                 name: "commonjs",
                 message: "Do you use CommonJS?",
                 default: false,
-                when: function(answers) {
+                when(answers) {
                     return answers.env.some(function(env) {
                         return env === "browser";
                     });
@@ -410,7 +410,7 @@ function promptUser(callback) {
                 name: "react",
                 message: "Do you use React",
                 default: false,
-                when: function(answers) {
+                when(answers) {
                     return answers.jsx;
                 }
             }
@@ -489,9 +489,9 @@ function promptUser(callback) {
 //------------------------------------------------------------------------------
 
 let init = {
-    getConfigForStyleGuide: getConfigForStyleGuide,
-    processAnswers: processAnswers,
-    initializeConfig: /* istanbul ignore next */ function(callback) {
+    getConfigForStyleGuide,
+    processAnswers,
+    /* istanbul ignore next */initializeConfig(callback) {
         promptUser(callback);
     }
 };

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -36,7 +36,7 @@ module.exports = {
      * Creates an empty configuration object suitable for merging as a base.
      * @returns {Object} A configuration object.
      */
-    createEmptyConfig: function() {
+    createEmptyConfig() {
         return {
             globals: {},
             env: {},
@@ -51,7 +51,7 @@ module.exports = {
      * @returns {Object} A configuration object with the appropriate rules and globals
      *      set.
      */
-    createEnvironmentConfig: function(env) {
+    createEnvironmentConfig(env) {
 
         let envConfig = this.createEmptyConfig();
 
@@ -86,7 +86,7 @@ module.exports = {
      * @param {Object} config The configuration information.
      * @returns {Object} The updated configuration information.
      */
-    applyEnvironments: function(config) {
+    applyEnvironments(config) {
         if (config.env && typeof config.env === "object") {
             debug("Apply environment settings to config");
             return this.merge(this.createEnvironmentConfig(config.env), config);
@@ -198,7 +198,7 @@ module.exports = {
      * @param {Object} config The config object to normalize.
      * @returns {void}
      */
-    normalize: function(config) {
+    normalize(config) {
 
         if (config.rules) {
             Object.keys(config.rules).forEach(function(ruleId) {
@@ -220,7 +220,7 @@ module.exports = {
      * @param {Object} config The config object to normalize.
      * @returns {void}
      */
-    normalizeToStrings: function(config) {
+    normalizeToStrings(config) {
 
         if (config.rules) {
             Object.keys(config.rules).forEach(function(ruleId) {
@@ -240,7 +240,7 @@ module.exports = {
      * @param {int|string|Array} ruleConfig The configuration for an individual rule.
      * @returns {boolean} True if the rule represents an error, false if not.
      */
-    isErrorSeverity: function(ruleConfig) {
+    isErrorSeverity(ruleConfig) {
 
         let severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
 
@@ -256,7 +256,7 @@ module.exports = {
      * @param {number|string|Array} ruleConfig - The configuration for an individual rule.
      * @returns {boolean} `true` if the configuration has valid severity.
      */
-    isValidSeverity: function(ruleConfig) {
+    isValidSeverity(ruleConfig) {
         let severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
 
         if (typeof severity === "string") {
@@ -270,7 +270,7 @@ module.exports = {
      * @param {Object} config - The configuration for rules.
      * @returns {boolean} `true` if the configuration has valid severity.
      */
-    isEverySeverityValid: function(config) {
+    isEverySeverityValid(config) {
         return Object.keys(config).every(function(ruleId) {
             return this.isValidSeverity(config[ruleId]);
         }, this);

--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -202,7 +202,7 @@ RuleConfigSet.prototype = {
     * @param {number} [severity=2] The level of severity for the rule (0, 1, 2)
     * @returns {void}
     */
-    addErrorSeverity: function(severity) {
+    addErrorSeverity(severity) {
         severity = severity || 2;
 
         this.ruleConfigs = this.ruleConfigs.map(function(config) {
@@ -219,7 +219,7 @@ RuleConfigSet.prototype = {
     * @param  {string[]} enums Array of valid rule options (e.g. ["always", "never"])
     * @returns {void}
     */
-    addEnums: function(enums) {
+    addEnums(enums) {
         this.ruleConfigs = this.ruleConfigs.concat(combineArrays(this.ruleConfigs, enums));
     },
 
@@ -228,10 +228,10 @@ RuleConfigSet.prototype = {
     * @param  {Object} obj Schema item with type === "object"
     * @returns {void}
     */
-    addObject: function(obj) {
+    addObject(obj) {
         let objectConfigSet = {
             objectConfigs: [],
-            add: function(property, values) {
+            add(property, values) {
                 let optionObj;
 
                 for (let idx = 0; idx < values.length; idx++) {
@@ -241,7 +241,7 @@ RuleConfigSet.prototype = {
                 }
             },
 
-            combine: function() {
+            combine() {
                 this.objectConfigs = groupByProperty(this.objectConfigs).reduce(function(accumulator, objArr) {
                     return combinePropertyObjects(accumulator, objArr);
                 }, []);
@@ -318,6 +318,6 @@ function createCoreRuleConfigs() {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    generateConfigsFromSchema: generateConfigsFromSchema,
-    createCoreRuleConfigs: createCoreRuleConfigs
+    generateConfigsFromSchema,
+    createCoreRuleConfigs
 };

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -172,7 +172,7 @@ function validate(config, source) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    getRuleOptionsSchema: getRuleOptionsSchema,
-    validate: validate,
-    validateRuleOptions: validateRuleOptions
+    getRuleOptionsSchema,
+    validate,
+    validateRuleOptions
 };

--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -56,9 +56,9 @@ function removeNamespace(pluginName) {
 
 module.exports = {
 
-    removePrefix: removePrefix,
-    getNamespace: getNamespace,
-    removeNamespace: removeNamespace,
+    removePrefix,
+    getNamespace,
+    removeNamespace,
 
     /**
      * Defines a plugin with a given name rather than loading from disk.
@@ -66,7 +66,7 @@ module.exports = {
      * @param {Object} plugin The plugin object.
      * @returns {void}
      */
-    define: function(pluginName, plugin) {
+    define(pluginName, plugin) {
         let pluginNameWithoutNamespace = removeNamespace(pluginName),
             pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace);
 
@@ -85,7 +85,7 @@ module.exports = {
      * @param {string} pluginName The name of the plugin to retrieve.
      * @returns {Object} The plugin or null if not loaded.
      */
-    get: function(pluginName) {
+    get(pluginName) {
         return plugins[pluginName] || null;
     },
 
@@ -93,7 +93,7 @@ module.exports = {
      * Returns all plugins that are loaded.
      * @returns {Object} The plugins cache.
      */
-    getAll: function() {
+    getAll() {
         return plugins;
     },
 
@@ -103,7 +103,7 @@ module.exports = {
      * @returns {void}
      * @throws {Error} If the plugin cannot be loaded.
      */
-    load: function(pluginName) {
+    load(pluginName) {
         let pluginNamespace = getNamespace(pluginName),
             pluginNameWithoutNamespace = removeNamespace(pluginName),
             pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace),
@@ -132,7 +132,7 @@ module.exports = {
      * @returns {void}
      * @throws {Error} If a plugin cannot be loaded.
      */
-    loadAll: function(pluginNames) {
+    loadAll(pluginNames) {
         pluginNames.forEach(this.load, this);
     },
 
@@ -140,7 +140,7 @@ module.exports = {
      * Resets plugin information. Use for tests only.
      * @returns {void}
      */
-    testReset: function() {
+    testReset() {
         plugins = Object.create(null);
     }
 };

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -60,7 +60,7 @@ function parseBooleanConfig(string, comment) {
 
         items[name] = {
             value: (value === "true"),
-            comment: comment
+            comment
         };
 
     });
@@ -241,14 +241,14 @@ function disableReporting(reportingConfig, start, rulesToDisable) {
     if (rulesToDisable.length) {
         rulesToDisable.forEach(function(rule) {
             reportingConfig.push({
-                start: start,
+                start,
                 end: null,
-                rule: rule
+                rule
             });
         });
     } else {
         reportingConfig.push({
-            start: start,
+            start,
             end: null,
             rule: null
         });
@@ -487,7 +487,7 @@ function createStubRule(message) {
      */
     function createRuleModule(context) {
         return {
-            Program: function(node) {
+            Program(node) {
                 context.report(node, message);
             }
         };
@@ -634,7 +634,7 @@ module.exports = (function() {
                 ruleId: null,
                 fatal: true,
                 severity: 2,
-                source: source,
+                source,
                 message: "Parsing error: " + message,
 
                 line: ex.lineNumber,
@@ -849,7 +849,7 @@ module.exports = (function() {
                 ignoreEval: true,
                 nodejsScope: ecmaFeatures.globalReturn,
                 impliedStrict: ecmaFeatures.impliedStrict,
-                ecmaVersion: ecmaVersion,
+                ecmaVersion,
                 sourceType: currentConfig.parserOptions.sourceType || "script",
                 fallback: Traverser.getKeys
             });
@@ -898,11 +898,11 @@ module.exports = (function() {
              * and react accordingly.
              */
             traverser.traverse(ast, {
-                enter: function(node, parent) {
+                enter(node, parent) {
                     node.parent = parent;
                     eventGenerator.enterNode(node);
                 },
-                leave: function(node) {
+                leave(node) {
                     eventGenerator.leaveNode(node);
                 }
             });
@@ -973,9 +973,9 @@ module.exports = (function() {
         }
 
         let problem = {
-            ruleId: ruleId,
-            severity: severity,
-            message: message,
+            ruleId,
+            severity,
+            message,
             line: location.line,
             column: location.column + 1,   // switch to 1-base instead of 0-base
             nodeType: node && node.type,

--- a/lib/formatters/html.js
+++ b/lib/formatters/html.js
@@ -78,9 +78,9 @@ function renderMessages(messages, parentIndex) {
         columnNumber = message.column || 0;
 
         return messageTemplate({
-            parentIndex: parentIndex,
-            lineNumber: lineNumber,
-            columnNumber: columnNumber,
+            parentIndex,
+            lineNumber,
+            columnNumber,
             severityNumber: message.severity,
             severityName: message.severity === 1 ? "Warning" : "Error",
             message: message.message,
@@ -96,7 +96,7 @@ function renderMessages(messages, parentIndex) {
 function renderResults(results) {
     return lodash.map(results, function(result, index) {
         return resultTemplate({
-            index: index,
+            index,
             color: renderColor(result.errorCount, result.warningCount),
             filePath: result.filePath,
             summary: renderSummary(result.errorCount, result.warningCount)

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -67,7 +67,7 @@ module.exports = function(results) {
             }),
             {
                 align: ["", "r", "l"],
-                stringLength: function(str) {
+                stringLength(str) {
                     return chalk.stripColor(str).length;
                 }
             }

--- a/lib/formatters/table.js
+++ b/lib/formatters/table.js
@@ -84,7 +84,7 @@ function drawTable(messages) {
                 wrapWord: true
             }
         },
-        drawHorizontalLine: function(index) {
+        drawHorizontalLine(index) {
             return index === 1;
         }
     });
@@ -149,7 +149,7 @@ module.exports = function(report) {
                 wrapWord: true
             }
         },
-        drawHorizontalLine: function() {
+        drawHorizontalLine() {
             return true;
         }
     });

--- a/lib/internal-rules/internal-no-invalid-meta.js
+++ b/lib/internal-rules/internal-no-invalid-meta.js
@@ -166,12 +166,12 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let metaExportsValue;
         let ruleIsFixable = false;
 
         return {
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
                 if (node.left &&
                     node.right &&
                     node.left.type === "MemberExpression" &&
@@ -182,7 +182,7 @@ module.exports = {
                 }
             },
 
-            CallExpression: function(node) {
+            CallExpression(node) {
 
                 // If the rule has a call for `context.report` and a property `fix`
                 // is being passed in, then we consider that the rule is fixable.
@@ -204,7 +204,7 @@ module.exports = {
                 }
             },
 
-            "Program:exit": function() {
+            "Program:exit"() {
                 checkMetaValidity(context, metaExportsValue, ruleIsFixable);
             }
         };

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -14,7 +14,7 @@ module.exports = {
      * Cover for console.log
      * @returns {void}
      */
-    info: function() {
+    info() {
         console.log.apply(console, Array.prototype.slice.call(arguments));
     },
 
@@ -22,7 +22,7 @@ module.exports = {
      * Cover for console.error
      * @returns {void}
      */
-    error: function() {
+    error() {
         console.error.apply(console, Array.prototype.slice.call(arguments));
     }
 };

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -96,7 +96,7 @@ RuleContext.prototype = {
      * Passthrough to eslint.getSourceCode().
      * @returns {SourceCode} The SourceCode object for the code.
      */
-    getSourceCode: function() {
+    getSourceCode() {
         return this.eslint.getSourceCode();
     },
 
@@ -110,7 +110,7 @@ RuleContext.prototype = {
      *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    report: function(nodeOrDescriptor, location, message, opts) {
+    report(nodeOrDescriptor, location, message, opts) {
         let descriptor,
             fix = null;
 

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -65,7 +65,7 @@ function importPlugin(pluginRules, pluginName) {
  * @param {string} ruleId Rule id (file name).
  * @returns {Function} Rule handler.
  */
-function get(ruleId) {
+function getHandler(ruleId) {
     if (typeof rules[ruleId] === "string") {
         return require(rules[ruleId]);
     } else {
@@ -83,17 +83,17 @@ function testClear() {
 }
 
 module.exports = {
-    define: define,
-    load: load,
+    define,
+    load,
     import: importPlugin,
-    get: get,
-    testClear: testClear,
+    get: getHandler,
+    testClear,
 
     /**
      * Resets rules to its starting state. Use for tests only.
      * @returns {void}
      */
-    testReset: function() {
+    testReset() {
         testClear();
         load();
     }

--- a/lib/rules/accessor-pairs.js
+++ b/lib/rules/accessor-pairs.js
@@ -90,7 +90,7 @@ module.exports = {
             additionalProperties: false
         }]
     },
-    create: function(context) {
+    create(context) {
         let config = context.options[0] || {};
         let checkGetWithoutSet = config.getWithoutSet === true;
         let checkSetWithoutGet = config.setWithoutGet !== false;
@@ -146,7 +146,7 @@ module.exports = {
         }
 
         return {
-            ObjectExpression: function(node) {
+            ObjectExpression(node) {
                 if (checkSetWithoutGet || checkGetWithoutSet) {
                     checkLonelySetGet(node);
                 }

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -39,7 +39,7 @@ module.exports = {
             }
         ]
     },
-    create: function(context) {
+    create(context) {
         let spaced = context.options[0] === "always",
             sourceCode = context.getSourceCode();
 
@@ -55,7 +55,7 @@ module.exports = {
         }
 
         let options = {
-            spaced: spaced,
+            spaced,
             singleElementException: isOptionSet("singleValue"),
             objectsInArraysException: isOptionSet("objectsInArrays"),
             arraysInArraysException: isOptionSet("arraysInArrays")
@@ -73,10 +73,10 @@ module.exports = {
         */
         function reportNoBeginningSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "There should be no space after '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     let nextToken = sourceCode.getTokenAfter(token);
 
                     return fixer.removeRange([token.range[1], nextToken.range[0]]);
@@ -92,10 +92,10 @@ module.exports = {
         */
         function reportNoEndingSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "There should be no space before '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     let previousToken = sourceCode.getTokenBefore(token);
 
                     return fixer.removeRange([previousToken.range[1], token.range[0]]);
@@ -111,10 +111,10 @@ module.exports = {
         */
         function reportRequiredBeginningSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "A space is required after '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.insertTextAfter(token, " ");
                 }
             });
@@ -128,10 +128,10 @@ module.exports = {
         */
         function reportRequiredEndingSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "A space is required before '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.insertTextBefore(token, " ");
                 }
             });

--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -176,7 +176,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let funcInfo = {
             upper: null,
             codePath: null,
@@ -199,7 +199,7 @@ module.exports = {
                 funcInfo.codePath.currentSegments.some(isReachable)
             ) {
                 context.report({
-                    node: node,
+                    node,
                     loc: getLocation(node, context.getSourceCode()).loc.start,
                     message: funcInfo.hasReturn
                         ? "Expected to return a value at the end of this function."
@@ -211,10 +211,10 @@ module.exports = {
         return {
 
             // Stacks this function's information.
-            onCodePathStart: function(codePath, node) {
+            onCodePathStart(codePath, node) {
                 funcInfo = {
                     upper: funcInfo,
-                    codePath: codePath,
+                    codePath,
                     hasReturn: false,
                     shouldCheck:
                         TARGET_NODE_TYPE.test(node.type) &&
@@ -224,18 +224,18 @@ module.exports = {
             },
 
             // Pops this function's information.
-            onCodePathEnd: function() {
+            onCodePathEnd() {
                 funcInfo = funcInfo.upper;
             },
 
             // Checks the return statement is valid.
-            ReturnStatement: function(node) {
+            ReturnStatement(node) {
                 if (funcInfo.shouldCheck) {
                     funcInfo.hasReturn = true;
 
                     if (!node.argument) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Expected a return value."
                         });
                     }

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -49,7 +49,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options;
         let always = options[0] === "always";
         let asNeeded = !options[0] || options[0] === "as-needed";
@@ -67,7 +67,7 @@ module.exports = {
             if (arrowBody.type === "BlockStatement") {
                 if (never) {
                     context.report({
-                        node: node,
+                        node,
                         loc: arrowBody.loc.start,
                         message: "Unexpected block statement surrounding arrow body."
                     });
@@ -85,7 +85,7 @@ module.exports = {
 
                     if (asNeeded && blockBody[0].type === "ReturnStatement") {
                         context.report({
-                            node: node,
+                            node,
                             loc: arrowBody.loc.start,
                             message: "Unexpected block statement surrounding arrow body."
                         });
@@ -94,7 +94,7 @@ module.exports = {
             } else {
                 if (always || (asNeeded && requireReturnForObjectLiteral && arrowBody.type === "ObjectExpression")) {
                     context.report({
-                        node: node,
+                        node,
                         loc: arrowBody.loc.start,
                         message: "Expected block statement surrounding arrow body."
                     });

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -25,7 +25,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let message = "Expected parentheses around arrow function argument.";
         let asNeededMessage = "Unexpected parentheses around single function argument.";
         let asNeeded = context.options[0] === "as-needed";
@@ -44,9 +44,9 @@ module.exports = {
             if (asNeeded && node.params.length === 1 && node.params[0].type === "Identifier") {
                 if (token.type === "Punctuator" && token.value === "(") {
                     context.report({
-                        node: node,
+                        node,
                         message: asNeededMessage,
-                        fix: function(fixer) {
+                        fix(fixer) {
                             let paramToken = context.getTokenAfter(token);
                             let closingParenToken = context.getTokenAfter(paramToken);
 
@@ -66,9 +66,9 @@ module.exports = {
                 // (x) => x
                 if (after.value !== ")") {
                     context.report({
-                        node: node,
-                        message: message,
-                        fix: function(fixer) {
+                        node,
+                        message,
+                        fix(fixer) {
                             return fixer.replaceText(token, "(" + token.value + ")");
                         }
                     });

--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -34,7 +34,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         // merge rules with default
         let rule = { before: true, after: true },
@@ -60,7 +60,7 @@ module.exports = {
             }
             let after = sourceCode.getTokenAfter(t);
 
-            return { before: before, arrow: t, after: after };
+            return { before, arrow: t, after };
         }
 
         /**
@@ -72,7 +72,7 @@ module.exports = {
             let before = tokens.arrow.range[0] - tokens.before.range[1];
             let after = tokens.after.range[0] - tokens.arrow.range[1];
 
-            return { before: before, after: after };
+            return { before, after };
         }
 
         /**
@@ -93,7 +93,7 @@ module.exports = {
                     context.report({
                         node: tokens.before,
                         message: "Missing space before =>.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextBefore(tokens.arrow, " ");
                         }
                     });
@@ -105,7 +105,7 @@ module.exports = {
                     context.report({
                         node: tokens.before,
                         message: "Unexpected space before =>.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([tokens.before.range[1], tokens.arrow.range[0]]);
                         }
                     });
@@ -119,7 +119,7 @@ module.exports = {
                     context.report({
                         node: tokens.after,
                         message: "Missing space after =>.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextAfter(tokens.arrow, " ");
                         }
                     });
@@ -131,7 +131,7 @@ module.exports = {
                     context.report({
                         node: tokens.after,
                         message: "Unexpected space after =>.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([tokens.arrow.range[1], tokens.after.range[0]]);
                         }
                     });

--- a/lib/rules/block-scoped-var.js
+++ b/lib/rules/block-scoped-var.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let stack = [];
 
         /**
@@ -92,7 +92,7 @@ module.exports = {
         }
 
         return {
-            Program: function(node) {
+            Program(node) {
                 stack = [node.range];
             },
 

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -26,7 +26,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let always = (context.options[0] !== "never"),
             message = always ? "Requires a space" : "Unexpected space(s)",
             sourceCode = context.getSourceCode();
@@ -95,10 +95,10 @@ module.exports = {
             // Check.
             if (!isValid(openBrace, firstToken)) {
                 context.report({
-                    node: node,
+                    node,
                     loc: openBrace.loc.start,
                     message: message + " after '{'.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         if (always) {
                             return fixer.insertTextBefore(firstToken, " ");
                         }
@@ -109,10 +109,10 @@ module.exports = {
             }
             if (!isValid(lastToken, closeBrace)) {
                 context.report({
-                    node: node,
+                    node,
                     loc: closeBrace.loc.start,
                     message: message + " before '}'.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         if (always) {
                             return fixer.insertTextAfter(lastToken, " ");
                         }

--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -33,7 +33,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let style = context.options[0] || "1tbs",
             params = context.options[1] || {},
             sourceCode = context.getSourceCode();

--- a/lib/rules/callback-return.js
+++ b/lib/rules/callback-return.js
@@ -22,7 +22,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
 
         let callbacks = context.options[0] || ["callback", "cb", "next"],
             sourceCode = context.getSourceCode();
@@ -110,7 +110,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
 
                 // if we're not a callback we can return
                 if (!isCallback(node)) {

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -30,7 +30,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -73,7 +73,7 @@ module.exports = {
 
         return {
 
-            Identifier: function(node) {
+            Identifier(node) {
 
                 /*
                  * Leading and trailing underscores are commonly used to flag

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -44,7 +44,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let mode = context.options[0];
         let UNEXPECTED_MESSAGE = "Unexpected trailing comma.";
         let MISSING_MESSAGE = "Missing trailing comma.";
@@ -112,7 +112,7 @@ module.exports = {
                     node: lastItem,
                     loc: trailingToken.loc.start,
                     message: UNEXPECTED_MESSAGE,
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.remove(trailingToken);
                     }
                 });
@@ -157,7 +157,7 @@ module.exports = {
                     node: lastItem,
                     loc: lastItem.loc.end,
                     message: MISSING_MESSAGE,
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.insertTextAfter(penultimateToken, ",");
                     }
                 });

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -36,7 +36,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let sourceCode = context.getSourceCode();
         let tokensAndComments = sourceCode.tokensAndComments;
@@ -73,8 +73,8 @@ module.exports = {
          */
         function report(node, dir, otherNode) {
             context.report({
-                node: node,
-                fix: function(fixer) {
+                node,
+                fix(fixer) {
                     if (options[dir]) {
                         if (dir === "before") {
                             return fixer.insertTextBefore(node, " ");
@@ -160,7 +160,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            "Program:exit": function() {
+            "Program:exit"() {
 
                 let previousToken,
                     nextToken;

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -38,7 +38,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let style = context.options[0] || "last",
             exceptions = {},
             sourceCode = context.getSourceCode();

--- a/lib/rules/complexity.js
+++ b/lib/rules/complexity.js
@@ -44,7 +44,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let option = context.options[0],
             THRESHOLD = 20;
 
@@ -91,7 +91,7 @@ module.exports = {
             }
 
             if (complexity > THRESHOLD) {
-                context.report(node, "Function '{{name}}' has a complexity of {{complexity}}.", { name: name, complexity: complexity });
+                context.report(node, "Function '{{name}}' has a complexity of {{complexity}}.", { name, complexity });
             }
         }
 

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -27,7 +27,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
         let propertyNameMustBeSpaced = context.options[0] === "always"; // default is "never"
 
@@ -44,10 +44,10 @@ module.exports = {
         */
         function reportNoBeginningSpace(node, token, tokenAfter) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "There should be no space after '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.removeRange([token.range[1], tokenAfter.range[0]]);
                 }
             });
@@ -62,10 +62,10 @@ module.exports = {
         */
         function reportNoEndingSpace(node, token, tokenBefore) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "There should be no space before '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.removeRange([tokenBefore.range[1], token.range[0]]);
                 }
             });
@@ -79,10 +79,10 @@ module.exports = {
         */
         function reportRequiredBeginningSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "A space is required after '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.insertTextAfter(token, " ");
                 }
             });
@@ -96,10 +96,10 @@ module.exports = {
         */
         function reportRequiredEndingSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "A space is required before '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.insertTextBefore(token, " ");
                 }
             });

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -56,7 +56,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let treatUndefinedAsUnspecified = options.treatUndefinedAsUnspecified === true;
         let funcInfo = null;
@@ -110,31 +110,31 @@ module.exports = {
 
             // Reports.
             context.report({
-                node: node,
-                loc: loc,
+                node,
+                loc,
                 message: "Expected to return a value at the end of this {{type}}.",
-                data: {type: type}
+                data: {type}
             });
         }
 
         return {
 
             // Initializes/Disposes state of each code path.
-            onCodePathStart: function(codePath) {
+            onCodePathStart(codePath) {
                 funcInfo = {
                     upper: funcInfo,
-                    codePath: codePath,
+                    codePath,
                     hasReturn: false,
                     hasReturnValue: false,
                     message: ""
                 };
             },
-            onCodePathEnd: function() {
+            onCodePathEnd() {
                 funcInfo = funcInfo.upper;
             },
 
             // Reports a given return statement if it's inconsistent.
-            ReturnStatement: function(node) {
+            ReturnStatement(node) {
                 let argument = node.argument;
                 let hasReturnValue = Boolean(argument);
 
@@ -147,7 +147,7 @@ module.exports = {
                     funcInfo.hasReturnValue = hasReturnValue;
                     funcInfo.message = "Expected " + (hasReturnValue ? "a" : "no") + " return value.";
                 } else if (funcInfo.hasReturnValue !== hasReturnValue) {
-                    context.report({node: node, message: funcInfo.message});
+                    context.report({node, message: funcInfo.message});
                 }
             },
 

--- a/lib/rules/consistent-this.js
+++ b/lib/rules/consistent-this.js
@@ -26,7 +26,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
         let aliases = [];
 
         if (context.options.length === 0) {
@@ -45,7 +45,7 @@ module.exports = {
         function reportBadAssignment(node, alias) {
             context.report(node,
                 "Designated alias '{{alias}}' is not assigned to 'this'.",
-                { alias: alias });
+                { alias });
         }
 
         /**
@@ -65,7 +65,7 @@ module.exports = {
                 }
             } else if (isThis) {
                 context.report(node,
-                    "Unexpected alias '{{name}}' for 'this'.", { name: name });
+                    "Unexpected alias '{{name}}' for 'this'.", { name });
             }
         }
 
@@ -127,7 +127,7 @@ module.exports = {
             "FunctionExpression:exit": ensureWasAssigned,
             "FunctionDeclaration:exit": ensureWasAssigned,
 
-            VariableDeclarator: function(node) {
+            VariableDeclarator(node) {
                 let id = node.id;
                 let isDestructuring =
                     id.type === "ArrayPattern" || id.type === "ObjectPattern";
@@ -137,7 +137,7 @@ module.exports = {
                 }
             },
 
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
                 if (node.left.type === "Identifier") {
                     checkAssignment(node, node.left.name, node.right);
                 }

--- a/lib/rules/constructor-super.js
+++ b/lib/rules/constructor-super.js
@@ -101,7 +101,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /*
          * {{hasExtends: boolean, scope: Scope, codePath: CodePath}[]}
@@ -160,7 +160,7 @@ module.exports = {
              * @param {ASTNode} node - The current node.
              * @returns {void}
              */
-            onCodePathStart: function(codePath, node) {
+            onCodePathStart(codePath, node) {
                 if (isConstructorFunction(node)) {
 
                     // Class > ClassBody > MethodDefinition > FunctionExpression
@@ -172,7 +172,7 @@ module.exports = {
                         isConstructor: true,
                         hasExtends: Boolean(superClass),
                         superIsConstructor: isPossibleConstructor(superClass),
-                        codePath: codePath
+                        codePath
                     };
                 } else {
                     funcInfo = {
@@ -180,7 +180,7 @@ module.exports = {
                         isConstructor: false,
                         hasExtends: false,
                         superIsConstructor: false,
-                        codePath: codePath
+                        codePath
                     };
                 }
             },
@@ -192,7 +192,7 @@ module.exports = {
              * @param {ASTNode} node - The current node.
              * @returns {void}
              */
-            onCodePathEnd: function(codePath, node) {
+            onCodePathEnd(codePath, node) {
                 let hasExtends = funcInfo.hasExtends;
 
                 // Pop.
@@ -222,7 +222,7 @@ module.exports = {
              * @param {CodePathSegment} segment - A code path segment to initialize.
              * @returns {void}
              */
-            onCodePathSegmentStart: function(segment) {
+            onCodePathSegmentStart(segment) {
                 if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
                     return;
                 }
@@ -252,7 +252,7 @@ module.exports = {
              *      of a loop.
              * @returns {void}
              */
-            onCodePathSegmentLoop: function(fromSegment, toSegment) {
+            onCodePathSegmentLoop(fromSegment, toSegment) {
                 if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
                     return;
                 }
@@ -281,7 +281,7 @@ module.exports = {
 
                                 context.report({
                                     message: "Unexpected duplicate 'super()'.",
-                                    node: node
+                                    node
                                 });
                             }
                         }
@@ -294,7 +294,7 @@ module.exports = {
              * @param {ASTNode} node - A CallExpression node to check.
              * @returns {void}
              */
-            "CallExpression:exit": function(node) {
+            "CallExpression:exit"(node) {
                 if (!(funcInfo && funcInfo.isConstructor)) {
                     return;
                 }
@@ -325,12 +325,12 @@ module.exports = {
                         if (duplicate) {
                             context.report({
                                 message: "Unexpected duplicate 'super()'.",
-                                node: node
+                                node
                             });
                         } else if (!funcInfo.superIsConstructor) {
                             context.report({
                                 message: "Unexpected 'super()' because 'super' is not a constructor.",
-                                node: node
+                                node
                             });
                         } else {
                             info.validNodes.push(node);
@@ -339,7 +339,7 @@ module.exports = {
                 } else if (funcInfo.codePath.currentSegments.some(isReachable)) {
                     context.report({
                         message: "Unexpected 'super()'.",
-                        node: node
+                        node
                     });
                 }
             },
@@ -349,7 +349,7 @@ module.exports = {
              * @param {ASTNode} node - A ReturnStatement node to check.
              * @returns {void}
              */
-            ReturnStatement: function(node) {
+            ReturnStatement(node) {
                 if (!(funcInfo && funcInfo.isConstructor && funcInfo.hasExtends)) {
                     return;
                 }
@@ -377,7 +377,7 @@ module.exports = {
              * Resets state.
              * @returns {void}
              */
-            "Program:exit": function() {
+            "Program:exit"() {
                 segInfoMap = Object.create(null);
             }
         };

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -51,7 +51,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
 
         let multiOnly = (context.options[0] === "multi");
         let multiLine = (context.options[0] === "multi-line");
@@ -144,11 +144,11 @@ module.exports = {
          */
         function reportExpectedBraceError(node, name, suffix) {
             context.report({
-                node: node,
+                node,
                 loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
                 message: "Expected { after '{{name}}'{{suffix}}.",
                 data: {
-                    name: name,
+                    name,
                     suffix: (suffix ? " " + suffix : "")
                 }
             });
@@ -164,11 +164,11 @@ module.exports = {
          */
         function reportUnnecessaryBraceError(node, name, suffix) {
             context.report({
-                node: node,
+                node,
                 loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
                 message: "Unnecessary { after '{{name}}'{{suffix}}.",
                 data: {
-                    name: name,
+                    name,
                     suffix: (suffix ? " " + suffix : "")
                 }
             });
@@ -214,8 +214,8 @@ module.exports = {
 
             return {
                 actual: hasBlock,
-                expected: expected,
-                check: function() {
+                expected,
+                check() {
                     if (this.expected !== null && this.expected !== this.actual) {
                         if (this.expected) {
                             reportExpectedBraceError(node, name, suffix);
@@ -272,7 +272,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            IfStatement: function(node) {
+            IfStatement(node) {
                 if (node.parent.type !== "IfStatement") {
                     prepareIfChecks(node).forEach(function(preparedCheck) {
                         preparedCheck.check();
@@ -280,23 +280,23 @@ module.exports = {
                 }
             },
 
-            WhileStatement: function(node) {
+            WhileStatement(node) {
                 prepareCheck(node, node.body, "while", "condition").check();
             },
 
-            DoWhileStatement: function(node) {
+            DoWhileStatement(node) {
                 prepareCheck(node, node.body, "do").check();
             },
 
-            ForStatement: function(node) {
+            ForStatement(node) {
                 prepareCheck(node, node.body, "for", "condition").check();
             },
 
-            ForInStatement: function(node) {
+            ForInStatement(node) {
                 prepareCheck(node, node.body, "for-in").check();
             },
 
-            ForOfStatement: function(node) {
+            ForOfStatement(node) {
                 prepareCheck(node, node.body, "for-of").check();
             }
         };

--- a/lib/rules/default-case.js
+++ b/lib/rules/default-case.js
@@ -29,7 +29,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let commentPattern = options.commentPattern ?
             new RegExp(options.commentPattern) :
@@ -56,7 +56,7 @@ module.exports = {
 
         return {
 
-            SwitchStatement: function(node) {
+            SwitchStatement(node) {
 
                 if (!node.cases.length) {
 

--- a/lib/rules/dot-location.js
+++ b/lib/rules/dot-location.js
@@ -26,7 +26,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let config = context.options[0];
 

--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -35,7 +35,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let allowKeywords = options.allowKeywords === void 0 || !!options.allowKeywords;
 
@@ -46,7 +46,7 @@ module.exports = {
         }
 
         return {
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 if (
                     node.computed &&
                     node.property.type === "Literal" &&

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -25,7 +25,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Public
@@ -46,10 +46,10 @@ module.exports = {
                     // file is not newline-terminated
                     location.line = src.split(/\n/g).length;
                     context.report({
-                        node: node,
+                        node,
                         loc: location,
                         message: "Newline required at end of file but not found.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextAfterRange([0, src.length], linebreak);
                         }
                     });

--- a/lib/rules/eqeqeq.js
+++ b/lib/rules/eqeqeq.js
@@ -24,7 +24,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         /**
@@ -82,7 +82,7 @@ module.exports = {
         }
 
         return {
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
                 if (node.operator !== "==" && node.operator !== "!=") {
                     return;
                 }
@@ -97,7 +97,7 @@ module.exports = {
                 }
 
                 context.report({
-                    node: node,
+                    node,
                     loc: getOperatorLocation(node),
                     message: "Expected '{{op}}=' and instead saw '{{op}}'.",
                     data: { op: node.operator }

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -33,7 +33,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let never = context.options[0] === "never";
 
         /**
@@ -54,7 +54,7 @@ module.exports = {
         }
 
         return {
-            "FunctionExpression:exit": function(node) {
+            "FunctionExpression:exit"(node) {
 
                 // Skip recursive functions.
                 let nameVar = context.getDeclaredVariables(node)[0];

--- a/lib/rules/func-style.js
+++ b/lib/rules/func-style.js
@@ -32,7 +32,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let style = context.options[0],
             allowArrowFunctions = context.options[1] && context.options[1].allowArrowFunctions === true,
@@ -40,33 +40,33 @@ module.exports = {
             stack = [];
 
         let nodesToCheck = {
-            Program: function() {
+            Program() {
                 stack = [];
             },
 
-            FunctionDeclaration: function(node) {
+            FunctionDeclaration(node) {
                 stack.push(false);
 
                 if (!enforceDeclarations && node.parent.type !== "ExportDefaultDeclaration") {
                     context.report(node, "Expected a function expression.");
                 }
             },
-            "FunctionDeclaration:exit": function() {
+            "FunctionDeclaration:exit"() {
                 stack.pop();
             },
 
-            FunctionExpression: function(node) {
+            FunctionExpression(node) {
                 stack.push(false);
 
                 if (enforceDeclarations && node.parent.type === "VariableDeclarator") {
                     context.report(node.parent, "Expected a function declaration.");
                 }
             },
-            "FunctionExpression:exit": function() {
+            "FunctionExpression:exit"() {
                 stack.pop();
             },
 
-            ThisExpression: function() {
+            ThisExpression() {
                 if (stack.length > 0) {
                     stack[stack.length - 1] = true;
                 }

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -38,7 +38,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let mode = (function(option) {
             if (!option || typeof option === "string") {
@@ -90,9 +90,9 @@ module.exports = {
                 let message = type + " space " + side + " *.";
 
                 context.report({
-                    node: node,
-                    message: message,
-                    fix: function(fixer) {
+                    node,
+                    message,
+                    fix(fixer) {
                         if (spaceRequired) {
                             if (after) {
                                 return fixer.insertTextAfter(node, " ");

--- a/lib/rules/global-require.js
+++ b/lib/rules/global-require.js
@@ -59,9 +59,9 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
                 let currentScope = context.getScope(),
                     isGoodRequire;
 

--- a/lib/rules/guard-for-in.js
+++ b/lib/rules/guard-for-in.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            ForInStatement: function(node) {
+            ForInStatement(node) {
 
                 /*
                  * If the for-in statement has {}, then the real body is the body

--- a/lib/rules/handle-callback-err.js
+++ b/lib/rules/handle-callback-err.js
@@ -24,7 +24,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let errorArgument = context.options[0] || "err";
 

--- a/lib/rules/id-blacklist.js
+++ b/lib/rules/id-blacklist.js
@@ -27,7 +27,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
 
 
         //--------------------------------------------------------------------------
@@ -74,7 +74,7 @@ module.exports = {
 
         return {
 
-            Identifier: function(node) {
+            Identifier(node) {
                 let name = node.name,
                     effectiveParent = (node.parent.type === "MemberExpression") ? node.parent.parent : node.parent;
 

--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -44,7 +44,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let minLength = typeof options.min !== "undefined" ? options.min : 2;
         let maxLength = typeof options.max !== "undefined" ? options.max : Infinity;
@@ -66,10 +66,10 @@ module.exports = {
                     parent.parent.parent.type === "ObjectPattern" && parent.parent.parent.parent.left === parent.parent.parent)
                 );
             },
-            AssignmentPattern: function(parent, node) {
+            AssignmentPattern(parent, node) {
                 return parent.left === node;
             },
-            VariableDeclarator: function(parent, node) {
+            VariableDeclarator(parent, node) {
                 return parent.id === node;
             },
             Property: properties && function(parent, node) {
@@ -86,7 +86,7 @@ module.exports = {
         };
 
         return {
-            Identifier: function(node) {
+            Identifier(node) {
                 let name = node.name;
                 let parent = node.parent;
 
@@ -105,7 +105,7 @@ module.exports = {
                         isShort ?
                             "Identifier name '{{name}}' is too short (< {{min}})." :
                             "Identifier name '{{name}}' is too long (> {{max}}).",
-                        { name: name, min: minLength, max: maxLength }
+                        { name, min: minLength, max: maxLength }
                     );
                 }
             }

--- a/lib/rules/id-match.js
+++ b/lib/rules/id-match.js
@@ -32,7 +32,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -77,13 +77,13 @@ module.exports = {
         function report(node) {
             context.report(node, "Identifier '{{name}}' does not match the pattern '{{pattern}}'.", {
                 name: node.name,
-                pattern: pattern
+                pattern
             });
         }
 
         return {
 
-            Identifier: function(node) {
+            Identifier(node) {
                 let name = node.name,
                     parent = node.parent,
                     effectiveParent = (parent.type === "MemberExpression") ? parent.parent : parent;

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -82,7 +82,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let MESSAGE = "Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.";
         let DEFAULT_VARIABLE_INDENT = 1;
@@ -154,10 +154,10 @@ module.exports = {
          */
         function report(node, needed, gotten, loc, isLastNodeCheck) {
             let msgContext = {
-                needed: needed,
+                needed,
                 type: indentType,
                 characters: needed === 1 ? "character" : "characters",
-                gotten: gotten
+                gotten
             };
             let indentChar = indentType === "space" ? " " : "\t";
 
@@ -208,15 +208,15 @@ module.exports = {
 
             if (loc) {
                 context.report({
-                    node: node,
-                    loc: loc,
+                    node,
+                    loc,
                     message: MESSAGE,
                     data: msgContext,
                     fix: getFixerFunction()
                 });
             } else {
                 context.report({
-                    node: node,
+                    node,
                     message: MESSAGE,
                     data: msgContext,
                     fix: getFixerFunction()
@@ -786,7 +786,7 @@ module.exports = {
         }
 
         return {
-            Program: function(node) {
+            Program(node) {
                 if (node.body.length > 0) {
 
                     // Root nodes should have no indent
@@ -808,27 +808,27 @@ module.exports = {
 
             DoWhileStatement: blockLessNodes,
 
-            IfStatement: function(node) {
+            IfStatement(node) {
                 if (node.consequent.type !== "BlockStatement" && node.consequent.loc.start.line > node.loc.start.line) {
                     blockIndentationCheck(node);
                 }
             },
 
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 if (node.declarations[node.declarations.length - 1].loc.start.line > node.declarations[0].loc.start.line) {
                     checkIndentInVariableDeclarations(node);
                 }
             },
 
-            ObjectExpression: function(node) {
+            ObjectExpression(node) {
                 checkIndentInArrayOrObjectBlock(node);
             },
 
-            ArrayExpression: function(node) {
+            ArrayExpression(node) {
                 checkIndentInArrayOrObjectBlock(node);
             },
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 if (typeof options.MemberExpression === "undefined") {
                     return;
                 }
@@ -862,7 +862,7 @@ module.exports = {
                 checkNodesIndent(checkNodes, propertyIndent);
             },
 
-            SwitchStatement: function(node) {
+            SwitchStatement(node) {
 
                 // Switch is not a 'BlockStatement'
                 let switchIndent = getNodeIndent(node);
@@ -874,7 +874,7 @@ module.exports = {
                 checkLastNodeLineIndent(node, switchIndent);
             },
 
-            SwitchCase: function(node) {
+            SwitchCase(node) {
 
                 // Skip inline cases
                 if (isSingleLineNode(node)) {

--- a/lib/rules/init-declarations.js
+++ b/lib/rules/init-declarations.js
@@ -85,7 +85,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
 
         let MODE_ALWAYS = "always",
             MODE_NEVER = "never";
@@ -98,7 +98,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            "VariableDeclaration:exit": function(node) {
+            "VariableDeclaration:exit"(node) {
 
                 let kind = node.kind,
                     declarations = node.declarations;

--- a/lib/rules/jsx-quotes.js
+++ b/lib/rules/jsx-quotes.js
@@ -19,14 +19,14 @@ let QUOTE_SETTINGS = {
     "prefer-double": {
         quote: "\"",
         description: "singlequote",
-        convert: function(str) {
+        convert(str) {
             return str.replace(/'/g, "\"");
         }
     },
     "prefer-single": {
         quote: "'",
         description: "doublequote",
-        convert: function(str) {
+        convert(str) {
             return str.replace(/"/g, "'");
         }
     }
@@ -53,7 +53,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let quoteOption = context.options[0] || "prefer-double",
             setting = QUOTE_SETTINGS[quoteOption];
 
@@ -68,14 +68,14 @@ module.exports = {
         }
 
         return {
-            JSXAttribute: function(node) {
+            JSXAttribute(node) {
                 let attributeValue = node.value;
 
                 if (attributeValue && astUtils.isStringLiteral(attributeValue) && !usesExpectedQuotes(attributeValue)) {
                     context.report({
                         node: attributeValue,
                         message: "Unexpected usage of " + setting.description + ".",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.replaceText(attributeValue, setting.convert(attributeValue.raw));
                         }
                     });

--- a/lib/rules/key-spacing.js
+++ b/lib/rules/key-spacing.js
@@ -323,7 +323,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * OPTIONS
@@ -464,7 +464,7 @@ module.exports = {
                         computed: property.computed ? "computed " : "",
                         key: getKey(property)
                     },
-                    fix: fix
+                    fix
                 });
             }
         }
@@ -618,7 +618,7 @@ module.exports = {
         if (alignmentOptions) { // Verify vertical alignment
 
             return {
-                ObjectExpression: function(node) {
+                ObjectExpression(node) {
                     if (isSingleLine(node)) {
                         verifyListSpacing(node.properties.filter(isKeyValueProperty));
                     } else {
@@ -630,7 +630,7 @@ module.exports = {
         } else { // Obey beforeColon and afterColon in each property as configured
 
             return {
-                Property: function(node) {
+                Property(node) {
                     verifySpacing(node, isSingleLine(node.parent) ? singleLineOptions : multiLineOptions);
                 }
             };

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -100,7 +100,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         /**
@@ -126,7 +126,7 @@ module.exports = {
                     loc: token.loc.start,
                     message: "Expected space(s) before \"{{value}}\".",
                     data: token,
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.insertTextBefore(token, " ");
                     }
                 });
@@ -156,7 +156,7 @@ module.exports = {
                     loc: token.loc.start,
                     message: "Unexpected space(s) before \"{{value}}\".",
                     data: token,
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.removeRange([prevToken.range[1], token.range[0]]);
                     }
                 });
@@ -186,7 +186,7 @@ module.exports = {
                     loc: token.loc.start,
                     message: "Expected space(s) after \"{{value}}\".",
                     data: token,
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.insertTextAfter(token, " ");
                     }
                 });
@@ -216,7 +216,7 @@ module.exports = {
                     loc: token.loc.start,
                     message: "Unexpected space(s) after \"{{value}}\".",
                     data: token,
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.removeRange([token.range[1], nextToken.range[0]]);
                     }
                 });

--- a/lib/rules/linebreak-style.js
+++ b/lib/rules/linebreak-style.js
@@ -26,7 +26,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let EXPECTED_LF_MSG = "Expected linebreaks to be 'LF' but found 'CRLF'.",
             EXPECTED_CRLF_MSG = "Expected linebreaks to be 'CRLF' but found 'LF'.";
@@ -76,7 +76,7 @@ module.exports = {
                     index = match.index;
                     range = [index, index + match[0].length];
                     context.report({
-                        node: node,
+                        node,
                         loc: {
                             line: i,
                             column: sourceCode.lines[i - 1].length

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -106,7 +106,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let options = context.options[0] ? lodash.assign({}, context.options[0]) : {};
 
@@ -316,9 +316,9 @@ module.exports = {
                 let range = [lineStart, lineStart];
 
                 context.report({
-                    node: node,
+                    node,
                     message: "Expected line before comment.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.insertTextBeforeRange(range, "\n");
                     }
                 });
@@ -328,9 +328,9 @@ module.exports = {
             if (!exceptionEndAllowed && after && !lodash.includes(commentAndEmptyLines, nextLineNum) &&
                     !(isCommentNodeType(nextTokenOrComment) && astUtils.isTokenOnSameLine(node, nextTokenOrComment))) {
                 context.report({
-                    node: node,
+                    node,
                     message: "Expected line after comment.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.insertTextAfter(node, "\n");
                     }
                 });
@@ -344,7 +344,7 @@ module.exports = {
 
         return {
 
-            LineComment: function(node) {
+            LineComment(node) {
                 if (options.beforeLineComment || options.afterLineComment) {
                     checkForEmptyLine(node, {
                         after: options.afterLineComment,
@@ -353,7 +353,7 @@ module.exports = {
                 }
             },
 
-            BlockComment: function(node) {
+            BlockComment(node) {
                 if (options.beforeBlockComment || options.afterBlockComment) {
                     checkForEmptyLine(node, {
                         after: options.afterBlockComment,

--- a/lib/rules/max-depth.js
+++ b/lib/rules/max-depth.js
@@ -43,7 +43,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -115,7 +115,7 @@ module.exports = {
             FunctionExpression: startFunction,
             ArrowFunctionExpression: startFunction,
 
-            IfStatement: function(node) {
+            IfStatement(node) {
                 if (node.parent.type !== "IfStatement") {
                     pushBlock(node);
                 }

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -69,7 +69,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         /*
          * Inspired by http://tools.ietf.org/html/rfc3986#appendix-B, however:

--- a/lib/rules/max-lines.js
+++ b/lib/rules/max-lines.js
@@ -51,7 +51,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let option = context.options[0],
             max = 300;
 
@@ -113,9 +113,9 @@ module.exports = {
         }
 
         return {
-            "Program:exit": function() {
+            "Program:exit"() {
                 let lines = sourceCode.lines.map(function(text, i) {
-                    return { lineNumber: i + 1, text: text };
+                    return { lineNumber: i + 1, text };
                 });
 
                 if (skipBlankLines) {

--- a/lib/rules/max-nested-callbacks.js
+++ b/lib/rules/max-nested-callbacks.js
@@ -43,7 +43,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Constants

--- a/lib/rules/max-params.js
+++ b/lib/rules/max-params.js
@@ -43,7 +43,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let option = context.options[0],
             numParams = 3;

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -30,7 +30,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let sourceCode = context.getSourceCode(),
             options = context.options[0] || {},
@@ -89,7 +89,7 @@ module.exports = {
 
             // Reports if the node violated this rule.
             if (numberOfStatementsOnThisLine === maxStatementsPerLine + 1) {
-                context.report({node: node, message: message});
+                context.report({node, message});
             }
         }
 
@@ -166,7 +166,7 @@ module.exports = {
             // Empty blocks should be warned if `{max: 0}` was given.
             BlockStatement: function reportIfZero(node) {
                 if (maxStatementsPerLine === 0 && node.body.length === 0) {
-                    context.report({node: node, message: message});
+                    context.report({node, message});
                 }
             }
         };

--- a/lib/rules/max-statements.js
+++ b/lib/rules/max-statements.js
@@ -52,7 +52,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -87,7 +87,7 @@ module.exports = {
                 context.report(
                     node,
                     "This function has too many statements ({{count}}). Maximum allowed is {{max}}.",
-                    { count: count, max: max });
+                    { count, max });
             }
         }
 
@@ -110,7 +110,7 @@ module.exports = {
             let count = functionStack.pop();
 
             if (ignoreTopLevelFunctions && functionStack.length === 0) {
-                topLevelFunctions.push({ node: node, count: count});
+                topLevelFunctions.push({ node, count});
             } else {
                 reportIfTooManyStatements(node, count, maxStatements);
             }
@@ -141,7 +141,7 @@ module.exports = {
             "FunctionExpression:exit": endFunction,
             "ArrowFunctionExpression:exit": endFunction,
 
-            "Program:exit": function() {
+            "Program:exit"() {
                 if (topLevelFunctions.length === 1) {
                     return;
                 }

--- a/lib/rules/multiline-ternary.js
+++ b/lib/rules/multiline-ternary.js
@@ -21,7 +21,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -36,7 +36,7 @@ module.exports = {
          */
         function reportError(node, parentNode) {
             context.report({
-                node: node,
+                node,
                 message: "Expected newline between {{typeOfError}} of ternary expression.",
                 data: {
                     typeOfError: node === parentNode.test ? "test and consequent" : "consequent and alternate"
@@ -49,7 +49,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            ConditionalExpression: function(node) {
+            ConditionalExpression(node) {
                 let areTestAndConsequentOnSameLine = astUtils.isTokenOnSameLine(node.test, node.consequent);
                 let areConsequentAndAlternateOnSameLine = astUtils.isTokenOnSameLine(node.consequent, node.alternate);
 

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -113,7 +113,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let config = context.options[0] ? lodash.assign({}, context.options[0]) : {};
 

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -20,12 +20,12 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
 
-            NewExpression: function(node) {
+            NewExpression(node) {
                 let tokens = sourceCode.getTokens(node);
                 let prenticesTokens = tokens.filter(function(token) {
                     return token.value === "(" || token.value === ")";

--- a/lib/rules/newline-after-var.js
+++ b/lib/rules/newline-after-var.js
@@ -24,7 +24,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let ALWAYS_MESSAGE = "Expected blank line after variable declarations.",
             NEVER_MESSAGE = "Unexpected blank line after variable declarations.";

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
@@ -138,10 +138,10 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            ReturnStatement: function(node) {
+            ReturnStatement(node) {
                 if (!isFirstNode(node) && !hasNewlineBefore(node)) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Expected newline before return statement."
                     });
                 }

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -31,7 +31,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
 
         let options = context.options[0] || {},
             ignoreChainWithDepth = options.ignoreChainWithDepth || 2;
@@ -54,7 +54,7 @@ module.exports = {
         }
 
         return {
-            "CallExpression:exit": function(node) {
+            "CallExpression:exit"(node) {
                 if (!node.callee || node.callee.type !== "MemberExpression") {
                     return;
                 }

--- a/lib/rules/no-alert.js
+++ b/lib/rules/no-alert.js
@@ -107,16 +107,16 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let globalScope;
 
         return {
 
-            Program: function() {
+            Program() {
                 globalScope = context.getScope();
             },
 
-            CallExpression: function(node) {
+            CallExpression(node) {
                 let callee = node.callee,
                     identifierName,
                     currentScope = context.getScope();

--- a/lib/rules/no-array-constructor.js
+++ b/lib/rules/no-array-constructor.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Disallow construction of dense arrays using the Array constructor

--- a/lib/rules/no-bitwise.js
+++ b/lib/rules/no-bitwise.js
@@ -46,7 +46,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let allowed = options.allow || [];
         let int32Hint = options.int32Hint === true;

--- a/lib/rules/no-caller.js
+++ b/lib/rules/no-caller.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 let objectName = node.object.name,
                     propertyName = node.property.name;
 

--- a/lib/rules/no-case-declarations.js
+++ b/lib/rules/no-case-declarations.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Checks whether or not a node is a lexical declaration.
@@ -39,13 +39,13 @@ module.exports = {
         }
 
         return {
-            SwitchCase: function(node) {
+            SwitchCase(node) {
                 for (let i = 0; i < node.consequent.length; i++) {
                     let statement = node.consequent[i];
 
                     if (isLexicalDeclaration(statement)) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Unexpected lexical declaration in case block."
                         });
                     }

--- a/lib/rules/no-catch-shadow.js
+++ b/lib/rules/no-catch-shadow.js
@@ -26,7 +26,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -48,7 +48,7 @@ module.exports = {
 
         return {
 
-            CatchClause: function(node) {
+            CatchClause(node) {
                 let scope = context.getScope();
 
                 // When blockBindings is enabled, CatchClause creates its own scope

--- a/lib/rules/no-class-assign.js
+++ b/lib/rules/no-class-assign.js
@@ -22,7 +22,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Finds and reports references that are non initializer and writable.

--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -30,7 +30,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let prohibitAssign = (context.options[0] || "except-parens");
 
@@ -107,7 +107,7 @@ module.exports = {
 
                 // must match JSHint's error message
                 context.report({
-                    node: node,
+                    node,
                     loc: node.test.loc.start,
                     message: "Expected a conditional expression and instead saw an assignment."
                 });

--- a/lib/rules/no-confusing-arrow.js
+++ b/lib/rules/no-confusing-arrow.js
@@ -42,7 +42,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
         let config = context.options[0] || {};
         let sourceCode = context.getSourceCode();
 

--- a/lib/rules/no-console.js
+++ b/lib/rules/no-console.js
@@ -35,11 +35,11 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
 
                 if (node.object.name === "console") {
                     let blockConsole = true;

--- a/lib/rules/no-const-assign.js
+++ b/lib/rules/no-const-assign.js
@@ -22,7 +22,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Finds and reports references that are non initializer and writable.
@@ -39,7 +39,7 @@ module.exports = {
         }
 
         return {
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 if (node.kind === "const") {
                     context.getDeclaredVariables(node).forEach(checkVariable);
                 }

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -31,7 +31,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {},
             checkLoops = options.checkLoops !== false;
 

--- a/lib/rules/no-continue.js
+++ b/lib/rules/no-continue.js
@@ -20,10 +20,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            ContinueStatement: function(node) {
+            ContinueStatement(node) {
                 context.report(node, "Unexpected use of continue statement.");
             }
         };

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Get the regex expression
@@ -77,7 +77,7 @@ module.exports = {
         }
 
         return {
-            Literal: function(node) {
+            Literal(node) {
                 let computedValue,
                     regex = getRegExp(node);
 

--- a/lib/rules/no-debugger.js
+++ b/lib/rules/no-debugger.js
@@ -20,10 +20,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            DebuggerStatement: function(node) {
+            DebuggerStatement(node) {
                 context.report(node, "Unexpected 'debugger' statement.");
             }
         };

--- a/lib/rules/no-delete-var.js
+++ b/lib/rules/no-delete-var.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            UnaryExpression: function(node) {
+            UnaryExpression(node) {
                 if (node.operator === "delete" && node.argument.type === "Identifier") {
                     context.report(node, "Variables should not be deleted.");
                 }

--- a/lib/rules/no-div-regex.js
+++ b/lib/rules/no-div-regex.js
@@ -20,12 +20,12 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
                 let token = sourceCode.getFirstToken(node);
 
                 if (token.type === "RegularExpression" && token.value[1] === "=") {

--- a/lib/rules/no-dupe-args.js
+++ b/lib/rules/no-dupe-args.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -52,7 +52,7 @@ module.exports = {
 
                 if (defs.length >= 2) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Duplicate param '{{name}}'.",
                         data: {name: variable.name}
                     });

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let stack = [];
 
         /**
@@ -65,22 +65,22 @@ module.exports = {
         return {
 
             // Initializes the stack of state of member declarations.
-            Program: function() {
+            Program() {
                 stack = [];
             },
 
             // Initializes state of member declarations for the class.
-            ClassBody: function() {
+            ClassBody() {
                 stack.push(Object.create(null));
             },
 
             // Disposes the state for the class.
-            "ClassBody:exit": function() {
+            "ClassBody:exit"() {
                 stack.pop();
             },
 
             // Reports the node if its name has been declared already.
-            MethodDefinition: function(node) {
+            MethodDefinition(node) {
                 if (node.computed) {
                     return;
                 }
@@ -101,7 +101,7 @@ module.exports = {
                 }
 
                 if (isDuplicate) {
-                    context.report(node, "Duplicate name '{{name}}'.", {name: name});
+                    context.report(node, "Duplicate name '{{name}}'.", {name});
                 }
             }
         };

--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            ObjectExpression: function(node) {
+            ObjectExpression(node) {
 
                 // Object that will be a map of properties--safe because we will
                 // prefix all of the keys.

--- a/lib/rules/no-duplicate-case.js
+++ b/lib/rules/no-duplicate-case.js
@@ -21,11 +21,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
-            SwitchStatement: function(node) {
+            SwitchStatement(node) {
                 let mapping = {};
 
                 node.cases.forEach(function(switchCase) {

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -36,7 +36,7 @@ function getValue(node) {
 function checkAndReport(context, node, value, array, message) {
     if (array.indexOf(value) !== -1) {
         context.report({
-            node: node,
+            node,
             message: "'{{module}}' " + message,
             data: {module: value}
         });
@@ -115,7 +115,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
         let includeExports = (context.options[0] || {}).includeExports,
             importsInFile = [],
             exportsInFile = [];

--- a/lib/rules/no-else-return.js
+++ b/lib/rules/no-else-return.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -127,7 +127,7 @@ module.exports = {
 
         return {
 
-            IfStatement: function(node) {
+            IfStatement(node) {
                 let parent = context.getAncestors().pop(),
                     consequents,
                     alternate;

--- a/lib/rules/no-empty-character-class.js
+++ b/lib/rules/no-empty-character-class.js
@@ -38,12 +38,12 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
                 let token = sourceCode.getFirstToken(node);
 
                 if (token.type === "RegularExpression" && !regex.test(token.value)) {

--- a/lib/rules/no-empty-function.js
+++ b/lib/rules/no-empty-function.js
@@ -117,7 +117,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let allowed = options.allow || [];
 
@@ -144,7 +144,7 @@ module.exports = {
                 sourceCode.getComments(node.body).trailing.length === 0
             ) {
                 context.report({
-                    node: node,
+                    node,
                     loc: node.body.loc.start,
                     message: "Unexpected empty " + SHOW_KIND[kind] + "."
                 });

--- a/lib/rules/no-empty-pattern.js
+++ b/lib/rules/no-empty-pattern.js
@@ -19,14 +19,14 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         return {
-            ObjectPattern: function(node) {
+            ObjectPattern(node) {
                 if (node.properties.length === 0) {
                     context.report(node, "Unexpected empty object pattern.");
                 }
             },
-            ArrayPattern: function(node) {
+            ArrayPattern(node) {
                 if (node.elements.length === 0) {
                     context.report(node, "Unexpected empty array pattern.");
                 }

--- a/lib/rules/no-empty.js
+++ b/lib/rules/no-empty.js
@@ -35,14 +35,14 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {},
             allowEmptyCatch = options.allowEmptyCatch || false;
 
         let sourceCode = context.getSourceCode();
 
         return {
-            BlockStatement: function(node) {
+            BlockStatement(node) {
 
                 // if the body is not empty, we can just return immediately
                 if (node.body.length !== 0) {
@@ -66,7 +66,7 @@ module.exports = {
                 context.report(node, "Empty block statement.");
             },
 
-            SwitchStatement: function(node) {
+            SwitchStatement(node) {
 
                 if (typeof node.cases === "undefined" || node.cases.length === 0) {
                     context.report(node, "Empty switch statement.");

--- a/lib/rules/no-eq-null.js
+++ b/lib/rules/no-eq-null.js
@@ -21,11 +21,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
                 let badOperator = node.operator === "==" || node.operator === "!=";
 
                 if (node.right.type === "Literal" && node.right.raw === "null" && badOperator ||

--- a/lib/rules/no-eval.js
+++ b/lib/rules/no-eval.js
@@ -93,7 +93,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let allowIndirect = Boolean(
             context.options[0] &&
             context.options[0].allowIndirect
@@ -116,8 +116,8 @@ module.exports = {
 
             funcInfo = {
                 upper: funcInfo,
-                node: node,
-                strict: strict,
+                node,
+                strict,
                 defaultThis: false,
                 initialized: strict
             };
@@ -157,7 +157,7 @@ module.exports = {
             }
 
             context.report({
-                node: node,
+                node,
                 loc: locationNode.loc.start,
                 message: "eval can be harmful."
             });
@@ -228,7 +228,7 @@ module.exports = {
 
             // Checks only direct calls to eval. It's simple!
             return {
-                "CallExpression:exit": function(node) {
+                "CallExpression:exit"(node) {
                     let callee = node.callee;
 
                     if (isIdentifier(callee, "eval")) {
@@ -239,7 +239,7 @@ module.exports = {
         }
 
         return {
-            "CallExpression:exit": function(node) {
+            "CallExpression:exit"(node) {
                 let callee = node.callee;
 
                 if (isIdentifier(callee, "eval")) {
@@ -247,7 +247,7 @@ module.exports = {
                 }
             },
 
-            Program: function(node) {
+            Program(node) {
                 let scope = context.getScope(),
                     features = context.parserOptions.ecmaFeatures || {},
                     strict =
@@ -257,14 +257,14 @@ module.exports = {
 
                 funcInfo = {
                     upper: null,
-                    node: node,
-                    strict: strict,
+                    node,
+                    strict,
                     defaultThis: true,
                     initialized: true
                 };
             },
 
-            "Program:exit": function() {
+            "Program:exit"() {
                 let globalScope = context.getScope();
 
                 exitVarScope();
@@ -279,7 +279,7 @@ module.exports = {
             ArrowFunctionExpression: enterVarScope,
             "ArrowFunctionExpression:exit": exitVarScope,
 
-            ThisExpression: function(node) {
+            ThisExpression(node) {
                 if (!isMember(node.parent, "eval")) {
                     return;
                 }

--- a/lib/rules/no-ex-assign.js
+++ b/lib/rules/no-ex-assign.js
@@ -22,7 +22,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Finds and reports references that are non initializer and writable.
@@ -38,7 +38,7 @@ module.exports = {
         }
 
         return {
-            CatchClause: function(node) {
+            CatchClause(node) {
                 context.getDeclaredVariables(node).forEach(checkVariable);
             }
         };

--- a/lib/rules/no-extend-native.js
+++ b/lib/rules/no-extend-native.js
@@ -40,7 +40,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let config = context.options[0] || {};
         let exceptions = config.exceptions || [];
@@ -57,7 +57,7 @@ module.exports = {
         return {
 
             // handle the Array.prototype.extra style case
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
                 let lhs = node.left,
                     affectsProto;
 
@@ -81,7 +81,7 @@ module.exports = {
             },
 
             // handle the Object.definePropert[y|ies](Array.prototype) case
-            CallExpression: function(node) {
+            CallExpression(node) {
 
                 let callee = node.callee,
                     subject,

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         // Node types which have a test which will coerce values to booleans.
         let BOOLEAN_NODE_TYPES = [
@@ -51,7 +51,7 @@ module.exports = {
 
 
         return {
-            UnaryExpression: function(node) {
+            UnaryExpression(node) {
                 let ancestors = context.getAncestors(),
                     parent = ancestors.pop(),
                     grandparent = ancestors.pop();
@@ -73,7 +73,7 @@ module.exports = {
                     context.report(node, "Redundant double negation.");
                 }
             },
-            CallExpression: function(node) {
+            CallExpression(node) {
                 let parent = node.parent;
 
                 if (node.callee.type !== "Identifier" || node.callee.name !== "Boolean") {

--- a/lib/rules/no-extra-label.js
+++ b/lib/rules/no-extra-label.js
@@ -26,7 +26,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -53,7 +53,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         let isParenthesised = astUtils.isParenthesised.bind(astUtils, sourceCode);
@@ -329,7 +329,7 @@ module.exports = {
         }
 
         return {
-            ArrayExpression: function(node) {
+            ArrayExpression(node) {
                 [].forEach.call(node.elements, function(e) {
                     if (e && hasExcessParens(e) && precedence(e) >= precedence({type: "AssignmentExpression"})) {
                         report(e);
@@ -337,7 +337,7 @@ module.exports = {
                 });
             },
 
-            ArrowFunctionExpression: function(node) {
+            ArrowFunctionExpression(node) {
                 if (isReturnAssignException(node)) {
                     return;
                 }
@@ -356,7 +356,7 @@ module.exports = {
                 }
             },
 
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
                 if (isReturnAssignException(node)) {
                     return;
                 }
@@ -369,7 +369,7 @@ module.exports = {
             BinaryExpression: dryBinaryLogical,
             CallExpression: dryCallNew,
 
-            ConditionalExpression: function(node) {
+            ConditionalExpression(node) {
                 if (isReturnAssignException(node)) {
                     return;
                 }
@@ -387,13 +387,13 @@ module.exports = {
                 }
             },
 
-            DoWhileStatement: function(node) {
+            DoWhileStatement(node) {
                 if (hasDoubleExcessParens(node.test) && !isCondAssignException(node)) {
                     report(node.test);
                 }
             },
 
-            ExpressionStatement: function(node) {
+            ExpressionStatement(node) {
                 let firstToken, secondToken, firstTokens;
 
                 if (hasExcessParens(node.expression)) {
@@ -417,19 +417,19 @@ module.exports = {
                 }
             },
 
-            ForInStatement: function(node) {
+            ForInStatement(node) {
                 if (hasExcessParens(node.right)) {
                     report(node.right);
                 }
             },
 
-            ForOfStatement: function(node) {
+            ForOfStatement(node) {
                 if (hasExcessParens(node.right)) {
                     report(node.right);
                 }
             },
 
-            ForStatement: function(node) {
+            ForStatement(node) {
                 if (node.init && hasExcessParens(node.init)) {
                     report(node.init);
                 }
@@ -443,7 +443,7 @@ module.exports = {
                 }
             },
 
-            IfStatement: function(node) {
+            IfStatement(node) {
                 if (hasDoubleExcessParens(node.test) && !isCondAssignException(node)) {
                     report(node.test);
                 }
@@ -451,7 +451,7 @@ module.exports = {
 
             LogicalExpression: dryBinaryLogical,
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 if (
                     hasExcessParens(node.object) &&
                     precedence(node.object) >= precedence(node) &&
@@ -482,7 +482,7 @@ module.exports = {
 
             NewExpression: dryCallNew,
 
-            ObjectExpression: function(node) {
+            ObjectExpression(node) {
                 [].forEach.call(node.properties, function(e) {
                     let v = e.value;
 
@@ -492,7 +492,7 @@ module.exports = {
                 });
             },
 
-            ReturnStatement: function(node) {
+            ReturnStatement(node) {
                 let returnToken = sourceCode.getFirstToken(node);
 
                 if (isReturnAssignException(node)) {
@@ -508,7 +508,7 @@ module.exports = {
                 }
             },
 
-            SequenceExpression: function(node) {
+            SequenceExpression(node) {
                 [].forEach.call(node.expressions, function(e) {
                     if (hasExcessParens(e) && precedence(e) >= precedence(node)) {
                         report(e);
@@ -516,19 +516,19 @@ module.exports = {
                 });
             },
 
-            SwitchCase: function(node) {
+            SwitchCase(node) {
                 if (node.test && hasExcessParens(node.test)) {
                     report(node.test);
                 }
             },
 
-            SwitchStatement: function(node) {
+            SwitchStatement(node) {
                 if (hasDoubleExcessParens(node.discriminant)) {
                     report(node.discriminant);
                 }
             },
 
-            ThrowStatement: function(node) {
+            ThrowStatement(node) {
                 let throwToken = sourceCode.getFirstToken(node);
 
                 if (hasExcessParensNoLineTerminator(throwToken, node.argument)) {
@@ -539,7 +539,7 @@ module.exports = {
             UnaryExpression: dryUnaryUpdate,
             UpdateExpression: dryUnaryUpdate,
 
-            VariableDeclarator: function(node) {
+            VariableDeclarator(node) {
                 if (node.init && hasExcessParens(node.init) &&
                         precedence(node.init) >= precedence({type: "AssignmentExpression"}) &&
 
@@ -549,19 +549,19 @@ module.exports = {
                 }
             },
 
-            WhileStatement: function(node) {
+            WhileStatement(node) {
                 if (hasDoubleExcessParens(node.test) && !isCondAssignException(node)) {
                     report(node.test);
                 }
             },
 
-            WithStatement: function(node) {
+            WithStatement(node) {
                 if (hasDoubleExcessParens(node.object)) {
                     report(node.object);
                 }
             },
 
-            YieldExpression: function(node) {
+            YieldExpression(node) {
                 let yieldToken;
 
                 if (node.argument) {

--- a/lib/rules/no-extra-semi.js
+++ b/lib/rules/no-extra-semi.js
@@ -21,7 +21,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         /**
@@ -33,7 +33,7 @@ module.exports = {
             context.report({
                 node: nodeOrToken,
                 message: "Unnecessary semicolon.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.remove(nodeOrToken);
                 }
             });
@@ -64,7 +64,7 @@ module.exports = {
              * @param {Node} node - A EmptyStatement node to be reported.
              * @returns {void}
              */
-            EmptyStatement: function(node) {
+            EmptyStatement(node) {
                 let parent = node.parent,
                     allowedParentTypes = [
                         "ForStatement",
@@ -87,7 +87,7 @@ module.exports = {
              * @param {Node} node - A ClassBody node to check.
              * @returns {void}
              */
-            ClassBody: function(node) {
+            ClassBody(node) {
                 checkForPartOfClassBody(sourceCode.getFirstToken(node, 1)); // 0 is `{`.
             },
 
@@ -96,7 +96,7 @@ module.exports = {
              * @param {Node} node - A MethodDefinition node of the start point.
              * @returns {void}
              */
-            MethodDefinition: function(node) {
+            MethodDefinition(node) {
                 checkForPartOfClassBody(sourceCode.getTokenAfter(node));
             }
         };

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -74,7 +74,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let currentCodePath = null;
         let sourceCode = context.getSourceCode();
@@ -93,14 +93,14 @@ module.exports = {
         }
 
         return {
-            onCodePathStart: function(codePath) {
+            onCodePathStart(codePath) {
                 currentCodePath = codePath;
             },
-            onCodePathEnd: function() {
+            onCodePathEnd() {
                 currentCodePath = currentCodePath.upper;
             },
 
-            SwitchCase: function(node) {
+            SwitchCase(node) {
 
                 /*
                  * Checks whether or not there is a fallthrough comment.
@@ -110,13 +110,13 @@ module.exports = {
                     context.report({
                         message: "Expected a 'break' statement before '{{type}}'.",
                         data: {type: node.test ? "case" : "default"},
-                        node: node
+                        node
                     });
                 }
                 fallthroughCase = null;
             },
 
-            "SwitchCase:exit": function(node) {
+            "SwitchCase:exit"(node) {
                 let nextToken = sourceCode.getTokenAfter(node);
 
                 /*

--- a/lib/rules/no-floating-decimal.js
+++ b/lib/rules/no-floating-decimal.js
@@ -20,10 +20,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            Literal: function(node) {
+            Literal(node) {
 
                 if (typeof node.value === "number") {
                     if (node.raw.indexOf(".") === 0) {

--- a/lib/rules/no-func-assign.js
+++ b/lib/rules/no-func-assign.js
@@ -22,7 +22,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Reports a reference if is non initializer and writable.

--- a/lib/rules/no-global-assign.js
+++ b/lib/rules/no-global-assign.js
@@ -32,7 +32,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let config = context.options[0];
         let exceptions = (config && config.exceptions) || [];
 
@@ -73,7 +73,7 @@ module.exports = {
         }
 
         return {
-            Program: function() {
+            Program() {
                 let globalScope = context.getScope();
 
                 globalScope.variables.forEach(checkVariable);

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -175,14 +175,14 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
         let options = parseOptions(context.options[0]),
             operatorAllowed = false;
 
         let sourceCode = context.getSourceCode();
 
         return {
-            UnaryExpression: function(node) {
+            UnaryExpression(node) {
 
                 // !!foo
                 operatorAllowed = options.allow.indexOf("!!") >= 0;
@@ -216,7 +216,7 @@ module.exports = {
             },
 
             // Use `:exit` to prevent double reporting
-            "BinaryExpression:exit": function(node) {
+            "BinaryExpression:exit"(node) {
 
                 // 1 * foo
                 operatorAllowed = options.allow.indexOf("*") >= 0;
@@ -241,7 +241,7 @@ module.exports = {
                 }
             },
 
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
 
                 // foo += ""
                 operatorAllowed = options.allow.indexOf("+") >= 0;

--- a/lib/rules/no-implicit-globals.js
+++ b/lib/rules/no-implicit-globals.js
@@ -20,9 +20,9 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         return {
-            Program: function() {
+            Program() {
                 let scope = context.getScope();
 
                 scope.variables.forEach(function(variable) {

--- a/lib/rules/no-implied-eval.js
+++ b/lib/rules/no-implied-eval.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let CALLEE_RE = /set(?:Timeout|Interval)|execScript/;
 
         /*
@@ -114,7 +114,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
                 if (isImpliedEvalCallExpression(node)) {
 
                     // call expressions create a new substack
@@ -122,7 +122,7 @@ module.exports = {
                 }
             },
 
-            "CallExpression:exit": function(node) {
+            "CallExpression:exit"(node) {
                 if (node === last(last(impliedEvalAncestorsStack))) {
 
                     /* Destroys the entire sub-stack, rather than just using
@@ -133,25 +133,25 @@ module.exports = {
                 }
             },
 
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
                 if (node.operator === "+" && hasImpliedEvalParent(node)) {
                     last(impliedEvalAncestorsStack).push(node);
                 }
             },
 
-            "BinaryExpression:exit": function(node) {
+            "BinaryExpression:exit"(node) {
                 if (node === last(last(impliedEvalAncestorsStack))) {
                     last(impliedEvalAncestorsStack).pop();
                 }
             },
 
-            Literal: function(node) {
+            Literal(node) {
                 if (typeof node.value === "string") {
                     checkString(node);
                 }
             },
 
-            TemplateLiteral: function(node) {
+            TemplateLiteral(node) {
                 checkString(node);
             }
         };

--- a/lib/rules/no-inline-comments.js
+++ b/lib/rules/no-inline-comments.js
@@ -21,7 +21,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         /**

--- a/lib/rules/no-inner-declarations.js
+++ b/lib/rules/no-inner-declarations.js
@@ -24,7 +24,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Find the nearest Program or Function ancestor node.
@@ -77,7 +77,7 @@ module.exports = {
         return {
 
             FunctionDeclaration: check,
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 if (context.options[0] === "both" && node.kind === "var") {
                     check(node);
                 }

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -36,7 +36,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
 
         let options = context.options[0],
             allowedFlags = "";

--- a/lib/rules/no-invalid-this.js
+++ b/lib/rules/no-invalid-this.js
@@ -26,7 +26,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let stack = [],
             sourceCode = context.getSourceCode();
 
@@ -66,7 +66,7 @@ module.exports = {
             // `this` can be invalid only under strict mode.
             stack.push({
                 init: !context.getScope().isStrict,
-                node: node,
+                node,
                 valid: true
             });
         }
@@ -85,13 +85,13 @@ module.exports = {
              * `this` is invalid only under strict mode.
              * Modules is always strict mode.
              */
-            Program: function(node) {
+            Program(node) {
                 let scope = context.getScope(),
                     features = context.parserOptions.ecmaFeatures || {};
 
                 stack.push({
                     init: true,
-                    node: node,
+                    node,
                     valid: !(
                         scope.isStrict ||
                         node.sourceType === "module" ||
@@ -100,7 +100,7 @@ module.exports = {
                 });
             },
 
-            "Program:exit": function() {
+            "Program:exit"() {
                 stack.pop();
             },
 
@@ -110,7 +110,7 @@ module.exports = {
             "FunctionExpression:exit": exitFunction,
 
             // Reports if `this` of the current context is invalid.
-            ThisExpression: function(node) {
+            ThisExpression(node) {
                 let current = stack.getCurrent();
 
                 if (current && !current.valid) {

--- a/lib/rules/no-irregular-whitespace.js
+++ b/lib/rules/no-irregular-whitespace.js
@@ -49,7 +49,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         // Module store of errors that we have found
         let errors = [];

--- a/lib/rules/no-iterator.js
+++ b/lib/rules/no-iterator.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
 
                 if (node.property &&
                         (node.property.type === "Identifier" && node.property.name === "__iterator__" && !node.computed) ||

--- a/lib/rules/no-label-var.js
+++ b/lib/rules/no-label-var.js
@@ -26,7 +26,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -49,7 +49,7 @@ module.exports = {
 
         return {
 
-            LabeledStatement: function(node) {
+            LabeledStatement(node) {
 
                 // Fetch the innermost scope.
                 let scope = context.getScope();

--- a/lib/rules/no-labels.js
+++ b/lib/rules/no-labels.js
@@ -38,7 +38,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0];
         let allowLoop = Boolean(options && options.allowLoop);
         let allowSwitch = Boolean(options && options.allowSwitch);
@@ -99,7 +99,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            LabeledStatement: function(node) {
+            LabeledStatement(node) {
                 scopeInfo = {
                     label: node.label.name,
                     kind: getBodyKind(node.body),
@@ -107,10 +107,10 @@ module.exports = {
                 };
             },
 
-            "LabeledStatement:exit": function(node) {
+            "LabeledStatement:exit"(node) {
                 if (!isAllowed(scopeInfo.kind)) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Unexpected labeled statement."
                     });
                 }
@@ -118,19 +118,19 @@ module.exports = {
                 scopeInfo = scopeInfo.upper;
             },
 
-            BreakStatement: function(node) {
+            BreakStatement(node) {
                 if (node.label && !isAllowed(getKind(node.label.name))) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Unexpected label in break statement."
                     });
                 }
             },
 
-            ContinueStatement: function(node) {
+            ContinueStatement(node) {
                 if (node.label && !isAllowed(getKind(node.label.name))) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Unexpected label in continue statement."
                     });
                 }

--- a/lib/rules/no-lone-blocks.js
+++ b/lib/rules/no-lone-blocks.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         // A stack of lone blocks to be checked for block-level bindings
         let loneBlocks = [],
@@ -69,7 +69,7 @@ module.exports = {
 
         // Default rule definition: report all lone blocks
         ruleDef = {
-            BlockStatement: function(node) {
+            BlockStatement(node) {
                 if (isLoneBlock(node)) {
                     report(node);
                 }
@@ -79,12 +79,12 @@ module.exports = {
         // ES6: report blocks without block-level bindings
         if (context.parserOptions.ecmaVersion >= 6) {
             ruleDef = {
-                BlockStatement: function(node) {
+                BlockStatement(node) {
                     if (isLoneBlock(node)) {
                         loneBlocks.push(node);
                     }
                 },
-                "BlockStatement:exit": function(node) {
+                "BlockStatement:exit"(node) {
                     if (loneBlocks.length > 0 && loneBlocks[loneBlocks.length - 1] === node) {
                         loneBlocks.pop();
                         report(node);

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -19,10 +19,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            IfStatement: function(node) {
+            IfStatement(node) {
                 let ancestors = context.getAncestors(),
                     parent = ancestors.pop(),
                     grandparent = ancestors.pop();

--- a/lib/rules/no-loop-func.js
+++ b/lib/rules/no-loop-func.js
@@ -162,7 +162,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Reports functions which match the following condition:

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -41,7 +41,7 @@ module.exports = {
         }]
     },
 
-    create: function(context) {
+    create(context) {
         let config = context.options[0] || {},
             detectObjects = !!config.detectObjects,
             enforceConst = !!config.enforceConst,
@@ -99,7 +99,7 @@ module.exports = {
         }
 
         return {
-            Literal: function(node) {
+            Literal(node) {
                 let parent = node.parent,
                     value = node.value,
                     raw = node.raw,
@@ -127,14 +127,14 @@ module.exports = {
                 if (parent.type === "VariableDeclarator") {
                     if (enforceConst && parent.parent.kind !== "const") {
                         context.report({
-                            node: node,
+                            node,
                             message: "Number constants declarations must use 'const'."
                         });
                     }
                 } else if (okTypes.indexOf(parent.type) === -1 ||
                     (parent.type === "AssignmentExpression" && parent.operator !== "=")) {
                     context.report({
-                        node: node,
+                        node,
                         message: "No magic number: " + raw + "."
                     });
                 }

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -48,8 +48,8 @@ function normalizeOptions(options) {
     let allowSamePrecedence = (options && options.allowSamePrecedence) !== false;
 
     return {
-        groups: groups,
-        allowSamePrecedence: allowSamePrecedence
+        groups,
+        allowSamePrecedence
     };
 }
 
@@ -101,7 +101,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
         let options = normalizeOptions(context.options[0]);
 
@@ -179,12 +179,12 @@ module.exports = {
             context.report({
                 node: left,
                 loc: getOperatorToken(left).loc.start,
-                message: message
+                message
             });
             context.report({
                 node: right,
                 loc: getOperatorToken(right).loc.start,
-                message: message
+                message
             });
         }
 

--- a/lib/rules/no-mixed-requires.js
+++ b/lib/rules/no-mixed-requires.js
@@ -40,7 +40,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let grouping = false,
             allowCall = false,
@@ -202,7 +202,7 @@ module.exports = {
 
         return {
 
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
 
                 if (isMixed(node.declarations)) {
                     context.report(

--- a/lib/rules/no-mixed-spaces-and-tabs.js
+++ b/lib/rules/no-mixed-spaces-and-tabs.js
@@ -23,7 +23,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         let smartTabs,
@@ -74,11 +74,11 @@ module.exports = {
 
         return {
 
-            TemplateElement: function(node) {
+            TemplateElement(node) {
                 ignoredLocs.push(node.loc);
             },
 
-            "Program:exit": function(node) {
+            "Program:exit"(node) {
 
                 /*
                  * At least one space followed by a tab
@@ -133,7 +133,7 @@ module.exports = {
                             return;
                         }
 
-                        context.report(node, { line: lineNumber, column: column }, "Mixed spaces and tabs.");
+                        context.report(node, { line: lineNumber, column }, "Mixed spaces and tabs.");
                     }
                 });
             }

--- a/lib/rules/no-multi-spaces.js
+++ b/lib/rules/no-multi-spaces.js
@@ -38,7 +38,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         // the index of the last comment that was checked
         let exceptions = { Property: true },
@@ -93,7 +93,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            Program: function() {
+            Program() {
 
                 let sourceCode = context.getSourceCode(),
                     source = sourceCode.getText(),

--- a/lib/rules/no-multi-str.js
+++ b/lib/rules/no-multi-str.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Determines if a given node is part of JSX syntax.
@@ -38,7 +38,7 @@ module.exports = {
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
                 let lineBreak = /\n/;
 
                 if (lineBreak.test(node.raw) && !isJSXElement(node.parent)) {

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -42,7 +42,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         // Use options.max or 2 as default
         let max = 2,
@@ -66,7 +66,7 @@ module.exports = {
 
         return {
 
-            TemplateLiteral: function(node) {
+            TemplateLiteral(node) {
                 let start = node.loc.start.line;
                 let end = node.loc.end.line;
 
@@ -141,10 +141,10 @@ module.exports = {
                     rangeStart = linesRangeStart[firstNonBlankLine - diff];
                     rangeEnd = linesRangeStart[firstNonBlankLine];
                     context.report({
-                        node: node,
+                        node,
                         loc: node.loc.start,
                         message: "Too many blank lines at the beginning of file. Max of " + maxBOF + " allowed.",
-                        fix: fix
+                        fix
                     });
                 }
                 currentLocation = firstNonBlankLine - 1;
@@ -171,10 +171,10 @@ module.exports = {
                                 rangeEnd = linesRangeStart[location.line];
 
                                 context.report({
-                                    node: node,
+                                    node,
                                     loc: location,
                                     message: "More than " + max + " blank " + (max === 1 ? "line" : "lines") + " not allowed.",
-                                    fix: fix
+                                    fix
                                 });
                             }
                         } else {
@@ -185,10 +185,10 @@ module.exports = {
                                 rangeStart = linesRangeStart[location.line - diff];
                                 rangeEnd = linesRangeStart[location.line - 1];
                                 context.report({
-                                    node: node,
+                                    node,
                                     loc: location,
                                     message: "Too many blank lines at the end of file. Max of " + maxEOF + " allowed.",
-                                    fix: fix
+                                    fix
                                 });
                             }
                         }

--- a/lib/rules/no-native-reassign.js
+++ b/lib/rules/no-native-reassign.js
@@ -36,7 +36,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let config = context.options[0];
         let exceptions = (config && config.exceptions) || [];
 
@@ -77,7 +77,7 @@ module.exports = {
         }
 
         return {
-            Program: function() {
+            Program() {
                 let globalScope = context.getScope();
 
                 globalScope.variables.forEach(checkVariable);

--- a/lib/rules/no-negated-condition.js
+++ b/lib/rules/no-negated-condition.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Determines if a given node is an if-else without a condition on the else
@@ -63,7 +63,7 @@ module.exports = {
         }
 
         return {
-            IfStatement: function(node) {
+            IfStatement(node) {
                 if (!hasElseWithoutCondition(node)) {
                     return;
                 }
@@ -72,7 +72,7 @@ module.exports = {
                     context.report(node, "Unexpected negated condition.");
                 }
             },
-            ConditionalExpression: function(node) {
+            ConditionalExpression(node) {
                 if (isNegatedIf(node)) {
                     context.report(node, "Unexpected negated condition.");
                 }

--- a/lib/rules/no-negated-in-lhs.js
+++ b/lib/rules/no-negated-in-lhs.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
                 if (node.operator === "in" && node.left.type === "UnaryExpression" && node.left.operator === "!") {
                     context.report(node, "The 'in' expression's left operand is negated.");
                 }

--- a/lib/rules/no-nested-ternary.js
+++ b/lib/rules/no-nested-ternary.js
@@ -20,10 +20,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            ConditionalExpression: function(node) {
+            ConditionalExpression(node) {
                 if (node.alternate.type === "ConditionalExpression" ||
                         node.consequent.type === "ConditionalExpression") {
                     context.report(node, "Do not nest ternary expressions.");

--- a/lib/rules/no-new-func.js
+++ b/lib/rules/no-new-func.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Helpers

--- a/lib/rules/no-new-object.js
+++ b/lib/rules/no-new-object.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            NewExpression: function(node) {
+            NewExpression(node) {
                 if (node.callee.name === "Object") {
                     context.report(node, "The object literal notation {} is preferrable.");
                 }

--- a/lib/rules/no-new-require.js
+++ b/lib/rules/no-new-require.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            NewExpression: function(node) {
+            NewExpression(node) {
                 if (node.callee.type === "Identifier" && node.callee.name === "require") {
                     context.report(node, "Unexpected use of new with require.");
                 }

--- a/lib/rules/no-new-symbol.js
+++ b/lib/rules/no-new-symbol.js
@@ -20,10 +20,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            "Program:exit": function() {
+            "Program:exit"() {
                 let globalScope = context.getScope();
                 let variable = globalScope.set.get("Symbol");
 

--- a/lib/rules/no-new-wrappers.js
+++ b/lib/rules/no-new-wrappers.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            NewExpression: function(node) {
+            NewExpression(node) {
                 let wrapperObjects = ["String", "Number", "Boolean", "Math", "JSON"];
 
                 if (wrapperObjects.indexOf(node.callee.name) > -1) {

--- a/lib/rules/no-new.js
+++ b/lib/rules/no-new.js
@@ -21,11 +21,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            ExpressionStatement: function(node) {
+            ExpressionStatement(node) {
 
                 if (node.expression.type === "NewExpression") {
                     context.report(node, "Do not use 'new' for side effects.");

--- a/lib/rules/no-obj-calls.js
+++ b/lib/rules/no-obj-calls.js
@@ -20,16 +20,16 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
 
                 if (node.callee.type === "Identifier") {
                     let name = node.callee.name;
 
                     if (name === "Math" || name === "JSON") {
-                        context.report(node, "'{{name}}' is not a function.", { name: name });
+                        context.report(node, "'{{name}}' is not a function.", { name });
                     }
                 }
             }

--- a/lib/rules/no-octal-escape.js
+++ b/lib/rules/no-octal-escape.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
                 if (typeof node.value !== "string") {
                     return;
                 }
@@ -38,7 +38,7 @@ module.exports = {
                     // \0 is actually not considered an octal
                     if (match[2] !== "0" || typeof match[3] !== "undefined") {
                         context.report(node, "Don't use octal: '\\{{octalDigit}}'. Use '\\u....' instead.",
-                                { octalDigit: octalDigit });
+                                { octalDigit });
                     }
                 }
             }

--- a/lib/rules/no-octal.js
+++ b/lib/rules/no-octal.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
                 if (typeof node.value === "number" && /^0[0-7]/.test(node.raw)) {
                     context.report(node, "Octal literals should not be used.");
                 }

--- a/lib/rules/no-param-reassign.js
+++ b/lib/rules/no-param-reassign.js
@@ -29,7 +29,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let props = context.options[0] && Boolean(context.options[0].props);
 
         /**

--- a/lib/rules/no-path-concat.js
+++ b/lib/rules/no-path-concat.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         let MATCHER = /^__(?:dir|file)name$/;
 
@@ -29,7 +29,7 @@ module.exports = {
 
         return {
 
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
 
                 let left = node.left,
                     right = node.right;

--- a/lib/rules/no-plusplus.js
+++ b/lib/rules/no-plusplus.js
@@ -31,7 +31,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let config = context.options[0],
             allowInForAfterthought = false;
@@ -42,7 +42,7 @@ module.exports = {
 
         return {
 
-            UpdateExpression: function(node) {
+            UpdateExpression(node) {
                 if (allowInForAfterthought && node.parent.type === "ForStatement") {
                     return;
                 }

--- a/lib/rules/no-process-env.js
+++ b/lib/rules/no-process-env.js
@@ -19,11 +19,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 let objectName = node.object.name,
                     propertyName = node.property.name;
 

--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Public
@@ -27,7 +27,7 @@ module.exports = {
 
         return {
 
-            CallExpression: function(node) {
+            CallExpression(node) {
                 let callee = node.callee;
 
                 if (callee.type === "MemberExpression" && callee.object.name === "process" &&

--- a/lib/rules/no-proto.js
+++ b/lib/rules/no-proto.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
 
                 if (node.property &&
                         (node.property.type === "Identifier" && node.property.name === "__proto__" && !node.computed) ||

--- a/lib/rules/no-prototype-builtins.js
+++ b/lib/rules/no-prototype-builtins.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let DISALLOWED_PROPS = [
             "hasOwnProperty",
             "isPrototypeOf",
@@ -42,7 +42,7 @@ module.exports = {
                     message: "Do not access Object.prototype method '{{prop}}' from target object.",
                     loc: node.callee.property.loc.start,
                     data: {prop: propName},
-                    node: node
+                    node
                 });
             }
         }

--- a/lib/rules/no-redeclare.js
+++ b/lib/rules/no-redeclare.js
@@ -28,7 +28,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = {
             builtinGlobals: Boolean(context.options[0] && context.options[0].builtinGlobals)
         };

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         /**

--- a/lib/rules/no-restricted-globals.js
+++ b/lib/rules/no-restricted-globals.js
@@ -25,7 +25,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
         let restrictedGlobals = context.options;
 
         // if no globals are restricted we don't need to check
@@ -56,7 +56,7 @@ module.exports = {
         }
 
         return {
-            Program: function() {
+            Program() {
                 let scope = context.getScope();
 
                 // Report variables declared elsewhere (ex: variables defined as "global" by eslint)

--- a/lib/rules/no-restricted-imports.js
+++ b/lib/rules/no-restricted-imports.js
@@ -25,7 +25,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
         let restrictedImports = context.options;
 
         // if no imports are restricted we don"t need to check
@@ -34,7 +34,7 @@ module.exports = {
         }
 
         return {
-            ImportDeclaration: function(node) {
+            ImportDeclaration(node) {
                 if (node && node.source && node.source.value) {
 
                     let value = node.source.value.trim();

--- a/lib/rules/no-restricted-modules.js
+++ b/lib/rules/no-restricted-modules.js
@@ -25,7 +25,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
 
         // trim restricted module names
         let restrictedModules = context.options;
@@ -75,7 +75,7 @@ module.exports = {
         }
 
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
                 if (isRequireCall(node)) {
                     let restrictedModuleName = getRestrictedModuleName(node);
 

--- a/lib/rules/no-restricted-syntax.js
+++ b/lib/rules/no-restricted-syntax.js
@@ -32,7 +32,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Generates a warning from the provided node, saying that node type is not allowed.

--- a/lib/rules/no-return-assign.js
+++ b/lib/rules/no-return-assign.js
@@ -42,12 +42,12 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let always = (context.options[0] || "except-parens") !== "except-parens";
         let sourceCode = context.getSourceCode();
 
         return {
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
                 if (!always && isEnclosedInParens(node, sourceCode)) {
                     return;
                 }

--- a/lib/rules/no-script-url.js
+++ b/lib/rules/no-script-url.js
@@ -22,11 +22,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
 
                 let value;
 

--- a/lib/rules/no-self-assign.js
+++ b/lib/rules/no-self-assign.js
@@ -106,7 +106,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Reports a given node as self assignments.
@@ -116,14 +116,14 @@ module.exports = {
          */
         function report(node) {
             context.report({
-                node: node,
+                node,
                 message: "'{{name}}' is assigned to itself.",
                 data: node
             });
         }
 
         return {
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
                 if (node.operator === "=") {
                     eachSelfAssignment(node.left, node.right, report);
                 }

--- a/lib/rules/no-self-compare.js
+++ b/lib/rules/no-self-compare.js
@@ -21,11 +21,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
                 let operators = ["===", "==", "!==", "!=", ">", "<", ">=", "<="];
 
                 if (operators.indexOf(node.operator) > -1 &&

--- a/lib/rules/no-sequences.js
+++ b/lib/rules/no-sequences.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         /**
@@ -80,7 +80,7 @@ module.exports = {
         }
 
         return {
-            SequenceExpression: function(node) {
+            SequenceExpression(node) {
 
                 // Always allow sequences in for statement update
                 if (node.parent.type === "ForStatement" &&

--- a/lib/rules/no-shadow-restricted-names.js
+++ b/lib/rules/no-shadow-restricted-names.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         let RESTRICTED = ["undefined", "NaN", "Infinity", "arguments", "eval"];
 
@@ -36,25 +36,25 @@ module.exports = {
         }
 
         return {
-            VariableDeclarator: function(node) {
+            VariableDeclarator(node) {
                 checkForViolation(node.id);
             },
-            ArrowFunctionExpression: function(node) {
+            ArrowFunctionExpression(node) {
                 [].map.call(node.params, checkForViolation);
             },
-            FunctionExpression: function(node) {
+            FunctionExpression(node) {
                 if (node.id) {
                     checkForViolation(node.id);
                 }
                 [].map.call(node.params, checkForViolation);
             },
-            FunctionDeclaration: function(node) {
+            FunctionDeclaration(node) {
                 if (node.id) {
                     checkForViolation(node.id);
                     [].map.call(node.params, checkForViolation);
                 }
             },
-            CatchClause: function(node) {
+            CatchClause(node) {
                 checkForViolation(node.param);
             }
         };

--- a/lib/rules/no-shadow.js
+++ b/lib/rules/no-shadow.js
@@ -41,7 +41,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let options = {
             builtinGlobals: Boolean(context.options[0] && context.options[0].builtinGlobals),
@@ -171,7 +171,7 @@ module.exports = {
         }
 
         return {
-            "Program:exit": function() {
+            "Program:exit"() {
                 let globalScope = context.getScope();
                 let stack = globalScope.childScopes.slice();
                 let scope;

--- a/lib/rules/no-spaced-func.js
+++ b/lib/rules/no-spaced-func.js
@@ -21,7 +21,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         let sourceCode = context.getSourceCode();
 
@@ -52,10 +52,10 @@ module.exports = {
                 sourceCode.isSpaceBetweenTokens(prevToken, parenToken)
             ) {
                 context.report({
-                    node: node,
+                    node,
                     loc: lastCalleeToken.loc.start,
                     message: "Unexpected space between function name and paren.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.removeRange([prevToken.range[1], parenToken.range[0]]);
                     }
                 });

--- a/lib/rules/no-sparse-arrays.js
+++ b/lib/rules/no-sparse-arrays.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
 
         //--------------------------------------------------------------------------
@@ -28,7 +28,7 @@ module.exports = {
 
         return {
 
-            ArrayExpression: function(node) {
+            ArrayExpression(node) {
 
                 let emptySpot = node.elements.indexOf(null) > -1;
 

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -22,11 +22,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 let propertyName = node.property.name,
                     syncRegex = /.*Sync$/;
 

--- a/lib/rules/no-ternary.js
+++ b/lib/rules/no-ternary.js
@@ -20,11 +20,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            ConditionalExpression: function(node) {
+            ConditionalExpression(node) {
                 context.report(node, "Ternary operator used.");
             }
 

--- a/lib/rules/no-this-before-super.js
+++ b/lib/rules/no-this-before-super.js
@@ -45,7 +45,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /*
          * Information for each constructor.
@@ -136,7 +136,7 @@ module.exports = {
              * @param {ASTNode} node - The current node.
              * @returns {void}
              */
-            onCodePathStart: function(codePath, node) {
+            onCodePathStart(codePath, node) {
                 if (isConstructorFunction(node)) {
 
                     // Class > ClassBody > MethodDefinition > FunctionExpression
@@ -149,14 +149,14 @@ module.exports = {
                             classNode.superClass &&
                             !astUtils.isNullOrUndefined(classNode.superClass)
                         ),
-                        codePath: codePath
+                        codePath
                     };
                 } else {
                     funcInfo = {
                         upper: funcInfo,
                         isConstructor: false,
                         hasExtends: false,
-                        codePath: codePath
+                        codePath
                     };
                 }
             },
@@ -171,7 +171,7 @@ module.exports = {
              * @param {ASTNode} node - The current node.
              * @returns {void}
              */
-            onCodePathEnd: function(codePath) {
+            onCodePathEnd(codePath) {
                 let isDerivedClass = funcInfo.hasExtends;
 
                 funcInfo = funcInfo.upper;
@@ -205,7 +205,7 @@ module.exports = {
              * @param {CodePathSegment} segment - A code path segment to initialize.
              * @returns {void}
              */
-            onCodePathSegmentStart: function(segment) {
+            onCodePathSegmentStart(segment) {
                 if (!isInConstructorOfDerivedClass(funcInfo)) {
                     return;
                 }
@@ -229,7 +229,7 @@ module.exports = {
              *      of a loop.
              * @returns {void}
              */
-            onCodePathSegmentLoop: function(fromSegment, toSegment) {
+            onCodePathSegmentLoop(fromSegment, toSegment) {
                 if (!isInConstructorOfDerivedClass(funcInfo)) {
                     return;
                 }
@@ -259,7 +259,7 @@ module.exports = {
              * @param {ASTNode} node - A target node.
              * @returns {void}
              */
-            ThisExpression: function(node) {
+            ThisExpression(node) {
                 if (isBeforeCallOfSuper()) {
                     setInvalid(node);
                 }
@@ -270,7 +270,7 @@ module.exports = {
              * @param {ASTNode} node - A target node.
              * @returns {void}
              */
-            Super: function(node) {
+            Super(node) {
                 if (!astUtils.isCallee(node) && isBeforeCallOfSuper()) {
                     setInvalid(node);
                 }
@@ -281,7 +281,7 @@ module.exports = {
              * @param {ASTNode} node - A target node.
              * @returns {void}
              */
-            "CallExpression:exit": function(node) {
+            "CallExpression:exit"(node) {
                 if (node.callee.type === "Super" && isBeforeCallOfSuper()) {
                     setSuperCalled();
                 }
@@ -291,7 +291,7 @@ module.exports = {
              * Resets state.
              * @returns {void}
              */
-            "Program:exit": function() {
+            "Program:exit"() {
                 segInfoMap = Object.create(null);
             }
         };

--- a/lib/rules/no-throw-literal.js
+++ b/lib/rules/no-throw-literal.js
@@ -59,11 +59,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            ThrowStatement: function(node) {
+            ThrowStatement(node) {
                 if (!couldBeError(node.argument)) {
                     context.report(node, "Expected an object to be thrown.");
                 } else if (node.argument.type === "Identifier") {

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -31,7 +31,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         let BLANK_CLASS = "[ \t\u00a0\u2000-\u200b\u2028\u2029\u3000]",
@@ -57,10 +57,10 @@ module.exports = {
              * plugin.
              */
             context.report({
-                node: node,
+                node,
                 loc: location,
                 message: "Trailing spaces not allowed.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.removeRange(fixRange);
                 }
             });

--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -20,16 +20,16 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            VariableDeclarator: function(node) {
+            VariableDeclarator(node) {
                 let name = node.id.name,
                     init = node.init && node.init.name;
 
                 if (init === "undefined" && node.parent.kind !== "const") {
-                    context.report(node, "It's not necessary to initialize '{{name}}' to undefined.", { name: name });
+                    context.report(node, "It's not necessary to initialize '{{name}}' to undefined.", { name });
                 }
             }
         };

--- a/lib/rules/no-undef.js
+++ b/lib/rules/no-undef.js
@@ -44,12 +44,12 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0];
         let considerTypeOf = options && options.typeof === true || false;
 
         return {
-            "Program:exit": function(/* node */) {
+            "Program:exit"(/* node */) {
                 let globalScope = context.getScope();
 
                 globalScope.through.forEach(function(ref) {

--- a/lib/rules/no-undefined.js
+++ b/lib/rules/no-undefined.js
@@ -19,11 +19,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
 
-            Identifier: function(node) {
+            Identifier(node) {
                 if (node.name === "undefined") {
                     let parent = context.getAncestors().pop();
 

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -39,7 +39,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let options = context.options[0] || {};
         let ALLOWED_VARIABLES = options.allow ? options.allow : [];

--- a/lib/rules/no-unexpected-multiline.js
+++ b/lib/rules/no-unexpected-multiline.js
@@ -18,7 +18,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         let FUNCTION_MESSAGE = "Unexpected newline between function and ( of function call.";
         let PROPERTY_MESSAGE = "Unexpected newline between object and [ of property access.";
@@ -55,21 +55,21 @@ module.exports = {
 
         return {
 
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 if (!node.computed) {
                     return;
                 }
                 checkForBreakAfter(node.object, PROPERTY_MESSAGE);
             },
 
-            TaggedTemplateExpression: function(node) {
+            TaggedTemplateExpression(node) {
                 if (node.tag.loc.end.line === node.quasi.loc.start.line) {
                     return;
                 }
                 context.report(node, node.loc.start, TAGGED_TEMPLATE_MESSAGE);
             },
 
-            CallExpression: function(node) {
+            CallExpression(node) {
                 if (node.arguments.length === 0) {
                     return;
                 }

--- a/lib/rules/no-unmodified-loop-condition.js
+++ b/lib/rules/no-unmodified-loop-condition.js
@@ -98,7 +98,7 @@ function isInRange(node, reference) {
 let isInLoop = {
     WhileStatement: isInRange,
     DoWhileStatement: isInRange,
-    ForStatement: function(node, reference) {
+    ForStatement(node, reference) {
         return (
             isInRange(node, reference) &&
             !(node.init && isInRange(node.init, reference))
@@ -118,7 +118,7 @@ function hasDynamicExpressions(root) {
         traverser = new Traverser();
 
     traverser.traverse(root, {
-        enter: function(node) {
+        enter(node) {
             if (DYNAMIC_PATTERN.test(node.type)) {
                 retv = true;
                 this.break();
@@ -152,8 +152,8 @@ function toLoopCondition(reference) {
 
                 // This reference is inside of a loop condition.
                 return {
-                    reference: reference,
-                    group: group,
+                    reference,
+                    group,
                     isInLoop: isInLoop[node.type].bind(null, node),
                     modified: false
                 };
@@ -253,7 +253,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let groupMap = null;
 
         /**
@@ -266,7 +266,7 @@ module.exports = {
             let node = condition.reference.identifier;
 
             context.report({
-                node: node,
+                node,
                 message: "'{{name}}' is not modified in this loop.",
                 data: node
             });
@@ -346,7 +346,7 @@ module.exports = {
         }
 
         return {
-            "Program:exit": function() {
+            "Program:exit"() {
                 let queue = [context.getScope()];
 
                 groupMap = new Map();

--- a/lib/rules/no-unneeded-ternary.js
+++ b/lib/rules/no-unneeded-ternary.js
@@ -30,7 +30,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let defaultAssignment = options.defaultAssignment !== false;
 
@@ -58,7 +58,7 @@ module.exports = {
 
         return {
 
-            ConditionalExpression: function(node) {
+            ConditionalExpression(node) {
                 if (isBooleanLiteral(node.alternate) && isBooleanLiteral(node.consequent)) {
                     context.report(node, node.consequent.loc.start, "Unnecessary use of boolean literals in conditional expression.");
                 } else if (!defaultAssignment && matchesDefaultAssignment(node)) {

--- a/lib/rules/no-unreachable.js
+++ b/lib/rules/no-unreachable.js
@@ -110,7 +110,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let currentCodePath = null;
 
         const range = new ConsecutiveRange(context.getSourceCode());
@@ -162,11 +162,11 @@ module.exports = {
         return {
 
             // Manages the current code path.
-            onCodePathStart: function(codePath) {
+            onCodePathStart(codePath) {
                 currentCodePath = codePath;
             },
 
-            onCodePathEnd: function() {
+            onCodePathEnd() {
                 currentCodePath = currentCodePath.upper;
             },
 
@@ -190,7 +190,7 @@ module.exports = {
             ThrowStatement: reportIfUnreachable,
             TryStatement: reportIfUnreachable,
 
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 if (node.kind !== "var" || node.declarations.some(isInitialized)) {
                     reportIfUnreachable(node);
                 }
@@ -202,7 +202,7 @@ module.exports = {
             ExportDefaultDeclaration: reportIfUnreachable,
             ExportAllDeclaration: reportIfUnreachable,
 
-            "Program:exit": function() {
+            "Program:exit"() {
                 reportIfUnreachable();
             }
         };

--- a/lib/rules/no-unsafe-finally.js
+++ b/lib/rules/no-unsafe-finally.js
@@ -28,7 +28,7 @@ module.exports = {
 
         schema: []
     },
-    create: function(context) {
+    create(context) {
 
         /**
          * Checks if the node is the finalizer of a TryStatement
@@ -84,7 +84,7 @@ module.exports = {
             if (isInFinallyBlock(node, node.label)) {
                 context.report({
                     message: "Unsafe usage of " + node.type + ".",
-                    node: node,
+                    node,
                     line: node.loc.line,
                     column: node.loc.column
                 });

--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -32,7 +32,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let config = context.options[0] || {},
             allowShortCircuit = config.allowShortCircuit || false,
             allowTernary = config.allowTernary || false;
@@ -106,7 +106,7 @@ module.exports = {
         }
 
         return {
-            ExpressionStatement: function(node) {
+            ExpressionStatement(node) {
                 if (!isValidExpression(node.expression) && !isDirective(node, context.getAncestors())) {
                     context.report(node, "Expected an assignment or function call and instead saw an expression.");
                 }

--- a/lib/rules/no-unused-labels.js
+++ b/lib/rules/no-unused-labels.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let scopeInfo = null;
 
         /**

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -58,7 +58,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let MESSAGE = "'{{name}}' is defined but never used.";
 
@@ -550,7 +550,7 @@ module.exports = {
 
             return {
                 line: baseLoc.line + lineInComment,
-                column: column
+                column
             };
         }
 
@@ -559,7 +559,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            "Program:exit": function(programNode) {
+            "Program:exit"(programNode) {
                 let unusedVars = collectUnusedVariables(context.getScope(), []);
 
                 for (let i = 0, l = unusedVars.length; i < l; ++i) {

--- a/lib/rules/no-use-before-define.js
+++ b/lib/rules/no-use-before-define.js
@@ -29,7 +29,7 @@ function parseOptions(options) {
         classes = options.classes !== false;
     }
 
-    return {functions: functions, classes: classes};
+    return {functions, classes};
 }
 
 /**
@@ -164,7 +164,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = parseOptions(context.options[0]);
 
         // Defines a function which checks whether or not a reference is allowed according to the option.
@@ -227,7 +227,7 @@ module.exports = {
         }
 
         let ruleDefinition = {
-            "Program:exit": function(node) {
+            "Program:exit"(node) {
                 let scope = context.getScope(),
                     ecmaFeatures = context.parserOptions.ecmaFeatures || {};
 

--- a/lib/rules/no-useless-call.js
+++ b/lib/rules/no-useless-call.js
@@ -82,11 +82,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
                 if (!isCallOrNonVariadicApply(node)) {
                     return;
                 }

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -20,11 +20,11 @@ module.exports = {
 
         schema: []
     },
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
-            Property: function(node) {
+            Property(node) {
                 if (!node.computed) {
                     return;
                 }

--- a/lib/rules/no-useless-concat.js
+++ b/lib/rules/no-useless-concat.js
@@ -66,11 +66,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
 
                 // check if not concatenation
                 if (node.operator !== "+") {

--- a/lib/rules/no-useless-constructor.js
+++ b/lib/rules/no-useless-constructor.js
@@ -151,7 +151,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Checks whether a node is a redundant constructor
@@ -169,7 +169,7 @@ module.exports = {
 
             if (superClass ? isRedundantSuperCall(body, ctorParams) : (body.length === 0)) {
                 context.report({
-                    node: node,
+                    node,
                     message: "Useless constructor."
                 });
             }

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -68,7 +68,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Checks if the escape character in given slice is unnecessary.
@@ -85,7 +85,7 @@ module.exports = {
 
             if (escapeNotFound && !isQuoteEscape) {
                 context.report({
-                    node: node,
+                    node,
                     loc: {
                         line: node.loc.start.line,
                         column: node.loc.start.column + elm.index

--- a/lib/rules/no-useless-rename.js
+++ b/lib/rules/no-useless-rename.js
@@ -30,7 +30,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {},
             ignoreDestructuring = options.ignoreDestructuring === true,
             ignoreImport = options.ignoreImport === true,
@@ -52,13 +52,13 @@ module.exports = {
             let name = initial.type === "Identifier" ? initial.name : initial.value;
 
             return context.report({
-                node: node,
+                node,
                 message: "{{type}} {{name}} unnecessarily renamed.",
                 data: {
-                    name: name,
-                    type: type
+                    name,
+                    type
                 },
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.replaceTextRange([
                         initial.range[0],
                         result.range[1]

--- a/lib/rules/no-var.js
+++ b/lib/rules/no-var.js
@@ -87,7 +87,7 @@ module.exports = {
         fixable: "code"
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         /**
@@ -139,10 +139,10 @@ module.exports = {
             let varToken = sourceCode.getFirstToken(node);
 
             context.report({
-                node: node,
+                node,
                 message: "Unexpected var, use let or const instead.",
 
-                fix: function(fixer) {
+                fix(fixer) {
                     if (canFix(node)) {
                         return fixer.replaceText(varToken, "let");
                     }
@@ -152,7 +152,7 @@ module.exports = {
         }
 
         return {
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 if (node.kind === "var") {
                     report(node);
                 }

--- a/lib/rules/no-void.js
+++ b/lib/rules/no-void.js
@@ -19,14 +19,14 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
 
         return {
-            UnaryExpression: function(node) {
+            UnaryExpression(node) {
                 if (node.operator === "void") {
                     context.report(node, "Expected 'undefined' and instead saw 'void'.");
                 }

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -38,7 +38,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let configuration = context.options[0] || {},
             warningTerms = configuration.terms || ["todo", "fixme", "xxx"],

--- a/lib/rules/no-whitespace-before-property.js
+++ b/lib/rules/no-whitespace-before-property.js
@@ -22,7 +22,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         //--------------------------------------------------------------------------
@@ -56,12 +56,12 @@ module.exports = {
             let replacementText = node.computed ? "" : ".";
 
             context.report({
-                node: node,
+                node,
                 message: "Unexpected whitespace before property {{propName}}.",
                 data: {
                     propName: sourceCode.getText(node.property)
                 },
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], replacementText);
                 }
             });
@@ -72,7 +72,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            MemberExpression: function(node) {
+            MemberExpression(node) {
                 let rightToken;
                 let leftToken;
 

--- a/lib/rules/no-with.js
+++ b/lib/rules/no-with.js
@@ -20,10 +20,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            WithStatement: function(node) {
+            WithStatement(node) {
                 context.report(node, "Unexpected use of 'with' statement.");
             }
         };

--- a/lib/rules/object-curly-newline.js
+++ b/lib/rules/object-curly-newline.js
@@ -61,7 +61,7 @@ function normalizeOptionValue(value) {
         multiline = true;
     }
 
-    return {multiline: multiline, minProperties: minProperties};
+    return {multiline, minProperties};
 }
 
 /**
@@ -113,7 +113,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
         let normalizedOptions = normalizeOptions(context.options[0]);
 
@@ -154,9 +154,9 @@ module.exports = {
                 if (astUtils.isTokenOnSameLine(openBrace, first)) {
                     context.report({
                         message: "Expected a line break after this opening brace.",
-                        node: node,
+                        node,
                         loc: openBrace.loc.start,
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextAfter(openBrace, "\n");
                         }
                     });
@@ -164,9 +164,9 @@ module.exports = {
                 if (astUtils.isTokenOnSameLine(last, closeBrace)) {
                     context.report({
                         message: "Expected a line break before this closing brace.",
-                        node: node,
+                        node,
                         loc: closeBrace.loc.start,
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextBefore(closeBrace, "\n");
                         }
                     });
@@ -175,9 +175,9 @@ module.exports = {
                 if (!astUtils.isTokenOnSameLine(openBrace, first)) {
                     context.report({
                         message: "Unexpected line break after this opening brace.",
-                        node: node,
+                        node,
                         loc: openBrace.loc.start,
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([
                                 openBrace.range[1],
                                 first.range[0]
@@ -188,9 +188,9 @@ module.exports = {
                 if (!astUtils.isTokenOnSameLine(last, closeBrace)) {
                     context.report({
                         message: "Unexpected line break before this closing brace.",
-                        node: node,
+                        node,
                         loc: closeBrace.loc.start,
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([
                                 last.range[1],
                                 closeBrace.range[0]

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -39,7 +39,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let spaced = context.options[0] === "always",
             sourceCode = context.getSourceCode();
 
@@ -55,7 +55,7 @@ module.exports = {
         }
 
         let options = {
-            spaced: spaced,
+            spaced,
             arraysInObjectsException: isOptionSet("arraysInObjects"),
             objectsInObjectsException: isOptionSet("objectsInObjects")
         };
@@ -72,10 +72,10 @@ module.exports = {
         */
         function reportNoBeginningSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "There should be no space after '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     let nextToken = context.getSourceCode().getTokenAfter(token);
 
                     return fixer.removeRange([token.range[1], nextToken.range[0]]);
@@ -91,10 +91,10 @@ module.exports = {
         */
         function reportNoEndingSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "There should be no space before '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     let previousToken = context.getSourceCode().getTokenBefore(token);
 
                     return fixer.removeRange([previousToken.range[1], token.range[0]]);
@@ -110,10 +110,10 @@ module.exports = {
         */
         function reportRequiredBeginningSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "A space is required after '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.insertTextAfter(token, " ");
                 }
             });
@@ -127,10 +127,10 @@ module.exports = {
         */
         function reportRequiredEndingSpace(node, token) {
             context.report({
-                node: node,
+                node,
                 loc: token.loc.start,
                 message: "A space is required before '" + token.value + "'.",
-                fix: function(fixer) {
+                fix(fixer) {
                     return fixer.insertTextBefore(token, " ");
                 }
             });

--- a/lib/rules/object-property-newline.js
+++ b/lib/rules/object-property-newline.js
@@ -30,7 +30,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let allowSameLine = context.options[0] && Boolean(context.options[0].allowMultiplePropertiesPerLine);
         let errorMessage = allowSameLine ?
             "Object properties must go on a new line if they aren't all on the same line." :
@@ -39,7 +39,7 @@ module.exports = {
         let sourceCode = context.getSourceCode();
 
         return {
-            ObjectExpression: function(node) {
+            ObjectExpression(node) {
                 let lastTokenOfPreviousProperty, firstTokenOfCurrentProperty;
 
                 if (allowSameLine) {
@@ -61,7 +61,7 @@ module.exports = {
 
                     if (lastTokenOfPreviousProperty.loc.end.line === firstTokenOfCurrentProperty.loc.start.line) {
                         context.report({
-                            node: node,
+                            node,
                             loc: firstTokenOfCurrentProperty.loc.start,
                             message: errorMessage
                         });

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -82,7 +82,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
         let APPLY = context.options[0] || OPTIONS.always;
         let APPLY_TO_METHODS = APPLY === OPTIONS.methods || APPLY === OPTIONS.always;
         let APPLY_TO_PROPS = APPLY === OPTIONS.properties || APPLY === OPTIONS.always;
@@ -122,7 +122,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            Property: function(node) {
+            Property(node) {
                 let isConciseProperty = node.method || node.shorthand,
                     type;
 
@@ -149,9 +149,9 @@ module.exports = {
                     if (APPLY_NEVER) {
                         type = node.method ? "method" : "property";
                         context.report({
-                            node: node,
+                            node,
                             message: "Expected longform " + type + " syntax.",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 if (node.method) {
                                     if (node.value.generator) {
                                         return fixer.replaceTextRange([node.range[0], node.key.range[1]], node.key.name + ": function*");
@@ -168,9 +168,9 @@ module.exports = {
                     // {'xyz'() {}} should be written as {'xyz': function() {}}
                     if (AVOID_QUOTES && isStringLiteral(node.key)) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Expected longform method syntax for string literal keys.",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 if (node.computed) {
                                     return fixer.insertTextAfterRange([node.key.range[0], node.key.range[1] + 1], ": function");
                                 }
@@ -196,9 +196,9 @@ module.exports = {
                     // {[x]: function(){}} should be written as {[x]() {}}
                     if (node.computed) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Expected method shorthand.",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 if (node.value.generator) {
                                     return fixer.replaceTextRange(
                                         [node.key.range[0], node.value.range[0] + "function*".length],
@@ -214,9 +214,9 @@ module.exports = {
 
                     // {x: function(){}} should be written as {x() {}}
                     context.report({
-                        node: node,
+                        node,
                         message: "Expected method shorthand.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             if (node.value.generator) {
                                 return fixer.replaceTextRange(
                                     [node.key.range[0], node.value.range[0] + "function*".length],
@@ -231,9 +231,9 @@ module.exports = {
 
                     // {x: x} should be written as {x}
                     context.report({
-                        node: node,
+                        node,
                         message: "Expected property shorthand.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.replaceText(node, node.value.name);
                         }
                     });
@@ -244,9 +244,9 @@ module.exports = {
 
                     // {"x": x} should be written as {x}
                     context.report({
-                        node: node,
+                        node,
                         message: "Expected property shorthand.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.replaceText(node, node.value.name);
                         }
                     });

--- a/lib/rules/one-var-declaration-per-line.js
+++ b/lib/rules/one-var-declaration-per-line.js
@@ -23,7 +23,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let ERROR_MESSAGE = "Expected variable declaration to be on a new line.";
         let always = context.options[0] === "always";
@@ -61,7 +61,7 @@ module.exports = {
                 if (prev && prev.loc.end.line === current.loc.start.line) {
                     if (always || prev.init || current.init) {
                         context.report({
-                            node: node,
+                            node,
                             message: ERROR_MESSAGE,
                             loc: current.loc.start
                         });

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -55,7 +55,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let MODE_ALWAYS = "always",
             MODE_NEVER = "never";
@@ -265,7 +265,7 @@ module.exports = {
             ForOfStatement: startBlock,
             SwitchStatement: startBlock,
 
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 let parent = node.parent,
                     type, declarations, declarationCounts;
 

--- a/lib/rules/operator-assignment.js
+++ b/lib/rules/operator-assignment.js
@@ -85,7 +85,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Ensures that an assignment uses the shorthand form where possible.

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -42,7 +42,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let usedDefaultGlobal = !context.options[0];
         let globalStyle = context.options[0] || "after";
@@ -145,12 +145,12 @@ module.exports = {
             BinaryExpression: validateBinaryExpression,
             LogicalExpression: validateBinaryExpression,
             AssignmentExpression: validateBinaryExpression,
-            VariableDeclarator: function(node) {
+            VariableDeclarator(node) {
                 if (node.init) {
                     validateNode(node, node.id);
                 }
             },
-            ConditionalExpression: function(node) {
+            ConditionalExpression(node) {
                 validateNode(node, node.test);
                 validateNode(node, node.consequent);
             }

--- a/lib/rules/padded-blocks.js
+++ b/lib/rules/padded-blocks.js
@@ -46,7 +46,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = {};
         let config = context.options[0] || "always";
 
@@ -164,9 +164,9 @@ module.exports = {
             if (requirePaddingFor(node)) {
                 if (!blockHasTopPadding) {
                     context.report({
-                        node: node,
+                        node,
                         loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextAfter(openBrace, "\n");
                         },
                         message: ALWAYS_MESSAGE
@@ -174,9 +174,9 @@ module.exports = {
                 }
                 if (!blockHasBottomPadding) {
                     context.report({
-                        node: node,
+                        node,
                         loc: {line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextBefore(closeBrace, "\n");
                         },
                         message: ALWAYS_MESSAGE
@@ -187,9 +187,9 @@ module.exports = {
                     let nextToken = sourceCode.getTokenOrCommentAfter(openBrace);
 
                     context.report({
-                        node: node,
+                        node,
                         loc: { line: openBrace.loc.start.line, column: openBrace.loc.start.column },
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.replaceTextRange([openBrace.end, nextToken.start - nextToken.loc.start.column], "\n");
                         },
                         message: NEVER_MESSAGE
@@ -200,10 +200,10 @@ module.exports = {
                     let previousToken = sourceCode.getTokenOrCommentBefore(closeBrace);
 
                     context.report({
-                        node: node,
+                        node,
                         loc: {line: closeBrace.loc.end.line, column: closeBrace.loc.end.column - 1 },
                         message: NEVER_MESSAGE,
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.replaceTextRange([previousToken.end, closeBrace.start - closeBrace.loc.start.column], "\n");
                         }
                     });

--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -143,7 +143,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
 
         let allowUnboundThis = options.allowUnboundThis !== false;  // default to true
@@ -176,12 +176,12 @@ module.exports = {
         return {
 
             // Reset internal state.
-            Program: function() {
+            Program() {
                 stack = [];
             },
 
             // If there are below, it cannot replace with arrow functions merely.
-            ThisExpression: function() {
+            ThisExpression() {
                 let info = stack[stack.length - 1];
 
                 if (info) {
@@ -189,7 +189,7 @@ module.exports = {
                 }
             },
 
-            Super: function() {
+            Super() {
                 let info = stack[stack.length - 1];
 
                 if (info) {
@@ -197,7 +197,7 @@ module.exports = {
                 }
             },
 
-            MetaProperty: function(node) {
+            MetaProperty(node) {
                 let info = stack[stack.length - 1];
 
                 if (info && checkMetaProperty(node, "new", "target")) {
@@ -211,7 +211,7 @@ module.exports = {
 
             // Main.
             FunctionExpression: enterScope,
-            "FunctionExpression:exit": function(node) {
+            "FunctionExpression:exit"(node) {
                 let scopeInfo = exitScope();
 
                 // Skip named function expressions

--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -247,7 +247,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options[0] || {};
         let checkingMixedDestructuring = options.destructuring !== "all";
         let ignoreReadBeforeAssign = options.ignoreReadBeforeAssign === true;
@@ -261,7 +261,7 @@ module.exports = {
          */
         function report(node) {
             let reportArgs = {
-                    node: node,
+                    node,
                     message: "'{{name}}' is never reassigned. Use 'const' instead.",
                     data: node
                 },
@@ -345,11 +345,11 @@ module.exports = {
         }
 
         return {
-            Program: function() {
+            Program() {
                 variables = [];
             },
 
-            "Program:exit": function() {
+            "Program:exit"() {
                 if (checkingMixedDestructuring) {
                     variables.forEach(checkVariable);
                 } else {
@@ -360,7 +360,7 @@ module.exports = {
                 variables = null;
             },
 
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 if (node.kind === "let" && !isInitOfForStatement(node)) {
                     pushAll(variables, context.getDeclaredVariables(node));
                 }

--- a/lib/rules/prefer-reflect.js
+++ b/lib/rules/prefer-reflect.js
@@ -44,7 +44,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let existingNames = {
             apply: "Function.prototype.apply",
             call: "Function.prototype.call",
@@ -80,13 +80,13 @@ module.exports = {
          */
         function report(node, existing, substitute) {
             context.report(node, "Avoid using {{existing}}, instead use {{substitute}}.", {
-                existing: existing,
-                substitute: substitute
+                existing,
+                substitute
             });
         }
 
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
                 let methodName = (node.callee.property || {}).name;
                 let isReflectCall = (node.callee.object || {}).name === "Reflect";
                 let hasReflectSubsitute = reflectSubsitutes.hasOwnProperty(methodName);
@@ -96,7 +96,7 @@ module.exports = {
                     report(node, existingNames[methodName], reflectSubsitutes[methodName]);
                 }
             },
-            UnaryExpression: function(node) {
+            UnaryExpression(node) {
                 let isDeleteOperator = node.operator === "delete";
                 let targetsIdentifier = node.argument.type === "Identifier";
                 let userConfiguredException = exceptions.indexOf("delete") !== -1;

--- a/lib/rules/prefer-rest-params.js
+++ b/lib/rules/prefer-rest-params.js
@@ -47,7 +47,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         /**
          * Reports a given reference.

--- a/lib/rules/prefer-spread.js
+++ b/lib/rules/prefer-spread.js
@@ -81,11 +81,11 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
-            CallExpression: function(node) {
+            CallExpression(node) {
                 if (!isVariadicApplyCalling(node)) {
                     return;
                 }

--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -65,7 +65,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let done = Object.create(null);
 
         /**
@@ -95,7 +95,7 @@ module.exports = {
         }
 
         return {
-            Program: function() {
+            Program() {
                 done = Object.create(null);
             },
 

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -64,7 +64,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
 
         let MODE = context.options[0],
             KEYWORDS = context.options[1] && context.options[1].keywords,
@@ -209,7 +209,7 @@ module.exports = {
         }
 
         return {
-            Property: function(node) {
+            Property(node) {
                 if (MODE === "always" || !MODE) {
                     checkOmittedQuotes(node);
                 }
@@ -217,7 +217,7 @@ module.exports = {
                     checkUnnecessaryQuotes(node);
                 }
             },
-            ObjectExpression: function(node) {
+            ObjectExpression(node) {
                 if (MODE === "consistent") {
                     checkConsistency(node, false);
                 }

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -107,7 +107,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let quoteOption = context.options[0],
             settings = QUOTE_SETTINGS[quoteOption || "double"],
@@ -208,7 +208,7 @@ module.exports = {
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
                 let val = node.value,
                     rawVal = node.raw,
                     isValid;
@@ -224,9 +224,9 @@ module.exports = {
 
                     if (!isValid) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Strings must use " + settings.description + ".",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.replaceText(node, settings.convert(node.raw));
                             }
                         });
@@ -234,7 +234,7 @@ module.exports = {
                 }
             },
 
-            TemplateLiteral: function(node) {
+            TemplateLiteral(node) {
 
                 // If backticks are expected or it's a tagged template, then this shouldn't throw an errors
                 if (allowTemplateLiterals || quoteOption === "backtick" || node.parent.type === "TaggedTemplateExpression") {
@@ -245,9 +245,9 @@ module.exports = {
 
                 if (shouldWarn) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Strings must use " + settings.description + ".",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.replaceText(node, settings.convert(sourceCode.getText(node)));
                         }
                     });

--- a/lib/rules/radix.js
+++ b/lib/rules/radix.js
@@ -91,7 +91,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let mode = context.options[0] || MODE_ALWAYS;
 
         /**
@@ -107,7 +107,7 @@ module.exports = {
             switch (args.length) {
                 case 0:
                     context.report({
-                        node: node,
+                        node,
                         message: "Missing parameters."
                     });
                     break;
@@ -115,7 +115,7 @@ module.exports = {
                 case 1:
                     if (mode === MODE_ALWAYS) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Missing radix parameter."
                         });
                     }
@@ -124,12 +124,12 @@ module.exports = {
                 default:
                     if (mode === MODE_AS_NEEDED && isDefaultRadix(args[1])) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Redundant radix parameter."
                         });
                     } else if (!isValidRadix(args[1])) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Invalid radix parameter."
                         });
                     }
@@ -138,7 +138,7 @@ module.exports = {
         }
 
         return {
-            "Program:exit": function() {
+            "Program:exit"() {
                 let scope = context.getScope();
                 let variable;
 

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -39,7 +39,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let source = context.getSourceCode();
         let DEFAULT_OPTIONS = {
             FunctionDeclaration: true,
@@ -86,17 +86,17 @@ module.exports = {
         }
 
         return {
-            FunctionDeclaration: function(node) {
+            FunctionDeclaration(node) {
                 if (options.FunctionDeclaration) {
                     checkJsDoc(node);
                 }
             },
-            FunctionExpression: function(node) {
+            FunctionExpression(node) {
                 if (options.MethodDefinition) {
                     checkClassMethodJsDoc(node);
                 }
             },
-            ClassDeclaration: function(node) {
+            ClassDeclaration(node) {
                 if (options.ClassDeclaration) {
                     checkJsDoc(node);
                 }

--- a/lib/rules/require-yield.js
+++ b/lib/rules/require-yield.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let stack = [];
 
         /**
@@ -61,7 +61,7 @@ module.exports = {
             "FunctionExpression:exit": endChecking,
 
             // Increases the count of `yield` keyword.
-            YieldExpression: function() {
+            YieldExpression() {
 
                 /* istanbul ignore else */
                 if (stack.length > 0) {

--- a/lib/rules/rest-spread-spacing.js
+++ b/lib/rules/rest-spread-spacing.js
@@ -24,7 +24,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode(),
             alwaysSpace = context.options[0] === "always";
 
@@ -62,31 +62,31 @@ module.exports = {
 
             if (alwaysSpace && !hasWhitespace) {
                 context.report({
-                    node: node,
+                    node,
                     loc: {
                         line: operator.loc.end.line,
                         column: operator.loc.end.column
                     },
                     message: "Expected whitespace after {{type}} operator.",
                     data: {
-                        type: type
+                        type
                     },
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.replaceTextRange([operator.range[1], nextToken.range[0]], " ");
                     }
                 });
             } else if (!alwaysSpace && hasWhitespace) {
                 context.report({
-                    node: node,
+                    node,
                     loc: {
                         line: operator.loc.end.line,
                         column: operator.loc.end.column
                     },
                     message: "Unexpected whitespace after {{type}} operator.",
                     data: {
-                        type: type
+                        type
                     },
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.removeRange([operator.range[1], nextToken.range[0]]);
                     }
                 });

--- a/lib/rules/semi-spacing.js
+++ b/lib/rules/semi-spacing.js
@@ -37,7 +37,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let config = context.options[0],
             requireSpaceBefore = false,
@@ -136,10 +136,10 @@ module.exports = {
                 if (hasLeadingSpace(token)) {
                     if (!requireSpaceBefore) {
                         context.report({
-                            node: node,
+                            node,
                             loc: location,
                             message: "Unexpected whitespace before semicolon.",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 let tokenBefore = sourceCode.getTokenBefore(token);
 
                                 return fixer.removeRange([tokenBefore.range[1], token.range[0]]);
@@ -149,10 +149,10 @@ module.exports = {
                 } else {
                     if (requireSpaceBefore) {
                         context.report({
-                            node: node,
+                            node,
                             loc: location,
                             message: "Missing whitespace before semicolon.",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.insertTextBefore(token, " ");
                             }
                         });
@@ -163,10 +163,10 @@ module.exports = {
                     if (hasTrailingSpace(token)) {
                         if (!requireSpaceAfter) {
                             context.report({
-                                node: node,
+                                node,
                                 loc: location,
                                 message: "Unexpected whitespace after semicolon.",
-                                fix: function(fixer) {
+                                fix(fixer) {
                                     let tokenAfter = sourceCode.getTokenAfter(token);
 
                                     return fixer.removeRange([token.range[1], tokenAfter.range[0]]);
@@ -176,10 +176,10 @@ module.exports = {
                     } else {
                         if (requireSpaceAfter) {
                             context.report({
-                                node: node,
+                                node,
                                 loc: location,
                                 message: "Missing whitespace after semicolon.",
-                                fix: function(fixer) {
+                                fix(fixer) {
                                     return fixer.insertTextAfter(token, " ");
                                 }
                             });
@@ -208,7 +208,7 @@ module.exports = {
             DebuggerStatement: checkNode,
             ReturnStatement: checkNode,
             ThrowStatement: checkNode,
-            ForStatement: function(node) {
+            ForStatement(node) {
                 if (node.init) {
                     checkSemicolonSpacing(sourceCode.getTokenAfter(node.init), node);
                 }

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -51,7 +51,7 @@ module.exports = {
         }
     },
 
-    create: function(context) {
+    create(context) {
 
         let OPT_OUT_PATTERN = /[\[\(\/\+\-]/; // One of [(/+-
         let options = context.options[1];
@@ -90,10 +90,10 @@ module.exports = {
             }
 
             context.report({
-                node: node,
-                loc: loc,
-                message: message,
-                fix: fix
+                node,
+                loc,
+                message,
+                fix
             });
 
         }
@@ -210,12 +210,12 @@ module.exports = {
             ContinueStatement: checkForSemicolon,
             ImportDeclaration: checkForSemicolon,
             ExportAllDeclaration: checkForSemicolon,
-            ExportNamedDeclaration: function(node) {
+            ExportNamedDeclaration(node) {
                 if (!node.declaration) {
                     checkForSemicolon(node);
                 }
             },
-            ExportDefaultDeclaration: function(node) {
+            ExportDefaultDeclaration(node) {
                 if (!/(?:Class|Function)Declaration/.test(node.declaration.type)) {
                     checkForSemicolon(node);
                 }

--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -42,7 +42,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let configuration = context.options[0] || {},
             ignoreCase = configuration.ignoreCase || false,
@@ -96,7 +96,7 @@ module.exports = {
         }
 
         return {
-            ImportDeclaration: function(node) {
+            ImportDeclaration(node) {
                 if (previousDeclaration) {
                     let currentLocalMemberName = getFirstLocalMemberName(node),
                         currentMemberSyntaxGroupIndex = getMemberParameterGroupIndex(node),
@@ -114,7 +114,7 @@ module.exports = {
                     if (currentMemberSyntaxGroupIndex !== previousMemberSyntaxGroupIndex) {
                         if (currentMemberSyntaxGroupIndex < previousMemberSyntaxGroupIndex) {
                             context.report({
-                                node: node,
+                                node,
                                 message: "Expected '{{syntaxA}}' syntax before '{{syntaxB}}' syntax.",
                                 data: {
                                     syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
@@ -128,7 +128,7 @@ module.exports = {
                             currentLocalMemberName < previousLocalMemberName
                         ) {
                             context.report({
-                                node: node,
+                                node,
                                 message: "Imports should be sorted alphabetically."
                             });
                         }

--- a/lib/rules/sort-vars.js
+++ b/lib/rules/sort-vars.js
@@ -30,13 +30,13 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let configuration = context.options[0] || {},
             ignoreCase = configuration.ignoreCase || false;
 
         return {
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 node.declarations.reduce(function(memo, decl) {
                     if (decl.id.type === "ObjectPattern" || decl.id.type === "ArrayPattern") {
                         return memo;

--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -47,7 +47,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let config = context.options[0],
             sourceCode = context.getSourceCode(),
             checkFunctions = true,
@@ -100,9 +100,9 @@ module.exports = {
                 if (requireSpace) {
                     if (!hasSpace) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Missing space before opening brace.",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.insertTextBefore(node, " ");
                             }
                         });
@@ -110,9 +110,9 @@ module.exports = {
                 } else {
                     if (hasSpace) {
                         context.report({
-                            node: node,
+                            node,
                             message: "Unexpected space before opening brace.",
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.removeRange([precedingToken.range[1], node.range[0]]);
                             }
                         });

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -41,7 +41,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let configuration = context.options[0],
             sourceCode = context.getSourceCode(),
@@ -112,10 +112,10 @@ module.exports = {
             if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken)) {
                 if ((isNamed && forbidNamedFunctionSpacing) || (!isNamed && forbidAnonymousFunctionSpacing)) {
                     context.report({
-                        node: node,
+                        node,
                         loc: location,
                         message: "Unexpected space before function parentheses.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([leftToken.range[1], rightToken.range[0]]);
                         }
                     });
@@ -123,10 +123,10 @@ module.exports = {
             } else {
                 if ((isNamed && requireNamedFunctionSpacing) || (!isNamed && requireAnonymousFunctionSpacing)) {
                     context.report({
-                        node: node,
+                        node,
                         loc: location,
                         message: "Missing space before function parentheses.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextAfter(leftToken, " ");
                         }
                     });

--- a/lib/rules/space-in-parens.js
+++ b/lib/rules/space-in-parens.js
@@ -40,7 +40,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let MISSING_SPACE_MESSAGE = "There must be a space inside this paren.",
             REJECTED_SPACE_MESSAGE = "There should be no spaces inside this paren.",
@@ -88,8 +88,8 @@ module.exports = {
             }
 
             return {
-                openers: openers,
-                closers: closers
+                openers,
+                closers
             };
         }
 
@@ -236,19 +236,19 @@ module.exports = {
 
                     if (token.value === "(" && shouldOpenerHaveSpace(token, nextToken)) {
                         context.report({
-                            node: node,
+                            node,
                             loc: token.loc.start,
                             message: MISSING_SPACE_MESSAGE,
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.insertTextAfter(token, " ");
                             }
                         });
                     } else if (token.value === "(" && shouldOpenerRejectSpace(token, nextToken)) {
                         context.report({
-                            node: node,
+                            node,
                             loc: token.loc.start,
                             message: REJECTED_SPACE_MESSAGE,
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.removeRange([token.range[1], nextToken.range[0]]);
                             }
                         });
@@ -256,19 +256,19 @@ module.exports = {
 
                         // context.report(node, token.loc.start, MISSING_SPACE_MESSAGE);
                         context.report({
-                            node: node,
+                            node,
                             loc: token.loc.start,
                             message: MISSING_SPACE_MESSAGE,
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.insertTextBefore(token, " ");
                             }
                         });
                     } else if (token.value === ")" && shouldCloserRejectSpace(prevToken, token)) {
                         context.report({
-                            node: node,
+                            node,
                             loc: token.loc.start,
                             message: REJECTED_SPACE_MESSAGE,
-                            fix: function(fixer) {
+                            fix(fixer) {
                                 return fixer.removeRange([prevToken.range[1], token.range[0]]);
                             }
                         });

--- a/lib/rules/space-infix-ops.js
+++ b/lib/rules/space-infix-ops.js
@@ -31,7 +31,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let int32Hint = context.options[0] ? context.options[0].int32Hint === true : false;
 
         let OPERATORS = [
@@ -79,7 +79,7 @@ module.exports = {
                 node: mainNode,
                 loc: culpritToken.loc.start,
                 message: "Infix operators must be spaced.",
-                fix: function(fixer) {
+                fix(fixer) {
                     let previousToken = sourceCode.getTokenBefore(culpritToken);
                     let afterToken = sourceCode.getTokenAfter(culpritToken);
                     let fixString = "";

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -40,7 +40,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let options = context.options && Array.isArray(context.options) && context.options[0] || { words: true, nonwords: false };
 
         let sourceCode = context.getSourceCode();
@@ -99,9 +99,9 @@ module.exports = {
         function verifyWordHasSpaces(node, firstToken, secondToken, word) {
             if (secondToken.range[0] === firstToken.range[1]) {
                 context.report({
-                    node: node,
+                    node,
                     message: "Unary word operator '" + word + "' must be followed by whitespace.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         return fixer.insertTextAfter(firstToken, " ");
                     }
                 });
@@ -120,9 +120,9 @@ module.exports = {
             if (isArgumentObjectExpression(node)) {
                 if (secondToken.range[0] > firstToken.range[1]) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Unexpected space after unary word operator '" + word + "'.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
                         }
                     });
@@ -184,9 +184,9 @@ module.exports = {
                 }
                 if (firstToken.range[1] === secondToken.range[0]) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Unary operator '" + firstToken.value + "' must be followed by whitespace.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextAfter(firstToken, " ");
                         }
                     });
@@ -194,9 +194,9 @@ module.exports = {
             } else {
                 if (firstToken.range[1] === secondToken.range[0]) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Space is required before unary expressions '" + secondToken.value + "'.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextBefore(secondToken, " ");
                         }
                     });
@@ -215,9 +215,9 @@ module.exports = {
             if (node.prefix) {
                 if (secondToken.range[0] > firstToken.range[1]) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Unexpected space after unary operator '" + firstToken.value + "'.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
                         }
                     });
@@ -225,9 +225,9 @@ module.exports = {
             } else {
                 if (secondToken.range[0] > firstToken.range[1]) {
                     context.report({
-                        node: node,
+                        node,
                         message: "Unexpected space before unary operator '" + secondToken.value + "'.",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
                         }
                     });

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -227,7 +227,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         // Unless the first option is never, require a space
         let requireSpace = context.options[0] !== "never";
@@ -268,8 +268,8 @@ module.exports = {
                 commentIdentifier = type === "block" ? "/*" : "//";
 
             context.report({
-                node: node,
-                fix: function(fixer) {
+                node,
+                fix(fixer) {
                     let start = node.range[0],
                         end = start + 2;
 
@@ -283,7 +283,7 @@ module.exports = {
                         return fixer.replaceTextRange([start, end], commentIdentifier + (match[1] ? match[1] : ""));
                     }
                 },
-                message: message
+                message
             });
         }
 
@@ -296,8 +296,8 @@ module.exports = {
          */
         function reportEnd(node, message, match) {
             context.report({
-                node: node,
-                fix: function(fixer) {
+                node,
+                fix(fixer) {
                     if (requireSpace) {
                         return fixer.insertTextAfterRange([node.start, node.end - 2], " ");
                     } else {
@@ -307,7 +307,7 @@ module.exports = {
                         return fixer.replaceTextRange([start, end], "");
                     }
                 },
-                message: message
+                message
             });
         }
 

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -94,7 +94,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let mode = context.options[0] || "safe",
             ecmaFeatures = context.parserOptions.ecmaFeatures || {},
@@ -211,7 +211,7 @@ module.exports = {
         }
 
         rule = {
-            Program: function(node) {
+            Program(node) {
                 let useStrictDirectives = getUseStrictDirectives(node.body);
 
                 if (node.sourceType === "module") {
@@ -236,10 +236,10 @@ module.exports = {
             lodash.assign(rule, {
 
                 // Inside of class bodies are always strict mode.
-                ClassBody: function() {
+                ClassBody() {
                     classScopes.push(true);
                 },
-                "ClassBody:exit": function() {
+                "ClassBody:exit"() {
                     classScopes.pop();
                 },
 

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -37,7 +37,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
         let always = context.options[0] === "always";
         let prefix = always ? "Expected" : "Unexpected";
@@ -58,7 +58,7 @@ module.exports = {
                 context.report({
                     loc: token.loc.start,
                     message: prefix + " space(s) before '}'.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         if (always) {
                             return fixer.insertTextBefore(token, " ");
                         }
@@ -90,7 +90,7 @@ module.exports = {
                         column: token.loc.end.column - 2
                     },
                     message: prefix + " space(s) after '${'.",
-                    fix: function(fixer) {
+                    fix(fixer) {
                         if (always) {
                             return fixer.insertTextAfter(token, " ");
                         }
@@ -104,7 +104,7 @@ module.exports = {
         }
 
         return {
-            TemplateElement: function(node) {
+            TemplateElement(node) {
                 let token = sourceCode.getFirstToken(node);
 
                 checkSpacingBefore(token);

--- a/lib/rules/unicode-bom.js
+++ b/lib/rules/unicode-bom.js
@@ -25,7 +25,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         //--------------------------------------------------------------------------
         // Public
@@ -41,19 +41,19 @@ module.exports = {
 
                 if (!sourceCode.hasBOM && (requireBOM === "always")) {
                     context.report({
-                        node: node,
+                        node,
                         loc: location,
                         message: "Expected Unicode BOM (Byte Order Mark).",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.insertTextBefore(node, "\uFEFF");
                         }
                     });
                 } else if (sourceCode.hasBOM && (requireBOM === "never")) {
                     context.report({
-                        node: node,
+                        node,
                         loc: location,
                         message: "Unexpected Unicode BOM (Byte Order Mark).",
-                        fix: function(fixer) {
+                        fix(fixer) {
                             return fixer.removeRange([-1, 0]);
                         }
                     });

--- a/lib/rules/use-isnan.js
+++ b/lib/rules/use-isnan.js
@@ -20,10 +20,10 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         return {
-            BinaryExpression: function(node) {
+            BinaryExpression(node) {
                 if (/^(?:[<>]|[!=]=)=?$/.test(node.operator) && (node.left.name === "NaN" || node.right.name === "NaN")) {
                     context.report(node, "Use the isNaN function to compare with NaN.");
                 }

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -59,7 +59,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let options = context.options[0] || {},
             prefer = options.prefer || {},
@@ -160,8 +160,8 @@ module.exports = {
             expectedType = currentType && preferType[currentType];
 
             return {
-                currentType: currentType,
-                expectedType: expectedType
+                currentType,
+                expectedType
             };
         }
 
@@ -350,12 +350,12 @@ module.exports = {
                         if (param.type === "Identifier") {
                             if (jsdocParams[i] && (name !== jsdocParams[i])) {
                                 context.report(jsdocNode, "Expected JSDoc for '{{name}}' but found '{{jsdocName}}'.", {
-                                    name: name,
+                                    name,
                                     jsdocName: jsdocParams[i]
                                 });
                             } else if (!params[name] && !isOverride) {
                                 context.report(jsdocNode, "Missing JSDoc for parameter '{{name}}'.", {
-                                    name: name
+                                    name
                                 });
                             }
                         }

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -19,7 +19,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
 
         let VALID_TYPES = ["symbol", "undefined", "object", "boolean", "number", "string", "function"],
             OPERATORS = ["==", "===", "!=", "!=="];
@@ -30,7 +30,7 @@ module.exports = {
 
         return {
 
-            UnaryExpression: function(node) {
+            UnaryExpression(node) {
                 let parent, sibling;
 
                 if (node.operator === "typeof") {

--- a/lib/rules/vars-on-top.js
+++ b/lib/rules/vars-on-top.js
@@ -20,7 +20,7 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let errorMessage = "All 'var' declarations must be at the top of the function scope.";
 
         //--------------------------------------------------------------------------
@@ -124,7 +124,7 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            VariableDeclaration: function(node) {
+            VariableDeclaration(node) {
                 let ancestors = context.getAncestors();
                 let parent = ancestors.pop();
                 let grandParent = ancestors.pop();

--- a/lib/rules/wrap-iife.js
+++ b/lib/rules/wrap-iife.js
@@ -24,7 +24,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         let style = context.options[0] || "outside";
 
@@ -46,7 +46,7 @@ module.exports = {
 
         return {
 
-            CallExpression: function(node) {
+            CallExpression(node) {
                 if (node.callee.type === "FunctionExpression") {
                     let callExpressionWrapped = wrapped(node),
                         functionExpressionWrapped = wrapped(node.callee);

--- a/lib/rules/wrap-regex.js
+++ b/lib/rules/wrap-regex.js
@@ -20,12 +20,12 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         return {
 
-            Literal: function(node) {
+            Literal(node) {
                 let token = sourceCode.getFirstToken(node),
                     nodeType = token.type,
                     source,

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -38,7 +38,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
         let sourceCode = context.getSourceCode();
 
         let mode = (function(option) {
@@ -71,9 +71,9 @@ module.exports = {
                 let message = type + " space " + side + " *.";
 
                 context.report({
-                    node: node,
-                    message: message,
-                    fix: function(fixer) {
+                    node,
+                    message,
+                    fix(fixer) {
                         if (spaceRequired) {
                             if (after) {
                                 return fixer.insertTextAfter(node, " ");

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -144,7 +144,7 @@ module.exports = {
         ]
     },
 
-    create: function(context) {
+    create(context) {
 
         // Default to "never" (!always) if no option
         let always = (context.options[0] === "always");

--- a/lib/testers/event-generator-tester.js
+++ b/lib/testers/event-generator-tester.js
@@ -43,7 +43,7 @@ module.exports = {
      * @param {Object} instance - An object to check.
      * @returns {void}
      */
-    testEventGeneratorInterface: function(instance) {
+    testEventGeneratorInterface(instance) {
         this.describe("should implement EventGenerator interface", function() {
             this.it("should have `emitter` property.", function() {
                 assert.equal(typeof instance.emitter, "object");

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -198,7 +198,7 @@ RuleTester.prototype = {
      * @param {Function} rule The rule definition.
      * @returns {void}
      */
-    defineRule: function(name, rule) {
+    defineRule(name, rule) {
         eslint.defineRule(name, rule);
     },
 
@@ -209,7 +209,7 @@ RuleTester.prototype = {
      * @param {Object} test The collection of tests to run.
      * @returns {void}
      */
-    run: function(ruleName, rule, test) {
+    run(ruleName, rule, test) {
 
         let testerConfig = this.testerConfig,
             result = {};
@@ -308,7 +308,7 @@ RuleTester.prototype = {
                     } else {
                         return {
                             meta: rule.meta,
-                            create: function(context) {
+                            create(context) {
                                 Object.freeze(context);
                                 freezeDeeply(context.options);
                                 freezeDeeply(context.settings);
@@ -322,8 +322,8 @@ RuleTester.prototype = {
 
                 return {
                     messages: eslint.verify(code, config, filename, true),
-                    beforeAST: beforeAST,
-                    afterAST: afterAST
+                    beforeAST,
+                    afterAST
                 };
             } finally {
                 rules.get = originalGet;

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -137,8 +137,8 @@ module.exports = (function() {
     }
 
     return {
-        time: time,
-        enabled: enabled
+        time,
+        enabled
     };
 
 }());

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -146,7 +146,7 @@ function listFilesToProcess(globPatterns, options) {
         if (added[filename]) {
             return;
         }
-        files.push({filename: filename, ignored: ignored});
+        files.push({filename, ignored});
         added[filename] = true;
     }
 
@@ -154,7 +154,7 @@ function listFilesToProcess(globPatterns, options) {
     ignoredPaths = new IgnoredPaths(options);
     globOptions = {
         nodir: true,
-        cwd: cwd,
+        cwd,
         ignore: ignoredPaths.getIgnoredFoldersGlobPatterns()
     };
 
@@ -175,6 +175,6 @@ function listFilesToProcess(globPatterns, options) {
 }
 
 module.exports = {
-    resolveFileGlobPatterns: resolveFileGlobPatterns,
-    listFilesToProcess: listFilesToProcess
+    resolveFileGlobPatterns,
+    listFilesToProcess
 };

--- a/lib/util/module-resolver.js
+++ b/lib/util/module-resolver.js
@@ -53,7 +53,7 @@ ModuleResolver.prototype = {
      * @returns {string} The resolved file path for the module.
      * @throws {Error} If the module cannot be resolved.
      */
-    resolve: function(name, extraLookupPath) {
+    resolve(name, extraLookupPath) {
 
         /*
          * First, clone the lookup paths so we're not messing things up for

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -139,8 +139,8 @@ function checkPackageJson(startDir) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    installSyncSaveDev: installSyncSaveDev,
-    checkDeps: checkDeps,
-    checkDevDeps: checkDevDeps,
-    checkPackageJson: checkPackageJson
+    installSyncSaveDev,
+    checkDeps,
+    checkDevDeps,
+    checkPackageJson
 };

--- a/lib/util/path-util.js
+++ b/lib/util/path-util.js
@@ -69,6 +69,6 @@ function getRelativePath(filepath, baseDir) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    convertPathToPosix: convertPathToPosix,
-    getRelativePath: getRelativePath
+    convertPathToPosix,
+    getRelativePath
 };

--- a/lib/util/rule-fixer.js
+++ b/lib/util/rule-fixer.js
@@ -24,7 +24,7 @@
 function insertTextAt(index, text) {
     return {
         range: [index, index],
-        text: text
+        text
     };
 }
 
@@ -50,7 +50,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextAfter: function(nodeOrToken, text) {
+    insertTextAfter(nodeOrToken, text) {
         return this.insertTextAfterRange(nodeOrToken.range, text);
     },
 
@@ -62,7 +62,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextAfterRange: function(range, text) {
+    insertTextAfterRange(range, text) {
         return insertTextAt(range[1], text);
     },
 
@@ -73,7 +73,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextBefore: function(nodeOrToken, text) {
+    insertTextBefore(nodeOrToken, text) {
         return this.insertTextBeforeRange(nodeOrToken.range, text);
     },
 
@@ -85,7 +85,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextBeforeRange: function(range, text) {
+    insertTextBeforeRange(range, text) {
         return insertTextAt(range[0], text);
     },
 
@@ -96,7 +96,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    replaceText: function(nodeOrToken, text) {
+    replaceText(nodeOrToken, text) {
         return this.replaceTextRange(nodeOrToken.range, text);
     },
 
@@ -108,10 +108,10 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    replaceTextRange: function(range, text) {
+    replaceTextRange(range, text) {
         return {
-            range: range,
-            text: text
+            range,
+            text
         };
     },
 
@@ -121,7 +121,7 @@ RuleFixer.prototype = {
      * @param {ASTNode|Token} nodeOrToken The node or token to remove.
      * @returns {Object} The fix command.
      */
-    remove: function(nodeOrToken) {
+    remove(nodeOrToken) {
         return this.removeRange(nodeOrToken.range);
     },
 
@@ -132,9 +132,9 @@ RuleFixer.prototype = {
      *      is end of range.
      * @returns {Object} The fix command.
      */
-    removeRange: function(range) {
+    removeRange(range) {
         return {
-            range: range,
+            range,
             text: ""
         };
     }

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -60,7 +60,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         debug("No source code to fix");
         return {
             fixed: false,
-            messages: messages,
+            messages,
             output: ""
         };
     }
@@ -128,7 +128,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         debug("No fixes to apply");
         return {
             fixed: false,
-            messages: messages,
+            messages,
             output: prefix + text
         };
     }

--- a/lib/util/source-code-util.js
+++ b/lib/util/source-code-util.js
@@ -108,5 +108,5 @@ function getSourceCodeOfFiles(patterns, options, cb) {
 }
 
 module.exports = {
-    getSourceCodeOfFiles: getSourceCodeOfFiles
+    getSourceCodeOfFiles
 };

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -159,7 +159,7 @@ SourceCode.prototype = {
      * @param {int=} afterCount The number of characters after the node to retrieve.
      * @returns {string} The text representing the AST node.
      */
-    getText: function(node, beforeCount, afterCount) {
+    getText(node, beforeCount, afterCount) {
         if (node) {
             return this.text.slice(Math.max(node.range[0] - (beforeCount || 0), 0),
                 node.range[1] + (afterCount || 0));
@@ -173,7 +173,7 @@ SourceCode.prototype = {
      * Gets the entire source text split into an array of lines.
      * @returns {Array} The source text as an array of lines.
      */
-    getLines: function() {
+    getLines() {
         return this.lines;
     },
 
@@ -181,7 +181,7 @@ SourceCode.prototype = {
      * Retrieves an array containing all comments in the source code.
      * @returns {ASTNode[]} An array of comment nodes.
      */
-    getAllComments: function() {
+    getAllComments() {
         return this.ast.comments;
     },
 
@@ -191,7 +191,7 @@ SourceCode.prototype = {
      * @returns {Object} The list of comments indexed by their position.
      * @public
      */
-    getComments: function(node) {
+    getComments(node) {
 
         let leadingComments = node.leadingComments || [],
             trailingComments = node.trailingComments || [];
@@ -220,7 +220,7 @@ SourceCode.prototype = {
      *      given node or null if not found.
      * @public
      */
-    getJSDocComment: function(node) {
+    getJSDocComment(node) {
 
         let parent = node.parent;
 
@@ -260,13 +260,13 @@ SourceCode.prototype = {
      * @param {int} index Range index of the desired node.
      * @returns {ASTNode} The node if found or null if not found.
      */
-    getNodeByRangeIndex: function(index) {
+    getNodeByRangeIndex(index) {
         let result = null,
             resultParent = null,
             traverser = new Traverser();
 
         traverser.traverse(this.ast, {
-            enter: function(node, parent) {
+            enter(node, parent) {
                 if (node.range[0] <= index && index < node.range[1]) {
                     result = node;
                     resultParent = parent;
@@ -274,7 +274,7 @@ SourceCode.prototype = {
                     this.skip();
                 }
             },
-            leave: function(node) {
+            leave(node) {
                 if (node === result) {
                     this.break();
                 }
@@ -293,7 +293,7 @@ SourceCode.prototype = {
      * @returns {boolean} True if there is only space between tokens, false
      *  if there is anything other than whitespace between tokens.
      */
-    isSpaceBetweenTokens: function(first, second) {
+    isSpaceBetweenTokens(first, second) {
         let text = this.text.slice(first.range[1], second.range[0]);
 
         return /\s/.test(text.replace(/\/\*.*?\*\//g, ""));

--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -88,6 +88,7 @@ rules:
     no-useless-constructor: "error"
     no-with: "error"
     no-var: "error"
+    object-shorthand: "error"
     one-var-declaration-per-line: "error"
     quotes: ["error", "double"]
     quote-props: ["error", "as-needed"]

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -909,7 +909,7 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                cwd: cwd,
+                cwd,
                 rulePaths: ["./"],
                 configFile: "eslint.json"
             });
@@ -1628,7 +1628,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     cache: true,
-                    cwd: cwd,
+                    cwd,
                     rules: {
                         "no-console": 0
                     },
@@ -1760,7 +1760,7 @@ describe("CLIEngine", function() {
 
                     // specifying cache true the cache will be created
                     cache: true,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1801,7 +1801,7 @@ describe("CLIEngine", function() {
 
                     // specifying cache true the cache will be created
                     cache: true,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1833,7 +1833,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1854,7 +1854,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1876,7 +1876,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
                     cache: true,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1899,7 +1899,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1987,10 +1987,10 @@ describe("CLIEngine", function() {
                 engine.addPlugin("test-processor", {
                     processors: {
                         ".txt": {
-                            preprocess: function(text) {
+                            preprocess(text) {
                                 return [text];
                             },
-                            postprocess: function(messages) {
+                            postprocess(messages) {
                                 return messages[0];
                             }
                         }
@@ -2030,10 +2030,10 @@ describe("CLIEngine", function() {
                 engine.addPlugin("test-processor", {
                     processors: {
                         ".txt": {
-                            preprocess: function(text) {
+                            preprocess(text) {
                                 return [text.replace("a()", "b()")];
                             },
-                            postprocess: function(messages) {
+                            postprocess(messages) {
                                 messages[0][0].ruleId = "post-processed";
                                 return messages[0];
                             }
@@ -2074,10 +2074,10 @@ describe("CLIEngine", function() {
                 engine.addPlugin("test-processor", {
                     processors: {
                         ".txt": {
-                            preprocess: function(text) {
+                            preprocess(text) {
                                 return [text.replace("a()", "b()")];
                             },
-                            postprocess: function(messages) {
+                            postprocess(messages) {
                                 messages[0][0].ruleId = "post-processed";
                                 return messages[0];
                             }

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -69,7 +69,7 @@ describe("CodePathAnalyzer", function() {
             actual = [];
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathStart: function(codePath) {
+                    onCodePathStart(codePath) {
                         actual.push(codePath);
                     }
                 };
@@ -149,14 +149,14 @@ describe("CodePathAnalyzer", function() {
                 let codePath = null;
 
                 return {
-                    onCodePathStart: function(cp) {
+                    onCodePathStart(cp) {
                         codePath = cp;
                     },
-                    ReturnStatement: function() {
+                    ReturnStatement() {
                         assert(codePath.currentSegments.length === 1);
                         assert(codePath.currentSegments[0] instanceof CodePathSegment);
                     },
-                    ThrowStatement: function() {
+                    ThrowStatement() {
                         assert(codePath.currentSegments.length === 1);
                         assert(codePath.currentSegments[0] instanceof CodePathSegment);
                     }
@@ -176,7 +176,7 @@ describe("CodePathAnalyzer", function() {
             actual = [];
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentStart: function(segment) {
+                    onCodePathSegmentStart(segment) {
                         actual.push(segment);
                     }
                 };
@@ -265,7 +265,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathStart: function(cp, node) {
+                    onCodePathStart(cp, node) {
                         count += 1;
                         lastCodePathNodeType = node.type;
 
@@ -280,16 +280,16 @@ describe("CodePathAnalyzer", function() {
                             assert(node.type === "ArrowFunctionExpression");
                         }
                     },
-                    Program: function() {
+                    Program() {
                         assert(lastCodePathNodeType === "Program");
                     },
-                    FunctionDeclaration: function() {
+                    FunctionDeclaration() {
                         assert(lastCodePathNodeType === "FunctionDeclaration");
                     },
-                    FunctionExpression: function() {
+                    FunctionExpression() {
                         assert(lastCodePathNodeType === "FunctionExpression");
                     },
-                    ArrowFunctionExpression: function() {
+                    ArrowFunctionExpression() {
                         assert(lastCodePathNodeType === "ArrowFunctionExpression");
                     }
                 };
@@ -310,7 +310,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathEnd: function(cp, node) {
+                    onCodePathEnd(cp, node) {
                         count += 1;
 
                         assert(cp instanceof CodePath);
@@ -325,16 +325,16 @@ describe("CodePathAnalyzer", function() {
                         }
                         assert(node.type === lastNodeType);
                     },
-                    "Program:exit": function() {
+                    "Program:exit"() {
                         lastNodeType = "Program";
                     },
-                    "FunctionDeclaration:exit": function() {
+                    "FunctionDeclaration:exit"() {
                         lastNodeType = "FunctionDeclaration";
                     },
-                    "FunctionExpression:exit": function() {
+                    "FunctionExpression:exit"() {
                         lastNodeType = "FunctionExpression";
                     },
-                    "ArrowFunctionExpression:exit": function() {
+                    "ArrowFunctionExpression:exit"() {
                         lastNodeType = "ArrowFunctionExpression";
                     }
                 };
@@ -355,7 +355,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentStart: function(segment, node) {
+                    onCodePathSegmentStart(segment, node) {
                         count += 1;
                         lastCodePathNodeType = node.type;
 
@@ -370,16 +370,16 @@ describe("CodePathAnalyzer", function() {
                             assert(node.type === "ArrowFunctionExpression");
                         }
                     },
-                    Program: function() {
+                    Program() {
                         assert(lastCodePathNodeType === "Program");
                     },
-                    FunctionDeclaration: function() {
+                    FunctionDeclaration() {
                         assert(lastCodePathNodeType === "FunctionDeclaration");
                     },
-                    FunctionExpression: function() {
+                    FunctionExpression() {
                         assert(lastCodePathNodeType === "FunctionExpression");
                     },
-                    ArrowFunctionExpression: function() {
+                    ArrowFunctionExpression() {
                         assert(lastCodePathNodeType === "ArrowFunctionExpression");
                     }
                 };
@@ -400,7 +400,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentEnd: function(cp, node) {
+                    onCodePathSegmentEnd(cp, node) {
                         count += 1;
 
                         assert(cp instanceof CodePathSegment);
@@ -415,16 +415,16 @@ describe("CodePathAnalyzer", function() {
                         }
                         assert(node.type === lastNodeType);
                     },
-                    "Program:exit": function() {
+                    "Program:exit"() {
                         lastNodeType = "Program";
                     },
-                    "FunctionDeclaration:exit": function() {
+                    "FunctionDeclaration:exit"() {
                         lastNodeType = "FunctionDeclaration";
                     },
-                    "FunctionExpression:exit": function() {
+                    "FunctionExpression:exit"() {
                         lastNodeType = "FunctionExpression";
                     },
-                    "ArrowFunctionExpression:exit": function() {
+                    "ArrowFunctionExpression:exit"() {
                         lastNodeType = "ArrowFunctionExpression";
                     }
                 };
@@ -444,7 +444,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -465,7 +465,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -486,7 +486,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -514,7 +514,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -542,7 +542,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -580,7 +580,7 @@ describe("CodePathAnalyzer", function() {
 
                 eslint.defineRule("test", function() {
                     return {
-                        onCodePathEnd: function(codePath) {
+                        onCodePathEnd(codePath) {
                             actual.push(debug.makeDotArrows(codePath));
                         }
                     };

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -28,7 +28,7 @@ function parseCodePaths(code) {
     eslint.reset();
     eslint.defineRule("test", function() {
         return {
-            onCodePathStart: function(codePath) {
+            onCodePathStart(codePath) {
                 retv.push(codePath);
             }
         };

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -161,7 +161,7 @@ describe("ConfigFile", function() {
 
                 // Hacky: need to override isFile for each call for testing
                 "../util/module-resolver": createStubModuleResolver({ "eslint-config-foo": resolvedPath }),
-                "require-uncached": function(filename) {
+                "require-uncached"(filename) {
                     return configDeps[filename];
                 }
             };
@@ -232,7 +232,7 @@ describe("ConfigFile", function() {
                     "eslint-config-foo": resolvedPaths[0],
                     "eslint-config-bar": resolvedPaths[1]
                 }),
-                "require-uncached": function(filename) {
+                "require-uncached"(filename) {
                     return configDeps[filename];
                 }
             };

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -230,7 +230,7 @@ describe("configInitializer", function() {
 
                 answers = {
                     source: "auto",
-                    patterns: patterns,
+                    patterns,
                     es6: false,
                     env: ["browser"],
                     jsx: false,

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -99,7 +99,7 @@ describe("ConfigOps", function() {
         it("should return correct config for env with no globals", function() {
             let StubbedConfigOps = proxyquire("../../../lib/config/config-ops", {
                 "./environments": {
-                    get: function() {
+                    get() {
                         return {
                             parserOptions: {
                                 sourceType: "module"

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -25,7 +25,7 @@ let assert = require("chai").assert,
  */
 function mockRule(context) {
     return {
-        Program: function(node) {
+        Program(node) {
             context.report(node, "Expected a validation error.");
         }
     };
@@ -45,7 +45,7 @@ mockRule.schema = [
  */
 function mockObjectRule(context) {
     return {
-        Program: function(node) {
+        Program(node) {
             context.report(node, "Expected a validation error.");
         }
     };
@@ -63,7 +63,7 @@ mockObjectRule.schema = {
  */
 function mockNoOptionsRule(context) {
     return {
-        Program: function(node) {
+        Program(node) {
             context.report(node, "Expected a validation error.");
         }
     };

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -890,7 +890,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter name}}", {
                             "parameter name": "yay!"
                         });
@@ -909,7 +909,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{code}}");
                     }
                 };
@@ -926,7 +926,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter-name}}", {
                             "parameter-name": "yay!"
                         });
@@ -945,7 +945,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter}}", {});
                     }
                 };
@@ -962,7 +962,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter}}", {});
                     }
                 };
@@ -980,7 +980,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{ parameter}}", {
                             parameter: "yay!"
                         });
@@ -999,7 +999,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter }}", {
                             parameter: "yay!"
                         });
@@ -1018,7 +1018,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{ parameter name }}", {
                             "parameter name": "yay!"
                         });
@@ -1037,7 +1037,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{ parameter-name }}", {
                             "parameter-name": "yay!"
                         });
@@ -1161,7 +1161,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, context.settings.info);
                     }
                 };
@@ -1181,7 +1181,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         if (Object.getOwnPropertyNames(context.settings).length !== 0) {
                             context.report(node, "Settings should be empty");
                         }
@@ -1212,10 +1212,10 @@ describe("eslint", function() {
 
             eslint.reset();
             eslint.defineRule("test-rule", sandbox.mock().withArgs(
-                sinon.match({parserOptions: parserOptions})
+                sinon.match({parserOptions})
             ).returns({}));
 
-            let config = { rules: { "test-rule": 2 }, parserOptions: parserOptions };
+            let config = { rules: { "test-rule": 2 }, parserOptions };
 
             eslint.verify("0", config, filename);
         });
@@ -1226,7 +1226,7 @@ describe("eslint", function() {
 
             eslint.reset();
             eslint.defineRule("test-rule", sandbox.mock().withArgs(
-                sinon.match({parserOptions: parserOptions})
+                sinon.match({parserOptions})
             ).returns({}));
 
             let config = { rules: { "test-rule": 2 } };
@@ -1679,7 +1679,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message");
                     }
                 };
@@ -1709,7 +1709,7 @@ describe("eslint", function() {
                 config.rules[item] = 1;
                 newRules[item] = function(context) {
                     return {
-                        Literal: function(node) {
+                        Literal(node) {
                             context.report(node, "message");
                         }
                     };
@@ -1738,7 +1738,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, context.getFilename());
                     }
                 };
@@ -1757,7 +1757,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, context.getFilename());
                     }
                 };
@@ -1903,7 +1903,7 @@ describe("eslint", function() {
 
         eslint.defineRule("test-plugin/test-rule", function(context) {
             return {
-                Literal: function(node) {
+                Literal(node) {
                     if (node.value === "trigger violation") {
                         context.report(node, "Reporting violation.");
                     }
@@ -2851,7 +2851,7 @@ describe("eslint", function() {
             };
 
             let messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2871,9 +2871,9 @@ describe("eslint", function() {
             };
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         let scope = context.getScope();
                         let sourceCode = context.getSourceCode();
                         let comments = sourceCode.getAllComments();
@@ -2905,7 +2905,7 @@ describe("eslint", function() {
             };
 
             let messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2925,7 +2925,7 @@ describe("eslint", function() {
             };
 
             let messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2943,7 +2943,7 @@ describe("eslint", function() {
             };
 
             let messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2962,9 +2962,9 @@ describe("eslint", function() {
             };
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         let scope = context.getScope();
                         let sourceCode = context.getSourceCode();
                         let comments = sourceCode.getAllComments();
@@ -2998,7 +2998,7 @@ describe("eslint", function() {
             };
 
             let messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: true
             });
 
@@ -3304,9 +3304,9 @@ describe("eslint", function() {
             let code = "/* global foo */\n/* global bar, baz */";
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         let scope = context.getScope();
                         let sourceCode = context.getSourceCode();
                         let comments = sourceCode.getAllComments();
@@ -3370,9 +3370,9 @@ describe("eslint", function() {
         beforeEach(function() {
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         scope = context.getScope();
                         ok = true;
                     }
@@ -3482,7 +3482,7 @@ describe("eslint", function() {
          * @returns {void}
          */
         function verify(code, type, expectedNamesList) {
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 let rule = {
                     Program: checkEmpty,
                     EmptyStatement: checkEmpty,
@@ -3802,7 +3802,7 @@ describe("eslint", function() {
 
             it("should strip leading line: prefix from parser error", function() {
                 let parser = path.join(parserFixtures, "line-error.js");
-                let messages = eslint.verify(";", { parser: parser }, "filename");
+                let messages = eslint.verify(";", { parser }, "filename");
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);
@@ -3812,7 +3812,7 @@ describe("eslint", function() {
 
             it("should not modify a parser error message without a leading line: prefix", function() {
                 let parser = path.join(parserFixtures, "no-line-error.js");
-                let messages = eslint.verify(";", { parser: parser }, "filename");
+                let messages = eslint.verify(";", { parser }, "filename");
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -18,13 +18,13 @@ let assert = require("chai").assert,
 // for Sinon to work.
 let chalkStub = Object.create(chalk, {
     yellow: {
-        value: function(str) {
+        value(str) {
             return chalk.yellow(str);
         },
         writable: true
     },
     red: {
-        value: function(str) {
+        value(str) {
             return chalk.red(str);
         },
         writable: true

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -159,7 +159,7 @@ describe("IgnoredPaths", function() {
             let ignorePattern = ["a", "b"];
 
             let ignoredPaths = new IgnoredPaths({
-                ignorePattern: ignorePattern
+                ignorePattern
             });
 
             assert.ok(ignorePattern.every(function(pattern) {

--- a/tests/lib/rule-context.js
+++ b/tests/lib/rule-context.js
@@ -82,11 +82,11 @@ describe("RuleContext", function() {
                     .withArgs("fake-rule", 2, node, location, message, messageOpts, fixerObj);
 
                 ruleContext.report({
-                    node: node,
+                    node,
                     loc: location,
-                    message: message,
+                    message,
                     data: messageOpts,
-                    fix: fix
+                    fix
                 });
 
                 fix.verify();

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -58,7 +58,7 @@ describe("rules", function() {
     describe("when importing plugin rules", function() {
         let customPlugin = {
                 rules: {
-                    "custom-rule": function() { }
+                    "custom-rule"() { }
                 }
             },
             pluginName = "custom-plugin";

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -49,8 +49,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 1,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -60,8 +60,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 1,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -71,8 +71,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 1,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -82,8 +82,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 8,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -93,8 +93,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 8,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -104,8 +104,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 3,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
 
@@ -119,7 +119,7 @@ let invalid = [
             line: 1,
             column: 1,
             message: asNeededMessage,
-            type: type
+            type
         }]
     },
     {
@@ -131,13 +131,13 @@ let invalid = [
             line: 1,
             column: 1,
             message: asNeededMessage,
-            type: type
+            type
         }]
     }
 
 ];
 
 ruleTester.run("arrow-parens", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -332,6 +332,6 @@ let invalid = [
 ];
 
 ruleTester.run("arrow-spacing", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/consistent-this.js
+++ b/tests/lib/rules/consistent-this.js
@@ -23,7 +23,7 @@ let rule = require("../../../lib/rules/consistent-this"),
  */
 function destructuringTest(code) {
     return {
-        code: code,
+        code,
         options: ["self"],
         env: { es6: true },
         parserOptions: { ecmaVersion: 6 }

--- a/tests/lib/rules/global-require.js
+++ b/tests/lib/rules/global-require.js
@@ -44,8 +44,8 @@ let invalid = [
         errors: [{
             line: 2,
             column: 2,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -53,8 +53,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 21,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -62,8 +62,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 21,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -71,8 +71,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 16,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -80,8 +80,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 7,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
 
@@ -92,8 +92,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 22,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -102,8 +102,8 @@ let invalid = [
         errors: [{
             line: 1,
             column: 15,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -111,13 +111,13 @@ let invalid = [
         errors: [{
             line: 1,
             column: 23,
-            message: message,
-            type: type
+            message,
+            type
         }]
     }
 ];
 
 ruleTester.run("global-require", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -25,12 +25,12 @@ function invalid(code, type, line, config) {
     config = config || {};
 
     let result = {
-        code: code,
+        code,
         parserOptions: config.parserOptions || {},
         errors: [
             {
                 message: "Gratuitous parentheses around expression.",
-                type: type
+                type
             }
         ],
         options: config.options || []

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -104,7 +104,7 @@ let patterns = [
     {
         code: "console.log(this); z(x => console.log(x, this));",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -114,7 +114,7 @@ let patterns = [
             ecmaVersion: 6,
             ecmaFeatures: {globalReturn: true}
         },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -123,7 +123,7 @@ let patterns = [
     {
         code: "(function() { console.log(this); z(x => console.log(x, this)); })();",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -132,14 +132,14 @@ let patterns = [
     {
         code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "function foo() { \"use strict\"; console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -149,14 +149,14 @@ let patterns = [
             ecmaVersion: 6,
             ecmaFeatures: {globalReturn: true}
         },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT] // modules cannot return on global.
     },
     {
         code: "var foo = (function() { console.log(this); z(x => console.log(x, this)); }).bar(obj);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -165,49 +165,49 @@ let patterns = [
     {
         code: "var obj = {foo: function() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "var obj = {foo() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "var obj = {foo: function() { return function() { console.log(this); z(x => console.log(x, this)); }; }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "var obj = {foo: function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "obj.foo = function() { return function() { console.log(this); z(x => console.log(x, this)); }; };",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "obj.foo = function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; };",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "class A { foo() { return function() { console.log(this); z(x => console.log(x, this)); }; } }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -216,7 +216,7 @@ let patterns = [
     {
         code: "class A {static foo() { console.log(this); z(x => console.log(x, this)); }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
     },
@@ -329,7 +329,7 @@ let patterns = [
     {
         code: "var foo = function() { console.log(this); z(x => console.log(x, this)); }.bind(null);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -342,7 +342,7 @@ let patterns = [
     {
         code: "(function() { console.log(this); z(x => console.log(x, this)); }).call(undefined);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -355,7 +355,7 @@ let patterns = [
     {
         code: "(function() { console.log(this); z(x => console.log(x, this)); }).apply(void 0);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -370,56 +370,56 @@ let patterns = [
     {
         code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -474,7 +474,7 @@ let patterns = [
     {
         code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, null);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -495,21 +495,21 @@ let patterns = [
     {
         code: "/** @returns {void} */ function foo() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "/** @this Obj */ foo(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo(/* @this Obj */ function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
     },
@@ -518,7 +518,7 @@ let patterns = [
     {
         code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -29,7 +29,7 @@ function getExpectedError(lines) {
         : "More than " + lines + " blank lines not allowed.";
 
     return {
-        message: message,
+        message,
         type: "Program"
     };
 }

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -83,6 +83,6 @@ let invalid = [
 ];
 
 ruleTester.run("no-prototype-builtins", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/no-sequences.js
+++ b/tests/lib/rules/no-sequences.js
@@ -26,7 +26,7 @@ function errors(column) {
         message: "Unexpected use of comma operator.",
         type: "SequenceExpression",
         line: 1,
-        column: column
+        column
     }];
 }
 

--- a/tests/lib/rules/no-undefined.js
+++ b/tests/lib/rules/no-undefined.js
@@ -34,14 +34,14 @@ ruleTester.run("no-undefined", rule, {
         "global['undefined']"
     ],
     invalid: [
-        { code: "undefined", errors: errors },
-        { code: "undefined.a", errors: errors },
-        { code: "a[undefined]", errors: errors },
-        { code: "undefined[0]", errors: errors },
-        { code: "f(undefined)", errors: errors },
-        { code: "function f(undefined) {}", errors: errors },
-        { code: "var undefined;", errors: errors },
-        { code: "try {} catch(undefined) {}", errors: errors },
-        { code: "(function undefined(){}())", errors: errors }
+        { code: "undefined", errors },
+        { code: "undefined.a", errors },
+        { code: "a[undefined]", errors },
+        { code: "undefined[0]", errors },
+        { code: "f(undefined)", errors },
+        { code: "function f(undefined) {}", errors },
+        { code: "var undefined;", errors },
+        { code: "try {} catch(undefined) {}", errors },
+        { code: "(function undefined(){}())", errors }
     ]
 });

--- a/tests/lib/rules/one-var-declaration-per-line.js
+++ b/tests/lib/rules/one-var-declaration-per-line.js
@@ -27,8 +27,8 @@ function errorAt(line, column) {
     return {
         message: "Expected variable declaration to be on a new line.",
         type: "VariableDeclaration",
-        line: line,
-        column: column
+        line,
+        column
     };
 }
 

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -44,19 +44,19 @@ ruleTester.run("prefer-arrow-callback", rule, {
         {code: "foo(function bar() { new.target; }.bind(this));", parserOptions: { ecmaVersion: 6 }}
     ],
     invalid: [
-        {code: "foo(function bar() {});", errors: errors},
-        {code: "foo(function() {});", options: [{ allowNamedFunctions: true }], errors: errors},
-        {code: "foo(function bar() {});", options: [{ allowNamedFunctions: false }], errors: errors},
-        {code: "foo(function() {});", errors: errors},
-        {code: "foo(nativeCb || function() {});", errors: errors},
+        {code: "foo(function bar() {});", errors},
+        {code: "foo(function() {});", options: [{ allowNamedFunctions: true }], errors},
+        {code: "foo(function bar() {});", options: [{ allowNamedFunctions: false }], errors},
+        {code: "foo(function() {});", errors},
+        {code: "foo(nativeCb || function() {});", errors},
         {code: "foo(bar ? function() {} : function() {});", errors: [errors[0], errors[0]]},
-        {code: "foo(function() { (function() { this; }); });", errors: errors},
-        {code: "foo(function() { this; }.bind(this));", errors: errors},
-        {code: "foo(function() { (() => this); }.bind(this));", parserOptions: { ecmaVersion: 6 }, errors: errors},
-        {code: "foo(function bar(a) { a; });", errors: errors},
-        {code: "foo(function(a) { a; });", errors: errors},
-        {code: "foo(function(arguments) { arguments; });", errors: errors},
-        {code: "foo(function() { this; });", options: [{ allowUnboundThis: false }], errors: errors},
-        {code: "foo(function() { (() => this); });", parserOptions: { ecmaVersion: 6 }, options: [{ allowUnboundThis: false }], errors: errors}
+        {code: "foo(function() { (function() { this; }); });", errors},
+        {code: "foo(function() { this; }.bind(this));", errors},
+        {code: "foo(function() { (() => this); }.bind(this));", parserOptions: { ecmaVersion: 6 }, errors},
+        {code: "foo(function bar(a) { a; });", errors},
+        {code: "foo(function(a) { a; });", errors},
+        {code: "foo(function(arguments) { arguments; });", errors},
+        {code: "foo(function() { this; });", options: [{ allowUnboundThis: false }], errors},
+        {code: "foo(function() { (() => this); });", parserOptions: { ecmaVersion: 6 }, options: [{ allowUnboundThis: false }], errors}
     ]
 });

--- a/tests/lib/rules/prefer-spread.js
+++ b/tests/lib/rules/prefer-spread.js
@@ -41,13 +41,13 @@ ruleTester.run("prefer-spread", rule, {
         {code: "obj.foo.apply();"}
     ],
     invalid: [
-        {code: "foo.apply(undefined, args);", errors: errors},
-        {code: "foo.apply(void 0, args);", errors: errors},
-        {code: "foo.apply(null, args);", errors: errors},
-        {code: "obj.foo.apply(obj, args);", errors: errors},
-        {code: "a.b.c.foo.apply(a.b.c, args);", errors: errors},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors: errors},
-        {code: "[].concat.apply([ ], args);", errors: errors},
-        {code: "[].concat.apply([\n/*empty*/\n], args);", errors: errors}
+        {code: "foo.apply(undefined, args);", errors},
+        {code: "foo.apply(void 0, args);", errors},
+        {code: "foo.apply(null, args);", errors},
+        {code: "obj.foo.apply(obj, args);", errors},
+        {code: "a.b.c.foo.apply(a.b.c, args);", errors},
+        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors},
+        {code: "[].concat.apply([ ], args);", errors},
+        {code: "[].concat.apply([\n/*empty*/\n], args);", errors}
     ]
 });

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -37,13 +37,13 @@ ruleTester.run("prefer-template", rule, {
         {code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";", parserOptions: { ecmaVersion: 6 }}
     ],
     invalid: [
-        {code: "var foo = 'hello, ' + name + '!';", errors: errors},
-        {code: "var foo = bar + 'baz';", errors: errors},
-        {code: "var foo = bar + `baz`;", parserOptions: { ecmaVersion: 6 }, errors: errors},
-        {code: "var foo = +100 + 'yen';", errors: errors},
-        {code: "var foo = 'bar' + baz;", errors: errors},
-        {code: "var foo = '￥' + (n * 1000) + '-'", errors: errors},
+        {code: "var foo = 'hello, ' + name + '!';", errors},
+        {code: "var foo = bar + 'baz';", errors},
+        {code: "var foo = bar + `baz`;", parserOptions: { ecmaVersion: 6 }, errors},
+        {code: "var foo = +100 + 'yen';", errors},
+        {code: "var foo = 'bar' + baz;", errors},
+        {code: "var foo = '￥' + (n * 1000) + '-'", errors},
         {code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;", errors: [errors[0], errors[0]]},
-        {code: "var string = (number + 1) + 'px';", errors: errors}
+        {code: "var string = (number + 1) + 'px';", errors}
     ]
 });

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -34,31 +34,31 @@ ruleTester.run("sort-imports", rule, {
                 "import a from 'foo.js';\n" +
                 "import b from 'bar.js';\n" +
                 "import c from 'baz.js';\n",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as B from 'foo.js';\n" +
                 "import A from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as B from 'foo.js';\n" +
                 "import {a, b} from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import {b, c} from 'bar.js';\n" +
                 "import A from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import A from 'bar.js';\n" +
                 "import {b, c} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 memberSyntaxSortOrder: [ "single", "multiple", "none", "all" ]
             }]
@@ -67,84 +67,84 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import {a, b} from 'bar.js';\n" +
                 "import {b, c} from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import A from 'foo.js';\n" +
                 "import B from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import A from 'foo.js';\n" +
                 "import a from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import a, * as b from 'foo.js';\n" +
                 "import b from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import 'foo.js';\n" +
                 " import a from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import B from 'foo.js';\n" +
                 "import a from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import B from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: ignoreCaseArgs
         },
         {
             code: "import {a, b, c, d} from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code: "import {b, A, C, d} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 ignoreMemberSort: true
             }]
         },
         {
             code: "import {B, a, C, d} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 ignoreMemberSort: true
             }]
         },
         {
             code: "import {a, B, c, D} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: ignoreCaseArgs
         },
         {
             code: "import a, * as b from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as a from 'foo.js';\n" +
                 "\n" +
                 "import b from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as bar from 'bar.js';\n" +
                 "import * as foo from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
 
         // https://github.com/eslint/eslint/issues/5130
@@ -152,14 +152,14 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import 'foo';\n" +
                 "import bar from 'bar';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: ignoreCaseArgs
         },
 
         // https://github.com/eslint/eslint/issues/5305
         {
             code: "import React, {Component} from 'react';",
-            parserOptions: parserOptions
+            parserOptions
         }
     ],
     invalid: [
@@ -167,35 +167,35 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import A from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import b from 'foo.js';\n" +
                 "import a from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import {b, c} from 'foo.js';\n" +
                 "import {a, b} from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import * as foo from 'foo.js';\n" +
                 "import * as bar from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import {b, c} from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Expected 'multiple' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -205,7 +205,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import * as b from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Expected 'all' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -215,7 +215,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Expected 'none' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -225,7 +225,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import b from 'bar.js';\n" +
                 "import * as a from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 memberSyntaxSortOrder: [ "all", "single", "multiple", "none" ]
             }],
@@ -236,7 +236,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {b, a, d, c} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Member 'a' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -247,7 +247,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {a, B, c, D} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Member 'B' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"

--- a/tests/lib/util/comment-event-generator.js
+++ b/tests/lib/util/comment-event-generator.js
@@ -63,10 +63,10 @@ describe("NodeEventGenerator", function() {
         generator = new CommentEventGenerator(generator, sourceCode);
 
         estraverse.traverse(ast, {
-            enter: function(node) {
+            enter(node) {
                 generator.enterNode(node);
             },
-            leave: function(node) {
+            leave(node) {
                 generator.leaveNode(node);
             }
         });

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -237,7 +237,7 @@ describe("globUtil", function() {
             });
 
             assert.equal(result.length, 1);
-            assert.deepEqual(result[0], { filename: filename, ignored: true });
+            assert.deepEqual(result[0], { filename, ignored: true });
         });
 
         it("should silently ignore default ignored files if not passed explicitly even if ignore is false", function() {
@@ -260,7 +260,7 @@ describe("globUtil", function() {
             });
 
             assert.equal(result.length, 1);
-            assert.deepEqual(result[0], { filename: filename, ignored: false });
+            assert.deepEqual(result[0], { filename, ignored: false });
         });
 
         it("should not return a file which does not exist", function() {
@@ -328,7 +328,7 @@ describe("globUtil", function() {
 
             assert.equal(result.length, 1);
             assert.deepEqual(result, [
-                {filename: filename, ignored: true}
+                {filename, ignored: true}
             ]);
         });
 

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -102,7 +102,7 @@ describe("SourceCode", function() {
                 { range: [8, 10] },
                 { range: [12, 20] }
             ];
-            let sourceCode = new SourceCode("", { comments: comments, tokens: tokens, loc: {}, range: [] });
+            let sourceCode = new SourceCode("", { comments, tokens, loc: {}, range: [] });
 
             let actual = sourceCode.tokensAndComments;
             let expected = [comments[0], tokens[0], tokens[1], comments[1], tokens[2]];


### PR DESCRIPTION
**What issue does this pull request address?**
#6407

**What changes did you make? (Give an overview)**
Enabled `object-shorthand` rule and ran auto-fix on codebase.
 
Command used to make changes:
`bin/eslint.js --no-eslintrc --rule 'object-shorthand: 2' --env 'es6' --fix lib bin conf packages tests Makefile.js`

**Is there anything you'd like reviewers to focus on?**
Would love a few more pairs of eyes to scan all the changes to make sure they look good!

Pretty straightforward, aside from two things:
 *  Had to move a `/* istanbul ignore next */` comment to work for the shorthand notation (see [this issue in the Istanbul repo](https://github.com/gotwarlost/istanbul/issues/609) for more info)
 * There's a bug in Node v4.x.x when using `get` as a shorthand property name. We actually saw [a bug report](https://github.com/eslint/eslint/issues/6408) for this very situation and decided against fixing it, so my solution was to just rename the function. Will comment the specific location in the code.