### PR TITLE
New: `symbol-description` rule (fixes #6778)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -218,6 +218,7 @@
         "space-unary-ops": "off",
         "spaced-comment": "off",
         "strict": "off",
+        "symbol-description": "off",
         "template-curly-spacing": "off",
         "unicode-bom": "off",
         "use-isnan": "error",

--- a/docs/rules/symbol-description.md
+++ b/docs/rules/symbol-description.md
@@ -1,0 +1,61 @@
+# require symbol description (symbol-description)
+
+The `Symbol` function may have optional description:
+
+```js
+var foo = Symbol("some description");
+
+var someString = "some description";
+var bar = Symbol(someString);
+```
+
+
+Using `description` promotes easier debugging: when a symbol is logged the description is used:
+
+```js
+var foo = Symbol("some description");
+
+> console.log(foo);
+// Symbol(some description)
+```
+
+It may facilitate identifying symbols when one is observed during debugging.
+
+
+## Rule Details
+
+This rules requires a description when creating symbols.
+
+
+## Examples
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint symbol-description: "error"*/
+/*eslint-env es6*/
+
+var foo = Symbol();
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint symbol-description: "error"*/
+/*eslint-env es6*/
+
+var foo = Symbol("some description");
+
+var someString = "some description";
+var bar = Symbol(someString);
+```
+
+
+## When Not To Use It
+
+This rule should not be used in ES3/5 environments.
+In addition, this rule can be safely turned off if you don't want to enforce presence of `description` when creating Symbols.
+
+## Further Reading
+
+* [Symbol Objects specification: Symbol description](http://www.ecma-international.org/ecma-262/6.0/#sec-symbol-description)

--- a/lib/rules/symbol-description.js
+++ b/lib/rules/symbol-description.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Rule to enforce description with the `Symbol` object
+ * @author Jarek Rencz
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "require symbol descriptions",
+            category: "ECMAScript 6",
+            recommended: false
+        },
+
+        schema: []
+    },
+
+    create(context) {
+
+        /**
+         * Reports if node does not conform the rule in case rule is set to
+         * report missing description
+         *
+         * @param {ASTNode} node - A CallExpression node to check.
+         * @returns {void}
+         */
+        function checkArgument(node) {
+            if (node.arguments.length === 0) {
+                context.report({
+                    node,
+                    message: "Expected Symbol to have a description."
+                });
+            }
+        }
+
+        return {
+            "Program:exit"() {
+                const scope = context.getScope();
+                const variable = astUtils.getVariableByName(scope, "Symbol");
+
+                if (variable && variable.defs.length === 0) {
+                    variable.references.forEach(function(reference) {
+                        const node = reference.identifier;
+
+                        if (astUtils.isCallee(node)) {
+                            checkArgument(node.parent);
+                        }
+                    });
+                }
+            }
+        };
+
+    }
+};

--- a/tests/lib/rules/symbol-description.js
+++ b/tests/lib/rules/symbol-description.js
@@ -1,0 +1,68 @@
+/**
+ * @fileoverview Tests for symbol-description rule.
+ * @author Jarek Rencz
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/symbol-description");
+const RuleTester = require("../../../lib/testers/rule-tester");
+
+const ruleTester = new RuleTester();
+
+ruleTester.run("symbol-description", rule, {
+
+    valid: [
+        {
+            code: "Symbol(\"Foo\");",
+            env: {es6: true}
+        },
+        {
+            code: "var foo = \"foo\"; Symbol(foo);",
+            env: {es6: true}
+        },
+
+        // Ignore if it's shadowed.
+        {
+            code: "var Symbol = function () {}; Symbol();",
+            env: {es6: true}
+        },
+        {
+            code: "Symbol(); var Symbol = function () {};",
+            env: {es6: true}
+        },
+        {
+            code: "function bar() { var Symbol = function () {}; Symbol(); }",
+            env: {es6: true}
+        },
+
+        // Ignore if it's an argument.
+        {
+            code: "function bar(Symbol) { Symbol(); }",
+            env: {es6: true}
+        },
+    ],
+
+    invalid: [
+        {
+            code: "Symbol();",
+            errors: [{
+                message: "Expected Symbol to have a description.",
+                type: "CallExpression"
+            }],
+            env: {es6: true}
+        },
+        {
+            code: "Symbol(); Symbol = function () {};",
+            errors: [{
+                message: "Expected Symbol to have a description.",
+                type: "CallExpression"
+            }],
+            env: {es6: true}
+        },
+    ]
+});


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6778

**What changes did you make? (Give an overview)**
I implemented `symbol-description` rule

**Is there anything you'd like reviewers to focus on?**
- whether rule is supposed to be recommended or not
- in which group (Best practices or ES6) should this rule be placed in

TODO:
- [x] rule should allow string as a description
- [x] rule should allow variable as a description
- [x] [if `Symbol` is redefined `Symbol()` should be valid](https://github.com/eslint/eslint/pull/6825#issuecomment-236982849)
- [x] [if `Symbol` is shadowed `Symbol()` should be valid](https://github.com/eslint/eslint/pull/6825#issuecomment-236982849)