### PR TITLE
Docs: Remove incorrect "constructor" statemant from `no-new-symbol` docs

### DIFF
--- a/docs/rules/no-new-symbol.md
+++ b/docs/rules/no-new-symbol.md
@@ -1,6 +1,6 @@
 # Disallow Symbol Constructor (no-new-symbol)
 
-The `Symbol` constructor is not intended to be used with the `new` operator, but to be called as a function.
+`Symbol` is not intended to be used with the `new` operator, but to be called as a function.
 
 ```js
 var foo = new Symbol("foo");


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
It refers to [a comment in #6825](https://github.com/eslint/eslint/pull/6825#discussion_r73200235)

**What changes did you make? (Give an overview)**
I removed "constructor" word from the rule overview.

**Is there anything you'd like reviewers to focus on?**
n/a