### PR TITLE
Chore: use native `Object.assign` (refs #6407)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -17,9 +17,6 @@
 
 const fs = require("fs"),
     path = require("path"),
-
-    lodash = require("lodash"),
-
     rules = require("./rules"),
     eslint = require("./eslint"),
     defaultOptions = require("../conf/cli-options"),
@@ -436,7 +433,7 @@ function getCacheFile(cacheFile, cwd) {
  */
 function CLIEngine(options) {
 
-    options = lodash.assign(
+    options = Object.assign(
         Object.create(null),
         defaultOptions,
         {cwd: process.cwd()},

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -172,7 +172,7 @@ Registry.prototype = {
         const ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
-        newRegistry.rules = lodash.assign({}, this.rules);
+        newRegistry.rules = Object.assign({}, this.rules);
         ruleIds.forEach(function(ruleId) {
             const errorFreeItems = newRegistry.rules[ruleId].filter(function(registryItem) {
                 return (registryItem.errorCount === 0);
@@ -197,7 +197,7 @@ Registry.prototype = {
         const ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
-        newRegistry.rules = lodash.assign({}, this.rules);
+        newRegistry.rules = Object.assign({}, this.rules);
         ruleIds.forEach(function(ruleId) {
             newRegistry.rules[ruleId] = newRegistry.rules[ruleId].filter(function(registryItem) {
                 return (typeof registryItem.errorCount !== "undefined");
@@ -260,7 +260,7 @@ Registry.prototype = {
         const ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
-        newRegistry.rules = lodash.assign({}, this.rules);
+        newRegistry.rules = Object.assign({}, this.rules);
         ruleIds.forEach(function(ruleId) {
             newRegistry.rules[ruleId] = this.rules[ruleId].filter(function(registryItem) {
                 return (registryItem.specificity === specificity);
@@ -283,7 +283,7 @@ Registry.prototype = {
             lintedRegistry;
 
         lintedRegistry = new Registry();
-        lintedRegistry.rules = lodash.assign({}, this.rules);
+        lintedRegistry.rules = Object.assign({}, this.rules);
 
         const ruleSets = lintedRegistry.buildRuleSets();
 
@@ -300,7 +300,7 @@ Registry.prototype = {
             ruleSetIdx = 0;
 
             ruleSets.forEach(function(ruleSet) {
-                const lintConfig = lodash.assign({}, config, {rules: ruleSet});
+                const lintConfig = Object.assign({}, config, {rules: ruleSet});
                 const lintResults = eslint.verify(sourceCodes[filename], lintConfig);
 
                 lintResults.forEach(function(result) {
@@ -338,7 +338,7 @@ Registry.prototype = {
  * @returns {Object}        config object using `"extends": "eslint:recommended"`
  */
 function extendFromRecommended(config) {
-    const newConfig = lodash.assign({}, config);
+    const newConfig = Object.assign({}, config);
 
     ConfigOps.normalizeToStrings(newConfig);
 

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -10,7 +10,6 @@
 //------------------------------------------------------------------------------
 
 const util = require("util"),
-    lodash = require("lodash"),
     inquirer = require("inquirer"),
     ProgressBar = require("progress"),
     autoconfig = require("./autoconfig.js"),
@@ -112,7 +111,7 @@ function installModules(config) {
 function configureRules(answers, config) {
     const BAR_TOTAL = 20,
         BAR_SOURCE_CODE_TOTAL = 4,
-        newConfig = lodash.assign({}, config),
+        newConfig = Object.assign({}, config),
         disabledConfigs = {};
     let sourceCodes,
         registry;
@@ -187,7 +186,7 @@ function configureRules(answers, config) {
     const defaultConfigs = registry.filterBySpecificity(1).createConfig().rules;
 
     // Combine configs in reverse priority order (later take precedence)
-    newConfig.rules = lodash.assign({}, disabledConfigs, defaultConfigs, specThreeConfigs, specTwoConfigs, singleConfigs);
+    newConfig.rules = Object.assign({}, disabledConfigs, defaultConfigs, specThreeConfigs, specTwoConfigs, singleConfigs);
 
     // Make sure progress bar has finished (floating point rounding)
     bar.update(BAR_TOTAL);
@@ -410,7 +409,7 @@ function promptUser(callback) {
             // early exit if you are using automatic style generation
             if (earlyAnswers.source === "auto") {
                 try {
-                    const combinedAnswers = lodash.assign({}, earlyAnswers, secondAnswers);
+                    const combinedAnswers = Object.assign({}, earlyAnswers, secondAnswers);
 
                     config = processAnswers(combinedAnswers);
                     installModules(config);
@@ -460,7 +459,7 @@ function promptUser(callback) {
                 }
             ], function(answers) {
                 try {
-                    const totalAnswers = lodash.assign({}, earlyAnswers, secondAnswers, answers);
+                    const totalAnswers = Object.assign({}, earlyAnswers, secondAnswers, answers);
 
                     config = processAnswers(totalAnswers);
                     installModules(config);

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -9,8 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash"),
-    Environments = require("./environments");
+const Environments = require("./environments");
 
 const debug = require("debug")("eslint:config-ops");
 
@@ -66,11 +65,11 @@ module.exports = {
                 if (environment) {
                     debug("Creating config for environment " + name);
                     if (environment.globals) {
-                        lodash.assign(envConfig.globals, environment.globals);
+                        Object.assign(envConfig.globals, environment.globals);
                     }
 
                     if (environment.parserOptions) {
-                        lodash.assign(envConfig.parserOptions, environment.parserOptions);
+                        Object.assign(envConfig.parserOptions, environment.parserOptions);
                     }
                 }
             });

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -13,7 +13,6 @@ const assert = require("assert"),
     EventEmitter = require("events").EventEmitter,
     escope = require("escope"),
     levn = require("levn"),
-    lodash = require("lodash"),
     blankScriptAST = require("../conf/blank-script.json"),
     DEFAULT_PARSER = require("../conf/eslint.json").parser,
     replacements = require("../conf/replacements.json"),
@@ -152,7 +151,7 @@ function addDeclaredGlobals(program, globalScope, config) {
         explicitGlobals = {},
         builtin = Environments.get("builtin");
 
-    lodash.assign(declaredGlobals, builtin);
+    Object.assign(declaredGlobals, builtin);
 
     Object.keys(config.env).forEach(function(name) {
         if (config.env[name]) {
@@ -160,14 +159,14 @@ function addDeclaredGlobals(program, globalScope, config) {
                 environmentGlobals = env && env.globals;
 
             if (environmentGlobals) {
-                lodash.assign(declaredGlobals, environmentGlobals);
+                Object.assign(declaredGlobals, environmentGlobals);
             }
         }
     });
 
-    lodash.assign(exportedGlobals, config.exported);
-    lodash.assign(declaredGlobals, config.globals);
-    lodash.assign(explicitGlobals, config.astGlobals);
+    Object.assign(exportedGlobals, config.exported);
+    Object.assign(declaredGlobals, config.globals);
+    Object.assign(explicitGlobals, config.astGlobals);
 
     Object.keys(declaredGlobals).forEach(function(name) {
         let variable = globalScope.set.get(name);
@@ -325,16 +324,16 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
             if (comment.type === "Block") {
                 switch (match[1]) {
                     case "exported":
-                        lodash.assign(commentConfig.exported, parseBooleanConfig(value, comment));
+                        Object.assign(commentConfig.exported, parseBooleanConfig(value, comment));
                         break;
 
                     case "globals":
                     case "global":
-                        lodash.assign(commentConfig.astGlobals, parseBooleanConfig(value, comment));
+                        Object.assign(commentConfig.astGlobals, parseBooleanConfig(value, comment));
                         break;
 
                     case "eslint-env":
-                        lodash.assign(commentConfig.env, parseListConfig(value));
+                        Object.assign(commentConfig.env, parseListConfig(value));
                         break;
 
                     case "eslint-disable":
@@ -379,7 +378,7 @@ function modifyConfigsFromComments(filename, ast, config, reportingConfig, messa
             commentConfig = ConfigOps.merge(commentConfig, env);
         }
     });
-    lodash.assign(commentConfig.rules, commentRules);
+    Object.assign(commentConfig.rules, commentRules);
 
     return ConfigOps.merge(config, commentConfig);
 }
@@ -527,7 +526,7 @@ function findEslintEnv(text) {
     eslintEnvPattern.lastIndex = 0;
 
     while ((match = eslintEnvPattern.exec(text))) {
-        retv = lodash.assign(retv || {}, parseListConfig(match[1]));
+        retv = Object.assign(retv || {}, parseListConfig(match[1]));
     }
 
     return retv;
@@ -612,7 +611,7 @@ module.exports = (function() {
 
         // merge in any additional parser options
         if (config.parserOptions) {
-            parserOptions = lodash.assign({}, config.parserOptions, parserOptions);
+            parserOptions = Object.assign({}, config.parserOptions, parserOptions);
         }
 
         /*
@@ -740,10 +739,10 @@ module.exports = (function() {
 
         if (envInFile) {
             if (!config || !config.env) {
-                config = lodash.assign({}, config || {}, {env: envInFile});
+                config = Object.assign({}, config || {}, {env: envInFile});
             } else {
-                config = lodash.assign({}, config);
-                config.env = lodash.assign({}, config.env, envInFile);
+                config = Object.assign({}, config);
+                config.env = Object.assign({}, config.env, envInFile);
             }
         }
 

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -9,8 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash"),
-    fs = require("fs"),
+const fs = require("fs"),
     path = require("path"),
     ignore = require("ignore"),
     pathUtil = require("./util/path-util");
@@ -58,7 +57,7 @@ function findIgnoreFile(cwd) {
  */
 function mergeDefaultOptions(options) {
     options = (options || {});
-    return lodash.assign({}, DEFAULT_OPTIONS, options);
+    return Object.assign({}, DEFAULT_OPTIONS, options);
 }
 
 //------------------------------------------------------------------------------

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -12,7 +12,6 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 const util = require("util");
-const lodash = require("lodash");
 
 module.exports = {
     meta: {
@@ -123,7 +122,7 @@ module.exports = {
                         const: variableDeclaratorRules
                     };
                 } else if (typeof variableDeclaratorRules === "object") {
-                    lodash.assign(options.VariableDeclarator, variableDeclaratorRules);
+                    Object.assign(options.VariableDeclarator, variableDeclaratorRules);
                 }
 
                 if (typeof opts.outerIIFEBody === "number") {

--- a/lib/rules/lines-around-comment.js
+++ b/lib/rules/lines-around-comment.js
@@ -108,7 +108,7 @@ module.exports = {
 
     create: function(context) {
 
-        const options = context.options[0] ? lodash.assign({}, context.options[0]) : {};
+        const options = context.options[0] ? Object.assign({}, context.options[0]) : {};
 
         options.beforeLineComment = options.beforeLineComment || false;
         options.afterLineComment = options.afterLineComment || false;

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -9,8 +9,6 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash");
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -115,7 +113,7 @@ module.exports = {
 
     create: function(context) {
 
-        const config = context.options[0] ? lodash.assign({}, context.options[0]) : {};
+        const config = context.options[0] ? Object.assign({}, context.options[0]) : {};
 
         config.newIsCap = config.newIsCap !== false;
         config.capIsNew = config.capIsNew !== false;

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -5,8 +5,7 @@
 
 "use strict";
 
-const lodash = require("lodash"),
-    astUtils = require("../ast-utils");
+const astUtils = require("../ast-utils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -47,7 +46,7 @@ module.exports = {
         const usedDefaultGlobal = !context.options[0];
         const globalStyle = context.options[0] || "after";
         const options = context.options[1] || {};
-        const styleOverrides = options.overrides ? lodash.assign({}, options.overrides) : {};
+        const styleOverrides = options.overrides ? Object.assign({}, options.overrides) : {};
 
         if (usedDefaultGlobal && !styleOverrides["?"]) {
             styleOverrides["?"] = "before";

--- a/lib/rules/require-jsdoc.js
+++ b/lib/rules/require-jsdoc.js
@@ -4,8 +4,6 @@
  */
 "use strict";
 
-const lodash = require("lodash");
-
 module.exports = {
     meta: {
         docs: {
@@ -46,7 +44,7 @@ module.exports = {
             MethodDefinition: false,
             ClassDeclaration: false
         };
-        const options = lodash.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
+        const options = Object.assign(DEFAULT_OPTIONS, context.options[0] && context.options[0].require || {});
 
         /**
          * Report the error message

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -9,8 +9,6 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash");
-
 //------------------------------------------------------------------------------
 // Helpers
 //------------------------------------------------------------------------------
@@ -231,7 +229,7 @@ module.exports = {
         };
 
         if (mode === "function") {
-            lodash.assign(rule, {
+            Object.assign(rule, {
 
                 // Inside of class bodies are always strict mode.
                 ClassBody: function() {

--- a/lib/util/module-resolver.js
+++ b/lib/util/module-resolver.js
@@ -9,8 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash"),
-    Module = require("module");
+const Module = require("module");
 
 //------------------------------------------------------------------------------
 // Private
@@ -39,7 +38,7 @@ const DEFAULT_OPTIONS = {
 function ModuleResolver(options) {
     options = options || {};
 
-    this.options = lodash.assign({}, DEFAULT_OPTIONS, options);
+    this.options = Object.assign({}, DEFAULT_OPTIONS, options);
 }
 
 ModuleResolver.prototype = {

--- a/lib/util/source-code-util.js
+++ b/lib/util/source-code-util.js
@@ -9,8 +9,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash"),
-    CLIEngine = require("../cli-engine"),
+const CLIEngine = require("../cli-engine"),
     eslint = require("../eslint"),
     globUtil = require("./glob-util"),
     baseDefaultOptions = require("../../conf/cli-options");
@@ -30,7 +29,7 @@ const debug = require("debug")("eslint:source-code-util");
  */
 function getSourceCodeOfFile(filename, options) {
     debug("getting sourceCode of", filename);
-    const opts = lodash.assign({}, options, { rules: {}});
+    const opts = Object.assign({}, options, { rules: {}});
     const cli = new CLIEngine(opts);
     const results = cli.executeOnFiles([filename]);
 
@@ -72,7 +71,7 @@ function getSourceCodeOfFiles(patterns, options, cb) {
         patterns = [patterns];
     }
 
-    const defaultOptions = lodash.assign({}, baseDefaultOptions, {cwd: process.cwd()});
+    const defaultOptions = Object.assign({}, baseDefaultOptions, {cwd: process.cwd()});
 
     if (typeof options === "undefined") {
         opts = defaultOptions;
@@ -80,7 +79,7 @@ function getSourceCodeOfFiles(patterns, options, cb) {
         cb = options;
         opts = defaultOptions;
     } else if (typeof options === "object") {
-        opts = lodash.assign({}, defaultOptions, options);
+        opts = Object.assign({}, defaultOptions, options);
     }
     debug("constructed options:", opts);
     patterns = globUtil.resolveFileGlobPatterns(patterns, opts);

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -8,8 +8,7 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash"),
-    createTokenStore = require("../token-store.js"),
+const createTokenStore = require("../token-store.js"),
     Traverser = require("./traverser");
 
 //------------------------------------------------------------------------------
@@ -281,7 +280,7 @@ SourceCode.prototype = {
             }
         });
 
-        return result ? lodash.assign({parent: resultParent}, result) : null;
+        return result ? Object.assign({parent: resultParent}, result) : null;
     },
 
     /**

--- a/tests/lib/config/autoconfig.js
+++ b/tests/lib/config/autoconfig.js
@@ -9,13 +9,12 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const lodash = require("lodash"),
-    assert = require("chai").assert,
+const assert = require("chai").assert,
     autoconfig = require("../../../lib/config/autoconfig"),
     sourceCodeUtil = require("../../../lib/util/source-code-util"),
     baseDefaultOptions = require("../../../conf/cli-options");
 
-const defaultOptions = lodash.assign({}, baseDefaultOptions, {cwd: process.cwd()});
+const defaultOptions = Object.assign({}, baseDefaultOptions, {cwd: process.cwd()});
 
 //------------------------------------------------------------------------------
 // Data

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -9,7 +9,6 @@
 //------------------------------------------------------------------------------
 
 const assert = require("chai").assert,
-    lodash = require("lodash"),
     leche = require("leche"),
     environments = require("../../../conf/environments"),
     ConfigOps = require("../../../lib/config/config-ops");
@@ -77,7 +76,7 @@ describe("ConfigOps", function() {
                     ecmaVersion: 6,
                     ecmaFeatures: environments.node.parserOptions.ecmaFeatures
                 },
-                globals: lodash.assign({}, environments.node.globals, environments.es6.globals)
+                globals: Object.assign({}, environments.node.globals, environments.es6.globals)
             });
         });
     });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
Use native function rather than a polyfill from `lodash`. This way we are more native bound than library bound :smile: 

**What changes did you make? (Give an overview)**
Replaced `lodash.assign` with native `Object.assign`. As a result of this i was able to get rid of `lodash` in many modules.

**Is there anything you'd like reviewers to focus on?**

nothing specific
