### PR TITLE
Update: validate void operator in no-constant-condition (fixes #5726)

### DIFF
--- a/docs/rules/no-constant-condition.md
+++ b/docs/rules/no-constant-condition.md
@@ -24,6 +24,10 @@ if (false) {
     doSomethingUnfinished();
 }
 
+if (void x) {
+    doSomethingUnfinished();
+}
+
 for (;-2;) {
     doSomethingForever();
 }
@@ -32,7 +36,7 @@ while (typeof x) {
     doSomethingForever();
 }
 
-do{
+do {
     doSomethingForever();
 } while (x = -1);
 
@@ -56,7 +60,7 @@ while (typeof x === "undefined") {
     doSomething();
 }
 
-do{
+do {
     doSomething();
 } while (x);
 

--- a/lib/rules/no-constant-condition.js
+++ b/lib/rules/no-constant-condition.js
@@ -51,11 +51,15 @@ module.exports = {
                 case "Literal":
                     return (operator === "||" && node.value === true) ||
                            (operator === "&&" && node.value === false);
+
+                case "UnaryExpression":
+                    return (operator === "&&" && node.operator === "void");
+
                 case "LogicalExpression":
                     return isLogicalIdentity(node.left, node.operator) ||
                              isLogicalIdentity(node.right, node.operator);
 
-                     // no default
+                // no default
             }
             return false;
         }
@@ -78,6 +82,10 @@ module.exports = {
                     return true;
 
                 case "UnaryExpression":
+                    if (node.operator === "void") {
+                        return true;
+                    }
+
                     return (node.operator === "typeof" && inBooleanPosition) ||
                         isConstant(node.argument, true);
 

--- a/tests/lib/rules/no-constant-condition.js
+++ b/tests/lib/rules/no-constant-condition.js
@@ -37,7 +37,11 @@ ruleTester.run("no-constant-condition", rule, {
         "if(typeof x === 'undefined'){}",
         "if(a === 'str' && typeof b){}",
         "typeof a == typeof b",
-        "typeof 'a'==='string'|| typeof b ==='string'",
+        "typeof 'a' === 'string'|| typeof b === 'string'",
+
+        // #5726, void conditions
+        "if (void a || a);",
+        "if (a || void a);",
 
          // #5693
         "if(xyz === 'str1' && abc==='str2'){}",
@@ -69,6 +73,7 @@ ruleTester.run("no-constant-condition", rule, {
         { code: "if(0 < 1);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
         { code: "if(0 || 1);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
         { code: "if(a, 1);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+
         { code: "while([]);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
         { code: "while(~!0);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
         { code: "while(x = 1);", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
@@ -80,8 +85,17 @@ ruleTester.run("no-constant-condition", rule, {
         { code: "if(typeof 'abc' === 'string'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
         { code: "if(a = typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
         { code: "if(a, typeof b){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
-        { code: "if(typeof 'a' =='string' || typeof 'b' =='string'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(typeof 'a' == 'string' || typeof 'b' == 'string'){}", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
         { code: "while(typeof x){}", errors: [{ message: "Unexpected constant condition.", type: "WhileStatement"}] },
+
+        // #5726, void conditions
+        { code: "if(1 || void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(y = void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(x, void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(void x === void y);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(void x && a);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
+        { code: "if(a && void x);", errors: [{ message: "Unexpected constant condition.", type: "IfStatement"}] },
 
         // #5693
          { code: "if(false && abc==='str'){}", errors: [{message: "Unexpected constant condition.", type: "IfStatement"}]},


### PR DESCRIPTION
**What issue does this pull request address?**
#5726 Add check for the void operator to the `no-constant-condition` rule

**What changes did you make? (Give an overview)**
I added the check for the rule, updated the rule description, and added a bunch of tests for all the cases I could think of.

**Is there anything you'd like reviewers to focus on?**
Are there any more test cases I could add?
