### PR TITLE
Update: improve error message in `no-control-regex`

### DIFF
--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -51,29 +51,42 @@ module.exports = {
             return null;
         }
 
+
+        const controlChar = /[\x00-\x1f]/g; // eslint-disable-line no-control-regex
+        const doubleSlashes = /\\\\/g;
+        const multipleSlashes = /\\+$/g;
+
         /**
-         * Check if given regex string has control characters in it
+         * Return a list of the control characters in the given regex string
          * @param {string} regexStr regex as string to check
-         * @returns {boolean} returns true if finds control characters on given string
+         * @returns {array} returns a list of found control characters on given string
          * @private
          */
-        function hasControlCharacters(regexStr) {
+        function getControlCharacters(regexStr) {
 
             // check control characters, if RegExp object used
-            let hasControlChars = /[\x00-\x1f]/.test(regexStr); // eslint-disable-line no-control-regex
+            const controlChars = regexStr.match(controlChar) || [];
+
+            let stringControlChars = [];
 
             // check substr, if regex literal used
             const subStrIndex = regexStr.search(/\\x[01][0-9a-f]/i);
 
-            if (!hasControlChars && subStrIndex > -1) {
+            if (subStrIndex > -1) {
 
                 // is it escaped, check backslash count
-                const possibleEscapeCharacters = regexStr.substr(0, subStrIndex).match(/\\+$/gi);
+                const possibleEscapeCharacters = regexStr.slice(0, subStrIndex).match(multipleSlashes);
 
-                hasControlChars = possibleEscapeCharacters === null || !(possibleEscapeCharacters[0].length % 2);
+                const hasControlChars = possibleEscapeCharacters === null || !(possibleEscapeCharacters[0].length % 2);
+
+                if (hasControlChars) {
+                    stringControlChars = regexStr.slice(subStrIndex, -1).replace(doubleSlashes, ",\\").split(",");
+                }
             }
 
-            return hasControlChars;
+            return controlChars.map(function(x) {
+                return "\\x" + ("00" + x.charCodeAt(0).toString(16)).slice(-2);
+            }).concat(stringControlChars);
         }
 
         return {
@@ -83,8 +96,16 @@ module.exports = {
                 if (regex) {
                     const computedValue = regex.toString();
 
-                    if (hasControlCharacters(computedValue)) {
-                        context.report(node, "Unexpected control character in regular expression.");
+                    const controlCharacters = getControlCharacters(computedValue);
+
+                    if (controlCharacters.length > 0) {
+                        context.report({
+                            node,
+                            message: "Unexpected control character(s) in regular expression: {{controlChars}}.",
+                            data: {
+                                controlChars: controlCharacters.join(", ")
+                            }
+                        });
                     }
                 }
             }

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -53,8 +53,8 @@ module.exports = {
 
 
         const controlChar = /[\x00-\x1f]/g; // eslint-disable-line no-control-regex
-        const multipleSlashes = /\\+/g;
-        const multipleSlashesAtEnd = /\\+$/g;
+        const consecutiveSlashes = /\\+/g;
+        const consecutiveSlashesAtEnd = /\\+$/g;
         const stringControlChar = /\\x[01][0-9a-f]/ig;
         const stringControlCharWithoutSlash = /x[01][0-9a-f]/ig;
 
@@ -77,13 +77,13 @@ module.exports = {
             if (subStrIndex > -1) {
 
                 // is it escaped, check backslash count
-                const possibleEscapeCharacters = regexStr.slice(0, subStrIndex).match(multipleSlashesAtEnd);
+                const possibleEscapeCharacters = regexStr.slice(0, subStrIndex).match(consecutiveSlashesAtEnd);
 
                 const hasControlChars = possibleEscapeCharacters === null || !(possibleEscapeCharacters[0].length % 2);
 
                 if (hasControlChars) {
                     stringControlChars = regexStr.slice(subStrIndex, -1)
-                        .split(multipleSlashes)
+                        .split(consecutiveSlashes)
                         .filter(Boolean)
                         .map(function(x) {
                             const match = x.match(stringControlCharWithoutSlash) || [x];

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -55,6 +55,8 @@ module.exports = {
         const controlChar = /[\x00-\x1f]/g; // eslint-disable-line no-control-regex
         const multipleSlashes = /\\+/g;
         const multipleSlashesAtEnd = /\\+$/g;
+        const stringControlChar = /\\x[01][0-9a-f]/ig;
+        const stringControlCharWithoutSlash = /x[01][0-9a-f]/ig;
 
         /**
          * Return a list of the control characters in the given regex string
@@ -70,7 +72,7 @@ module.exports = {
             let stringControlChars = [];
 
             // check substr, if regex literal used
-            const subStrIndex = regexStr.search(/\\x[01][0-9a-f]/i);
+            const subStrIndex = regexStr.search(stringControlChar);
 
             if (subStrIndex > -1) {
 
@@ -84,7 +86,9 @@ module.exports = {
                         .split(multipleSlashes)
                         .filter(Boolean)
                         .map(function(x) {
-                            return "\\" + x;
+                            const match = x.match(stringControlCharWithoutSlash) || [x];
+
+                            return "\\" + match[0];
                         });
                 }
             }

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -53,8 +53,8 @@ module.exports = {
 
 
         const controlChar = /[\x00-\x1f]/g; // eslint-disable-line no-control-regex
-        const doubleSlashes = /\\\\/g;
-        const multipleSlashes = /\\+$/g;
+        const multipleSlashes = /\\+/g;
+        const multipleSlashesAtEnd = /\\+$/g;
 
         /**
          * Return a list of the control characters in the given regex string
@@ -75,12 +75,17 @@ module.exports = {
             if (subStrIndex > -1) {
 
                 // is it escaped, check backslash count
-                const possibleEscapeCharacters = regexStr.slice(0, subStrIndex).match(multipleSlashes);
+                const possibleEscapeCharacters = regexStr.slice(0, subStrIndex).match(multipleSlashesAtEnd);
 
                 const hasControlChars = possibleEscapeCharacters === null || !(possibleEscapeCharacters[0].length % 2);
 
                 if (hasControlChars) {
-                    stringControlChars = regexStr.slice(subStrIndex, -1).replace(doubleSlashes, ",\\").split(",");
+                    stringControlChars = regexStr.slice(subStrIndex, -1)
+                        .split(multipleSlashes)
+                        .filter(Boolean)
+                        .map(function(x) {
+                            return "\\" + x;
+                        });
                 }
             }
 

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -90,7 +90,7 @@ module.exports = {
             }
 
             return controlChars.map(function(x) {
-                return "\\x" + ("00" + x.charCodeAt(0).toString(16)).slice(-2);
+                return "\\x" + ("0" + x.charCodeAt(0).toString(16)).slice(-2);
             }).concat(stringControlChars);
         }
 

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -31,7 +31,11 @@ ruleTester.run("no-control-regex", rule, {
     invalid: [
         { code: "var regex = " + /\x1f/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f.", type: "Literal"}] }, // eslint-disable-line no-control-regex
         { code: "var regex = " + /\\\x1f\\x1e/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1e.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: "var regex = " + /\\\x1fFOO\\x00/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x00.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: "var regex = " + /FOO\\\x1fFOO\\x1f/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1f.", type: "Literal"}] }, // eslint-disable-line no-control-regex
         { code: "var regex = new RegExp('\\x1f\\x1e')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1e.", type: "Literal"}] },
+        { code: "var regex = new RegExp('\\x1fFOO\\x00')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x00.", type: "Literal"}] },
+        { code: "var regex = new RegExp('FOO\\x1fFOO\\x1f')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1f.", type: "Literal"}] },
         { code: "var regex = RegExp('\\x1f')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f.", type: "Literal"}] }
     ]
 });

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -29,9 +29,9 @@ ruleTester.run("no-control-regex", rule, {
         "new (function foo(){})('\\x1f')"
     ],
     invalid: [
-        { code: "var regex = " + /\x1f/, errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] }, // eslint-disable-line no-control-regex
-        { code: "var regex = " + /\\\x1f/, errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] }, // eslint-disable-line no-control-regex
-        { code: "var regex = new RegExp('\\x1f')", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] },
-        { code: "var regex = RegExp('\\x1f')", errors: [{ message: "Unexpected control character in regular expression.", type: "Literal"}] }
+        { code: "var regex = " + /\x1f/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: "var regex = " + /\\\x1f\\x1e/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1e.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: "var regex = new RegExp('\\x1f\\x1e')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1e.", type: "Literal"}] },
+        { code: "var regex = RegExp('\\x1f')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f.", type: "Literal"}] }
     ]
 });


### PR DESCRIPTION
**What issue does this pull request address?**
Fixes #6293 - this makes the `no-control-regex` error message more useful by including the control characters that were found.

**What changes did you make? (Give an overview)**
I changed the "has control characters" boolean to a "get control characters" list, and converted that list of characters into a display string (ie, `"\x00"` to `"\\x00"`.

**Is there anything you'd like reviewers to focus on?**
Nothing I can think of.