### PR TITLE
Fix: Allow linting of .hidden files/folders (fixes #4828)

### DIFF
--- a/tests/fixtures/cli-engine/hidden/.hiddenfolder/double-quotes.js
+++ b/tests/fixtures/cli-engine/hidden/.hiddenfolder/double-quotes.js
@@ -1,0 +1,2 @@
+var bar = "<div>Hello world!</div>";
+bar(bar);

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -523,6 +523,22 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages[0].message, expectedMsg);
         });
 
+        it("should report on globs with explicit inclusion of dotfiles, even though ignored by default", function() {
+
+            engine = new CLIEngine({
+                cwd: getFixturePath("cli-engine"),
+                rules: {
+                    quotes: [2, "single"]
+                }
+            });
+
+            const report = engine.executeOnFiles(["hidden/.hiddenfolder/*.js"]);
+
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].errorCount, 1);
+            assert.equal(report.results[0].warningCount, 0);
+        });
+
         it("should not check default ignored files without --no-ignore flag", function() {
 
             engine = new CLIEngine({
@@ -578,6 +594,26 @@ describe("CLIEngine", function() {
             });
 
             const report = engine.executeOnFiles(["fixtures/files/.bar.js"]);
+
+            assert.equal(report.results.length, 1);
+            assert.equal(report.results[0].warningCount, 0);
+            assert.equal(report.results[0].errorCount, 1);
+            assert.equal(report.results[0].messages[0].ruleId, "quotes");
+        });
+
+        it("should check .hidden files if they are unignored with an --ignore-pattern", function() {
+
+            engine = new CLIEngine({
+                cwd: getFixturePath("cli-engine"),
+                ignore: true,
+                useEslintrc: false,
+                ignorePattern: "!.hidden*",
+                rules: {
+                    quotes: [2, "single"]
+                }
+            });
+
+            const report = engine.executeOnFiles(["hidden/"]);
 
             assert.equal(report.results.length, 1);
             assert.equal(report.results[0].warningCount, 0);

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -199,7 +199,9 @@ describe("globUtil", function() {
 
         it("should not return hidden files for standard glob patterns", function() {
             const patterns = [getFixturePath("glob-util", "hidden", "**/*.js")];
-            const result = globUtil.listFilesToProcess(patterns);
+            const result = globUtil.listFilesToProcess(patterns, {
+                cwd: getFixturePath()
+            });
 
             assert.equal(result.length, 0);
         });
@@ -207,8 +209,7 @@ describe("globUtil", function() {
         it("should return hidden files if included in glob pattern", function() {
             const patterns = [getFixturePath("glob-util", "hidden", "**/.*.js")];
             const result = globUtil.listFilesToProcess(patterns, {
-                cwd: getFixturePath(),
-                dotfiles: true
+                cwd: getFixturePath()
             });
 
             const file1 = getFixturePath("glob-util", "hidden", ".foo.js");


### PR DESCRIPTION
**What issue does this pull request address?**
#4828

**What changes did you make? (Give an overview)**
The main change here is to set an option on node_glob to return dotfiles from glob patterns (anything other than explicitly passed files).   In order for dotfiles to actually be linted, though, a negating ignore pattern like `!.*` will need to be used to override the default ignore behavior.

This turned out to be a bit more involved than just returning hidden files from our glob patterns.  That's because we were _not_ ignoring dotfiles by default in all cases, only when an `options` object was provided to `listFilesToProcess`, which was nearly always.  Except, it turns out, in the test `"should not return hidden files for standard glob patterns"`.  That _was_ okay, because globs would never return dotfiles, but that started failing as soon as I made the core change in this PR.  

Now that the glob pattern will include hidden files, we need to apply the default ignore rules.  _However_, we also want to _not_ ignore dotfiles if they are explicitly included in the glob pattern.  The only way I could find to solve this problem was to directly check the glob pattern with a regex to see if it includes hidden files.  If so, dotfiles are not ignored, and otherwise they are.

**Is there anything you'd like reviewers to focus on?**
Please give my regex a sanity check.  I tried to test it out and it seems to work, but I'm not super-confident in my regex skills.

I would also be happy to include any other tests that anyone thinks might be useful.  