### PR TITLE
Fix: update peerDependencies of airbnb option for `--init` (fixes #6843)

### DIFF
--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -267,7 +267,7 @@ function processAnswers(answers) {
 function getConfigForStyleGuide(guide) {
     const guides = {
         google: {extends: "google"},
-        airbnb: {extends: "airbnb", plugins: ["react"]},
+        airbnb: {extends: "airbnb", plugins: ["react", "jsx-a11y", "import"]},
         standard: {extends: "standard", plugins: ["standard", "promise"]}
     };
 

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -187,7 +187,7 @@ describe("configInitializer", function() {
             it("should support the airbnb style guide", function() {
                 const config = init.getConfigForStyleGuide("airbnb");
 
-                assert.deepEqual(config, {extends: "airbnb", installedESLint: true, plugins: ["react"]});
+                assert.deepEqual(config, {extends: "airbnb", installedESLint: true, plugins: ["react", "jsx-a11y", "import"]});
             });
 
             it("should support the standard style guide", function() {


### PR DESCRIPTION
**What issue does this pull request address?**
#6843 Updates the peerDependencies of eslint-config-airbnb for the `--init` option.

**What changes did you make? (Give an overview)**
Updated the array of plugins to include the new peerDependencies.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular. As mentioned in https://github.com/eslint/eslint/issues/6843#issuecomment-237647498, I kept this short and to the point.
I propose we discuss having an automated way of keeping these in sync on a separate issue, if need be.

