### PR TITLE
Fix: don't throw if rule is in old format (fixes #6848)

### DIFF
--- a/lib/internal-rules/internal-no-invalid-meta.js
+++ b/lib/internal-rules/internal-no-invalid-meta.js
@@ -151,6 +151,16 @@ function checkMetaValidity(context, exportsNode, ruleIsFixable) {
     }
 }
 
+/**
+ * Whether this node is the correct format for a rule definition or not.
+ *
+ * @param {ASTNode} node node that the rule exports.
+ * @returns {boolean} `true` if the exported node is the correct format for a rule definition
+ */
+function isCorrectExportsFormat(node) {
+    return node.type === "ObjectExpression";
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -167,7 +177,7 @@ module.exports = {
     },
 
     create: function(context) {
-        let metaExportsValue;
+        let exportsNode;
         let ruleIsFixable = false;
 
         return {
@@ -178,7 +188,7 @@ module.exports = {
                     node.left.object.name === "module" &&
                     node.left.property.name === "exports") {
 
-                    metaExportsValue = node.right;
+                    exportsNode = node.right;
                 }
             },
 
@@ -205,7 +215,12 @@ module.exports = {
             },
 
             "Program:exit": function() {
-                checkMetaValidity(context, metaExportsValue, ruleIsFixable);
+                if (!isCorrectExportsFormat(exportsNode)) {
+                    context.report(exportsNode, "Rule does not export an Object. Make sure the rule follows the new rule format.");
+                    return;
+                }
+
+                checkMetaValidity(context, exportsNode, ruleIsFixable);
             }
         };
     }

--- a/tests/lib/internal-rules/internal-no-valid-meta.js
+++ b/tests/lib/internal-rules/internal-no-valid-meta.js
@@ -98,6 +98,20 @@ ruleTester.run("internal-no-invalid-meta", rule, {
     invalid: [
         {
             code: [
+                "module.exports = function(context) {",
+                "    return {",
+                "        Program: function(node) {}",
+                "    };",
+                "};"
+            ].join("\n"),
+            errors: [{
+                message: "Rule does not export an Object. Make sure the rule follows the new rule format.",
+                line: 1,
+                column: 18
+            }]
+        },
+        {
+            code: [
                 "module.exports = {",
                 "    create: function(context) {",
                 "        return {",


### PR DESCRIPTION
**What issue does this pull request address?**
#6848: `internal-no-invalid-meta` was throwing an error when it ran on a rule in the old format.

**What changes did you make? (Give an overview)**
I changed `internal-no-invalid-meta` so it now reports a linting error when the rule is in the old format, instead of throwing an unrecognizable error.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular.
