### PR TITLE
Update: Add fixer for strict (fixes #6668)

### DIFF
--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -1,5 +1,7 @@
 # require or disallow strict mode directives (strict)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes some instances of problems reported by this rule.
+
 A strict mode directive is a `"use strict"` literal at the beginning of a script or function body. It enables strict mode semantics.
 
 When a directive occurs in global scope, strict mode applies to the entire script:

--- a/lib/rules/strict.js
+++ b/lib/rules/strict.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const lodash = require("lodash");
+
 //------------------------------------------------------------------------------
 // Requirements
 //------------------------------------------------------------------------------
@@ -72,6 +74,26 @@ function isSimpleParameterList(params) {
     return params.every(isSimpleParameter);
 }
 
+/**
+ * Gets a fixer function that removes a use strict directive.
+ *
+ * @param {ASTNode} useStrictDirective - A use strict directive to remove.
+ * @returns {Function} a function that can be passed to context.report() to remove the use strict directive.
+ */
+function getFix(useStrictDirective) {
+    return fixer => fixer.remove(useStrictDirective);
+}
+
+/**
+ * Gets a list of fixer functions that remove the corresponding use strict directive in the input list.
+ *
+ * @param {ASTNode[]} useStrictDirectives - A list of use strict directives to remove.
+ * @returns {Function[]} a list of functions that can be passed to context.report() to remove the corresponding use strict directive.
+ */
+function getFixes(useStrictDirectives) {
+    return useStrictDirectives.map(getFix);
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -83,6 +105,8 @@ module.exports = {
             category: "Strict Mode",
             recommended: false
         },
+
+        fixable: "code",
 
         schema: [
             {
@@ -110,13 +134,14 @@ module.exports = {
          * @param {string} start Index to start from.
          * @param {string} end Index to end before.
          * @param {string} message Message to display.
+         * @param {Function} fixes Fixer functions corresponding to each node. This list will be empty is no fix should be applied.
          * @returns {void}
          */
-        function reportSlice(nodes, start, end, message) {
+        function reportSlice(nodes, start, end, message, fixes) {
             let i;
 
             for (i = start; i < end; i++) {
-                context.report(nodes[i], message);
+                context.report({node: nodes[i], message, fix: lodash.get(fixes, i)});
             }
         }
 
@@ -124,10 +149,11 @@ module.exports = {
          * Report all nodes in an array with a given message.
          * @param {ASTNode[]} nodes Nodes.
          * @param {string} message Message to display.
+         * @param {Function} fixes Fixer functions corresponding to each node. This list will be empty is no fix should be applied.
          * @returns {void}
          */
-        function reportAll(nodes, message) {
-            reportSlice(nodes, 0, nodes.length, message);
+        function reportAll(nodes, message, fixes) {
+            reportSlice(nodes, 0, nodes.length, message, fixes);
         }
 
         /**
@@ -198,7 +224,7 @@ module.exports = {
                 enterFunctionInFunctionMode(node, useStrictDirectives);
             } else if (useStrictDirectives.length > 0) {
                 if (isSimpleParameterList(node.params)) {
-                    reportAll(useStrictDirectives, messages[mode]);
+                    reportAll(useStrictDirectives, messages[mode], getFixes(useStrictDirectives));
                 } else {
                     context.report(useStrictDirectives[0], messages.nonSimpleParameterList);
                     reportAllExceptFirst(useStrictDirectives, messages.multiple);
@@ -220,7 +246,7 @@ module.exports = {
                     }
                     reportAllExceptFirst(useStrictDirectives, messages.multiple);
                 } else {
-                    reportAll(useStrictDirectives, messages[mode]);
+                    reportAll(useStrictDirectives, messages[mode], getFixes(useStrictDirectives));
                 }
             },
             FunctionDeclaration: enterFunction,

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -92,30 +92,35 @@ ruleTester.run("strict", rule, {
         // "never" mode
         {
             code: "\"use strict\"; foo();",
+            output: " foo();",
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "function foo() { 'use strict'; return; }",
+            output: "function foo() {  return; }",
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "var foo = function() { 'use strict'; return; };",
+            output: "var foo = function() {  return; };",
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "function foo() { return function() { 'use strict'; return; }; }",
+            output: "function foo() { return function() {  return; }; }",
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" }
             ]
         }, {
             code: "'use strict'; function foo() { \"use strict\"; return; }",
+            output: " function foo() {  return; }",
             options: ["never"],
             errors: [
                 { message: "Strict mode is not permitted.", type: "ExpressionStatement" },
@@ -123,6 +128,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "\"use strict\"; foo();",
+            output: " foo();",
             options: ["never"],
             parserOptions: { sourceType: "module" },
             errors: [
@@ -130,6 +136,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["never"],
             parserOptions: { ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -138,6 +145,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["never"],
             parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
             errors: [


### PR DESCRIPTION
**What issue does this pull request address?**
#6668

**What changes did you make? (Give an overview)**
Modified the `strict` rule to sometimes pass a `fix` property to `context.report`.

I tried to minimize invasiveness of the changes, which makes the code a little awkward in some places. I think this is the right approach but I'm happy to hear alternate opinions.

**Is there anything you'd like reviewers to focus on?**
This PR works with the existing test cases. There are more test cases that could potentially be added. I'm happy to do so if you think that's a good idea.

The fixer will currently change this:

```js
'use strict'; foo();
```

to:

```js
 foo();
```

There will be a leading space, because `fixer.remove(useStrictDirective)` will only remove up to the `;`. I think that this may be ok, because a subsequent fixing pass can remove the whitespace. Does that sound right? 
