### PR TITLE
Chore: use eslint-plugin-node (refs #6407)

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,11 +1,7 @@
 root: true
 
-env:
-    node: true
-    es6: true
-
-parserOptions:
-    ecmaVersion: 6
-
+plugins:
+    - node
 extends:
-    "./packages/eslint-config-eslint/default.yml"
+    - "./packages/eslint-config-eslint/default.yml"
+    - "plugin:node/recommended"

--- a/Makefile.js
+++ b/Makefile.js
@@ -650,7 +650,7 @@ target.gensite = function(prereleaseVersion) {
                 }
                 const added = versions.added[baseName];
 
-                if (!versions.removed[baseName] && !fs.existsSync(sourcePath)) {
+                if (!versions.removed[baseName] && !test("-f", sourcePath)) {
                     versions.removed[baseName] = getFirstVersionOfDeletion(sourcePath);
                 }
                 const removed = versions.removed[baseName];

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -17,6 +17,7 @@
 
 const fs = require("fs"),
     path = require("path"),
+    shell = require("shelljs"),
     options = require("./options"),
     CLIEngine = require("./cli-engine"),
     mkdirp = require("mkdirp"),
@@ -82,7 +83,7 @@ function printResults(engine, results, format, outputFile) {
         if (outputFile) {
             const filePath = path.resolve(process.cwd(), outputFile);
 
-            if (fs.existsSync(filePath) && fs.statSync(filePath).isDirectory()) {
+            if (shell.test("-d", filePath)) {
                 log.error("Cannot write to output file path, it is a directory: %s", outputFile);
                 return false;
             }

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -13,6 +13,7 @@
 
 const fs = require("fs"),
     path = require("path"),
+    shell = require("shelljs"),
     ConfigOps = require("./config-ops"),
     validator = require("./config-validator"),
     Plugins = require("./plugins"),
@@ -565,7 +566,7 @@ module.exports = {
         for (let i = 0, len = CONFIG_FILES.length; i < len; i++) {
             const filename = path.join(directory, CONFIG_FILES[i]);
 
-            if (fs.existsSync(filename)) {
+            if (shell.test("-f", filename)) {
                 return filename;
             }
         }

--- a/lib/ignored-paths.js
+++ b/lib/ignored-paths.js
@@ -12,6 +12,7 @@
 const fs = require("fs"),
     path = require("path"),
     ignore = require("ignore"),
+    shell = require("shelljs"),
     pathUtil = require("./util/path-util");
 
 const debug = require("debug")("eslint:ignored-paths");
@@ -47,7 +48,7 @@ function findIgnoreFile(cwd) {
 
     const ignoreFilePath = path.resolve(cwd, ESLINT_IGNORE_FILENAME);
 
-    return fs.existsSync(ignoreFilePath) ? ignoreFilePath : "";
+    return shell.test("-f", ignoreFilePath) ? ignoreFilePath : "";
 }
 
 /**

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -11,7 +11,6 @@
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
-const util = require("util");
 
 module.exports = {
     meta: {
@@ -679,7 +678,7 @@ module.exports = {
 
             if (node.type === "IfStatement" && node.consequent.type !== "BlockStatement") {
                 nodesToCheck = [node.consequent];
-            } else if (util.isArray(node.body)) {
+            } else if (Array.isArray(node.body)) {
                 nodesToCheck = node.body;
             } else {
                 nodesToCheck = [node.body];

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -31,7 +31,7 @@ function findPackageJson(startDir) {
     do {
         const pkgfile = path.join(dir, "package.json");
 
-        if (!fs.existsSync(pkgfile)) {
+        if (!shell.test("-f", pkgfile)) {
             dir = path.join(dir, "..");
             continue;
         }

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "coveralls": "2.11.4",
     "dateformat": "^1.0.8",
     "ejs": "^2.3.3",
+    "eslint-plugin-node": "^2.0.0",
     "eslint-release": "^0.5.0",
     "esprima": "^2.4.1",
     "esprima-fb": "^15001.1001.0-dev-harmony-fb",

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -13,6 +13,7 @@ const assert = require("chai").assert,
     path = require("path"),
     sinon = require("sinon"),
     leche = require("leche"),
+    shell = require("shelljs"),
     Config = require("../../lib/config"),
     Plugins = require("../../lib/config/plugins"),
     fs = require("fs"),
@@ -1570,7 +1571,7 @@ describe("CLIEngine", function() {
                 });
 
                 it("should create the cache file inside the provided directory", function() {
-                    assert.isFalse(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
+                    assert.isFalse(shell.test("-d", path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
 
                     engine = new CLIEngine({
                         useEslintrc: false,
@@ -1590,14 +1591,14 @@ describe("CLIEngine", function() {
 
                     engine.executeOnFiles([file]);
 
-                    assert.isTrue(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
+                    assert.isTrue(shell.test("-f", path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
 
                     sandbox.restore();
                 });
             });
 
             it("should create the cache file inside the provided directory using the cacheLocation option", function() {
-                assert.isFalse(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
+                assert.isFalse(shell.test("-d", path.resolve("./tmp/.cacheFileDir/.cache_hashOfCurrentWorkingDirectory")), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
                     useEslintrc: false,
@@ -1617,7 +1618,7 @@ describe("CLIEngine", function() {
 
                 engine.executeOnFiles([file]);
 
-                assert.isTrue(fs.existsSync(path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
+                assert.isTrue(shell.test("-f", path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
 
                 sandbox.restore();
             });
@@ -1640,11 +1641,11 @@ describe("CLIEngine", function() {
 
                 engine.executeOnFiles([file]);
 
-                assert.isTrue(fs.existsSync(path.resolve(cwd, ".eslintcache")), "the cache for eslint was created at provided cwd");
+                assert.isTrue(shell.test("-f", path.resolve(cwd, ".eslintcache")), "the cache for eslint was created at provided cwd");
             });
 
             it("should invalidate the cache if the configuration changed between executions", function() {
-                assert.isFalse(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint does not exist");
+                assert.isFalse(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
                     useEslintrc: false,
@@ -1669,7 +1670,7 @@ describe("CLIEngine", function() {
 
                 assert.equal(result.errorCount + result.warningCount, 0, "the file passed without errors or warnings");
                 assert.equal(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
-                assert.isTrue(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint was created");
+                assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
 
                 // destroy the spy
                 sandbox.restore();
@@ -1694,12 +1695,12 @@ describe("CLIEngine", function() {
 
                 assert.equal(spy.getCall(0).args[0], file, "the module read the file because is considered changed because the config changed");
                 assert.equal(cachedResult.errorCount, 1, "since configuration changed the cache was not used an one error was reported");
-                assert.isTrue(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint was created");
+                assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
             });
 
             it("should remember the files from a previous run and do not operate on them if not changed", function() {
 
-                assert.isFalse(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint does not exist");
+                assert.isFalse(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
                     useEslintrc: false,
@@ -1723,7 +1724,7 @@ describe("CLIEngine", function() {
                 const result = engine.executeOnFiles([file]);
 
                 assert.equal(spy.getCall(0).args[0], file, "the module read the file because is considered changed");
-                assert.isTrue(fs.existsSync(path.resolve(".eslintcache")), "the cache for eslint was created");
+                assert.isTrue(shell.test("-f", path.resolve(".eslintcache")), "the cache for eslint was created");
 
                 // destroy the spy
                 sandbox.restore();
@@ -1769,7 +1770,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 };
 
-                assert.isFalse(fs.existsSync(cacheFile), "the cache for eslint does not exist");
+                assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint does not exist");
 
                 engine = new CLIEngine(cliEngineOptions);
 
@@ -1779,21 +1780,21 @@ describe("CLIEngine", function() {
 
                 engine.executeOnFiles([file]);
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint was created");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint was created");
 
                 cliEngineOptions.cache = false;
                 engine = new CLIEngine(cliEngineOptions);
 
                 engine.executeOnFiles([file]);
 
-                assert.isFalse(fs.existsSync(cacheFile), "the cache for eslint was deleted since last run did not used the cache");
+                assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint was deleted since last run did not used the cache");
             });
 
             it("should not store in the cache a file that failed the test", function() {
 
                 const cacheFile = getFixturePath(".eslintcache");
 
-                assert.isFalse(fs.existsSync(cacheFile), "the cache for eslint does not exist");
+                assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint does not exist");
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
@@ -1814,7 +1815,7 @@ describe("CLIEngine", function() {
 
                 const result = engine.executeOnFiles([badFile, goodFile]);
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint was created");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint was created");
 
                 const cache = JSON.parse(fs.readFileSync(cacheFile));
 
@@ -1841,11 +1842,11 @@ describe("CLIEngine", function() {
                     extensions: ["js"]
                 });
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint exists");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
                 engine.executeOnText("var foo = 'bar';");
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint still exists");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
             it("should not delete cache when executing on text with a provided filename", function() {
@@ -1862,11 +1863,11 @@ describe("CLIEngine", function() {
                     extensions: ["js"]
                 });
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint exists");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
                 engine.executeOnText("var bar = foo;", "fixtures/passing.js");
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint still exists");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
             it("should not delete cache when executing on files with --cache flag", function() {
@@ -1886,11 +1887,11 @@ describe("CLIEngine", function() {
 
                 const file = getFixturePath("cli-engine", "console.js");
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint exists");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
                 engine.executeOnFiles([file]);
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint still exists");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint still exists");
             });
 
             it("should delete cache when executing on files without --cache flag", function() {
@@ -1909,18 +1910,18 @@ describe("CLIEngine", function() {
 
                 const file = getFixturePath("cli-engine", "console.js");
 
-                assert.isTrue(fs.existsSync(cacheFile), "the cache for eslint exists");
+                assert.isTrue(shell.test("-f", cacheFile), "the cache for eslint exists");
 
                 engine.executeOnFiles([file]);
 
-                assert.isFalse(fs.existsSync(cacheFile), "the cache for eslint has been deleted");
+                assert.isFalse(shell.test("-f", cacheFile), "the cache for eslint has been deleted");
             });
 
             describe("cacheFile", function() {
                 it("should use the specified cache file", function() {
                     const customCacheFile = path.resolve(".cache/custom-cache");
 
-                    assert.isFalse(fs.existsSync(customCacheFile), "the cache for eslint does not exist");
+                    assert.isFalse(shell.test("-f", customCacheFile), "the cache for eslint does not exist");
 
                     engine = new CLIEngine({
                         useEslintrc: false,
@@ -1943,7 +1944,7 @@ describe("CLIEngine", function() {
 
                     const result = engine.executeOnFiles([badFile, goodFile]);
 
-                    assert.isTrue(fs.existsSync(customCacheFile), "the cache for eslint was created");
+                    assert.isTrue(shell.test("-f", customCacheFile), "the cache for eslint was created");
 
                     const cache = JSON.parse(fs.readFileSync(customCacheFile));
 

--- a/tests/lib/util/npm-util.js
+++ b/tests/lib/util/npm-util.js
@@ -61,7 +61,7 @@ describe("npmUtil", function() {
         });
 
         it("should handle missing devDependencies key", function() {
-            sandbox.stub(fs, "existsSync", function() {
+            sandbox.stub(shell, "test", function() {
                 return true;
             });
             sandbox.stub(fs, "readFileSync", function() {
@@ -79,7 +79,7 @@ describe("npmUtil", function() {
         it("should throw with message when parsing invalid package.json", function() {
             const logInfo = sandbox.stub(log, "info");
 
-            sandbox.stub(fs, "existsSync", function() {
+            sandbox.stub(shell, "test", function() {
                 return true;
             });
             sandbox.stub(fs, "readFileSync", function() {
@@ -129,7 +129,7 @@ describe("npmUtil", function() {
         });
 
         it("should handle missing dependencies key", function() {
-            sandbox.stub(fs, "existsSync", function() {
+            sandbox.stub(shell, "test", function() {
                 return true;
             });
             sandbox.stub(fs, "readFileSync", function() {
@@ -143,14 +143,14 @@ describe("npmUtil", function() {
 
             assert.doesNotThrow(fn);
 
-            fs.existsSync.restore();
+            shell.test.restore();
             fs.readFileSync.restore();
         });
 
         it("should throw with message when parsing invalid package.json", function() {
             const logInfo = sandbox.stub(log, "info");
 
-            sandbox.stub(fs, "existsSync", function() {
+            sandbox.stub(shell, "test", function() {
                 return true;
             });
             sandbox.stub(fs, "readFileSync", function() {
@@ -163,7 +163,7 @@ describe("npmUtil", function() {
             assert(logInfo.calledOnce);
             assert.equal(logInfo.firstCall.args[0], "Could not read package.json file. Please check that the file contains valid JSON.");
 
-            fs.existsSync.restore();
+            shell.test.restore();
             fs.readFileSync.restore();
             logInfo.restore();
         });


### PR DESCRIPTION
Refs #6407.

This PR enables [eslint-plugin-node] to lint our codebase.

    plugins:
        - node
    extends:
        - "plugin:node/recommended"

This would help us:

- To early warn a use of unsupported ecma features in Node 4.
- To warn a use of deprecated API.
- To early warn invalid paths in `require(...)`.
- To early warn paths which are not included in dependencies in `require(...)`.

Also, this PR removes some uses of deprecated API.

- `util.isArray`
- `fs.existsSync`

[eslint-plugin-node]: https://www.npmjs.com/package/eslint-plugin-node