### PR TITLE
Fix: Use Node's resolution algorithm for plugins & parsers (refs #3458)

### DIFF
--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -13,6 +13,7 @@
 
 const fs = require("fs"),
     path = require("path"),
+    resolveSync = require("resolve").sync,
     ConfigOps = require("./config-ops"),
     validator = require("./config-validator"),
     Plugins = require("./plugins"),
@@ -492,15 +493,14 @@ function resolve(filePath, relativeTo) {
  */
 function load(filePath, applyEnvironments, relativeTo) {
     const resolvedPath = resolve(filePath, relativeTo),
-        dirname = path.dirname(resolvedPath.filePath),
-        lookupPath = getLookupPath(dirname);
+        dirname = path.dirname(resolvedPath.filePath);
     let config = loadConfigFile(resolvedPath);
 
     if (config) {
 
         // ensure plugins are properly loaded first
         if (config.plugins) {
-            Plugins.loadAll(config.plugins);
+            Plugins.loadAll(config.plugins, dirname);
         }
 
         // remove parser from config if it is the default parser
@@ -513,7 +513,9 @@ function load(filePath, applyEnvironments, relativeTo) {
             if (isFilePath(config.parser)) {
                 config.parser = path.resolve(dirname || "", config.parser);
             } else {
-                config.parser = resolver.resolve(config.parser, lookupPath);
+                config.parser = resolveSync(config.parser, {
+                    basedir: dirname
+                });
             }
         }
 

--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 const Environments = require("./environments"),
+    resolve = require("resolve"),
     rules = require("../rules");
 
 const debug = require("debug")("eslint:plugins");
@@ -99,10 +100,11 @@ module.exports = {
     /**
      * Loads a plugin with the given name.
      * @param {string} pluginName The name of the plugin to load.
+     * @param {string?} relativeTo Path to the config that included the plugins
      * @returns {void}
      * @throws {Error} If the plugin cannot be loaded.
      */
-    load: function(pluginName) {
+    load: function(pluginName, relativeTo) {
         const pluginNamespace = getNamespace(pluginName),
             pluginNameWithoutNamespace = removeNamespace(pluginName),
             pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace);
@@ -110,7 +112,21 @@ module.exports = {
 
         if (!plugins[pluginNameWithoutPrefix]) {
             try {
-                plugin = require(pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+                let moduleName = pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix;
+
+                if (relativeTo) {
+                    try {
+                        moduleName = resolve.sync(moduleName, {
+                            basedir: relativeTo
+                        });
+                    } catch (e) {
+
+                        // resolve.sync throws an error when a module isn't
+                        // found. That's not really what we want here.
+                    }
+                }
+
+                plugin = require(moduleName);
             } catch (err) {
                 debug("Failed to load plugin eslint-plugin-" + pluginNameWithoutPrefix + ". Proceeding without it.");
                 err.message = "Failed to load plugin " + pluginName + ": " + err.message;
@@ -128,11 +144,14 @@ module.exports = {
     /**
      * Loads all plugins from an array.
      * @param {string[]} pluginNames An array of plugins names.
+     * @param {string?} relativeTo Path to the config that included the plugins
      * @returns {void}
      * @throws {Error} If a plugin cannot be loaded.
      */
-    loadAll: function(pluginNames) {
-        pluginNames.forEach(this.load, this);
+    loadAll: function(pluginNames, relativeTo) {
+        pluginNames.forEach(function(name) {
+            this.load(name, relativeTo);
+        }, this);
     },
 
     /**

--- a/package.json
+++ b/package.json
@@ -62,6 +62,7 @@
     "pluralize": "^1.2.1",
     "progress": "^1.1.8",
     "require-uncached": "^1.0.2",
+    "resolve": "^1.1.7",
     "shelljs": "^0.6.0",
     "strip-bom": "^3.0.0",
     "strip-json-comments": "~1.0.1",


### PR DESCRIPTION
**What issue does this pull request address?**

Having plugins or parsers in shared configs. The current behavior isn't always able to find the referenced module.

**What changes did you make? (Give an overview)**

I used [`resolve`](https://www.npmjs.com/package/resolve) to get eslint to look up the modules relative to the configuration file that actually references them.

**Is there anything you'd like reviewers to focus on?**

I'm aware this doesn't answer @nzakas 's [question](https://github.com/eslint/eslint/issues/3458#issuecomment-234387438)

> (primarily, what happens when two different versions of a plugin are required by different configs used in the same project?)

Under this implementation eslint just picks up the first version of a plugin it finds and uses it. I can have it error when it encounters a 2nd reference to the same plugin, but I don't think that's ideal because it may prevent mixing two otherwise compatible configurations. I don't see any way to get the version of the imported plugin that would allow me to throw an error if they don't match.

**Minimal steps to reproduce #3458**

1. `npm install -g create-react-app`
2. `create-react-app eslint-demo`
3. `cd eslint-demo`
4. `eslint src`

If you use the published version of eslint you see:

```
Oops! Something went wrong! :(

ESLint couldn't find the plugin "eslint-plugin-flowtype". This can happen for a couple different reasons:

1. If ESLint is installed globally, then make sure eslint-plugin-flowtype is also installed globally. A globally-installed ESLint cannot find a locally-installed plugin.

2. If ESLint is installed locally, then it's likely that the plugin isn't installed correctly. Try reinstalling by running the following:

    npm i eslint-plugin-flowtype@latest --save-dev

If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.
```