### PR TITLE
Sort-imports autofixer. Issue #6866

### DIFF
--- a/lib/rules/sort-imports.js
+++ b/lib/rules/sort-imports.js
@@ -17,6 +17,8 @@ module.exports = {
             recommended: false
         },
 
+        fixable: "code",
+
         schema: [
             {
                 type: "object",
@@ -27,7 +29,7 @@ module.exports = {
                     memberSyntaxSortOrder: {
                         type: "array",
                         items: {
-                            enum: ["none", "all", "multiple", "single"]
+                            enum: ["none", "all", "single", "multiple"]
                         },
                         uniqueItems: true,
                         minItems: 4,
@@ -43,12 +45,67 @@ module.exports = {
     },
 
     create: function(context) {
-
         const configuration = context.options[0] || {},
             ignoreCase = configuration.ignoreCase || false,
             ignoreMemberSort = configuration.ignoreMemberSort || false,
-            memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"];
-        let previousDeclaration = null;
+            memberSyntaxSortOrder = configuration.memberSyntaxSortOrder || ["none", "all", "multiple", "single"],
+            sourceCode = context.getSourceCode();
+
+        let declarations = [],
+            previousDeclaration = null,
+            firstDeclaration = null,
+            lastDeclaration = null;
+
+        /**
+         * Sorts specifiers
+         *
+         * @param {Object} specifierA - a node specifier
+         * @param {Object} specifierB - a node specifier
+         * @returns {number} - sorting result
+         */
+        function specifierSortingFunction(specifierA, specifierB) {
+            if (specifierA.type !== "ImportSpecifier" || specifierB.type !== "ImportSpecifier") {
+                return 0;
+            }
+
+            let specifierAText = specifierA.local.name;
+            let specifierBText = specifierB.local.name;
+
+            if (ignoreCase) {
+                specifierAText = specifierAText.toLowerCase();
+                specifierBText = specifierBText.toLowerCase();
+            }
+
+            if (specifierAText < specifierBText) {
+                return -1;
+            }
+            if (specifierAText > specifierBText) {
+                return 1;
+            }
+            return 0;
+        }
+
+        /**
+         * Fixes orders of specifiers
+         *
+         * @param {importSpecifiers} importSpecifiers - array of specifiers
+         * @param {firstSpecifier} firstSpecifier - specifier
+         * @param {lastSpecifier} lastSpecifier - specifier
+         * @param {fixer} fixer - the RuleFixer
+         * @returns {*|boolean} fixer result
+         */
+        function specifierFixingFunction(importSpecifiers, firstSpecifier, lastSpecifier, fixer) {
+            const replaceOutput = [];
+
+            for (let i = 0; i < importSpecifiers.length; i++) {
+                replaceOutput.push(importSpecifiers[i].local.name);
+            }
+
+            return fixer.replaceTextRange(
+                [firstSpecifier.range[0], lastSpecifier.range[1]],
+                replaceOutput.join(", ")
+            );
+        }
 
         /**
          * Gets the used member syntax style.
@@ -83,92 +140,148 @@ module.exports = {
         }
 
         /**
-         * Gets the local name of the first imported module.
-         * @param {ASTNode} node - the ImportDeclaration node.
-         * @returns {?string} the local name of the first imported module.
+         * Sorts import statements
+         *
+         * @param {nodeA} nodeA ImportDeclaration node.
+         * @param {nodeB} nodeB  ImportDeclaration node.
+         * @returns {number} returns a number - result of sort
          */
-        function getFirstLocalMemberName(node) {
-            if (node.specifiers[0]) {
-                return node.specifiers[0].local.name;
-            } else {
-                return null;
+        function sortingFunction(nodeA, nodeB) {
+
+            // usedMemberSyntax is different
+            const nodeAGroupOrder = getMemberParameterGroupIndex(nodeA);
+            const nodeBGroupOrder = getMemberParameterGroupIndex(nodeB);
+
+            if (nodeAGroupOrder < nodeBGroupOrder) {
+                return -1;
             }
+            if (nodeAGroupOrder > nodeBGroupOrder) {
+                return 1;
+            }
+
+            // usedMemberSyntax is the same
+            let sourceCodeA = sourceCode.getText(nodeA);
+            let sourceCodeB = sourceCode.getText(nodeB);
+
+            if (ignoreCase) {
+                sourceCodeA = sourceCodeA.toLowerCase();
+                sourceCodeB = sourceCodeB.toLowerCase();
+            }
+
+            if (sourceCodeA < sourceCodeB) {
+                return -1;
+            }
+            if (sourceCodeA > sourceCodeB) {
+                return 1;
+            }
+            return 0;
+        }
+
+        /**
+         * Fixes declaration order
+         *
+         * @param {fixer} fixer - fixer the RuleFixer
+         * @returns {*} - fixer result
+         */
+        function declarationsFixerFunction(fixer) {
+            const replaceOutput = [];
+
+            for (let i = 0; i < declarations.length; i++) {
+                replaceOutput.push(sourceCode.getText(declarations[i]));
+            }
+
+            return fixer.replaceTextRange(
+                [firstDeclaration.range[0], lastDeclaration.range[1]],
+                replaceOutput.join("\n")
+            );
         }
 
         return {
             ImportDeclaration: function(node) {
-                if (previousDeclaration) {
+                firstDeclaration = firstDeclaration || node;
+                lastDeclaration = node;
+
+                declarations.push(node);
+                const sortedDeclarations = declarations.slice().sort(sortingFunction);
+
+                if (declarations.length > 1) {
+                    previousDeclaration = declarations[declarations.length - 2];
+                }
+
+                const isDeclarationsSorted = declarations.every((importNode, ind) => {
+                    if (sortedDeclarations[ind] !== declarations[ind]) {
+                        return false;
+                    }
+                    return true;
+                });
+
+                declarations = sortedDeclarations;
+
+                if (!isDeclarationsSorted) {
+                    let message;
+                    let data = null;
+
                     const currentMemberSyntaxGroupIndex = getMemberParameterGroupIndex(node),
                         previousMemberSyntaxGroupIndex = getMemberParameterGroupIndex(previousDeclaration);
-                    let currentLocalMemberName = getFirstLocalMemberName(node),
-                        previousLocalMemberName = getFirstLocalMemberName(previousDeclaration);
 
-                    if (ignoreCase) {
-                        previousLocalMemberName = previousLocalMemberName && previousLocalMemberName.toLowerCase();
-                        currentLocalMemberName = currentLocalMemberName && currentLocalMemberName.toLowerCase();
-                    }
-
-                    // When the current declaration uses a different member syntax,
-                    // then check if the ordering is correct.
-                    // Otherwise, make a default string compare (like rule sort-vars to be consistent) of the first used local member name.
                     if (currentMemberSyntaxGroupIndex !== previousMemberSyntaxGroupIndex) {
-                        if (currentMemberSyntaxGroupIndex < previousMemberSyntaxGroupIndex) {
-                            context.report({
-                                node: node,
-                                message: "Expected '{{syntaxA}}' syntax before '{{syntaxB}}' syntax.",
-                                data: {
-                                    syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
-                                    syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex]
-                                }
-                            });
-                        }
+                        message = "Expected '{{syntaxA}}' syntax before '{{syntaxB}}' syntax.";
+                        data = {
+                            syntaxA: memberSyntaxSortOrder[currentMemberSyntaxGroupIndex],
+                            syntaxB: memberSyntaxSortOrder[previousMemberSyntaxGroupIndex]
+                        };
+
                     } else {
-                        if (previousLocalMemberName &&
-                            currentLocalMemberName &&
-                            currentLocalMemberName < previousLocalMemberName
-                        ) {
-                            context.report({
-                                node: node,
-                                message: "Imports should be sorted alphabetically."
-                            });
-                        }
+                        message = "Imports should be sorted alphabetically.";
                     }
+
+                    context.report({
+                        data: data,
+                        node: node,
+                        message: message,
+                        fix: function(fixer) {
+                            return declarationsFixerFunction(fixer);
+                        }
+                    });
                 }
 
                 // Multiple members of an import declaration should also be sorted alphabetically.
                 if (!ignoreMemberSort && node.specifiers.length > 1) {
-                    let previousSpecifier = null;
-                    let previousSpecifierName = null;
+                    const importSpecifiers = node.specifiers;
+                    const sortedImportSpecifiers = importSpecifiers.slice();
+                    const firstSpecifier = importSpecifiers[0];
+                    const lastSpecifier = importSpecifiers[importSpecifiers.length - 1];
 
-                    for (let i = 0; i < node.specifiers.length; ++i) {
-                        const currentSpecifier = node.specifiers[i];
+                    sortedImportSpecifiers.sort(specifierSortingFunction);
 
-                        if (currentSpecifier.type !== "ImportSpecifier") {
-                            continue;
+                    const isSpecifiersSorted = importSpecifiers.every(function(specifier, ind) {
+                        if (sortedImportSpecifiers[ind] !== importSpecifiers[ind]) {
+                            return false;
                         }
+                        return true;
+                    });
 
-                        let currentSpecifierName = currentSpecifier.local.name;
+                    const importSpecifiersText = "{" + importSpecifiers.map(function(specifier) {
+                        return specifier.local.name;
+                    }).join(", ") + "}";
 
-                        if (ignoreCase) {
-                            currentSpecifierName = currentSpecifierName.toLowerCase();
-                        }
 
-                        if (previousSpecifier && currentSpecifierName < previousSpecifierName) {
-                            context.report({
-                                node: currentSpecifier,
-                                message: "Member '{{memberName}}' of the import declaration should be sorted alphabetically.",
-                                data: {
-                                    memberName: currentSpecifier.local.name
-                                }
-                            });
-                        }
-
-                        previousSpecifier = currentSpecifier;
-                        previousSpecifierName = currentSpecifierName;
+                    if (!isSpecifiersSorted) {
+                        context.report({
+                            node: firstSpecifier,
+                            message: "Members '{{memberNames}}' of the import declaration should be sorted alphabetically.",
+                            data: {
+                                memberNames: importSpecifiersText
+                            },
+                            fix: specifierFixingFunction.bind(
+                                this,
+                                sortedImportSpecifiers,
+                                firstSpecifier,
+                                lastSpecifier
+                            )
+                        });
                     }
                 }
-
-                previousDeclaration = node;
             }
         };
     }

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -33,7 +33,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import b from 'bar.js';\n" +
-                "import c from 'baz.js';\n",
+                "import c from 'baz.js';",
             parserOptions: parserOptions
         },
         {
@@ -165,8 +165,23 @@ ruleTester.run("sort-imports", rule, {
     invalid: [
         {
             code:
+                "import c from 'foo.js';\n" +
+                "import a from 'bar.js';\n" +
+                "import b from 'baz.js';",
+            output:
+                "import a from 'bar.js';\n" +
+                "import b from 'baz.js';\n" +
+                "import c from 'foo.js';",
+            errors: [expectedError, expectedError],
+            parserOptions: parserOptions
+        },
+        {
+            code:
                 "import a from 'foo.js';\n" +
                 "import A from 'bar.js';",
+            output:
+                "import A from 'bar.js';\n" +
+                "import a from 'foo.js';",
             parserOptions: parserOptions,
             errors: [expectedError]
         },
@@ -174,6 +189,9 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import b from 'foo.js';\n" +
                 "import a from 'bar.js';",
+            output:
+                "import a from 'bar.js';\n" +
+                "import b from 'foo.js';",
             parserOptions: parserOptions,
             errors: [expectedError]
         },
@@ -181,6 +199,9 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import {b, c} from 'foo.js';\n" +
                 "import {a, b} from 'bar.js';",
+            output:
+                "import {a, b} from 'bar.js';\n" +
+                "import {b, c} from 'foo.js';",
             parserOptions: parserOptions,
             errors: [expectedError]
         },
@@ -188,6 +209,9 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import * as foo from 'foo.js';\n" +
                 "import * as bar from 'bar.js';",
+            output:
+                "import * as bar from 'bar.js';\n" +
+                "import * as foo from 'foo.js';",
             parserOptions: parserOptions,
             errors: [expectedError]
         },
@@ -195,6 +219,9 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import {b, c} from 'bar.js';",
+            output:
+                "import {b, c} from 'bar.js';\n" +
+                "import a from 'foo.js';",
             parserOptions: parserOptions,
             errors: [{
                 message: "Expected 'multiple' syntax before 'single' syntax.",
@@ -205,6 +232,9 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import * as b from 'bar.js';",
+            output:
+                "import * as b from 'bar.js';\n" +
+                "import a from 'foo.js';",
             parserOptions: parserOptions,
             errors: [{
                 message: "Expected 'all' syntax before 'single' syntax.",
@@ -215,6 +245,9 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import 'bar.js';",
+            output:
+                "import 'bar.js';\n" +
+                "import a from 'foo.js';",
             parserOptions: parserOptions,
             errors: [{
                 message: "Expected 'none' syntax before 'single' syntax.",
@@ -225,6 +258,9 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import b from 'bar.js';\n" +
                 "import * as a from 'foo.js';",
+            output:
+                "import * as a from 'foo.js';\n" +
+                "import b from 'bar.js';",
             parserOptions: parserOptions,
             options: [{
                 memberSyntaxSortOrder: [ "all", "single", "multiple", "none" ]
@@ -236,23 +272,19 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {b, a, d, c} from 'foo.js';",
+            output: "import {a, b, c, d} from 'foo.js';",
             parserOptions: parserOptions,
             errors: [{
-                message: "Member 'a' of the import declaration should be sorted alphabetically.",
-                type: "ImportSpecifier"
-            }, {
-                message: "Member 'c' of the import declaration should be sorted alphabetically.",
+                message: "Members '{b, a, d, c}' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
             }]
         },
         {
             code: "import {a, B, c, D} from 'foo.js';",
+            output: "import {B, D, a, c} from 'foo.js';",
             parserOptions: parserOptions,
             errors: [{
-                message: "Member 'B' of the import declaration should be sorted alphabetically.",
-                type: "ImportSpecifier"
-            }, {
-                message: "Member 'D' of the import declaration should be sorted alphabetically.",
+                message: "Members '{a, B, c, D}' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
             }]
         }


### PR DESCRIPTION
Update: There is sort-imports rule but there is no autofixer. Changing multiple lines makes it hard to implement.
This PR will introduce sort-imports auto-fixer. It will auto-fix order of specifiers as well.

In a separate PR I will add a regex option for custom reordering.

(fixes #6868)
