### PR TITLE
Update: `prefer-rest-params` relax for member accesses (fixes #5990)

### DIFF
--- a/lib/rules/prefer-rest-params.js
+++ b/lib/rules/prefer-rest-params.js
@@ -32,6 +32,28 @@ function getVariableOfArguments(scope) {
     return null;
 }
 
+/**
+ * Checks if the given reference is not normal member access.
+ *
+ * - arguments         .... true    // not member access
+ * - arguments[i]      .... true    // computed member access
+ * - arguments[0]      .... true    // computed member access
+ * - arguments.length  .... false   // normal member access
+ *
+ * @param {escope.Reference} reference - The reference to check.
+ * @returns {boolean} `true` if the reference is not normal member access.
+ */
+function isNotNormalMemberAccess(reference) {
+    const id = reference.identifier;
+    const parent = id.parent;
+
+    return !(
+        parent.type === "MemberExpression" &&
+        parent.object === id &&
+        !parent.computed
+    );
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -58,6 +80,7 @@ module.exports = {
         function report(reference) {
             context.report({
                 node: reference.identifier,
+                loc: reference.identifier.loc,
                 message: "Use the rest parameters instead of 'arguments'."
             });
         }
@@ -71,13 +94,16 @@ module.exports = {
             const argumentsVar = getVariableOfArguments(context.getScope());
 
             if (argumentsVar) {
-                argumentsVar.references.forEach(report);
+                argumentsVar
+                    .references
+                    .filter(isNotNormalMemberAccess)
+                    .forEach(report);
             }
         }
 
         return {
-            FunctionDeclaration: checkForArguments,
-            FunctionExpression: checkForArguments
+            "FunctionDeclaration:exit": checkForArguments,
+            "FunctionExpression:exit": checkForArguments
         };
     }
 };

--- a/tests/lib/rules/prefer-rest-params.js
+++ b/tests/lib/rules/prefer-rest-params.js
@@ -20,9 +20,14 @@ ruleTester.run("prefer-rest-params", rule, {
         "function foo(arguments) { arguments; }",
         "function foo() { var arguments; arguments; }",
         {code: "var foo = () => arguments;", parserOptions: { ecmaVersion: 6 }}, // Arrows don't have "arguments".,
-        {code: "function foo(...args) { args; }", parserOptions: { ecmaVersion: 6 }}
+        {code: "function foo(...args) { args; }", parserOptions: { ecmaVersion: 6 }},
+        "function foo() { arguments.length; }",
+        "function foo() { arguments.callee; }",
     ],
     invalid: [
-        {code: "function foo() { arguments; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]}
+        {code: "function foo() { arguments; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
+        {code: "function foo() { arguments[0]; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
+        {code: "function foo() { arguments[1]; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
+        {code: "function foo() { arguments[Symbol.iterator]; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
     ]
 });


### PR DESCRIPTION
Fixes #5990.

This PR makes `prefer-rest-params` rule relaxing.
New behavior ignores `arguments` which is accessing non-computed property (e.g. `arguments.length`).

- Ignores:
    - `arguments.length`
    - `arguments.callee`
- Still errors:
    - `arguments`
    - `foo(arguments)`
    - `arguments[0]`
    - `arguments[i]`
    - `arguments[Symbol.iterator]`