### PR TITLE
Chore: Fix glob for core js files for lint (fixes #6870)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -62,7 +62,7 @@ const NODE = "node ", // intentional extra space
 
     // Files
     MAKEFILE = "./Makefile.js",
-    JS_FILES = find("lib/", "conf/").filter(fileType("js")).join(" "),
+    JS_FILES = "lib/**/*.js conf/**/*.js",
     JSON_FILES = find("conf/").filter(fileType("json")),
     MARKDOWN_FILES_ARRAY = find("docs/").concat(ls(".")).filter(fileType("md")),
     TEST_FILES = getTestFilePatterns(),


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

Build failure on windows for lint runs.

**What changes did you make? (Give an overview)**

Rather than getting all the files and then sending them individually to eslint. we will now just send the glob pattern and let eslint figure out the files.
I think the cause of the issue was that we were exceeding the limit on how many things can be passed as arguments from cmd line.

**Is there anything you'd like reviewers to focus on?**

Nothing specific
