### PR TITLE
Update: Add regex support for exceptions (fixes #5187)

### DIFF
--- a/docs/rules/new-cap.md
+++ b/docs/rules/new-cap.md
@@ -40,7 +40,9 @@ This rule has an object option:
 * `"capIsNew": true` (default) requires all uppercase-started functions to be called with `new` operators.
 * `"capIsNew": false` allows uppercase-started functions to be called without `new` operators.
 * `"newIsCapExceptions"` allows specified lowercase-started function names to be called with the `new` operator.
+* `"newIsCapExceptionPattern"` allows any lowercase-started function names that match the specified regex pattern to be called with the `new` operator.
 * `"capIsNewExceptions"` allows specified uppercase-started function names to be called without the `new` operator.
+* `"capIsNewExceptionPattern"` allows any uppercase-started function names that match the specified regex pattern to be called without the `new` operator.
 * `"properties": true` (default) enables checks on object properties
 * `"properties": false` disables checks on object properties
 
@@ -108,6 +110,17 @@ var events = require('events');
 var emitter = new events();
 ```
 
+### newIsCapExceptionPattern
+
+Examples of additional **correct** code for this rule with the `{ "newIsCapExceptionPattern": "^person\.." }` option:
+
+```js
+/*eslint new-cap: ["error", { "newIsCapExceptionPattern": "^person\.." }]*/
+
+var friend = new person.acquaintance();
+var bestFriend = new person.friend();
+```
+
 ### capIsNewExceptions
 
 Examples of additional **correct** code for this rule with the `{ "capIsNewExceptions": ["Person"] }` option:
@@ -118,6 +131,17 @@ Examples of additional **correct** code for this rule with the `{ "capIsNewExcep
 function foo(arg) {
     return Person(arg);
 }
+```
+
+### capIsNewExceptionPattern
+
+Examples of additional **correct** code for this rule with the `{ "capIsNewExceptionPattern": "^Person\.." }` option:
+
+```js
+/*eslint new-cap: ["error", { "capIsNewExceptionPattern": "^Person\.." }]*/
+
+var friend = person.Acquaintance();
+var bestFriend = person.Friend();
 ```
 
 ### properties

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -96,11 +96,17 @@ module.exports = {
                             type: "string"
                         }
                     },
+                    newIsCapExceptionPattern: {
+                        type: "string"
+                    },
                     capIsNewExceptions: {
                         type: "array",
                         items: {
                             type: "string"
                         }
+                    },
+                    capIsNewExceptionPattern: {
+                        type: "string"
                     },
                     properties: {
                         type: "boolean"
@@ -120,8 +126,10 @@ module.exports = {
         const skipProperties = config.properties === false;
 
         const newIsCapExceptions = checkArray(config, "newIsCapExceptions", []).reduce(invert, {});
+        const newIsCapExceptionPattern = config.newIsCapExceptionPattern ? new RegExp(config.newIsCapExceptionPattern) : null;
 
         const capIsNewExceptions = calculateCapIsNewExceptions(config);
+        const capIsNewExceptionPattern = config.capIsNewExceptionPattern ? new RegExp(config.capIsNewExceptionPattern) : null;
 
         const listeners = {};
 
@@ -182,10 +190,17 @@ module.exports = {
          * @param {Object} allowedMap Object mapping calleeName to a Boolean
          * @param {ASTNode} node CallExpression node
          * @param {string} calleeName Capitalized callee name from a CallExpression
+         * @param {Object} pattern RegExp object from options pattern
          * @returns {boolean} Returns true if the callee may be capitalized
          */
-        function isCapAllowed(allowedMap, node, calleeName) {
-            if (allowedMap[calleeName] || allowedMap[sourceCode.getText(node.callee)]) {
+        function isCapAllowed(allowedMap, node, calleeName, pattern) {
+            const sourceText = sourceCode.getText(node.callee);
+
+            if (allowedMap[calleeName] || allowedMap[sourceText]) {
+                return true;
+            }
+
+            if (pattern && pattern.test(sourceText)) {
                 return true;
             }
 
@@ -226,7 +241,7 @@ module.exports = {
 
                 if (constructorName) {
                     const capitalization = getCap(constructorName);
-                    const isAllowed = capitalization !== "lower" || isCapAllowed(newIsCapExceptions, node, constructorName);
+                    const isAllowed = capitalization !== "lower" || isCapAllowed(newIsCapExceptions, node, constructorName, newIsCapExceptionPattern);
 
                     if (!isAllowed) {
                         report(node, "A constructor name should not start with a lowercase letter.");
@@ -242,7 +257,7 @@ module.exports = {
 
                 if (calleeName) {
                     const capitalization = getCap(calleeName);
-                    const isAllowed = capitalization !== "upper" || isCapAllowed(capIsNewExceptions, node, calleeName);
+                    const isAllowed = capitalization !== "upper" || isCapAllowed(capIsNewExceptions, node, calleeName, capIsNewExceptionPattern);
 
                     if (!isAllowed) {
                         report(node, "A function with a name starting with an uppercase letter should only be used as a constructor.");

--- a/tests/lib/rules/new-cap.js
+++ b/tests/lib/rules/new-cap.js
@@ -55,13 +55,17 @@ ruleTester.run("new-cap", rule, {
         "var o = { 1: function() {} }; o[1]();",
         "var o = { 1: function() {} }; new o[1]();",
         { code: "var x = Foo(42);", options: [{ capIsNew: true, capIsNewExceptions: ["Foo"] }] },
+        { code: "var x = Foo(42);", options: [{ capIsNewExceptionPattern: "^Foo" }] },
         { code: "var x = new foo(42);", options: [{ newIsCap: true, newIsCapExceptions: ["foo"] }] },
+        { code: "var x = new foo(42);", options: [{ newIsCapExceptionPattern: "^foo" }] },
         { code: "var x = Object(42);", options: [{ capIsNewExceptions: ["Foo"] }] },
 
         { code: "var x = Foo.Bar(42);", options: [{ capIsNewExceptions: ["Bar"] }] },
         { code: "var x = Foo.Bar(42);", options: [{ capIsNewExceptions: ["Foo.Bar"] }] },
+        { code: "var x = Foo.Bar(42);", options: [{ capIsNewExceptionPattern: "^Foo\.." }] },
         { code: "var x = new foo.bar(42);", options: [{ newIsCapExceptions: ["bar"] }] },
         { code: "var x = new foo.bar(42);", options: [{ newIsCapExceptions: ["foo.bar"] }] },
+        { code: "var x = new foo.bar(42);", options: [{ newIsCapExceptionPattern: "^foo\.." }] },
         { code: "var x = new foo.bar(42);", options: [{ properties: false }] },
         { code: "var x = Foo.bar(42);", options: [{ properties: false }] },
         { code: "var x = foo.Bar(42);", options: [{ capIsNew: false, properties: false }] }
@@ -138,8 +142,18 @@ ruleTester.run("new-cap", rule, {
             errors: [{type: "CallExpression", message: "A function with a name starting with an uppercase letter should only be used as a constructor."}]
         },
         {
+            code: "var x = Bar.Foo(42);",
+            options: [{capIsNewExceptionPattern: "^Foo\.."}],
+            errors: [{type: "CallExpression", message: "A function with a name starting with an uppercase letter should only be used as a constructor."}]
+        },
+        {
             code: "var x = new foo.bar(42);",
             options: [{newIsCapExceptions: ["foo"]}],
+            errors: [{type: "NewExpression", message: "A constructor name should not start with a lowercase letter."}]
+        },
+        {
+            code: "var x = new bar.foo(42);",
+            options: [{newIsCapExceptionPattern: "^foo\.."}],
             errors: [{type: "NewExpression", message: "A constructor name should not start with a lowercase letter."}]
         }
     ]


### PR DESCRIPTION
ref: https://github.com/eslint/eslint/issues/5187

adds regex options for exceptions to newIsCap and capIsNew

