### PR TITLE
Fix: `no-dupe-keys` type errors (fixes #6886)

### DIFF
--- a/lib/rules/no-dupe-keys.js
+++ b/lib/rules/no-dupe-keys.js
@@ -107,6 +107,11 @@ module.exports = {
             Property(node) {
                 const name = astUtils.getStaticPropertyName(node);
 
+                // Skip destructuring.
+                if (node.parent.type !== "ObjectExpression") {
+                    return;
+                }
+
                 // Skip if the name is not static.
                 if (!name) {
                     return;

--- a/tests/lib/rules/no-dupe-keys.js
+++ b/tests/lib/rules/no-dupe-keys.js
@@ -27,6 +27,7 @@ ruleTester.run("no-dupe-keys", rule, {
         { code: "var x = { a: b, ...c }", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }},
         { code: "var x = { get a() {}, set a (value) {} };", parserOptions: { ecmaVersion: 6 }},
         { code: "var x = { a: 1, b: { a: 2 } };", parserOptions: { ecmaVersion: 6 }},
+        { code: "var {a, a} = obj", parserOptions: { ecmaVersion: 6 }},
     ],
     invalid: [
         { code: "var x = { a: b, ['a']: b };", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Duplicate key 'a'.", type: "ObjectExpression"}] },


### PR DESCRIPTION
Fixes #6886.

`Property` nodes exist on `ObjectPattern` nodes. It needs to avoid those.