### PR TITLE
Chore: Use object-shorthand batch 1 (Refs #6407)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -398,8 +398,8 @@ function lintMarkdown(files) {
             MD041: false  // First line in file should be a top level header
         },
         result = markdownlint.sync({
-            files: files,
-            config: config
+            files,
+            config
         }),
         resultString = result.toString(),
         returnCode = resultString ? 1 : 0;

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -910,7 +910,7 @@ describe("CLIEngine", function() {
 
             engine = new CLIEngine({
                 ignore: false,
-                cwd: cwd,
+                cwd,
                 rulePaths: ["./"],
                 configFile: "eslint.json"
             });
@@ -1629,7 +1629,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     useEslintrc: false,
                     cache: true,
-                    cwd: cwd,
+                    cwd,
                     rules: {
                         "no-console": 0
                     },
@@ -1761,7 +1761,7 @@ describe("CLIEngine", function() {
 
                     // specifying cache true the cache will be created
                     cache: true,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1802,7 +1802,7 @@ describe("CLIEngine", function() {
 
                     // specifying cache true the cache will be created
                     cache: true,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1834,7 +1834,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1855,7 +1855,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1877,7 +1877,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
                     cache: true,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1900,7 +1900,7 @@ describe("CLIEngine", function() {
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
                     useEslintrc: false,
-                    cacheFile: cacheFile,
+                    cacheFile,
                     rules: {
                         "no-console": 0,
                         "no-unused-vars": 2
@@ -1988,10 +1988,10 @@ describe("CLIEngine", function() {
                 engine.addPlugin("test-processor", {
                     processors: {
                         ".txt": {
-                            preprocess: function(text) {
+                            preprocess(text) {
                                 return [text];
                             },
-                            postprocess: function(messages) {
+                            postprocess(messages) {
                                 return messages[0];
                             }
                         }
@@ -2031,10 +2031,10 @@ describe("CLIEngine", function() {
                 engine.addPlugin("test-processor", {
                     processors: {
                         ".txt": {
-                            preprocess: function(text) {
+                            preprocess(text) {
                                 return [text.replace("a()", "b()")];
                             },
-                            postprocess: function(messages) {
+                            postprocess(messages) {
                                 messages[0][0].ruleId = "post-processed";
                                 return messages[0];
                             }
@@ -2075,10 +2075,10 @@ describe("CLIEngine", function() {
                 engine.addPlugin("test-processor", {
                     processors: {
                         ".txt": {
-                            preprocess: function(text) {
+                            preprocess(text) {
                                 return [text.replace("a()", "b()")];
                             },
-                            postprocess: function(messages) {
+                            postprocess(messages) {
                                 messages[0][0].ruleId = "post-processed";
                                 return messages[0];
                             }

--- a/tests/lib/code-path-analysis/code-path-analyzer.js
+++ b/tests/lib/code-path-analysis/code-path-analyzer.js
@@ -69,7 +69,7 @@ describe("CodePathAnalyzer", function() {
             actual = [];
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathStart: function(codePath) {
+                    onCodePathStart(codePath) {
                         actual.push(codePath);
                     }
                 };
@@ -149,14 +149,14 @@ describe("CodePathAnalyzer", function() {
                 let codePath = null;
 
                 return {
-                    onCodePathStart: function(cp) {
+                    onCodePathStart(cp) {
                         codePath = cp;
                     },
-                    ReturnStatement: function() {
+                    ReturnStatement() {
                         assert(codePath.currentSegments.length === 1);
                         assert(codePath.currentSegments[0] instanceof CodePathSegment);
                     },
-                    ThrowStatement: function() {
+                    ThrowStatement() {
                         assert(codePath.currentSegments.length === 1);
                         assert(codePath.currentSegments[0] instanceof CodePathSegment);
                     }
@@ -176,7 +176,7 @@ describe("CodePathAnalyzer", function() {
             actual = [];
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentStart: function(segment) {
+                    onCodePathSegmentStart(segment) {
                         actual.push(segment);
                     }
                 };
@@ -265,7 +265,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathStart: function(cp, node) {
+                    onCodePathStart(cp, node) {
                         count += 1;
                         lastCodePathNodeType = node.type;
 
@@ -280,16 +280,16 @@ describe("CodePathAnalyzer", function() {
                             assert(node.type === "ArrowFunctionExpression");
                         }
                     },
-                    Program: function() {
+                    Program() {
                         assert(lastCodePathNodeType === "Program");
                     },
-                    FunctionDeclaration: function() {
+                    FunctionDeclaration() {
                         assert(lastCodePathNodeType === "FunctionDeclaration");
                     },
-                    FunctionExpression: function() {
+                    FunctionExpression() {
                         assert(lastCodePathNodeType === "FunctionExpression");
                     },
-                    ArrowFunctionExpression: function() {
+                    ArrowFunctionExpression() {
                         assert(lastCodePathNodeType === "ArrowFunctionExpression");
                     }
                 };
@@ -310,7 +310,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathEnd: function(cp, node) {
+                    onCodePathEnd(cp, node) {
                         count += 1;
 
                         assert(cp instanceof CodePath);
@@ -325,16 +325,16 @@ describe("CodePathAnalyzer", function() {
                         }
                         assert(node.type === lastNodeType);
                     },
-                    "Program:exit": function() {
+                    "Program:exit"() {
                         lastNodeType = "Program";
                     },
-                    "FunctionDeclaration:exit": function() {
+                    "FunctionDeclaration:exit"() {
                         lastNodeType = "FunctionDeclaration";
                     },
-                    "FunctionExpression:exit": function() {
+                    "FunctionExpression:exit"() {
                         lastNodeType = "FunctionExpression";
                     },
-                    "ArrowFunctionExpression:exit": function() {
+                    "ArrowFunctionExpression:exit"() {
                         lastNodeType = "ArrowFunctionExpression";
                     }
                 };
@@ -355,7 +355,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentStart: function(segment, node) {
+                    onCodePathSegmentStart(segment, node) {
                         count += 1;
                         lastCodePathNodeType = node.type;
 
@@ -370,16 +370,16 @@ describe("CodePathAnalyzer", function() {
                             assert(node.type === "ArrowFunctionExpression");
                         }
                     },
-                    Program: function() {
+                    Program() {
                         assert(lastCodePathNodeType === "Program");
                     },
-                    FunctionDeclaration: function() {
+                    FunctionDeclaration() {
                         assert(lastCodePathNodeType === "FunctionDeclaration");
                     },
-                    FunctionExpression: function() {
+                    FunctionExpression() {
                         assert(lastCodePathNodeType === "FunctionExpression");
                     },
-                    ArrowFunctionExpression: function() {
+                    ArrowFunctionExpression() {
                         assert(lastCodePathNodeType === "ArrowFunctionExpression");
                     }
                 };
@@ -400,7 +400,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentEnd: function(cp, node) {
+                    onCodePathSegmentEnd(cp, node) {
                         count += 1;
 
                         assert(cp instanceof CodePathSegment);
@@ -415,16 +415,16 @@ describe("CodePathAnalyzer", function() {
                         }
                         assert(node.type === lastNodeType);
                     },
-                    "Program:exit": function() {
+                    "Program:exit"() {
                         lastNodeType = "Program";
                     },
-                    "FunctionDeclaration:exit": function() {
+                    "FunctionDeclaration:exit"() {
                         lastNodeType = "FunctionDeclaration";
                     },
-                    "FunctionExpression:exit": function() {
+                    "FunctionExpression:exit"() {
                         lastNodeType = "FunctionExpression";
                     },
-                    "ArrowFunctionExpression:exit": function() {
+                    "ArrowFunctionExpression:exit"() {
                         lastNodeType = "ArrowFunctionExpression";
                     }
                 };
@@ -444,7 +444,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -465,7 +465,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -486,7 +486,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -514,7 +514,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -542,7 +542,7 @@ describe("CodePathAnalyzer", function() {
 
             eslint.defineRule("test", function() {
                 return {
-                    onCodePathSegmentLoop: function(fromSegment, toSegment, node) {
+                    onCodePathSegmentLoop(fromSegment, toSegment, node) {
                         count += 1;
                         assert(fromSegment instanceof CodePathSegment);
                         assert(toSegment instanceof CodePathSegment);
@@ -580,7 +580,7 @@ describe("CodePathAnalyzer", function() {
 
                 eslint.defineRule("test", function() {
                     return {
-                        onCodePathEnd: function(codePath) {
+                        onCodePathEnd(codePath) {
                             actual.push(debug.makeDotArrows(codePath));
                         }
                     };

--- a/tests/lib/code-path-analysis/code-path.js
+++ b/tests/lib/code-path-analysis/code-path.js
@@ -28,7 +28,7 @@ function parseCodePaths(code) {
     eslint.reset();
     eslint.defineRule("test", function() {
         return {
-            onCodePathStart: function(codePath) {
+            onCodePathStart(codePath) {
                 retv.push(codePath);
             }
         };

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -158,7 +158,7 @@ describe("ConfigFile", function() {
 
                 // Hacky: need to override isFile for each call for testing
                 "../util/module-resolver": createStubModuleResolver({ "eslint-config-foo": resolvedPath }),
-                "require-uncached": function(filename) {
+                "require-uncached"(filename) {
                     return configDeps[filename];
                 }
             };
@@ -229,7 +229,7 @@ describe("ConfigFile", function() {
                     "eslint-config-foo": resolvedPaths[0],
                     "eslint-config-bar": resolvedPaths[1]
                 }),
-                "require-uncached": function(filename) {
+                "require-uncached"(filename) {
                     return configDeps[filename];
                 }
             };

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -227,7 +227,7 @@ describe("configInitializer", function() {
 
                 answers = {
                     source: "auto",
-                    patterns: patterns,
+                    patterns,
                     es6: false,
                     env: ["browser"],
                     jsx: false,

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -97,7 +97,7 @@ describe("ConfigOps", function() {
         it("should return correct config for env with no globals", function() {
             const StubbedConfigOps = proxyquire("../../../lib/config/config-ops", {
                 "./environments": {
-                    get: function() {
+                    get() {
                         return {
                             parserOptions: {
                                 sourceType: "module"

--- a/tests/lib/config/config-validator.js
+++ b/tests/lib/config/config-validator.js
@@ -25,7 +25,7 @@ const assert = require("chai").assert,
  */
 function mockRule(context) {
     return {
-        Program: function(node) {
+        Program(node) {
             context.report(node, "Expected a validation error.");
         }
     };
@@ -45,7 +45,7 @@ mockRule.schema = [
  */
 function mockObjectRule(context) {
     return {
-        Program: function(node) {
+        Program(node) {
             context.report(node, "Expected a validation error.");
         }
     };
@@ -63,7 +63,7 @@ mockObjectRule.schema = {
  */
 function mockNoOptionsRule(context) {
     return {
-        Program: function(node) {
+        Program(node) {
             context.report(node, "Expected a validation error.");
         }
     };

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -886,7 +886,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter name}}", {
                             "parameter name": "yay!"
                         });
@@ -905,7 +905,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{code}}");
                     }
                 };
@@ -922,7 +922,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter-name}}", {
                             "parameter-name": "yay!"
                         });
@@ -941,7 +941,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter}}", {});
                     }
                 };
@@ -958,7 +958,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter}}", {});
                     }
                 };
@@ -976,7 +976,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{ parameter}}", {
                             parameter: "yay!"
                         });
@@ -995,7 +995,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{parameter }}", {
                             parameter: "yay!"
                         });
@@ -1014,7 +1014,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{ parameter name }}", {
                             "parameter name": "yay!"
                         });
@@ -1033,7 +1033,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message {{ parameter-name }}", {
                             "parameter-name": "yay!"
                         });
@@ -1157,7 +1157,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, context.settings.info);
                     }
                 };
@@ -1177,7 +1177,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         if (Object.getOwnPropertyNames(context.settings).length !== 0) {
                             context.report(node, "Settings should be empty");
                         }
@@ -1208,10 +1208,10 @@ describe("eslint", function() {
 
             eslint.reset();
             eslint.defineRule("test-rule", sandbox.mock().withArgs(
-                sinon.match({parserOptions: parserOptions})
+                sinon.match({parserOptions})
             ).returns({}));
 
-            const config = { rules: { "test-rule": 2 }, parserOptions: parserOptions };
+            const config = { rules: { "test-rule": 2 }, parserOptions };
 
             eslint.verify("0", config, filename);
         });
@@ -1222,7 +1222,7 @@ describe("eslint", function() {
 
             eslint.reset();
             eslint.defineRule("test-rule", sandbox.mock().withArgs(
-                sinon.match({parserOptions: parserOptions})
+                sinon.match({parserOptions})
             ).returns({}));
 
             const config = { rules: { "test-rule": 2 } };
@@ -1675,7 +1675,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, "message");
                     }
                 };
@@ -1705,7 +1705,7 @@ describe("eslint", function() {
                 config.rules[item] = 1;
                 newRules[item] = function(context) {
                     return {
-                        Literal: function(node) {
+                        Literal(node) {
                             context.report(node, "message");
                         }
                     };
@@ -1734,7 +1734,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, context.getFilename());
                     }
                 };
@@ -1753,7 +1753,7 @@ describe("eslint", function() {
             eslint.reset();
             eslint.defineRule(code, function(context) {
                 return {
-                    Literal: function(node) {
+                    Literal(node) {
                         context.report(node, context.getFilename());
                     }
                 };
@@ -1899,7 +1899,7 @@ describe("eslint", function() {
 
         eslint.defineRule("test-plugin/test-rule", function(context) {
             return {
-                Literal: function(node) {
+                Literal(node) {
                     if (node.value === "trigger violation") {
                         context.report(node, "Reporting violation.");
                     }
@@ -2847,7 +2847,7 @@ describe("eslint", function() {
             };
 
             const messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2867,9 +2867,9 @@ describe("eslint", function() {
             };
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         const scope = context.getScope();
                         const sourceCode = context.getSourceCode();
                         const comments = sourceCode.getAllComments();
@@ -2901,7 +2901,7 @@ describe("eslint", function() {
             };
 
             const messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2921,7 +2921,7 @@ describe("eslint", function() {
             };
 
             const messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2939,7 +2939,7 @@ describe("eslint", function() {
             };
 
             const messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: false
             });
 
@@ -2958,9 +2958,9 @@ describe("eslint", function() {
             };
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         const scope = context.getScope();
                         const sourceCode = context.getSourceCode();
                         const comments = sourceCode.getAllComments();
@@ -2994,7 +2994,7 @@ describe("eslint", function() {
             };
 
             const messages = eslint.verify(code, config, {
-                filename: filename,
+                filename,
                 allowInlineConfig: true
             });
 
@@ -3300,9 +3300,9 @@ describe("eslint", function() {
             const code = "/* global foo */\n/* global bar, baz */";
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         const scope = context.getScope();
                         const sourceCode = context.getSourceCode();
                         const comments = sourceCode.getAllComments();
@@ -3366,9 +3366,9 @@ describe("eslint", function() {
         beforeEach(function() {
             let ok = false;
 
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 return {
-                    Program: function() {
+                    Program() {
                         scope = context.getScope();
                         ok = true;
                     }
@@ -3478,7 +3478,7 @@ describe("eslint", function() {
          * @returns {void}
          */
         function verify(code, type, expectedNamesList) {
-            eslint.defineRules({test: function(context) {
+            eslint.defineRules({test(context) {
                 const rule = {
                     Program: checkEmpty,
                     EmptyStatement: checkEmpty,
@@ -3798,7 +3798,7 @@ describe("eslint", function() {
 
             it("should strip leading line: prefix from parser error", function() {
                 const parser = path.join(parserFixtures, "line-error.js");
-                const messages = eslint.verify(";", { parser: parser }, "filename");
+                const messages = eslint.verify(";", { parser }, "filename");
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);
@@ -3808,7 +3808,7 @@ describe("eslint", function() {
 
             it("should not modify a parser error message without a leading line: prefix", function() {
                 const parser = path.join(parserFixtures, "no-line-error.js");
-                const messages = eslint.verify(";", { parser: parser }, "filename");
+                const messages = eslint.verify(";", { parser }, "filename");
 
                 assert.equal(messages.length, 1);
                 assert.equal(messages[0].severity, 2);

--- a/tests/lib/formatters/stylish.js
+++ b/tests/lib/formatters/stylish.js
@@ -18,13 +18,13 @@ const assert = require("chai").assert,
 // for Sinon to work.
 const chalkStub = Object.create(chalk, {
     yellow: {
-        value: function(str) {
+        value(str) {
             return chalk.yellow(str);
         },
         writable: true
     },
     red: {
-        value: function(str) {
+        value(str) {
             return chalk.red(str);
         },
         writable: true

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -159,7 +159,7 @@ describe("IgnoredPaths", function() {
             const ignorePattern = ["a", "b"];
 
             const ignoredPaths = new IgnoredPaths({
-                ignorePattern: ignorePattern
+                ignorePattern
             });
 
             assert.ok(ignorePattern.every(function(pattern) {

--- a/tests/lib/rule-context.js
+++ b/tests/lib/rule-context.js
@@ -82,11 +82,11 @@ describe("RuleContext", function() {
                     .withArgs("fake-rule", 2, node, location, message, messageOpts, fixerObj);
 
                 ruleContext.report({
-                    node: node,
+                    node,
                     loc: location,
-                    message: message,
+                    message,
                     data: messageOpts,
-                    fix: fix
+                    fix
                 });
 
                 fix.verify();

--- a/tests/lib/rules.js
+++ b/tests/lib/rules.js
@@ -58,7 +58,7 @@ describe("rules", function() {
     describe("when importing plugin rules", function() {
         const customPlugin = {
                 rules: {
-                    "custom-rule": function() { }
+                    "custom-rule"() { }
                 }
             },
             pluginName = "custom-plugin";

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -75,8 +75,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 1,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -86,8 +86,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 1,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -97,8 +97,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 1,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -108,8 +108,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 8,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -119,8 +119,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 8,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -130,8 +130,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 3,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
 
@@ -145,7 +145,7 @@ const invalid = [
             line: 1,
             column: 1,
             message: asNeededMessage,
-            type: type
+            type
         }]
     },
 
@@ -159,7 +159,7 @@ const invalid = [
             line: 1,
             column: 1,
             message: requireForBlockBodyNoParensMessage,
-            type: type
+            type
         }]
     },
     {
@@ -171,12 +171,12 @@ const invalid = [
             line: 1,
             column: 1,
             message: requireForBlockBodyMessage,
-            type: type
+            type
         }]
     }
 ];
 
 ruleTester.run("arrow-parens", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -332,6 +332,6 @@ const invalid = [
 ];
 
 ruleTester.run("arrow-spacing", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/consistent-this.js
+++ b/tests/lib/rules/consistent-this.js
@@ -23,7 +23,7 @@ const rule = require("../../../lib/rules/consistent-this"),
  */
 function destructuringTest(code) {
     return {
-        code: code,
+        code,
         options: ["self"],
         env: { es6: true },
         parserOptions: { ecmaVersion: 6 }

--- a/tests/lib/rules/global-require.js
+++ b/tests/lib/rules/global-require.js
@@ -44,8 +44,8 @@ const invalid = [
         errors: [{
             line: 2,
             column: 2,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -53,8 +53,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 21,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -62,8 +62,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 21,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -71,8 +71,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 16,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -80,8 +80,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 7,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
 
@@ -92,8 +92,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 22,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -102,8 +102,8 @@ const invalid = [
         errors: [{
             line: 1,
             column: 15,
-            message: message,
-            type: type
+            message,
+            type
         }]
     },
     {
@@ -111,13 +111,13 @@ const invalid = [
         errors: [{
             line: 1,
             column: 23,
-            message: message,
-            type: type
+            message,
+            type
         }]
     }
 ];
 
 ruleTester.run("global-require", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -25,12 +25,12 @@ function invalid(code, type, line, config) {
     config = config || {};
 
     const result = {
-        code: code,
+        code,
         parserOptions: config.parserOptions || {},
         errors: [
             {
                 message: "Gratuitous parentheses around expression.",
-                type: type
+                type
             }
         ],
         options: config.options || []

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -104,7 +104,7 @@ const patterns = [
     {
         code: "console.log(this); z(x => console.log(x, this));",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -114,7 +114,7 @@ const patterns = [
             ecmaVersion: 6,
             ecmaFeatures: {globalReturn: true}
         },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -123,7 +123,7 @@ const patterns = [
     {
         code: "(function() { console.log(this); z(x => console.log(x, this)); })();",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -132,14 +132,14 @@ const patterns = [
     {
         code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "function foo() { \"use strict\"; console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -149,14 +149,14 @@ const patterns = [
             ecmaVersion: 6,
             ecmaFeatures: {globalReturn: true}
         },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT] // modules cannot return on global.
     },
     {
         code: "var foo = (function() { console.log(this); z(x => console.log(x, this)); }).bar(obj);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -165,49 +165,49 @@ const patterns = [
     {
         code: "var obj = {foo: function() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "var obj = {foo() { function foo() { console.log(this); z(x => console.log(x, this)); } foo(); }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "var obj = {foo: function() { return function() { console.log(this); z(x => console.log(x, this)); }; }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "var obj = {foo: function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "obj.foo = function() { return function() { console.log(this); z(x => console.log(x, this)); }; };",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "obj.foo = function() { \"use strict\"; return function() { console.log(this); z(x => console.log(x, this)); }; };",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "class A { foo() { return function() { console.log(this); z(x => console.log(x, this)); }; } }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [],
         invalid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -216,7 +216,7 @@ const patterns = [
     {
         code: "class A {static foo() { console.log(this); z(x => console.log(x, this)); }};",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
     },
@@ -329,7 +329,7 @@ const patterns = [
     {
         code: "var foo = function() { console.log(this); z(x => console.log(x, this)); }.bind(null);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -342,7 +342,7 @@ const patterns = [
     {
         code: "(function() { console.log(this); z(x => console.log(x, this)); }).call(undefined);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -355,7 +355,7 @@ const patterns = [
     {
         code: "(function() { console.log(this); z(x => console.log(x, this)); }).apply(void 0);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -370,56 +370,56 @@ const patterns = [
     {
         code: "Array.from([], function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.every(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.filter(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.find(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.findIndex(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.map(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo.some(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -474,7 +474,7 @@ const patterns = [
     {
         code: "foo.forEach(function() { console.log(this); z(x => console.log(x, this)); }, null);",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -495,21 +495,21 @@ const patterns = [
     {
         code: "/** @returns {void} */ function foo() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "/** @this Obj */ foo(function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
     {
         code: "foo(/* @this Obj */ function() { console.log(this); z(x => console.log(x, this)); });",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL, USE_STRICT, IMPLIED_STRICT, MODULES],
         invalid: []
     },
@@ -518,7 +518,7 @@ const patterns = [
     {
         code: "function foo() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -541,7 +541,7 @@ const patterns = [
     {
         code: "var func = function() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -554,7 +554,7 @@ const patterns = [
     {
         code: "func = function() { console.log(this); z(x => console.log(x, this)); }",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -567,7 +567,7 @@ const patterns = [
     {
         code: "function foo(func = function() { console.log(this); z(x => console.log(x, this)); }) {}",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },
@@ -580,7 +580,7 @@ const patterns = [
     {
         code: "[func = function() { console.log(this); z(x => console.log(x, this)); }] = a",
         parserOptions: { ecmaVersion: 6 },
-        errors: errors,
+        errors,
         valid: [NORMAL],
         invalid: [USE_STRICT, IMPLIED_STRICT, MODULES]
     },

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -29,7 +29,7 @@ function getExpectedError(lines) {
         : "More than " + lines + " blank lines not allowed.";
 
     return {
-        message: message,
+        message,
         type: "Program"
     };
 }

--- a/tests/lib/rules/no-prototype-builtins.js
+++ b/tests/lib/rules/no-prototype-builtins.js
@@ -83,6 +83,6 @@ const invalid = [
 ];
 
 ruleTester.run("no-prototype-builtins", rule, {
-    valid: valid,
-    invalid: invalid
+    valid,
+    invalid
 });

--- a/tests/lib/rules/no-sequences.js
+++ b/tests/lib/rules/no-sequences.js
@@ -26,7 +26,7 @@ function errors(column) {
         message: "Unexpected use of comma operator.",
         type: "SequenceExpression",
         line: 1,
-        column: column
+        column
     }];
 }
 

--- a/tests/lib/rules/no-undefined.js
+++ b/tests/lib/rules/no-undefined.js
@@ -34,14 +34,14 @@ ruleTester.run("no-undefined", rule, {
         "global['undefined']"
     ],
     invalid: [
-        { code: "undefined", errors: errors },
-        { code: "undefined.a", errors: errors },
-        { code: "a[undefined]", errors: errors },
-        { code: "undefined[0]", errors: errors },
-        { code: "f(undefined)", errors: errors },
-        { code: "function f(undefined) {}", errors: errors },
-        { code: "var undefined;", errors: errors },
-        { code: "try {} catch(undefined) {}", errors: errors },
-        { code: "(function undefined(){}())", errors: errors }
+        { code: "undefined", errors },
+        { code: "undefined.a", errors },
+        { code: "a[undefined]", errors },
+        { code: "undefined[0]", errors },
+        { code: "f(undefined)", errors },
+        { code: "function f(undefined) {}", errors },
+        { code: "var undefined;", errors },
+        { code: "try {} catch(undefined) {}", errors },
+        { code: "(function undefined(){}())", errors }
     ]
 });

--- a/tests/lib/rules/one-var-declaration-per-line.js
+++ b/tests/lib/rules/one-var-declaration-per-line.js
@@ -27,8 +27,8 @@ function errorAt(line, column) {
     return {
         message: "Expected variable declaration to be on a new line.",
         type: "VariableDeclaration",
-        line: line,
-        column: column
+        line,
+        column
     };
 }
 

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -44,19 +44,19 @@ ruleTester.run("prefer-arrow-callback", rule, {
         {code: "foo(function bar() { new.target; }.bind(this));", parserOptions: { ecmaVersion: 6 }}
     ],
     invalid: [
-        {code: "foo(function bar() {});", errors: errors},
-        {code: "foo(function() {});", options: [{ allowNamedFunctions: true }], errors: errors},
-        {code: "foo(function bar() {});", options: [{ allowNamedFunctions: false }], errors: errors},
-        {code: "foo(function() {});", errors: errors},
-        {code: "foo(nativeCb || function() {});", errors: errors},
+        {code: "foo(function bar() {});", errors},
+        {code: "foo(function() {});", options: [{ allowNamedFunctions: true }], errors},
+        {code: "foo(function bar() {});", options: [{ allowNamedFunctions: false }], errors},
+        {code: "foo(function() {});", errors},
+        {code: "foo(nativeCb || function() {});", errors},
         {code: "foo(bar ? function() {} : function() {});", errors: [errors[0], errors[0]]},
-        {code: "foo(function() { (function() { this; }); });", errors: errors},
-        {code: "foo(function() { this; }.bind(this));", errors: errors},
-        {code: "foo(function() { (() => this); }.bind(this));", parserOptions: { ecmaVersion: 6 }, errors: errors},
-        {code: "foo(function bar(a) { a; });", errors: errors},
-        {code: "foo(function(a) { a; });", errors: errors},
-        {code: "foo(function(arguments) { arguments; });", errors: errors},
-        {code: "foo(function() { this; });", options: [{ allowUnboundThis: false }], errors: errors},
-        {code: "foo(function() { (() => this); });", parserOptions: { ecmaVersion: 6 }, options: [{ allowUnboundThis: false }], errors: errors}
+        {code: "foo(function() { (function() { this; }); });", errors},
+        {code: "foo(function() { this; }.bind(this));", errors},
+        {code: "foo(function() { (() => this); }.bind(this));", parserOptions: { ecmaVersion: 6 }, errors},
+        {code: "foo(function bar(a) { a; });", errors},
+        {code: "foo(function(a) { a; });", errors},
+        {code: "foo(function(arguments) { arguments; });", errors},
+        {code: "foo(function() { this; });", options: [{ allowUnboundThis: false }], errors},
+        {code: "foo(function() { (() => this); });", parserOptions: { ecmaVersion: 6 }, options: [{ allowUnboundThis: false }], errors}
     ]
 });

--- a/tests/lib/rules/prefer-spread.js
+++ b/tests/lib/rules/prefer-spread.js
@@ -41,13 +41,13 @@ ruleTester.run("prefer-spread", rule, {
         {code: "obj.foo.apply();"}
     ],
     invalid: [
-        {code: "foo.apply(undefined, args);", errors: errors},
-        {code: "foo.apply(void 0, args);", errors: errors},
-        {code: "foo.apply(null, args);", errors: errors},
-        {code: "obj.foo.apply(obj, args);", errors: errors},
-        {code: "a.b.c.foo.apply(a.b.c, args);", errors: errors},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors: errors},
-        {code: "[].concat.apply([ ], args);", errors: errors},
-        {code: "[].concat.apply([\n/*empty*/\n], args);", errors: errors}
+        {code: "foo.apply(undefined, args);", errors},
+        {code: "foo.apply(void 0, args);", errors},
+        {code: "foo.apply(null, args);", errors},
+        {code: "obj.foo.apply(obj, args);", errors},
+        {code: "a.b.c.foo.apply(a.b.c, args);", errors},
+        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors},
+        {code: "[].concat.apply([ ], args);", errors},
+        {code: "[].concat.apply([\n/*empty*/\n], args);", errors}
     ]
 });

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -37,13 +37,13 @@ ruleTester.run("prefer-template", rule, {
         {code: "var foo = `foo` +\n    `bar` +\n    \"hoge\";", parserOptions: { ecmaVersion: 6 }}
     ],
     invalid: [
-        {code: "var foo = 'hello, ' + name + '!';", errors: errors},
-        {code: "var foo = bar + 'baz';", errors: errors},
-        {code: "var foo = bar + `baz`;", parserOptions: { ecmaVersion: 6 }, errors: errors},
-        {code: "var foo = +100 + 'yen';", errors: errors},
-        {code: "var foo = 'bar' + baz;", errors: errors},
-        {code: "var foo = '￥' + (n * 1000) + '-'", errors: errors},
+        {code: "var foo = 'hello, ' + name + '!';", errors},
+        {code: "var foo = bar + 'baz';", errors},
+        {code: "var foo = bar + `baz`;", parserOptions: { ecmaVersion: 6 }, errors},
+        {code: "var foo = +100 + 'yen';", errors},
+        {code: "var foo = 'bar' + baz;", errors},
+        {code: "var foo = '￥' + (n * 1000) + '-'", errors},
         {code: "var foo = 'aaa' + aaa; var bar = 'bbb' + bbb;", errors: [errors[0], errors[0]]},
-        {code: "var string = (number + 1) + 'px';", errors: errors}
+        {code: "var string = (number + 1) + 'px';", errors}
     ]
 });

--- a/tests/lib/rules/sort-imports.js
+++ b/tests/lib/rules/sort-imports.js
@@ -34,31 +34,31 @@ ruleTester.run("sort-imports", rule, {
                 "import a from 'foo.js';\n" +
                 "import b from 'bar.js';\n" +
                 "import c from 'baz.js';\n",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as B from 'foo.js';\n" +
                 "import A from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as B from 'foo.js';\n" +
                 "import {a, b} from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import {b, c} from 'bar.js';\n" +
                 "import A from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import A from 'bar.js';\n" +
                 "import {b, c} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 memberSyntaxSortOrder: [ "single", "multiple", "none", "all" ]
             }]
@@ -67,84 +67,84 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import {a, b} from 'bar.js';\n" +
                 "import {b, c} from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import A from 'foo.js';\n" +
                 "import B from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import A from 'foo.js';\n" +
                 "import a from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import a, * as b from 'foo.js';\n" +
                 "import b from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import 'foo.js';\n" +
                 " import a from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import B from 'foo.js';\n" +
                 "import a from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import B from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: ignoreCaseArgs
         },
         {
             code: "import {a, b, c, d} from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code: "import {b, A, C, d} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 ignoreMemberSort: true
             }]
         },
         {
             code: "import {B, a, C, d} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 ignoreMemberSort: true
             }]
         },
         {
             code: "import {a, B, c, D} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: ignoreCaseArgs
         },
         {
             code: "import a, * as b from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as a from 'foo.js';\n" +
                 "\n" +
                 "import b from 'bar.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
         {
             code:
                 "import * as bar from 'bar.js';\n" +
                 "import * as foo from 'foo.js';",
-            parserOptions: parserOptions
+            parserOptions
         },
 
         // https://github.com/eslint/eslint/issues/5130
@@ -152,14 +152,14 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import 'foo';\n" +
                 "import bar from 'bar';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: ignoreCaseArgs
         },
 
         // https://github.com/eslint/eslint/issues/5305
         {
             code: "import React, {Component} from 'react';",
-            parserOptions: parserOptions
+            parserOptions
         }
     ],
     invalid: [
@@ -167,35 +167,35 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import A from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import b from 'foo.js';\n" +
                 "import a from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import {b, c} from 'foo.js';\n" +
                 "import {a, b} from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import * as foo from 'foo.js';\n" +
                 "import * as bar from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [expectedError]
         },
         {
             code:
                 "import a from 'foo.js';\n" +
                 "import {b, c} from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Expected 'multiple' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -205,7 +205,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import * as b from 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Expected 'all' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -215,7 +215,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import a from 'foo.js';\n" +
                 "import 'bar.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Expected 'none' syntax before 'single' syntax.",
                 type: "ImportDeclaration"
@@ -225,7 +225,7 @@ ruleTester.run("sort-imports", rule, {
             code:
                 "import b from 'bar.js';\n" +
                 "import * as a from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             options: [{
                 memberSyntaxSortOrder: [ "all", "single", "multiple", "none" ]
             }],
@@ -236,7 +236,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {b, a, d, c} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Member 'a' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"
@@ -247,7 +247,7 @@ ruleTester.run("sort-imports", rule, {
         },
         {
             code: "import {a, B, c, D} from 'foo.js';",
-            parserOptions: parserOptions,
+            parserOptions,
             errors: [{
                 message: "Member 'B' of the import declaration should be sorted alphabetically.",
                 type: "ImportSpecifier"

--- a/tests/lib/util/comment-event-generator.js
+++ b/tests/lib/util/comment-event-generator.js
@@ -63,10 +63,10 @@ describe("NodeEventGenerator", function() {
         generator = new CommentEventGenerator(generator, sourceCode);
 
         estraverse.traverse(ast, {
-            enter: function(node) {
+            enter(node) {
                 generator.enterNode(node);
             },
-            leave: function(node) {
+            leave(node) {
                 generator.leaveNode(node);
             }
         });

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -237,7 +237,7 @@ describe("globUtil", function() {
             });
 
             assert.equal(result.length, 1);
-            assert.deepEqual(result[0], { filename: filename, ignored: true });
+            assert.deepEqual(result[0], { filename, ignored: true });
         });
 
         it("should silently ignore default ignored files if not passed explicitly even if ignore is false", function() {
@@ -260,7 +260,7 @@ describe("globUtil", function() {
             });
 
             assert.equal(result.length, 1);
-            assert.deepEqual(result[0], { filename: filename, ignored: false });
+            assert.deepEqual(result[0], { filename, ignored: false });
         });
 
         it("should not return a file which does not exist", function() {
@@ -328,7 +328,7 @@ describe("globUtil", function() {
 
             assert.equal(result.length, 1);
             assert.deepEqual(result, [
-                {filename: filename, ignored: true}
+                {filename, ignored: true}
             ]);
         });
 

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -102,7 +102,7 @@ describe("SourceCode", function() {
                 { range: [8, 10] },
                 { range: [12, 20] }
             ];
-            const sourceCode = new SourceCode("", { comments: comments, tokens: tokens, loc: {}, range: [] });
+            const sourceCode = new SourceCode("", { comments, tokens, loc: {}, range: [] });
 
             const actual = sourceCode.tokensAndComments;
             const expected = [comments[0], tokens[0], tokens[1], comments[1], tokens[2]];


### PR DESCRIPTION
Breaking this up into batches as per the discussion here: https://github.com/eslint/eslint/pull/6812

This is the first batch (everything outside of `/lib`). I'll actually enable the rule in the final batch :)

@eslint/eslint-team Will merge this after I get a few pairs of eyes on this. Discussed with @nzakas in Gitter and we decided to get these reviewed and merged without having to wait the full two days. Since this touches so many files, waiting even a few days can lead to merge conflicts.