### PR TITLE
Docs: Make env match ecmaVersion in example

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -42,6 +42,9 @@ Here's an example `.eslintrc.json` file:
     },
     "rules": {
         "semi": 2
+    },
+    "env": {
+        "es6": true
     }
 }
 ```


### PR DESCRIPTION
**What issue does this pull request address?**
This is a docs improvement to help avoid the confusion I experienced in #6894

**What changes did you make? (Give an overview)**
Added es6 env to example config where ecmaVersion is set to 6

**Is there anything you'd like reviewers to focus on?**
No
