### PR TITLE
Chore: Use object-shorthand batch 2 (refs #6407)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -210,23 +210,23 @@ module.exports = {
      * @returns {boolean} Whether or not the tokens are on the same line.
      * @public
      */
-    isTokenOnSameLine: function(left, right) {
+    isTokenOnSameLine(left, right) {
         return left.loc.end.line === right.loc.start.line;
     },
 
-    isNullOrUndefined: isNullOrUndefined,
-    isCallee: isCallee,
-    isES5Constructor: isES5Constructor,
-    getUpperFunction: getUpperFunction,
-    isArrayFromMethod: isArrayFromMethod,
-    isParenthesised: isParenthesised,
+    isNullOrUndefined,
+    isCallee,
+    isES5Constructor,
+    getUpperFunction,
+    isArrayFromMethod,
+    isParenthesised,
 
     /**
      * Checks whether or not a given node is a string literal.
      * @param {ASTNode} node - A node to check.
      * @returns {boolean} `true` if the node is a string literal.
      */
-    isStringLiteral: function(node) {
+    isStringLiteral(node) {
         return (
             (node.type === "Literal" && typeof node.value === "string") ||
             node.type === "TemplateLiteral"
@@ -247,7 +247,7 @@ module.exports = {
      * @param {ASTNode} node - A node to check.
      * @returns {boolean} `true` if the node is breakable.
      */
-    isBreakableStatement: function(node) {
+    isBreakableStatement(node) {
         return breakableTypePattern.test(node.type);
     },
 
@@ -257,7 +257,7 @@ module.exports = {
      * @param {ASTNode} node - A node to get.
      * @returns {string|null} The label or `null`.
      */
-    getLabel: function(node) {
+    getLabel(node) {
         if (node.parent.type === "LabeledStatement") {
             return node.parent.label.name;
         }
@@ -270,7 +270,7 @@ module.exports = {
      * @returns {Reference[]} An array of only references which are non initializer and writable.
      * @public
      */
-    getModifyingReferences: function(references) {
+    getModifyingReferences(references) {
         return references.filter(isModifyingReference);
     },
 
@@ -281,7 +281,7 @@ module.exports = {
      * @returns {boolean} True if the text is surrounded by the character, false if not.
      * @private
      */
-    isSurroundedBy: function(val, character) {
+    isSurroundedBy(val, character) {
         return val[0] === character && val[val.length - 1] === character;
     },
 
@@ -290,7 +290,7 @@ module.exports = {
      * @param {LineComment|BlockComment} node The node to be checked
      * @returns {boolean} `true` if the node is an ESLint directive comment
      */
-    isDirectiveComment: function(node) {
+    isDirectiveComment(node) {
         const comment = node.value.trim();
 
         return (
@@ -323,7 +323,7 @@ module.exports = {
      * @param {string} name - A variable name to find.
      * @returns {escope.Variable|null} A found variable or `null`.
      */
-    getVariableByName: function(initScope, name) {
+    getVariableByName(initScope, name) {
         let scope = initScope;
 
         while (scope) {
@@ -360,7 +360,7 @@ module.exports = {
      * @param {SourceCode} sourceCode - A SourceCode instance to get comments.
      * @returns {boolean} The function node is the default `this` binding.
      */
-    isDefaultThisBinding: function(node, sourceCode) {
+    isDefaultThisBinding(node, sourceCode) {
         if (isES5Constructor(node) || hasJSDocThisTag(node, sourceCode)) {
             return false;
         }
@@ -496,7 +496,7 @@ module.exports = {
      * @returns {int} precedence level
      * @private
      */
-    getPrecedence: function(node) {
+    getPrecedence(node) {
         switch (node.type) {
             case "SequenceExpression":
                 return 0;
@@ -594,7 +594,7 @@ module.exports = {
      * @param {ASTNode|null} node - A node to check.
      * @returns {boolean} `true` if the node is a loop node.
      */
-    isLoop: function(node) {
+    isLoop(node) {
         return Boolean(node && anyLoopPattern.test(node.type));
     },
 
@@ -609,7 +609,7 @@ module.exports = {
      * @param {ASTNode|null} node - A node to check.
      * @returns {boolean} `true` if the node is a function node.
      */
-    isFunction: function(node) {
+    isFunction(node) {
         return Boolean(node && anyFunctionPattern.test(node.type));
     },
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -241,8 +241,8 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
 
         parsedBlocks.forEach(function(block) {
             unprocessedMessages.push(eslint.verify(block, config, {
-                filename: filename,
-                allowInlineConfig: allowInlineConfig
+                filename,
+                allowInlineConfig
             }));
         });
 
@@ -254,14 +254,14 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
 
         if (fix) {
             fixedResult = multipassFix(text, config, {
-                filename: filename,
-                allowInlineConfig: allowInlineConfig
+                filename,
+                allowInlineConfig
             });
             messages = fixedResult.messages;
         } else {
             messages = eslint.verify(text, config, {
-                filename: filename,
-                allowInlineConfig: allowInlineConfig
+                filename,
+                allowInlineConfig
             });
         }
     }
@@ -270,7 +270,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
 
     const result = {
         filePath: filename,
-        messages: messages,
+        messages,
         errorCount: stats.errorCount,
         warningCount: stats.warningCount
     };
@@ -329,7 +329,7 @@ function createIgnoreResult(filePath, baseDir) {
             {
                 fatal: false,
                 severity: 1,
-                message: message
+                message
             }
         ],
         errorCount: 0,
@@ -559,7 +559,7 @@ CLIEngine.prototype = {
      * @param {Object} pluginobject Plugin configuration object.
      * @returns {void}
      */
-    addPlugin: function(name, pluginobject) {
+    addPlugin(name, pluginobject) {
         Plugins.define(name, pluginobject);
     },
 
@@ -569,7 +569,7 @@ CLIEngine.prototype = {
      * @param {string[]} patterns The file patterns passed on the command line.
      * @returns {string[]} The equivalent glob patterns.
      */
-    resolveFileGlobPatterns: function(patterns) {
+    resolveFileGlobPatterns(patterns) {
         return globUtil.resolveFileGlobPatterns(patterns, this.options);
     },
 
@@ -578,7 +578,7 @@ CLIEngine.prototype = {
      * @param {string[]} patterns An array of file and directory names.
      * @returns {Object} The results for all files that were linted.
      */
-    executeOnFiles: function(patterns) {
+    executeOnFiles(patterns) {
         const results = [],
             options = this.options,
             fileCache = this._fileCache,
@@ -716,7 +716,7 @@ CLIEngine.prototype = {
         debug("Linting complete in: " + (Date.now() - startTime) + "ms");
 
         return {
-            results: results,
+            results,
             errorCount: stats.errorCount,
             warningCount: stats.warningCount
         };
@@ -729,7 +729,7 @@ CLIEngine.prototype = {
      * @param {boolean} warnIgnored Always warn when a file is ignored
      * @returns {Object} The results for the linting.
      */
-    executeOnText: function(text, filename, warnIgnored) {
+    executeOnText(text, filename, warnIgnored) {
 
         const results = [],
             options = this.options,
@@ -752,7 +752,7 @@ CLIEngine.prototype = {
         const stats = calculateStatsPerRun(results);
 
         return {
-            results: results,
+            results,
             errorCount: stats.errorCount,
             warningCount: stats.warningCount
         };
@@ -765,7 +765,7 @@ CLIEngine.prototype = {
      * @param {string} filePath The path of the file to retrieve a config object for.
      * @returns {Object} A configuration object for the file.
      */
-    getConfigForFile: function(filePath) {
+    getConfigForFile(filePath) {
         const configHelper = new Config(this.options);
 
         return configHelper.getConfig(filePath);
@@ -776,7 +776,7 @@ CLIEngine.prototype = {
      * @param {string} filePath The path of the file to check.
      * @returns {boolean} Whether or not the given path is ignored.
      */
-    isPathIgnored: function(filePath) {
+    isPathIgnored(filePath) {
         const resolvedPath = path.resolve(this.options.cwd, filePath);
         const ignoredPaths = new IgnoredPaths(this.options);
 

--- a/lib/cli.js
+++ b/lib/cli.js
@@ -120,7 +120,7 @@ const cli = {
      * @param {string} [text] The text to lint (used for TTY).
      * @returns {int} The exit code for the operation.
      */
-    execute: function(args, text) {
+    execute(args, text) {
 
         let currentOptions;
 

--- a/lib/code-path-analysis/code-path-analyzer.js
+++ b/lib/code-path-analysis/code-path-analyzer.js
@@ -592,7 +592,7 @@ CodePathAnalyzer.prototype = {
      * @param {ASTNode} node - A node which is entering.
      * @returns {void}
      */
-    enterNode: function(node) {
+    enterNode(node) {
         this.currentNode = node;
 
         // Updates the code path due to node's position in its parent node.
@@ -617,7 +617,7 @@ CodePathAnalyzer.prototype = {
      * @param {ASTNode} node - A node which is leaving.
      * @returns {void}
      */
-    leaveNode: function(node) {
+    leaveNode(node) {
         this.currentNode = node;
 
         // Updates the code path.
@@ -641,7 +641,7 @@ CodePathAnalyzer.prototype = {
      * @param {CodePathSegment} toSegment - A segment of next.
      * @returns {void}
      */
-    onLooped: function(fromSegment, toSegment) {
+    onLooped(fromSegment, toSegment) {
         if (fromSegment.reachable && toSegment.reachable) {
             debug.dump("onCodePathSegmentLoop " + fromSegment.id + " -> " + toSegment.id);
             this.emitter.emit(

--- a/lib/code-path-analysis/code-path-segment.js
+++ b/lib/code-path-analysis/code-path-segment.js
@@ -138,7 +138,7 @@ CodePathSegment.prototype = {
      * @param {CodePathSegment} segment - A previous segment to check.
      * @returns {boolean} `true` if the segment is coming from the end of a loop.
      */
-    isLoopedPrevSegment: function(segment) {
+    isLoopedPrevSegment(segment) {
         return this.internal.loopedPrevSegments.indexOf(segment) !== -1;
     }
 };

--- a/lib/code-path-analysis/code-path-state.js
+++ b/lib/code-path-analysis/code-path-state.js
@@ -278,7 +278,7 @@ CodePathState.prototype = {
      *   "finally" block.
      * @returns {ForkContext} The created context.
      */
-    pushForkContext: function(forkLeavingPath) {
+    pushForkContext(forkLeavingPath) {
         this.forkContext = ForkContext.newEmpty(
             this.forkContext,
             forkLeavingPath
@@ -291,7 +291,7 @@ CodePathState.prototype = {
      * Pops and merges the last forking context.
      * @returns {ForkContext} The last context.
      */
-    popForkContext: function() {
+    popForkContext() {
         const lastContext = this.forkContext;
 
         this.forkContext = lastContext.upper;
@@ -304,7 +304,7 @@ CodePathState.prototype = {
      * Creates a new path.
      * @returns {void}
      */
-    forkPath: function() {
+    forkPath() {
         this.forkContext.add(this.parentForkContext.makeNext(-1, -1));
     },
 
@@ -314,7 +314,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    forkBypassPath: function() {
+    forkBypassPath() {
         this.forkContext.add(this.parentForkContext.head);
     },
 
@@ -353,11 +353,11 @@ CodePathState.prototype = {
      *   paths between `true` and `false`.
      * @returns {void}
      */
-    pushChoiceContext: function(kind, isForkingAsResult) {
+    pushChoiceContext(kind, isForkingAsResult) {
         this.choiceContext = {
             upper: this.choiceContext,
-            kind: kind,
-            isForkingAsResult: isForkingAsResult,
+            kind,
+            isForkingAsResult,
             trueForkContext: ForkContext.newEmpty(this.forkContext),
             falseForkContext: ForkContext.newEmpty(this.forkContext),
             processed: false
@@ -369,7 +369,7 @@ CodePathState.prototype = {
      *
      * @returns {ChoiceContext} The popped context.
      */
-    popChoiceContext: function() {
+    popChoiceContext() {
         const context = this.choiceContext;
 
         this.choiceContext = context.upper;
@@ -457,7 +457,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeLogicalRight: function() {
+    makeLogicalRight() {
         const context = this.choiceContext;
         const forkContext = this.forkContext;
 
@@ -501,7 +501,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeIfConsequent: function() {
+    makeIfConsequent() {
         const context = this.choiceContext;
         const forkContext = this.forkContext;
 
@@ -528,7 +528,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeIfAlternate: function() {
+    makeIfAlternate() {
         const context = this.choiceContext;
         const forkContext = this.forkContext;
 
@@ -558,10 +558,10 @@ CodePathState.prototype = {
      * @param {string|null} label - The label text.
      * @returns {void}
      */
-    pushSwitchContext: function(hasCase, label) {
+    pushSwitchContext(hasCase, label) {
         this.switchContext = {
             upper: this.switchContext,
-            hasCase: hasCase,
+            hasCase,
             defaultSegments: null,
             defaultBodySegments: null,
             foundDefault: false,
@@ -582,7 +582,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    popSwitchContext: function() {
+    popSwitchContext() {
         const context = this.switchContext;
 
         this.switchContext = context.upper;
@@ -658,7 +658,7 @@ CodePathState.prototype = {
      * @param {boolean} isDefault - `true` if the body is the default case.
      * @returns {void}
      */
-    makeSwitchCaseBody: function(isEmpty, isDefault) {
+    makeSwitchCaseBody(isEmpty, isDefault) {
         const context = this.switchContext;
 
         if (!context.hasCase) {
@@ -709,11 +709,11 @@ CodePathState.prototype = {
      *   `finally` block.
      * @returns {void}
      */
-    pushTryContext: function(hasFinalizer) {
+    pushTryContext(hasFinalizer) {
         this.tryContext = {
             upper: this.tryContext,
             position: "try",
-            hasFinalizer: hasFinalizer,
+            hasFinalizer,
 
             returnedForkContext: hasFinalizer
                 ? ForkContext.newEmpty(this.forkContext)
@@ -730,7 +730,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    popTryContext: function() {
+    popTryContext() {
         const context = this.tryContext;
 
         this.tryContext = context.upper;
@@ -784,7 +784,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeCatchBlock: function() {
+    makeCatchBlock() {
         const context = this.tryContext;
         const forkContext = this.forkContext;
         const thrown = context.thrownForkContext;
@@ -813,7 +813,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeFinallyBlock: function() {
+    makeFinallyBlock() {
         const context = this.tryContext;
         let forkContext = this.forkContext;
         const returned = context.returnedForkContext;
@@ -871,7 +871,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeFirstThrowablePathInTryBlock: function() {
+    makeFirstThrowablePathInTryBlock() {
         const forkContext = this.forkContext;
 
         if (!forkContext.reachable) {
@@ -904,7 +904,7 @@ CodePathState.prototype = {
      * @param {string|null} label - A label of the node which was triggered.
      * @returns {void}
      */
-    pushLoopContext: function(type, label) {
+    pushLoopContext(type, label) {
         const forkContext = this.forkContext;
         const breakContext = this.pushBreakContext(true, label);
 
@@ -913,8 +913,8 @@ CodePathState.prototype = {
                 this.pushChoiceContext("loop", false);
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     test: void 0,
                     continueDestSegments: null,
                     brokenForkContext: breakContext.brokenForkContext
@@ -925,8 +925,8 @@ CodePathState.prototype = {
                 this.pushChoiceContext("loop", false);
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     test: void 0,
                     entrySegments: null,
                     continueForkContext: ForkContext.newEmpty(forkContext),
@@ -938,8 +938,8 @@ CodePathState.prototype = {
                 this.pushChoiceContext("loop", false);
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     test: void 0,
                     endOfInitSegments: null,
                     testSegments: null,
@@ -955,8 +955,8 @@ CodePathState.prototype = {
             case "ForOfStatement":
                 this.loopContext = {
                     upper: this.loopContext,
-                    type: type,
-                    label: label,
+                    type,
+                    label,
                     prevSegments: null,
                     leftSegments: null,
                     endOfLeftSegments: null,
@@ -976,7 +976,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    popLoopContext: function() {
+    popLoopContext() {
         const context = this.loopContext;
 
         this.loopContext = context.upper;
@@ -1047,7 +1047,7 @@ CodePathState.prototype = {
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
-    makeWhileTest: function(test) {
+    makeWhileTest(test) {
         const context = this.loopContext;
         const forkContext = this.forkContext;
         const testSegments = forkContext.makeNext(0, -1);
@@ -1063,7 +1063,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeWhileBody: function() {
+    makeWhileBody() {
         const context = this.loopContext;
         const choiceContext = this.choiceContext;
         const forkContext = this.forkContext;
@@ -1085,7 +1085,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeDoWhileBody: function() {
+    makeDoWhileBody() {
         const context = this.loopContext;
         const forkContext = this.forkContext;
         const bodySegments = forkContext.makeNext(-1, -1);
@@ -1101,7 +1101,7 @@ CodePathState.prototype = {
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
-    makeDoWhileTest: function(test) {
+    makeDoWhileTest(test) {
         const context = this.loopContext;
         const forkContext = this.forkContext;
 
@@ -1122,7 +1122,7 @@ CodePathState.prototype = {
      * @param {boolean|undefined} test - The test value (only when constant).
      * @returns {void}
      */
-    makeForTest: function(test) {
+    makeForTest(test) {
         const context = this.loopContext;
         const forkContext = this.forkContext;
         const endOfInitSegments = forkContext.head;
@@ -1140,7 +1140,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForUpdate: function() {
+    makeForUpdate() {
         const context = this.loopContext;
         const choiceContext = this.choiceContext;
         const forkContext = this.forkContext;
@@ -1167,7 +1167,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForBody: function() {
+    makeForBody() {
         const context = this.loopContext;
         const choiceContext = this.choiceContext;
         const forkContext = this.forkContext;
@@ -1219,7 +1219,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForInOfLeft: function() {
+    makeForInOfLeft() {
         const context = this.loopContext;
         const forkContext = this.forkContext;
         const leftSegments = forkContext.makeDisconnected(-1, -1);
@@ -1236,7 +1236,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForInOfRight: function() {
+    makeForInOfRight() {
         const context = this.loopContext;
         const forkContext = this.forkContext;
         const temp = ForkContext.newEmpty(forkContext);
@@ -1255,7 +1255,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeForInOfBody: function() {
+    makeForInOfBody() {
         const context = this.loopContext;
         const forkContext = this.forkContext;
         const temp = ForkContext.newEmpty(forkContext);
@@ -1283,11 +1283,11 @@ CodePathState.prototype = {
      * @param {string|null} label - The label of this context.
      * @returns {Object} The new context.
      */
-    pushBreakContext: function(breakable, label) {
+    pushBreakContext(breakable, label) {
         this.breakContext = {
             upper: this.breakContext,
-            breakable: breakable,
-            label: label,
+            breakable,
+            label,
             brokenForkContext: ForkContext.newEmpty(this.forkContext)
         };
         return this.breakContext;
@@ -1298,7 +1298,7 @@ CodePathState.prototype = {
      *
      * @returns {Object} The removed context.
      */
-    popBreakContext: function() {
+    popBreakContext() {
         const context = this.breakContext;
         const forkContext = this.forkContext;
 
@@ -1326,7 +1326,7 @@ CodePathState.prototype = {
      * @param {string} label - A label of the break statement.
      * @returns {void}
      */
-    makeBreak: function(label) {
+    makeBreak(label) {
         const forkContext = this.forkContext;
 
         if (!forkContext.reachable) {
@@ -1352,7 +1352,7 @@ CodePathState.prototype = {
      * @param {string} label - A label of the continue statement.
      * @returns {void}
      */
-    makeContinue: function(label) {
+    makeContinue(label) {
         const forkContext = this.forkContext;
 
         if (!forkContext.reachable) {
@@ -1387,7 +1387,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeReturn: function() {
+    makeReturn() {
         const forkContext = this.forkContext;
 
         if (forkContext.reachable) {
@@ -1404,7 +1404,7 @@ CodePathState.prototype = {
      *
      * @returns {void}
      */
-    makeThrow: function() {
+    makeThrow() {
         const forkContext = this.forkContext;
 
         if (forkContext.reachable) {
@@ -1417,7 +1417,7 @@ CodePathState.prototype = {
      * Makes the final path.
      * @returns {void}
      */
-    makeFinal: function() {
+    makeFinal() {
         const segments = this.currentSegments;
 
         if (segments.length > 0 && segments[0].reachable) {

--- a/lib/code-path-analysis/code-path.js
+++ b/lib/code-path-analysis/code-path.js
@@ -123,7 +123,7 @@ CodePath.prototype = {
      * @param {Function} callback - A callback function.
      * @returns {void}
      */
-    traverseSegments: function(options, callback) {
+    traverseSegments(options, callback) {
         if (typeof options === "function") {
             callback = options;
             options = null;
@@ -142,14 +142,14 @@ CodePath.prototype = {
         let skippedSegment = null;
         let broken = false;
         const controller = {
-            skip: function() {
+            skip() {
                 if (stack.length <= 1) {
                     broken = true;
                 } else {
                     skippedSegment = stack[stack.length - 2][0];
                 }
             },
-            break: function() {
+            break() {
                 broken = true;
             }
         };

--- a/lib/code-path-analysis/debug-helpers.js
+++ b/lib/code-path-analysis/debug-helpers.js
@@ -143,7 +143,7 @@ module.exports = {
      * @param {Object} traceMap - Optional. A map to check whether or not segments had been done.
      * @returns {string} A DOT code of the code path.
      */
-    makeDotArrows: function(codePath, traceMap) {
+    makeDotArrows(codePath, traceMap) {
         const stack = [[codePath.initialSegment, 0]];
         const done = traceMap || Object.create(null);
         let lastId = codePath.initialSegment.id;

--- a/lib/code-path-analysis/fork-context.js
+++ b/lib/code-path-analysis/fork-context.js
@@ -150,7 +150,7 @@ ForkContext.prototype = {
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
-    makeNext: function(begin, end) {
+    makeNext(begin, end) {
         return makeSegments(this, begin, end, CodePathSegment.newNext);
     },
 
@@ -162,7 +162,7 @@ ForkContext.prototype = {
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
-    makeUnreachable: function(begin, end) {
+    makeUnreachable(begin, end) {
         return makeSegments(this, begin, end, CodePathSegment.newUnreachable);
     },
 
@@ -175,7 +175,7 @@ ForkContext.prototype = {
      * @param {number} end - The last index of previous segments.
      * @returns {CodePathSegment[]} New segments.
      */
-    makeDisconnected: function(begin, end) {
+    makeDisconnected(begin, end) {
         return makeSegments(this, begin, end, CodePathSegment.newDisconnected);
     },
 
@@ -186,7 +186,7 @@ ForkContext.prototype = {
      * @param {CodePathSegment[]} segments - Segments to add.
      * @returns {void}
      */
-    add: function(segments) {
+    add(segments) {
         assert(segments.length >= this.count, segments.length + " >= " + this.count);
 
         this.segmentsList.push(mergeExtraSegments(this, segments));
@@ -199,7 +199,7 @@ ForkContext.prototype = {
      * @param {CodePathSegment[]} segments - Segments to add.
      * @returns {void}
      */
-    replaceHead: function(segments) {
+    replaceHead(segments) {
         assert(segments.length >= this.count, segments.length + " >= " + this.count);
 
         this.segmentsList.splice(-1, 1, mergeExtraSegments(this, segments));
@@ -211,7 +211,7 @@ ForkContext.prototype = {
      * @param {ForkContext} context - A fork context to add.
      * @returns {void}
      */
-    addAll: function(context) {
+    addAll(context) {
         assert(context.count === this.count);
 
         const source = context.segmentsList;
@@ -226,7 +226,7 @@ ForkContext.prototype = {
      *
      * @returns {void}
      */
-    clear: function() {
+    clear() {
         this.segmentsList = [];
     }
 };

--- a/lib/config.js
+++ b/lib/config.js
@@ -163,7 +163,7 @@ function getLocalConfig(thisConfig, directory) {
 
             noConfigError.messageTemplate = "no-config-found";
             noConfigError.messageData = {
-                directory: directory,
+                directory,
                 filesExamined: localConfigFiles
             };
 

--- a/lib/config/autoconfig.js
+++ b/lib/config/autoconfig.js
@@ -52,7 +52,7 @@ function makeRegistryItems(rulesConfig) {
     return Object.keys(rulesConfig).reduce(function(accumulator, ruleId) {
         accumulator[ruleId] = rulesConfig[ruleId].map(function(config) {
             return {
-                config: config,
+                config,
                 specificity: config.length || 1,
                 errorCount: void 0
             };
@@ -87,7 +87,7 @@ Registry.prototype = {
      *
      * @returns {void}
      */
-    populateFromCoreRules: function() {
+    populateFromCoreRules() {
         const rulesConfig = configRule.createCoreRuleConfigs();
 
         this.rules = makeRegistryItems(rulesConfig);
@@ -107,7 +107,7 @@ Registry.prototype = {
      * @param   {Object}   registry The autoconfig registry
      * @returns {Object[]}          "rules" configurations to use for linting
      */
-    buildRuleSets: function() {
+    buildRuleSets() {
         let idx = 0;
         const ruleIds = Object.keys(this.rules),
             ruleSets = [];
@@ -168,7 +168,7 @@ Registry.prototype = {
      *
      * @returns {void}
      */
-    stripFailingConfigs: function() {
+    stripFailingConfigs() {
         const ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
@@ -193,7 +193,7 @@ Registry.prototype = {
      *
      * @returns {void}
      */
-    stripExtraConfigs: function() {
+    stripExtraConfigs() {
         const ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
@@ -214,7 +214,7 @@ Registry.prototype = {
      *
      * @returns {Registry}  A registry of failing rules.
      */
-    getFailingRulesRegistry: function() {
+    getFailingRulesRegistry() {
         const ruleIds = Object.keys(this.rules),
             failingRegistry = new Registry();
 
@@ -237,7 +237,7 @@ Registry.prototype = {
      *
      * @returns {Object} An eslint config with rules section populated
      */
-    createConfig: function() {
+    createConfig() {
         const ruleIds = Object.keys(this.rules),
             config = {rules: {}};
 
@@ -256,7 +256,7 @@ Registry.prototype = {
      * @param   {number} specificity Only keep configs with this specificity
      * @returns {Registry}           A registry of rules
      */
-    filterBySpecificity: function(specificity) {
+    filterBySpecificity(specificity) {
         const ruleIds = Object.keys(this.rules),
             newRegistry = new Registry();
 
@@ -278,7 +278,7 @@ Registry.prototype = {
      * @param   {progressCallback} [cb] Optional callback for reporting execution status
      * @returns {Registry}              New registry with errorCount populated
      */
-    lintSourceCode: function(sourceCodes, config, cb) {
+    lintSourceCode(sourceCodes, config, cb) {
         let ruleSetIdx,
             lintedRegistry;
 
@@ -361,6 +361,6 @@ function extendFromRecommended(config) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    Registry: Registry,
-    extendFromRecommended: extendFromRecommended
+    Registry,
+    extendFromRecommended
 };

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -471,12 +471,12 @@ function resolve(filePath, relativeTo) {
             normalizedPackageName = normalizePackageName(packagePath, "eslint-plugin");
             debug("Attempting to resolve " + normalizedPackageName);
             filePath = resolver.resolve(normalizedPackageName, getLookupPath(relativeTo));
-            return { filePath: filePath, configName: configName };
+            return { filePath, configName };
         } else {
             normalizedPackageName = normalizePackageName(filePath, "eslint-config");
             debug("Attempting to resolve " + normalizedPackageName);
             filePath = resolver.resolve(normalizedPackageName, getLookupPath(relativeTo));
-            return { filePath: filePath };
+            return { filePath };
         }
     }
 
@@ -546,14 +546,14 @@ function load(filePath, applyEnvironments, relativeTo) {
 
 module.exports = {
 
-    getBaseDir: getBaseDir,
-    getLookupPath: getLookupPath,
-    load: load,
-    resolve: resolve,
-    write: write,
-    applyExtends: applyExtends,
-    normalizePackageName: normalizePackageName,
-    CONFIG_FILES: CONFIG_FILES,
+    getBaseDir,
+    getLookupPath,
+    load,
+    resolve,
+    write,
+    applyExtends,
+    normalizePackageName,
+    CONFIG_FILES,
 
     /**
      * Retrieves the configuration filename for a given directory. It loops over all
@@ -562,7 +562,7 @@ module.exports = {
      * @returns {?string} The filename of the configuration file for the directory
      *      or null if there is no configuration file in the directory.
      */
-    getFilenameForDirectory: function(directory) {
+    getFilenameForDirectory(directory) {
         for (let i = 0, len = CONFIG_FILES.length; i < len; i++) {
             const filename = path.join(directory, CONFIG_FILES[i]);
 

--- a/lib/config/config-initializer.js
+++ b/lib/config/config-initializer.js
@@ -306,7 +306,7 @@ function promptUser(callback) {
             name: "styleguide",
             message: "Which style guide do you want to follow?",
             choices: [{name: "Google", value: "google"}, {name: "AirBnB", value: "airbnb"}, {name: "Standard", value: "standard"}],
-            when: function(answers) {
+            when(answers) {
                 answers.packageJsonExists = npmUtil.checkPackageJson();
                 return answers.source === "guide" && answers.packageJsonExists;
             }
@@ -315,10 +315,10 @@ function promptUser(callback) {
             type: "input",
             name: "patterns",
             message: "Which file(s), path(s), or glob(s) should be examined?",
-            when: function(answers) {
+            when(answers) {
                 return (answers.source === "auto");
             },
-            validate: function(input) {
+            validate(input) {
                 if (input.trim().length === 0 && input.trim() !== ",") {
                     return "You must tell us what code to examine. Try again.";
                 }
@@ -331,7 +331,7 @@ function promptUser(callback) {
             message: "What format do you want your config file to be in?",
             default: "JavaScript",
             choices: ["JavaScript", "YAML", "JSON"],
-            when: function(answers) {
+            when(answers) {
                 return ((answers.source === "guide" && answers.packageJsonExists) || answers.source === "auto");
             }
         }
@@ -367,7 +367,7 @@ function promptUser(callback) {
                 name: "modules",
                 message: "Are you using ES6 modules?",
                 default: false,
-                when: function(answers) {
+                when(answers) {
                     return answers.es6 === true;
                 }
             },
@@ -383,7 +383,7 @@ function promptUser(callback) {
                 name: "commonjs",
                 message: "Do you use CommonJS?",
                 default: false,
-                when: function(answers) {
+                when(answers) {
                     return answers.env.some(function(env) {
                         return env === "browser";
                     });
@@ -400,7 +400,7 @@ function promptUser(callback) {
                 name: "react",
                 message: "Do you use React",
                 default: false,
-                when: function(answers) {
+                when(answers) {
                     return answers.jsx;
                 }
             }
@@ -479,9 +479,9 @@ function promptUser(callback) {
 //------------------------------------------------------------------------------
 
 const init = {
-    getConfigForStyleGuide: getConfigForStyleGuide,
-    processAnswers: processAnswers,
-    initializeConfig: /* istanbul ignore next */ function(callback) {
+    getConfigForStyleGuide,
+    processAnswers,
+    /* istanbul ignore next */initializeConfig(callback) {
         promptUser(callback);
     }
 };

--- a/lib/config/config-ops.js
+++ b/lib/config/config-ops.js
@@ -34,7 +34,7 @@ module.exports = {
      * Creates an empty configuration object suitable for merging as a base.
      * @returns {Object} A configuration object.
      */
-    createEmptyConfig: function() {
+    createEmptyConfig() {
         return {
             globals: {},
             env: {},
@@ -49,7 +49,7 @@ module.exports = {
      * @returns {Object} A configuration object with the appropriate rules and globals
      *      set.
      */
-    createEnvironmentConfig: function(env) {
+    createEnvironmentConfig(env) {
 
         const envConfig = this.createEmptyConfig();
 
@@ -84,7 +84,7 @@ module.exports = {
      * @param {Object} config The configuration information.
      * @returns {Object} The updated configuration information.
      */
-    applyEnvironments: function(config) {
+    applyEnvironments(config) {
         if (config.env && typeof config.env === "object") {
             debug("Apply environment settings to config");
             return this.merge(this.createEnvironmentConfig(config.env), config);
@@ -196,7 +196,7 @@ module.exports = {
      * @param {Object} config The config object to normalize.
      * @returns {void}
      */
-    normalize: function(config) {
+    normalize(config) {
 
         if (config.rules) {
             Object.keys(config.rules).forEach(function(ruleId) {
@@ -218,7 +218,7 @@ module.exports = {
      * @param {Object} config The config object to normalize.
      * @returns {void}
      */
-    normalizeToStrings: function(config) {
+    normalizeToStrings(config) {
 
         if (config.rules) {
             Object.keys(config.rules).forEach(function(ruleId) {
@@ -238,7 +238,7 @@ module.exports = {
      * @param {int|string|Array} ruleConfig The configuration for an individual rule.
      * @returns {boolean} True if the rule represents an error, false if not.
      */
-    isErrorSeverity: function(ruleConfig) {
+    isErrorSeverity(ruleConfig) {
 
         let severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
 
@@ -254,7 +254,7 @@ module.exports = {
      * @param {number|string|Array} ruleConfig - The configuration for an individual rule.
      * @returns {boolean} `true` if the configuration has valid severity.
      */
-    isValidSeverity: function(ruleConfig) {
+    isValidSeverity(ruleConfig) {
         let severity = Array.isArray(ruleConfig) ? ruleConfig[0] : ruleConfig;
 
         if (typeof severity === "string") {
@@ -268,7 +268,7 @@ module.exports = {
      * @param {Object} config - The configuration for rules.
      * @returns {boolean} `true` if the configuration has valid severity.
      */
-    isEverySeverityValid: function(config) {
+    isEverySeverityValid(config) {
         return Object.keys(config).every(function(ruleId) {
             return this.isValidSeverity(config[ruleId]);
         }, this);

--- a/lib/config/config-rule.js
+++ b/lib/config/config-rule.js
@@ -202,7 +202,7 @@ RuleConfigSet.prototype = {
     * @param {number} [severity=2] The level of severity for the rule (0, 1, 2)
     * @returns {void}
     */
-    addErrorSeverity: function(severity) {
+    addErrorSeverity(severity) {
         severity = severity || 2;
 
         this.ruleConfigs = this.ruleConfigs.map(function(config) {
@@ -219,7 +219,7 @@ RuleConfigSet.prototype = {
     * @param  {string[]} enums Array of valid rule options (e.g. ["always", "never"])
     * @returns {void}
     */
-    addEnums: function(enums) {
+    addEnums(enums) {
         this.ruleConfigs = this.ruleConfigs.concat(combineArrays(this.ruleConfigs, enums));
     },
 
@@ -228,10 +228,10 @@ RuleConfigSet.prototype = {
     * @param  {Object} obj Schema item with type === "object"
     * @returns {void}
     */
-    addObject: function(obj) {
+    addObject(obj) {
         const objectConfigSet = {
             objectConfigs: [],
-            add: function(property, values) {
+            add(property, values) {
                 for (let idx = 0; idx < values.length; idx++) {
                     const optionObj = {};
 
@@ -240,7 +240,7 @@ RuleConfigSet.prototype = {
                 }
             },
 
-            combine: function() {
+            combine() {
                 this.objectConfigs = groupByProperty(this.objectConfigs).reduce(function(accumulator, objArr) {
                     return combinePropertyObjects(accumulator, objArr);
                 }, []);
@@ -317,6 +317,6 @@ function createCoreRuleConfigs() {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    generateConfigsFromSchema: generateConfigsFromSchema,
-    createCoreRuleConfigs: createCoreRuleConfigs
+    generateConfigsFromSchema,
+    createCoreRuleConfigs
 };

--- a/lib/config/config-validator.js
+++ b/lib/config/config-validator.js
@@ -171,7 +171,7 @@ function validate(config, source) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    getRuleOptionsSchema: getRuleOptionsSchema,
-    validate: validate,
-    validateRuleOptions: validateRuleOptions
+    getRuleOptionsSchema,
+    validate,
+    validateRuleOptions
 };

--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -55,9 +55,9 @@ function removeNamespace(pluginName) {
 
 module.exports = {
 
-    removePrefix: removePrefix,
-    getNamespace: getNamespace,
-    removeNamespace: removeNamespace,
+    removePrefix,
+    getNamespace,
+    removeNamespace,
 
     /**
      * Defines a plugin with a given name rather than loading from disk.
@@ -65,7 +65,7 @@ module.exports = {
      * @param {Object} plugin The plugin object.
      * @returns {void}
      */
-    define: function(pluginName, plugin) {
+    define(pluginName, plugin) {
         const pluginNameWithoutNamespace = removeNamespace(pluginName),
             pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace);
 
@@ -84,7 +84,7 @@ module.exports = {
      * @param {string} pluginName The name of the plugin to retrieve.
      * @returns {Object} The plugin or null if not loaded.
      */
-    get: function(pluginName) {
+    get(pluginName) {
         return plugins[pluginName] || null;
     },
 
@@ -92,7 +92,7 @@ module.exports = {
      * Returns all plugins that are loaded.
      * @returns {Object} The plugins cache.
      */
-    getAll: function() {
+    getAll() {
         return plugins;
     },
 
@@ -102,7 +102,7 @@ module.exports = {
      * @returns {void}
      * @throws {Error} If the plugin cannot be loaded.
      */
-    load: function(pluginName) {
+    load(pluginName) {
         const pluginNamespace = getNamespace(pluginName),
             pluginNameWithoutNamespace = removeNamespace(pluginName),
             pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace);
@@ -131,7 +131,7 @@ module.exports = {
      * @returns {void}
      * @throws {Error} If a plugin cannot be loaded.
      */
-    loadAll: function(pluginNames) {
+    loadAll(pluginNames) {
         pluginNames.forEach(this.load, this);
     },
 
@@ -139,7 +139,7 @@ module.exports = {
      * Resets plugin information. Use for tests only.
      * @returns {void}
      */
-    testReset: function() {
+    testReset() {
         plugins = Object.create(null);
     }
 };

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -59,7 +59,7 @@ function parseBooleanConfig(string, comment) {
 
         items[name] = {
             value: (value === "true"),
-            comment: comment
+            comment
         };
 
     });
@@ -240,14 +240,14 @@ function disableReporting(reportingConfig, start, rulesToDisable) {
     if (rulesToDisable.length) {
         rulesToDisable.forEach(function(rule) {
             reportingConfig.push({
-                start: start,
+                start,
                 end: null,
-                rule: rule
+                rule
             });
         });
     } else {
         reportingConfig.push({
-            start: start,
+            start,
             end: null,
             rule: null
         });
@@ -485,7 +485,7 @@ function createStubRule(message) {
      */
     function createRuleModule(context) {
         return {
-            Program: function(node) {
+            Program(node) {
                 context.report(node, message);
             }
         };
@@ -632,7 +632,7 @@ module.exports = (function() {
                 ruleId: null,
                 fatal: true,
                 severity: 2,
-                source: source,
+                source,
                 message: "Parsing error: " + message,
 
                 line: ex.lineNumber,
@@ -841,7 +841,7 @@ module.exports = (function() {
                 ignoreEval: true,
                 nodejsScope: ecmaFeatures.globalReturn,
                 impliedStrict: ecmaFeatures.impliedStrict,
-                ecmaVersion: ecmaVersion,
+                ecmaVersion,
                 sourceType: currentConfig.parserOptions.sourceType || "script",
                 fallback: Traverser.getKeys
             });
@@ -890,11 +890,11 @@ module.exports = (function() {
              * and react accordingly.
              */
             traverser.traverse(ast, {
-                enter: function(node, parent) {
+                enter(node, parent) {
                     node.parent = parent;
                     eventGenerator.enterNode(node);
                 },
-                leave: function(node) {
+                leave(node) {
                     eventGenerator.leaveNode(node);
                 }
             });
@@ -965,9 +965,9 @@ module.exports = (function() {
         }
 
         const problem = {
-            ruleId: ruleId,
-            severity: severity,
-            message: message,
+            ruleId,
+            severity,
+            message,
             line: location.line,
             column: location.column + 1,   // switch to 1-base instead of 0-base
             nodeType: node && node.type,

--- a/lib/formatters/html.js
+++ b/lib/formatters/html.js
@@ -75,9 +75,9 @@ function renderMessages(messages, parentIndex) {
         const columnNumber = message.column || 0;
 
         return messageTemplate({
-            parentIndex: parentIndex,
-            lineNumber: lineNumber,
-            columnNumber: columnNumber,
+            parentIndex,
+            lineNumber,
+            columnNumber,
             severityNumber: message.severity,
             severityName: message.severity === 1 ? "Warning" : "Error",
             message: message.message,
@@ -93,7 +93,7 @@ function renderMessages(messages, parentIndex) {
 function renderResults(results) {
     return lodash.map(results, function(result, index) {
         return resultTemplate({
-            index: index,
+            index,
             color: renderColor(result.errorCount, result.warningCount),
             filePath: result.filePath,
             summary: renderSummary(result.errorCount, result.warningCount)

--- a/lib/formatters/stylish.js
+++ b/lib/formatters/stylish.js
@@ -67,7 +67,7 @@ module.exports = function(results) {
             }),
             {
                 align: ["", "r", "l"],
-                stringLength: function(str) {
+                stringLength(str) {
                     return chalk.stripColor(str).length;
                 }
             }

--- a/lib/formatters/table.js
+++ b/lib/formatters/table.js
@@ -78,7 +78,7 @@ function drawTable(messages) {
                 wrapWord: true
             }
         },
-        drawHorizontalLine: function(index) {
+        drawHorizontalLine(index) {
             return index === 1;
         }
     });
@@ -143,7 +143,7 @@ module.exports = function(report) {
                 wrapWord: true
             }
         },
-        drawHorizontalLine: function() {
+        drawHorizontalLine() {
             return true;
         }
     });

--- a/lib/internal-rules/internal-no-invalid-meta.js
+++ b/lib/internal-rules/internal-no-invalid-meta.js
@@ -176,12 +176,12 @@ module.exports = {
         schema: []
     },
 
-    create: function(context) {
+    create(context) {
         let exportsNode;
         let ruleIsFixable = false;
 
         return {
-            AssignmentExpression: function(node) {
+            AssignmentExpression(node) {
                 if (node.left &&
                     node.right &&
                     node.left.type === "MemberExpression" &&
@@ -192,7 +192,7 @@ module.exports = {
                 }
             },
 
-            CallExpression: function(node) {
+            CallExpression(node) {
 
                 // If the rule has a call for `context.report` and a property `fix`
                 // is being passed in, then we consider that the rule is fixable.
@@ -214,7 +214,7 @@ module.exports = {
                 }
             },
 
-            "Program:exit": function() {
+            "Program:exit"() {
                 if (!isCorrectExportsFormat(exportsNode)) {
                     context.report(exportsNode, "Rule does not export an Object. Make sure the rule follows the new rule format.");
                     return;

--- a/lib/logging.js
+++ b/lib/logging.js
@@ -14,7 +14,7 @@ module.exports = {
      * Cover for console.log
      * @returns {void}
      */
-    info: function() {
+    info() {
         console.log.apply(console, Array.prototype.slice.call(arguments));
     },
 
@@ -22,7 +22,7 @@ module.exports = {
      * Cover for console.error
      * @returns {void}
      */
-    error: function() {
+    error() {
         console.error.apply(console, Array.prototype.slice.call(arguments));
     }
 };

--- a/lib/rule-context.js
+++ b/lib/rule-context.js
@@ -96,7 +96,7 @@ RuleContext.prototype = {
      * Passthrough to eslint.getSourceCode().
      * @returns {SourceCode} The SourceCode object for the code.
      */
-    getSourceCode: function() {
+    getSourceCode() {
         return this.eslint.getSourceCode();
     },
 
@@ -110,7 +110,7 @@ RuleContext.prototype = {
      *     with symbols being replaced by this object's values.
      * @returns {void}
      */
-    report: function(nodeOrDescriptor, location, message, opts) {
+    report(nodeOrDescriptor, location, message, opts) {
 
         // check to see if it's a new style call
         if (arguments.length === 1) {

--- a/lib/rules.js
+++ b/lib/rules.js
@@ -65,7 +65,7 @@ function importPlugin(pluginRules, pluginName) {
  * @param {string} ruleId Rule id (file name).
  * @returns {Function} Rule handler.
  */
-function get(ruleId) {
+function getHandler(ruleId) {
     if (typeof rules[ruleId] === "string") {
         return require(rules[ruleId]);
     } else {
@@ -83,17 +83,17 @@ function testClear() {
 }
 
 module.exports = {
-    define: define,
-    load: load,
+    define,
+    load,
     import: importPlugin,
-    get: get,
-    testClear: testClear,
+    get: getHandler,
+    testClear,
 
     /**
      * Resets rules to its starting state. Use for tests only.
      * @returns {void}
      */
-    testReset: function() {
+    testReset() {
         testClear();
         load();
     }

--- a/lib/testers/event-generator-tester.js
+++ b/lib/testers/event-generator-tester.js
@@ -43,7 +43,7 @@ module.exports = {
      * @param {Object} instance - An object to check.
      * @returns {void}
      */
-    testEventGeneratorInterface: function(instance) {
+    testEventGeneratorInterface(instance) {
         this.describe("should implement EventGenerator interface", function() {
             this.it("should have `emitter` property.", function() {
                 assert.equal(typeof instance.emitter, "object");

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -198,7 +198,7 @@ RuleTester.prototype = {
      * @param {Function} rule The rule definition.
      * @returns {void}
      */
-    defineRule: function(name, rule) {
+    defineRule(name, rule) {
         eslint.defineRule(name, rule);
     },
 
@@ -209,7 +209,7 @@ RuleTester.prototype = {
      * @param {Object} test The collection of tests to run.
      * @returns {void}
      */
-    run: function(ruleName, rule, test) {
+    run(ruleName, rule, test) {
 
         const testerConfig = this.testerConfig,
             result = {};
@@ -308,7 +308,7 @@ RuleTester.prototype = {
                     } else {
                         return {
                             meta: rule.meta,
-                            create: function(context) {
+                            create(context) {
                                 Object.freeze(context);
                                 freezeDeeply(context.options);
                                 freezeDeeply(context.settings);
@@ -322,8 +322,8 @@ RuleTester.prototype = {
 
                 return {
                     messages: eslint.verify(code, config, filename, true),
-                    beforeAST: beforeAST,
-                    afterAST: afterAST
+                    beforeAST,
+                    afterAST
                 };
             } finally {
                 rules.get = originalGet;

--- a/lib/timing.js
+++ b/lib/timing.js
@@ -136,8 +136,8 @@ module.exports = (function() {
     }
 
     return {
-        time: time,
-        enabled: enabled
+        time,
+        enabled
     };
 
 }());

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -113,7 +113,7 @@ function listFilesToProcess(globPatterns, options) {
     const ignoredPaths = new IgnoredPaths(options);
     const globOptions = {
         nodir: true,
-        cwd: cwd,
+        cwd,
         ignore: ignoredPaths.getIgnoredFoldersGlobPatterns()
     };
 
@@ -151,7 +151,7 @@ function listFilesToProcess(globPatterns, options) {
         if (added[filename]) {
             return;
         }
-        files.push({filename: filename, ignored: ignored});
+        files.push({filename, ignored});
         added[filename] = true;
     }
 
@@ -172,6 +172,6 @@ function listFilesToProcess(globPatterns, options) {
 }
 
 module.exports = {
-    resolveFileGlobPatterns: resolveFileGlobPatterns,
-    listFilesToProcess: listFilesToProcess
+    resolveFileGlobPatterns,
+    listFilesToProcess
 };

--- a/lib/util/module-resolver.js
+++ b/lib/util/module-resolver.js
@@ -52,7 +52,7 @@ ModuleResolver.prototype = {
      * @returns {string} The resolved file path for the module.
      * @throws {Error} If the module cannot be resolved.
      */
-    resolve: function(name, extraLookupPath) {
+    resolve(name, extraLookupPath) {
 
         /*
          * First, clone the lookup paths so we're not messing things up for

--- a/lib/util/npm-util.js
+++ b/lib/util/npm-util.js
@@ -139,8 +139,8 @@ function checkPackageJson(startDir) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    installSyncSaveDev: installSyncSaveDev,
-    checkDeps: checkDeps,
-    checkDevDeps: checkDevDeps,
-    checkPackageJson: checkPackageJson
+    installSyncSaveDev,
+    checkDeps,
+    checkDevDeps,
+    checkPackageJson
 };

--- a/lib/util/path-util.js
+++ b/lib/util/path-util.js
@@ -69,6 +69,6 @@ function getRelativePath(filepath, baseDir) {
 //------------------------------------------------------------------------------
 
 module.exports = {
-    convertPathToPosix: convertPathToPosix,
-    getRelativePath: getRelativePath
+    convertPathToPosix,
+    getRelativePath
 };

--- a/lib/util/rule-fixer.js
+++ b/lib/util/rule-fixer.js
@@ -24,7 +24,7 @@
 function insertTextAt(index, text) {
     return {
         range: [index, index],
-        text: text
+        text
     };
 }
 
@@ -50,7 +50,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextAfter: function(nodeOrToken, text) {
+    insertTextAfter(nodeOrToken, text) {
         return this.insertTextAfterRange(nodeOrToken.range, text);
     },
 
@@ -62,7 +62,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextAfterRange: function(range, text) {
+    insertTextAfterRange(range, text) {
         return insertTextAt(range[1], text);
     },
 
@@ -73,7 +73,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextBefore: function(nodeOrToken, text) {
+    insertTextBefore(nodeOrToken, text) {
         return this.insertTextBeforeRange(nodeOrToken.range, text);
     },
 
@@ -85,7 +85,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    insertTextBeforeRange: function(range, text) {
+    insertTextBeforeRange(range, text) {
         return insertTextAt(range[0], text);
     },
 
@@ -96,7 +96,7 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    replaceText: function(nodeOrToken, text) {
+    replaceText(nodeOrToken, text) {
         return this.replaceTextRange(nodeOrToken.range, text);
     },
 
@@ -108,10 +108,10 @@ RuleFixer.prototype = {
      * @param {string} text The text to insert.
      * @returns {Object} The fix command.
      */
-    replaceTextRange: function(range, text) {
+    replaceTextRange(range, text) {
         return {
-            range: range,
-            text: text
+            range,
+            text
         };
     },
 
@@ -121,7 +121,7 @@ RuleFixer.prototype = {
      * @param {ASTNode|Token} nodeOrToken The node or token to remove.
      * @returns {Object} The fix command.
      */
-    remove: function(nodeOrToken) {
+    remove(nodeOrToken) {
         return this.removeRange(nodeOrToken.range);
     },
 
@@ -132,9 +132,9 @@ RuleFixer.prototype = {
      *      is end of range.
      * @returns {Object} The fix command.
      */
-    removeRange: function(range) {
+    removeRange(range) {
         return {
-            range: range,
+            range,
             text: ""
         };
     }

--- a/lib/util/source-code-fixer.js
+++ b/lib/util/source-code-fixer.js
@@ -60,7 +60,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         debug("No source code to fix");
         return {
             fixed: false,
-            messages: messages,
+            messages,
             output: ""
         };
     }
@@ -128,7 +128,7 @@ SourceCodeFixer.applyFixes = function(sourceCode, messages) {
         debug("No fixes to apply");
         return {
             fixed: false,
-            messages: messages,
+            messages,
             output: prefix + text
         };
     }

--- a/lib/util/source-code-util.js
+++ b/lib/util/source-code-util.js
@@ -106,5 +106,5 @@ function getSourceCodeOfFiles(patterns, options, cb) {
 }
 
 module.exports = {
-    getSourceCodeOfFiles: getSourceCodeOfFiles
+    getSourceCodeOfFiles
 };

--- a/lib/util/source-code.js
+++ b/lib/util/source-code.js
@@ -158,7 +158,7 @@ SourceCode.prototype = {
      * @param {int=} afterCount The number of characters after the node to retrieve.
      * @returns {string} The text representing the AST node.
      */
-    getText: function(node, beforeCount, afterCount) {
+    getText(node, beforeCount, afterCount) {
         if (node) {
             return this.text.slice(Math.max(node.range[0] - (beforeCount || 0), 0),
                 node.range[1] + (afterCount || 0));
@@ -172,7 +172,7 @@ SourceCode.prototype = {
      * Gets the entire source text split into an array of lines.
      * @returns {Array} The source text as an array of lines.
      */
-    getLines: function() {
+    getLines() {
         return this.lines;
     },
 
@@ -180,7 +180,7 @@ SourceCode.prototype = {
      * Retrieves an array containing all comments in the source code.
      * @returns {ASTNode[]} An array of comment nodes.
      */
-    getAllComments: function() {
+    getAllComments() {
         return this.ast.comments;
     },
 
@@ -190,7 +190,7 @@ SourceCode.prototype = {
      * @returns {Object} The list of comments indexed by their position.
      * @public
      */
-    getComments: function(node) {
+    getComments(node) {
 
         let leadingComments = node.leadingComments || [];
         const trailingComments = node.trailingComments || [];
@@ -219,7 +219,7 @@ SourceCode.prototype = {
      *      given node or null if not found.
      * @public
      */
-    getJSDocComment: function(node) {
+    getJSDocComment(node) {
 
         let parent = node.parent;
 
@@ -259,13 +259,13 @@ SourceCode.prototype = {
      * @param {int} index Range index of the desired node.
      * @returns {ASTNode} The node if found or null if not found.
      */
-    getNodeByRangeIndex: function(index) {
+    getNodeByRangeIndex(index) {
         let result = null,
             resultParent = null;
         const traverser = new Traverser();
 
         traverser.traverse(this.ast, {
-            enter: function(node, parent) {
+            enter(node, parent) {
                 if (node.range[0] <= index && index < node.range[1]) {
                     result = node;
                     resultParent = parent;
@@ -273,7 +273,7 @@ SourceCode.prototype = {
                     this.skip();
                 }
             },
-            leave: function(node) {
+            leave(node) {
                 if (node === result) {
                     this.break();
                 }
@@ -292,7 +292,7 @@ SourceCode.prototype = {
      * @returns {boolean} True if there is only space between tokens, false
      *  if there is anything other than whitespace between tokens.
      */
-    isSpaceBetweenTokens: function(first, second) {
+    isSpaceBetweenTokens(first, second) {
         const text = this.text.slice(first.range[1], second.range[0]);
 
         return /\s/.test(text.replace(/\/\*.*?\*\//g, ""));


### PR DESCRIPTION
First batch: https://github.com/eslint/eslint/pull/6893

Breaking this up into batches as per the discussion here: https://github.com/eslint/eslint/pull/6812

This is the second batch (everything in `/lib` except `/lib/rules`). I'll actually enable the rule in the final batch :)

@eslint/eslint-team Will merge this after I get a few pairs of eyes on this. Discussed with @nzakas in Gitter and we decided to get these reviewed and merged without having to wait the full two days. Since this touches so many files, waiting even a few days can lead to merge conflicts.

Ported from the original PR:
Pretty straightforward, aside from two things:
 *  Had to move a `/* istanbul ignore next */` comment to work for the shorthand notation (see [this issue in the Istanbul repo](https://github.com/gotwarlost/istanbul/issues/609) for more info)
 * There's a bug in Node v4.x.x when using `get` as a shorthand property name. We actually saw [a bug report](https://github.com/eslint/eslint/issues/6408) for this very situation and decided against fixing it, so my solution was to just rename the function. Will comment the specific location in the code.