### PR TITLE
Docs: Update options in `object-shorthand`

### DIFF
--- a/docs/rules/object-shorthand.md
+++ b/docs/rules/object-shorthand.md
@@ -86,10 +86,9 @@ var foo = {
 
 ## Options
 
-The rule takes an option which specifies when it should be applied. It can be set to
-"always", "properties", "methods", or "never". The default is "always".
+The rule takes an option which specifies when it should be applied. It can be set to one of the following values:
 
-* `"always"` expects that the shorthand will be used whenever possible.
+* `"always"` (default) expects that the shorthand will be used whenever possible.
 * `"methods"` ensures the method shorthand is used (also applies to generators).
 * `"properties` ensures the property shorthand is used (where the key and variable name match).
 * `"never"` ensures that no property or method shorthand is used in any object literal.


### PR DESCRIPTION
**What issue does this pull request address?**

Minor documentation issue. The option values for the `object-shorthand` rule were listed twice, but when the new `consistent` and `consistent-as-needed` values were added only the second list was updated.

**What changes did you make? (Give an overview)**

Rather than update the first list with the new option values, I just got rid of it. It seemed unnecessary to have two lists given that the first list was right above the second list.

**Is there anything you'd like reviewers to focus on?**

Global warming