### PR TITLE
Docs: clarify rule details for no-template-curly-in-string

### DIFF
--- a/docs/rules/no-template-curly-in-string.md
+++ b/docs/rules/no-template-curly-in-string.md
@@ -5,7 +5,7 @@ ECMAScript 6 allows programmers to create strings containing variable or express
 
 ## Rule Details
 
-This rule aims to warn when a regular string contains what looks like a template literal placeholder. It will warn when it finds a string containing the template literal place holder (`${something}`) that uses either `\"` or `\'` for the quotes.
+This rule aims to warn when a regular string contains what looks like a template literal placeholder. It will warn when it finds a string containing the template literal place holder (`${something}`) that uses either `"` or `'` for the quotes.
 
 ## Examples
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?** N/A (docs update)


**What changes did you make? (Give an overview)**

This clarifies the documentation for the `no-template-curly-in-string` rule. Escaping the quotes in the description makes it seem like the rule might be looking for actual escaped quotes in the string, when it is simply looking for quotes surrounding the string.


**Is there anything you'd like reviewers to focus on?** No

