### PR TITLE
New: Add CLI option for exiting 0 (fixes #2949)

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -54,7 +54,8 @@ function translateOptions(cliOptions) {
         cacheFile: cliOptions.cacheFile,
         cacheLocation: cliOptions.cacheLocation,
         fix: cliOptions.fix,
-        allowInlineConfig: cliOptions.inlineConfig
+        allowInlineConfig: cliOptions.inlineConfig,
+        exitZeroEvenIfErrors: cliOptions.exitZeroEvenIfErrors
     };
 }
 
@@ -120,7 +121,7 @@ const cli = {
      * @param {string} [text] The text to lint (used for TTY).
      * @returns {int} The exit code for the operation.
      */
-    execute(args, text) {
+    execute: function(args, text) {
 
         let currentOptions;
 
@@ -188,6 +189,10 @@ const cli = {
 
                 if (!report.errorCount && tooManyWarnings) {
                     log.error("ESLint found too many warnings (maximum: %s).", currentOptions.maxWarnings);
+                }
+
+                if (currentOptions.exitZeroEvenIfErrors) {
+                    return 0;
                 }
 
                 return (report.errorCount || tooManyWarnings) ? 1 : 0;

--- a/lib/options.js
+++ b/lib/options.js
@@ -218,6 +218,12 @@ module.exports = optionator({
             option: "print-config",
             type: "Boolean",
             description: "Print the configuration to be used"
+        },
+        {
+            option: "exit-zero-even-if-errors",
+            type: "Boolean",
+            default: "false",
+            description: "Always exit with a status code of zero, regardless of severity. Only exit with nonzero if ESLint itself fails."
         }
     ]
 });

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -128,6 +128,20 @@ describe("cli", function() {
         });
     });
 
+    describe("when passed --exit-zero-even-if-errors", function() {
+        it("should have a status code of 0 even if there are checks that produce errors", function() {
+            const exitCode = cli.execute("--exit-zero-even-if-errors", "foo = bar;");
+
+            assert.equal(exitCode, 0);
+        });
+
+        it("should not have a status code of 0 if there are internal problems", function() {
+            const exitCode = cli.execute("--exit-zero-even-if-errors --print-config", "foo = bar;");
+
+            assert.equal(exitCode, 1);
+        });
+    });
+
     describe("when there is a local config file", function() {
         const code = "lib/cli.js";
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -365,4 +365,12 @@ describe("options", function() {
             assert.isTrue(currentOptions.printConfig);
         });
     });
+
+    describe("--exit-zero-even-if-errors", function() {
+        it("should return true when passed --exit-zero-even-if-errors", function() {
+            const currentOptions = options.parse("--exit-zero-even-if-errors");
+
+            assert.isTrue(currentOptions.exitZeroEvenIfErrors);
+        });
+    });
 });


### PR DESCRIPTION
Normally, if checks produce errors, ESLint exits with a status code of 1.
With this option, it will always exit 0, even if there are errors.
However, if ESLint fails internally (e.g. config is not in the proper format) it will still exit with a nonzero status code.

I added tests for this functionality as well.

I did not update the documentation. I will do so if this is considered a worthwhile option and the code changes I made pass the code review.