### PR TITLE
Build: optimize rule page title for small browser tabs (fixes #6888)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -622,7 +622,7 @@ target.gensite = function(prereleaseVersion) {
 
             // 5. Prepend page title and layout variables at the top of rules
             if (path.dirname(filename).indexOf("rules") >= 0) {
-                text = "---\ntitle: Rule " + ruleName + "\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n" + text;
+                text = "---\ntitle: " + ruleName + " - Rules\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n" + text;
             } else {
 
                 // extract the title from the file itself


### PR DESCRIPTION
**What issue does this pull request address?**
eslint/eslint.github.io#268 and #6888 : optimize rule doc page title so the name of the rule comes first.
E.g. for the `template-curly-spacing` rule:
From:
`Rule template-curly-spacing - ESLint - Pluggable JavaScript linter`
To:
`template-curly-spacing - Rules - ESLint - Pluggable JavaScript linter`

**What changes did you make? (Give an overview)**
Modified the `gensite` task so that the `title` in the frontmatter for each rule doc page is using the new format described above.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular.
