### PR TITLE
Update: add support for ecmaVersion 20xx (fixes #6750)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -407,6 +407,28 @@ function isDisabledByReportingConfig(reportingConfig, ruleId, location) {
 }
 
 /**
+ * Normalize ECMAScript version from the initial config
+ * @param  {number} ecmaVersion ECMAScript version from the initial config
+ * @param  {boolean} isModule Whether the source type is module or not
+ * @returns {number} normalized ECMAScript version
+ */
+function normalizeEcmaVersion(ecmaVersion, isModule) {
+
+    // Need at least ES6 for modules
+    if (isModule && (!ecmaVersion || ecmaVersion < 6)) {
+        ecmaVersion = 6;
+    }
+
+    // Calculate ECMAScript edition number from official year version starting with
+    // ES2015, which corresponds with ES6 (or a difference of 2009).
+    if (ecmaVersion >= 2015) {
+        ecmaVersion -= 2009;
+    }
+
+    return ecmaVersion;
+}
+
+/**
  * Process initial config to make it safe to extend by file comment config
  * @param  {Object} config Initial config
  * @returns {Object}        Processed config
@@ -453,20 +475,18 @@ function prepareConfig(config) {
         settings: ConfigOps.merge({}, config.settings || {}),
         parserOptions: ConfigOps.merge(parserOptions, config.parserOptions || {})
     };
+    const isModule = preparedConfig.parserOptions.sourceType === "module";
 
-    if (preparedConfig.parserOptions.sourceType === "module") {
+    if (isModule) {
         if (!preparedConfig.parserOptions.ecmaFeatures) {
             preparedConfig.parserOptions.ecmaFeatures = {};
         }
 
         // can't have global return inside of modules
         preparedConfig.parserOptions.ecmaFeatures.globalReturn = false;
-
-        // also need at least ES6 for modules
-        if (!preparedConfig.parserOptions.ecmaVersion || preparedConfig.parserOptions.ecmaVersion < 6) {
-            preparedConfig.parserOptions.ecmaVersion = 6;
-        }
     }
+
+    preparedConfig.parserOptions.ecmaVersion = normalizeEcmaVersion(preparedConfig.parserOptions.ecmaVersion, isModule);
 
     return preparedConfig;
 }

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -3052,7 +3052,6 @@ describe("eslint", function() {
     });
 
     describe("verify()", function() {
-
         describe("filenames", function() {
             it("should allow filename to be passed on options object", function() {
 
@@ -3095,10 +3094,7 @@ describe("eslint", function() {
                 eslint.verify("foo;", {}, { saveState: true });
                 assert.equal(spy.callCount, 0);
             });
-
-
         });
-
 
         it("should report warnings in order by line and column when called", function() {
 
@@ -3116,15 +3112,60 @@ describe("eslint", function() {
             assert.equal(messages[2].column, 18);
         });
 
-        it("should properly parse let declaration when passed ecmaVersion", function() {
+        describe("ecmaVersion", function() {
+            describe("it should properly parse let declaration when", function() {
+                it("the ECMAScript version number is 6", function() {
+                    const messages = eslint.verify("let x = 5;", {
+                        parserOptions: {
+                            ecmaVersion: 6
+                        }
+                    });
 
-            const messages = eslint.verify("let x = 5;", {
-                parserOptions: {
-                    ecmaVersion: 6
-                }
-            }, filename);
+                    assert.equal(messages.length, 0);
+                });
 
-            assert.equal(messages.length, 0);
+                it("the ECMAScript version number is 2015", function() {
+                    const messages = eslint.verify("let x = 5;", {
+                        parserOptions: {
+                            ecmaVersion: 2015
+                        }
+                    });
+
+                    assert.equal(messages.length, 0);
+                });
+            });
+
+            it("should fail to parse exponentiation operator when the ECMAScript version number is 2015", function() {
+                const messages = eslint.verify("x ** y;", {
+                    parserOptions: {
+                        ecmaVersion: 2015
+                    }
+                });
+
+                assert.equal(messages.length, 1);
+            });
+
+            describe("should properly parse exponentiation operator when", function() {
+                it("the ECMAScript version number is 7", function() {
+                    const messages = eslint.verify("x ** y;", {
+                        parserOptions: {
+                            ecmaVersion: 7
+                        }
+                    });
+
+                    assert.equal(messages.length, 0);
+                });
+
+                it("the ECMAScript version number is 2016", function() {
+                    const messages = eslint.verify("x ** y;", {
+                        parserOptions: {
+                            ecmaVersion: 2016
+                        }
+                    });
+
+                    assert.equal(messages.length, 0);
+                });
+            });
         });
 
         it("should properly parse object spread when passed ecmaFeatures", function() {


### PR DESCRIPTION
Thoughts on this approach? The way `verify()` works doesn't seem to make it easy to test this particular change. Is there something else I could spy on?