### PR TITLE
Fix: no-cond-assign within a function expression (fixes #6908)

### DIFF
--- a/lib/rules/no-cond-assign.js
+++ b/lib/rules/no-cond-assign.js
@@ -4,6 +4,8 @@
  */
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 const NODE_DESCRIPTIONS = {
     DoWhileStatement: "a 'do...while' statement",
     ForStatement: "a 'for' statement",
@@ -59,7 +61,7 @@ module.exports = {
                 if (isConditionalTestExpression(currentAncestor)) {
                     return currentAncestor.parent;
                 }
-            } while ((currentAncestor = currentAncestor.parent));
+            } while ((currentAncestor = currentAncestor.parent) && !astUtils.isFunction(currentAncestor));
 
             return null;
         }

--- a/tests/lib/rules/no-cond-assign.js
+++ b/tests/lib/rules/no-cond-assign.js
@@ -36,7 +36,12 @@ ruleTester.run("no-cond-assign", rule, {
         "while (someNode || (someNode = parentNode)) { }",
         "do { } while (someNode || (someNode = parentNode));",
         "for (;someNode || (someNode = parentNode););",
-        "if ((function(node) { return (node = parentNode); })(someNode)) { }",
+        { code: "if ((function(node) { return node = parentNode; })(someNode)) { }", options: ["except-parens"] },
+        { code: "if ((function(node) { return node = parentNode; })(someNode)) { }", options: ["always"] },
+        { code: "if ((node => node = parentNode)(someNode)) { }", options: ["except-parens"], parserOptions: { ecmaVersion: 6 } },
+        { code: "if ((node => node = parentNode)(someNode)) { }", options: ["always"], parserOptions: { ecmaVersion: 6 } },
+        { code: "if (function(node) { return node = parentNode; }) { }", options: ["except-parens"] },
+        { code: "if (function(node) { return node = parentNode; }) { }", options: ["always"] },
         { code: "x = 0;", options: ["always"] }
     ],
     invalid: [
@@ -49,7 +54,6 @@ ruleTester.run("no-cond-assign", rule, {
         { code: "while (someNode || (someNode = parentNode)) { }", options: ["always"], errors: [{ message: "Unexpected assignment within a 'while' statement.", type: "WhileStatement"}] },
         { code: "do { } while (someNode || (someNode = parentNode));", options: ["always"], errors: [{ message: "Unexpected assignment within a 'do...while' statement.", type: "DoWhileStatement"}] },
         { code: "for (; (typeof l === 'undefined' ? (l = 0) : l); i++) { }", options: ["always"], errors: [{ message: "Unexpected assignment within a 'for' statement.", type: "ForStatement"}] },
-        { code: "if ((function(node) { return (node = parentNode); })(someNode)) { }", options: ["always"], errors: [{ message: "Unexpected assignment within an 'if' statement.", type: "IfStatement"}] },
         { code: "if (x = 0) { }", options: ["always"], errors: [{ message: "Unexpected assignment within an 'if' statement.", type: "IfStatement"}] },
         { code: "while (x = 0) { }", options: ["always"], errors: [{ message: "Unexpected assignment within a 'while' statement.", type: "WhileStatement"}] },
         { code: "do { } while (x = x + 1);", options: ["always"], errors: [{ message: "Unexpected assignment within a 'do...while' statement.", type: "DoWhileStatement"}] },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6908 

Stops checking to see if an assignment is within a condition if the assignment is wrapped in a call expression, making the behavior consistent between "except-parens" and "always"

**What changes did you make? (Give an overview)**
I noticed that the behavior depends on whether the configuration is set to "always" or "except-parens". If configured to "except-parens" the behavior was as expected in the bug report. "always" is more strict.


**Is there anything you'd like reviewers to focus on?**
This might be a breaking change. I actually moved one of the unit tests from invalid to valid. But we should probably discuss that in the issue. 

