### PR TITLE
Fix: Check indentation on multiline variable declarations (fixes #6911)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -74,6 +74,7 @@ This rule has an object option:
 * `"VariableDeclarator"` (default: 1) enforces indentation level for `var` declarators; can also take an object to define separate rules for `var`, `let` and `const` declarations.
 * `"outerIIFEBody"` (default: 1) enforces indentation level for file-level IIFEs.
 * `"MemberExpression"` (off by default) enforces indentation level for multi-line property chains (except in variable declarations and assignments)
+* `"BinaryExpression"` (off by default) enforces indentation level for multi-line continuations (currently only in variable declarations)
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -87,6 +88,9 @@ Level of indentation denotes the multiple of the indent specified. Example:
 * Indent of 2 spaces with `MemberExpression` set to `0` will indent the multi-line property chains with 0 spaces.
 * Indent of 2 spaces with `MemberExpression` set to `1` will indent the multi-line property chains with 2 spaces.
 * Indent of 2 spaces with `MemberExpression` set to `2` will indent the multi-line property chains with 4 spaces.
+* Indent of 2 spaces with `BinaryExpression` set to `0` will indent the multi-line continuations with 0 spaces.
+* Indent of 2 spaces with `BinaryExpression` set to `1` will indent the multi-line continuations with 2 spaces.
+* Indent of 2 spaces with `BinaryExpression` set to `2` will indent the multi-line continuations with 4 spaces.
 
 ### tab
 
@@ -278,6 +282,30 @@ foo
 // Any indentation is permitted in variable declarations and assignments.
 var bip = aardvark.badger
                   .coyote;
+```
+
+### BinaryExpression
+
+Examples of **incorrect** code for this rule with the `2, { "BinaryExpression": 1 }` options:
+
+```js
+/*eslint indent: ["error", 2, { "BinaryExpression": 1 }]*/
+
+var foo = 'bar' +
+'baz';
+```
+
+Examples of **correct** code for this rule with the `2, { "BinaryExpression": 1 }` option:
+
+```js
+/*eslint indent: ["error", 2, { "BinaryExpression": 1 }]*/
+
+var foo = 'bar' +
+  'baz';
+
+// Any indentation is permitted outside of variable declarations.
+bip = 'bim' +
+'bee';
 ```
 
 ## Compatibility

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -8,6 +8,8 @@
 
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -73,6 +75,10 @@ module.exports = {
                     MemberExpression: {
                         type: "integer",
                         minimum: 0
+                    },
+                    BinaryExpression: {
+                        type: "integer",
+                        minimum: 0
                     }
                 },
                 additionalProperties: false
@@ -130,6 +136,10 @@ module.exports = {
 
                 if (typeof opts.MemberExpression === "number") {
                     options.MemberExpression = opts.MemberExpression;
+                }
+
+                if (typeof opts.BinaryExpression === "number") {
+                    options.BinaryExpression = opts.BinaryExpression;
                 }
             }
         }
@@ -815,6 +825,60 @@ module.exports = {
             VariableDeclaration: function(node) {
                 if (node.declarations[node.declarations.length - 1].loc.start.line > node.declarations[0].loc.start.line) {
                     checkIndentInVariableDeclarations(node);
+                }
+            },
+
+            VariableDeclarator: function(node) {
+                if (typeof options.BinaryExpression === "undefined") {
+                    return;
+                }
+
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+
+                /**
+                 * Returns the nodes to check for indentation issues
+                 * @param {ASTNode} startNode node to examine
+                 * @returns {Array} nodes
+                 */
+                function recursiveFind(startNode) {
+                    if (startNode.type !== "BinaryExpression") {
+                        return [startNode];
+                    }
+
+                    const left = startNode.left;
+                    const right = startNode.right;
+
+                    let leftNodes;
+
+                    if (left.type === "BinaryExpression") {
+                        leftNodes = recursiveFind(left);
+                    } else {
+                        leftNodes = [left];
+                    }
+
+                    const operatorToken = sourceCode.getTokenAfter(left);
+
+                    let rightNodes;
+
+                    if (right.type === "BinaryExpression") {
+                        rightNodes = recursiveFind(right);
+                    } else {
+                        if (astUtils.isTokenOnSameLine(right, operatorToken)) {
+                            rightNodes = [operatorToken];
+                        } else {
+                            rightNodes = [right];
+                        }
+                    }
+
+                    return leftNodes.concat(rightNodes);
+                }
+
+                if (node.init) {
+                    const continuationIndent = getNodeIndent(node) + indentSize * options.BinaryExpression;
+
+                    checkNodesIndent(recursiveFind(node.init), continuationIndent);
                 }
             },
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1395,6 +1395,12 @@ ruleTester.run("indent", rule, {
             "foo = bar.baz()\n" +
             "        .bip();",
             options: [4, {MemberExpression: 1}]
+        },
+        {
+            code:
+            "var foo = 'bar' +\n" +
+            "  'baz';",
+            options: [2, { BinaryExpression: 1 }]
         }
     ],
     invalid: [
@@ -2435,6 +2441,48 @@ ruleTester.run("indent", rule, {
             "    .bar",
             options: [2, { MemberExpression: 2 }],
             errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 2, "Punctuator"]])
+        },
+        {
+            code:
+            "var foo =\n" +
+            "'baz';",
+            output:
+            "var foo =\n" +
+            "  'baz';",
+            options: [2, { BinaryExpression: 1 }],
+            errors: expectedErrors([2, 2, 0, "Literal"])
+        },
+        {
+            code:
+            "var foo = 'bar' +\n" +
+            "'baz';",
+            output:
+            "var foo = 'bar' +\n" +
+            "  'baz';",
+            options: [2, { BinaryExpression: 1 }],
+            errors: expectedErrors([2, 2, 0, "Literal"])
+        },
+        {
+            code:
+            "var foo = 'bar' +\n" +
+            "    'baz' +\n" +
+            "    'bip';",
+            output:
+            "var foo = 'bar' +\n" +
+            "  'baz' +\n" +
+            "  'bip';",
+            options: [2, { BinaryExpression: 1 }],
+            errors: expectedErrors([[2, 2, 4, "Literal"], [3, 2, 4, "Literal"]])
+        },
+        {
+            code:
+            "var foo = 'bar'\n" +
+            "+ 'baz';",
+            output:
+            "var foo = 'bar'\n" +
+            "  + 'baz';",
+            options: [2, { BinaryExpression: 1 }],
+            errors: expectedErrors([2, 2, 0, "Punctuator"])
         }
     ]
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6911: Indent rule doesn't cover multiline VariableDeclarations

**What changes did you make? (Give an overview)**
Added a `BinaryExpression` option to the indent rule that (for now) only is used inside a `VariableDeclaration`. It warns if continuations are not indented.

**Is there anything you'd like reviewers to focus on?**

Add `BinaryExpression` option for `indent` rule to check multi-line
variable declarations for indentation issues.