### PR TITLE
Docs: Change rule descriptions for consistent casing

### DIFF
--- a/lib/rules/no-tabs.js
+++ b/lib/rules/no-tabs.js
@@ -17,7 +17,7 @@ const regex = /\t/;
 module.exports = {
     meta: {
         docs: {
-            description: "Disallow tabs in file",
+            description: "disallow tabs in file",
             category: "Stylistic Issues",
             recommended: false
         },

--- a/lib/rules/no-template-curly-in-string.js
+++ b/lib/rules/no-template-curly-in-string.js
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "Disallow template literal placeholder syntax in regular strings",
+            description: "disallow template literal placeholder syntax in regular strings",
             category: "Possible Errors",
             recommended: false
         },


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

Scrolling through http://eslint.org/docs/rules, I found two descriptions that began with uppercase letters, while all the rest were lowercase.

**What changes did you make? (Give an overview)**

I changed the two inconsistent descriptions to begin with lowercase letters.

**Is there anything you'd like reviewers to focus on?**

For the curious, here's how I ran a quick check to be sure I didn't miss any:

```js
Array.from(document.querySelectorAll('tr td:last-child p'))
    .map(p => p.innerText)
    .filter(description =>
        description[0].toLowerCase() !== description[0]
    )
```