### PR TITLE
New: do not remove non visited files from cache. (Fixes #6780)

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "espree": "^3.1.6",
     "estraverse": "^4.2.0",
     "esutils": "^2.0.2",
-    "file-entry-cache": "^1.3.1",
+    "file-entry-cache": "^2.0.0",
     "glob": "^7.0.3",
     "globals": "^9.2.0",
     "ignore": "^3.1.5",

--- a/tests/fixtures/cache/src/file-to-delete.js
+++ b/tests/fixtures/cache/src/file-to-delete.js
@@ -1,0 +1,3 @@
+var abc = 3;
+
+console.log(abc);

--- a/tests/fixtures/cache/src/test-file2.js
+++ b/tests/fixtures/cache/src/test-file2.js
@@ -1,0 +1,3 @@
+var abc = 2;
+
+console.log(abc);


### PR DESCRIPTION
**What issue does this pull request address?**
It allows cache file to keep non used files in the cache between executions of eslint, also files that don't exist anymore are removed from the cache both when loaded and when saved.

**What changes did you make? (Give an overview)**
- updated file-entry-cache to 2.0.0
- added unit tests to cover the expected functionality

**Is there anything you'd like reviewers to focus on?**
- correctness of the tests
- Also would be nice to review also this https://github.com/royriojas/file-entry-cache/commit/408374d0398533db237cde3fef1ad509ed2dab39 where the actual removal of non found files happen.

cc. @IanVS 
