### PR TITLE
Update: `requireStringLiterals` option for `valid-typeof` (fixes #6698)

### DIFF
--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -6,6 +6,12 @@ For a vast majority of use cases, the result of the `typeof` operator is one of 
 
 This rule enforces comparing `typeof` expressions to valid string literals.
 
+## Options
+
+This rule has an object option:
+
+* `"requireStringLiterals": true` requires `typeof` expressions to only be compared to string literals, and disallows comparisons to any other value.
+
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -26,6 +32,26 @@ typeof foo === "string"
 typeof bar == "undefined"
 typeof foo === baz
 typeof bar === typeof qux
+```
+
+Examples of **incorrect** code with the `{ "requireStringLiterals": true }` option:
+
+```js
+typeof foo === undefined
+typeof bar == Object
+typeof baz === "strnig"
+typeof qux === "some invalid type"
+typeof baz === anotherVariable
+typeof foo == 5
+typeof bar === typeof qux
+```
+
+Examples of **correct** code with the `{ "requireStringLiterals": true }` option:
+
+```js
+typeof foo === "undefined"
+typeof bar == "object"
+typeof baz === "string"
 ```
 
 ## When Not To Use It

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -16,7 +16,17 @@ module.exports = {
             recommended: true
         },
 
-        schema: []
+        schema: [
+            {
+                type: "object",
+                properties: {
+                    requireStringLiterals: {
+                        type: "boolean"
+                    }
+                },
+                additionalProperties: false
+            }
+        ]
     },
 
     create(context) {
@@ -37,8 +47,12 @@ module.exports = {
                     if (parent.type === "BinaryExpression" && OPERATORS.indexOf(parent.operator) !== -1) {
                         const sibling = parent.left === node ? parent.right : parent.left;
 
-                        if (sibling.type === "Literal" && VALID_TYPES.indexOf(sibling.value) === -1) {
-                            context.report(sibling, "Invalid typeof comparison value.");
+                        if (sibling.type === "Literal") {
+                            if (VALID_TYPES.indexOf(sibling.value) === -1) {
+                                context.report(sibling, "Invalid typeof comparison value.");
+                            }
+                        } else if (context.options[0] && context.options[0].requireStringLiterals) {
+                            context.report(sibling, "Typeof comparisons should be to string literals.");
                         }
                     }
                 }

--- a/tests/lib/rules/valid-typeof.js
+++ b/tests/lib/rules/valid-typeof.js
@@ -43,7 +43,19 @@ ruleTester.run("valid-typeof", rule, {
         "typeof(foo) !== 'string'",
         "typeof(foo) == 'string'",
         "typeof(foo) != 'string'",
-        "var oddUse = typeof foo + 'thing'"
+        "var oddUse = typeof foo + 'thing'",
+        {
+            code: "typeof foo === 'number'",
+            options: [{ requireStringLiterals: true }],
+        },
+        {
+            code: "typeof foo === \"number\"",
+            options: [{ requireStringLiterals: true }]
+        },
+        {
+            code: "var baz = typeof foo + 'thing'",
+            options: [{ requireStringLiterals: true }]
+        }
     ],
 
     invalid: [
@@ -94,6 +106,31 @@ ruleTester.run("valid-typeof", rule, {
         {
             code: "if (typeof bar == 'umdefined') {}",
             errors: [{ message: "Invalid typeof comparison value.", type: "Literal" }]
+        },
+        {
+            code: "typeof foo == 'invalid string'",
+            options: [{ requireStringLiterals: true }],
+            errors: [{ message: "Invalid typeof comparison value.", type: "Literal" }]
+        },
+        {
+            code: "typeof foo == Object",
+            options: [{ requireStringLiterals: true }],
+            errors: [{ message: "Typeof comparisons should be to string literals.", type: "Identifier" }]
+        },
+        {
+            code: "typeof foo === undefined",
+            options: [{ requireStringLiterals: true }],
+            errors: [{ message: "Typeof comparisons should be to string literals.", type: "Identifier" }]
+        },
+        {
+            code: "undefined === typeof foo",
+            options: [{ requireStringLiterals: true }],
+            errors: [{ message: "Typeof comparisons should be to string literals.", type: "Identifier" }]
+        },
+        {
+            code: "undefined == typeof foo",
+            options: [{ requireStringLiterals: true }],
+            errors: [{ message: "Typeof comparisons should be to string literals.", type: "Identifier" }]
         }
     ]
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6698

**What changes did you make? (Give an overview)**

This PR adds a `requireStringLiterals` option to `valid-typeof`, to enforce comparisons to string literals.

**Is there anything you'd like reviewers to focus on?** Not really

I noticed that #6698 hasn't been marked as "accepted" yet, but it seemed like there was enough support that it was worth making this PR. I realize that I'll probably have to wait for that issue to get accepted before this PR gets merged, though.

