### PR TITLE
Docs: Update semantic versioning policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,13 +155,14 @@ ESLint follows [semantic versioning](http://semver.org). However, due to the nat
 * Minor release (might break your lint build)
     * A bug fix in a rule that results in ESLint reporting more errors.
     * A new rule is created.
-    * A new option to an existing rule is created.
+    * A new option to an existing rule that does not result in ESLint reporting more errors by default.
     * An existing rule is deprecated.
     * A new CLI capability is created.
     * New capabilities to the public API are added (new classes, new methods, new arguments to existing methods, etc.).
     * A new formatter is created.
 * Major release (likely to break your lint build)
     * `eslint:recommended` is updated.
+    * A new option to an existing rule that results in ESLint reporting more errors by default.
     * An existing rule is removed.
     * An existing formatter is removed.
     * Part of the public API is removed or changed in an incompatible way.


### PR DESCRIPTION
Updated per TSC meeting 2016-08-18.