### PR TITLE
Fix: `no-trailing-spaces` wrong fixing (fixes #6933)

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -114,6 +114,7 @@ module.exports = {
                         // If the line has only whitespace, and skipBlankLines
                         // is true, don't report it
                         if (skipBlankLines && skipMatch.test(lines[i])) {
+                            totalLength += lineLength;
                             continue;
                         }
 

--- a/tests/lib/rules/no-trailing-spaces.js
+++ b/tests/lib/rules/no-trailing-spaces.js
@@ -383,6 +383,39 @@ ruleTester.run("no-trailing-spaces", rule, {
                     column: 7
                 }
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/6933
+        {
+            code: "    \nabcdefg ",
+            output: "    \nabcdefg",
+            options: [{skipBlankLines: true}],
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 2,
+                    column: 8
+                }
+            ]
+        },
+        {
+            code: "    \nabcdefg ",
+            output: "\nabcdefg",
+            errors: [
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 1,
+                    column: 1
+                },
+                {
+                    message: "Trailing spaces not allowed.",
+                    type: "Program",
+                    line: 2,
+                    column: 8
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
Fixes #6933.

If `skipBlankLines` option is enabled, counting total length for blank lines was lacking.