### PR TITLE
Fix: `object-curly-spacing` for type annotations (fixes #6940)

### DIFF
--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -181,6 +181,30 @@ module.exports = {
         }
 
         /**
+         * Gets '}' token of an object node.
+         *
+         * Because the last token of object patterns might be a type annotation,
+         * this traverses tokens preceded by the last property, then returns the
+         * first '}' token.
+         *
+         * @param {ASTNode} node - The node to get. This node is an
+         *      ObjectExpression or an ObjectPattern. And this node has one or
+         *      more properties.
+         * @returns {Token} '}' token.
+         */
+        function getClosingBraceOfObject(node) {
+            const lastProperty = node.properties[node.properties.length - 1];
+            let token = sourceCode.getTokenAfter(lastProperty);
+
+            // skip ')' and trailing commas.
+            while (token.type !== "Punctuator" || token.value !== "}") {
+                token = sourceCode.getTokenAfter(token);
+            }
+
+            return token;
+        }
+
+        /**
          * Reports a given object node if spacing in curly braces is invalid.
          * @param {ASTNode} node - An ObjectExpression or ObjectPattern node to check.
          * @returns {void}
@@ -191,7 +215,7 @@ module.exports = {
             }
 
             const first = sourceCode.getFirstToken(node),
-                last = sourceCode.getLastToken(node),
+                last = getClosingBraceOfObject(node),
                 second = sourceCode.getTokenAfter(first),
                 penultimate = sourceCode.getTokenBefore(last);
 

--- a/tests/fixtures/parsers/object-curly-spacing/flow-stub-parser-never-invalid.js
+++ b/tests/fixtures/parsers/object-curly-spacing/flow-stub-parser-never-invalid.js
@@ -1,0 +1,607 @@
+"use strict";
+
+/* This returns AST of:
+
+function foo ({a, b }: Props) {
+}
+
+*/
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 34,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 3,
+            "column": 0
+        }
+    },
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "start": 0,
+            "end": 33,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "name": "foo",
+                "range": [
+                    9,
+                    12
+                ],
+                "_babelType": "Identifier"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "ObjectPattern",
+                    "start": 14,
+                    "end": 28,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 28
+                        }
+                    },
+                    "properties": [
+                        {
+                            "type": "Property",
+                            "start": 15,
+                            "end": 16,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 16
+                                }
+                            },
+                            "method": false,
+                            "shorthand": true,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "a",
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "value": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "a",
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "range": [
+                                15,
+                                16
+                            ],
+                            "_babelType": "Property"
+                        },
+                        {
+                            "type": "Property",
+                            "start": 18,
+                            "end": 19,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 19
+                                }
+                            },
+                            "method": false,
+                            "shorthand": true,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    }
+                                },
+                                "name": "b",
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "value": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    }
+                                },
+                                "name": "b",
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "range": [
+                                18,
+                                19
+                            ],
+                            "_babelType": "Property"
+                        }
+                    ],
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 21,
+                        "end": 28,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 21
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 28
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "GenericTypeAnnotation",
+                            "start": 23,
+                            "end": 28,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 23
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 28
+                                }
+                            },
+                            "typeParameters": null,
+                            "id": {
+                                "type": "Identifier",
+                                "start": 23,
+                                "end": 28,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 23
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 28
+                                    }
+                                },
+                                "name": "Props",
+                                "range": [
+                                    23,
+                                    28
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "range": [
+                                23,
+                                28
+                            ],
+                            "_babelType": "GenericTypeAnnotation"
+                        },
+                        "range": [
+                            21,
+                            28
+                        ],
+                        "_babelType": "TypeAnnotation"
+                    },
+                    "range": [
+                        14,
+                        28
+                    ],
+                    "_babelType": "ObjectPattern"
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "start": 30,
+                "end": 33,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 30
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 1
+                    }
+                },
+                "body": [],
+                "range": [
+                    30,
+                    33
+                ],
+                "_babelType": "BlockStatement"
+            },
+            "range": [
+                0,
+                33
+            ],
+            "_babelType": "FunctionDeclaration"
+        }
+    ],
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "range": [
+                9,
+                12
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 13,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                13,
+                14
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 14,
+            "end": 15,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                14,
+                15
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 15,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "range": [
+                15,
+                16
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 18,
+            "end": 19,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            },
+            "range": [
+                18,
+                19
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 21,
+            "end": 22,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "range": [
+                21,
+                22
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "Props",
+            "start": 23,
+            "end": 28,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "range": [
+                23,
+                28
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 28,
+            "end": 29,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 28
+                },
+                "end": {
+                    "line": 1,
+                    "column": 29
+                }
+            },
+            "range": [
+                28,
+                29
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 30,
+            "end": 31,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 30
+                },
+                "end": {
+                    "line": 1,
+                    "column": 31
+                }
+            },
+            "range": [
+                30,
+                31
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 32,
+            "end": 33,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 1
+                }
+            },
+            "range": [
+                32,
+                33
+            ]
+        },
+        {
+            "type": {
+                "label": "eof",
+                "beforeExpr": false,
+                "startsExpr": false,
+                "rightAssociative": false,
+                "isLoop": false,
+                "isAssign": false,
+                "prefix": false,
+                "postfix": false,
+                "binop": null,
+                "updateContext": null
+            },
+            "start": 34,
+            "end": 34,
+            "loc": {
+                "start": {
+                    "line": 3,
+                    "column": 0
+                },
+                "end": {
+                    "line": 3,
+                    "column": 0
+                }
+            },
+            "range": [
+                34,
+                34
+            ]
+        }
+    ],
+    "comments": [],
+    "range": [
+        0,
+        34
+    ]
+});

--- a/tests/fixtures/parsers/object-curly-spacing/flow-stub-parser-never-valid.js
+++ b/tests/fixtures/parsers/object-curly-spacing/flow-stub-parser-never-valid.js
@@ -1,0 +1,607 @@
+"use strict";
+
+/* This returns AST of:
+
+function foo ({a, b}: Props) {
+}
+
+*/
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 32,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 2,
+            "column": 1
+        }
+    },
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "FunctionDeclaration",
+            "start": 0,
+            "end": 32,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 1
+                }
+            },
+            "id": {
+                "type": "Identifier",
+                "start": 9,
+                "end": 12,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 9
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 12
+                    }
+                },
+                "name": "foo",
+                "range": [
+                    9,
+                    12
+                ],
+                "_babelType": "Identifier"
+            },
+            "generator": false,
+            "expression": false,
+            "async": false,
+            "params": [
+                {
+                    "type": "ObjectPattern",
+                    "start": 14,
+                    "end": 27,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 14
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 27
+                        }
+                    },
+                    "properties": [
+                        {
+                            "type": "Property",
+                            "start": 15,
+                            "end": 16,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 15
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 16
+                                }
+                            },
+                            "method": false,
+                            "shorthand": true,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "a",
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "value": {
+                                "type": "Identifier",
+                                "start": 15,
+                                "end": 16,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 15
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 16
+                                    }
+                                },
+                                "name": "a",
+                                "range": [
+                                    15,
+                                    16
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "range": [
+                                15,
+                                16
+                            ],
+                            "_babelType": "Property"
+                        },
+                        {
+                            "type": "Property",
+                            "start": 18,
+                            "end": 19,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 18
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 19
+                                }
+                            },
+                            "method": false,
+                            "shorthand": true,
+                            "computed": false,
+                            "key": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    }
+                                },
+                                "name": "b",
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "kind": "init",
+                            "value": {
+                                "type": "Identifier",
+                                "start": 18,
+                                "end": 19,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 18
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 19
+                                    }
+                                },
+                                "name": "b",
+                                "range": [
+                                    18,
+                                    19
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "range": [
+                                18,
+                                19
+                            ],
+                            "_babelType": "Property"
+                        }
+                    ],
+                    "typeAnnotation": {
+                        "type": "TypeAnnotation",
+                        "start": 20,
+                        "end": 27,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 20
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 27
+                            }
+                        },
+                        "typeAnnotation": {
+                            "type": "GenericTypeAnnotation",
+                            "start": 22,
+                            "end": 27,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 22
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 27
+                                }
+                            },
+                            "typeParameters": null,
+                            "id": {
+                                "type": "Identifier",
+                                "start": 22,
+                                "end": 27,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 22
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 27
+                                    }
+                                },
+                                "name": "Props",
+                                "range": [
+                                    22,
+                                    27
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            "range": [
+                                22,
+                                27
+                            ],
+                            "_babelType": "GenericTypeAnnotation"
+                        },
+                        "range": [
+                            20,
+                            27
+                        ],
+                        "_babelType": "TypeAnnotation"
+                    },
+                    "range": [
+                        14,
+                        27
+                    ],
+                    "_babelType": "ObjectPattern"
+                }
+            ],
+            "body": {
+                "type": "BlockStatement",
+                "start": 29,
+                "end": 32,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 29
+                    },
+                    "end": {
+                        "line": 2,
+                        "column": 1
+                    }
+                },
+                "body": [],
+                "range": [
+                    29,
+                    32
+                ],
+                "_babelType": "BlockStatement"
+            },
+            "range": [
+                0,
+                32
+            ],
+            "_babelType": "FunctionDeclaration"
+        }
+    ],
+    "tokens": [
+        {
+            "type": "Keyword",
+            "value": "function",
+            "start": 0,
+            "end": 8,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                0,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "foo",
+            "start": 9,
+            "end": 12,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 12
+                }
+            },
+            "range": [
+                9,
+                12
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 13,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 13
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                13,
+                14
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 14,
+            "end": 15,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                14,
+                15
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "a",
+            "start": 15,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 15
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "range": [
+                15,
+                16
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "b",
+            "start": 18,
+            "end": 19,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 18
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            },
+            "range": [
+                18,
+                19
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 19,
+            "end": 20,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 19
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            },
+            "range": [
+                19,
+                20
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "Props",
+            "start": 22,
+            "end": 27,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 22
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "range": [
+                22,
+                27
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 27,
+            "end": 28,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "range": [
+                27,
+                28
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 29,
+            "end": 30,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 29
+                },
+                "end": {
+                    "line": 1,
+                    "column": 30
+                }
+            },
+            "range": [
+                29,
+                30
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 31,
+            "end": 32,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 0
+                },
+                "end": {
+                    "line": 2,
+                    "column": 1
+                }
+            },
+            "range": [
+                31,
+                32
+            ]
+        },
+        {
+            "type": {
+                "label": "eof",
+                "beforeExpr": false,
+                "startsExpr": false,
+                "rightAssociative": false,
+                "isLoop": false,
+                "isAssign": false,
+                "prefix": false,
+                "postfix": false,
+                "binop": null,
+                "updateContext": null
+            },
+            "start": 32,
+            "end": 32,
+            "loc": {
+                "start": {
+                    "line": 2,
+                    "column": 1
+                },
+                "end": {
+                    "line": 2,
+                    "column": 1
+                }
+            },
+            "range": [
+                32,
+                32
+            ]
+        }
+    ],
+    "comments": [],
+    "range": [
+        0,
+        32
+    ]
+});

--- a/tests/lib/rules/object-curly-spacing.js
+++ b/tests/lib/rules/object-curly-spacing.js
@@ -8,7 +8,8 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/object-curly-spacing"),
+const resolvePath = require("path").resolve,
+    rule = require("../../../lib/rules/object-curly-spacing"),
     RuleTester = require("../../../lib/testers/rule-tester");
 
 //------------------------------------------------------------------------------
@@ -138,7 +139,14 @@ ruleTester.run("object-curly-spacing", rule, {
         { code: "var {a: []} = foo;", options: ["never"], parserOptions: { ecmaVersion: 6 }},
         { code: "import {} from 'foo';", options: ["never"], parserOptions: { sourceType: "module" }},
         { code: "export {} from 'foo';", options: ["never"], parserOptions: { sourceType: "module" }},
-        { code: "export {};", options: ["never"], parserOptions: { sourceType: "module" }}
+        { code: "export {};", options: ["never"], parserOptions: { sourceType: "module" }},
+
+        // https://github.com/eslint/eslint/issues/6940
+        {
+            code: "function foo ({a, b}: Props) {\n}",
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-spacing/flow-stub-parser-never-valid"),
+            options: ["never"]
+        }
     ],
 
     invalid: [
@@ -749,6 +757,20 @@ ruleTester.run("object-curly-spacing", rule, {
                 {
                     message: "A space is required before '}'.",
                     type: "ObjectExpression"
+                }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/6940
+        {
+            code: "function foo ({a, b }: Props) {\n}",
+            output: "function foo ({a, b}: Props) {\n}",
+            parser: resolvePath(__dirname, "../../fixtures/parsers/object-curly-spacing/flow-stub-parser-never-invalid"),
+            options: ["never"],
+            errors: [
+                {
+                    message: "There should be no space before '}'.",
+                    type: "ObjectPattern"
                 }
             ]
         }


### PR DESCRIPTION
Fixes #6940.

This PR changes the way to find '}' token.

I followed #6723 about the way of tests.