### PR TITLE
Update: add fixer for no-extra-parens (fixes #6944)

### DIFF
--- a/docs/rules/no-extra-parens.md
+++ b/docs/rules/no-extra-parens.md
@@ -1,5 +1,7 @@
 # disallow unnecessary parentheses (no-extra-parens)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 This rule restricts the use of parentheses to only where they are necessary.
 
 ## Rule Details

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 const astUtils = require("../ast-utils.js");
+const esUtils = require("esutils");
 
 module.exports = {
     meta: {
@@ -17,6 +18,8 @@ module.exports = {
             category: "Possible Errors",
             recommended: false
         },
+
+        fixable: "code",
 
         schema: {
             anyOf: [
@@ -257,15 +260,63 @@ module.exports = {
         }
 
         /**
+         * Determines whether a node should be preceded by an additional space when removing parens
+         * @param {ASTNode} node node to evaluate; must be surrounded by parentheses
+         * @returns {boolean} `true` if a space should be inserted before the node
+         * @private
+         */
+        function requiresLeadingSpace(node) {
+            const leftParenToken = sourceCode.getTokenBefore(node);
+            const tokenBeforeLeftParen = sourceCode.getTokenBefore(node, 1);
+            const firstToken = sourceCode.getFirstToken(node);
+
+            // If there is already whitespace before the previous token, don't add more.
+            if (!tokenBeforeLeftParen || tokenBeforeLeftParen.end !== leftParenToken.start) {
+                return false;
+            }
+
+            // If the parens are preceded by a keyword (e.g. `typeof(0)`), a space should be inserted (`typeof 0`)
+            const precededByKeyword = tokenBeforeLeftParen.type === "Keyword";
+
+            // However, a space should not be inserted unless the first character of the token is an identifier part
+            // e.g. `typeof([])` should be fixed to `typeof[]`
+            const startsWithIdentifierPart = esUtils.code.isIdentifierPartES6(firstToken.value.charCodeAt(0));
+
+            // If the parens are preceded by and start with a unary plus/minus (e.g. `+(+foo)`), a space should be inserted (`+ +foo`)
+            const precededByUnaryPlus = tokenBeforeLeftParen.type === "Punctuator" && tokenBeforeLeftParen.value === "+";
+            const precededByUnaryMinus = tokenBeforeLeftParen.type === "Punctuator" && tokenBeforeLeftParen.value === "-";
+
+            const startsWithUnaryPlus = firstToken.type === "Punctuator" && firstToken.value === "+";
+            const startsWithUnaryMinus = firstToken.type === "Punctuator" && firstToken.value === "-";
+
+            return (precededByKeyword && startsWithIdentifierPart) ||
+                (precededByUnaryPlus && startsWithUnaryPlus) ||
+                (precededByUnaryMinus && startsWithUnaryMinus);
+        }
+
+        /**
          * Report the node
          * @param {ASTNode} node node to evaluate
          * @returns {void}
          * @private
          */
         function report(node) {
-            const previousToken = sourceCode.getTokenBefore(node);
+            const leftParenToken = sourceCode.getTokenBefore(node);
+            const rightParenToken = sourceCode.getTokenAfter(node);
 
-            context.report(node, previousToken.loc.start, "Gratuitous parentheses around expression.");
+            context.report({
+                node,
+                loc: leftParenToken.loc.start,
+                message: "Gratuitous parentheses around expression.",
+                fix(fixer) {
+                    const parenthesizedSource = sourceCode.text.slice(leftParenToken.range[1], rightParenToken.range[0]);
+
+                    return fixer.replaceTextRange([
+                        leftParenToken.range[0],
+                        rightParenToken.range[1]
+                    ], (requiresLeadingSpace(node) ? " " : "") + parenthesizedSource);
+                }
+            });
         }
 
         /**


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6944 

**What changes did you make? (Give an overview)**

This adds an autofixer to `no-extra-parens`, allowing it to be fixed automatically with the `--fix` option.


**Is there anything you'd like reviewers to focus on?**

#6944 has not been marked as accepted yet, so this PR shouldn't be merged until it is.

It's probably worth double-checking [this logic](/eslint/eslint/blob/185da9e73f9542e6fe54995e9a10f218724149fa/lib/rules/no-extra-parens.js#L279-L285) to make sure there are no other special cases that need to be addressed.

