### PR TITLE
Shareable plugins

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -98,11 +98,40 @@ module.exports = {
 
     /**
      * Loads a plugin with the given name.
-     * @param {string} pluginName The name of the plugin to load.
+     * @param {string | Object} pluginName The name of the plugin to load
+                                or an Object with the plugin's details.
      * @returns {void}
      * @throws {Error} If the plugin cannot be loaded.
      */
     load(pluginName) {
+        let loadPlugin = require;
+
+        if (typeof pluginName === "object") {
+            const pluginDefinition = pluginName;
+
+            if (typeof pluginDefinition.name !== "string") {
+                const err = new Error("Failed to load plugin " + JSON.stringify(pluginDefinition) + ". Missing name field. Proceeding without it.");
+
+                debug(err.message);
+                err.messageTemplate = "plugin-missing";
+                err.messageData = {
+                    pluginName: "unknown"
+                };
+                throw err;
+            }
+            pluginName = pluginDefinition.name;
+            if (typeof pluginDefinition.load !== "function") {
+                const err = new Error("Failed to load plugin eslint-plugin-" + removePrefix(pluginName) + ". Missing load function. Proceeding without it.");
+
+                debug(err.message);
+                err.messageTemplate = "plugin-missing";
+                err.messageData = {
+                    pluginName: removePrefix(pluginName)
+                };
+                throw err;
+            }
+            loadPlugin = pluginDefinition.load;
+        }
         const pluginNamespace = getNamespace(pluginName),
             pluginNameWithoutNamespace = removeNamespace(pluginName),
             pluginNameWithoutPrefix = removePrefix(pluginNameWithoutNamespace);
@@ -110,7 +139,7 @@ module.exports = {
 
         if (!plugins[pluginNameWithoutPrefix]) {
             try {
-                plugin = require(pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
+                plugin = loadPlugin(pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix);
             } catch (err) {
                 debug("Failed to load plugin eslint-plugin-" + pluginNameWithoutPrefix + ". Proceeding without it.");
                 err.message = "Failed to load plugin " + pluginName + ": " + err.message;

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -54,6 +54,14 @@ describe("Plugins", function() {
             assert.equal(StubbedPlugins.get("example"), plugin);
         });
 
+        it("should load a plugin when using custom load", function() {
+            StubbedPlugins.load({name: "example", load(fullName) {
+                assert.equal(fullName, "eslint-plugin-example");
+                return plugin;
+            }});
+            assert.equal(StubbedPlugins.get("example"), plugin);
+        });
+
         it("should register environments when plugin has environments", function() {
             plugin.environments = {
                 foo: {
@@ -85,6 +93,25 @@ describe("Plugins", function() {
         it("should throw an error when a plugin doesn't exist", function() {
             assert.throws(function() {
                 StubbedPlugins.load("nonexistentplugin");
+            }, /Failed to load plugin/);
+        });
+
+        it("should throw an error when on a malformed plugin definition", function() {
+            assert.throws(function() {
+                StubbedPlugins.load({});
+            }, /Failed to load plugin/);
+            assert.throws(function() {
+                StubbedPlugins.load({
+                    name() {
+                        return "example";
+                    }
+                });
+            }, /Failed to load plugin/);
+            assert.throws(function() {
+                StubbedPlugins.load({ name: "example" });
+            }, /Failed to load plugin/);
+            assert.throws(function() {
+                StubbedPlugins.load({ name: "example", load: "require" });
             }, /Failed to load plugin/);
         });
 


### PR DESCRIPTION
**What issue does this pull request address?**
#3458

**What changes did you make? (Give an overview)**
Allow the plugin to be an object with a `name` and `load` field instead of only a string in order to load the plugin from the config's scope.
This allows shareable configs to define plugins as such

```js
module.exports = {
  plugins: [
    {name: "some-plugin", load: require}
  ]
};
```

The `load` field needs to be a function, thus this format is only available for javascript configuration.

**Is there anything you'd like reviewers to focus on?**
Should focus on possible impacts an object in the plugins list could have.
The main place I am unsure is when merging configurations.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eslint/eslint/6951)
<!-- Reviewable:end -->
