### PR TITLE
Update: Add `always`/`never` option to `eol-last` (fixes #6938)

### DIFF
--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -1,4 +1,4 @@
-# Require or disallow file to end with single newline (eol-last)
+# require or disallow newline at the end of files (eol-last)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -43,7 +43,9 @@ This rule has a string option:
 * `"always"` (default) enforces that files end with a newline
 * `"never"` enforces that files do not end with a newline
 
+**Deprecated:** The string options `"windows"` and `"unix"` are deprecated. Please use the `style` property in the object option instead.
+
 This rule has an object option to adjust the behavior of the `"always"` option:
 
-* `"unix"` (default) enforces line feed (LF) as newline
-* `"windows"` enforces carriage return line feed (CRLF) as newline
+* `"style": "unix"` (default) enforces a line feed (LF) as newline
+* `"style": "windows"` enforces a carriage return line feed (CRLF) as newline

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -1,4 +1,4 @@
-# Require file to end with single newline (eol-last)
+# Require or disallow file to end with single newline (eol-last)
 
 (fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
 
@@ -42,4 +42,4 @@ This rule has a string option:
 
 * `"unix"` (default) enforces line feed (LF) as newline
 * `"windows"` enforces carriage return line feed (CRLF) as newline
-* `"none"` enforces that the last line ends with neither LF nor CRLF as newline
+* `"none"` enforces that the last line does not end with a newline

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -8,7 +8,8 @@ as output files to the terminal without interfering with shell prompts.
 
 ## Rule Details
 
-This rule requires at least one newline at the end of non-empty files.
+This rule enforces at least one newline (or absence thereof) at the end
+of non-empty files.
 
 Prior to v0.16.0 this rule also enforced that there was only a single line at
 the end of the file. If you still want this behaviour, consider enabling
@@ -32,8 +33,7 @@ Examples of **correct** code for this rule:
 
 function doSmth() {
   var foo = 2;
-}
-
+}\n
 ```
 
 ## Options
@@ -42,3 +42,4 @@ This rule has a string option:
 
 * `"unix"` (default) enforces line feed (LF) as newline
 * `"windows"` enforces carriage return line feed (CRLF) as newline
+* `"none"` enforces that the last line ends with neither LF nor CRLF as newline

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -40,6 +40,10 @@ function doSmth() {
 
 This rule has a string option:
 
+* `"always"` (default) enforces that files end with a newline
+* `"never"` enforces that files do not end with a newline
+
+This rule has an object option to adjust the behavior of the `"always"` option:
+
 * `"unix"` (default) enforces line feed (LF) as newline
 * `"windows"` enforces carriage return line feed (CRLF) as newline
-* `"none"` enforces that the last line does not end with a newline

--- a/docs/rules/eol-last.md
+++ b/docs/rules/eol-last.md
@@ -40,12 +40,9 @@ function doSmth() {
 
 This rule has a string option:
 
-* `"always"` (default) enforces that files end with a newline
+* `"always"` (default) enforces that files end with a newline (LF)
 * `"never"` enforces that files do not end with a newline
+* `"unix"` (deprecated) is identical to "always"
+* `"windows"` (deprecated) is identical to "always", but will use a CRLF character when autofixing
 
-**Deprecated:** The string options `"windows"` and `"unix"` are deprecated. Please use the `style` property in the object option instead.
-
-This rule has an object option to adjust the behavior of the `"always"` option:
-
-* `"style": "unix"` (default) enforces a line feed (LF) as newline
-* `"style": "windows"` enforces a carriage return line feed (CRLF) as newline
+**Deprecated:** The options `"unix"` and `"windows"` are deprecated. If you need to enforce a specific linebreak style, use this rule in conjunction with `linebreak-style`.

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -1,8 +1,15 @@
 /**
  * @fileoverview Require or disallow file to end with single newline.
  * @author Nodeca Team <https://github.com/nodeca>
+ * @author kdex <https://github.com/kdex>
  */
 "use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const lodash = require("lodash");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -15,16 +22,23 @@ module.exports = {
             category: "Stylistic Issues",
             recommended: false
         },
-
         fixable: "whitespace",
-
         schema: [
             {
-                enum: ["unix", "windows", "none"]
+                enum: ["always", "never", "unix", "windows"]
+            },
+            {
+                type: "object",
+                properties: {
+                    style: {
+                        type: "string"
+                    }
+                },
+                required: ["style"],
+                additionalProperties: false
             }
         ]
     },
-
     create(context) {
 
         //--------------------------------------------------------------------------
@@ -32,7 +46,6 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-
             Program: function checkBadEOF(node) {
                 const sourceCode = context.getSourceCode(),
                     src = sourceCode.getText(),
@@ -40,20 +53,32 @@ module.exports = {
                         column: 1,
                         line: sourceCode.lines.length
                     },
-                    linebreakStyle = context.options[0] || "unix",
                     linebreaks = {
                         unix: "\n",
-                        windows: "\r\n",
-                        none: ""
+                        windows: "\r\n"
                     },
-                    linebreak = linebreaks[linebreakStyle],
-                    lastCharacter = src[src.length - 1],
-                    endsWithNewline = lastCharacter === "\n";
+                    endsWithNewline = lodash.endsWith(src, "\n");
 
-                if (linebreakStyle !== "none") {
+                let useEOLs = context.options[0] || "always",
+                    options = context.options[1] || { style: "unix" },
+                    linebreak = "";
+
+                // Normalize arguments
+                if (!context.options[1]) {
+                    if (useEOLs !== "always" && useEOLs !== "never") {
+
+                        // Deprecated arguments; user has provided style only
+                        options = {
+                            style: useEOLs
+                        };
+                        useEOLs = "always";
+                    }
+                }
+                if (useEOLs === "always") {
+                    linebreak = linebreaks[options.style];
                     if (!endsWithNewline) {
 
-                        // file is not newline-terminated
+                        // File is not newline-terminated, but should be
                         context.report({
                             node,
                             loc: location,
@@ -62,10 +87,51 @@ module.exports = {
                                 return fixer.insertTextAfterRange([0, src.length], linebreak);
                             }
                         });
-                    }
-                } else if (endsWithNewline) {
+                    } else {
 
-                    // file is newline-terminated
+                        // File is newline-terminated, but it might be the wrong EOL
+                        if (linebreak === linebreaks.windows) {
+
+                            // For CRLF, it's enough to check if the file ends with CRLF
+                            if (!lodash.endsWith(src, linebreaks.windows)) {
+                                context.report({
+                                    node,
+                                    loc: location,
+                                    message: "Expected a Windows newline and instead found a Unix newline.",
+                                    fix(fixer) {
+                                        const finalEOL = /(?:\n)$/,
+                                            match = finalEOL.exec(sourceCode.text),
+                                            start = match.index,
+                                            end = sourceCode.text.length;
+
+                                        return fixer.replaceTextRange([start, end], linebreak);
+                                    }
+                                });
+                            }
+                        } else if (linebreak === linebreaks.unix) {
+
+                            // For LF, we must instead check that there's no CRLF.
+                            // This is necessary since both CRLF and LF end with LF.
+                            if (lodash.endsWith(src, linebreaks.windows)) {
+                                context.report({
+                                    node,
+                                    loc: location,
+                                    message: "Expected a Unix newline and instead found a Windows newline.",
+                                    fix(fixer) {
+                                        const finalEOL = /(?:\r\n)$/,
+                                            match = finalEOL.exec(sourceCode.text),
+                                            start = match.index,
+                                            end = sourceCode.text.length;
+
+                                        return fixer.replaceTextRange([start, end], linebreak);
+                                    }
+                                });
+                            }
+                        }
+                    }
+                } else if (useEOLs === "never" && endsWithNewline) {
+
+                    // File is newline-terminated, but shouldn't be
                     context.report({
                         node,
                         loc: location,
@@ -81,8 +147,6 @@ module.exports = {
                     });
                 }
             }
-
         };
-
     }
 };

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -1,7 +1,6 @@
 /**
  * @fileoverview Require or disallow file to end with single newline.
  * @author Nodeca Team <https://github.com/nodeca>
- * @author kdex <https://github.com/kdex>
  */
 "use strict";
 
@@ -18,7 +17,7 @@ const lodash = require("lodash");
 module.exports = {
     meta: {
         docs: {
-            description: "enforce at least one newline (or absence thereof) at the end of files",
+            description: "require or disallow newline at the end of files",
             category: "Stylistic Issues",
             recommended: false
         },

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Require file to end with single newline.
+ * @fileoverview Require or disallow file to end with single newline.
  * @author Nodeca Team <https://github.com/nodeca>
  */
 "use strict";
@@ -11,7 +11,7 @@
 module.exports = {
     meta: {
         docs: {
-            description: "enforce at least one newline at the end of files",
+            description: "enforce at least one newline (or absence thereof) at the end of files",
             category: "Stylistic Issues",
             recommended: false
         },

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Require or disallow file to end with single newline.
+ * @fileoverview Require or disallow newline at the end of files
  * @author Nodeca Team <https://github.com/nodeca>
  */
 "use strict";

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -20,7 +20,7 @@ module.exports = {
 
         schema: [
             {
-                enum: ["unix", "windows"]
+                enum: ["unix", "windows", "none"]
             }
         ]
     },
@@ -34,23 +34,49 @@ module.exports = {
         return {
 
             Program: function checkBadEOF(node) {
-
                 const sourceCode = context.getSourceCode(),
                     src = sourceCode.getText(),
-                    location = {column: 1},
+                    location = {
+                        column: 1,
+                        line: sourceCode.lines.length
+                    },
                     linebreakStyle = context.options[0] || "unix",
-                    linebreak = linebreakStyle === "unix" ? "\n" : "\r\n";
+                    linebreaks = {
+                        unix: "\n",
+                        windows: "\r\n",
+                        none: ""
+                    },
+                    linebreak = linebreaks[linebreakStyle],
+                    lastCharacter = src[src.length - 1],
+                    endsWithNewline = lastCharacter === "\n";
 
-                if (src[src.length - 1] !== "\n") {
+                if (linebreakStyle !== "none") {
+                    if (!endsWithNewline) {
 
-                    // file is not newline-terminated
-                    location.line = src.split(/\n/g).length;
+                        // file is not newline-terminated
+                        context.report({
+                            node,
+                            loc: location,
+                            message: "Newline required at end of file but not found.",
+                            fix(fixer) {
+                                return fixer.insertTextAfterRange([0, src.length], linebreak);
+                            }
+                        });
+                    }
+                } else if (endsWithNewline) {
+
+                    // file is newline-terminated
                     context.report({
                         node,
                         loc: location,
-                        message: "Newline required at end of file but not found.",
+                        message: "Newline not allowed at end of file.",
                         fix(fixer) {
-                            return fixer.insertTextAfterRange([0, src.length], linebreak);
+                            const finalEOLs = /(?:\r?\n)+$/,
+                                match = finalEOLs.exec(sourceCode.text),
+                                start = match.index,
+                                end = sourceCode.text.length;
+
+                            return fixer.replaceTextRange([start, end], "");
                         }
                     });
                 }

--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -26,16 +26,6 @@ module.exports = {
         schema: [
             {
                 enum: ["always", "never", "unix", "windows"]
-            },
-            {
-                type: "object",
-                properties: {
-                    style: {
-                        type: "string"
-                    }
-                },
-                required: ["style"],
-                additionalProperties: false
             }
         ]
     },
@@ -53,83 +43,36 @@ module.exports = {
                         column: 1,
                         line: sourceCode.lines.length
                     },
-                    linebreaks = {
-                        unix: "\n",
-                        windows: "\r\n"
-                    },
-                    endsWithNewline = lodash.endsWith(src, "\n");
+                    LF = "\n",
+                    CRLF = "\r" + LF,
+                    endsWithNewline = lodash.endsWith(src, LF);
 
-                let useEOLs = context.options[0] || "always",
-                    options = context.options[1] || { style: "unix" },
-                    linebreak = "";
+                let mode = context.options[0] || "always",
+                    appendCRLF = false;
 
-                // Normalize arguments
-                if (!context.options[1]) {
-                    if (useEOLs !== "always" && useEOLs !== "never") {
+                if (mode === "unix") {
 
-                        // Deprecated arguments; user has provided style only
-                        options = {
-                            style: useEOLs
-                        };
-                        useEOLs = "always";
-                    }
+                    // `"unix"` should behave exactly as `"always"`
+                    mode = "always";
                 }
-                if (useEOLs === "always") {
-                    linebreak = linebreaks[options.style];
-                    if (!endsWithNewline) {
+                if (mode === "windows") {
 
-                        // File is not newline-terminated, but should be
-                        context.report({
-                            node,
-                            loc: location,
-                            message: "Newline required at end of file but not found.",
-                            fix(fixer) {
-                                return fixer.insertTextAfterRange([0, src.length], linebreak);
-                            }
-                        });
-                    } else {
+                    // `"windows"` should behave exactly as `"always"`, but append CRLF in the fixer for backwards compatibility
+                    mode = "always";
+                    appendCRLF = true;
+                }
+                if (mode === "always" && !endsWithNewline) {
 
-                        // File is newline-terminated, but it might be the wrong EOL
-                        if (linebreak === linebreaks.windows) {
-
-                            // For CRLF, it's enough to check if the file ends with CRLF
-                            if (!lodash.endsWith(src, linebreaks.windows)) {
-                                context.report({
-                                    node,
-                                    loc: location,
-                                    message: "Expected a Windows newline and instead found a Unix newline.",
-                                    fix(fixer) {
-                                        const finalEOL = /(?:\n)$/,
-                                            match = finalEOL.exec(sourceCode.text),
-                                            start = match.index,
-                                            end = sourceCode.text.length;
-
-                                        return fixer.replaceTextRange([start, end], linebreak);
-                                    }
-                                });
-                            }
-                        } else if (linebreak === linebreaks.unix) {
-
-                            // For LF, we must instead check that there's no CRLF.
-                            // This is necessary since both CRLF and LF end with LF.
-                            if (lodash.endsWith(src, linebreaks.windows)) {
-                                context.report({
-                                    node,
-                                    loc: location,
-                                    message: "Expected a Unix newline and instead found a Windows newline.",
-                                    fix(fixer) {
-                                        const finalEOL = /(?:\r\n)$/,
-                                            match = finalEOL.exec(sourceCode.text),
-                                            start = match.index,
-                                            end = sourceCode.text.length;
-
-                                        return fixer.replaceTextRange([start, end], linebreak);
-                                    }
-                                });
-                            }
+                    // File is not newline-terminated, but should be
+                    context.report({
+                        node,
+                        loc: location,
+                        message: "Newline required at end of file but not found.",
+                        fix(fixer) {
+                            return fixer.insertTextAfterRange([0, src.length], appendCRLF ? CRLF : LF);
                         }
-                    }
-                } else if (useEOLs === "never" && endsWithNewline) {
+                    });
+                } else if (mode === "never" && endsWithNewline) {
 
                     // File is newline-terminated, but shouldn't be
                     context.report({

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -1,6 +1,7 @@
 /**
- * @fileoverview Check, that file is ended with newline, and there are no multiple empty lines at the end.
+ * @fileoverview Tests for eol-last rule.
  * @author Nodeca Team <https://github.com/nodeca>
+ * @author kdex <https://github.com/kdex>
  */
 "use strict";
 
@@ -26,14 +27,33 @@ ruleTester.run("eol-last", rule, {
         "var a = 123;\n\n",
         "var a = 123;\n   \n",
 
-        "\r\n",
-        "var a = 123;\r\n",
-        "var a = 123;\r\n\r\n",
-        "var a = 123;\r\n   \r\n",
+        { code: "", options: ["unix"] },
+        { code: "\n", options: ["unix"] },
+        { code: "var a = 123;\n", options: ["unix"] },
+        { code: "var a = 123;\n\n", options: ["unix"] },
+        { code: "var a = 123;\n   \n", options: ["unix"] },
 
-        { code: "var a = 123;", options: ["none"] },
-        { code: "var a = 123;\nvar b = 456;", options: ["none"] },
-        { code: "var a = 123;\r\nvar b = 456;", options: ["none"] }
+        { code: "", options: ["always", { style: "unix"} ] },
+        { code: "\n", options: ["always", { style: "unix"} ] },
+        { code: "var a = 123;\n", options: ["always", { style: "unix"} ] },
+        { code: "var a = 123;\n\n", options: ["always", { style: "unix"} ] },
+        { code: "var a = 123;\n   \n", options: ["always", { style: "unix"} ] },
+
+        { code: "", options: ["windows"] },
+        { code: "\r\n", options: ["windows"] },
+        { code: "var a = 123;\r\n", options: ["windows"] },
+        { code: "var a = 123;\r\n\r\n", options: ["windows"] },
+        { code: "var a = 123;\r\n   \r\n", options: ["windows"] },
+
+        { code: "", options: ["always", { style: "windows" }] },
+        { code: "\r\n", options: ["always", { style: "windows" }] },
+        { code: "var a = 123;\r\n", options: ["always", { style: "windows" }] },
+        { code: "var a = 123;\r\n\r\n", options: ["always", { style: "windows" }] },
+        { code: "var a = 123;\r\n   \r\n", options: ["always", { style: "windows" }] },
+
+        { code: "var a = 123;", options: ["never"] },
+        { code: "var a = 123;\nvar b = 456;", options: ["never"] },
+        { code: "var a = 123;\r\nvar b = 456;", options: ["never"] }
     ],
 
     invalid: [
@@ -44,6 +64,66 @@ ruleTester.run("eol-last", rule, {
         },
         {
             code: "var a = 123;\n   ",
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\n   \n"
+        },
+        {
+            code: "var a = 123;",
+            options: ["unix"],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\n"
+        },
+        {
+            code: "var a = 123;\n   ",
+            options: ["unix"],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\n   \n"
+        },
+        {
+            code: "var a = 123;\r\n",
+            options: ["unix"],
+            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
+            output: "var a = 123;\n"
+        },
+        {
+            code: "var a = 123;\r\n\r\n",
+            options: ["unix"],
+            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
+            output: "var a = 123;\r\n\n"
+        },
+        {
+            code: "var a = 123;\r\n   \r\n",
+            options: ["unix"],
+            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
+            output: "var a = 123;\r\n   \n"
+        },
+        {
+            code: "var a = 123;",
+            options: ["always", { style: "unix" }],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\n"
+        },
+        {
+            code: "var a = 123;\r\n",
+            options: ["always", { style: "unix" }],
+            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
+            output: "var a = 123;\n"
+        },
+        {
+            code: "var a = 123;\r\n\r\n",
+            options: ["always", { style: "unix" }],
+            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
+            output: "var a = 123;\r\n\n"
+        },
+        {
+            code: "var a = 123;\r\n   \r\n",
+            options: ["always", { style: "unix" }],
+            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
+            output: "var a = 123;\r\n   \n"
+        },
+        {
+            code: "var a = 123;\n   ",
+            options: ["always", { style: "unix" }],
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
             output: "var a = 123;\n   \n"
         },
@@ -61,33 +141,81 @@ ruleTester.run("eol-last", rule, {
         },
         {
             code: "var a = 123;\n",
-            options: ["none"],
+            options: ["windows"],
+            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
+            output: "var a = 123;\r\n"
+        },
+        {
+            code: "var a = 123;\r\n\n",
+            options: ["windows"],
+            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
+            output: "var a = 123;\r\n\r\n"
+        },
+        {
+            code: "var a = 123;\n   \n",
+            options: ["windows"],
+            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
+            output: "var a = 123;\n   \r\n"
+        },
+        {
+            code: "var a = 123;",
+            options: ["always", { style: "windows" }],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\r\n"
+        },
+        {
+            code: "var a = 123;\r\n   ",
+            options: ["always", { style: "windows" }],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\r\n   \r\n"
+        },
+        {
+            code: "var a = 123;\n",
+            options: ["always", { style: "windows" }],
+            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
+            output: "var a = 123;\r\n"
+        },
+        {
+            code: "var a = 123;\r\n\n",
+            options: ["always", { style: "windows" }],
+            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
+            output: "var a = 123;\r\n\r\n"
+        },
+        {
+            code: "var a = 123;\n   \n",
+            options: ["always", { style: "windows" }],
+            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
+            output: "var a = 123;\n   \r\n"
+        },
+        {
+            code: "var a = 123;\n",
+            options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
             output: "var a = 123;"
         },
         {
             code: "var a = 123;\r\n",
-            options: ["none"],
+            options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
             output: "var a = 123;"
         },
         {
             code: "var a = 123;\r\n\r\n",
-            options: ["none"],
+            options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
             output: "var a = 123;"
         },
         {
-            code: "var a = 123;\nvar b = 456;\n",
-            options: ["none"],
+            code: "var a = 123;\nvar a = 456;\n",
+            options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
-            output: "var a = 123;\nvar b = 456;"
+            output: "var a = 123;\nvar a = 456;"
         },
         {
-            code: "var a = 123;\r\nvar b = 456;\r\n",
-            options: ["none"],
+            code: "var a = 123;\r\nvar a = 456;\r\n",
+            options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
-            output: "var a = 123;\r\nvar b = 456;"
+            output: "var a = 123;\r\nvar a = 456;"
         }
     ]
 });

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -54,6 +54,24 @@ ruleTester.run("eol-last", rule, {
             options: ["windows"],
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
             output: "var a = 123;\r\n   \r\n"
+        },
+        {
+            code: "var a = 123;\n",
+            options: ["none"],
+            errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
+            output: "var a = 123;"
+        },
+        {
+            code: "var a = 123;\r\n",
+            options: ["none"],
+            errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
+            output: "var a = 123;"
+        },
+        {
+            code: "var a = 123;\r\n\r\n",
+            options: ["none"],
+            errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
+            output: "var a = 123;"
         }
     ]
 });

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -206,16 +206,16 @@ ruleTester.run("eol-last", rule, {
             output: "var a = 123;"
         },
         {
-            code: "var a = 123;\nvar a = 456;\n",
+            code: "var a = 123;\nvar b = 456;\n",
             options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
-            output: "var a = 123;\nvar a = 456;"
+            output: "var a = 123;\nvar b = 456;"
         },
         {
-            code: "var a = 123;\r\nvar a = 456;\r\n",
+            code: "var a = 123;\r\nvar b = 456;\r\n",
             options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
-            output: "var a = 123;\r\nvar a = 456;"
+            output: "var a = 123;\r\nvar b = 456;"
         }
     ]
 });

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -1,7 +1,6 @@
 /**
  * @fileoverview Tests for eol-last rule.
  * @author Nodeca Team <https://github.com/nodeca>
- * @author kdex <https://github.com/kdex>
  */
 "use strict";
 
@@ -27,22 +26,29 @@ ruleTester.run("eol-last", rule, {
         "var a = 123;\n\n",
         "var a = 123;\n   \n",
 
+        "\r\n",
+        "var a = 123;\r\n",
+        "var a = 123;\r\n\r\n",
+        "var a = 123;\r\n   \r\n",
+
+        { code: "var a = 123;", options: ["never"] },
+        { code: "var a = 123;\nvar b = 456;", options: ["never"] },
+        { code: "var a = 123;\r\nvar b = 456;", options: ["never"] },
+
+        // Deprecated: `"unix"` parameter
         { code: "", options: ["unix"] },
         { code: "\n", options: ["unix"] },
         { code: "var a = 123;\n", options: ["unix"] },
         { code: "var a = 123;\n\n", options: ["unix"] },
         { code: "var a = 123;\n   \n", options: ["unix"] },
 
+        // Deprecated: `"windows"` parameter
         { code: "", options: ["windows"] },
         { code: "\n", options: ["windows"] },
         { code: "\r\n", options: ["windows"] },
         { code: "var a = 123;\r\n", options: ["windows"] },
         { code: "var a = 123;\r\n\r\n", options: ["windows"] },
-        { code: "var a = 123;\r\n   \r\n", options: ["windows"] },
-
-        { code: "var a = 123;", options: ["never"] },
-        { code: "var a = 123;\nvar b = 456;", options: ["never"] },
-        { code: "var a = 123;\r\nvar b = 456;", options: ["never"] }
+        { code: "var a = 123;\r\n   \r\n", options: ["windows"] }
     ],
 
     invalid: [
@@ -55,30 +61,6 @@ ruleTester.run("eol-last", rule, {
             code: "var a = 123;\n   ",
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
             output: "var a = 123;\n   \n"
-        },
-        {
-            code: "var a = 123;",
-            options: ["unix"],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\n"
-        },
-        {
-            code: "var a = 123;\n   ",
-            options: ["unix"],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\n   \n"
-        },
-        {
-            code: "var a = 123;",
-            options: ["windows"],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\r\n"
-        },
-        {
-            code: "var a = 123;\r\n   ",
-            options: ["windows"],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\r\n   \r\n"
         },
         {
             code: "var a = 123;\n",
@@ -109,6 +91,34 @@ ruleTester.run("eol-last", rule, {
             options: ["never"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
             output: "var a = 123;\r\nvar b = 456;"
+        },
+
+        // Deprecated: `"unix"` parameter
+        {
+            code: "var a = 123;",
+            options: ["unix"],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\n"
+        },
+        {
+            code: "var a = 123;\n   ",
+            options: ["unix"],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\n   \n"
+        },
+
+        // Deprecated: `"windows"` parameter
+        {
+            code: "var a = 123;",
+            options: ["windows"],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\r\n"
+        },
+        {
+            code: "var a = 123;\r\n   ",
+            options: ["windows"],
+            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
+            output: "var a = 123;\r\n   \r\n"
         }
     ]
 });

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -33,23 +33,12 @@ ruleTester.run("eol-last", rule, {
         { code: "var a = 123;\n\n", options: ["unix"] },
         { code: "var a = 123;\n   \n", options: ["unix"] },
 
-        { code: "", options: ["always", { style: "unix"} ] },
-        { code: "\n", options: ["always", { style: "unix"} ] },
-        { code: "var a = 123;\n", options: ["always", { style: "unix"} ] },
-        { code: "var a = 123;\n\n", options: ["always", { style: "unix"} ] },
-        { code: "var a = 123;\n   \n", options: ["always", { style: "unix"} ] },
-
         { code: "", options: ["windows"] },
+        { code: "\n", options: ["windows"] },
         { code: "\r\n", options: ["windows"] },
         { code: "var a = 123;\r\n", options: ["windows"] },
         { code: "var a = 123;\r\n\r\n", options: ["windows"] },
         { code: "var a = 123;\r\n   \r\n", options: ["windows"] },
-
-        { code: "", options: ["always", { style: "windows" }] },
-        { code: "\r\n", options: ["always", { style: "windows" }] },
-        { code: "var a = 123;\r\n", options: ["always", { style: "windows" }] },
-        { code: "var a = 123;\r\n\r\n", options: ["always", { style: "windows" }] },
-        { code: "var a = 123;\r\n   \r\n", options: ["always", { style: "windows" }] },
 
         { code: "var a = 123;", options: ["never"] },
         { code: "var a = 123;\nvar b = 456;", options: ["never"] },
@@ -80,54 +69,6 @@ ruleTester.run("eol-last", rule, {
             output: "var a = 123;\n   \n"
         },
         {
-            code: "var a = 123;\r\n",
-            options: ["unix"],
-            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
-            output: "var a = 123;\n"
-        },
-        {
-            code: "var a = 123;\r\n\r\n",
-            options: ["unix"],
-            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
-            output: "var a = 123;\r\n\n"
-        },
-        {
-            code: "var a = 123;\r\n   \r\n",
-            options: ["unix"],
-            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
-            output: "var a = 123;\r\n   \n"
-        },
-        {
-            code: "var a = 123;",
-            options: ["always", { style: "unix" }],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\n"
-        },
-        {
-            code: "var a = 123;\r\n",
-            options: ["always", { style: "unix" }],
-            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
-            output: "var a = 123;\n"
-        },
-        {
-            code: "var a = 123;\r\n\r\n",
-            options: ["always", { style: "unix" }],
-            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
-            output: "var a = 123;\r\n\n"
-        },
-        {
-            code: "var a = 123;\r\n   \r\n",
-            options: ["always", { style: "unix" }],
-            errors: [{ message: "Expected a Unix newline and instead found a Windows newline.", type: "Program" }],
-            output: "var a = 123;\r\n   \n"
-        },
-        {
-            code: "var a = 123;\n   ",
-            options: ["always", { style: "unix" }],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\n   \n"
-        },
-        {
             code: "var a = 123;",
             options: ["windows"],
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
@@ -138,54 +79,6 @@ ruleTester.run("eol-last", rule, {
             options: ["windows"],
             errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
             output: "var a = 123;\r\n   \r\n"
-        },
-        {
-            code: "var a = 123;\n",
-            options: ["windows"],
-            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
-            output: "var a = 123;\r\n"
-        },
-        {
-            code: "var a = 123;\r\n\n",
-            options: ["windows"],
-            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
-            output: "var a = 123;\r\n\r\n"
-        },
-        {
-            code: "var a = 123;\n   \n",
-            options: ["windows"],
-            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
-            output: "var a = 123;\n   \r\n"
-        },
-        {
-            code: "var a = 123;",
-            options: ["always", { style: "windows" }],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\r\n"
-        },
-        {
-            code: "var a = 123;\r\n   ",
-            options: ["always", { style: "windows" }],
-            errors: [{ message: "Newline required at end of file but not found.", type: "Program" }],
-            output: "var a = 123;\r\n   \r\n"
-        },
-        {
-            code: "var a = 123;\n",
-            options: ["always", { style: "windows" }],
-            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
-            output: "var a = 123;\r\n"
-        },
-        {
-            code: "var a = 123;\r\n\n",
-            options: ["always", { style: "windows" }],
-            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
-            output: "var a = 123;\r\n\r\n"
-        },
-        {
-            code: "var a = 123;\n   \n",
-            options: ["always", { style: "windows" }],
-            errors: [{ message: "Expected a Windows newline and instead found a Unix newline.", type: "Program" }],
-            output: "var a = 123;\n   \r\n"
         },
         {
             code: "var a = 123;\n",

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -29,7 +29,11 @@ ruleTester.run("eol-last", rule, {
         "\r\n",
         "var a = 123;\r\n",
         "var a = 123;\r\n\r\n",
-        "var a = 123;\r\n   \r\n"
+        "var a = 123;\r\n   \r\n",
+
+        { code: "var a = 123;", options: ["none"] },
+        { code: "var a = 123;\nvar b = 456;", options: ["none"] },
+        { code: "var a = 123;\r\nvar b = 456;", options: ["none"] }
     ],
 
     invalid: [
@@ -72,6 +76,18 @@ ruleTester.run("eol-last", rule, {
             options: ["none"],
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
             output: "var a = 123;"
+        },
+        {
+            code: "var a = 123;\nvar b = 456;\n",
+            options: ["none"],
+            errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
+            output: "var a = 123;\nvar b = 456;"
+        },
+        {
+            code: "var a = 123;\r\nvar b = 456;\r\n",
+            options: ["none"],
+            errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
+            output: "var a = 123;\r\nvar b = 456;"
         }
     ]
 });

--- a/tests/lib/rules/eol-last.js
+++ b/tests/lib/rules/eol-last.js
@@ -92,6 +92,12 @@ ruleTester.run("eol-last", rule, {
             errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
             output: "var a = 123;\r\nvar b = 456;"
         },
+        {
+            code: "var a = 123;\n\n",
+            options: ["never"],
+            errors: [{ message: "Newline not allowed at end of file.", type: "Program" }],
+            output: "var a = 123;"
+        },
 
         // Deprecated: `"unix"` parameter
         {


### PR DESCRIPTION
In short, `eol-last`'s behavior could thus far only enforce that files ended with an OS-specific EOL. The rule's negation (i.e. that files should not end with an EOL) wasn't possible.

This PR adds a `"none"` option to `eol-last` which adds a way to check that a file doesn't end with an EOL, which fixes issue #6938. Additionally, there's also a fixer and some tests.

Here's a short overview of changes:
- Replaced ternary check of options with object access
- Initialized `location` with both `column` and `line` directly (note that `line` is now set by `sourceCode.lines.length` instead of performing a `.split("\n")`)
- Divided `checkBadEOF`'s code flow into two paths, where one path treats different operating systems' EOLs just like before, while the other path treats enforcing their absence
- Added a fixer that removes EOLs from the end of the file
- Added some tests for `"none"` option
- Extended `eol-last`'s documentation to mention `"none"`