### PR TITLE
Update: Throw error if whitespace found in plugin name (fixes #6854)

### DIFF
--- a/lib/config/plugins.js
+++ b/lib/config/plugins.js
@@ -114,6 +114,16 @@ module.exports = {
             longName = pluginNamespace + PLUGIN_NAME_PREFIX + pluginNameWithoutPrefix;
         let plugin = null;
 
+        if (pluginName.match(/\s+/)) {
+            const whitespaceError = new Error("Whitespace found in plugin name '" + pluginName + "'");
+
+            whitespaceError.messageTemplate = "whitespace-found";
+            whitespaceError.messageData = {
+                pluginName: longName
+            };
+            throw whitespaceError;
+        }
+
         if (!plugins[shortName]) {
             try {
                 plugin = require(longName);

--- a/messages/whitespace-found.txt
+++ b/messages/whitespace-found.txt
@@ -1,0 +1,3 @@
+ESLint couldn't find the plugin "<%- pluginName %>". because there is whitespace in the name. Please check your configuration and remove all whitespace from the plugin name.
+
+If you still can't figure out the problem, please stop by https://gitter.im/eslint/eslint to chat with the team.

--- a/tests/lib/config/plugins.js
+++ b/tests/lib/config/plugins.js
@@ -85,6 +85,21 @@ describe("Plugins", function() {
             assert.deepEqual(Rules.get("example/qux"), plugin.rules.qux);
         });
 
+        it("should throw an error when a plugin has whitespace", function() {
+            assert.throws(function() {
+                StubbedPlugins.load("whitespace ");
+            }, /Whitespace found in plugin name 'whitespace '/);
+            assert.throws(function() {
+                StubbedPlugins.load("whitespace\t");
+            }, /Whitespace found in plugin name/);
+            assert.throws(function() {
+                StubbedPlugins.load("whitespace\n");
+            }, /Whitespace found in plugin name/);
+            assert.throws(function() {
+                StubbedPlugins.load("whitespace\r");
+            }, /Whitespace found in plugin name/);
+        });
+
         it("should throw an error when a plugin doesn't exist", function() {
             assert.throws(function() {
                 StubbedPlugins.load("nonexistentplugin");


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

Issue #6854 

**What changes did you make? (Give an overview)**

Added a check to see if white-space is in the plugin name before requiring plugins and throw an error if white-space is found. Also added test. 

**Is there anything you'd like reviewers to focus on?**

Not exactly sure on the wording of the error messages. Will update if needed. 