### PR TITLE
Fix: false negative of `indent` with `else if` statements (fixes #6956)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -268,6 +268,16 @@ module.exports = {
             ) {
                 report(node, indent, nodeIndent);
             }
+
+            if (node.type === "IfStatement" && node.alternate) {
+                const elseToken = sourceCode.getTokenBefore(node.alternate);
+
+                checkNodeIndent(elseToken, indent, excludeCommas);
+
+                if (!isNodeFirstInLine(node.alternate)) {
+                    checkNodeIndent(node.alternate, indent, excludeCommas);
+                }
+            }
         }
 
         /**
@@ -278,14 +288,7 @@ module.exports = {
          * @returns {void}
          */
         function checkNodesIndent(nodes, indent, excludeCommas) {
-            nodes.forEach(function(node) {
-                if (node.type === "IfStatement" && node.alternate) {
-                    const elseToken = sourceCode.getTokenBefore(node.alternate);
-
-                    checkNodeIndent(elseToken, indent, excludeCommas);
-                }
-                checkNodeIndent(node, indent, excludeCommas);
-            });
+            nodes.forEach(node => checkNodeIndent(node, indent, excludeCommas));
         }
 
         /**

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1395,6 +1395,17 @@ ruleTester.run("indent", rule, {
             "foo = bar.baz()\n" +
             "        .bip();",
             options: [4, {MemberExpression: 1}]
+        },
+        {
+            code:
+            "if (foo) {\n" +
+            "  bar();\n" +
+            "} else if (baz) {\n" +
+            "  foobar();\n" +
+            "} else if (qux) {\n" +
+            "  qux();\n" +
+            "}",
+            options: [2]
         }
     ],
     invalid: [
@@ -2435,6 +2446,79 @@ ruleTester.run("indent", rule, {
             "    .bar",
             options: [2, { MemberExpression: 2 }],
             errors: expectedErrors([[2, 4, 2, "Punctuator"], [3, 4, 2, "Punctuator"]])
+        },
+        {
+
+            // Indentation with multiple else statements: https://github.com/eslint/eslint/issues/6956
+
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "  else if (qux) qux();",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "else if (qux) qux();",
+            options: [2],
+            errors: expectedErrors([3, 0, 2, "Keyword"])
+        },
+        {
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "  else qux();",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "else qux();",
+            options: [2],
+            errors: expectedErrors([3, 0, 2, "Keyword"])
+        },
+        {
+            code:
+            "foo();\n" +
+            "  if (baz) foobar();\n" +
+            "  else qux();",
+            output:
+            "foo();\n" +
+            "if (baz) foobar();\n" +
+            "else qux();",
+            options: [2],
+            errors: expectedErrors([[2, 0, 2, "IfStatement"], [3, 0, 2, "Keyword"]])
+        },
+        {
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "     else if (bip) {\n" +
+            "       qux();\n" +
+            "     }",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) foobar();\n" +
+            "else if (bip) {\n" +
+            "       qux();\n" + // (fixed on the next pass)
+            "     }",
+            options: [2],
+            errors: expectedErrors([3, 0, 5, "Keyword"])
+        },
+        {
+            code:
+            "if (foo) bar();\n" +
+            "else if (baz) {\n" +
+            "    foobar();\n" +
+            "     } else if (boop) {\n" +
+            "       qux();\n" +
+            "     }",
+            output:
+            "if (foo) bar();\n" +
+            "else if (baz) {\n" +
+            "  foobar();\n" +
+            "} else if (boop) {\n" +
+            "       qux();\n" + // (fixed on the next pass)
+            "     }",
+            options: [2],
+            errors: expectedErrors([[3, 2, 4, "ExpressionStatement"], [4, 0, 5, "BlockStatement"]])
         }
     ]
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#6956

**What changes did you make? (Give an overview)**

Previously, only the first `else` statement in a chain would be checked for correct indentation. This PR fixes the issue by recursively checking nodes in `else if` chains to ensure that all nodes have the right indentation.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.