### PR TITLE
Fix: `prefer-const` false negative about `eslintUsed` (fixes #5837)

### DIFF
--- a/lib/rules/prefer-const.js
+++ b/lib/rules/prefer-const.js
@@ -70,9 +70,14 @@ function canBecomeVariableDeclaration(identifier) {
  *
  * If the variable should not change to const, this function returns null.
  * - If the variable is reassigned.
- * - If the variable is never initialized and assigned.
+ * - If the variable is never initialized nor assigned.
  * - If the variable is initialized in a different scope from the declaration.
  * - If the unique assignment of the variable cannot change to a declaration.
+ *   e.g. `if (a) b = 1` / `return (b = 1)`
+ * - If the variable is declared in the global scope and `eslintUsed` is `true`.
+ *   `/*exported foo` directive comment makes such variables. This rule does not
+ *   warn such variables because this rule cannot distinguish whether the
+ *   exported variables are reassigned or not.
  *
  * @param {escope.Variable} variable - A variable to get.
  * @param {boolean} ignoreReadBeforeAssign -
@@ -82,7 +87,7 @@ function canBecomeVariableDeclaration(identifier) {
  *      Otherwise, null.
  */
 function getIdentifierIfShouldBeConst(variable, ignoreReadBeforeAssign) {
-    if (variable.eslintUsed) {
+    if (variable.eslintUsed && variable.scope.type === "global") {
         return null;
     }
 


### PR DESCRIPTION
Fixes #5837.

This PR makes `prefer-const` warning used variables by `context.markVariableAsUsed(name)` API, **on except global scope**.

`/*exported*/` comments also are using `eslintUsed`.
I thought `prefer-const` should not warn `foo` in the following code.

```js
/*exported foo*/
let foo = 1
```

`prefer-const` still ignore used global variables by `context.markVariableAsUsed(name)` API (since `/*exported*/` comment is applied to only global variables).
But this PR will improve the issue.
In most cases, the variables that `react/jsx-use-vars` marks are on Node.js/CommonJS scope or Module scope.

**EDIT:** This needs **minor** bump since this will increase warnings.