### PR TITLE
Chore: Rule messages use internal rule message format (fixes #6977)

### DIFF
--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -75,7 +75,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "There should be no space after '" + token.value + "'.",
+                message: "There should be no space after '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     const nextToken = sourceCode.getTokenAfter(token);
 
@@ -94,7 +97,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "There should be no space before '" + token.value + "'.",
+                message: "There should be no space before '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     const previousToken = sourceCode.getTokenBefore(token);
 
@@ -113,7 +119,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "A space is required after '" + token.value + "'.",
+                message: "A space is required after '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     return fixer.insertTextAfter(token, " ");
                 }
@@ -130,7 +139,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "A space is required before '" + token.value + "'.",
+                message: "A space is required before '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     return fixer.insertTextBefore(token, " ");
                 }

--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -87,7 +87,7 @@ module.exports = {
                         node,
                         message: requireForBlockBodyNoParensMessage,
                         fix(fixer) {
-                            return fixer.replaceText(token, "(" + token.value + ")");
+                            return fixer.replaceText(token, `(${token.value})`);
                         }
                     });
                 }
@@ -123,7 +123,7 @@ module.exports = {
                         node,
                         message,
                         fix(fixer) {
-                            return fixer.replaceText(token, "(" + token.value + ")");
+                            return fixer.replaceText(token, `(${token.value})`);
                         }
                     });
                 }

--- a/lib/rules/block-spacing.js
+++ b/lib/rules/block-spacing.js
@@ -97,7 +97,10 @@ module.exports = {
                 context.report({
                     node,
                     loc: openBrace.loc.start,
-                    message: message + " after '{'.",
+                    message: "{{message}} after '{'.",
+                    data: {
+                        message
+                    },
                     fix(fixer) {
                         if (always) {
                             return fixer.insertTextBefore(firstToken, " ");
@@ -111,7 +114,10 @@ module.exports = {
                 context.report({
                     node,
                     loc: closeBrace.loc.start,
-                    message: message + " before '}'.",
+                    message: "{{message}} before '}'.",
+                    data: {
+                        message
+                    },
                     fix(fixer) {
                         if (always) {
                             return fixer.insertTextAfter(lastToken, " ");

--- a/lib/rules/class-methods-use-this.js
+++ b/lib/rules/class-methods-use-this.js
@@ -53,7 +53,13 @@ module.exports = {
             const methodUsesThis = stack.pop();
 
             if (isInstanceMethod(node.parent) && !methodUsesThis) {
-                context.report(node, "Expected 'this' to be used by class method '" + node.parent.key.name + "'.");
+                context.report({
+                    node,
+                    message: "Expected 'this' to be used by class method '{{classMethod}}'.",
+                    data: {
+                        classMethod: node.parent.key.name
+                    }
+                });
             }
         }
 

--- a/lib/rules/comma-spacing.js
+++ b/lib/rules/comma-spacing.js
@@ -97,8 +97,11 @@ module.exports = {
                     }
                 },
                 message: options[dir] ?
-                  "A space is required " + dir + " ','." :
-                  "There should be no space " + dir + " ','."
+                  "A space is required {{dir}} ','." :
+                  "There should be no space {{dir}} ','.",
+                data: {
+                    dir
+                }
             });
         }
 

--- a/lib/rules/computed-property-spacing.js
+++ b/lib/rules/computed-property-spacing.js
@@ -46,7 +46,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "There should be no space after '" + token.value + "'.",
+                message: "There should be no space after '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     return fixer.removeRange([token.range[1], tokenAfter.range[0]]);
                 }
@@ -64,7 +67,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "There should be no space before '" + token.value + "'.",
+                message: "There should be no space before '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     return fixer.removeRange([tokenBefore.range[1], token.range[0]]);
                 }
@@ -81,7 +87,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "A space is required after '" + token.value + "'.",
+                message: "A space is required after '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     return fixer.insertTextAfter(token, " ");
                 }
@@ -98,7 +107,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "A space is required before '" + token.value + "'.",
+                message: "A space is required before '{{tokenValue}}'.",
+                data: {
+                    tokenValue: token.value
+                },
                 fix(fixer) {
                     return fixer.insertTextBefore(token, " ");
                 }

--- a/lib/rules/consistent-return.js
+++ b/lib/rules/consistent-return.js
@@ -145,9 +145,16 @@ module.exports = {
                 if (!funcInfo.hasReturn) {
                     funcInfo.hasReturn = true;
                     funcInfo.hasReturnValue = hasReturnValue;
-                    funcInfo.message = "Expected " + (hasReturnValue ? "a" : "no") + " return value.";
+                    funcInfo.message = "Expected {{which}} return value.";
+                    funcInfo.data = {
+                        which: hasReturnValue ? "a" : "no"
+                    };
                 } else if (funcInfo.hasReturnValue !== hasReturnValue) {
-                    context.report({node, message: funcInfo.message});
+                    context.report({
+                        node,
+                        message: funcInfo.message,
+                        data: funcInfo.data
+                    });
                 }
             },
 

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -149,7 +149,7 @@ module.exports = {
                 message: "Expected { after '{{name}}'{{suffix}}.",
                 data: {
                     name,
-                    suffix: (suffix ? " " + suffix : "")
+                    suffix: (suffix ? ` ${suffix}` : "")
                 }
             });
         }
@@ -169,7 +169,7 @@ module.exports = {
                 message: "Unnecessary { after '{{name}}'{{suffix}}.",
                 data: {
                     name,
-                    suffix: (suffix ? " " + suffix : "")
+                    suffix: (suffix ? ` ${suffix}` : "")
                 }
             });
         }

--- a/lib/rules/dot-notation.js
+++ b/lib/rules/dot-notation.js
@@ -51,18 +51,30 @@ module.exports = {
                     node.computed &&
                     node.property.type === "Literal" &&
                     validIdentifier.test(node.property.value) &&
-                    (allowKeywords || keywords.indexOf("" + node.property.value) === -1)
+                    (allowKeywords || keywords.indexOf(String(node.property.value)) === -1)
                 ) {
                     if (!(allowPattern && allowPattern.test(node.property.value))) {
-                        context.report(node.property, "[" + JSON.stringify(node.property.value) + "] is better written in dot notation.");
+                        context.report({
+                            node: node.property,
+                            message: "[{{propertyValue}}] is better written in dot notation.",
+                            data: {
+                                propertyValue: JSON.stringify(node.property.value)
+                            }
+                        });
                     }
                 }
                 if (
                     !allowKeywords &&
                     !node.computed &&
-                    keywords.indexOf("" + node.property.name) !== -1
+                    keywords.indexOf(String(node.property.name)) !== -1
                 ) {
-                    context.report(node.property, "." + node.property.name + " is a syntax error.");
+                    context.report({
+                        node: node.property,
+                        message: ".{{propertyName}} is a syntax error.",
+                        data: {
+                            propertyName: node.property.name
+                        }
+                    });
                 }
             }
         };

--- a/lib/rules/generator-star-spacing.js
+++ b/lib/rules/generator-star-spacing.js
@@ -87,11 +87,16 @@ module.exports = {
                 const spaceRequired = mode[side];
                 const node = after ? leftToken : rightToken;
                 const type = spaceRequired ? "Missing" : "Unexpected";
-                const message = type + " space " + side + " *.";
+                const message = "{{type}} space {{side}} *.";
+                const data = {
+                    type,
+                    side
+                };
 
                 context.report({
                     node,
                     message,
+                    data,
                     fix(fixer) {
                         if (spaceRequired) {
                             if (after) {

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -168,7 +168,7 @@ module.exports = {
                 let rangeToFix = [];
 
                 if (needed > gotten) {
-                    const spaces = "" + new Array(needed - gotten + 1).join(indentChar);  // replace with repeat in future
+                    const spaces = indentChar.repeat(needed - gotten);
 
                     if (isLastNodeCheck === true) {
                         rangeToFix = [

--- a/lib/rules/init-declarations.js
+++ b/lib/rules/init-declarations.js
@@ -114,9 +114,21 @@ module.exports = {
                     }
 
                     if (mode === MODE_ALWAYS && !initialized) {
-                        context.report(declaration, "Variable '" + id.name + "' should be initialized on declaration.");
+                        context.report({
+                            node: declaration,
+                            message: "Variable '{{idName}}' should be initialized on declaration.",
+                            data: {
+                                idName: id.name
+                            }
+                        });
                     } else if (mode === MODE_NEVER && kind !== "const" && initialized && !isIgnoredForLoop) {
-                        context.report(declaration, "Variable '" + id.name + "' should not be initialized on declaration.");
+                        context.report({
+                            node: declaration,
+                            message: "Variable '{{idName}}' should not be initialized on declaration.",
+                            data: {
+                                idName: id.name
+                            }
+                        });
                     }
                 }
             }

--- a/lib/rules/jsx-quotes.js
+++ b/lib/rules/jsx-quotes.js
@@ -74,7 +74,10 @@ module.exports = {
                 if (attributeValue && astUtils.isStringLiteral(attributeValue) && !usesExpectedQuotes(attributeValue)) {
                     context.report({
                         node: attributeValue,
-                        message: "Unexpected usage of " + setting.description + ".",
+                        message: "Unexpected usage of {{description}}.",
+                        data: {
+                            description: setting.description
+                        },
                         fix(fixer) {
                             return fixer.replaceText(attributeValue, setting.convert(attributeValue.raw));
                         }

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -30,7 +30,7 @@ const KEYS = keywords.concat(["as", "await", "from", "get", "let", "of", "set", 
     KEYS.sort();
     for (let i = 1; i < KEYS.length; ++i) {
         if (KEYS[i] === KEYS[i - 1]) {
-            throw new Error("Duplication was found in the keyword list: " + KEYS[i]);
+            throw new Error(`Duplication was found in the keyword list: ${KEYS[i]}`);
         }
     }
 }());

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -242,9 +242,25 @@ module.exports = {
                 }
 
                 if (lineIsComment && lineLength > maxCommentLength) {
-                    context.report(node, { line: lineNumber, column: 0 }, "Line " + (i + 1) + " exceeds the maximum comment line length of " + maxCommentLength + ".");
+                    context.report({
+                        node,
+                        loc: { line: lineNumber, column: 0 },
+                        message: "Line {{lineNumber}} exceeds the maximum comment line length of {{maxCommentLength}}.",
+                        data: {
+                            lineNumber: i + 1,
+                            maxCommentLength
+                        }
+                    });
                 } else if (lineLength > maxLength) {
-                    context.report(node, { line: lineNumber, column: 0 }, "Line " + (i + 1) + " exceeds the maximum line length of " + maxLength + ".");
+                    context.report({
+                        node,
+                        loc: { line: lineNumber, column: 0 },
+                        message: "Line {{lineNumber}} exceeds the maximum line length of {{maxLength}}.",
+                        data: {
+                            lineNumber: i + 1,
+                            maxLength
+                        }
+                    });
                 }
             });
         }

--- a/lib/rules/max-statements-per-line.js
+++ b/lib/rules/max-statements-per-line.js
@@ -35,7 +35,9 @@ module.exports = {
         const sourceCode = context.getSourceCode(),
             options = context.options[0] || {},
             maxStatementsPerLine = typeof options.max !== "undefined" ? options.max : 1,
-            message = "This line has too many statements. Maximum allowed is " + maxStatementsPerLine + ".";
+            message = "This line has too many statements. Maximum allowed is {{maxStatementsPerLine}}.",
+            data = { maxStatementsPerLine };
+
         let lastStatementLine = 0,
             numberOfStatementsOnThisLine = 0;
 
@@ -89,7 +91,7 @@ module.exports = {
 
             // Reports if the node violated this rule.
             if (numberOfStatementsOnThisLine === maxStatementsPerLine + 1) {
-                context.report({node, message});
+                context.report({node, message, data});
             }
         }
 
@@ -166,7 +168,7 @@ module.exports = {
             // Empty blocks should be warned if `{max: 0}` was given.
             BlockStatement: function reportIfZero(node) {
                 if (maxStatementsPerLine === 0 && node.body.length === 0) {
-                    context.report({node, message});
+                    context.report({node, message, data});
                 }
             }
         };

--- a/lib/rules/new-cap.js
+++ b/lib/rules/new-cap.js
@@ -37,7 +37,7 @@ function checkArray(obj, key, fallback) {
 
     /* istanbul ignore if */
     if (Object.prototype.hasOwnProperty.call(obj, key) && !Array.isArray(obj[key])) {
-        throw new TypeError(key + ", if provided, must be an Array");
+        throw new TypeError(`${key}, if provided, must be an Array`);
     }
     return obj[key] || fallback;
 }

--- a/lib/rules/newline-per-chained-call.js
+++ b/lib/rules/newline-per-chained-call.js
@@ -69,11 +69,14 @@ module.exports = {
                 }
 
                 if (depth > ignoreChainWithDepth && callee.property.loc.start.line === callee.object.loc.end.line) {
-                    context.report(
-                        callee.property,
-                        callee.property.loc.start,
-                        "Expected line break before `" + getPropertyText(callee) + "`."
-                    );
+                    context.report({
+                        node: callee.property,
+                        loc: callee.property.loc.start,
+                        message: "Expected line break before `{{callee}}`.",
+                        data: {
+                            callee: getPropertyText(callee)
+                        }
+                    });
                 }
             }
         };

--- a/lib/rules/no-control-regex.js
+++ b/lib/rules/no-control-regex.js
@@ -88,13 +88,15 @@ module.exports = {
                         .map(function(x) {
                             const match = x.match(stringControlCharWithoutSlash) || [x];
 
-                            return "\\" + match[0];
+                            return `\\${match[0]}`;
                         });
                 }
             }
 
             return controlChars.map(function(x) {
-                return "\\x" + ("0" + x.charCodeAt(0).toString(16)).slice(-2);
+                const hexCode = `0${x.charCodeAt(0).toString(16)}`.slice(-2);
+
+                return `\\x${hexCode}`;
             }).concat(stringControlChars);
         }
 

--- a/lib/rules/no-dupe-class-members.js
+++ b/lib/rules/no-dupe-class-members.js
@@ -34,7 +34,7 @@ module.exports = {
          */
         function getState(name, isStatic) {
             const stateMap = stack[stack.length - 1];
-            const key = "$" + name; // to avoid "__proto__".
+            const key = `$${name}`; // to avoid "__proto__".
 
             if (!stateMap[key]) {
                 stateMap[key] = {

--- a/lib/rules/no-duplicate-imports.js
+++ b/lib/rules/no-duplicate-imports.js
@@ -37,8 +37,11 @@ function checkAndReport(context, node, value, array, message) {
     if (array.indexOf(value) !== -1) {
         context.report({
             node,
-            message: "'{{module}}' " + message,
-            data: {module: value}
+            message: "'{{module}}' {{message}}",
+            data: {
+                module: value,
+                message
+            }
         });
     }
 }

--- a/lib/rules/no-empty-function.js
+++ b/lib/rules/no-empty-function.js
@@ -146,7 +146,10 @@ module.exports = {
                 context.report({
                     node,
                     loc: node.body.loc.start,
-                    message: "Unexpected empty " + SHOW_KIND[kind] + "."
+                    message: "Unexpected empty {{kind}}.",
+                    data: {
+                        kind: SHOW_KIND[kind]
+                    }
                 });
             }
         }

--- a/lib/rules/no-extend-native.js
+++ b/lib/rules/no-extend-native.js
@@ -74,7 +74,13 @@ module.exports = {
 
                 modifiedBuiltins.forEach(function(builtin) {
                     if (lhs.object.object.name === builtin) {
-                        context.report(node, builtin + " prototype is read only, properties should not be added.");
+                        context.report({
+                            node,
+                            message: "{{builtin}} prototype is read only, properties should not be added.",
+                            data: {
+                                builtin
+                            }
+                        });
                     }
                 });
             },
@@ -98,7 +104,13 @@ module.exports = {
                         (modifiedBuiltins.indexOf(object.name) > -1) &&
                         subject.property.name === "prototype") {
 
-                        context.report(node, object.name + " prototype is read only, properties should not be added.");
+                        context.report({
+                            node,
+                            message: "{{objectName}} prototype is read only, properties should not be added.",
+                            data: {
+                                objectName: object.name
+                            }
+                        });
                     }
                 }
 

--- a/lib/rules/no-invalid-regexp.js
+++ b/lib/rules/no-invalid-regexp.js
@@ -66,21 +66,30 @@ module.exports = {
                 let flags = isString(node.arguments[1]) ? node.arguments[1].value : "";
 
                 if (allowedFlags) {
-                    flags = flags.replace(new RegExp("[" + allowedFlags + "]", "gi"), "");
+                    flags = flags.replace(new RegExp(`[${allowedFlags}]`, "gi"), "");
                 }
 
                 try {
                     void new RegExp(node.arguments[0].value);
                 } catch (e) {
-                    context.report(node, e.message + ".");
+                    context.report({
+                        node,
+                        message: `${e.message}.`
+                    });
                 }
 
                 if (flags) {
 
                     try {
-                        espree.parse("/./" + flags, context.parserOptions);
+                        espree.parse(`/./${flags}`, context.parserOptions);
                     } catch (ex) {
-                        context.report(node, "Invalid flags supplied to RegExp constructor '" + flags + "'.");
+                        context.report({
+                            node,
+                            message: "Invalid flags supplied to RegExp constructor '{{flags}}'.",
+                            data: {
+                                flags
+                            }
+                        });
                     }
                 }
 

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -114,7 +114,7 @@ module.exports = {
                     node = parent;
                     parent = node.parent;
                     value = -value;
-                    raw = "-" + raw;
+                    raw = `-${raw}`;
                 }
 
                 if (shouldIgnoreNumber(value) ||
@@ -135,7 +135,10 @@ module.exports = {
                     (parent.type === "AssignmentExpression" && parent.operator !== "=")) {
                     context.report({
                         node,
-                        message: "No magic number: " + raw + "."
+                        message: "No magic number: {{raw}}.",
+                        data: {
+                            raw
+                        }
                     });
                 }
             }

--- a/lib/rules/no-mixed-operators.js
+++ b/lib/rules/no-mixed-operators.js
@@ -173,18 +173,23 @@ module.exports = {
             const left = (parent.left === node) ? node : parent;
             const right = (parent.left !== node) ? node : parent;
             const message =
-                "Unexpected mix of '" + left.operator + "' and '" +
-                right.operator + "'.";
+                "Unexpected mix of '{{leftOperator}}' and '{{rightOperator}}'.";
+            const data = {
+                leftOperator: left.operator,
+                rightOperator: right.operator
+            };
 
             context.report({
                 node: left,
                 loc: getOperatorToken(left).loc.start,
-                message
+                message,
+                data
             });
             context.report({
                 node: right,
                 loc: getOperatorToken(right).loc.start,
-                message
+                message,
+                data
             });
         }
 

--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -146,7 +146,10 @@ module.exports = {
                     context.report({
                         node,
                         loc: node.loc.start,
-                        message: "Too many blank lines at the beginning of file. Max of " + maxBOF + " allowed.",
+                        message: "Too many blank lines at the beginning of file. Max of {{maxBOF}} allowed.",
+                        data: {
+                            maxBOF
+                        },
                         fix
                     });
                 }
@@ -176,7 +179,11 @@ module.exports = {
                                 context.report({
                                     node,
                                     loc: location,
-                                    message: "More than " + max + " blank " + (max === 1 ? "line" : "lines") + " not allowed.",
+                                    message: "More than {{max}} blank {{lines}} not allowed.",
+                                    data: {
+                                        max,
+                                        lines: (max === 1 ? "line" : "lines")
+                                    },
                                     fix
                                 });
                             }
@@ -190,7 +197,10 @@ module.exports = {
                                 context.report({
                                     node,
                                     loc: location,
-                                    message: "Too many blank lines at the end of file. Max of " + maxEOF + " allowed.",
+                                    message: "Too many blank lines at the end of file. Max of {{maxEOF}} allowed.",
+                                    data: {
+                                        maxEOF
+                                    },
                                     fix
                                 });
                             }

--- a/lib/rules/no-plusplus.js
+++ b/lib/rules/no-plusplus.js
@@ -46,7 +46,13 @@ module.exports = {
                 if (allowInForAfterthought && node.parent.type === "ForStatement") {
                     return;
                 }
-                context.report(node, "Unary operator '" + node.operator + "' used.");
+                context.report({
+                    node,
+                    message: "Unary operator '{{operator}}' used.",
+                    data: {
+                        operator: node.operator
+                    }
+                });
             }
 
         };

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -35,7 +35,15 @@ module.exports = {
                 regexResults = multipleSpacesRegex.exec(value);
 
             if (regexResults !== null) {
-                context.report(node, "Spaces are hard to count. Use {" + regexResults[0].length + "}.");
+                context.report({
+                    node,
+                    message: `Spaces are hard to count. Use {${regexResults[0].length}}.`
+                });
+
+                /*
+                 * TODO: (platinumazure) Fix message to use rule message
+                 * substitution when api.report is fixed in lib/eslint.js.
+                 */
             }
         }
 

--- a/lib/rules/no-shadow-restricted-names.js
+++ b/lib/rules/no-shadow-restricted-names.js
@@ -31,7 +31,13 @@ module.exports = {
          */
         function checkForViolation(id) {
             if (RESTRICTED.indexOf(id.name) > -1) {
-                context.report(id, "Shadowing of global property '" + id.name + "'.");
+                context.report({
+                    node: id,
+                    message: "Shadowing of global property '{{idName}}'.",
+                    data: {
+                        idName: id.name
+                    }
+                });
             }
         }
 

--- a/lib/rules/no-sync.js
+++ b/lib/rules/no-sync.js
@@ -31,7 +31,13 @@ module.exports = {
                     syncRegex = /.*Sync$/;
 
                 if (syncRegex.exec(propertyName) !== null) {
-                    context.report(node, "Unexpected sync method: '" + propertyName + "'.");
+                    context.report({
+                        node,
+                        message: "Unexpected sync method: '{{propertyName}}'.",
+                        data: {
+                            propertyName
+                        }
+                    });
                 }
             }
         };

--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -35,8 +35,8 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         const BLANK_CLASS = "[ \t\u00a0\u2000-\u200b\u2028\u2029\u3000]",
-            SKIP_BLANK = "^" + BLANK_CLASS + "*$",
-            NONBLANK = BLANK_CLASS + "+$";
+            SKIP_BLANK = `^${BLANK_CLASS}*$`,
+            NONBLANK = `${BLANK_CLASS}+$`;
 
         const options = context.options[0] || {},
             skipBlankLines = options.skipBlankLines || false;

--- a/lib/rules/no-underscore-dangle.js
+++ b/lib/rules/no-underscore-dangle.js
@@ -107,7 +107,13 @@ module.exports = {
                 const identifier = node.id.name;
 
                 if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) && !isAllowed(identifier)) {
-                    context.report(node, "Unexpected dangling '_' in '" + identifier + "'.");
+                    context.report({
+                        node,
+                        message: "Unexpected dangling '_' in '{{identifier}}'.",
+                        data: {
+                            identifier
+                        }
+                    });
                 }
             }
         }
@@ -123,7 +129,13 @@ module.exports = {
 
             if (typeof identifier !== "undefined" && hasTrailingUnderscore(identifier) &&
                 !isSpecialCaseIdentifierInVariableExpression(identifier) && !isAllowed(identifier)) {
-                context.report(node, "Unexpected dangling '_' in '" + identifier + "'.");
+                context.report({
+                    node,
+                    message: "Unexpected dangling '_' in '{{identifier}}'.",
+                    data: {
+                        identifier
+                    }
+                });
             }
         }
 
@@ -142,7 +154,13 @@ module.exports = {
                 !(isMemberOfThis && allowAfterThis) &&
                 !(isMemberOfSuper && allowAfterSuper) &&
                 !isSpecialCaseIdentifierForMemberExpression(identifier) && !isAllowed(identifier)) {
-                context.report(node, "Unexpected dangling '_' in '" + identifier + "'.");
+                context.report({
+                    node,
+                    message: "Unexpected dangling '_' in '{{identifier}}'.",
+                    data: {
+                        identifier
+                    }
+                });
             }
         }
 

--- a/lib/rules/no-unsafe-finally.js
+++ b/lib/rules/no-unsafe-finally.js
@@ -83,7 +83,10 @@ module.exports = {
         function check(node) {
             if (isInFinallyBlock(node, node.label)) {
                 context.report({
-                    message: "Unsafe usage of " + node.type + ".",
+                    message: "Unsafe usage of {{nodeType}}.",
+                    data: {
+                        nodeType: node.type
+                    },
                     node,
                     line: node.loc.line,
                     column: node.loc.column

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -514,7 +514,7 @@ module.exports = {
          * @private
          */
         function getColumnInComment(variable, comment) {
-            const namePattern = new RegExp("[\\s,]" + lodash.escapeRegExp(variable.name) + "(?:$|[\\s,:])", "g");
+            const namePattern = new RegExp(`[\\s,]${lodash.escapeRegExp(variable.name)}(?:$|[\\s,:])`, "g");
 
             // To ignore the first text "global".
             namePattern.lastIndex = comment.value.indexOf("global") + 6;

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -90,7 +90,10 @@ module.exports = {
                         line: node.loc.start.line,
                         column: node.loc.start.column + elm.index
                     },
-                    message: "Unnecessary escape character: " + elm[0] + "."
+                    message: "Unnecessary escape character: {{character}}.",
+                    data: {
+                        character: elm[0]
+                    }
                 });
             }
         }

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -117,7 +117,13 @@ module.exports = {
             const matches = commentContainsWarningTerm(node.value);
 
             matches.forEach(function(matchedTerm) {
-                context.report(node, "Unexpected '" + matchedTerm + "' comment.");
+                context.report({
+                    node,
+                    message: "Unexpected '{{matchedTerm}}' comment.",
+                    data: {
+                        matchedTerm
+                    }
+                });
             });
         }
 

--- a/lib/rules/object-curly-spacing.js
+++ b/lib/rules/object-curly-spacing.js
@@ -74,7 +74,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "There should be no space after '" + token.value + "'.",
+                message: "There should be no space after '{{token}}'.",
+                data: {
+                    token: token.value
+                },
                 fix(fixer) {
                     const nextToken = context.getSourceCode().getTokenAfter(token);
 
@@ -93,7 +96,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "There should be no space before '" + token.value + "'.",
+                message: "There should be no space before '{{token}}'.",
+                data: {
+                    token: token.value
+                },
                 fix(fixer) {
                     const previousToken = context.getSourceCode().getTokenBefore(token);
 
@@ -112,7 +118,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "A space is required after '" + token.value + "'.",
+                message: "A space is required after '{{token}}'.",
+                data: {
+                    token: token.value
+                },
                 fix(fixer) {
                     return fixer.insertTextAfter(token, " ");
                 }
@@ -129,7 +138,10 @@ module.exports = {
             context.report({
                 node,
                 loc: token.loc.start,
-                message: "A space is required before '" + token.value + "'.",
+                message: "A space is required before '{{token}}'.",
+                data: {
+                    token: token.value
+                },
                 fix(fixer) {
                     return fixer.insertTextBefore(token, " ");
                 }

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -237,17 +237,20 @@ module.exports = {
 
                         context.report({
                             node,
-                            message: "Expected longform " + type + " syntax.",
+                            message: "Expected longform {{type}} syntax.",
+                            data: {
+                                type
+                            },
                             fix(fixer) {
                                 if (node.method) {
                                     if (node.value.generator) {
-                                        return fixer.replaceTextRange([node.range[0], node.key.range[1]], node.key.name + ": function*");
+                                        return fixer.replaceTextRange([node.range[0], node.key.range[1]], `${node.key.name}: function*`);
                                     }
 
                                     return fixer.insertTextAfter(node.key, ": function");
                                 }
 
-                                return fixer.insertTextAfter(node.key, ": " + node.key.name);
+                                return fixer.insertTextAfter(node.key, `: ${node.key.name}`);
                             }
                         });
                     }
@@ -289,7 +292,7 @@ module.exports = {
                                 if (node.value.generator) {
                                     return fixer.replaceTextRange(
                                         [node.key.range[0], node.value.range[0] + "function*".length],
-                                        "*[" + node.key.name + "]"
+                                        `*[${node.key.name}]`
                                     );
                                 }
 
@@ -307,7 +310,7 @@ module.exports = {
                             if (node.value.generator) {
                                 return fixer.replaceTextRange(
                                     [node.key.range[0], node.value.range[0] + "function*".length],
-                                    "*" + node.key.name
+                                    `*${node.key.name}`
                                 );
                             }
 

--- a/lib/rules/one-var.js
+++ b/lib/rules/one-var.js
@@ -279,16 +279,34 @@ module.exports = {
                 // always
                 if (!hasOnlyOneStatement(type, declarations)) {
                     if (options[type].initialized === MODE_ALWAYS && options[type].uninitialized === MODE_ALWAYS) {
-                        context.report(node, "Combine this with the previous '" + type + "' statement.");
+                        context.report({
+                            node,
+                            message: "Combine this with the previous '{{type}}' statement.",
+                            data: {
+                                type
+                            }
+                        });
                     } else {
                         if (options[type].initialized === MODE_ALWAYS) {
-                            context.report(node, "Combine this with the previous '" + type + "' statement with initialized variables.");
+                            context.report({
+                                node,
+                                message: "Combine this with the previous '{{type}}' statement with initialized variables.",
+                                data: {
+                                    type
+                                }
+                            });
                         }
                         if (options[type].uninitialized === MODE_ALWAYS) {
                             if (node.parent.left === node && (node.parent.type === "ForInStatement" || node.parent.type === "ForOfStatement")) {
                                 return;
                             }
-                            context.report(node, "Combine this with the previous '" + type + "' statement with uninitialized variables.");
+                            context.report({
+                                node,
+                                message: "Combine this with the previous '{{type}}' statement with uninitialized variables.",
+                                data: {
+                                    type
+                                }
+                            });
                         }
                     }
                 }
@@ -302,15 +320,33 @@ module.exports = {
                         if (options[type].initialized === MODE_NEVER && options[type].uninitialized === MODE_NEVER) {
 
                             // both initialized and uninitialized
-                            context.report(node, "Split '" + type + "' declarations into multiple statements.");
+                            context.report({
+                                node,
+                                message: "Split '{{type}}' declarations into multiple statements.",
+                                data: {
+                                    type
+                                }
+                            });
                         } else if (options[type].initialized === MODE_NEVER && declarationCounts.initialized > 0) {
 
                             // initialized
-                            context.report(node, "Split initialized '" + type + "' declarations into multiple statements.");
+                            context.report({
+                                node,
+                                message: "Split initialized '{{type}}' declarations into multiple statements.",
+                                data: {
+                                    type
+                                }
+                            });
                         } else if (options[type].uninitialized === MODE_NEVER && declarationCounts.uninitialized > 0) {
 
                             // uninitialized
-                            context.report(node, "Split uninitialized '" + type + "' declarations into multiple statements.");
+                            context.report({
+                                node,
+                                message: "Split uninitialized '{{type}}' declarations into multiple statements.",
+                                data: {
+                                    type
+                                }
+                            });
                         }
                     }
                 }

--- a/lib/rules/operator-linebreak.js
+++ b/lib/rules/operator-linebreak.js
@@ -98,31 +98,59 @@ module.exports = {
                     !astUtils.isTokenOnSameLine(operatorToken, rightToken)) {
 
                 // lone operator
-                context.report(node, {
-                    line: operatorToken.loc.end.line,
-                    column: operatorToken.loc.end.column
-                }, "Bad line breaking before and after '" + operator + "'.");
+                context.report({
+                    node,
+                    loc: {
+                        line: operatorToken.loc.end.line,
+                        column: operatorToken.loc.end.column
+                    },
+                    message: "Bad line breaking before and after '{{operator}}'.",
+                    data: {
+                        operator
+                    }
+                });
 
             } else if (style === "before" && astUtils.isTokenOnSameLine(leftToken, operatorToken)) {
 
-                context.report(node, {
-                    line: operatorToken.loc.end.line,
-                    column: operatorToken.loc.end.column
-                }, "'" + operator + "' should be placed at the beginning of the line.");
+                context.report({
+                    node,
+                    loc: {
+                        line: operatorToken.loc.end.line,
+                        column: operatorToken.loc.end.column
+                    },
+                    message: "'{{operator}}' should be placed at the beginning of the line.",
+                    data: {
+                        operator
+                    }
+                });
 
             } else if (style === "after" && astUtils.isTokenOnSameLine(operatorToken, rightToken)) {
 
-                context.report(node, {
-                    line: operatorToken.loc.end.line,
-                    column: operatorToken.loc.end.column
-                }, "'" + operator + "' should be placed at the end of the line.");
+                context.report({
+                    node,
+                    loc: {
+                        line: operatorToken.loc.end.line,
+                        column: operatorToken.loc.end.column
+                    },
+                    message: "'{{operator}}' should be placed at the end of the line.",
+                    data: {
+                        operator
+                    }
+                });
 
             } else if (style === "none") {
 
-                context.report(node, {
-                    line: operatorToken.loc.end.line,
-                    column: operatorToken.loc.end.column
-                }, "There should be no line break before or after '" + operator + "'.");
+                context.report({
+                    node,
+                    loc: {
+                        line: operatorToken.loc.end.line,
+                        column: operatorToken.loc.end.column
+                    },
+                    message: "There should be no line break before or after '{{operator}}'.",
+                    data: {
+                        operator
+                    }
+                });
 
             }
         }

--- a/lib/rules/quote-props.js
+++ b/lib/rules/quote-props.js
@@ -97,7 +97,7 @@ module.exports = {
         function areQuotesRedundant(rawKey, tokens, skipNumberLiterals) {
             return tokens.length === 1 && tokens[0].start === 0 && tokens[0].end === rawKey.length &&
                 (["Identifier", "Keyword", "Null", "Boolean"].indexOf(tokens[0].type) >= 0 ||
-                (tokens[0].type === "Numeric" && !skipNumberLiterals && "" + +tokens[0].value === tokens[0].value));
+                (tokens[0].type === "Numeric" && !skipNumberLiterals && String(+tokens[0].value) === tokens[0].value));
         }
 
         /**

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -56,7 +56,7 @@ QUOTE_SETTINGS.backtick.convert = function(str) {
             return escaped; // unescape
         }
         if (match === newQuote || newQuote === "`" && match === "${") {
-            return "\\" + match; // escape
+            return `\\${match}`; // escape
         }
         if (newline && oldQuote === "`") {
             return "\\n"; // escape newlines
@@ -225,7 +225,10 @@ module.exports = {
                     if (!isValid) {
                         context.report({
                             node,
-                            message: "Strings must use " + settings.description + ".",
+                            message: "Strings must use {{description}}.",
+                            data: {
+                                description: settings.description
+                            },
                             fix(fixer) {
                                 return fixer.replaceText(node, settings.convert(node.raw));
                             }
@@ -246,7 +249,10 @@ module.exports = {
                 if (shouldWarn) {
                     context.report({
                         node,
-                        message: "Strings must use " + settings.description + ".",
+                        message: "Strings must use {{description}}.",
+                        data: {
+                            description: settings.description,
+                        },
                         fix(fixer) {
                             return fixer.replaceText(node, settings.convert(sourceCode.getText(node)));
                         }

--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -100,7 +100,10 @@ module.exports = {
             if (secondToken.range[0] === firstToken.range[1]) {
                 context.report({
                     node,
-                    message: "Unary word operator '" + word + "' must be followed by whitespace.",
+                    message: "Unary word operator '{{word}}' must be followed by whitespace.",
+                    data: {
+                        word
+                    },
                     fix(fixer) {
                         return fixer.insertTextAfter(firstToken, " ");
                     }
@@ -121,7 +124,10 @@ module.exports = {
                 if (secondToken.range[0] > firstToken.range[1]) {
                     context.report({
                         node,
-                        message: "Unexpected space after unary word operator '" + word + "'.",
+                        message: "Unexpected space after unary word operator '{{word}}'.",
+                        data: {
+                            word
+                        },
                         fix(fixer) {
                             return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
                         }
@@ -185,7 +191,10 @@ module.exports = {
                 if (firstToken.range[1] === secondToken.range[0]) {
                     context.report({
                         node,
-                        message: "Unary operator '" + firstToken.value + "' must be followed by whitespace.",
+                        message: "Unary operator '{{operator}}' must be followed by whitespace.",
+                        data: {
+                            operator: firstToken.value
+                        },
                         fix(fixer) {
                             return fixer.insertTextAfter(firstToken, " ");
                         }
@@ -195,7 +204,10 @@ module.exports = {
                 if (firstToken.range[1] === secondToken.range[0]) {
                     context.report({
                         node,
-                        message: "Space is required before unary expressions '" + secondToken.value + "'.",
+                        message: "Space is required before unary expressions '{{token}}'.",
+                        data: {
+                            token: secondToken.value
+                        },
                         fix(fixer) {
                             return fixer.insertTextBefore(secondToken, " ");
                         }
@@ -216,7 +228,10 @@ module.exports = {
                 if (secondToken.range[0] > firstToken.range[1]) {
                     context.report({
                         node,
-                        message: "Unexpected space after unary operator '" + firstToken.value + "'.",
+                        message: "Unexpected space after unary operator '{{operator}}'.",
+                        data: {
+                            operator: firstToken.value
+                        },
                         fix(fixer) {
                             return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
                         }
@@ -226,7 +241,10 @@ module.exports = {
                 if (secondToken.range[0] > firstToken.range[1]) {
                     context.report({
                         node,
-                        message: "Unexpected space before unary operator '" + secondToken.value + "'.",
+                        message: "Unexpected space before unary operator '{{operator}}'.",
+                        data: {
+                            operator: secondToken.value
+                        },
                         fix(fixer) {
                             return fixer.removeRange([firstToken.range[1], secondToken.range[0]]);
                         }

--- a/lib/rules/spaced-comment.js
+++ b/lib/rules/spaced-comment.js
@@ -19,7 +19,7 @@ function escape(s) {
     const isOneChar = s.length === 1;
 
     s = lodash.escapeRegExp(s);
-    return isOneChar ? s : "(?:" + s + ")";
+    return isOneChar ? s : `(?:${s})`;
 }
 
 /**
@@ -29,7 +29,7 @@ function escape(s) {
  * @returns {string} An escaped string.
  */
 function escapeAndRepeat(s) {
-    return escape(s) + "+";
+    return `${escape(s)}+`;
 }
 
 /**
@@ -144,7 +144,7 @@ function createAlwaysStylePattern(markers, exceptions) {
  * @returns {RegExp} A RegExp object for `never` mode.
  */
 function createNeverStylePattern(markers) {
-    const pattern = "^(" + markers.map(escape).join("|") + ")?[ \t]+";
+    const pattern = `^(${markers.map(escape).join("|")})?[ \t]+`;
 
     return new RegExp(pattern);
 }
@@ -248,9 +248,9 @@ module.exports = {
             // Create RegExp object for valid patterns.
             rule[type] = {
                 beginRegex: requireSpace ? createAlwaysStylePattern(markers, exceptions) : createNeverStylePattern(markers),
-                endRegex: balanced && requireSpace ? new RegExp(createExceptionsPattern(exceptions) + "$") : new RegExp(endNeverPattern),
+                endRegex: balanced && requireSpace ? new RegExp(`${createExceptionsPattern(exceptions)}$`) : new RegExp(endNeverPattern),
                 hasExceptions: exceptions.length > 0,
-                markers: new RegExp("^(" + markers.map(escape).join("|") + ")")
+                markers: new RegExp(`^(${markers.map(escape).join("|")})`)
             };
 
             return rule;
@@ -261,9 +261,10 @@ module.exports = {
          * @param {ASTNode} node - A comment node to check.
          * @param {string} message - An error message to report.
          * @param {Array} match - An array of match results for markers.
+         * @param {string} refChar - Character used for reference in the error message.
          * @returns {void}
          */
-        function reportBegin(node, message, match) {
+        function reportBegin(node, message, match, refChar) {
             const type = node.type.toLowerCase(),
                 commentIdentifier = type === "block" ? "/*" : "//";
 
@@ -283,7 +284,8 @@ module.exports = {
                         return fixer.replaceTextRange([start, end], commentIdentifier + (match[1] ? match[1] : ""));
                     }
                 },
-                message
+                message,
+                data: { refChar }
             });
         }
 
@@ -336,9 +338,9 @@ module.exports = {
                     const marker = hasMarker ? commentIdentifier + hasMarker[0] : commentIdentifier;
 
                     if (rule.hasExceptions) {
-                        reportBegin(node, "Expected exception block, space or tab after '" + marker + "' in comment.", hasMarker);
+                        reportBegin(node, "Expected exception block, space or tab after '{{refChar}}' in comment.", hasMarker, marker);
                     } else {
-                        reportBegin(node, "Expected space or tab after '" + marker + "' in comment.", hasMarker);
+                        reportBegin(node, "Expected space or tab after '{{refChar}}' in comment.", hasMarker, marker);
                     }
                 }
 
@@ -348,9 +350,9 @@ module.exports = {
             } else {
                 if (beginMatch) {
                     if (!beginMatch[1]) {
-                        reportBegin(node, "Unexpected space or tab after '" + commentIdentifier + "' in comment.", beginMatch);
+                        reportBegin(node, "Unexpected space or tab after '{{refChar}}' in comment.", beginMatch, commentIdentifier);
                     } else {
-                        reportBegin(node, "Unexpected space or tab after marker (" + beginMatch[1] + ") in comment.", beginMatch);
+                        reportBegin(node, "Unexpected space or tab after marker ({{refChar}}) in comment.", beginMatch, beginMatch[1]);
                     }
                 }
 

--- a/lib/rules/template-curly-spacing.js
+++ b/lib/rules/template-curly-spacing.js
@@ -57,7 +57,10 @@ module.exports = {
             ) {
                 context.report({
                     loc: token.loc.start,
-                    message: prefix + " space(s) before '}'.",
+                    message: "{{prefix}} space(s) before '}'.",
+                    data: {
+                        prefix
+                    },
                     fix(fixer) {
                         if (always) {
                             return fixer.insertTextBefore(token, " ");
@@ -89,7 +92,10 @@ module.exports = {
                         line: token.loc.end.line,
                         column: token.loc.end.column - 2
                     },
-                    message: prefix + " space(s) after '${'.",
+                    message: "{{prefix}} space(s) after '${'.",
+                    data: {
+                        prefix
+                    },
                     fix(fixer) {
                         if (always) {
                             return fixer.insertTextAfter(token, " ");

--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -279,7 +279,13 @@ module.exports = {
                             hasReturns = true;
 
                             if (!requireReturn && !functionData.returnPresent && (tag.type === null || !isValidReturnType(tag)) && !isAbstract) {
-                                context.report(jsdocNode, "Unexpected @" + tag.title + " tag; function has no return statement.");
+                                context.report({
+                                    node: jsdocNode,
+                                    message: "Unexpected @{{title}} tag; function has no return statement.",
+                                    data: {
+                                        title: tag.title
+                                    }
+                                });
                             } else {
                                 if (requireReturnType && !tag.type) {
                                     context.report(jsdocNode, "Missing JSDoc return type.");
@@ -330,7 +336,13 @@ module.exports = {
                     node.parent.kind !== "get" && node.parent.kind !== "constructor" &&
                     node.parent.kind !== "set" && !isTypeClass(node)) {
                     if (requireReturn || functionData.returnPresent) {
-                        context.report(jsdocNode, "Missing JSDoc @" + (prefer.returns || "returns") + " for function.");
+                        context.report({
+                            node: jsdocNode,
+                            message: "Missing JSDoc @{{returns}} for function.",
+                            data: {
+                                returns: prefer.returns || "returns"
+                            }
+                        });
                     }
                 }
 

--- a/lib/rules/yield-star-spacing.js
+++ b/lib/rules/yield-star-spacing.js
@@ -68,11 +68,15 @@ module.exports = {
                 const spaceRequired = mode[side];
                 const node = after ? leftToken : rightToken;
                 const type = spaceRequired ? "Missing" : "Unexpected";
-                const message = type + " space " + side + " *.";
+                const message = "{{type}} space {{side}} *.";
 
                 context.report({
                     node,
                     message,
+                    data: {
+                        type,
+                        side
+                    },
                     fix(fixer) {
                         if (spaceRequired) {
                             if (after) {

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -69,7 +69,7 @@ function getNormalizedLiteral(node) {
         return {
             type: "Literal",
             value: -node.argument.value,
-            raw: "-" + node.argument.value
+            raw: `-${node.argument.value}`
         };
     }
 
@@ -234,7 +234,13 @@ module.exports = {
                     isComparisonOperator(node.operator) &&
                     !(exceptRange && isRangeTest(context.getAncestors().pop()))
                 ) {
-                    context.report(node, "Expected literal to be on the left side of " + node.operator + ".");
+                    context.report({
+                        node,
+                        message: "Expected literal to be on the left side of {{operator}}.",
+                        data: {
+                            operator: node.operator
+                        }
+                    });
                 }
 
             } : function(node) {
@@ -247,7 +253,13 @@ module.exports = {
                     isComparisonOperator(node.operator) &&
                     !(exceptRange && isRangeTest(context.getAncestors().pop()))
                 ) {
-                    context.report(node, "Expected literal to be on the right side of " + node.operator + ".");
+                    context.report({
+                        node,
+                        message: "Expected literal to be on the right side of {{operator}}.",
+                        data: {
+                            operator: node.operator
+                        }
+                    });
                 }
 
             }


### PR DESCRIPTION
**What issue does this pull request address?**

Issue #6977.

**What changes did you make? (Give an overview)**

Using the prefer-template rule, I fixed all violations in lib/rules. Rule messages were transformed into rule substitution format, and everything else turned into a template string.

Oh, except for no-regex-spaces due to issue #6988.

**Is there anything you'd like reviewers to focus on?**

I had to use a template string for no-regex-spaces due to issue #6988. Hope that's okay.

Please feel free to pull the branch down locally and run a command like the following in order to check that I didn't miss anything:

```shell
$ node ./bin/eslint.js --no-eslintrc --rule "prefer-template:error" "./lib/rules/*.js"
```