### PR TITLE
Fix: `new-parens` false negative (fixes #6997)

### DIFF
--- a/docs/rules/new-parens.md
+++ b/docs/rules/new-parens.md
@@ -16,6 +16,7 @@ Examples of **incorrect** code for this rule:
 /*eslint new-parens: "error"*/
 
 var person = new Person;
+var person = new (Person);
 ```
 
 Examples of **correct** code for this rule:
@@ -24,4 +25,5 @@ Examples of **correct** code for this rule:
 /*eslint new-parens: "error"*/
 
 var person = new Person();
+var person = new (Person)();
 ```

--- a/lib/rules/new-parens.js
+++ b/lib/rules/new-parens.js
@@ -6,6 +6,44 @@
 "use strict";
 
 //------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether the given token is an opening parenthesis or not.
+ *
+ * @param {Token} token - The token to check.
+ * @returns {boolean} `true` if the token is an opening parenthesis.
+ */
+function isOpeningParen(token) {
+    return token.type === "Punctuator" && token.value === "(";
+}
+
+/**
+ * Checks whether the given token is an closing parenthesis or not.
+ *
+ * @param {Token} token - The token to check.
+ * @returns {boolean} `true` if the token is an closing parenthesis.
+ */
+function isClosingParen(token) {
+    return token.type === "Punctuator" && token.value === ")";
+}
+
+/**
+ * Checks whether the given node is inside of another given node.
+ *
+ * @param {ASTNode|Token} inner - The inner node to check.
+ * @param {ASTNode|Token} outer - The outer node to check.
+ * @returns {boolean} `true` if the `inner` is in `outer`.
+ */
+function isInRange(inner, outer) {
+    const ir = inner.range;
+    const or = outer.range;
+
+    return or[0] <= ir[0] && ir[1] <= or[1];
+}
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 
@@ -24,18 +62,21 @@ module.exports = {
         const sourceCode = context.getSourceCode();
 
         return {
-
             NewExpression(node) {
-                const tokens = sourceCode.getTokens(node);
-                const prenticesTokens = tokens.filter(function(token) {
-                    return token.value === "(" || token.value === ")";
-                });
+                let token = sourceCode.getTokenAfter(node.callee);
 
-                if (prenticesTokens.length < 2) {
-                    context.report(node, "Missing '()' invoking a constructor.");
+                // Skip ')'
+                while (token && isClosingParen(token)) {
+                    token = sourceCode.getTokenAfter(token);
+                }
+
+                if (!(token && isOpeningParen(token) && isInRange(token, node))) {
+                    context.report({
+                        node,
+                        message: "Missing '()' invoking a constructor."
+                    });
                 }
             }
         };
-
     }
 };

--- a/tests/lib/rules/new-parens.js
+++ b/tests/lib/rules/new-parens.js
@@ -21,9 +21,19 @@ const ruleTester = new RuleTester();
 ruleTester.run("new-parens", rule, {
     valid: [
         "var a = new Date();",
-        "var a = new Date(function() {});"
+        "var a = new Date(function() {});",
+        "var a = new (Date)();",
+        "var a = new ((Date))();",
+        "var a = (new Date());",
     ],
     invalid: [
-        { code: "var a = new Date;", errors: [{ message: "Missing '()' invoking a constructor.", type: "NewExpression"}] }
+        { code: "var a = new Date;", errors: [{ message: "Missing '()' invoking a constructor.", type: "NewExpression"}] },
+        { code: "var a = new Date", errors: [{ message: "Missing '()' invoking a constructor.", type: "NewExpression"}] },
+        { code: "var a = new (Date);", errors: [{ message: "Missing '()' invoking a constructor.", type: "NewExpression"}] },
+        { code: "var a = new (Date)", errors: [{ message: "Missing '()' invoking a constructor.", type: "NewExpression"}] },
+        { code: "var a = (new Date)", errors: [{ message: "Missing '()' invoking a constructor.", type: "NewExpression"}] },
+
+        // This `()` is `CallExpression`'s. This is a call of the result of `new Date`.
+        { code: "var a = (new Date)()", errors: [{ message: "Missing '()' invoking a constructor.", type: "NewExpression"}] },
     ]
 });


### PR DESCRIPTION
Fixes #6997.

This PR changes the logic of `new-parens`.
Old logic counts parentheses in a `NewExpression` node. Then OK if it's 2 or more.
New logic checks a token (except `)`) preceded by the callee of a `NewExpression`. Then OK if the token is an opening parenthesis and is inside of the `NewExpression` node.

NOTE: this needs minor bump.