### PR TITLE
Update: add fixer for prefer-arrow-callback (fixes #7002)

### DIFF
--- a/docs/rules/prefer-arrow-callback.md
+++ b/docs/rules/prefer-arrow-callback.md
@@ -1,5 +1,7 @@
 # Suggest using arrow functions as callbacks. (prefer-arrow-callback)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Arrow functions are suited to callbacks, because:
 
 - `this` keywords in arrow functions bind to the upper scope's.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#7002

**What changes did you make? (Give an overview)**

This allows errors reported by the `prefer-arrow-callback` rule to be autofixed, matching the behavior described in #7002.

**Is there anything you'd like reviewers to focus on?**

I'm unsure about whether [this check](/not-an-aardvark/eslint/blob/75affc68ea7162a912046ba2580f3e6919b117b7/lib/rules/prefer-arrow-callback.js#L257-L262) is correct. The intention is to detect whether the current parser configuration supports arrow functions, to avoid causing SyntaxErrors if ES6-mode is off. However, there might be a better/more complete way to do this.

~~#7002 has not been marked as accepted, so this PR should not be merged yet.~~ (edit: #7002 is now marked as accepted.)