### PR TITLE
add allowCommentBody option to no-fallthrough

### DIFF
--- a/docs/rules/no-fallthrough.md
+++ b/docs/rules/no-fallthrough.md
@@ -117,6 +117,14 @@ switch(foo) {
 }
 
 switch(foo) {
+    // We need to handle 1.
+    case 1:
+    // We also need to handle 2.
+    case 2:
+        doSomething();
+}
+
+switch(foo) {
     case 1:
         doSomething();
         // falls through
@@ -130,9 +138,10 @@ Note that the last `case` statement in these examples does not cause a warning b
 
 ## Options
 
-This rule accepts a single options argument:
+This rule accepts two options arguments:
 
 * Set the `commentPattern` option to a regular expression string to change the test for intentional fallthrough comment
+* Set the `allowCommentBody` to allow comments between multiple immediately falling-through cases
 
 ### commentPattern
 
@@ -156,6 +165,28 @@ switch(foo) {
         // caution: break is omitted intentionally
 
     default:
+        doSomething();
+}
+```
+
+### allowCommentBody
+
+Multiple cases with a single body are always allowed but placing comments between the cases is only allowed when this option is set to `true`.
+
+```js
+/*eslint no-fallthrough: ["error", { "allowCommentBody": true }]*/
+
+switch(foo) {
+    case 1:
+    case 2:
+        doSomething();
+}
+
+switch(foo) {
+    // We need to handle 1.
+    case 1:
+    // We also need to handle 2.
+    case 2:
         doSomething();
 }
 ```

--- a/lib/rules/no-fallthrough.js
+++ b/lib/rules/no-fallthrough.js
@@ -65,6 +65,9 @@ module.exports = {
             {
                 type: "object",
                 properties: {
+                    allowCommentBody: {
+                        type: "boolean"
+                    },
                     commentPattern: {
                         type: "string"
                     }
@@ -78,6 +81,12 @@ module.exports = {
         const options = context.options[0] || {};
         let currentCodePath = null;
         const sourceCode = context.getSourceCode();
+
+        /*
+         * We need to check whether there is any code inside the preceeding
+         * SwitchCase.
+         */
+        let preceedingCase = null;
 
         /*
          * We need to use leading comments of the next SwitchCase node because
@@ -107,13 +116,21 @@ module.exports = {
                  * And reports the previous fallthrough node if that does not exist.
                  */
                 if (fallthroughCase && !hasFallthroughComment(node, context, fallthroughCommentPattern)) {
-                    context.report({
-                        message: "Expected a 'break' statement before '{{type}}'.",
-                        data: {type: node.test ? "case" : "default"},
-                        node
-                    });
+
+                    /*
+                     * Checks whether or not there is any code inside the preceeding
+                     * SwitchCase while ignoring comments.
+                     */
+                    if (!options.allowCommentBody || preceedingCase.consequent.length !== 0) {
+                        context.report({
+                            message: "Expected a 'break' statement before '{{type}}'.",
+                            data: {type: node.test ? "case" : "default"},
+                            node
+                        });
+                    }
                 }
                 fallthroughCase = null;
+                preceedingCase = node;
             },
 
             "SwitchCase:exit"(node) {

--- a/tests/lib/rules/no-fallthrough.js
+++ b/tests/lib/rules/no-fallthrough.js
@@ -85,6 +85,12 @@ ruleTester.run("no-fallthrough", rule, {
             options: [{
                 commentPattern: "break[\\s\\w]+omitted"
             }]
+        },
+        {
+            code: "switch(foo) { case 0:\n// We also need to handle 1\n case 1: b(); }",
+            options: [{
+                allowCommentBody: true
+            }]
         }
     ],
     invalid: [
@@ -166,6 +172,20 @@ ruleTester.run("no-fallthrough", rule, {
                     message: errorsDefault.message,
                     type: errorsDefault.type,
                     line: 4,
+                    column: 1
+                }
+            ]
+        },
+        {
+            code: "switch(foo) { case 0: a();\n // We also need to handle 1.\ncase 1: b(); }",
+            options: [{
+                allowCommentBody: true
+            }],
+            errors: [
+                {
+                    message: "Expected a 'break' statement before 'case'.",
+                    type: "SwitchCase",
+                    line: 3,
                     column: 1
                 }
             ]


### PR DESCRIPTION
Closes #7025 

Set the `allowCommentBody` to allow comments between multiple
immediately falling-through cases.

Multiple cases with a single body are always allowed but placing
comments between the cases is only allowed when this option is set to
`true`.

``` js
/*eslint no-fallthrough: ["error", { "allowCommentBody": true }]*/

switch(foo) {
    case 1:
    case 2:
        doSomething();
}

switch(foo) {
    // We need to handle 1.
    case 1:
    // We also need to handle 2.
    case 2:
        doSomething();
}
```
