### PR TITLE
Update: no-magic-numbers false negative on reassigned vars (fixes #4616)

### DIFF
--- a/docs/rules/no-magic-numbers.md
+++ b/docs/rules/no-magic-numbers.md
@@ -30,6 +30,14 @@ var data = ['foo', 'bar', 'baz'];
 var dataLast = data[2];
 ```
 
+```js
+/*eslint no-magic-numbers: "error"*/
+
+var SECONDS;
+
+SECONDS = 60;
+```
+
 Examples of **correct** code for this rule:
 
 ```js

--- a/lib/rules/no-magic-numbers.js
+++ b/lib/rules/no-magic-numbers.js
@@ -131,8 +131,10 @@ module.exports = {
                             message: "Number constants declarations must use 'const'."
                         });
                     }
-                } else if (okTypes.indexOf(parent.type) === -1 ||
-                    (parent.type === "AssignmentExpression" && parent.operator !== "=")) {
+                } else if (
+                    okTypes.indexOf(parent.type) === -1 ||
+                    (parent.type === "AssignmentExpression" && parent.left.type === "Identifier")
+                ) {
                     context.report({
                         node,
                         message: "No magic number: " + raw + "."

--- a/tests/lib/rules/no-magic-numbers.js
+++ b/tests/lib/rules/no-magic-numbers.js
@@ -56,9 +56,6 @@ ruleTester.run("no-magic-numbers", rule, {
             }]
         },
         {
-            code: "var min, max, mean; min = 1; max = 10; mean = 4;"
-        },
-        {
             code: "var foo = { bar:10 }"
         },
         {
@@ -232,6 +229,15 @@ ruleTester.run("no-magic-numbers", rule, {
                 { message: "No magic number: 1.", line: 1 },
                 { message: "No magic number: 2.", line: 1 },
                 { message: "No magic number: 3.", line: 1 }
+            ]
+        },
+        {
+            code: "var min, max, mean; min = 1; max = 10; mean = 4;",
+            options: [{}],
+            errors: [
+                {message: "No magic number: 1.", line: 1},
+                {message: "No magic number: 10.", line: 1},
+                {message: "No magic number: 4.", line: 1}
             ]
         }
     ]


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#4616 

**What changes did you make? (Give an overview)**

This causes `no-magic-numbers` to report cases where variables are reassigned to magic numbers:

```js
var foo;
foo = 1234;
```

**Is there anything you'd like reviewers to focus on?**

Since `no-magic-numbers` had a test ensuring the opposite behavior, this might be considered a breaking change rather than a bugfix.