### PR TITLE
Update: Added disallowMultipleSpaces option to the space-before-block…

### DIFF
--- a/lib/rules/space-before-blocks.js
+++ b/lib/rules/space-before-blocks.js
@@ -38,6 +38,9 @@ module.exports = {
                             },
                             classes: {
                                 enum: ["always", "never"]
+                            },
+                            disallowMultipleSpaces: {
+                                type: "boolean"
                             }
                         },
                         additionalProperties: false
@@ -52,12 +55,14 @@ module.exports = {
             sourceCode = context.getSourceCode();
         let checkFunctions = true,
             checkKeywords = true,
-            checkClasses = true;
+            checkClasses = true,
+            disallowMultipleSpaces = false;
 
         if (typeof config === "object") {
             checkFunctions = config.functions !== "never";
             checkKeywords = config.keywords !== "never";
             checkClasses = config.classes !== "never";
+            disallowMultipleSpaces = config.disallowMultipleSpaces === true;
         } else if (config === "never") {
             checkFunctions = false;
             checkKeywords = false;
@@ -97,6 +102,20 @@ module.exports = {
                 }
 
                 if (requireSpace) {
+                    if (disallowMultipleSpaces) {
+                        const whiteSpace = sourceCode.text.slice(precedingToken.range[1], node.range[0]);
+
+                        if (whiteSpace.length > 1) {
+                            context.report({
+                                node,
+                                message: "More than one space before opening brace.",
+                                fix(fixer) {
+                                    return fixer.replaceTextRange([ precedingToken.range[1], node.range[0] ], " ");
+                                }
+                            });
+                        }
+                    }
+
                     if (!hasSpace) {
                         context.report({
                             node,

--- a/tests/lib/rules/space-before-blocks.js
+++ b/tests/lib/rules/space-before-blocks.js
@@ -20,11 +20,14 @@ const ruleTester = new RuleTester(),
     neverArgs = ["never"],
     functionsOnlyArgs = [ { functions: "always", keywords: "never", classes: "never" } ],
     keywordOnlyArgs = [ { functions: "never", keywords: "always", classes: "never" } ],
-    classesOnlyArgs = [ { functions: "never", keywords: "never", classes: "always" }],
+    classesOnlyArgs = [ { functions: "never", keywords: "never", classes: "always" } ],
+    alwaysArgsOneSpace = [ { disallowMultipleSpaces: true } ],
     expectedSpacingErrorMessage = "Missing space before opening brace.",
     expectedSpacingError = { message: expectedSpacingErrorMessage },
     expectedNoSpacingErrorMessage = "Unexpected space before opening brace.",
-    expectedNoSpacingError = { message: "Unexpected space before opening brace."};
+    expectedNoSpacingError = { message: "Unexpected space before opening brace."},
+    expectedOneSpaceErrorMessage = "More than one space before opening brace.",
+    expectedOneSpaceError = { message: expectedOneSpaceErrorMessage };
 
 ruleTester.run("space-before-blocks", rule, {
     valid: [
@@ -140,7 +143,10 @@ ruleTester.run("space-before-blocks", rule, {
         {code: "if(a) {}else{}"},
         {code: "if(a){}else {}", options: neverArgs},
         {code: "try {}catch(a){}", options: functionsOnlyArgs},
-        {code: "export default class{}", options: classesOnlyArgs, parserOptions: { sourceType: "module" }}
+        {code: "export default class{}", options: classesOnlyArgs, parserOptions: { sourceType: "module" }},
+
+        // https://github.com/eslint/eslint/issues/7023
+        {code: "function a() {}", options: alwaysArgsOneSpace}
     ],
     invalid: [
         {
@@ -427,6 +433,18 @@ ruleTester.run("space-before-blocks", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors: [ expectedNoSpacingError ],
             output: "class test{}"
+        },
+
+        // https://github.com/eslint/eslint/issues/7023
+        {
+            code: "function a()    {}",
+            options: alwaysArgsOneSpace,
+            errors: [ expectedOneSpaceError ]
+        },
+        {
+            code: "function a(){}",
+            options: alwaysArgsOneSpace,
+            errors: [ expectedSpacingError ]
         }
     ]
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
Issue 7023

**What changes did you make? (Give an overview)**
Added the disallowMultipleSpaces option to the space-before-blocks rule, it only executes if that option is set. It has no impact if the never option for one of the fields is set.

**Is there anything you'd like reviewers to focus on?**
Not sure about commit message length .... 72 chars is no description at all, would be: 

Update: Added disallowMultipleSpaces space-before-blocks (fixes #7023)

Seems like that's not really a description, but keywords ...

…s rule (fixes #7023)