### PR TITLE
Fix: Rule message placeholders can be inside braces (fixes #6988)

### DIFF
--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -974,7 +974,7 @@ module.exports = (function() {
         }
 
         if (opts) {
-            message = message.replace(/\{\{\s*(.+?)\s*\}\}/g, function(fullMatch, term) {
+            message = message.replace(/\{\{\s*([^{}]+?)\s*\}\}/g, function(fullMatch, term) {
                 if (term in opts) {
                     return opts[term];
                 }

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -937,6 +937,25 @@ describe("eslint", function() {
             assert.equal(messages[0].message, "message yay!");
         });
 
+        it("should allow template parameter wrapped in braces", function() {
+            eslint.reset();
+            eslint.defineRule("test-rule", function(context) {
+                return {
+                    Literal(node) {
+                        context.report(node, "message {{{param}}}", {
+                            param: "yay!"
+                        });
+                    }
+                };
+            });
+
+            config.rules["test-rule"] = 1;
+
+            const messages = eslint.verify("0", config);
+
+            assert.equal(messages[0].message, "message {yay!}");
+        });
+
         it("should ignore template parameter with no specified value", function() {
             eslint.reset();
             eslint.defineRule("test-rule", function(context) {


### PR DESCRIPTION
**What issue does this pull request address?**

Issue #6988.

**What changes did you make? (Give an overview)**

Tightened up a regular expression to filter out brace characters from rule message parameters, since those are the delimiters used.

**Is there anything you'd like reviewers to focus on?**

Is this approach okay? I could also just have the *first* character not be an open brace, but I don't know if that's just more complexity for not a lot of gain.