### PR TITLE
Update: add fixer for wrap-regex (fixes #7013)

### DIFF
--- a/docs/rules/wrap-regex.md
+++ b/docs/rules/wrap-regex.md
@@ -1,5 +1,7 @@
 # Require Regex Literals to be Wrapped (wrap-regex)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 When a regular expression is used in certain situations, it can end up looking like a division operator. For example:
 
 ```js

--- a/lib/rules/wrap-regex.js
+++ b/lib/rules/wrap-regex.js
@@ -17,7 +17,9 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -36,7 +38,11 @@ module.exports = {
 
                     if (grandparent.type === "MemberExpression" && grandparent.object === node &&
                         (!source || source.value !== "(")) {
-                        context.report(node, "Wrap the regexp literal in parens to disambiguate the slash.");
+                        context.report({
+                            node,
+                            message: "Wrap the regexp literal in parens to disambiguate the slash.",
+                            fix: fixer => fixer.replaceText(node, `(${sourceCode.getText(node)})`)
+                        });
                     }
                 }
             }

--- a/tests/lib/rules/wrap-regex.js
+++ b/tests/lib/rules/wrap-regex.js
@@ -28,10 +28,15 @@ ruleTester.run("wrap-regex", rule, {
         "a[/b/];"
     ],
     invalid: [
-        { code: "/foo/.test(bar);",
-          errors: [{ message: "Wrap the regexp literal in parens to disambiguate the slash.", type: "Literal"}] },
-        { code: "/foo/ig.test(bar);",
-          errors: [{ message: "Wrap the regexp literal in parens to disambiguate the slash.", type: "Literal"}] }
-
+        {
+            code: "/foo/.test(bar);",
+            errors: [{ message: "Wrap the regexp literal in parens to disambiguate the slash.", type: "Literal"}],
+            output: "(/foo/).test(bar);"
+        },
+        {
+            code: "/foo/ig.test(bar);",
+            errors: [{ message: "Wrap the regexp literal in parens to disambiguate the slash.", type: "Literal"}],
+            output: "(/foo/ig).test(bar);"
+        }
     ]
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#7013 

**What changes did you make? (Give an overview)**

This adds a fixer for the `wrap-regex` rule by surrounding regular expressions literals with parentheses, as described in #7013.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular. ~~#7013 has not been accepted yet, so this PR should not be merged yet.~~