### PR TITLE
Update: add fixer for newline-before-return (fixes #5958)

### DIFF
--- a/docs/rules/newline-before-return.md
+++ b/docs/rules/newline-before-return.md
@@ -1,5 +1,7 @@
 # require an empty line before `return` statements (newline-before-return)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 There is no hard and fast rule about whether empty lines should precede `return` statements in JavaScript. However, clearly delineating where a function is returning can greatly increase the readability and clarity of the code. For example:
 
 ```js

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -138,7 +138,6 @@ module.exports = {
         function hasNewlineBefore(node) {
             const lineNumNode = node.loc.start.line;
             const lineNumTokenBefore = getLineNumberOfTokenBefore(node);
-
             const commentLines = calcCommentLines(node, lineNumTokenBefore);
 
             return (lineNumNode - lineNumTokenBefore - commentLines) > 1;
@@ -191,7 +190,10 @@ module.exports = {
                         message: "Expected newline before return statement.",
                         fix(fixer) {
                             if (canFix(node)) {
-                                return fixer.insertTextBefore(node, "\n");
+                                const tokenBefore = sourceCode.getTokenBefore(node);
+                                const newlines = node.loc.start.line === tokenBefore.loc.end.line ? "\n\n" : "\n";
+
+                                return fixer.insertTextBefore(node, newlines);
                             }
                             return null;
                         }

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -15,9 +15,7 @@ module.exports = {
             category: "Stylistic Issues",
             recommended: false
         },
-
         fixable: "whitespace",
-
         schema: []
     },
 
@@ -106,8 +104,9 @@ module.exports = {
 
         /**
          * Returns the line number of the token before the node that is passed in as an argument
-         * @param {ASTNode} node - node from
+         * @param {ASTNode} node - The node to use as the start of the calculation
          * @returns {number} Line number of the token before `node`
+         * @private
          */
         function getLineNumberOfTokenBefore(node) {
             const tokenBefore = sourceCode.getTokenBefore(node);
@@ -154,16 +153,30 @@ module.exports = {
          *
          * @param {ASTNode} node - The return statement node to check.
          * @returns {boolean} `true` if it can fix the node.
+         * @private
          */
         function canFix(node) {
-            const lineNumTokenBefore = getLineNumberOfTokenBefore(node);
-            const tokenHasComments = calcCommentLines(node, lineNumTokenBefore) > 0;
+            const leadingComments = sourceCode.getComments(node).leading;
+            const lastLeadingComment = leadingComments[leadingComments.length - 1];
+            const tokenBefore = sourceCode.getTokenBefore(node);
 
-            if (tokenHasComments) {
-                return false;
+            if (leadingComments.length === 0) {
+                return true;
             }
 
-            return true;
+            // if the last leading comment ends in the same line as the previous token and
+            // does not share a line with the `return` node, we can consider it safe to fix.
+            // Example:
+            // function a() {
+            //     var b; //comment
+            //     return;
+            // }
+            if (lastLeadingComment.loc.end.line === tokenBefore.loc.end.line &&
+                lastLeadingComment.loc.end.line !== node.loc.start.line) {
+                return true;
+            }
+
+            return false;
         }
 
         //--------------------------------------------------------------------------

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -113,13 +113,13 @@ module.exports = {
             let lineNumTokenBefore;
 
             /**
-            * Global return (at the beginning of a script) is a special case.
-            * If there is no token before `return`, then we expect no line
-            * break before the return. Comments are allowed to occupy lines
-            * before the global return, just no blank lines.
-            * Setting lineNumTokenBefore to zero in that case results in the
-            * desired behavior.
-            */
+             * Global return (at the beginning of a script) is a special case.
+             * If there is no token before `return`, then we expect no line
+             * break before the return. Comments are allowed to occupy lines
+             * before the global return, just no blank lines.
+             * Setting lineNumTokenBefore to zero in that case results in the
+             * desired behavior.
+             */
             if (tokenBefore) {
                 lineNumTokenBefore = tokenBefore.loc.end.line;
             } else {

--- a/lib/rules/newline-before-return.js
+++ b/lib/rules/newline-before-return.js
@@ -16,6 +16,8 @@ module.exports = {
             recommended: false
         },
 
+        fixable: "whitespace",
+
         schema: []
     },
 
@@ -103,33 +105,65 @@ module.exports = {
         }
 
         /**
-         * Checks whether node is preceded by a newline
-         * @param {ASTNode} node - node to check
-         * @returns {boolean} Whether or not the node is preceded by a newline
-         * @private
+         * Returns the line number of the token before the node that is passed in as an argument
+         * @param {ASTNode} node - node from
+         * @returns {number} Line number of the token before `node`
          */
-        function hasNewlineBefore(node) {
-            const tokenBefore = sourceCode.getTokenBefore(node),
-                lineNumNode = node.loc.start.line;
+        function getLineNumberOfTokenBefore(node) {
+            const tokenBefore = sourceCode.getTokenBefore(node);
             let lineNumTokenBefore;
 
             /**
-             * Global return (at the beginning of a script) is a special case.
-             * If there is no token before `return`, then we expect no line
-             * break before the return. Comments are allowed to occupy lines
-             * before the global return, just no blank lines.
-             * Setting lineNumTokenBefore to zero in that case results in the
-             * desired behavior.
-             */
+            * Global return (at the beginning of a script) is a special case.
+            * If there is no token before `return`, then we expect no line
+            * break before the return. Comments are allowed to occupy lines
+            * before the global return, just no blank lines.
+            * Setting lineNumTokenBefore to zero in that case results in the
+            * desired behavior.
+            */
             if (tokenBefore) {
                 lineNumTokenBefore = tokenBefore.loc.end.line;
             } else {
                 lineNumTokenBefore = 0;     // global return at beginning of script
             }
 
+            return lineNumTokenBefore;
+        }
+
+        /**
+         * Checks whether node is preceded by a newline
+         * @param {ASTNode} node - node to check
+         * @returns {boolean} Whether or not the node is preceded by a newline
+         * @private
+         */
+        function hasNewlineBefore(node) {
+            const lineNumNode = node.loc.start.line;
+            const lineNumTokenBefore = getLineNumberOfTokenBefore(node);
+
             const commentLines = calcCommentLines(node, lineNumTokenBefore);
 
             return (lineNumNode - lineNumTokenBefore - commentLines) > 1;
+        }
+
+        /**
+         * Checks whether it is safe to apply a fix to a given return statement.
+         *
+         * The fix is not considered safe if the given return statement has leading comments,
+         * as we cannot safely determine if the newline should be added before or after the comments.
+         * For more information, see: https://github.com/eslint/eslint/issues/5958#issuecomment-222767211
+         *
+         * @param {ASTNode} node - The return statement node to check.
+         * @returns {boolean} `true` if it can fix the node.
+         */
+        function canFix(node) {
+            const lineNumTokenBefore = getLineNumberOfTokenBefore(node);
+            const tokenHasComments = calcCommentLines(node, lineNumTokenBefore) > 0;
+
+            if (tokenHasComments) {
+                return false;
+            }
+
+            return true;
         }
 
         //--------------------------------------------------------------------------
@@ -141,7 +175,13 @@ module.exports = {
                 if (!isFirstNode(node) && !hasNewlineBefore(node)) {
                     context.report({
                         node,
-                        message: "Expected newline before return statement."
+                        message: "Expected newline before return statement.",
+                        fix(fixer) {
+                            if (canFix(node)) {
+                                return fixer.insertTextBefore(node, "\n");
+                            }
+                            return null;
+                        }
                     });
                 }
             }

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -111,6 +111,11 @@ ruleTester.run("newline-before-return", rule, {
 
     invalid: [
         {
+            code: "function a() {\nvar b; return;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b; \nreturn;\n}"
+        },
+        {
             code: "function a() {\nvar b;\nreturn;\n}",
             errors: ["Expected newline before return statement."],
             output: "function a() {\nvar b;\n\nreturn;\n}"
@@ -174,7 +179,7 @@ ruleTester.run("newline-before-return", rule, {
         {
             code: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ return c;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ \nreturn c;\n}"
+            output: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ return c;\n}"
         },
         {
             code: "var a;\nreturn;",
@@ -196,6 +201,59 @@ ruleTester.run("newline-before-return", rule, {
             code: "function a() {\nfor (var b; b < c; b++) {\nif (d) {\nbreak; //comment\n}\nreturn;\n}\n}",
             errors: ["Expected newline before return statement."],
             output: "function a() {\nfor (var b; b < c; b++) {\nif (d) {\nbreak; //comment\n}\n\nreturn;\n}\n}"
+        },
+
+        // Testing edge cases of the fixer when the `return` statement has leading comments.
+        // https://github.com/eslint/eslint/issues/5958
+        {
+            code: "function a() {\nvar b; /*multi-line\ncomment*/\nreturn c;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b; /*multi-line\ncomment*/\nreturn c;\n}"
+        },
+        {
+            code: "function a() {\nvar b;\n/*multi-line\ncomment*/ return c;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b;\n/*multi-line\ncomment*/ return c;\n}"
+        },
+        {
+            code: "function a() {\nvar b; /*multi-line\ncomment*/ return c;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b; /*multi-line\ncomment*/ return c;\n}"
+        },
+        {
+            code: "function a() {\nvar b;\n//comment\nreturn;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b;\n//comment\nreturn;\n}"
+        },
+        {
+            code: "function a() {\nvar b; //comment\nreturn;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b; //comment\n\nreturn;\n}"
+        },
+        {
+            code: "function a() {\nvar b;\n/* comment */ return;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b;\n/* comment */ return;\n}"
+        },
+        {
+            code: "function a() {\nvar b;\n//comment\n/* comment */ return;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b;\n//comment\n/* comment */ return;\n}"
+        },
+        {
+            code: "function a() {\nvar b; /* comment */ return;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b; /* comment */ return;\n}"
+        },
+        {
+            code: "function a() {\nvar b; /* comment */\nreturn;\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b; /* comment */\n\nreturn;\n}"
+        },
+        {
+            code: "function a() {\nvar b;\nreturn; //comment\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b;\n\nreturn; //comment\n}"
         }
     ]
 });

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -113,7 +113,7 @@ ruleTester.run("newline-before-return", rule, {
         {
             code: "function a() {\nvar b; return;\n}",
             errors: ["Expected newline before return statement."],
-            output: "function a() {\nvar b; \nreturn;\n}"
+            output: "function a() {\nvar b; \n\nreturn;\n}"
         },
         {
             code: "function a() {\nvar b;\nreturn;\n}",
@@ -124,6 +124,11 @@ ruleTester.run("newline-before-return", rule, {
             code: "function a() {\nif (b) return b;\nelse if (c) return c;\nelse {\ne();\nreturn d;\n}\n}",
             errors: ["Expected newline before return statement."],
             output: "function a() {\nif (b) return b;\nelse if (c) return c;\nelse {\ne();\n\nreturn d;\n}\n}"
+        },
+        {
+            code: "function a() {\nif (b) return b;\nelse if (c) return c;\nelse {\ne(); return d;\n}\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) return b;\nelse if (c) return c;\nelse {\ne(); \n\nreturn d;\n}\n}"
         },
         {
             code: "function a() {\n while (b) {\nc();\nreturn;\n}\n}",
@@ -188,9 +193,20 @@ ruleTester.run("newline-before-return", rule, {
             output: "var a;\n\nreturn;"
         },
         {
+            code: "var a; return;",
+            parserOptions: { ecmaFeatures: { globalReturn: true } },
+            errors: ["Expected newline before return statement."],
+            output: "var a; \n\nreturn;"
+        },
+        {
             code: "function a() {\n{\n//comment\n}\nreturn\n}",
             errors: ["Expected newline before return statement."],
             output: "function a() {\n{\n//comment\n}\n\nreturn\n}"
+        },
+        {
+            code: "function a() {\n{\n//comment\n} return\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\n{\n//comment\n} \n\nreturn\n}"
         },
         {
             code: "function a() {\nvar c;\nwhile (b) {\n c = d; //comment\n}\nreturn c;\n}",
@@ -254,6 +270,11 @@ ruleTester.run("newline-before-return", rule, {
             code: "function a() {\nvar b;\nreturn; //comment\n}",
             errors: ["Expected newline before return statement."],
             output: "function a() {\nvar b;\n\nreturn; //comment\n}"
+        },
+        {
+            code: "function a() {\nvar b; return; //comment\n}",
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b; \n\nreturn; //comment\n}"
         }
     ]
 });

--- a/tests/lib/rules/newline-before-return.js
+++ b/tests/lib/rules/newline-before-return.js
@@ -112,77 +112,90 @@ ruleTester.run("newline-before-return", rule, {
     invalid: [
         {
             code: "function a() {\nvar b;\nreturn;\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar b;\n\nreturn;\n}"
         },
         {
             code: "function a() {\nif (b) return b;\nelse if (c) return c;\nelse {\ne();\nreturn d;\n}\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) return b;\nelse if (c) return c;\nelse {\ne();\n\nreturn d;\n}\n}"
         },
         {
             code: "function a() {\n while (b) {\nc();\nreturn;\n}\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\n while (b) {\nc();\n\nreturn;\n}\n}"
         },
         {
             code: "function a() {\ndo {\nc();\nreturn;\n} while (b);\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\ndo {\nc();\n\nreturn;\n} while (b);\n}"
         },
         {
             code: "function a() {\nfor (var b; b < c; b++) {\nc();\nreturn;\n}\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nfor (var b; b < c; b++) {\nc();\n\nreturn;\n}\n}"
         },
         {
             code: "function a() {\nfor (b in c) {\nd();\nreturn;\n}\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nfor (b in c) {\nd();\n\nreturn;\n}\n}"
         },
         {
             code: "function a() {\nfor (b of c) {\nd();\nreturn;\n}\n}",
             parserOptions: { ecmaVersion: 6 },
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nfor (b of c) {\nd();\n\nreturn;\n}\n}"
         },
         {
             code: "function a() {\nif (b) {\nc();\n}\n//comment\nreturn b;\n}",
-            errors: ["Expected newline before return statement."]
-        },
-        {
-            code: "function a() {\nif (b) {\nc();\n}\n//comment\nreturn b;\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) {\nc();\n}\n//comment\nreturn b;\n}"
         },
         {
             code: "function a() {\n/*comment\ncomment*/\nif (b) {\nc();\nreturn b;\n} else {\n//comment\n\nreturn d;\n}\n/*multi-line\ncomment*/\nreturn e;\n}",
-            errors: ["Expected newline before return statement.", "Expected newline before return statement."]
+            errors: ["Expected newline before return statement.", "Expected newline before return statement."],
+            output: "function a() {\n/*comment\ncomment*/\nif (b) {\nc();\n\nreturn b;\n} else {\n//comment\n\nreturn d;\n}\n/*multi-line\ncomment*/\nreturn e;\n}"
         },
         {
             code: "function a() {\nif (b) { return; } //comment\nreturn c;\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) { return; } //comment\n\nreturn c;\n}"
         },
         {
             code: "function a() {\nif (b) { return; } /*multi-line\ncomment*/\nreturn c;\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) { return; } /*multi-line\ncomment*/\nreturn c;\n}"
         },
         {
             code: "function a() {\nif (b) { return; }\n/*multi-line\ncomment*/ return c;\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) { return; }\n/*multi-line\ncomment*/ return c;\n}"
         },
         {
             code: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ return c;\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nif (b) { return; } /*multi-line\ncomment*/ \nreturn c;\n}"
         },
         {
             code: "var a;\nreturn;",
             parserOptions: { ecmaFeatures: { globalReturn: true } },
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "var a;\n\nreturn;"
         },
         {
             code: "function a() {\n{\n//comment\n}\nreturn\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\n{\n//comment\n}\n\nreturn\n}"
         },
         {
             code: "function a() {\nvar c;\nwhile (b) {\n c = d; //comment\n}\nreturn c;\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nvar c;\nwhile (b) {\n c = d; //comment\n}\n\nreturn c;\n}"
         },
         {
             code: "function a() {\nfor (var b; b < c; b++) {\nif (d) {\nbreak; //comment\n}\nreturn;\n}\n}",
-            errors: ["Expected newline before return statement."]
+            errors: ["Expected newline before return statement."],
+            output: "function a() {\nfor (var b; b < c; b++) {\nif (d) {\nbreak; //comment\n}\n\nreturn;\n}\n}"
         }
     ]
 });


### PR DESCRIPTION
**What issue does this pull request address?**
#5958 Add auto-fixing for "newline-before-return" rule.

**What changes did you make? (Give an overview)**
Added a fixer for all the cases that can be safely fixed, i.e. when the return statement does not have a comment attached to it.
I did some refactorings so I could re-use the logic that the rule already uses to calculate the number of preceding lines of a given return statement. The fixer uses that same logic to determine if the return statement is safe to fix or not.

**Is there anything you'd like reviewers to focus on?**
I added a couple of questions as comments in the diff. Otherwise, nothing in particular.
