### PR TITLE
Chore: no-regex-spaces uses internal rule message format (fixes #7052)

### DIFF
--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -37,7 +37,10 @@ module.exports = {
             if (regexResults !== null) {
                 context.report({
                     node,
-                    message: `Spaces are hard to count. Use {${regexResults[0].length}}.`
+                    message: "Spaces are hard to count. Use {{{count}}}.",
+                    data: {
+                        count: regexResults[0].length
+                    }
                 });
 
                 /*


### PR DESCRIPTION
**What issue does this pull request address?**

Issue #7052

**What changes did you make? (Give an overview)**

no-regex-spaces now uses internal rule message formatting. (This was previously blocked until #7041 was merged.)

**Is there anything you'd like reviewers to focus on?**

Nah, should be pretty self-explanatory.