### PR TITLE
New: add individual options for `brace-style` (fixes #6828)

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -5,6 +5,38 @@
 
 "use strict";
 
+const blocks = [
+    "FunctionDeclaration",
+    "FunctionExpression",
+    "ArrowFunctionExpression",
+    "IfStatement",
+    "TryStatement",
+    "DoWhileStatement",
+    "WhileStatement",
+    "WithStatement",
+    "ForStatement",
+    "ForInStatement",
+    "ForOfStatement",
+    "SwitchStatement"
+];
+
+const styles = {
+    "1tbs": blocks.reduce(function(acc, type) {
+        acc[type] = "always";
+        return acc;
+    }, {}),
+
+    allman: blocks.reduce(function(acc, type) {
+        acc[type] = "never";
+        return acc;
+    }, {})
+};
+
+styles.stroustrup = Object.assign({
+    noCuddledElse: true,
+    noCuddledCatchFinally: true
+}, styles["1tbs"]);
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -19,14 +51,23 @@ module.exports = {
 
         schema: [
             {
-                enum: ["1tbs", "stroustrup", "allman"]
+                oneOf: [
+                    { enum: ["1tbs", "stroustrup", "allman"] },
+                    {
+                        type: "object",
+                        properties: blocks.reduce(function(acc, type) {
+                            acc[type] = { enum: ["always", "never", "ignore"] };
+                            return acc;
+                        }, {})
+                    }
+                ]
             },
             {
                 type: "object",
                 properties: {
-                    allowSingleLine: {
-                        type: "boolean"
-                    }
+                    allowSingleLine: { type: "boolean" },
+                    noCuddledElse: { type: "boolean" },
+                    noCuddledCatchFinally: { type: "boolean" }
                 },
                 additionalProperties: false
             }
@@ -34,9 +75,8 @@ module.exports = {
     },
 
     create(context) {
-        const style = context.options[0] || "1tbs",
-            params = context.options[1] || {},
-            sourceCode = context.getSourceCode();
+        const sourceCode = context.getSourceCode();
+        let style = context.options[0] || "1tbs";
 
         const OPEN_MESSAGE = "Opening curly brace does not appear on the same line as controlling statement.",
             OPEN_MESSAGE_ALLMAN = "Opening curly brace appears on the same line as controlling statement.",
@@ -44,6 +84,22 @@ module.exports = {
             CLOSE_MESSAGE = "Closing curly brace does not appear on the same line as the subsequent block.",
             CLOSE_MESSAGE_SINGLE = "Closing curly brace should be on the same line as opening curly brace or on the line after the previous block.",
             CLOSE_MESSAGE_STROUSTRUP_ALLMAN = "Closing curly brace appears on the same line as the subsequent block.";
+
+        if (typeof style === "string") {
+            style = styles[style];
+        }
+
+        const options = Object.assign({}, style, context.options[1]);
+
+        blocks.forEach(function(type) {
+            if (type in options) {
+                if (options[type] === "ignore") {
+                    delete options[type];
+                } else {
+                    options[type] = options[type] === "always";
+                }
+            }
+        });
 
         //--------------------------------------------------------------------------
         // Helpers
@@ -73,49 +129,98 @@ module.exports = {
          * Binds a list of properties to a function that verifies that the opening
          * curly brace is on the same line as its controlling statement of a given
          * node.
-         * @param {...string} The properties to check on the node.
-         * @returns {Function} A function that will perform the check on a node
+         * @param {ASTNode} node the node to check.
+         * @param {boolean} expectSameLine whether the brace should start on the same line.
+         * @param {ASTNode} parentNode the parent node.
+         * @returns {void}
          * @private
          */
-        function checkBlock() {
-            const blockProperties = arguments;
+        function checkBlock(node, expectSameLine, parentNode) {
+            if (!isBlock(node)) {
+                return;
+            }
+
+            const previousToken = sourceCode.getTokenBefore(node);
+            const curlyToken = sourceCode.getFirstToken(node);
+            const curlyTokenEnd = sourceCode.getLastToken(node);
+            const allOnSameLine = previousToken.loc.start.line === curlyTokenEnd.loc.start.line;
+
+            if (allOnSameLine && options.allowSingleLine) {
+                return;
+            }
+
+            const startSameLine = previousToken.loc.start.line === curlyToken.loc.start.line;
+
+            if (startSameLine !== expectSameLine) {
+                context.report({
+                    node: parentNode || node,
+                    message: startSameLine ? OPEN_MESSAGE_ALLMAN : OPEN_MESSAGE
+                });
+            }
+
+            if (!node.body.length) {
+                return;
+            }
+
+            if (curlyToken.loc.start.line === node.body[0].loc.start.line) {
+                context.report({
+                    node: node.body[0],
+                    message: BODY_MESSAGE
+                });
+            }
+
+            const lastToken = node.body[node.body.length - 1];
+            const endOnSameLine = curlyTokenEnd.loc.start.line === lastToken.loc.start.line;
+
+            if (endOnSameLine) {
+                context.report({
+                    node: lastToken,
+                    message: CLOSE_MESSAGE_SINGLE
+                });
+            }
+        }
+
+        /**
+         * Creates a block check for the given node.
+         * @param {string} type the type of AST node.
+         * @returns {Function} A function that will check the a node.
+         * @private
+         */
+        function checkNode(type) {
+            if (!(type in options)) {
+                return () => {};
+            }
 
             return function(node) {
-                Array.prototype.forEach.call(blockProperties, function(blockProp) {
-                    const block = node[blockProp];
-
-                    if (!isBlock(block)) {
-                        return;
-                    }
-
-                    const previousToken = sourceCode.getTokenBefore(block);
-                    const curlyToken = sourceCode.getFirstToken(block);
-                    const curlyTokenEnd = sourceCode.getLastToken(block);
-                    const allOnSameLine = previousToken.loc.start.line === curlyTokenEnd.loc.start.line;
-
-                    if (allOnSameLine && params.allowSingleLine) {
-                        return;
-                    }
-
-                    if (style !== "allman" && previousToken.loc.start.line !== curlyToken.loc.start.line) {
-                        context.report(node, OPEN_MESSAGE);
-                    } else if (style === "allman" && previousToken.loc.start.line === curlyToken.loc.start.line) {
-                        context.report(node, OPEN_MESSAGE_ALLMAN);
-                    }
-
-                    if (!block.body.length) {
-                        return;
-                    }
-
-                    if (curlyToken.loc.start.line === block.body[0].loc.start.line) {
-                        context.report(block.body[0], BODY_MESSAGE);
-                    }
-
-                    if (curlyTokenEnd.loc.start.line === block.body[block.body.length - 1].loc.start.line) {
-                        context.report(block.body[block.body.length - 1], CLOSE_MESSAGE_SINGLE);
-                    }
-                });
+                checkBlock(node.body, options[type], node);
             };
+        }
+
+        /**
+         * Checks a given block for a cuddled keyword
+         * @param {ASTNode} node the node to check.
+         * @param {Object} previousToken the previous token.
+         * @param {Object} firstToken the first token.
+         * @param {boolean} expectSameLine whether the brace should be on the same line
+         * @returns {void}
+         * @private
+         */
+        function checkForCuddled(node, previousToken, firstToken, expectSameLine) {
+            const closeOnSameLine = previousToken.loc.start.line === firstToken.loc.start.line;
+
+            if (expectSameLine) {
+                if (!closeOnSameLine && isCurlyPunctuator(previousToken)) {
+                    context.report({
+                        node,
+                        message: CLOSE_MESSAGE
+                    });
+                }
+            } else if (closeOnSameLine) {
+                context.report({
+                    node,
+                    message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN
+                });
+            }
         }
 
         /**
@@ -125,22 +230,17 @@ module.exports = {
          * @private
          */
         function checkIfStatement(node) {
-            checkBlock("consequent", "alternate")(node);
+            if (!("IfStatement" in options)) {
+                return;
+            }
+
+            checkBlock(node.consequent, options.IfStatement, node);
+            checkBlock(node.alternate, options.IfStatement, node);
 
             if (node.alternate) {
-
                 const tokens = sourceCode.getTokensBefore(node.alternate, 2);
 
-                if (style === "1tbs") {
-                    if (tokens[0].loc.start.line !== tokens[1].loc.start.line &&
-                        node.consequent.type === "BlockStatement" &&
-                        isCurlyPunctuator(tokens[0])) {
-                        context.report(node.alternate, CLOSE_MESSAGE);
-                    }
-                } else if (tokens[0].loc.start.line === tokens[1].loc.start.line) {
-                    context.report(node.alternate, CLOSE_MESSAGE_STROUSTRUP_ALLMAN);
-                }
-
+                checkForCuddled(node.alternate, tokens[0], tokens[1], options.IfStatement && !options.noCuddledElse && isBlock(node.consequent));
             }
         }
 
@@ -151,42 +251,30 @@ module.exports = {
          * @private
          */
         function checkTryStatement(node) {
-            checkBlock("block", "finalizer")(node);
+            if (!("TryStatement" in options)) {
+                return;
+            }
 
-            if (isBlock(node.finalizer)) {
-                const tokens = sourceCode.getTokensBefore(node.finalizer, 2);
+            checkBlock(node.block, options.TryStatement, node);
 
-                if (style === "1tbs") {
-                    if (tokens[0].loc.start.line !== tokens[1].loc.start.line) {
-                        context.report(node.finalizer, CLOSE_MESSAGE);
-                    }
-                } else if (tokens[0].loc.start.line === tokens[1].loc.start.line) {
-                    context.report(node.finalizer, CLOSE_MESSAGE_STROUSTRUP_ALLMAN);
+            if (node.handler) {
+                checkBlock(node.handler.body, options.TryStatement, node.handler);
+
+                if (isBlock(node.handler.body)) {
+                    const previousToken = sourceCode.getTokenBefore(node.handler),
+                        firstToken = sourceCode.getFirstToken(node.handler);
+
+                    checkForCuddled(node.handler, previousToken, firstToken, options.TryStatement && !options.noCuddledCatchFinally);
                 }
             }
-        }
 
-        /**
-         * Enforces the configured brace style on CatchClauses
-         * @param {ASTNode} node A CatchClause node.
-         * @returns {void}
-         * @private
-         */
-        function checkCatchClause(node) {
-            const previousToken = sourceCode.getTokenBefore(node),
-                firstToken = sourceCode.getFirstToken(node);
+            if (node.finalizer) {
+                checkBlock(node.finalizer, options.TryStatement, node);
 
-            checkBlock("body")(node);
+                if (isBlock(node.finalizer)) {
+                    const tokens = sourceCode.getTokensBefore(node.finalizer, 2);
 
-            if (isBlock(node.body)) {
-                if (style === "1tbs") {
-                    if (previousToken.loc.start.line !== firstToken.loc.start.line) {
-                        context.report(node, CLOSE_MESSAGE);
-                    }
-                } else {
-                    if (previousToken.loc.start.line === firstToken.loc.start.line) {
-                        context.report(node, CLOSE_MESSAGE_STROUSTRUP_ALLMAN);
-                    }
+                    checkForCuddled(node.finalizer, tokens[0], tokens[1], options.TryStatement && !options.noCuddledCatchFinally);
                 }
             }
         }
@@ -198,6 +286,10 @@ module.exports = {
          * @private
          */
         function checkSwitchStatement(node) {
+            if (!("SwitchStatement" in options)) {
+                return;
+            }
+
             let tokens;
 
             if (node.cases && node.cases.length) {
@@ -206,10 +298,13 @@ module.exports = {
                 tokens = sourceCode.getLastTokens(node, 3);
             }
 
-            if (style !== "allman" && tokens[0].loc.start.line !== tokens[1].loc.start.line) {
-                context.report(node, OPEN_MESSAGE);
-            } else if (style === "allman" && tokens[0].loc.start.line === tokens[1].loc.start.line) {
-                context.report(node, OPEN_MESSAGE_ALLMAN);
+            const sameLine = tokens[0].loc.start.line === tokens[1].loc.start.line;
+
+            if (options.SwitchStatement !== sameLine) {
+                context.report({
+                    node,
+                    message: sameLine ? OPEN_MESSAGE_ALLMAN : OPEN_MESSAGE
+                });
             }
         }
 
@@ -218,20 +313,18 @@ module.exports = {
         //--------------------------------------------------------------------------
 
         return {
-            FunctionDeclaration: checkBlock("body"),
-            FunctionExpression: checkBlock("body"),
-            ArrowFunctionExpression: checkBlock("body"),
+            FunctionDeclaration: checkNode("FunctionDeclaration"),
+            FunctionExpression: checkNode("FunctionExpression"),
+            ArrowFunctionExpression: checkNode("ArrowFunctionExpression"),
             IfStatement: checkIfStatement,
             TryStatement: checkTryStatement,
-            CatchClause: checkCatchClause,
-            DoWhileStatement: checkBlock("body"),
-            WhileStatement: checkBlock("body"),
-            WithStatement: checkBlock("body"),
-            ForStatement: checkBlock("body"),
-            ForInStatement: checkBlock("body"),
-            ForOfStatement: checkBlock("body"),
+            DoWhileStatement: checkNode("DoWhileStatement"),
+            WhileStatement: checkNode("WhileStatement"),
+            WithStatement: checkNode("WithStatement"),
+            ForStatement: checkNode("ForStatement"),
+            ForInStatement: checkNode("ForInStatement"),
+            ForOfStatement: checkNode("ForOfStatement"),
             SwitchStatement: checkSwitchStatement
         };
-
     }
 };

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -89,7 +89,60 @@ ruleTester.run("brace-style", rule, {
         {
             code: "switch(x) \n{ \n case 1: \nbar(); \n }\n ",
             options: ["allman"]
-        }
+        },
+
+        // individual options
+        { code: "function foo () {\n return;\n}", options: [{ FunctionDeclaration: "always" }] },
+        { code: "function foo () \n{\nreturn;\n}", options: [{ FunctionDeclaration: "never" }] },
+        { code: "function foo () { return; }", options: [{ FunctionDeclaration: "always" }, { allowSingleLine: true }] },
+        { code: "function foo () { return; }", options: [{ FunctionDeclaration: "never" }, { allowSingleLine: true }] },
+
+        { code: "var foo = function() {\n return;\n}", options: [{ FunctionExpression: "always" }] },
+        { code: "var foo = function() \n{\nreturn;\n}", options: [{ FunctionExpression: "never" }] },
+        { code: "var foo = function() { return; }", options: [{ FunctionExpression: "always" }, { allowSingleLine: true }] },
+        { code: "var foo = function() { return; }", options: [{ FunctionExpression: "never" }, { allowSingleLine: true }] },
+
+        { code: "var foo = () => {\n return;\n}", parserOptions: { ecmaVersion: 6 }, options: [{ ArrowFunctionExpression: "always" }] },
+        { code: "var foo = () => \n{\nreturn;\n}", parserOptions: { ecmaVersion: 6 }, options: [{ ArrowFunctionExpression: "never" }] },
+        { code: "var foo = () => { return; }", parserOptions: { ecmaVersion: 6 }, options: [{ ArrowFunctionExpression: "always" }, { allowSingleLine: true }] },
+        { code: "var foo = () => { return; }", parserOptions: { ecmaVersion: 6 }, options: [{ ArrowFunctionExpression: "never" }, { allowSingleLine: true }] },
+
+        { code: "if (a) { \nb();\n } else { \nc();\n }", options: [{ IfStatement: "always" }] },
+        { code: "if (a) \n{\nb();\n}\nelse\n{\nc();\n}", options: [{ IfStatement: "never" }] },
+        { code: "if (a) { b(); }", options: [{ IfStatement: "always" }, { allowSingleLine: true }] },
+        { code: "if (a) { b(); }", options: [{ IfStatement: "never" }, { allowSingleLine: true }] },
+
+        { code: "try { \n bar();\n} catch (e) {\n baz(); \n}", options: [{ TryStatement: "always" }] },
+        { code: "try\n{\n bar();\n}\ncatch (e)\n{\n baz(); \n}", options: [{ TryStatement: "never" }] },
+
+        { code: "do { \n bar();\n } while (true)", options: [{ DoWhileStatement: "always" }] },
+        { code: "do\n{\n bar();\n}\nwhile (true)", options: [{ DoWhileStatement: "never" }] },
+
+        { code: "while (foo) { \n bar();\n }", options: [{ WhileStatement: "always" }] },
+        { code: "while (foo)\n{\n bar();\n}", options: [{ WhileStatement: "never" }] },
+        { code: "while (foo) { bar(); }", options: [{ WhileStatement: "always" }, { allowSingleLine: true }] },
+        { code: "while (foo) { bar(); }", options: [{ WhileStatement: "never" }, { allowSingleLine: true }] },
+
+        { code: "with (foo) { \n bar(); \n}", options: [{ WithStatement: "always" }] },
+        { code: "with (foo)\n{\n bar();\n}", options: [{ WithStatement: "never" }] },
+
+        { code: "for (;;) { \n bar(); \n}", options: [{ ForStatement: "always" }] },
+        { code: "for (;;)\n{\n bar();\n}", options: [{ ForStatement: "never" }] },
+        { code: "for (;;) { bar(); }", options: [{ ForStatement: "always" }, { allowSingleLine: true }] },
+        { code: "for (;;) { bar(); }", options: [{ ForStatement: "never" }, { allowSingleLine: true }] },
+
+        { code: "for (foo in bar) { \n baz(); \n }", options: [{ ForInStatement: "always" }] },
+        { code: "for (foo in bar)\n{\n baz();\n}", options: [{ ForInStatement: "never" }] },
+        { code: "for (foo in bar) { baz(); }", options: [{ ForInStatement: "always" }, { allowSingleLine: true }] },
+        { code: "for (foo in bar) { baz(); }", options: [{ ForInStatement: "always" }, { allowSingleLine: true }] },
+
+        { code: "for (foo of bar) { \n baz(); \n }", parserOptions: { ecmaVersion: 6 }, options: [{ ForOfStatement: "always" }] },
+        { code: "for (foo of bar)\n{\n baz();\n}", parserOptions: { ecmaVersion: 6 }, options: [{ ForOfStatement: "never" }] },
+        { code: "for (foo of bar) { baz(); }", parserOptions: { ecmaVersion: 6 }, options: [{ ForOfStatement: "always" }, { allowSingleLine: true }] },
+        { code: "for (foo of bar) { baz(); }", parserOptions: { ecmaVersion: 6 }, options: [{ ForOfStatement: "always" }, { allowSingleLine: true }] },
+
+        { code: "switch (foo) { \n case \"bar\": break;\n }", options: [{ SwitchStatement: "always" }] },
+        { code: "switch (foo)\n{\n case \"bar\": break;\n}", options: [{ SwitchStatement: "never" }] }
     ],
 
     invalid: [
@@ -187,6 +240,40 @@ ruleTester.run("brace-style", rule, {
             { message: CLOSE_MESSAGE_STROUSTRUP_ALLMAN, type: "IfStatement" },
             { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
             { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" }
-        ] }
+        ] },
+
+        // individual options
+        { code: "function foo () {\n return;\n}", options: [{ FunctionDeclaration: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "FunctionDeclaration" }] },
+        { code: "function foo () \n{\nreturn;\n}", options: [{ FunctionDeclaration: "always" }], errors: [{ message: OPEN_MESSAGE, type: "FunctionDeclaration" }] },
+
+        { code: "var foo = function() {\n return;\n}", options: [{ FunctionExpression: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "FunctionExpression" }] },
+        { code: "var foo = function() \n{\nreturn;\n}", options: [{ FunctionExpression: "always" }], errors: [{ message: OPEN_MESSAGE, type: "FunctionExpression" }] },
+
+        { code: "var foo = () => {\n return;\n}", parserOptions: { ecmaVersion: 6 }, options: [{ ArrowFunctionExpression: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "ArrowFunctionExpression" }] },
+        { code: "var foo = () => \n{\nreturn;\n}", parserOptions: { ecmaVersion: 6 }, options: [{ ArrowFunctionExpression: "always" }], errors: [{ message: OPEN_MESSAGE, type: "ArrowFunctionExpression" }] },
+
+        { code: "if (a) { \nb();\n } else\n{ \nc();\n }", options: [{ IfStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "IfStatement" }] },
+        { code: "if (a) \n{\nb();\n}\nelse {\nc();\n}", options: [{ IfStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" }] },
+
+        { code: "try { \n bar();\n} catch (e)\n{\n baz(); \n}", options: [{ TryStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "CatchClause" }] },
+        { code: "try\n{\n bar();\n}\ncatch (e) {\n baz(); \n}", options: [{ TryStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "CatchClause" }] },
+
+        { code: "do { \n bar();\n } while (true)", options: [{ DoWhileStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "DoWhileStatement" }] },
+        { code: "do\n{\n bar();\n}\nwhile (true)", options: [{ DoWhileStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "DoWhileStatement" }] },
+
+        { code: "while (foo) { \n bar();\n }", options: [{ WhileStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "WhileStatement" }] },
+        { code: "while (foo)\n{\n bar();\n}", options: [{ WhileStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "WhileStatement" }] },
+
+        { code: "with (foo) { \n bar(); \n}", options: [{ WithStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "WithStatement" }] },
+        { code: "with (foo)\n{\n bar();\n}", options: [{ WithStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "WithStatement" }] },
+
+        { code: "for (;;) { \n bar(); \n}", options: [{ ForStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "ForStatement" }] },
+        { code: "for (;;)\n{\n bar();\n}", options: [{ ForStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "ForStatement" }] },
+
+        { code: "for (foo in bar) { \n baz(); \n }", options: [{ ForInStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "ForInStatement" }] },
+        { code: "for (foo in bar)\n{\n baz();\n}", options: [{ ForInStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "ForInStatement" }] },
+
+        { code: "for (foo of bar) { \n baz(); \n }", parserOptions: { ecmaVersion: 6 }, options: [{ ForOfStatement: "never" }], errors: [{ message: OPEN_MESSAGE_ALLMAN, type: "ForOfStatement" }] },
+        { code: "for (foo of bar)\n{\n baz();\n}", parserOptions: { ecmaVersion: 6 }, options: [{ ForOfStatement: "always" }], errors: [{ message: OPEN_MESSAGE, type: "ForOfStatement" }] }
     ]
 });


### PR DESCRIPTION
**What issue does this pull request address?**
#6828

**What changes did you make? (Give an overview)**
- Added individual options for each type of AST node supported by the rule, using enum `always`, `never`, `ignore` to specify whether the brace should start on the same line or not
- Refactor existing predefined rules to use these options
- Add options `noCuddledElse` and `noCuddledCatchFinally` to account for variance in "Stroustrup" style
- Add support for fixing violations found by the rule

**Is there anything you'd like reviewers to focus on?**
I added tests for the individual options (though technically they should be covered by the defined styles), but i could not find a way to test the rule fixes. I did runtime tests, but would feel more comfortable being able to unit test it.
