### PR TITLE
[Docs] Clarify that `es6` env also sets `ecmaVersion` to 6

### DIFF
--- a/docs/user-guide/configuring.md
+++ b/docs/user-guide/configuring.md
@@ -84,7 +84,7 @@ An environment defines global variables that are predefined. The available envir
 * `node` - Node.js global variables and Node.js scoping.
 * `commonjs` - CommonJS global variables and CommonJS scoping (use this for browser-only code that uses Browserify/WebPack).
 * `shared-node-browser` - Globals common to both Node and Browser.
-* `es6` - enable all ECMAScript 6 features except for modules.
+* `es6` - enable all ECMAScript 6 features except for modules (this automatically sets the `ecmaVersion` parser option to 6).
 * `worker` - web workers global variables.
 * `amd` - defines `require()` and `define()` as global variables as per the [amd](https://github.com/amdjs/amdjs-api/wiki/AMD) spec.
 * `mocha` - adds all of the Mocha testing global variables.


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

None, this is a documentation-only pull request.

**What changes did you make? (Give an overview)**

Reading the docs, it is not clear why ESLint's parser will stop complaining about ES6 specifics when `es6` env is set and `ecmaVersion: 6` is omitted.
It is actually done [on purpose](https://github.com/eslint/eslint/blob/e1187285f137d685bcfc9e2a771fa059ef9637a9/conf/environments.js#L98-L103), but the documentation didn't mention this at all.

**Is there anything you'd like reviewers to focus on?**

N/A