### PR TITLE
Missing arguments in examples

### DIFF
--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -54,12 +54,12 @@ Examples of **correct** code for this rule when used without exceptions:
 ```js
 /*eslint prefer-reflect: "error"*/
 
-Reflect.apply(undefined, args);
-Reflect.apply(null, args);
+Reflect.apply(foo, undefined, args);
+Reflect.apply(foo, null, args);
 Reflect.apply(obj.foo, obj, args);
 Reflect.apply(obj.foo, other, args);
-Reflect.apply(undefined, [arg]);
-Reflect.apply(null, [arg]);
+Reflect.apply(foo, undefined, [arg]);
+Reflect.apply(foo, null, [arg]);
 Reflect.apply(obj.foo, obj, [arg]);
 Reflect.apply(obj.foo, other, [arg]);
 ```


### PR DESCRIPTION
**What issue does this pull request address?**

An error in documentation

**What changes did you make? (Give an overview)**

Added the missing function argument in Reflect.apply() calls

**Is there anything you'd like reviewers to focus on?**

Not really