### PR TITLE
Update: Make `indent` report lines with mixed spaces/tabs (fixes #4274)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -121,8 +121,6 @@ module.exports = {
     },
 
     create(context) {
-
-        const MESSAGE = "Expected indentation of {{needed}} {{type}} {{characters}} but found {{gotten}}.";
         const DEFAULT_VARIABLE_INDENT = 1;
         const DEFAULT_PARAMETER_INDENT = null; // For backwards compatibility, don't check parameter indentation unless specified in the config
         const DEFAULT_FUNCTION_BODY_INDENT = 1;
@@ -192,92 +190,61 @@ module.exports = {
             }
         }
 
-        const indentPattern = {
-            normal: indentType === "space" ? /^ +/ : /^\t+/,
-            excludeCommas: indentType === "space" ? /^[ ,]+/ : /^[\t,]+/
-        };
-
         const caseIndentStore = {};
 
         /**
-         * Reports a given indent violation and properly pluralizes the message
+         * Creates an error message for a line, given the expected/actual indentation.
+         * @param {int} expectedAmount The expected amount of indentation characters for this line
+         * @param {int} actualSpaces The actual number of indentation spaces that were found on this line
+         * @param {int} actualTabs The actual number of indentation tabs that were found on this line
+         * @returns {string} An error message for this line
+         */
+        function createErrorMessage(expectedAmount, actualSpaces, actualTabs) {
+            const expectedStatement = `${expectedAmount} ${indentType}${expectedAmount === 1 ? "" : "s"}`; // e.g. "2 tabs"
+            const foundSpacesWord = `space${actualSpaces === 1 ? "" : "s"}`; // e.g. "space"
+            const foundTabsWord = `tab${actualTabs === 1 ? "" : "s"}`; // e.g. "tabs"
+            let foundStatement;
+
+            if (actualSpaces > 0 && actualTabs > 0) {
+                foundStatement = `${actualSpaces} ${foundSpacesWord} and ${actualTabs} ${foundTabsWord}`; // e.g. "1 space and 2 tabs"
+            } else if (actualSpaces > 0) {
+
+                // Abbreviate the message if the expected indentation is also spaces.
+                // e.g. 'Expected 4 spaces but found 2' rather than 'Expected 4 spaces but found 2 spaces'
+                foundStatement = indentType === "space" ? actualSpaces : `${actualSpaces} ${foundSpacesWord}`;
+            } else if (actualTabs > 0) {
+                foundStatement = indentType === "tab" ? actualTabs : `${actualTabs} ${foundTabsWord}`;
+            } else {
+                foundStatement = "0";
+            }
+
+            return `Expected indentation of ${expectedStatement} but found ${foundStatement}.`;
+        }
+
+        /**
+         * Reports a given indent violation
          * @param {ASTNode} node Node violating the indent rule
          * @param {int} needed Expected indentation character count
-         * @param {int} gotten Indentation character count in the actual node/code
+         * @param {int} gottenSpaces Indentation space count in the actual node/code
+         * @param {int} gottenTabs Indentation tab count in the actual node/code
          * @param {Object=} loc Error line and column location
          * @param {boolean} isLastNodeCheck Is the error for last node check
          * @returns {void}
          */
-        function report(node, needed, gotten, loc, isLastNodeCheck) {
-            const msgContext = {
-                needed,
-                type: indentType,
-                characters: needed === 1 ? "character" : "characters",
-                gotten
-            };
-            const indentChar = indentType === "space" ? " " : "\t";
+        function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck) {
 
-            /**
-             * Responsible for fixing the indentation issue fix
-             * @returns {Function} function to be executed by the fixer
-             * @private
-             */
-            function getFixerFunction() {
-                let rangeToFix = [];
+            const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed);
 
-                if (needed > gotten) {
-                    const spaces = indentChar.repeat(needed - gotten);
+            const textRange = isLastNodeCheck
+                ? [node.range[1] - gottenSpaces - gottenTabs - 1, node.range[1] - 1]
+                : [node.range[0] - gottenSpaces - gottenTabs, node.range[0]];
 
-                    if (isLastNodeCheck === true) {
-                        rangeToFix = [
-                            node.range[1] - 1,
-                            node.range[1] - 1
-                        ];
-                    } else {
-                        rangeToFix = [
-                            node.range[0],
-                            node.range[0]
-                        ];
-                    }
-
-                    return function(fixer) {
-                        return fixer.insertTextBeforeRange(rangeToFix, spaces);
-                    };
-                } else {
-                    if (isLastNodeCheck === true) {
-                        rangeToFix = [
-                            node.range[1] - (gotten - needed) - 1,
-                            node.range[1] - 1
-                        ];
-                    } else {
-                        rangeToFix = [
-                            node.range[0] - (gotten - needed),
-                            node.range[0]
-                        ];
-                    }
-
-                    return function(fixer) {
-                        return fixer.removeRange(rangeToFix);
-                    };
-                }
-            }
-
-            if (loc) {
-                context.report({
-                    node,
-                    loc,
-                    message: MESSAGE,
-                    data: msgContext,
-                    fix: getFixerFunction()
-                });
-            } else {
-                context.report({
-                    node,
-                    message: MESSAGE,
-                    data: msgContext,
-                    fix: getFixerFunction()
-                });
-            }
+            context.report({
+                node,
+                loc,
+                message: createErrorMessage(needed, gottenSpaces, gottenTabs),
+                fix: fixer => fixer.replaceTextRange(textRange, desiredIndent)
+            });
         }
 
         /**
@@ -285,15 +252,23 @@ module.exports = {
          * @param {ASTNode|Token} node Node to examine
          * @param {boolean} [byLastLine=false] get indent of node's last line
          * @param {boolean} [excludeCommas=false] skip comma on start of line
-         * @returns {int} Indent
+         * @returns {Object} The node's indent. Contains keys `space` and `tab`, representing the indent of each character. Also
+         contains keys `goodChar` and `badChar`, where `goodChar` is the amount of the user's desired indentation character, and
+         `badChar` is the amount of the other indentation character.
          */
-        function getNodeIndent(node, byLastLine, excludeCommas) {
+        function getNodeIndent(node, byLastLine) {
             const token = byLastLine ? sourceCode.getLastToken(node) : sourceCode.getFirstToken(node);
-            const src = sourceCode.getText(token, token.loc.start.column);
-            const regExp = excludeCommas ? indentPattern.excludeCommas : indentPattern.normal;
-            const indent = regExp.exec(src);
+            const srcCharsBeforeNode = sourceCode.getText(token, token.loc.start.column).split("");
+            const indentChars = srcCharsBeforeNode.slice(0, srcCharsBeforeNode.findIndex(char => char !== " " && char !== "\t"));
+            const spaces = indentChars.filter(char => char === " ").length;
+            const tabs = indentChars.filter(char => char === "\t").length;
 
-            return indent ? indent[0].length : 0;
+            return {
+                space: spaces,
+                tab: tabs,
+                goodChar: indentType === "space" ? spaces : tabs,
+                badChar: indentType === "space" ? tabs : spaces
+            };
         }
 
         /**
@@ -313,27 +288,29 @@ module.exports = {
         /**
          * Check indent for node
          * @param {ASTNode} node Node to check
-         * @param {int} indent needed indent
+         * @param {int} neededIndent needed indent
          * @param {boolean} [excludeCommas=false] skip comma on start of line
          * @returns {void}
          */
-        function checkNodeIndent(node, indent, excludeCommas) {
-            const nodeIndent = getNodeIndent(node, false, excludeCommas);
+        function checkNodeIndent(node, neededIndent) {
+            const actualIndent = getNodeIndent(node, false);
 
             if (
-                node.type !== "ArrayExpression" && node.type !== "ObjectExpression" &&
-                nodeIndent !== indent && isNodeFirstInLine(node)
+                node.type !== "ArrayExpression" &&
+                node.type !== "ObjectExpression" &&
+                (actualIndent.goodChar !== neededIndent || actualIndent.badChar !== 0) &&
+                isNodeFirstInLine(node)
             ) {
-                report(node, indent, nodeIndent);
+                report(node, neededIndent, actualIndent.space, actualIndent.tab);
             }
 
             if (node.type === "IfStatement" && node.alternate) {
                 const elseToken = sourceCode.getTokenBefore(node.alternate);
 
-                checkNodeIndent(elseToken, indent, excludeCommas);
+                checkNodeIndent(elseToken, neededIndent);
 
                 if (!isNodeFirstInLine(node.alternate)) {
-                    checkNodeIndent(node.alternate, indent, excludeCommas);
+                    checkNodeIndent(node.alternate, neededIndent);
                 }
             }
         }
@@ -345,8 +322,8 @@ module.exports = {
          * @param {boolean} [excludeCommas=false] skip comma on start of line
          * @returns {void}
          */
-        function checkNodesIndent(nodes, indent, excludeCommas) {
-            nodes.forEach(node => checkNodeIndent(node, indent, excludeCommas));
+        function checkNodesIndent(nodes, indent) {
+            nodes.forEach(node => checkNodeIndent(node, indent));
         }
 
         /**
@@ -359,11 +336,12 @@ module.exports = {
             const lastToken = sourceCode.getLastToken(node);
             const endIndent = getNodeIndent(lastToken, true);
 
-            if (endIndent !== lastLineIndent && isNodeFirstInLine(node, true)) {
+            if ((endIndent.goodChar !== lastLineIndent || endIndent.badChar !== 0) && isNodeFirstInLine(node, true)) {
                 report(
                     node,
                     lastLineIndent,
-                    endIndent,
+                    endIndent.space,
+                    endIndent.tab,
                     { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
                     true
                 );
@@ -379,11 +357,12 @@ module.exports = {
         function checkFirstNodeLineIndent(node, firstLineIndent) {
             const startIndent = getNodeIndent(node, false);
 
-            if (startIndent !== firstLineIndent && isNodeFirstInLine(node)) {
+            if ((startIndent.goodChar !== firstLineIndent || startIndent.badChar !== 0) && isNodeFirstInLine(node)) {
                 report(
                     node,
                     firstLineIndent,
-                    startIndent,
+                    startIndent.space,
+                    startIndent.tab,
                     { line: node.loc.start.line, column: node.loc.start.column }
                 );
             }
@@ -526,11 +505,11 @@ module.exports = {
                 calleeNode.parent.type === "ArrayExpression")) {
 
                 // If function is part of array or object, comma can be put at left
-                indent = getNodeIndent(calleeNode, false, false);
+                indent = getNodeIndent(calleeNode, false, false).goodChar;
             } else {
 
                 // If function is standalone, simple calculate indent
-                indent = getNodeIndent(calleeNode);
+                indent = getNodeIndent(calleeNode).goodChar;
             }
 
             if (calleeNode.parent.type === "CallExpression") {
@@ -538,13 +517,13 @@ module.exports = {
 
                 if (calleeNode.type !== "FunctionExpression" && calleeNode.type !== "ArrowFunctionExpression") {
                     if (calleeParent && calleeParent.loc.start.line < node.loc.start.line) {
-                        indent = getNodeIndent(calleeParent);
+                        indent = getNodeIndent(calleeParent).goodChar;
                     }
                 } else {
                     if (isArgBeforeCalleeNodeMultiline(calleeNode) &&
                         calleeParent.callee.loc.start.line === calleeParent.callee.loc.end.line &&
                         !isNodeFirstInLine(calleeNode)) {
-                        indent = getNodeIndent(calleeParent);
+                        indent = getNodeIndent(calleeParent).goodChar;
                     }
                 }
             }
@@ -644,7 +623,7 @@ module.exports = {
                         effectiveParent = parent.parent;
                     }
                 }
-                nodeIndent = getNodeIndent(effectiveParent);
+                nodeIndent = getNodeIndent(effectiveParent).goodChar;
                 if (parentVarNode && parentVarNode.loc.start.line !== node.loc.start.line) {
                     if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
                         if (parent.type === "VariableDeclarator" && parentVarNode.loc.start.line === effectiveParent.loc.start.line) {
@@ -667,7 +646,7 @@ module.exports = {
 
                 checkFirstNodeLineIndent(node, nodeIndent);
             } else {
-                nodeIndent = getNodeIndent(node);
+                nodeIndent = getNodeIndent(node).goodChar;
                 elementsIndent = nodeIndent + indentSize;
             }
 
@@ -679,8 +658,7 @@ module.exports = {
                 elementsIndent += indentSize * options.VariableDeclarator[parentVarNode.parent.kind];
             }
 
-            // Comma can be placed before property name
-            checkNodesIndent(elements, elementsIndent, true);
+            checkNodesIndent(elements, elementsIndent);
 
             if (elements.length > 0) {
 
@@ -736,9 +714,9 @@ module.exports = {
             ];
 
             if (node.parent && statementsWithProperties.indexOf(node.parent.type) !== -1 && isNodeBodyBlock(node)) {
-                indent = getNodeIndent(node.parent);
+                indent = getNodeIndent(node.parent).goodChar;
             } else {
-                indent = getNodeIndent(node);
+                indent = getNodeIndent(node).goodChar;
             }
 
             if (node.type === "IfStatement" && node.consequent.type !== "BlockStatement") {
@@ -784,13 +762,12 @@ module.exports = {
          */
         function checkIndentInVariableDeclarations(node) {
             const elements = filterOutSameLineVars(node);
-            const nodeIndent = getNodeIndent(node);
+            const nodeIndent = getNodeIndent(node).goodChar;
             const lastElement = elements[elements.length - 1];
 
             const elementsIndent = nodeIndent + indentSize * options.VariableDeclarator[node.kind];
 
-            // Comma can be placed before declaration
-            checkNodesIndent(elements, elementsIndent, true);
+            checkNodesIndent(elements, elementsIndent);
 
             // Only check the last line if there is any token after the last item
             if (sourceCode.getLastToken(node).loc.end.line <= lastElement.loc.end.line) {
@@ -802,7 +779,7 @@ module.exports = {
             if (tokenBeforeLastElement.value === ",") {
 
                 // Special case for comma-first syntax where the semicolon is indented
-                checkLastNodeLineIndent(node, getNodeIndent(tokenBeforeLastElement));
+                checkLastNodeLineIndent(node, getNodeIndent(tokenBeforeLastElement).goodChar);
             } else {
                 checkLastNodeLineIndent(node, elementsIndent - indentSize);
             }
@@ -834,7 +811,7 @@ module.exports = {
                 return caseIndentStore[switchNode.loc.start.line];
             } else {
                 if (typeof switchIndent === "undefined") {
-                    switchIndent = getNodeIndent(switchNode);
+                    switchIndent = getNodeIndent(switchNode).goodChar;
                 }
 
                 if (switchNode.cases.length > 0 && options.SwitchCase === 0) {
@@ -853,7 +830,7 @@ module.exports = {
                 if (node.body.length > 0) {
 
                     // Root nodes should have no indent
-                    checkNodesIndent(node.body, getNodeIndent(node));
+                    checkNodesIndent(node.body, getNodeIndent(node).goodChar);
                 }
             },
 
@@ -912,7 +889,7 @@ module.exports = {
                     return;
                 }
 
-                const propertyIndent = getNodeIndent(node) + indentSize * options.MemberExpression;
+                const propertyIndent = getNodeIndent(node).goodChar + indentSize * options.MemberExpression;
 
                 const checkNodes = [node.property];
 
@@ -928,7 +905,7 @@ module.exports = {
             SwitchStatement(node) {
 
                 // Switch is not a 'BlockStatement'
-                const switchIndent = getNodeIndent(node);
+                const switchIndent = getNodeIndent(node).goodChar;
                 const caseIndent = expectedCaseIndent(node, switchIndent);
 
                 checkNodesIndent(node.cases, caseIndent);

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -22,7 +22,7 @@ const fixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/inden
 const fixedFixture = fs.readFileSync(path.join(__dirname, "../../fixtures/rules/indent/indent-valid-fixture-1.js"), "utf8");
 
 /**
- * Create error message object for failure cases
+ * Create error message object for failure cases with a single 'found' indentation type
  * @param {string} indentType indent type of string or tab
  * @param {array} errors error info
  * @returns {Object} returns the error messages collection
@@ -39,13 +39,16 @@ function expectedErrors(indentType, errors) {
     }
 
     return errors.map(function(err) {
-        const chars = err[1] === 1 ? "character" : "characters";
+        let message;
 
-        return {
-            message: "Expected indentation of " + err[1] + " " + indentType + " " + chars + " but found " + err[2] + ".",
-            type: err[3] || "Program",
-            line: err[0]
-        };
+        if (typeof err[1] === "string" && typeof err[2] === "string") {
+            message = `Expected indentation of ${err[1]} but found ${err[2]}.`;
+        } else {
+            const chars = indentType + (err[1] === 1 ? "" : "s");
+
+            message = `Expected indentation of ${err[1]} ${chars} but found ${err[2]}.`;
+        }
+        return {message, type: err[3], line: err[0]};
     });
 }
 
@@ -2763,6 +2766,60 @@ ruleTester.run("indent", rule, {
             "}",
             options: [2, {FunctionExpression: {parameters: "first", body: 3}}],
             errors: expectedErrors([[3, 0, 4, "Identifier"], [4, 6, 2, "ExpressionStatement"]])
+        },
+        {
+            code:
+            "var foo = bar;\n" +
+            "  \t  \t  \t  var baz = qux;",
+            output:
+            "var foo = bar;\n" +
+            "var baz = qux;",
+            options: [2],
+            errors: expectedErrors([2, "0 spaces", "8 spaces and 3 tabs", "VariableDeclaration"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "  \tbaz();\n" +
+            "\t   \t\t\t  \t\t\t  \t   \tqux();\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "  baz();\n" +
+            "  qux();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "2 spaces", "2 spaces and 1 tab", "ExpressionStatement"], [4, "2 spaces", "10 spaces and 9 tabs", "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "\tbar();\n" +
+            "\t  baz();\n" +
+            "  \t\t \t     \t   \t  \t\t\t qux();\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "\tbar();\n" +
+            "\tbaz();\n" +
+            "\tqux();\n" +
+            "}",
+            options: ["tab"],
+            errors: expectedErrors("tab", [[3, "1 tab", "2 spaces and 1 tab", "ExpressionStatement"], [4, "1 tab", "14 spaces and 8 tabs", "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "\t\t}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
         }
     ]
 });


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#4274

**What changes did you make? (Give an overview)**

This updates the `indent` rule to parse both tabs and spaces as indent characters, regardless of which character lines are supposed to have. For example, if a line is supposed to be indented with two spaces, and it starts with two spaces followed by a tab, the line will get reported because the tab isn't supposed to be there. (Previously, the line would not get reported because the tab wasn't considered an indentation character in "spaces mode".)

Since it now has the ability to detect both spaces and tabs, the rule can also give more detailed error messages, e.g. `Expected indentation of 8 spaces but found 4 spaces and 2 tabs.`

This PR also updates the `getNodeIndent` function to only check indentation up to the first non-whitespace character on the node's line, rather than up to the node itself. This makes the logic a bit simpler; for example, lines that start with commas are no longer a special case. This also avoids the issues referenced [here](/eslint/eslint/pull/4363#issuecomment-172669298) where multiline comments could get mangled by the autofixer.

**Is there anything you'd like reviewers to focus on?**

This PR makes a few significant changes to the autofix logic. For example, all of the indentation on a reported line is now always replaced by the fixer. We should verify that this change doesn't introduce any regressions.