### PR TITLE
Update: fix false negative of `arrow-spacing` (fixes #7079)

### DIFF
--- a/lib/rules/arrow-spacing.js
+++ b/lib/rules/arrow-spacing.js
@@ -51,16 +51,18 @@ module.exports = {
          * @returns {Object} Tokens of arrow and before/after arrow.
          */
         function getTokens(node) {
-            let t = sourceCode.getFirstToken(node);
-            let before;
+            let arrow = sourceCode.getTokenBefore(node.body);
 
-            while (t.type !== "Punctuator" || t.value !== "=>") {
-                before = t;
-                t = sourceCode.getTokenAfter(t);
+            // skip '(' tokens.
+            while (arrow.value !== "=>") {
+                arrow = sourceCode.getTokenBefore(arrow);
             }
-            const after = sourceCode.getTokenAfter(t);
 
-            return { before, arrow: t, after };
+            return {
+                before: sourceCode.getTokenBefore(arrow),
+                arrow,
+                after: sourceCode.getTokenAfter(arrow)
+            };
         }
 
         /**

--- a/tests/lib/rules/arrow-spacing.js
+++ b/tests/lib/rules/arrow-spacing.js
@@ -328,7 +328,31 @@ const invalid = [
         errors: [
             { column: 1, line: 2, type: "Punctuator" }
         ]
-    }
+    },
+
+    // https://github.com/eslint/eslint/issues/7079
+    {
+        code: "(a = ()=>0)=>1",
+        output: "(a = () => 0) => 1",
+        parserOptions: { ecmaVersion: 6 },
+        errors: [
+            { column: 7, line: 1, message: "Missing space before =>." },
+            { column: 10, line: 1, message: "Missing space after =>." },
+            { column: 11, line: 1, message: "Missing space before =>." },
+            { column: 14, line: 1, message: "Missing space after =>." },
+        ],
+    },
+    {
+        code: "(a = ()=>0)=>(1)",
+        output: "(a = () => 0) => (1)",
+        parserOptions: { ecmaVersion: 6 },
+        errors: [
+            { column: 7, line: 1, message: "Missing space before =>." },
+            { column: 10, line: 1, message: "Missing space after =>." },
+            { column: 11, line: 1, message: "Missing space before =>." },
+            { column: 14, line: 1, message: "Missing space after =>." },
+        ],
+    },
 ];
 
 ruleTester.run("arrow-spacing", rule, {


### PR DESCRIPTION
Fixes #7079.

Original logic does traversing to right from the head of arrow function nodes, so it's going to stop at `=>` token in default parameters.
New logic does traversing to left from the head of arrow function body.

Semver-minor: this fix can increase warnings.