### PR TITLE
Fix: Don't report comparisons of two typeof expressions (fixes #7078)

### DIFF
--- a/docs/rules/valid-typeof.md
+++ b/docs/rules/valid-typeof.md
@@ -10,7 +10,7 @@ This rule enforces comparing `typeof` expressions to valid string literals.
 
 This rule has an object option:
 
-* `"requireStringLiterals": true` requires `typeof` expressions to only be compared to string literals, and disallows comparisons to any other value.
+* `"requireStringLiterals": true` requires `typeof` expressions to only be compared to string literals or other `typeof` expressions, and disallows comparisons to any other value.
 
 Examples of **incorrect** code for this rule:
 
@@ -43,7 +43,6 @@ typeof baz === "strnig"
 typeof qux === "some invalid type"
 typeof baz === anotherVariable
 typeof foo == 5
-typeof bar === typeof qux
 ```
 
 Examples of **correct** code with the `{ "requireStringLiterals": true }` option:
@@ -52,6 +51,7 @@ Examples of **correct** code with the `{ "requireStringLiterals": true }` option
 typeof foo === "undefined"
 typeof bar == "object"
 typeof baz === "string"
+typeof bar === typeof qux
 ```
 
 ## When Not To Use It

--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -34,6 +34,17 @@ module.exports = {
         const VALID_TYPES = ["symbol", "undefined", "object", "boolean", "number", "string", "function"],
             OPERATORS = ["==", "===", "!=", "!=="];
 
+        const requireStringLiterals = context.options[0] && context.options[0].requireStringLiterals;
+
+        /**
+        * Determines whether a node is a typeof expression.
+        * @param {ASTNode} node The node
+        * @returns {boolean} `true` if the node is a typeof expression
+        */
+        function isTypeofExpression(node) {
+            return node.type === "UnaryExpression" && node.operator === "typeof";
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
@@ -41,7 +52,7 @@ module.exports = {
         return {
 
             UnaryExpression(node) {
-                if (node.operator === "typeof") {
+                if (isTypeofExpression(node)) {
                     const parent = context.getAncestors().pop();
 
                     if (parent.type === "BinaryExpression" && OPERATORS.indexOf(parent.operator) !== -1) {
@@ -51,7 +62,7 @@ module.exports = {
                             if (VALID_TYPES.indexOf(sibling.value) === -1) {
                                 context.report(sibling, "Invalid typeof comparison value.");
                             }
-                        } else if (context.options[0] && context.options[0].requireStringLiterals) {
+                        } else if (requireStringLiterals && !isTypeofExpression(sibling)) {
                             context.report(sibling, "Typeof comparisons should be to string literals.");
                         }
                     }

--- a/tests/lib/rules/valid-typeof.js
+++ b/tests/lib/rules/valid-typeof.js
@@ -55,6 +55,10 @@ ruleTester.run("valid-typeof", rule, {
         {
             code: "var baz = typeof foo + 'thing'",
             options: [{ requireStringLiterals: true }]
+        },
+        {
+            code: "typeof foo === typeof bar",
+            options: [{ requireStringLiterals: true }]
         }
     ],
 


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**

#7078

**What changes did you make? (Give an overview)**

This prevents the `valid-typeof` rule from reporting comparisons between two `typeof` expressions (e.g. `typeof foo === typeof bar`) when the `requireStringLiterals` option is enabled.

This makes the option name `requireStringLiterals` a bit misleading, but it upholds the spirit behind the option (that `typeof` comparisons should be statically verifiable). #7078 also contains some discussion on this.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.