### PR TITLE
Fix: include LogicalExpression in indent length calc (fixes #6731)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -654,7 +654,8 @@ module.exports = {
                             parent.type === "ArrayExpression" ||
                             parent.type === "CallExpression" ||
                             parent.type === "ArrowFunctionExpression" ||
-                            parent.type === "NewExpression"
+                            parent.type === "NewExpression" ||
+                            parent.type === "LogicalExpression"
                         ) {
                             nodeIndent = nodeIndent + indentSize;
                         }

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -127,6 +127,60 @@ ruleTester.run("indent", rule, {
         },
         {
             code:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    };",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "\t{\n" +
+            "\t\ta: 1,\n" +
+            "\t\tb: 2\n" +
+            "\t};",
+            options: ["tab"]
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    }||\n" +
+            "    {\n" +
+            "        c: 3,\n" +
+            "        d: 4\n" +
+            "    };",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 && 1;",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 && { a: 1, b: 2 };",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "    (\n" +
+            "        1\n" +
+            "    );",
+            options: [4]
+        },
+        {
+            code:
+            "var x = 0 && { a: 1, b: 2 };",
+            options: [4]
+        },
+        {
+            code:
             "require('http').request({hostname: 'localhost',\n" +
             "                         port: 80}, function(res) {\n" +
             "  res.end();\n" +
@@ -1669,6 +1723,22 @@ ruleTester.run("indent", rule, {
                 "}",
             options: [4, {SwitchCase: 1}],
             errors: expectedErrors([[4, 8, 4, "BreakStatement"], [7, 8, 4, "BreakStatement"]])
+        },
+        {
+            code:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "       a: 1,\n" +
+            "          b: 2\n" +
+            "    };",
+            output:
+            "var x = 0 &&\n" +
+            "    {\n" +
+            "        a: 1,\n" +
+            "        b: 2\n" +
+            "    };",
+            options: [4],
+            errors: expectedErrors([[3, 8, 7, "Property"], [4, 8, 10, "Property"]])
         },
         {
             code:


### PR DESCRIPTION
<!--
Thanks for submitting a pull request to ESLint. Before continuing, please be sure you've read over our guidelines:
http://eslint.org/docs/developer-guide/contributing/pull-requests

Specifically, all pull requests containing code require an **accepted** issue (documentation-only pull requests do not require an issue). If this pull request contains code and there isn't yet an issue explaining why you're submitting this pull request, please stop and open a new issue first.

Please answer all questions below.
-->

**What issue does this pull request address?**
#6731 

**What changes did you make? (Give an overview)**
Essentially added `LogicalExpressions` to the whitelist of multiline cases for object assignments. 
**Is there anything you'd like reviewers to focus on?**

Yeah, It was mentioned in the issue thread that this rule has issues with multiline statements, this is a very simple fix to the specific scenario in #6731 I think people would agree that this https://github.com/eslint/eslint/blob/f4fcd1e6730b8355fbf071240dfdeb419cc93be2/lib/rules/indent.js#L648 segment could use some love via refactoring