### PR TITLE
Docs: Add link to awesome-eslint in integrations page

### DIFF
--- a/docs/user-guide/integrations.md
+++ b/docs/user-guide/integrations.md
@@ -51,3 +51,7 @@
 * [React](https://github.com/yannickcr/eslint-plugin-react)
 
 … and many more published on npm with the [eslintplugin](https://www.npmjs.com/browse/keyword/eslintplugin) keyword.
+
+## Other Integration Lists
+
+You can find a curated list of other popular integrations for ESLint in the [awesome-eslint](https://github.com/dustinspecker/awesome-eslint) GitHub repository.


### PR DESCRIPTION
**What issue does this pull request address?**
Add a link to awesome-eslint in the integrations page. I think they do a good job at curating a bunch of integrations for ESLint, and they seem to have good traction, so I believe it would be helpful to suggest people to take a look in there as well.

**What changes did you make? (Give an overview)**
I added a new section to the end of the integrations page that suggests awesome-eslint as another source for useful ESLint integrations.

**Is there anything you'd like reviewers to focus on?**
Wording suggestions, I guess.
