### PR TITLE
Update: add fixer for quote-props (fixes #6996)

### DIFF
--- a/docs/rules/quote-props.md
+++ b/docs/rules/quote-props.md
@@ -1,5 +1,7 @@
 # require quotes around object literal property names (quote-props)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Object literal property names can be defined in two ways: using literals or using strings. For example, these two objects are equivalent:
 
 ```js

--- a/tests/lib/rules/quote-props.js
+++ b/tests/lib/rules/quote-props.js
@@ -78,135 +78,232 @@ ruleTester.run("quote-props", rule, {
     ],
     invalid: [{
         code: "({ a: 0 })",
+        output: "({ \"a\": 0 })",
         errors: [{
             message: "Unquoted property 'a' found.", type: "Property"
         }]
     }, {
         code: "({ 0: '0' })",
+        output: "({ \"0\": '0' })",
         errors: [{
             message: "Unquoted property '0' found.", type: "Property"
         }]
     }, {
         code: "({ 'a': 0 })",
+        output: "({ a: 0 })",
         options: ["as-needed"],
         errors: [{
             message: "Unnecessarily quoted property 'a' found.", type: "Property"
         }]
     }, {
         code: "({ 'null': 0 })",
+        output: "({ null: 0 })",
         options: ["as-needed"],
         errors: [{
             message: "Unnecessarily quoted property 'null' found.", type: "Property"
         }]
     }, {
         code: "({ 'true': 0 })",
+        output: "({ true: 0 })",
         options: ["as-needed"],
         errors: [{
             message: "Unnecessarily quoted property 'true' found.", type: "Property"
         }]
     }, {
         code: "({ '0': 0 })",
+        output: "({ 0: 0 })",
         options: ["as-needed"],
         errors: [{
             message: "Unnecessarily quoted property '0' found.", type: "Property"
         }]
     }, {
         code: "({ '-a': 0, b: 0 })",
+        output: "({ '-a': 0, \"b\": 0 })",
         options: ["consistent"],
         errors: [{
-            message: "Inconsistently quoted property 'b' found.", type: "ObjectExpression"
+            message: "Inconsistently quoted property 'b' found.", type: "Property"
         }]
     }, {
         code: "({ a: 0, 'b': 0 })",
+        output: "({ \"a\": 0, 'b': 0 })",
         options: ["consistent"],
         errors: [{
-            message: "Inconsistently quoted property 'b' found.", type: "ObjectExpression"
+            message: "Inconsistently quoted property 'a' found.", type: "Property"
         }]
     }, {
         code: "({ '-a': 0, b: 0 })",
+        output: "({ '-a': 0, \"b\": 0 })",
         options: ["consistent-as-needed"],
         errors: [{
-            message: "Inconsistently quoted property 'b' found.", type: "ObjectExpression"
+            message: "Inconsistently quoted property 'b' found.", type: "Property"
         }]
     }, {
         code: "({ 'a': 0, 'b': 0 })",
+        output: "({ a: 0, b: 0 })",
         options: ["consistent-as-needed"],
-        errors: [{
-            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
-        }]
+        errors: [
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"},
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"}
+        ]
     }, {
         code: "({ 'a': 0, [x]: 0 })",
+        output: "({ a: 0, [x]: 0 })",
         env: {es6: true},
         options: ["consistent-as-needed"],
-        errors: [{
-            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
-        }]
+        errors: [
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"}
+        ]
     }, {
         code: "({ 'a': 0, x })",
+        output: "({ a: 0, x })",
         env: {es6: true},
         options: ["consistent-as-needed"],
         errors: [{
-            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
+            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"
         }]
     }, {
         code: "({ 'true': 0, 'null': 0 })",
+        output: "({ true: 0, null: 0 })",
         options: ["consistent-as-needed"],
+        errors: [
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"},
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"}
+        ]
+    }, {
+        code: "({ true: 0, 'null': 0 })",
+        output: "({ \"true\": 0, 'null': 0 })",
+        options: ["consistent"],
         errors: [{
-            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
+            message: "Inconsistently quoted property 'true' found.", type: "Property",
         }]
     }, {
         code: "({ 'a': 0, 'b': 0 })",
+        output: "({ a: 0, b: 0 })",
         options: ["consistent-as-needed", {keywords: true}],
-        errors: [{
-            message: "Properties shouldn't be quoted as all quotes are redundant.", type: "ObjectExpression"
-        }]
+        errors: [
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"},
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"}
+        ]
     }, {
         code: "({ while: 0, b: 0 })",
+        output: "({ \"while\": 0, \"b\": 0 })",
         options: ["consistent-as-needed", {keywords: true}],
-        errors: [{
-            message: "Properties should be quoted as 'while' is a reserved word.", type: "ObjectExpression"
-        }]
+        errors: [
+            {message: "Properties should be quoted as 'while' is a reserved word.", type: "Property"},
+            {message: "Properties should be quoted as 'while' is a reserved word.", type: "Property"}
+        ]
     }, {
         code: "({ while: 0, 'b': 0 })",
+        output: "({ \"while\": 0, 'b': 0 })",
         options: ["consistent-as-needed", {keywords: true}],
         errors: [{
-            message: "Properties should be quoted as 'while' is a reserved word.", type: "ObjectExpression"
+            message: "Properties should be quoted as 'while' is a reserved word.", type: "Property"
         }]
     }, {
+        code: "({ foo: 0, 'bar': 0 })",
+        output: "({ foo: 0, bar: 0 })",
+        options: ["consistent-as-needed", {keywords: true}],
+        errors: [
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"}
+        ]
+    }, {
+        code:
+        "({\n" +
+        "  /* a */ 'prop1' /* b */ : /* c */ value1 /* d */ ,\n" +
+        "  /* e */ prop2 /* f */ : /* g */ value2 /* h */,\n" +
+        "  /* i */ \"prop3\" /* j */ : /* k */ value3 /* l */\n" +
+        "})",
+        output:
+        "({\n" +
+        "  /* a */ 'prop1' /* b */ : /* c */ value1 /* d */ ,\n" +
+        "  /* e */ \"prop2\" /* f */ : /* g */ value2 /* h */,\n" +
+        "  /* i */ \"prop3\" /* j */ : /* k */ value3 /* l */\n" +
+        "})",
+        options: ["consistent"],
+        errors: [{
+            message: "Inconsistently quoted property 'prop2' found.", type: "Property"
+        }]
+    }, {
+        code:
+        "({\n" +
+        "  /* a */ \"foo\" /* b */ : /* c */ value1 /* d */ ,\n" +
+        "  /* e */ \"bar\" /* f */ : /* g */ value2 /* h */,\n" +
+        "  /* i */ \"baz\" /* j */ : /* k */ value3 /* l */\n" +
+        "})",
+        output:
+        "({\n" +
+        "  /* a */ foo /* b */ : /* c */ value1 /* d */ ,\n" +
+        "  /* e */ bar /* f */ : /* g */ value2 /* h */,\n" +
+        "  /* i */ baz /* j */ : /* k */ value3 /* l */\n" +
+        "})",
+        options: ["consistent-as-needed"],
+        errors: [
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"},
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"},
+            {message: "Properties shouldn't be quoted as all quotes are redundant.", type: "Property"}
+        ]
+    }, {
         code: "({'if': 0})",
+        output: "({if: 0})",
         options: ["as-needed"],
         errors: [{
             message: "Unnecessarily quoted property 'if' found.", type: "Property"
         }]
     }, {
         code: "({'synchronized': 0})",
+        output: "({synchronized: 0})",
         options: ["as-needed"],
         errors: [{
             message: "Unnecessarily quoted property 'synchronized' found.", type: "Property"
         }]
     }, {
         code: "({while: 0})",
+        output: "({\"while\": 0})",
         options: ["as-needed", {keywords: true}],
         errors: [{
             message: "Unquoted reserved word 'while' used as key.", type: "Property"
         }]
     }, {
         code: "({'unnecessary': 1, if: 0})",
+        output: "({'unnecessary': 1, \"if\": 0})",
         options: ["as-needed", {keywords: true, unnecessary: false}],
         errors: [{
             message: "Unquoted reserved word 'if' used as key.", type: "Property"
         }]
     }, {
         code: "({1: 1})",
+        output: "({\"1\": 1})",
         options: ["as-needed", {numbers: true}],
         errors: [{
             message: "Unquoted number literal '1' used as key.", type: "Property"
         }]
     }, {
         code: "({1: 1})",
+        output: "({\"1\": 1})",
         options: ["always", {numbers: false}],
         errors: [{
             message: "Unquoted property '1' found.", type: "Property"
+        }]
+    }, {
+        code: "({0x123: 1})",
+        output: "({\"291\": 1})", // 0x123 === 291
+        options: ["always"],
+        errors: [{
+            message: "Unquoted property '291' found."
+        }]
+    }, {
+        code: "({1e2: 1})",
+        output: "({\"100\": 1})",
+        options: ["always", {numbers: false}],
+        errors: [{
+            message: "Unquoted property '100' found."
+        }]
+    }, {
+        code: "({5.: 1})",
+        output: "({\"5\": 1})",
+        options: ["always", {numbers: false}],
+        errors: [{
+            message: "Unquoted property '5' found."
         }]
     }]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*



**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for `quote-props`, as described in #6996.

There was a bit of disagreement in #6996 about how to handle cases with number literals as keys:

```js
var myObject = {1e2: "foo", 0x123: "bar", 123.: "baz"};

// should get fixed to:

var myObject = {"100": "foo", "291": "bar", "123": "baz"};

// ...but maybe it shouldn't get fixed at all because this might be confusing.
```

At the moment, this PR does perform a fix in these cases.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.