### PR TITLE
Doc for `line-comment-position` rule states `above` instead of `beside`

### DIFF
--- a/docs/rules/line-comment-position.md
+++ b/docs/rules/line-comment-position.md
@@ -51,10 +51,10 @@ Examples of **correct** code for the `{ "position": "beside" }` option:
 ```
 
 
-Examples of **incorrect** code for the `{ "position": "above" }` option:
+Examples of **incorrect** code for the `{ "position": "beside" }` option:
 
 ```js
-/*eslint line-comment-position: ["error", { "position": "above" }]*/
+/*eslint line-comment-position: ["error", { "position": "beside" }]*/
 // invalid comment
 1 + 1;
 ```


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[x] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*



**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Docs for `line-comment-position` rule states `above` instead of `beside`. Fixed that.

**Is there anything you'd like reviewers to focus on?**

Nope. Should be pretty trivial.

