### PR TITLE
Fix: line-comment-position "above" string option now works (fixes #7100)

### DIFF
--- a/lib/rules/line-comment-position.js
+++ b/lib/rules/line-comment-position.js
@@ -50,7 +50,7 @@ module.exports = {
             ignorePattern,
             applyDefaultPatterns = true;
 
-        if (!options || typeof option === "string") {
+        if (!options || typeof options === "string") {
             above = !options || options === "above";
 
         } else {

--- a/tests/lib/rules/line-comment-position.js
+++ b/tests/lib/rules/line-comment-position.js
@@ -42,6 +42,10 @@ ruleTester.run("line-comment-position", rule, {
             options: [{position: "above", ignorePattern: "linter" } ]
         },
         {
+            code: "// Meep\nconsole.log('Meep');",
+            options: ["above"]
+        },
+        {
             code: "1 + 1; // valid comment",
             options: ["beside"]
         },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

Re: bug report template: See issue #7100.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Added test case given in #7100, and fixed the typo in the rule.

**Is there anything you'd like reviewers to focus on?**

~~Not really, this should be pretty straightforward.~~

I do have a question about whether I should include test cases for things like `// jscs:disable` being beside code with "above" option. I don't know if that case makes sense inline, though (i.e., I know jscs:disable applies to the next line, but maybe there are other cases that should be tested).