### PR TITLE
Chore: Enable `typeof` check for `no-undef` rule in eslint-config-eslint

### DIFF
--- a/packages/eslint-config-eslint/default.yml
+++ b/packages/eslint-config-eslint/default.yml
@@ -76,7 +76,7 @@ rules:
     no-shadow-restricted-names: "error"
     no-tabs: "error"
     no-trailing-spaces: "error"
-    no-undef: "error"
+    no-undef: ["error", {typeof: true}]
     no-undef-init: "error"
     no-undefined: "error"
     no-underscore-dangle: ["error", {allowAfterThis: true}]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
```

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
* (n/a) I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

As recommended on Gitter, this enables the `typeof: true` option for `no-undef` in `eslint-config-eslint`. It should hopefully prevent errors like the one in #7100.

**Is there anything you'd like reviewers to focus on?**

The tests will fail due to the issue in #7100, so I'll rebase this branch after that issue gets fixed.