### PR TITLE
Chore: Don't require an issue reference in check-commit npm script

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -72,7 +72,6 @@ const NODE = "node ", // intentional extra space
 
     // Regex
     TAG_REGEX = /^(?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade):/,
-    ISSUE_REGEX = /\((?:fixes|refs) #\d+(?:.*(?:fixes|refs) #\d+)*\)$/,
 
     // Settings
     MOCHA_TIMEOUT = 10000;
@@ -920,18 +919,6 @@ target.checkGitCommit = function() {
                 "    'Chore:'",
                 "   Please refer to the contribution guidelines for more details."].join("\n"));
             failed = true;
-        }
-
-        // Check for an issue reference at end (unless it's a documentation commit)
-        if (!/^Docs:/.test(commitMsgs[0])) {
-            if (!ISSUE_REGEX.test(commitMsgs[0])) {
-                echo([" - Commit summary must end with with one of:",
-                    "    '(fixes #1234)'",
-                    "    '(refs #1234)'",
-                    "   Where '1234' is the issue being addressed.",
-                    "   Please refer to the contribution guidelines for more details."].join("\n"));
-                failed = true;
-            }
         }
     }
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [ ] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This removes the check for an issue reference in the `npm run check-commit` script, since that is no longer required by eslintbot or the docs. (discussed in Gitter)

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

