### PR TITLE
Update: add fixer for `curly`

### DIFF
--- a/docs/rules/curly.md
+++ b/docs/rules/curly.md
@@ -1,5 +1,7 @@
 # Require Following Curly Brace Conventions (curly)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 JavaScript allows the omission of curly braces when a block contains only one statement. However, it is considered by many to be best practice to _never_ omit curly braces around blocks, even when they are optional, because it can lead to bugs and reduces code clarity. So the following:
 
 ```js

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -9,6 +9,7 @@
 //------------------------------------------------------------------------------
 
 const astUtils = require("../ast-utils");
+const esUtils = require("esutils");
 
 //------------------------------------------------------------------------------
 // Rule Definition
@@ -48,7 +49,9 @@ module.exports = {
                     maxItems: 2
                 }
             ]
-        }
+        },
+
+        fixable: "code"
     },
 
     create(context) {
@@ -137,12 +140,13 @@ module.exports = {
         /**
          * Reports "Expected { after ..." error
          * @param {ASTNode} node The node to report.
+         * @param {ASTNode} bodyNode The body node that is incorrectly missing curly brackets
          * @param {string} name The name to report.
          * @param {string} suffix Additional string to add to the end of a report.
          * @returns {void}
          * @private
          */
-        function reportExpectedBraceError(node, name, suffix) {
+        function reportExpectedBraceError(node, bodyNode, name, suffix) {
             context.report({
                 node,
                 loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
@@ -150,19 +154,73 @@ module.exports = {
                 data: {
                     name,
                     suffix: (suffix ? ` ${suffix}` : "")
-                }
+                },
+                fix: fixer => fixer.replaceText(bodyNode, `{${sourceCode.getText(bodyNode)}}`)
             });
+        }
+
+        /**
+        * Determines if a semicolon needs to be inserted after removing a set of curly brackets, in order to avoid a SyntaxError.
+        * @param {Token} closingBracket The } token
+        * @returns {boolean} `true` if a semicolon needs to be inserted after the last statement in the block.
+        */
+        function needsSemicolon(closingBracket) {
+            const tokenBefore = sourceCode.getTokenBefore(closingBracket);
+            const tokenAfter = sourceCode.getTokenAfter(closingBracket);
+            const lastBlockNode = sourceCode.getNodeByRangeIndex(tokenBefore.range[0]);
+
+            if (tokenBefore.value === ";") {
+
+                // If the last statement already has a semicolon, don't add another one.
+                return false;
+            }
+
+            if (!tokenAfter) {
+
+                // If there are no statements after this block, there is no need to add another one.
+                return false;
+            }
+
+            if (lastBlockNode.type === "BlockStatement" && lastBlockNode.parent.type !== "FunctionExpression" && lastBlockNode.parent.type !== "ArrowFunctionExpression") {
+
+                // If the last node surrounded by curly brackets is a BlockStatement (other than a FunctionExpression or an ArrowFunctionExpression),
+                // don't insert a semicolon. Otherwise, the semicolon would be parsed as a separate statement, which would cause
+                // a SyntaxError if it was followed by `else`.
+                return false;
+            }
+
+            if (tokenBefore.loc.end.line === tokenAfter.loc.start.line) {
+
+                // If the next token is on the same line, insert a semicolon.
+                return true;
+            }
+
+            if (/^[(\[+-`]/.test(tokenAfter.value)) {
+
+                // If the next token starts with a character that would disrupt ASI, insert a semicolon.
+                return true;
+            }
+
+            if (tokenBefore.type === "Punctuator" && (tokenBefore.value === "++" || tokenBefore.value === "--")) {
+
+                // If the last token is ++ or --, insert a semicolon to avoid disrupting ASI.
+                return true;
+            }
+
+            // Otherwise, do not insert a semicolon.
+            return false;
         }
 
         /**
          * Reports "Unnecessary { after ..." error
          * @param {ASTNode} node The node to report.
+         * @param {ASTNode} bodyNode The block statement that is incorrectly surrounded by parens
          * @param {string} name The name to report.
          * @param {string} suffix Additional string to add to the end of a report.
          * @returns {void}
          * @private
          */
-        function reportUnnecessaryBraceError(node, name, suffix) {
+        function reportUnnecessaryBraceError(node, bodyNode, name, suffix) {
             context.report({
                 node,
                 loc: (name !== "else" ? node : getElseKeyword(node)).loc.start,
@@ -170,6 +228,24 @@ module.exports = {
                 data: {
                     name,
                     suffix: (suffix ? ` ${suffix}` : "")
+                },
+                fix(fixer) {
+
+                    // `do while` expressions sometimes need a space to be inserted after `do`.
+                    // e.g. `do{foo()} while (bar)` should be corrected to `do foo() while (bar)`
+                    const needsPrecedingSpace = node.type === "DoWhileStatement" &&
+                        sourceCode.getTokenBefore(bodyNode).end === bodyNode.start &&
+                        esUtils.code.isIdentifierPartES6(sourceCode.getText(bodyNode).charCodeAt(1));
+
+                    const openingBracket = sourceCode.getFirstToken(bodyNode);
+                    const closingBracket = sourceCode.getLastToken(bodyNode);
+                    const lastTokenInBlock = sourceCode.getTokenBefore(closingBracket);
+                    const resultingBodyText = sourceCode.getText().slice(openingBracket.range[1], lastTokenInBlock.range[0]) +
+                        sourceCode.getText(lastTokenInBlock) +
+                        (needsSemicolon(closingBracket) ? ";" : "") +
+                        sourceCode.getText().slice(lastTokenInBlock.range[1], closingBracket.range[0]);
+
+                    return fixer.replaceText(bodyNode, (needsPrecedingSpace ? " " : "") + resultingBodyText);
                 }
             });
         }
@@ -218,9 +294,9 @@ module.exports = {
                 check() {
                     if (this.expected !== null && this.expected !== this.actual) {
                         if (this.expected) {
-                            reportExpectedBraceError(node, name, suffix);
+                            reportExpectedBraceError(node, body, name, suffix);
                         } else {
-                            reportUnnecessaryBraceError(node, name, suffix);
+                            reportUnnecessaryBraceError(node, body, name, suffix);
                         }
                     }
                 }

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -195,7 +195,7 @@ module.exports = {
                 return true;
             }
 
-            if (/^[(\[+-`]/.test(tokenAfter.value)) {
+            if (/^[(\[\/`+-]/.test(tokenAfter.value)) {
 
                 // If the next token starts with a character that would disrupt ASI, insert a semicolon.
                 return true;

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -177,7 +177,7 @@ module.exports = {
 
             if (!tokenAfter) {
 
-                // If there are no statements after this block, there is no need to add another one.
+                // If there are no statements after this block, there is no need to add a semicolon.
                 return false;
             }
 
@@ -240,9 +240,18 @@ module.exports = {
                     const openingBracket = sourceCode.getFirstToken(bodyNode);
                     const closingBracket = sourceCode.getLastToken(bodyNode);
                     const lastTokenInBlock = sourceCode.getTokenBefore(closingBracket);
+
+                    if (needsSemicolon(closingBracket)) {
+
+                        /*
+                         * If removing braces would cause a SyntaxError due to multiple statements on the same line (or
+                         * change the semantics of the code due to ASI), don't perform a fix.
+                         */
+                        return null;
+                    }
+
                     const resultingBodyText = sourceCode.getText().slice(openingBracket.range[1], lastTokenInBlock.range[0]) +
                         sourceCode.getText(lastTokenInBlock) +
-                        (needsSemicolon(closingBracket) ? ";" : "") +
                         sourceCode.getText().slice(lastTokenInBlock.range[1], closingBracket.range[0]);
 
                     return fixer.replaceText(bodyNode, (needsPrecedingSpace ? " " : "") + resultingBodyText);

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -338,7 +338,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (a) { if (b) console.log(1); else console.log(2) } else console.log(3)",
-            output: "if (a)  if (b) console.log(1); else console.log(2);  else console.log(3)",
+            output: "if (a) { if (b) console.log(1); else console.log(2) } else console.log(3)",
             options: ["multi"],
             errors: [
                 {
@@ -692,7 +692,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) {bar()} baz()",
-            output: "if (foo) bar(); baz()",
+            output: "if (foo) {bar()} baz()",
             options: ["multi"],
             errors: [
                 {
@@ -702,7 +702,7 @@ ruleTester.run("curly", rule, {
             ]
         },
         {
-            code: "do {foo()} while (bar)",
+            code: "do {foo();} while (bar)",
             output: "do foo(); while (bar)",
             options: ["multi"],
             errors: [
@@ -713,10 +713,10 @@ ruleTester.run("curly", rule, {
             ]
         },
 
-        // Semicolon insertion when removing curly braces
+        // Don't remove curly braces if it would cause issues due to ASI.
         {
             code: "if (foo) { bar }\n++baz;",
-            output: "if (foo)  bar; \n++baz;",
+            output: "if (foo) { bar }\n++baz;",
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
         },
@@ -728,25 +728,25 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { bar++ }\nbaz;",
-            output: "if (foo)  bar++; \nbaz;",
+            output: "if (foo) { bar++ }\nbaz;",
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
         },
         {
             code: "if (foo) { bar }\n[1, 2, 3].map(foo);",
-            output: "if (foo)  bar; \n[1, 2, 3].map(foo);",
+            output: "if (foo) { bar }\n[1, 2, 3].map(foo);",
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
         },
         {
             code: "if (foo) { bar }\n(1).toString();",
-            output: "if (foo)  bar; \n(1).toString();",
+            output: "if (foo) { bar }\n(1).toString();",
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
         },
         {
             code: "if (foo) { bar }\n/regex/.test('foo');",
-            output: "if (foo)  bar; \n/regex/.test('foo');",
+            output: "if (foo) { bar }\n/regex/.test('foo');",
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
@@ -777,20 +777,20 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { var foo = () => {} } else {}",
-            output: "if (foo)  var foo = () => {};  else {}",
+            output: "if (foo) { var foo = () => {} } else {}",
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
         {
             code: "if (foo) { var foo = function() {} } else {}",
-            output: "if (foo)  var foo = function() {};  else {}",
+            output: "if (foo) { var foo = function() {} } else {}",
             options: ["multi"],
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         },
         {
             code: "if (foo) { var foo = function*() {} } else {}",
-            output: "if (foo)  var foo = function*() {};  else {}",
+            output: "if (foo) { var foo = function*() {} } else {}",
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -752,6 +752,12 @@ ruleTester.run("curly", rule, {
             errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
         },
         {
+            code: "if (foo) { bar }\nBaz();",
+            output: "if (foo)  bar \nBaz();",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
+        },
+        {
             code:
             "if (a) {\n" +
             "  while (b) {\n" +

--- a/tests/lib/rules/curly.js
+++ b/tests/lib/rules/curly.js
@@ -202,6 +202,7 @@ ruleTester.run("curly", rule, {
     invalid: [
         {
             code: "if (foo) bar()",
+            output: "if (foo) {bar()}",
             errors: [
                 {
                     message: "Expected { after 'if' condition.",
@@ -211,6 +212,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { bar() } else baz()",
+            output: "if (foo) { bar() } else {baz()}",
             errors: [
                 {
                     message: "Expected { after 'else'.",
@@ -220,6 +222,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { bar() } else if (faa) baz()",
+            output: "if (foo) { bar() } else if (faa) {baz()}",
             errors: [
                 {
                     message: "Expected { after 'if' condition.",
@@ -229,6 +232,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "while (foo) bar()",
+            output: "while (foo) {bar()}",
             errors: [
                 {
                     message: "Expected { after 'while' condition.",
@@ -238,6 +242,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "do bar(); while (foo)",
+            output: "do {bar();} while (foo)",
             errors: [
                 {
                     message: "Expected { after 'do'.",
@@ -247,6 +252,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (;foo;) bar()",
+            output: "for (;foo;) {bar()}",
             errors: [
                 {
                     message: "Expected { after 'for' condition.",
@@ -256,6 +262,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo in bar) console.log(foo)",
+            output: "for (var foo in bar) {console.log(foo)}",
             errors: [
                 {
                     message: "Expected { after 'for-in'.",
@@ -265,6 +272,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo of bar) console.log(foo)",
+            output: "for (var foo of bar) {console.log(foo)}",
             parserOptions: { ecmaVersion: 6 },
             errors: [
                 {
@@ -275,6 +283,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (;foo;) { bar() }",
+            output: "for (;foo;)  bar() ",
             options: ["multi"],
             errors: [
                 {
@@ -285,6 +294,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { bar() }",
+            output: "if (foo)  bar() ",
             options: ["multi"],
             errors: [
                 {
@@ -295,6 +305,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "while (foo) { bar() }",
+            output: "while (foo)  bar() ",
             options: ["multi"],
             errors: [
                 {
@@ -305,6 +316,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) baz(); else { bar() }",
+            output: "if (foo) baz(); else  bar() ",
             options: ["multi"],
             errors: [
                 {
@@ -315,6 +327,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (true) { if (false) console.log(1) }",
+            output: "if (true)  if (false) console.log(1) ",
             options: ["multi"],
             errors: [
                 {
@@ -325,6 +338,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (a) { if (b) console.log(1); else console.log(2) } else console.log(3)",
+            output: "if (a)  if (b) console.log(1); else console.log(2);  else console.log(3)",
             options: ["multi"],
             errors: [
                 {
@@ -347,6 +361,19 @@ ruleTester.run("curly", rule, {
                 "        console.log(3)",
                 "}"
             ].join("\n"),
+            output: [
+                "if (0)",
+                "    console.log(0)",
+                "else if (1) {",
+                "    console.log(1)",
+                "    console.log(1)",
+                "} else ",
+                "    if (2)",
+                "        console.log(2)",
+                "    else",
+                "        console.log(3)",
+                ""
+            ].join("\n"),
             options: ["multi"],
             errors: [
                 {
@@ -359,6 +386,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo in bar) { console.log(foo) }",
+            output: "for (var foo in bar)  console.log(foo) ",
             options: ["multi"],
             errors: [
                 {
@@ -369,6 +397,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo of bar) { console.log(foo) }",
+            output: "for (var foo of bar)  console.log(foo) ",
             options: ["multi"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -380,6 +409,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) \n baz()",
+            output: "if (foo) \n {baz()}",
             options: ["multi-line"],
             errors: [
                 {
@@ -390,6 +420,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "while (foo) \n baz()",
+            output: "while (foo) \n {baz()}",
             options: ["multi-line"],
             errors: [
                 {
@@ -400,6 +431,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (;foo;) \n bar()",
+            output: "for (;foo;) \n {bar()}",
             options: ["multi-line"],
             errors: [
                 {
@@ -410,6 +442,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "while (bar && \n baz) \n foo()",
+            output: "while (bar && \n baz) \n {foo()}",
             options: ["multi-line"],
             errors: [
                 {
@@ -420,6 +453,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) bar(baz, \n baz)",
+            output: "if (foo) {bar(baz, \n baz)}",
             options: ["multi-line"],
             errors: [
                 {
@@ -430,6 +464,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "do \n foo(); \n while (bar)",
+            output: "do \n {foo();} \n while (bar)",
             options: ["multi-line"],
             errors: [
                 {
@@ -440,6 +475,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo in bar) \n console.log(foo)",
+            output: "for (var foo in bar) \n {console.log(foo)}",
             options: ["multi-line"],
             errors: [
                 {
@@ -450,6 +486,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo in bar) \n console.log(1); \n console.log(2)",
+            output: "for (var foo in bar) \n {console.log(1);} \n console.log(2)",
             options: ["multi-line"],
             errors: [
                 {
@@ -460,6 +497,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo of bar) \n console.log(foo)",
+            output: "for (var foo of bar) \n {console.log(foo)}",
             options: ["multi-line"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -471,6 +509,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo of bar) \n console.log(1); \n console.log(2)",
+            output: "for (var foo of bar) \n {console.log(1);} \n console.log(2)",
             options: ["multi-line"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -482,6 +521,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) \n quz = { \n bar: baz, \n qux: foo \n };",
+            output: "if (foo) \n {quz = { \n bar: baz, \n qux: foo \n };}",
             options: ["multi-or-nest"],
             errors: [
                 {
@@ -492,6 +532,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "while (true) \n if (foo) \n doSomething(); \n else \n doSomethingElse(); \n",
+            output: "while (true) \n {if (foo) \n doSomething(); \n else \n doSomethingElse();} \n",
             options: ["multi-or-nest"],
             errors: [
                 {
@@ -502,6 +543,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (foo) { \n quz = true; \n }",
+            output: "if (foo)  \n quz = true; \n ",
             options: ["multi-or-nest"],
             errors: [
                 {
@@ -512,6 +554,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "while (true) { \n doSomething(); \n }",
+            output: "while (true)  \n doSomething(); \n ",
             options: ["multi-or-nest"],
             errors: [
                 {
@@ -522,6 +565,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var i = 0; foo; i++) { \n doSomething(); \n }",
+            output: "for (var i = 0; foo; i++)  \n doSomething(); \n ",
             options: ["multi-or-nest"],
             errors: [
                 {
@@ -532,6 +576,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo in bar) \n if (foo) console.log(1); \n else console.log(2);",
+            output: "for (var foo in bar) \n {if (foo) console.log(1); \n else console.log(2);}",
             options: ["multi-or-nest"],
             errors: [
                 {
@@ -542,6 +587,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo in bar) { if (foo) console.log(1) }",
+            output: "for (var foo in bar)  if (foo) console.log(1) ",
             options: ["multi-or-nest"],
             errors: [
                 {
@@ -552,6 +598,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo of bar) \n if (foo) console.log(1); \n else console.log(2);",
+            output: "for (var foo of bar) \n {if (foo) console.log(1); \n else console.log(2);}",
             options: ["multi-or-nest"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -563,6 +610,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "for (var foo of bar) { if (foo) console.log(1) }",
+            output: "for (var foo of bar)  if (foo) console.log(1) ",
             options: ["multi-or-nest"],
             parserOptions: { ecmaVersion: 6 },
             errors: [
@@ -574,6 +622,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (true) foo(); \n else { \n bar(); \n baz(); \n }",
+            output: "if (true) {foo();} \n else { \n bar(); \n baz(); \n }",
             options: ["multi", "consistent"],
             errors: [
                 {
@@ -584,6 +633,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (true) { foo(); faa(); }\n else bar();",
+            output: "if (true) { foo(); faa(); }\n else {bar();}",
             options: ["multi", "consistent"],
             errors: [
                 {
@@ -594,6 +644,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (true) foo(); else { baz(); }",
+            output: "if (true) foo(); else  baz(); ",
             options: ["multi", "consistent"],
             errors: [
                 {
@@ -604,6 +655,7 @@ ruleTester.run("curly", rule, {
         },
         {
             code: "if (true) foo(); else if (true) faa(); else { bar(); baz(); }",
+            output: "if (true) {foo();} else if (true) {faa();} else { bar(); baz(); }",
             options: ["multi", "consistent"],
             errors: [
                 {
@@ -615,6 +667,133 @@ ruleTester.run("curly", rule, {
                     type: "IfStatement"
                 }
             ]
+        },
+        {
+            code: "do{foo();} while (bar)",
+            output: "do foo(); while (bar)",
+            options: ["multi"],
+            errors: [
+                {
+                    message: "Unnecessary { after 'do'.",
+                    type: "DoWhileStatement"
+                }
+            ]
+        },
+        {
+            code: "do{[1, 2, 3].map(bar);} while (bar)",
+            output: "do[1, 2, 3].map(bar); while (bar)",
+            options: ["multi"],
+            errors: [
+                {
+                    message: "Unnecessary { after 'do'.",
+                    type: "DoWhileStatement"
+                }
+            ]
+        },
+        {
+            code: "if (foo) {bar()} baz()",
+            output: "if (foo) bar(); baz()",
+            options: ["multi"],
+            errors: [
+                {
+                    message: "Unnecessary { after 'if' condition.",
+                    type: "IfStatement"
+                }
+            ]
+        },
+        {
+            code: "do {foo()} while (bar)",
+            output: "do foo(); while (bar)",
+            options: ["multi"],
+            errors: [
+                {
+                    message: "Unnecessary { after 'do'.",
+                    type: "DoWhileStatement"
+                }
+            ]
+        },
+
+        // Semicolon insertion when removing curly braces
+        {
+            code: "if (foo) { bar }\n++baz;",
+            output: "if (foo)  bar; \n++baz;",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
+        },
+        {
+            code: "if (foo) { bar; }\n++baz;",
+            output: "if (foo)  bar; \n++baz;",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
+        },
+        {
+            code: "if (foo) { bar++ }\nbaz;",
+            output: "if (foo)  bar++; \nbaz;",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
+        },
+        {
+            code: "if (foo) { bar }\n[1, 2, 3].map(foo);",
+            output: "if (foo)  bar; \n[1, 2, 3].map(foo);",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
+        },
+        {
+            code: "if (foo) { bar }\n(1).toString();",
+            output: "if (foo)  bar; \n(1).toString();",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
+        },
+        {
+            code: "if (foo) { bar }\n/regex/.test('foo');",
+            output: "if (foo)  bar; \n/regex/.test('foo');",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement"}]
+        },
+        {
+            code:
+            "if (a) {\n" +
+            "  while (b) {\n" +
+            "    c();\n" +
+            "    d();\n" +
+            "  }\n" +
+            "} else e();",
+            output:
+            "if (a) \n" +
+            "  while (b) {\n" +
+            "    c();\n" +
+            "    d();\n" +
+            "  }\n" +
+            " else e();",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { while (bar) {} } else {}",
+            output: "if (foo)  while (bar) {}  else {}",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { var foo = () => {} } else {}",
+            output: "if (foo)  var foo = () => {};  else {}",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { var foo = function() {} } else {}",
+            output: "if (foo)  var foo = function() {};  else {}",
+            options: ["multi"],
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
+        },
+        {
+            code: "if (foo) { var foo = function*() {} } else {}",
+            output: "if (foo)  var foo = function*() {};  else {}",
+            options: ["multi"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Unnecessary { after 'if' condition.", type: "IfStatement" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*



**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This introduces a fixer for the [`curly`](http://eslint.org/docs/rules/curly) rule.

In cases where the rule reports missing curly brackets, the fixer adds curly brackets to a node. If the rule reports extraneous curly brackets, the fixer removes the curly brackets.

When adding curly brackets, the fixer naively surrounds the block with curly brackets without modifying whitespace at all. For example:

```js
/* eslint curly: [2] */

if (foo) bar();

// gets fixed to:

if (foo) {bar();}
```

If the user has a preference for brace style, brace spacing, etc., it will get applied by the upcoming [`brace-style`](/eslint/eslint/issues/7074) fixer or the [`space-before-blocks`](http://eslint.org/docs/rules/space-before-blocks) fixer on the next pass.

Similarly, when removing curly brackets, only the brackets themselves are removed and everything else is left intact:

```js
/* eslint curly: [2, "multi"] */
if (foo) {
  bar();
}

// gets fixed to:

if (foo) 
  bar();

```

An exception is with `do ... while` statements where the first character in the `do` block is a valid identifier part. In this case, a space is inserted to avoid changing the `do` keyword.

```js
/* eslint curly: [2, "multi"] */

do{foo();} while (bar)

// gets fixed to:

do foo(); while (bar)  
```

~~The fixer also inserts a semicolon if necessary when removing braces to avoids SyntaxErrors:~~ (**edit**: it no longer does this; now it just declines to fix these cases)

```js
/* eslint curly: [2, "multi"] */

if (foo) {bar()} baz();

// gets fixed to:

if (foo) bar(); baz();
```

**Is there anything you'd like reviewers to focus on?**

~~This PR is not finished yet; it still needs to handle cases where there are statements after the closing bracket.~~

We should make sure to identify any other cases where naively removing/adding braces results in a SyntaxError.