### PR TITLE
Update: add fixer for `no-regex-spaces`

### DIFF
--- a/docs/rules/no-regex-spaces.md
+++ b/docs/rules/no-regex-spaces.md
@@ -1,5 +1,7 @@
 # disallow multiple spaces in regular expression literals (no-regex-spaces)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Regular expressions can be very complex and difficult to understand, which is why it's important to keep them as simple as possible in order to avoid mistakes. One of the more error-prone things you can do with a regular expression is to use more than one space, such as:
 
 ```js

--- a/lib/rules/no-regex-spaces.js
+++ b/lib/rules/no-regex-spaces.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,7 +19,9 @@ module.exports = {
             recommended: true
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -27,19 +31,27 @@ module.exports = {
          * Validate regular expressions
          * @param {ASTNode} node node to validate
          * @param {string} value regular expression to validate
+         * @param {number} valueStart The start location of the regex/string literal. It will always be the case that
+         `sourceCode.getText().slice(valueStart, valueStart + value.length) === value`
          * @returns {void}
          * @private
          */
-        function checkRegex(node, value) {
+        function checkRegex(node, value, valueStart) {
             const multipleSpacesRegex = /( {2,})+?/,
                 regexResults = multipleSpacesRegex.exec(value);
 
             if (regexResults !== null) {
+                const count = regexResults[0].length;
+
                 context.report({
                     node,
                     message: "Spaces are hard to count. Use {{{count}}}.",
-                    data: {
-                        count: regexResults[0].length
+                    data: {count},
+                    fix(fixer) {
+                        return fixer.replaceTextRange(
+                            [valueStart + regexResults.index, valueStart + regexResults.index + count],
+                            ` {${count}}`
+                        );
                     }
                 });
 
@@ -62,7 +74,7 @@ module.exports = {
                 nodeValue = token.value;
 
             if (nodeType === "RegularExpression") {
-                checkRegex(node, nodeValue);
+                checkRegex(node, nodeValue, token.start);
             }
         }
 
@@ -83,8 +95,12 @@ module.exports = {
          * @private
          */
         function checkFunction(node) {
-            if (node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(node.arguments[0])) {
-                checkRegex(node, node.arguments[0].value);
+            const scope = context.getScope();
+            const regExpVar = astUtils.getVariableByName(scope, "RegExp");
+            const shadowed = regExpVar && regExpVar.defs.length > 0;
+
+            if (node.callee.type === "Identifier" && node.callee.name === "RegExp" && isString(node.arguments[0]) && !shadowed) {
+                checkRegex(node, node.arguments[0].value, node.arguments[0].start + 1);
             }
         }
 

--- a/tests/lib/rules/no-regex-spaces.js
+++ b/tests/lib/rules/no-regex-spaces.js
@@ -21,12 +21,15 @@ ruleTester.run("no-regex-spaces", rule, {
         "var foo = new RegExp('bar {3}baz')",
         "var foo = /bar\t\t\tbaz/;",
         "var foo = RegExp('bar\t\t\tbaz');",
-        "var foo = new RegExp('bar\t\t\tbaz');"
+        "var foo = new RegExp('bar\t\t\tbaz');",
+        "var RegExp = function() {}; var foo = new RegExp('bar   baz');",
+        "var RegExp = function() {}; var foo = RegExp('bar   baz');"
     ],
 
     invalid: [
         {
             code: "var foo = /bar    baz/;",
+            output: "var foo = /bar {4}baz/;",
             errors: [
                 {
                     message: "Spaces are hard to count. Use {4}.",
@@ -36,6 +39,7 @@ ruleTester.run("no-regex-spaces", rule, {
         },
         {
             code: "var foo = RegExp('bar    baz');",
+            output: "var foo = RegExp('bar {4}baz');",
             errors: [
                 {
                     message: "Spaces are hard to count. Use {4}.",
@@ -45,10 +49,24 @@ ruleTester.run("no-regex-spaces", rule, {
         },
         {
             code: "var foo = new RegExp('bar    baz');",
+            output: "var foo = new RegExp('bar {4}baz');",
             errors: [
                 {
                     message: "Spaces are hard to count. Use {4}.",
                     type: "NewExpression"
+                }
+            ]
+        },
+        {
+
+            // `RegExp` is not shadowed in the scope where it's called
+            code: "{ let RegExp = function() {}; } var foo = RegExp('bar    baz');",
+            output: "{ let RegExp = function() {}; } var foo = RegExp('bar {4}baz');",
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                {
+                    message: "Spaces are hard to count. Use {4}.",
+                    type: "CallExpression"
                 }
             ]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*



**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-regex-spaces`](http://eslint.org/docs/rules/no-regex-spaces).

The rule's error message tells the user to use a quantifier, e.g. `/ {3}/`. The fixer makes this replacement.

```js
/* eslint no-regex-spaces: 2 */

var x = /foo   bar/;
var y = RegExp('foo   bar');
var z = new RegExp('foo   bar');

// gets fixed to:

var x = /foo {3}bar/;
var y = RegExp('foo {3}bar');
var z = new RegExp('foo {3}bar');
```

**Is there anything you'd like reviewers to focus on?**

~~Nothing in particular.~~

edit: Actually, there is one edge-case to consider: If someone modifies the `RegExp` global to be something other than its usual value, this might cause unexpected behavior. I think the only workaround for this would be to not fix expressions that use the `RegExp` constructor.
