### PR TITLE
Update: `prefer-rest-params` relax for spread (fixes #7130)

### DIFF
--- a/docs/rules/prefer-rest-params.md
+++ b/docs/rules/prefer-rest-params.md
@@ -43,6 +43,11 @@ function foo() {
     var arguments = 0;
     console.log(arguments); // This is a local variable.
 }
+
+// arguments can still be spread
+constructor() {
+  super(...arguments)
+}
 ```
 
 ## When Not To Use It

--- a/lib/rules/prefer-rest-params.js
+++ b/lib/rules/prefer-rest-params.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to
+ * @fileoverview Rule to require rest parameters instead of `arguments`
  * @author Toru Nagashima
  */
 
@@ -54,6 +54,19 @@ function isNotNormalMemberAccess(reference) {
     );
 }
 
+/**
+ * Checks that the given reference is not the operand of a spread
+ * - foo(...arguments)    .... false
+ * - [1, 2, ...arguments] .... false
+ * - foo(arguments)       .... true
+ *
+ * @param {escope.Reference} reference - The reference to check.
+ * @returns {boolean} `true` if the reference is not the operand of a spread.
+ */
+function isNotSpread(reference) {
+    return reference.identifier.parent.type !== "SpreadElement";
+}
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -97,6 +110,7 @@ module.exports = {
                 argumentsVar
                     .references
                     .filter(isNotNormalMemberAccess)
+                    .filter(isNotSpread)
                     .forEach(report);
             }
         }

--- a/tests/lib/rules/prefer-rest-params.js
+++ b/tests/lib/rules/prefer-rest-params.js
@@ -23,11 +23,14 @@ ruleTester.run("prefer-rest-params", rule, {
         {code: "function foo(...args) { args; }", parserOptions: { ecmaVersion: 6 }},
         "function foo() { arguments.length; }",
         "function foo() { arguments.callee; }",
+        {code: "function foo() { bar(...arguments); }", parserOptions: { ecmaVersion: 6 }},
+        {code: "function foo() { return [1, 2, ...arguments]; }", parserOptions: { ecmaVersion: 6 }},
     ],
     invalid: [
         {code: "function foo() { arguments; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
         {code: "function foo() { arguments[0]; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
         {code: "function foo() { arguments[1]; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
         {code: "function foo() { arguments[Symbol.iterator]; }", errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
+        {code: "function foo() { bar(...arguments); const a = arguments[0]; }", parserOptions: { ecmaVersion: 6 }, errors: [{type: "Identifier", message: "Use the rest parameters instead of 'arguments'."}]},
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*

See #7130 

**Please check each item to ensure your pull request is ready:**

- [X] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [X] I've included tests for my change
- [X] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Relaxes the rule `prefer-rest-params` to allow the use of spread arguments (`...arguments`)

**Is there anything you'd like reviewers to focus on?**



