### PR TITLE
Docs: Fixes examples for allowTemplateLiterals

### DIFF
--- a/docs/rules/quotes.md
+++ b/docs/rules/quotes.md
@@ -134,8 +134,8 @@ Examples of additional **correct** code for this rule with the `"double", { "all
 ```js
 /*eslint quotes: ["error", "double", { "allowTemplateLiterals": true }]*/
 
-var single = 'single';
-var single = `single`;
+var double = "double";
+var double = `double`;
 ```
 
 Examples of additional **correct** code for this rule with the `"single", { "allowTemplateLiterals": true }` options:
@@ -143,8 +143,8 @@ Examples of additional **correct** code for this rule with the `"single", { "all
 ```js
 /*eslint quotes: ["error", "single", { "allowTemplateLiterals": true }]*/
 
-var double = "double";
-var double = `double`;
+var single = 'single';
+var single = `single`;
 ```
 
 ## When Not To Use It


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ X] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*



**Please check each item to ensure your pull request is ready:**

- [X ] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [ X] I've included tests for my change
- [X ] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
In the allowTemplateLiterals section of the quotes rules, the code for "double" demonstrates examples for 'single' documentation, and vice versa. I changed the code in the double and single section to correspond to the appropriate example. 

**Is there anything you'd like reviewers to focus on?**



Corrects 'single' example to correlate to single, and "double" example to correlate to double