### PR TITLE
Fix: `max-len`: `ignoreTemplateLiterals`: handle 3+ lines (fixes #7125)

### DIFF
--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -235,8 +235,9 @@ module.exports = {
          * @private
          */
         function groupByLineNumber(acc, node) {
-            ensureArrayAndPush(acc, node.loc.start.line, node);
-            ensureArrayAndPush(acc, node.loc.end.line, node);
+            for (let i = node.loc.start.line; i <= node.loc.end.line; ++i) {
+                ensureArrayAndPush(acc, i, node);
+            }
             return acc;
         }
 

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -101,12 +101,21 @@ ruleTester.run("max-len", rule, {
             options: [29, 4, { ignoreStrings: true }]
         },
         {
+            code: "var str = \"this is a very long string\\\nwith continuation\\\nand with another very very long continuation\\\nand ending\";",
+            options: [29, 4, { ignoreStrings: true }]
+        },
+        {
             code: "var foo = veryLongIdentifier;\nvar bar = `this is a very long string`;",
             options: [29, 4, { ignoreTemplateLiterals: true }],
             parserOptions
         },
         {
             code: "var foo = veryLongIdentifier;\nvar bar = `this is a very long string\nand this is another line that is very long`;",
+            options: [29, 4, { ignoreTemplateLiterals: true }],
+            parserOptions
+        },
+        {
+            code: "var foo = veryLongIdentifier;\nvar bar = `this is a very long string\nand this is another line that is very long\nand here is another\n and another!`;",
             options: [29, 4, { ignoreTemplateLiterals: true }],
             parserOptions
         },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*
See https://github.com/eslint/eslint/issues/7125 for template answers


**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
In `groupByLineNumber`, instead of assuming that "start" and "end" are next to each other, add the entire range of lines to the group.

**Is there anything you'd like reviewers to focus on?**
¯\\\_(ツ)_/¯