### PR TITLE
Update: Make `no-restricted-properties` more flexible (fixes #7137)

### DIFF
--- a/docs/rules/no-restricted-properties.md
+++ b/docs/rules/no-restricted-properties.md
@@ -39,6 +39,32 @@ Multiple object/property values can be disallowed, and you can specify an option
 }
 ```
 
+If the object name is omitted, the property is disallowed for all objects:
+
+```json
+{
+    "rules": {
+        "no-restricted-properties": [2, {
+            "property": "__defineGetter__",
+            "message": "Please use Object.defineProperty instead."
+        }]
+    }
+}
+```
+
+If the property name is omitted, accessing any property of the given object is disallowed:
+
+```json
+{
+    "rules": {
+        "no-restricted-properties": [2, {
+            "object": "require",
+            "message": "Please call require() directly."
+        }]
+    }
+}
+```
+
 Examples of **incorrect** code for this rule:
 
 ```js
@@ -52,6 +78,22 @@ var example = disallowedObjectName.disallowedPropertyName; /*error Disallowed ob
 disallowedObjectName.disallowedPropertyName(); /*error Disallowed object property: disallowedObjectName.disallowedPropertyName.*/
 ```
 
+```js
+/* eslint no-restricted-properties: [2, {
+    "property": "__defineGetter__"
+}] */
+
+foo.__defineGetter__(bar, baz);
+```
+
+```js
+/* eslint no-restricted-properties: [2, {
+    "object": "require"
+}] */
+
+require.resolve('foo');
+```
+
 Examples of **correct** code for this rule:
 
 ```js
@@ -63,6 +105,14 @@ Examples of **correct** code for this rule:
 var example = disallowedObjectName.somePropertyName;
 
 allowedObjectName.disallowedPropertyName();
+```
+
+```js
+/* eslint no-restricted-properties: [2, {
+    "object": "require"
+}] */
+
+require('foo');
 ```
 
 ## When Not To Use It

--- a/lib/rules/no-restricted-properties.js
+++ b/lib/rules/no-restricted-properties.js
@@ -22,22 +22,39 @@ module.exports = {
         schema: {
             type: "array",
             items: {
-                type: "object",
-                properties: {
-                    object: {
-                        type: "string"
+                anyOf: [ // `object` and `property` are both optional, but at least one of them must be provided.
+                    {
+                        type: "object",
+                        properties: {
+                            object: {
+                                type: "string"
+                            },
+                            property: {
+                                type: "string"
+                            },
+                            message: {
+                                type: "string"
+                            }
+                        },
+                        additionalProperties: false,
+                        required: ["object"]
                     },
-                    property: {
-                        type: "string"
-                    },
-                    message: {
-                        type: "string"
+                    {
+                        type: "object",
+                        properties: {
+                            object: {
+                                type: "string"
+                            },
+                            property: {
+                                type: "string"
+                            },
+                            message: {
+                                type: "string"
+                            }
+                        },
+                        additionalProperties: false,
+                        required: ["property"]
                     }
-                },
-                additionalProperties: false,
-                required: [
-                    "object",
-                    "property"
                 ]
             },
             uniqueItems: true
@@ -51,33 +68,49 @@ module.exports = {
             return {};
         }
 
-        const restrictedProperties = restrictedCalls.reduce(function(restrictions, option) {
+        const restrictedProperties = new Map();
+        const globallyRestrictedObjects = new Map();
+        const globallyRestrictedProperties = new Map();
+
+        restrictedCalls.forEach(option => {
             const objectName = option.object;
             const propertyName = option.property;
 
-            if (!restrictions.has(objectName)) {
-                restrictions.set(objectName, new Map());
+            if (typeof objectName === "undefined") {
+                globallyRestrictedProperties.set(propertyName, {message: option.message});
+            } else if (typeof propertyName === "undefined") {
+                globallyRestrictedObjects.set(objectName, {message: option.message});
+            } else {
+                if (!restrictedProperties.has(objectName)) {
+                    restrictedProperties.set(objectName, new Map());
+                }
+
+                restrictedProperties.get(objectName).set(propertyName, {
+                    message: option.message
+                });
             }
-
-            restrictions.get(objectName).set(propertyName, {
-                message: option.message
-            });
-
-            return restrictions;
-        }, new Map());
+        });
 
         return {
             MemberExpression(node) {
                 const objectName = node.object && node.object.name;
                 const propertyName = astUtils.getStaticPropertyName(node);
                 const matchedObject = restrictedProperties.get(objectName);
-                const matchedObjectProperty = matchedObject && matchedObject.get(propertyName);
+                const matchedObjectProperty = matchedObject ? matchedObject.get(propertyName) : globallyRestrictedObjects.get(objectName);
+                const globalMatchedProperty = globallyRestrictedProperties.get(propertyName);
 
                 if (matchedObjectProperty) {
                     const message = matchedObjectProperty.message ? " " + matchedObjectProperty.message : "";
 
                     context.report(node, "'{{objectName}}.{{propertyName}}' is restricted from being used.{{message}}", {
                         objectName,
+                        propertyName,
+                        message
+                    });
+                } else if (globalMatchedProperty) {
+                    const message = globalMatchedProperty.message ? " " + globalMatchedProperty.message : "";
+
+                    context.report(node, "'{{propertyName}}' is restricted from being used.{{message}}", {
                         propertyName,
                         message
                     });

--- a/tests/lib/rules/no-restricted-properties.js
+++ b/tests/lib/rules/no-restricted-properties.js
@@ -75,6 +75,26 @@ ruleTester.run("no-restricted-properties", rule, {
                 object: "obj",
                 property: "foo"
             }]
+        }, {
+            code: "foo.bar",
+            options: [{
+                property: "baz"
+            }]
+        }, {
+            code: "foo.bar",
+            options: [{
+                object: "baz"
+            }]
+        }, {
+            code: "foo()",
+            options: [{
+                object: "foo"
+            }]
+        }, {
+            code: "foo;",
+            options: [{
+                object: "foo"
+            }]
         }
     ],
 
@@ -114,6 +134,69 @@ ruleTester.run("no-restricted-properties", rule, {
                 type: "MemberExpression"
             }, {
                 message: "'anotherObject.anotherDisallowedProperty' is restricted from being used.",
+                type: "MemberExpression"
+            }]
+        }, {
+            code: "foo.__proto__",
+            options: [{
+                property: "__proto__",
+                message: "Please use Object.getPrototypeOf instead."
+            }],
+            errors: [{
+                message: "'__proto__' is restricted from being used. Please use Object.getPrototypeOf instead.",
+                type: "MemberExpression"
+            }]
+        }, {
+            code: "foo['__proto__']",
+            options: [{
+                property: "__proto__",
+                message: "Please use Object.getPrototypeOf instead."
+            }],
+            errors: [{
+                message: "'__proto__' is restricted from being used. Please use Object.getPrototypeOf instead.",
+                type: "MemberExpression"
+            }]
+        }, {
+            code: "foo.bar.baz;",
+            options: [{ object: "foo" }],
+            errors: [{ message: "'foo.bar' is restricted from being used.", type: "MemberExpression" }]
+        }, {
+            code: "foo.bar();",
+            options: [{ object: "foo" }],
+            errors: [{ message: "'foo.bar' is restricted from being used.", type: "MemberExpression" }]
+        }, {
+            code: "foo.bar.baz();",
+            options: [{ object: "foo" }],
+            errors: [{ message: "'foo.bar' is restricted from being used.", type: "MemberExpression" }]
+        }, {
+            code: "foo.bar.baz;",
+            options: [{ property: "bar" }],
+            errors: [{ message: "'bar' is restricted from being used.", type: "MemberExpression" }]
+        }, {
+            code: "foo.bar();",
+            options: [{ property: "bar" }],
+            errors: [{ message: "'bar' is restricted from being used.", type: "MemberExpression" }]
+        }, {
+            code: "foo.bar.baz();",
+            options: [{ property: "bar" }],
+            errors: [{ message: "'bar' is restricted from being used.", type: "MemberExpression" }]
+        }, {
+            code: "require.call({}, 'foo')",
+            options: [{
+                object: "require",
+                message: "Please call require() directly."
+            }],
+            errors: [{
+                message: "'require.call' is restricted from being used. Please call require() directly.",
+                type: "MemberExpression"
+            }]
+        }, {
+            code: "require['resolve']",
+            options: [{
+                object: "require"
+            }],
+            errors: [{
+                message: "'require.resolve' is restricted from being used.",
                 type: "MemberExpression"
             }]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

See #7137 for template answers.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This allows the `object` or `properties` option to be omitted for `no-restricted-properties`.

For more information on the updated behavior, see #7137.

**Is there anything you'd like reviewers to focus on?**

* ~~Is it possible to require either the `object` or `property` key in a schema, while still throwing a validation error if neither `object` nor `property` is provided?~~ (edit: this is fixed)

