### PR TITLE
Update: fix `quotes` rule's false negative (fixes #7084)

### DIFF
--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -123,12 +123,26 @@ module.exports = {
 
         /**
          * Determines if a given node is part of JSX syntax.
-         * @param {ASTNode} node The node to check.
-         * @returns {boolean} True if the node is a JSX node, false if not.
+         *
+         * This function returns `ture` in the following cases:
+         *
+         * - `<div className="foo"></div>` ... If the literal is an attribute value, the parent of the literal is `JSXAttribute`.
+         * - `<div>foo</div>` ... If the literal is a text content, the parent of the literal is `JSXElement`.
+         *
+         * In particular, this function returns `false` in the following cases:
+         *
+         * - `<div className={"foo"}></div>`
+         * - `<div>{"foo"}</div>`
+         *
+         * In both cases, inside of the braces is handled as normal JavaScript.
+         * The braces are `JSXExpressionContainer` nodes.
+         *
+         * @param {ASTNode} node The Literal node to check.
+         * @returns {boolean} True if the node is a part of JSX, false if not.
          * @private
          */
-        function isJSXElement(node) {
-            return node.type === "JSXAttribute" || node.type === "JSXElement";
+        function isJSXLiteral(node) {
+            return node.parent.type === "JSXAttribute" || node.parent.type === "JSXElement";
         }
 
         /**
@@ -215,7 +229,7 @@ module.exports = {
 
                 if (settings && typeof val === "string") {
                     isValid = (quoteOption === "backtick" && isAllowedAsNonBacktick(node)) ||
-                        isJSXElement(node.parent) ||
+                        isJSXLiteral(node) ||
                         astUtils.isSurroundedBy(rawVal, settings.quote);
 
                     if (!isValid && avoidEscape) {

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -128,7 +128,7 @@ module.exports = {
          * @private
          */
         function isJSXElement(node) {
-            return node.type.indexOf("JSX") === 0;
+            return node.type === "JSXAttribute" || node.type === "JSXElement";
         }
 
         /**

--- a/lib/rules/quotes.js
+++ b/lib/rules/quotes.js
@@ -124,7 +124,7 @@ module.exports = {
         /**
          * Determines if a given node is part of JSX syntax.
          *
-         * This function returns `ture` in the following cases:
+         * This function returns `true` in the following cases:
          *
          * - `<div className="foo"></div>` ... If the literal is an attribute value, the parent of the literal is `JSXAttribute`.
          * - `<div>foo</div>` ... If the literal is a text content, the parent of the literal is `JSXElement`.

--- a/tests/lib/rules/quotes.js
+++ b/tests/lib/rules/quotes.js
@@ -205,6 +205,35 @@ ruleTester.run("quotes", rule, {
                 { message: "Strings must use backtick.", type: "Literal" },
                 { message: "Strings must use backtick.", type: "Literal" }
             ]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/7084
+        {
+            code: "<div blah={\"blah\"} />",
+            output: "<div blah={'blah'} />",
+            options: ["single"],
+            parserOptions: { ecmaFeatures: {jsx: true} },
+            errors: [
+                { message: "Strings must use singlequote.", type: "Literal" },
+            ],
+        },
+        {
+            code: "<div blah={'blah'} />",
+            output: "<div blah={\"blah\"} />",
+            options: ["double"],
+            parserOptions: { ecmaFeatures: {jsx: true} },
+            errors: [
+                { message: "Strings must use doublequote.", type: "Literal" },
+            ],
+        },
+        {
+            code: "<div blah={'blah'} />",
+            output: "<div blah={`blah`} />",
+            options: ["backtick"],
+            parserOptions: { ecmaFeatures: {jsx: true} },
+            errors: [
+                { message: "Strings must use backtick.", type: "Literal" },
+            ],
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

See the template of #7084.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- n/a I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

the spec of JSX AST is here: https://github.com/facebook/jsx/blob/master/AST.md

`JSXExpressionContainer` has a normal expression, so `quotes` rule should check string literals in `JSXExpressionContainer`. But the rule had ignored string literals in all node which starts with `JSX`.

As the spec, `quotes` rule should ignore string literals in only `JSXAttribute` and `JSXElement`.

**Semver-minor**: This is a bug fix which increases errors.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

