### PR TITLE
Update: fix `no-unused-vars` false negative (fixes #7124)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -415,6 +415,33 @@ module.exports = {
         }
 
         /**
+         * Checks whether the given variable is the last parameter in the non-ignored parameters.
+         *
+         * @param {espree.Variable} variable - The variable to check.
+         * @returns {boolean} `true` if the variable is the last.
+         */
+        function isLastInNonIgnoredParameters(variable) {
+            const def = variable.defs[0];
+
+            // This is the last.
+            if (def.index === def.node.params.length - 1) {
+                return true;
+            }
+
+            // if all parameters preceded by this variable are ignored, this is the last.
+            if (config.argsIgnorePattern) {
+                const params = context.getDeclaredVariables(def.node);
+                const posteriorParams = params.slice(params.indexOf(variable) + 1);
+
+                if (posteriorParams.every(v => config.argsIgnorePattern.test(v.name))) {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        /**
          * Gets an array of variables without read references.
          * @param {Scope} scope - an escope Scope object.
          * @param {Variable[]} unusedVars - an array that saving result.
@@ -481,7 +508,7 @@ module.exports = {
                             }
 
                             // if "args" option is "after-used", skip all but the last parameter
-                            if (config.args === "after-used" && def.index < def.node.params.length - 1) {
+                            if (config.args === "after-used" && !isLastInNonIgnoredParameters(variable)) {
                                 continue;
                             }
                         } else {

--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -417,7 +417,7 @@ module.exports = {
         /**
          * Checks whether the given variable is the last parameter in the non-ignored parameters.
          *
-         * @param {espree.Variable} variable - The variable to check.
+         * @param {escope.Variable} variable - The variable to check.
          * @returns {boolean} `true` if the variable is the last.
          */
         function isLastInNonIgnoredParameters(variable) {

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -212,7 +212,19 @@ ruleTester.run("no-unused-vars", rule, {
                 "}",
                 "someFunction();"
             ].join("\n")
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/7124
+        {
+            code: "(function(a, b, {c, d}) { d })",
+            options: [{argsIgnorePattern: "c"}],
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "(function(a, b, {c, d}) { c })",
+            options: [{argsIgnorePattern: "d"}],
+            parserOptions: {ecmaVersion: 6}
+        },
     ],
     invalid: [
         { code: "function foox() { return foox(); }", errors: [{ message: "'foox' is defined but never used.", type: "Identifier"}] },
@@ -451,6 +463,31 @@ ruleTester.run("no-unused-vars", rule, {
                 "}"
             ].join("\n"),
             errors: [{message: "'b' is defined but never used."}]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/7124
+        {
+            code: "(function(a, b, c) {})",
+            options: [{argsIgnorePattern: "c"}],
+            errors: [{message: "'b' is defined but never used."}]
+        },
+        {
+            code: "(function(a, b, {c, d}) {})",
+            options: [{argsIgnorePattern: "[cd]"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [{message: "'b' is defined but never used."}]
+        },
+        {
+            code: "(function(a, b, {c, d}) {})",
+            options: [{argsIgnorePattern: "c"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [{message: "'d' is defined but never used."}]
+        },
+        {
+            code: "(function(a, b, {c, d}) {})",
+            options: [{argsIgnorePattern: "d"}],
+            parserOptions: {ecmaVersion: 6},
+            errors: [{message: "'c' is defined but never used."}]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

See #7124.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- ~~I've updated documentation for my change (if appropriate)~~

**What changes did you make? (Give an overview)**

This PR solves a problem in combination of `{args: "after-used"}` and `argsIgnorePattern`.
If the last parameter was ignored, `{args: "after-used"}` ignored all parameters even if those are not used.

This PR changes the behavior. The new behavior is that `{args: "after-used"}` warns the last parameter in the non-ignored parameters.
If the last parameter is destructuring, this handles the parameter as ignored if all variables in the destructuring are ignored.

This might be a bit slow if `argsIgnorePattern` exists.

*semver-minor*: this is a bug fix which increases errors.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.