### PR TITLE
Fix: Report columns for `eol-last` correctly (fixes #7136)

### DIFF
--- a/lib/rules/eol-last.js
+++ b/lib/rules/eol-last.js
@@ -39,7 +39,7 @@ module.exports = {
                 const sourceCode = context.getSourceCode(),
                     src = sourceCode.getText(),
                     location = {
-                        column: 1,
+                        column: lodash.last(sourceCode.lines).length,
                         line: sourceCode.lines.length
                     },
                     LF = "\n",

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -113,9 +113,9 @@ describe("CLIEngine", function() {
             assert.equal(report.results[0].messages.length, 5);
             assert.equal(report.results[0].messages[0].ruleId, "strict");
             assert.equal(report.results[0].messages[1].ruleId, "no-var");
-            assert.equal(report.results[0].messages[2].ruleId, "eol-last");
-            assert.equal(report.results[0].messages[3].ruleId, "no-unused-vars");
-            assert.equal(report.results[0].messages[4].ruleId, "quotes");
+            assert.equal(report.results[0].messages[2].ruleId, "no-unused-vars");
+            assert.equal(report.results[0].messages[3].ruleId, "quotes");
+            assert.equal(report.results[0].messages[4].ruleId, "eol-last");
         });
 
         it("should report one message when using specific config file", function() {
@@ -2401,11 +2401,11 @@ describe("CLIEngine", function() {
             assert.equal(errorResults[0].messages[0].severity, 2);
             assert.equal(errorResults[0].messages[1].ruleId, "no-var");
             assert.equal(errorResults[0].messages[1].severity, 2);
-            assert.equal(errorResults[0].messages[2].ruleId, "eol-last");
+            assert.equal(errorResults[0].messages[2].ruleId, "no-unused-vars");
             assert.equal(errorResults[0].messages[2].severity, 2);
-            assert.equal(errorResults[0].messages[3].ruleId, "no-unused-vars");
+            assert.equal(errorResults[0].messages[3].ruleId, "quotes");
             assert.equal(errorResults[0].messages[3].severity, 2);
-            assert.equal(errorResults[0].messages[4].ruleId, "quotes");
+            assert.equal(errorResults[0].messages[4].ruleId, "eol-last");
             assert.equal(errorResults[0].messages[4].severity, 2);
         });
 

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -3126,7 +3126,7 @@ describe("eslint", function() {
             assert.equal(messages[0].line, 1);
             assert.equal(messages[0].column, 6);
             assert.equal(messages[1].line, 2);
-            assert.equal(messages[1].column, 2);
+            assert.equal(messages[1].column, 18);
             assert.equal(messages[2].line, 2);
             assert.equal(messages[2].column, 18);
         });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[ ] Documentation update
[X] Bug fix
[ ] New rule
[ ] Changes an existing rule
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

**Tell us about your environment**

* **ESLint Version:** 3.5.0
* **Node Version:** 6.5.0
* **npm Version:** 3.10.7

**What parser (default, Babel-ESLint, etc.) are you using?**
default

**Please show your full configuration:**
See source code below, it contains the configuration.

**What did you do? Please include the actual source code causing the issue.**
Check below.

**What did you expect to happen?**

The following file should report an issue at line 2, column 16.
```js
/* eslint eol-last: [1, "always"] */
var a = "test";
```

The following file should report an issue at line 3, column 1.
```js
/* eslint eol-last: [1, "never"] */
var a = "test";\n
```

**What actually happened? Please include the actual, raw output from ESLint.**

Instead, the following file reported an issue at line 2, column 1.
```js
/* eslint eol-last: [1, "always"] */
var a = "test";
```
The second test ran fine.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change (by fixing the tests that depended on column to be 1)
- [ ] <strike>I've updated documentation for my change</strike> (*not applicable*)

**What changes did you make? (Give an overview)**
Instead of reporting issues for column 1, the code now reports the issue for the last column of the line. This broke three tests, which have been fixed.

**Is there anything you'd like reviewers to focus on?**

More information is available in [this discussion](https://github.com/eslint/eslint/pull/6952#issuecomment-246533858).