### PR TITLE
Chore throw if no test scenarios

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -212,7 +212,25 @@ RuleTester.prototype = {
     run(ruleName, rule, test) {
 
         const testerConfig = this.testerConfig,
+            requiredScenarios = ["valid", "invalid"],
+            scenarioErrors = [],
             result = {};
+
+        if (lodash.isNil(test) || typeof test !== "object") {
+            throw new Error("Test Scenarios for rule " + ruleName + " : Could not find test scenario object");
+        }
+
+        requiredScenarios.forEach(function(scenarioType) {
+            if (lodash.isNil(test[scenarioType])) {
+                scenarioErrors.push("Could not find any " + scenarioType + " test scenarios");
+            }
+        });
+
+        if (scenarioErrors.length > 0) {
+            throw new Error([
+                "Test Scenarios for rule " + ruleName + " is invalid:"
+            ].concat(scenarioErrors).join("\n"));
+        }
 
         /* eslint-disable no-shadow */
 

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -636,4 +636,35 @@ describe("RuleTester", function() {
             });
         }, "Rule should not modify AST.");
     });
+
+    it("should throw an error if no test scenarios given", function() {
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"));
+        }, "Test Scenarios for rule foo : Could not find test scenario object");
+    });
+
+    it("should throw an error if no valid test scenario object given", function() {
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), []);
+        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), "");
+        }, "Test Scenarios for rule foo : Could not find test scenario object");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), 2);
+        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {});
+        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios\nCould not find any invalid test scenarios");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+                valid: []
+            });
+        }, "Test Scenarios for rule foo is invalid:\nCould not find any invalid test scenarios");
+        assert.throws(function() {
+            ruleTester.run("foo", require("../../fixtures/testers/rule-tester/modify-ast-at-last"), {
+                invalid: []
+            });
+        }, "Test Scenarios for rule foo is invalid:\nCould not find any valid test scenarios");
+    });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Tell us about your environment

ESLint Version: v3.4.0
Node Version: v5.5.0
npm Version: 3.5.3
What parser (default, Babel-ESLint, etc.) are you using?
Default
Please show your full configuration:
-
What did you do? Please include the actual source code causing the issue.
Edit a test rule in tests/lib/rules/array-bracket-space.js

Do not include the test {} object
ruleTester.run("array-bracket-spacing", rule)

Or do not include the required properties (valid, invalid)
ruleTester.run("array-bracket-spacing", rule, {})
ruleTester.run("array-bracket-spacing", rule, [])
ruleTester.run("array-bracket-spacing", rule, {pie: ''})
ruleTester.run("array-bracket-spacing", rule, 'string')

What did you expect to happen?
Should give me a clear error why my test is not working

What actually happened? Please include the actual, raw output from ESLint.
```
~/Desktop/eslint/eslint/lib/testers/rule-tester.js:453
                test.valid.forEach(function(valid) {
                    ^

TypeError: Cannot read property 'valid' of undefined
    at Function.<anonymous> (/Users/nicholassmith/Desktop/eslint/eslint/lib/testers/rule-tester.js:453:21)
    at Function.RuleTester.describe (/Users/nicholassmith/Desktop/eslint/eslint/lib/testers/rule-tester.js:186:19)
    at Function.<anonymous> (/Users/nicholassmith/Desktop/eslint/eslint/lib/testers/rule-tester.js:452:24)
    at Function.RuleTester.describe (/Users/nicholassmith/Desktop/eslint/eslint/lib/testers/rule-tester.js:186:19)
    at Object.run (/Users/nicholassmith/Desktop/eslint/eslint/lib/testers/rule-tester.js:451:20)
    at Object.<anonymous> (/Users/nicholassmith/Desktop/eslint/eslint/tests/lib/rules/array-bracket-spacing.js:20:12)
    at Module._compile (module.js:413:34)
    at Object.Module._extensions..js (module.js:422:10)
    at Module.load (module.js:357:32)
    at Function.Module._load (module.js:314:12)
```

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [ X ] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [ X ] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
Added some validation to the RuleTester so it is explicit that valid and invalid scenarios are required

**Is there anything you'd like reviewers to focus on?**
I wasn't able to find tests that test the test runner setup, are there any?