### PR TITLE
Update: Allow template string in `valid-typeof` comparison (fixes #7166)

### DIFF
--- a/lib/rules/valid-typeof.js
+++ b/lib/rules/valid-typeof.js
@@ -58,8 +58,10 @@ module.exports = {
                     if (parent.type === "BinaryExpression" && OPERATORS.indexOf(parent.operator) !== -1) {
                         const sibling = parent.left === node ? parent.right : parent.left;
 
-                        if (sibling.type === "Literal") {
-                            if (VALID_TYPES.indexOf(sibling.value) === -1) {
+                        if (sibling.type === "Literal" || sibling.type === "TemplateLiteral" && !sibling.expressions.length) {
+                            const value = sibling.type === "Literal" ? sibling.value : sibling.quasis[0].value.cooked;
+
+                            if (VALID_TYPES.indexOf(value) === -1) {
                                 context.report(sibling, "Invalid typeof comparison value.");
                             }
                         } else if (requireStringLiterals && !isTypeofExpression(sibling)) {

--- a/tests/lib/rules/valid-typeof.js
+++ b/tests/lib/rules/valid-typeof.js
@@ -59,6 +59,20 @@ ruleTester.run("valid-typeof", rule, {
         {
             code: "typeof foo === typeof bar",
             options: [{ requireStringLiterals: true }]
+        },
+        {
+            code: "typeof foo === `string`",
+            options: [{ requireStringLiterals: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "`object` === typeof foo",
+            options: [{ requireStringLiterals: true }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "typeof foo === `str${somethingElse}`",
+            parserOptions: { ecmaVersion: 6 }
         }
     ],
 
@@ -112,6 +126,11 @@ ruleTester.run("valid-typeof", rule, {
             errors: [{ message: "Invalid typeof comparison value.", type: "Literal" }]
         },
         {
+            code: "if (typeof bar === `umdefined`) {}",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Invalid typeof comparison value.", type: "TemplateLiteral" }],
+        },
+        {
             code: "typeof foo == 'invalid string'",
             options: [{ requireStringLiterals: true }],
             errors: [{ message: "Invalid typeof comparison value.", type: "Literal" }]
@@ -135,6 +154,18 @@ ruleTester.run("valid-typeof", rule, {
             code: "undefined == typeof foo",
             options: [{ requireStringLiterals: true }],
             errors: [{ message: "Typeof comparisons should be to string literals.", type: "Identifier" }]
+        },
+        {
+            code: "typeof foo === `undefined${foo}`",
+            options: [{ requireStringLiterals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Typeof comparisons should be to string literals.", type: "TemplateLiteral" }]
+        },
+        {
+            code: "typeof foo === `${string}`",
+            options: [{ requireStringLiterals: true }],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Typeof comparisons should be to string literals.", type: "TemplateLiteral" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

See #7166 for a description of the bug.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This allows `valid-typeof` to detect comparisons to template literals.

```js
/* eslint valid-typeof: 2 */

typeof foo === `bad value`           // error
typeof foo === `string`              // ok
typeof foo === `str${somethingElse}` // ok
```

```js
/* eslint valid-typeof: [2, {"requireStringLiterals": true}] */

typeof foo === `bad value`           // error
typeof foo === `string`              // ok
typeof foo === `str${somethingElse}` // error
```

**Is there anything you'd like reviewers to focus on?**

This is a semver-minor change, because it will cause the rule to report more errors in this case:

```js
/* eslint valid-typeof: 2 */
typeof foo === `bad value`           // previously ok, now an error
```