### PR TITLE
Fix: use Reflect.ownKeys in prefer-reflect (fixes #7075)

### DIFF
--- a/docs/rules/prefer-reflect.md
+++ b/docs/rules/prefer-reflect.md
@@ -6,8 +6,9 @@ The ES6 Reflect API comes with a handful of methods which somewhat deprecate met
 * [`Reflect.deleteProperty`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.deleteproperty) effectively deprecates the [`delete` keyword](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-delete-operator-runtime-semantics-evaluation)
 * [`Reflect.getOwnPropertyDescriptor`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.getownpropertydescriptor) effectively deprecates [`Object.getOwnPropertyDescriptor`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.getownpropertydescriptor)
 * [`Reflect.getPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.getprototypeof) effectively deprecates [`Object.getPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.getprototypeof)
-* [`Reflect.setPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.setprototypeof) effectively deprecates [`Object.setPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.setprototypeof)
+* [`Reflect.ownKeys`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.ownkeys) effectively deprecates [`Object.getOwnPropertyNames`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.getownpropertynames) and [`Object.getOwnPropertySymbols`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.getownpropertysymbols)
 * [`Reflect.preventExtensions`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.preventextensions)  effectively deprecates [`Object.preventExtensions`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.preventextensions)
+* [`Reflect.setPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-reflect.setprototypeof) effectively deprecates [`Object.setPrototypeOf`](http://www.ecma-international.org/ecma-262/6.0/index.html#sec-object.setprototypeof)
 
 The prefer-reflect rule will flag usage of any older method, suggesting to instead use the newer Reflect version.
 
@@ -117,6 +118,39 @@ Object.defineProperty({}, 'foo', {value: 1})
 Reflect.defineProperty({}, 'foo', {value: 1})
 ```
 
+### Reflect.deleteProperty
+
+Deprecates the `delete` keyword
+
+Examples of **incorrect** code for this rule when used without exceptions:
+
+```js
+/*eslint prefer-reflect: "error"*/
+
+delete foo.bar; // deleting object property
+```
+
+Examples of **correct** code for this rule when used without exceptions:
+
+```js
+/*eslint prefer-reflect: "error"*/
+
+delete bar; // deleting variable
+Reflect.deleteProperty(foo, 'bar');
+```
+
+Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md)
+
+Examples of **correct** code for this rule with the `{ "exceptions": ["delete"] }` option:
+
+```js
+/*eslint prefer-reflect: ["error", { "exceptions": ["delete"] }]*/
+
+delete bar
+delete foo.bar
+Reflect.deleteProperty(foo, 'bar');
+```
+
 ### Reflect.getOwnPropertyDescriptor
 
 Deprecates `Object.getOwnPropertyDescriptor()`
@@ -175,35 +209,6 @@ Object.getPrototypeOf({}, 'foo')
 Reflect.getPrototypeOf({}, 'foo')
 ```
 
-### Reflect.setPrototypeOf
-
-Deprecates `Object.setPrototypeOf()`
-
-Examples of **incorrect** code for this rule when used without exceptions:
-
-```js
-/*eslint prefer-reflect: "error"*/
-
-Object.setPrototypeOf({}, Object.prototype)
-```
-
-Examples of **correct** code for this rule when used without exceptions:
-
-```js
-/*eslint prefer-reflect: "error"*/
-
-Reflect.setPrototypeOf({}, Object.prototype)
-```
-
-Examples of **correct** code for this rule with the `{ "exceptions": ["setPrototypeOf"] }` option:
-
-```js
-/*eslint prefer-reflect: ["error", { "exceptions": ["setPrototypeOf"] }]*/
-
-Object.setPrototypeOf({}, Object.prototype)
-Reflect.setPrototypeOf({}, Object.prototype)
-```
-
 ### Reflect.isExtensible
 
 Deprecates `Object.isExtensible`
@@ -233,9 +238,11 @@ Object.isExtensible({})
 Reflect.isExtensible({})
 ```
 
-### Reflect.getOwnPropertyNames
+### Reflect.ownKeys
 
-Deprecates `Object.getOwnPropertyNames()`
+Deprecates `Object.getOwnPropertyNames()` and `Object.getOwnPropertySymbols`
+
+**Note:** Reflect.ownKeys includes both the object's own property names and Symbol properties. There is no exact equivalent to Object.getOwnPropertyNames and Object.getOwnPropertySymbols in the Reflect API. (Reflect.getOwnPropertyNames and Reflect.getOwnPropertySymbols are not part of the ES6 specification.)
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
@@ -243,6 +250,7 @@ Examples of **incorrect** code for this rule when used without exceptions:
 /*eslint prefer-reflect: "error"*/
 
 Object.getOwnPropertyNames({})
+Object.getOwnPropertySymbols({})
 ```
 
 Examples of **correct** code for this rule when used without exceptions:
@@ -250,7 +258,7 @@ Examples of **correct** code for this rule when used without exceptions:
 ```js
 /*eslint prefer-reflect: "error"*/
 
-Reflect.getOwnPropertyNames({})
+Reflect.ownKeys({})
 ```
 
 Examples of **correct** code for this rule with the `{ "exceptions": ["getOwnPropertyNames"] }` option:
@@ -259,7 +267,7 @@ Examples of **correct** code for this rule with the `{ "exceptions": ["getOwnPro
 /*eslint prefer-reflect: ["error", { "exceptions": ["getOwnPropertyNames"] }]*/
 
 Object.getOwnPropertyNames({})
-Reflect.getOwnPropertyNames({})
+Reflect.ownKeys({})
 ```
 
 ### Reflect.preventExtensions
@@ -291,16 +299,16 @@ Object.preventExtensions({})
 Reflect.preventExtensions({})
 ```
 
-### Reflect.deleteProperty
+### Reflect.setPrototypeOf
 
-Deprecates the `delete` keyword
+Deprecates `Object.setPrototypeOf()`
 
 Examples of **incorrect** code for this rule when used without exceptions:
 
 ```js
 /*eslint prefer-reflect: "error"*/
 
-delete foo.bar; // deleting object property
+Object.setPrototypeOf({}, Object.prototype)
 ```
 
 Examples of **correct** code for this rule when used without exceptions:
@@ -308,20 +316,16 @@ Examples of **correct** code for this rule when used without exceptions:
 ```js
 /*eslint prefer-reflect: "error"*/
 
-delete bar; // deleting variable
-Reflect.deleteProperty(foo, 'bar');
+Reflect.setPrototypeOf({}, Object.prototype)
 ```
 
-Note: For a rule preventing deletion of variables, see [no-delete-var instead](no-delete-var.md)
-
-Examples of **correct** code for this rule with the `{ "exceptions": ["delete"] }` option:
+Examples of **correct** code for this rule with the `{ "exceptions": ["setPrototypeOf"] }` option:
 
 ```js
-/*eslint prefer-reflect: ["error", { "exceptions": ["delete"] }]*/
+/*eslint prefer-reflect: ["error", { "exceptions": ["setPrototypeOf"] }]*/
 
-delete bar
-delete foo.bar
-Reflect.deleteProperty(foo, 'bar');
+Object.setPrototypeOf({}, Object.prototype)
+Reflect.setPrototypeOf({}, Object.prototype)
 ```
 
 ## When Not To Use It

--- a/lib/rules/prefer-reflect.js
+++ b/lib/rules/prefer-reflect.js
@@ -33,6 +33,7 @@ module.exports = {
                                 "setPrototypeOf",
                                 "isExtensible",
                                 "getOwnPropertyNames",
+                                "getOwnPropertySymbols",
                                 "preventExtensions"
                             ]
                         },
@@ -54,6 +55,7 @@ module.exports = {
             setPrototypeOf: "Object.setPrototypeOf",
             isExtensible: "Object.isExtensible",
             getOwnPropertyNames: "Object.getOwnPropertyNames",
+            getOwnPropertySymbols: "Object.getOwnPropertySymbols",
             preventExtensions: "Object.preventExtensions"
         };
 
@@ -65,7 +67,8 @@ module.exports = {
             getPrototypeOf: "Reflect.getPrototypeOf",
             setPrototypeOf: "Reflect.setPrototypeOf",
             isExtensible: "Reflect.isExtensible",
-            getOwnPropertyNames: "Reflect.getOwnPropertyNames",
+            getOwnPropertyNames: "Reflect.ownKeys",
+            getOwnPropertySymbols: "Reflect.ownKeys",
             preventExtensions: "Reflect.preventExtensions"
         };
 

--- a/tests/lib/rules/prefer-reflect.js
+++ b/tests/lib/rules/prefer-reflect.js
@@ -51,17 +51,19 @@ ruleTester.run("prefer-reflect", rule, {
         { code: "Reflect.isExtensible({});", options: [{ exceptions: ["isExtensible"] }] },
         { code: "Object.isExtensible({});", options: [{ exceptions: ["isExtensible"] }] },
 
-        // Reflect.getOwnPropertyNames
-        { code: "Reflect.getOwnPropertyNames({});" },
-        { code: "Reflect.getOwnPropertyNames({});", options: [{ exceptions: ["getOwnPropertyNames"] }] },
+        // Reflect.ownKeys
+        { code: "Reflect.ownKeys({});" },
+        { code: "Reflect.ownKeys({});", options: [{ exceptions: ["getOwnPropertyNames"] }] },
         { code: "Object.getOwnPropertyNames({});", options: [{ exceptions: ["getOwnPropertyNames"] }] },
+        { code: "Reflect.ownKeys({});", options: [{ exceptions: ["getOwnPropertySymbols"] }] },
+        { code: "Object.getOwnPropertySymbols({});", options: [{ exceptions: ["getOwnPropertySymbols"] }] },
 
-        // Reflect.getOwnPropertyNames
+        // Reflect.preventExtensions
         { code: "Reflect.preventExtensions({});" },
         { code: "Reflect.preventExtensions({});", options: [{ exceptions: ["preventExtensions"] }] },
         { code: "Object.preventExtensions({});", options: [{ exceptions: ["preventExtensions"] }] },
 
-        // Reflect.getOwnPropertyNames
+        // Reflect.deleteProperty
         { code: "Reflect.deleteProperty({}, 'foo');" },
         { code: "Reflect.deleteProperty({}, 'foo');", options: [{ exceptions: ["delete"] }] },
         { code: "delete foo;" },
@@ -206,7 +208,7 @@ ruleTester.run("prefer-reflect", rule, {
             code: "Object.getOwnPropertyNames({})",
             errors: [
                 {
-                    message: "Avoid using Object.getOwnPropertyNames, instead use Reflect.getOwnPropertyNames.",
+                    message: "Avoid using Object.getOwnPropertyNames, instead use Reflect.ownKeys.",
                     type: "CallExpression"
                 }
             ]
@@ -216,7 +218,26 @@ ruleTester.run("prefer-reflect", rule, {
             options: [{ exceptions: ["apply"] }],
             errors: [
                 {
-                    message: "Avoid using Object.getOwnPropertyNames, instead use Reflect.getOwnPropertyNames.",
+                    message: "Avoid using Object.getOwnPropertyNames, instead use Reflect.ownKeys.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getOwnPropertySymbols({})",
+            errors: [
+                {
+                    message: "Avoid using Object.getOwnPropertySymbols, instead use Reflect.ownKeys.",
+                    type: "CallExpression"
+                }
+            ]
+        },
+        {
+            code: "Object.getOwnPropertySymbols({})",
+            options: [{ exceptions: ["apply"] }],
+            errors: [
+                {
+                    message: "Avoid using Object.getOwnPropertySymbols, instead use Reflect.ownKeys.",
                     type: "CallExpression"
                 }
             ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

```
[X] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
```

*If the item you've check above has a template, please paste the template questions here and answer them.*

What rule do you want to change?
`prefer-reflect`

Does this change cause the rule to produce more or fewer warnings?
This rule produces one new warning.

How will the change be implemented? (New option, new default behavior, etc.)?
I changed the suggested alternative for `Object.getOwnPropertyNames` from `Reflect.getOwnPropertyNames` (which doesn't exist in the ES6 spec) to `Reflect.ownKeys`, which is the closest equivalent. It also adds `Reflect.ownKeys` as the suggested alternative for `Reflect.getOwnPropertySymbols`.

Please provide some example code that this change will affect:
```
Object.getOwnPropertyNames({})
Object.getOwnPropertySymbols({})
```

What does the rule currently do for this code?
Produces the warning `Avoid using Object.getOwnPropertyNames, instead use Reflect.getOwnPropertyNames.`

What will the rule do after it's changed?
It will produce two warnings:
* `Avoid using Object.getOwnPropertyNames, instead use Reflect.ownKeys.`
* `Avoid using Object.getOwnPropertySymbols, instead use Reflect.ownKeys.`

**Please check each item to ensure your pull request is ready:**

- [X] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [X] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
I replaced `Reflect.getOwnPropertyNames` with `Reflect.ownKeys` in both the code and documentation for `prefer-reflect`. I also added `Reflect.ownKeys` as the suggested alternative to `Object.getOwnPropertySymbols`.

**Is there anything you'd like reviewers to focus on?**
N/A