### PR TITLE
Fix: Don't report async/generator callbacks in `array-callback-return`

### DIFF
--- a/lib/rules/array-callback-return.js
+++ b/lib/rules/array-callback-return.js
@@ -185,7 +185,9 @@ module.exports = {
                     shouldCheck:
                         TARGET_NODE_TYPE.test(node.type) &&
                         node.body.type === "BlockStatement" &&
-                        isCallbackOfArrayMethod(node)
+                        isCallbackOfArrayMethod(node) &&
+                        !node.async &&
+                        !node.generator
                 };
             },
 

--- a/tests/lib/rules/array-callback-return.js
+++ b/tests/lib/rules/array-callback-return.js
@@ -41,7 +41,10 @@ ruleTester.run("array-callback-return", rule, {
         "foo.every(function() { try { bar(); } finally { return true; } })",
         "foo.every(function(){}())",
         "foo.every(function(){ return function() { return true; }; }())",
-        "foo.every(function(){ return function() { return; }; })"
+        "foo.every(function(){ return function() { return; }; })",
+        {code: "foo.map(async function(){})", parserOptions: { ecmaVersion: 8 }},
+        {code: "foo.map(async () => {})", parserOptions: { ecmaVersion: 8 }},
+        {code: "foo.map(function* () {})", parserOptions: { ecmaVersion: 6 }}
     ],
     invalid: [
         {code: "Array.from(x, function() {})", errors: ["Expected to return a value in this function."]},


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

See #7101 for context. This is one of the rule fixes that prevents incorrect behavior now that we can support async functions.

This fix updates `array-callback-return` to not report async callback functions, since async functions implicitly return a Promise value.

```js
/* eslint array-callback-return: 2 */
foo.map(async function () {}) // should not return an error
foo.map(async () => {}) // should not return an error
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.