### PR TITLE
Fix: Handle async functions correctly in `prefer-arrow-callback` fixer

### DIFF
--- a/lib/rules/prefer-arrow-callback.js
+++ b/lib/rules/prefer-arrow-callback.js
@@ -275,16 +275,17 @@ module.exports = {
 
                             const paramsLeftParen = node.params.length ? sourceCode.getTokenBefore(node.params[0]) : sourceCode.getTokenBefore(node.body, 1);
                             const paramsRightParen = sourceCode.getTokenBefore(node.body);
+                            const asyncKeyword = node.async ? "async " : "";
                             const paramsFullText = sourceCode.text.slice(paramsLeftParen.range[0], paramsRightParen.range[1]);
 
                             if (callbackInfo.isLexicalThis) {
 
                                 // If the callback function has `.bind(this)`, replace it with an arrow function and remove the binding.
-                                return fixer.replaceText(node.parent.parent, paramsFullText + " => " + sourceCode.getText(node.body));
+                                return fixer.replaceText(node.parent.parent, asyncKeyword + paramsFullText + " => " + sourceCode.getText(node.body));
                             }
 
                             // Otherwise, only replace the `function` keyword and parameters with the arrow function parameters.
-                            return fixer.replaceTextRange([node.start, node.body.start], paramsFullText + " => ");
+                            return fixer.replaceTextRange([node.start, node.body.start], asyncKeyword + paramsFullText + " => ");
                         }
                     });
                 }

--- a/tests/lib/rules/prefer-arrow-callback.js
+++ b/tests/lib/rules/prefer-arrow-callback.js
@@ -174,6 +174,18 @@ ruleTester.run("prefer-arrow-callback", rule, {
             parserOptions: { ecmaVersion: 6 },
             errors,
             output: "qux(( /* a */ foo /* b */ , /* c */ bar /* d */ , /* e */ baz /* f */ ) => { return foo; })"
+        },
+        {
+            code: "qux(async function (foo = 1, bar = 2, baz = 3) { return baz; })",
+            output: "qux(async (foo = 1, bar = 2, baz = 3) => { return baz; })",
+            parserOptions: { ecmaVersion: 8 },
+            errors
+        },
+        {
+            code: "qux(async function (foo = 1, bar = 2, baz = 3) { return this; }.bind(this))",
+            output: "qux(async (foo = 1, bar = 2, baz = 3) => { return this; })",
+            parserOptions: { ecmaVersion: 8 },
+            errors,
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

See #7101 for context. This allows the fixer for `prefer-arrow-callback` to emit async arrow functions. At the moment the fixer always emits regular arrow functions, which can lead to incorrect code now that the parser supports async functions.

```js
/* eslint prefer-arrow-callback: 2 */

foo(async function (bar, baz) { return qux; });

// should get fixed to:

foo(async (bar, baz) => { return qux; });

// but at the moment it just gets fixed to this (incorrect):

foo((bar, baz) => { return qux; });
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.