### PR TITLE
Update: Allow `space-unary-ops` to handle await expressions

### DIFF
--- a/lib/rules/space-unary-ops.js
+++ b/lib/rules/space-unary-ops.js
@@ -177,6 +177,17 @@ module.exports = {
         }
 
         /**
+        * Verifies AwaitExpressions satisfy spacing requirements
+        * @param {ASTNode} node AwaitExpression AST node
+        * @returns {void}
+        */
+        function checkForSpacesAfterAwait(node) {
+            const tokens = sourceCode.getFirstTokens(node, 3);
+
+            checkUnaryWordOperatorForSpaces(node, tokens[0], tokens[1], "await");
+        }
+
+        /**
         * Verifies UnaryExpression, UpdateExpression and NewExpression have spaces before or after the operator
         * @param {ASTnode} node AST node
         * @param {Object} firstToken First token in the expression
@@ -291,7 +302,8 @@ module.exports = {
             UnaryExpression: checkForSpaces,
             UpdateExpression: checkForSpaces,
             NewExpression: checkForSpaces,
-            YieldExpression: checkForSpacesAfterYield
+            YieldExpression: checkForSpacesAfterYield,
+            AwaitExpression: checkForSpacesAfterAwait
         };
 
     }

--- a/tests/lib/rules/space-unary-ops.js
+++ b/tests/lib/rules/space-unary-ops.js
@@ -157,6 +157,29 @@ ruleTester.run("space-unary-ops", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "async function foo() { await {foo: 1} }",
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: "async function foo() { await {bar: 2} }",
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: "async function foo() { await{baz: 3} }",
+            options: [{ words: false }],
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: "async function foo() { await {qux: 4} }",
+            options: [{ words: false, overrides: {await: true} }],
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: "async function foo() { await{foo: 5} }",
+            options: [{ words: true, overrides: {await: false} }],
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
             code: "foo++",
             options: [{ nonwords: true, overrides: {"++": false} }]
         },
@@ -502,6 +525,53 @@ ruleTester.run("space-unary-ops", rule, {
                 type: "YieldExpression",
                 line: 1,
                 column: 19
+            }]
+        },
+        {
+            code: "async function foo() { await{foo: 'bar'} }",
+            output: "async function foo() { await {foo: 'bar'} }",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unary word operator 'await' must be followed by whitespace.",
+                type: "AwaitExpression",
+                line: 1,
+                column: 24
+            }]
+        },
+        {
+            code: "async function foo() { await{baz: 'qux'} }",
+            output: "async function foo() { await {baz: 'qux'} }",
+            options: [{ words: false, overrides: {await: true} }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unary word operator 'await' must be followed by whitespace.",
+                type: "AwaitExpression",
+                line: 1,
+                column: 24
+            }]
+        },
+        {
+            code: "async function foo() { await {foo: 1} }",
+            output: "async function foo() { await{foo: 1} }",
+            options: [{ words: false }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unexpected space after unary word operator 'await'.",
+                type: "AwaitExpression",
+                line: 1,
+                column: 24
+            }]
+        },
+        {
+            code: "async function foo() { await {bar: 2} }",
+            output: "async function foo() { await{bar: 2} }",
+            options: [{ words: true, overrides: {await: false} }],
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unexpected space after unary word operator 'await'.",
+                type: "AwaitExpression",
+                line: 1,
+                column: 24
             }]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

See #7101 for context. Now that async functions can be parsed by `acorn`, this fix allows [`space-unary-ops`](http://eslint.org/docs/rules/space-unary-ops) to detect `await` expressions.

**What rule do you want to change?**

[`space-unary-ops`](http://eslint.org/docs/rules/space-unary-ops)

**Does this change cause the rule to produce more or fewer warnings?**

More, although it is not expected to break anyone's code since `await` expressions couldn't be parsed by Espree until a few hours ago.

**How will the change be implemented? (New option, new default behavior, etc.)?**

This would allow `await` expressions to be checked by `space-unary-ops`, in the same manner as `yield` expressions.
This would work the same way as `yield` currently does, i.e. `await` would be part of the `words` option, and it would be possible to specify `{await: true}` or `{await: false}` as an override.

**Please provide some example code that this change will affect:**

```js
/* eslint space-unary-ops: 2 */

async function foo() {
  await(5); // error: Unary word operator 'await' must be followed by whitespace.
  await (5); // ok
}
```

```js
/* eslint space-unary-ops: [2, {"words": false}] */

async function foo() {
  await(5); // ok
  await (5); // error: Unexpected space after unary word operator 'await'.
}
```

**What does the rule currently do for this code?**

`await` expressions are currently not linted at all.

**What will the rule do after it's changed?**

The rule will report `await` expressions that are not followed by a space (in the same way that it currently reports `yield` expressions).

**What changes did you make? (Give an overview)**

(Implements the behavior above)

**Is there anything you'd like reviewers to focus on?**

Would this change break cause errors for users who have been using `babel-eslint`? If so, is it still semver-minor?