### PR TITLE
Fix: Handle await expressions correctly in `no-unused-expressions`

### DIFF
--- a/lib/rules/no-unused-expressions.js
+++ b/lib/rules/no-unused-expressions.js
@@ -101,7 +101,7 @@ module.exports = {
                 }
             }
 
-            return /^(?:Assignment|Call|New|Update|Yield)Expression$/.test(node.type) ||
+            return /^(?:Assignment|Call|New|Update|Yield|Await)Expression$/.test(node.type) ||
                 (node.type === "UnaryExpression" && ["delete", "void"].indexOf(node.operator) >= 0);
         }
 

--- a/tests/lib/rules/no-unused-expressions.js
+++ b/tests/lib/rules/no-unused-expressions.js
@@ -42,6 +42,24 @@ ruleTester.run("no-unused-expressions", rule, {
         {
             code: "function* foo(){ yield 0; }",
             parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "async function foo() { await 5; }",
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: "async function foo() { await foo.bar; }",
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: "async function foo() { bar && await baz; }",
+            options: [{ allowShortCircuit: true }],
+            parserOptions: { ecmaVersion: 8 }
+        },
+        {
+            code: "async function foo() { foo ? await bar : await baz; }",
+            options: [{ allowTernary: true }],
+            parserOptions: { ecmaVersion: 8 }
         }
     ],
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 6.6.0
* **npm Version:** 3.10.3

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**

```json
{
  "parserOptions": {
    "ecmaVersion": 8
  },
  "rules": {
    "no-unused-expressions": 2
  }
}
```

**What did you do? Please include the actual source code causing the issue.**

```js
async function foo() {
  await bar;
  return baz;
}
```

**What did you expect to happen?**

No errors, since `await` expressions have side-effects (simlar to `yield` expressions)

**What actually happened? Please include the actual, raw output from ESLint.**

```
2:3  error  Expected an assignment or function call and instead saw an expression  no-unused-expressions
```


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

For context, see #7101. This updates `no-unused-expressions` to consider `AwaitExpression` nodes to have side-effects, preventing them from being reported as unused if they are actually used.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.