### PR TITLE
Update: Ensure `arrow-parens` handles async arrow functions correctly

### DIFF
--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -51,7 +51,7 @@ module.exports = {
          * @returns {void}
          */
         function parens(node) {
-            const token = sourceCode.getFirstToken(node);
+            const token = sourceCode.getFirstToken(node, node.async ? 1 : 0);
 
             // "as-needed", { "requireForBlockBody": true }: x => x
             if (

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -26,6 +26,7 @@ const valid = [
     { code: "(a) => {\n}", parserOptions: { ecmaVersion: 6 } },
     { code: "a.then((foo) => {});", parserOptions: { ecmaVersion: 6 } },
     { code: "a.then((foo) => { if (true) {}; });", parserOptions: { ecmaVersion: 6 } },
+    { code: "a.then(async (foo) => { if (true) {}; });", parserOptions: { ecmaVersion: 8 } },
 
     // "always" (explicit)
     { code: "() => {}", options: ["always"], parserOptions: { ecmaVersion: 6 } },
@@ -34,6 +35,7 @@ const valid = [
     { code: "(a) => {\n}", options: ["always"], parserOptions: { ecmaVersion: 6 } },
     { code: "a.then((foo) => {});", options: ["always"], parserOptions: { ecmaVersion: 6 } },
     { code: "a.then((foo) => { if (true) {}; });", options: ["always"], parserOptions: { ecmaVersion: 6 } },
+    { code: "a.then(async (foo) => { if (true) {}; });", options: ["always"], parserOptions: { ecmaVersion: 8 } },
 
     // "as-needed"
     { code: "() => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
@@ -44,6 +46,8 @@ const valid = [
     { code: "(a = 10) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
     { code: "(...a) => a[0]", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
     { code: "(a, b) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
+    { code: "async ([a, b]) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 8 } },
+    { code: "async (a, b) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 8 } },
 
     // "as-needed", { "requireForBlockBody": true }
     { code: "() => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
@@ -55,8 +59,9 @@ const valid = [
     { code: "(a = 10) => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
     { code: "(...a) => a[0]", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
     { code: "(a, b) => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
-    { code: "a => ({})", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } }
-
+    { code: "a => ({})", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
+    { code: "async a => ({})", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 8 } },
+    { code: "async a => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 8 } }
 ];
 
 const message = "Expected parentheses around arrow function argument.";
@@ -134,6 +139,17 @@ const invalid = [
             type
         }]
     },
+    {
+        code: "a(async foo => { if (true) {}; });",
+        output: "a(async (foo) => { if (true) {}; });",
+        parserOptions: { ecmaVersion: 8 },
+        errors: [{
+            line: 1,
+            column: 3,
+            message,
+            type
+        }]
+    },
 
     // "as-needed"
     {
@@ -141,6 +157,18 @@ const invalid = [
         output: "a => a",
         options: ["as-needed"],
         parserOptions: { ecmaVersion: 6 },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: asNeededMessage,
+            type
+        }]
+    },
+    {
+        code: "async (a) => a",
+        output: "async a => a",
+        options: ["as-needed"],
+        parserOptions: { ecmaVersion: 8 },
         errors: [{
             line: 1,
             column: 1,
@@ -167,6 +195,30 @@ const invalid = [
         output: "a => a",
         options: ["as-needed", {requireForBlockBody: true}],
         parserOptions: { ecmaVersion: 6 },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: requireForBlockBodyMessage,
+            type
+        }]
+    },
+    {
+        code: "async a => {}",
+        output: "async (a) => {}",
+        options: ["as-needed", {requireForBlockBody: true}],
+        parserOptions: { ecmaVersion: 8 },
+        errors: [{
+            line: 1,
+            column: 1,
+            message: requireForBlockBodyNoParensMessage,
+            type
+        }]
+    },
+    {
+        code: "async (a) => a",
+        output: "async a => a",
+        options: ["as-needed", {requireForBlockBody: true}],
+        parserOptions: { ecmaVersion: 8 },
         errors: [{
             line: 1,
             column: 1,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 6.6.0
* **npm Version:** 3.10.3

**What parser (default, Babel-ESLint, etc.) are you using?** default

**Please show your full configuration:**

```json
{
  "parserOptions": {
    "ecmaVersion": 8
  }
}
```

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint arrow-parens: [2, "always"] */

async (foo) => bar // expected no error, but an error was reported
```

```js
/* eslint arrow-parens: [2, "as-needed"] */

async (foo) => bar // expected an error to be reported, but nothing was reported.
```

**What did you expect to happen?**

No errors in the first case, since the param is surrounded by parens and the option is `always`.

One error in the second case, since the parens are unnecessary and the option is `as-needed`.

**What actually happened? Please include the actual, raw output from ESLint.**

An error was reported in the first case:

```
1:1  error  Expected parentheses around arrow function argument arrow-parens
```

No error was reported in the second case.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

For context, see #7101. This updates `arrow-parens` to handle async arrow functions correctly.

Previously, the first parameter token (i.e. either the opening paren of the parameters, or the first parameter itself) was assumed to be the first token of the arrow function itself. However, this isn't the case with async arrow functions; the `async` keyword should be skipped if the function is async.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.