### PR TITLE
Update: `no-extra-parens` supports async/await (refs #7101)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -560,6 +560,7 @@ module.exports = {
                 /* falls through */
 
             case "UnaryExpression":
+            case "AwaitExpression":
                 return 14;
 
             case "UpdateExpression":

--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -587,6 +587,7 @@ module.exports = {
 
             UnaryExpression: dryUnaryUpdate,
             UpdateExpression: dryUnaryUpdate,
+            AwaitExpression: dryUnaryUpdate,
 
             VariableDeclarator(node) {
                 if (node.init && hasExcessParens(node.init) &&

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -277,7 +277,13 @@ ruleTester.run("no-extra-parens", rule, {
                 "}"
             ].join("\n"),
             parserOptions: { ecmaVersion: 6 }
-        }
+        },
+
+        // async/await
+        { code: "async function a() { await (a + b) }", parserOptions: { ecmaVersion: 8 } },
+        { code: "async function a() { await (a + await b) }", parserOptions: { ecmaVersion: 8 } },
+        { code: "async function a() { (await a)() }", parserOptions: { ecmaVersion: 8 } },
+        { code: "async function a() { new (await a) }", parserOptions: { ecmaVersion: 8 } },
     ],
 
     invalid: [
@@ -662,6 +668,27 @@ ruleTester.run("no-extra-parens", rule, {
                 }
             ],
             output: "b => { return c ? d = b : e = b; }"
-        }
+        },
+
+        // async/await
+        {
+            code: "async function a() { (await a) + (await b); }",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [
+                {
+                    message: "Gratuitous parentheses around expression.",
+                    type: "AwaitExpression"
+                },
+                {
+                    message: "Gratuitous parentheses around expression.",
+                    type: "AwaitExpression"
+                },
+            ],
+            output: "async function a() { await a + await b; }"
+        },
+        invalid("async function a() { await (a); }", "async function a() { await a; }", "Identifier", null, {parserOptions: { ecmaVersion: 8 }}),
+        invalid("async function a() { await (a()); }", "async function a() { await a(); }", "CallExpression", null, {parserOptions: { ecmaVersion: 8 }}),
+        invalid("async function a() { await (+a); }", "async function a() { await +a; }", "UnaryExpression", null, {parserOptions: { ecmaVersion: 8 }}),
+        invalid("async function a() { +(await a); }", "async function a() { +await a; }", "AwaitExpression", null, {parserOptions: { ecmaVersion: 8 }}),
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 6.3.0
* **npm Version:** 3.8.9

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

A:

```
$ echo "async function a() { await (a); }" | eslint --stdin --no-eslintrc --parser-options "ecmaVersion:8" --rule "no-extra-parens:error"
```

B:

```
$ echo "async function a() { (await a)(); }" | eslint --stdin --no-eslintrc --parser-options "ecmaVersion:8" --rule "no-extra-parens:error"
```

**What did you expect to happen?**

In the case A, it should show an error: "Gratuitous parentheses around expression  no-extra-parens".
In the case B, it should not show errors.

**What actually happened? Please include the actual, raw output from ESLint.**

In the case A, it did not show the error.
In the case B, it showed the following errors:

```
<text>
  1:22  error  Gratuitous parentheses around expression  no-extra-parens

✖ 1 problem (1 error, 0 warnings)
```

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- ~~I've updated documentation for my change (if appropriate)~~

**What changes did you make? (Give an overview)**

This PR adds the supports of `await` expressions into `no-extra-parens`.
The precedence of `await` expression is same as unary expressions: https://tc39.github.io/ecmascript-asyncawait/#UnaryExpression

`Semver-minor`: this is a bug fix which increases errors.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

Refs #7101.

