### PR TITLE
Update: `keyword-spacing` supports async/await (refs #7101)

### DIFF
--- a/docs/rules/keyword-spacing.md
+++ b/docs/rules/keyword-spacing.md
@@ -19,7 +19,7 @@ Of course, you could also have a style guide that disallows spaces around keywor
 
 ## Rule Details
 
-This rule enforces consistent spacing around keywords and keyword-like tokens: `as` (in module declarations), `break`, `case`, `catch`, `class`, `const`, `continue`, `debugger`, `default`, `delete`, `do`, `else`, `export`, `extends`, `finally`, `for`, `from` (in module declarations), `function`, `get` (of getters), `if`, `import`, `in`, `instanceof`, `let`, `new`, `of` (in for-of statements), `return`, `set` (of setters), `static`, `super`, `switch`, `this`, `throw`, `try`, `typeof`, `var`, `void`, `while`, `with`, and `yield`. This rule is designed carefully not to conflict with other spacing rules: it does not apply to spacing where other rules report problems.
+This rule enforces consistent spacing around keywords and keyword-like tokens: `as` (in module declarations), `async` (of async functions), `await` (of await expressions), `break`, `case`, `catch`, `class`, `const`, `continue`, `debugger`, `default`, `delete`, `do`, `else`, `export`, `extends`, `finally`, `for`, `from` (in module declarations), `function`, `get` (of getters), `if`, `import`, `in`, `instanceof`, `let`, `new`, `of` (in for-of statements), `return`, `set` (of setters), `static`, `super`, `switch`, `this`, `throw`, `try`, `typeof`, `var`, `void`, `while`, `with`, and `yield`. This rule is designed carefully not to conflict with other spacing rules: it does not apply to spacing where other rules report problems.
 
 ## Options
 

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -137,6 +137,140 @@ ruleTester.run("keyword-spacing", rule, {
         {code: "import *as a from \"foo\"", options: [override("as", NEITHER)], parserOptions: {sourceType: "module"}},
 
         //----------------------------------------------------------------------
+        // async
+        //----------------------------------------------------------------------
+
+        {code: "{} async function foo() {}", parserOptions: {ecmaVersion: 8}},
+        {code: "{}async function foo() {}", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+        {code: "{} async function foo() {}", options: [override("async", BOTH)], parserOptions: {ecmaVersion: 8}},
+        {code: "{}async function foo() {}", options: [override("async", NEITHER)], parserOptions: {ecmaVersion: 8}},
+        {code: "{} async () => {}", parserOptions: {ecmaVersion: 8}},
+        {code: "{}async () => {}", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+        {code: "{} async () => {}", options: [override("async", BOTH)], parserOptions: {ecmaVersion: 8}},
+        {code: "{}async () => {}", options: [override("async", NEITHER)], parserOptions: {ecmaVersion: 8}},
+        {code: "({async [b]() {}})", parserOptions: {ecmaVersion: 8}},
+        {code: "({async[b]() {}})", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+        {code: "({async [b]() {}})", options: [override("async", BOTH)], parserOptions: {ecmaVersion: 8}},
+        {code: "({async[b]() {}})", options: [override("async", NEITHER)], parserOptions: {ecmaVersion: 8}},
+        {code: "class A {a(){} async [b]() {}}", parserOptions: {ecmaVersion: 8}},
+        {code: "class A {a(){}async[b]() {}}", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+        {code: "class A {a(){} async [b]() {}}", options: [override("async", BOTH)], parserOptions: {ecmaVersion: 8}},
+        {code: "class A {a(){}async[b]() {}}", options: [override("async", NEITHER)], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "[async function foo() {}]", parserOptions: {ecmaVersion: 8}},
+        {code: "[ async function foo() {}]", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `arrow-spacing`
+        {code: "() =>async function foo() {}", parserOptions: {ecmaVersion: 8}},
+        {code: "() => async function foo() {}", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `block-spacing`
+        {code: "{async function foo() {} }", parserOptions: {ecmaVersion: 8}},
+        {code: "{ async function foo() {} }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `comma-spacing`
+        {code: "(0,async function foo() {})", parserOptions: {ecmaVersion: 8}},
+        {code: "(0, async function foo() {})", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `computed-property-spacing`
+        {code: "a[async function foo() {}]", parserOptions: {ecmaVersion: 8}},
+        {code: "({[async function foo() {}]: 0})", parserOptions: {ecmaVersion: 8}},
+        {code: "a[ async function foo() {}]", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+        {code: "({[ async function foo() {}]: 0})", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `key-spacing`
+        {code: "({a:async function foo() {} })", parserOptions: {ecmaVersion: 8}},
+        {code: "({a: async function foo() {} })", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `semi-spacing`
+        {code: ";async function foo() {};", parserOptions: {ecmaVersion: 8}},
+        {code: "; async function foo() {} ;", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `space-before-function-paren`
+        {code: "async() => {}", parserOptions: {ecmaVersion: 8}},
+        {code: "async () => {}", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `space-in-parens`
+        {code: "(async function foo() {})", parserOptions: {ecmaVersion: 8}},
+        {code: "( async function foo() {})", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `space-infix-ops`
+        {code: "a =async function foo() {}", parserOptions: {ecmaVersion: 8}},
+        {code: "a = async function foo() {}", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `space-unary-ops`
+        {code: "!async function foo() {}", parserOptions: {ecmaVersion: 8}},
+        {code: "! async function foo() {}", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `template-curly-spacing`
+        {code: "`${async function foo() {}}`", parserOptions: {ecmaVersion: 8}},
+        {code: "`${ async function foo() {}}`", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "<Foo onClick={async function foo() {}} />", parserOptions: {ecmaVersion: 8, ecmaFeatures: {jsx: true}}},
+        {code: "<Foo onClick={ async function foo() {}} />", options: [NEITHER], parserOptions: {ecmaVersion: 8, ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
+        // await
+        //----------------------------------------------------------------------
+
+        {code: "async function wrap() { {} await +1 }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { {}await +1 }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { {} await +1 }", options: [override("await", BOTH)], parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { {}await +1 }", options: [override("await", NEITHER)], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `array-bracket-spacing`
+        {code: "async function wrap() { [await a] }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { [ await a] }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `arrow-spacing`
+        {code: "async () =>await a", parserOptions: {ecmaVersion: 8}},
+        {code: "async () => await a", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `block-spacing`
+        {code: "async function wrap() { {await a } }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { { await a } }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `comma-spacing`
+        {code: "async function wrap() { (0,await a) }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { (0, await a) }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `computed-property-spacing`
+        {code: "async function wrap() { a[await a] }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { ({[await a]: 0}) }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { a[ await a] }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { ({[ await a]: 0}) }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `key-spacing`
+        {code: "async function wrap() { ({a:await a }) }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { ({a: await a }) }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `semi-spacing`
+        {code: "async function wrap() { ;await a; }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { ; await a ; }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `space-in-parens`
+        {code: "async function wrap() { (await a) }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { ( await a) }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `space-infix-ops`
+        {code: "async function wrap() { a =await a }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { a = await a }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `space-unary-ops`
+        {code: "async function wrap() { !await'a' }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { ! await 'a' }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `template-curly-spacing`
+        {code: "async function wrap() { `${await a}` }", parserOptions: {ecmaVersion: 8}},
+        {code: "async function wrap() { `${ await a}` }", options: [NEITHER], parserOptions: {ecmaVersion: 8}},
+
+        // not conflict with `jsx-curly-spacing`
+        {code: "async function wrap() { <Foo onClick={await a} /> }", parserOptions: {ecmaVersion: 8, ecmaFeatures: {jsx: true}}},
+        {code: "async function wrap() { <Foo onClick={ await a} /> }", options: [NEITHER], parserOptions: {ecmaVersion: 8, ecmaFeatures: {jsx: true}}},
+
+        //----------------------------------------------------------------------
         // break
         //----------------------------------------------------------------------
 
@@ -1230,6 +1364,151 @@ ruleTester.run("keyword-spacing", rule, {
             errors: unexpectedBefore("as"),
             options: [override("as", NEITHER)],
             parserOptions: {sourceType: "module"}
+        },
+
+        //----------------------------------------------------------------------
+        // async
+        //----------------------------------------------------------------------
+
+        {
+            code: "{}async function foo() {}",
+            output: "{} async function foo() {}",
+            errors: expectedBefore("async"),
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "{} async function foo() {}",
+            output: "{}async function foo() {}",
+            errors: unexpectedBefore("async"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "{}async function foo() {}",
+            output: "{} async function foo() {}",
+            errors: expectedBefore("async"),
+            options: [override("async", BOTH)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "{} async function foo() {}",
+            output: "{}async function foo() {}",
+            errors: unexpectedBefore("async"),
+            options: [override("async", NEITHER)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "{}async () => {}",
+            output: "{} async () => {}",
+            errors: expectedBefore("async"),
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "{} async () => {}",
+            output: "{}async () => {}",
+            errors: unexpectedBefore("async"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "{}async () => {}",
+            output: "{} async () => {}",
+            errors: expectedBefore("async"),
+            options: [override("async", BOTH)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "{} async () => {}",
+            output: "{}async () => {}",
+            errors: unexpectedBefore("async"),
+            options: [override("async", NEITHER)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "({async[b]() {}})",
+            output: "({async [b]() {}})",
+            errors: expectedAfter("async"),
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "({async [b]() {}})",
+            output: "({async[b]() {}})",
+            errors: unexpectedAfter("async"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "({async[b]() {}})",
+            output: "({async [b]() {}})",
+            errors: expectedAfter("async"),
+            options: [override("async", BOTH)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "({async [b]() {}})",
+            output: "({async[b]() {}})",
+            errors: unexpectedAfter("async"),
+            options: [override("async", NEITHER)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "class A {a(){}async[b]() {}}",
+            output: "class A {a(){} async [b]() {}}",
+            errors: expectedBeforeAndAfter("async"),
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "class A {a(){} async [b]() {}}",
+            output: "class A {a(){}async[b]() {}}",
+            errors: unexpectedBeforeAndAfter("async"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "class A {a(){}async[b]() {}}",
+            output: "class A {a(){} async [b]() {}}",
+            errors: expectedBeforeAndAfter("async"),
+            options: [override("async", BOTH)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "class A {a(){} async [b]() {}}",
+            output: "class A {a(){}async[b]() {}}",
+            errors: unexpectedBeforeAndAfter("async"),
+            options: [override("async", NEITHER)],
+            parserOptions: {ecmaVersion: 8}
+        },
+
+        //----------------------------------------------------------------------
+        // await
+        //----------------------------------------------------------------------
+
+        {
+            code: "async function wrap() { {}await a }",
+            output: "async function wrap() { {} await a }",
+            errors: expectedBefore("await"),
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "async function wrap() { {} await a }",
+            output: "async function wrap() { {}await a }",
+            errors: unexpectedBefore("await"),
+            options: [NEITHER],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "async function wrap() { {}await a }",
+            output: "async function wrap() { {} await a }",
+            errors: expectedBefore("await"),
+            options: [override("await", BOTH)],
+            parserOptions: {ecmaVersion: 8}
+        },
+        {
+            code: "async function wrap() { {} await a }",
+            output: "async function wrap() { {}await a }",
+            errors: unexpectedBefore("await"),
+            options: [override("await", NEITHER)],
+            parserOptions: {ecmaVersion: 8}
         },
 
         //----------------------------------------------------------------------


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 6.3.0
* **npm Version:** 3.8.9

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- nothing

**What did you do? Please include the actual source code causing the issue.**

    $ echo "({async'foo'() { }})" | eslint --stdin --no-eslintrc --parser-options "ecmaVersion:8" --rule "keyword-spacing:error"

**What did you expect to happen?**

- ESLint shows an error since there is no space preceded by the `async` contextual keyword.

**What actually happened? Please include the actual, raw output from ESLint.**

- No error.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This PR fixes `keyword-spacing` rule to handle async/await contextual keywords.

`Semver-minor`: this is a bug fix which increases errors.

**Is there anything you'd like reviewers to focus on?**

There is the discussion about which rule should handle the space of between `async` and function-paren: https://github.com/eslint/eslint/issues/7101#issuecomment-246084656
In this PR, `keyword-spacing` does not handle the space since I preferred consistency https://github.com/eslint/eslint/issues/7101#issuecomment-246624843