### PR TITLE
Update: `space-before-function-paren` supports async/await (refs #7101)

### DIFF
--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -26,13 +26,31 @@ This rule aims to enforce consistent spacing before function parentheses and as 
 
 ## Options
 
-This rule takes one argument. If it is `"always"` then all named functions and anonymous functions must have space before function parentheses. If `"never"` then all named functions and anonymous functions must not have space before function parentheses. If you want different spacing for named and anonymous functions you can pass a configuration object as the rule argument to configure those separately (e. g. `{"anonymous": "always", "named": "never"}`). In this case, you can use "ignore" to only apply the rule to one type of function (e. g. `{"anonymous": "ignore", "named": "never"}` will warn on spaces for named functions, but will not warn on anonymous functions one way or the other).
+```js
+{
+    "space-before-function-paren": ["error", "always"],
+    // or
+    "space-before-function-paren": ["error", {
+        "anonymous": "always",
+        "named": "always",
+        "asyncArrow": "always"
+    }],
+}
+```
 
-The default configuration is `"always"`.
+* `always` (default) requires a space followed by the `(` of arguments.
+* `never` disallows any space followed by the `(` of arguments.
+* `ignore` do nothing. This is used in separated settings.
+
+It can separate setting for each kind of functions by object style options:
+
+* `anonymous` is for anonymous function expressions (e.g. `function () {}`).
+* `named` is for named function expressions (e.g. `function foo () {}`).
+* `asyncArrow` is for async arrow function expressions (e.g. `async () => {}`).
 
 ### "always"
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-function-paren: "error"*/
@@ -63,7 +81,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the default `"always"` option:
 
 ```js
 /*eslint space-before-function-paren: "error"*/
@@ -96,7 +114,7 @@ var foo = {
 
 ### "never"
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
@@ -127,7 +145,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `"never"` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", "never"]*/
@@ -158,12 +176,12 @@ var foo = {
 };
 ```
 
-### `{"anonymous": "always", "named": "never"}`
+### `{"anonymous": "always", "named": "never", "asyncArrow": "always"}`
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
 
 ```js
-/*eslint space-before-function-paren: ["error", { "anonymous": "always", "named": "never" }]*/
+/*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
 /*eslint-env es6*/
 
 function foo () {
@@ -185,12 +203,14 @@ var foo = {
         // ...
     }
 };
+
+var foo = async(a) => await a
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"anonymous": "always", "named": "never", "asyncArrow": "always"}` option:
 
 ```js
-/*eslint space-before-function-paren: ["error", { "anonymous": "always", "named": "never" }]*/
+/*eslint space-before-function-paren: ["error", {"anonymous": "always", "named": "never", "asyncArrow": "always"}]*/
 /*eslint-env es6*/
 
 function foo() {
@@ -212,11 +232,13 @@ var foo = {
         // ...
     }
 };
+
+var foo = async (a) => await a
 ```
 
 ### `{"anonymous": "never", "named": "always"}`
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -243,7 +265,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"anonymous": "never", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "never", "named": "always" }]*/
@@ -272,7 +294,7 @@ var foo = {
 
 ### `{"anonymous": "ignore", "named": "always"}`
 
-The following patterns are considered problems:
+Examples of **incorrect** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/
@@ -295,7 +317,7 @@ var foo = {
 };
 ```
 
-The following patterns are not considered problems:
+Examples of **correct** code for this rule with the `{"anonymous": "ignore", "named": "always"}` option:
 
 ```js
 /*eslint space-before-function-paren: ["error", { "anonymous": "ignore", "named": "always" }]*/

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -33,20 +33,22 @@ This rule aims to enforce consistent spacing before function parentheses and as 
     "space-before-function-paren": ["error", {
         "anonymous": "always",
         "named": "always",
-        "asyncArrow": "always"
+        "asyncArrow": "ignore"
     }],
 }
 ```
 
 * `always` (default) requires a space followed by the `(` of arguments.
 * `never` disallows any space followed by the `(` of arguments.
-* `ignore` do nothing. This is used in separated settings.
+* `ignore` does nothing. This is used in separated settings.
 
 It can separate setting for each kind of functions by object style options:
 
 * `anonymous` is for anonymous function expressions (e.g. `function () {}`).
 * `named` is for named function expressions (e.g. `function foo () {}`).
 * `asyncArrow` is for async arrow function expressions (e.g. `async () => {}`).
+  `asyncArrow` is ignored by default for backward compatibility.
+  If you want to warn async arrow function expressions, please use this separated setting.
 
 ### "always"
 
@@ -110,6 +112,10 @@ var foo = {
         // ...
     }
 };
+
+// async arrow function expressions are ignored by default.
+var foo = async () => 1
+var foo = async() => 1
 ```
 
 ### "never"
@@ -174,6 +180,10 @@ var foo = {
         // ...
     }
 };
+
+// async arrow function expressions are ignored by default.
+var foo = async () => 1
+var foo = async() => 1
 ```
 
 ### `{"anonymous": "always", "named": "never", "asyncArrow": "always"}`

--- a/docs/rules/space-before-function-paren.md
+++ b/docs/rules/space-before-function-paren.md
@@ -26,6 +26,8 @@ This rule aims to enforce consistent spacing before function parentheses and as 
 
 ## Options
 
+This rule has a string option or an object option:
+
 ```js
 {
     "space-before-function-paren": ["error", "always"],
@@ -40,15 +42,17 @@ This rule aims to enforce consistent spacing before function parentheses and as 
 
 * `always` (default) requires a space followed by the `(` of arguments.
 * `never` disallows any space followed by the `(` of arguments.
-* `ignore` does nothing. This is used in separated settings.
 
-It can separate setting for each kind of functions by object style options:
+The string option does not check async arrow function expressions for backward compatibility.
+
+You can also use a separate option for each type of function.
+Each of the following options can be set to `"always"`, `"never"`, or `"ignore"`.
+Default is `"always"` basically.
 
 * `anonymous` is for anonymous function expressions (e.g. `function () {}`).
 * `named` is for named function expressions (e.g. `function foo () {}`).
 * `asyncArrow` is for async arrow function expressions (e.g. `async () => {}`).
-  `asyncArrow` is ignored by default for backward compatibility.
-  If you want to warn async arrow function expressions, please use this separated setting.
+  `asyncArrow` is set to `"ignore"` by default for backwards compatibility.
 
 ### "always"
 

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -104,12 +104,15 @@ module.exports = {
         function validateSpacingBeforeParentheses(node) {
             const isArrow = node.type === "ArrowFunctionExpression";
             const isNamed = !isArrow && isNamedFunction(node);
+            const isAnonymousGenerator = node.generator && !isNamed;
+            const isNormalArrow = isArrow && !node.async;
+            const isArrowWithoutParens = isArrow && sourceCode.getFirstToken(node, 1).value !== "(";
             let forbidSpacing, requireSpacing, rightToken;
 
-            if ((node.generator && !isNamed) ||
-                (isArrow && !node.async) ||
-                (isArrow && sourceCode.getFirstToken(node, 1).value !== "(")
-            ) {
+            // isAnonymousGenerator → `generator-star-spacing` should warn it. E.g. `function* () {}`
+            // isNormalArrow → ignore always.
+            // isArrowWithoutParens → ignore always. E.g. `async a => a`
+            if (isAnonymousGenerator || isNormalArrow || isArrowWithoutParens) {
                 return;
             }
 

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -52,7 +52,7 @@ module.exports = {
             forbidAnonymousFunctionSpacing = false,
             requireNamedFunctionSpacing = true,
             forbidNamedFunctionSpacing = false,
-            requireArrowFunctionSpacing = true,
+            requireArrowFunctionSpacing = false,
             forbidArrowFunctionSpacing = false;
 
         if (typeof configuration === "object") {
@@ -62,16 +62,13 @@ module.exports = {
             requireNamedFunctionSpacing = (
                 !configuration.named || configuration.named === "always");
             forbidNamedFunctionSpacing = configuration.named === "never";
-            requireArrowFunctionSpacing = (
-                !configuration.asyncArrow || configuration.asyncArrow === "always");
+            requireArrowFunctionSpacing = configuration.asyncArrow === "always";
             forbidArrowFunctionSpacing = configuration.asyncArrow === "never";
         } else if (configuration === "never") {
             requireAnonymousFunctionSpacing = false;
             forbidAnonymousFunctionSpacing = true;
             requireNamedFunctionSpacing = false;
             forbidNamedFunctionSpacing = true;
-            requireArrowFunctionSpacing = false;
-            forbidArrowFunctionSpacing = true;
         }
 
         /**

--- a/lib/rules/space-before-function-paren.js
+++ b/lib/rules/space-before-function-paren.js
@@ -32,6 +32,9 @@ module.exports = {
                             },
                             named: {
                                 enum: ["always", "never", "ignore"]
+                            },
+                            asyncArrow: {
+                                enum: ["always", "never", "ignore"]
                             }
                         },
                         additionalProperties: false
@@ -48,7 +51,9 @@ module.exports = {
         let requireAnonymousFunctionSpacing = true,
             forbidAnonymousFunctionSpacing = false,
             requireNamedFunctionSpacing = true,
-            forbidNamedFunctionSpacing = false;
+            forbidNamedFunctionSpacing = false,
+            requireArrowFunctionSpacing = true,
+            forbidArrowFunctionSpacing = false;
 
         if (typeof configuration === "object") {
             requireAnonymousFunctionSpacing = (
@@ -57,11 +62,16 @@ module.exports = {
             requireNamedFunctionSpacing = (
                 !configuration.named || configuration.named === "always");
             forbidNamedFunctionSpacing = configuration.named === "never";
+            requireArrowFunctionSpacing = (
+                !configuration.asyncArrow || configuration.asyncArrow === "always");
+            forbidArrowFunctionSpacing = configuration.asyncArrow === "never";
         } else if (configuration === "never") {
             requireAnonymousFunctionSpacing = false;
             forbidAnonymousFunctionSpacing = true;
             requireNamedFunctionSpacing = false;
             forbidNamedFunctionSpacing = true;
+            requireArrowFunctionSpacing = false;
+            forbidArrowFunctionSpacing = true;
         }
 
         /**
@@ -92,11 +102,26 @@ module.exports = {
          * @returns {void}
          */
         function validateSpacingBeforeParentheses(node) {
-            const isNamed = isNamedFunction(node);
-            let rightToken;
+            const isArrow = node.type === "ArrowFunctionExpression";
+            const isNamed = !isArrow && isNamedFunction(node);
+            let forbidSpacing, requireSpacing, rightToken;
 
-            if (node.generator && !isNamed) {
+            if ((node.generator && !isNamed) ||
+                (isArrow && !node.async) ||
+                (isArrow && sourceCode.getFirstToken(node, 1).value !== "(")
+            ) {
                 return;
+            }
+
+            if (isArrow) {
+                forbidSpacing = forbidArrowFunctionSpacing;
+                requireSpacing = requireArrowFunctionSpacing;
+            } else if (isNamed) {
+                forbidSpacing = forbidNamedFunctionSpacing;
+                requireSpacing = requireNamedFunctionSpacing;
+            } else {
+                forbidSpacing = forbidAnonymousFunctionSpacing;
+                requireSpacing = requireAnonymousFunctionSpacing;
             }
 
             rightToken = sourceCode.getFirstToken(node);
@@ -107,7 +132,7 @@ module.exports = {
             const location = leftToken.loc.end;
 
             if (sourceCode.isSpaceBetweenTokens(leftToken, rightToken)) {
-                if ((isNamed && forbidNamedFunctionSpacing) || (!isNamed && forbidAnonymousFunctionSpacing)) {
+                if (forbidSpacing) {
                     context.report({
                         node,
                         loc: location,
@@ -118,7 +143,7 @@ module.exports = {
                     });
                 }
             } else {
-                if ((isNamed && requireNamedFunctionSpacing) || (!isNamed && requireAnonymousFunctionSpacing)) {
+                if (requireSpacing) {
                     context.report({
                         node,
                         loc: location,
@@ -133,7 +158,8 @@ module.exports = {
 
         return {
             FunctionDeclaration: validateSpacingBeforeParentheses,
-            FunctionExpression: validateSpacingBeforeParentheses
+            FunctionExpression: validateSpacingBeforeParentheses,
+            ArrowFunctionExpression: validateSpacingBeforeParentheses,
         };
     }
 };

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -99,13 +99,20 @@ ruleTester.run("space-before-function-paren", rule, {
         // Async arrow functions
         { code: "() => 1", parserOptions: {ecmaVersion: 6} },
         { code: "async a => a", parserOptions: {ecmaVersion: 8} },
-        { code: "async () => 1", parserOptions: {ecmaVersion: 8} },
-        { code: "async () => 1", options: ["always"], parserOptions: {ecmaVersion: 8} },
-        { code: "async() => 1", options: ["never"], parserOptions: {ecmaVersion: 8} },
+        { code: "async a => a", options: [{asyncArrow: "always"}], parserOptions: {ecmaVersion: 8} },
+        { code: "async a => a", options: [{asyncArrow: "never"}], parserOptions: {ecmaVersion: 8} },
         { code: "async () => 1", options: [{asyncArrow: "always"}], parserOptions: {ecmaVersion: 8} },
         { code: "async() => 1", options: [{asyncArrow: "never"}], parserOptions: {ecmaVersion: 8} },
         { code: "async () => 1", options: [{asyncArrow: "ignore"}], parserOptions: {ecmaVersion: 8} },
         { code: "async() => 1", options: [{asyncArrow: "ignore"}], parserOptions: {ecmaVersion: 8} },
+
+        // ignore by default for now.
+        { code: "async () => 1", parserOptions: {ecmaVersion: 8} },
+        { code: "async() => 1", parserOptions: {ecmaVersion: 8} },
+        { code: "async () => 1", options: ["always"], parserOptions: {ecmaVersion: 8} },
+        { code: "async() => 1", options: ["always"], parserOptions: {ecmaVersion: 8} },
+        { code: "async () => 1", options: ["never"], parserOptions: {ecmaVersion: 8} },
+        { code: "async() => 1", options: ["never"], parserOptions: {ecmaVersion: 8} },
     ],
 
     invalid: [
@@ -469,26 +476,6 @@ ruleTester.run("space-before-function-paren", rule, {
         },
 
         // Async arrow functions
-        {
-            code: "async() => 1",
-            output: "async () => 1",
-            parserOptions: {ecmaVersion: 8},
-            errors: ["Missing space before function parentheses."]
-        },
-        {
-            code: "async() => 1",
-            output: "async () => 1",
-            options: ["always"],
-            parserOptions: {ecmaVersion: 8},
-            errors: ["Missing space before function parentheses."]
-        },
-        {
-            code: "async () => 1",
-            output: "async() => 1",
-            options: ["never"],
-            parserOptions: {ecmaVersion: 8},
-            errors: ["Unexpected space before function parentheses."]
-        },
         {
             code: "async() => 1",
             output: "async () => 1",

--- a/tests/lib/rules/space-before-function-paren.js
+++ b/tests/lib/rules/space-before-function-paren.js
@@ -94,7 +94,18 @@ ruleTester.run("space-before-function-paren", rule, {
         },
         { code: "var bar = function foo () {}",
           options: [ { named: "ignore", anonymous: "always" } ]
-        }
+        },
+
+        // Async arrow functions
+        { code: "() => 1", parserOptions: {ecmaVersion: 6} },
+        { code: "async a => a", parserOptions: {ecmaVersion: 8} },
+        { code: "async () => 1", parserOptions: {ecmaVersion: 8} },
+        { code: "async () => 1", options: ["always"], parserOptions: {ecmaVersion: 8} },
+        { code: "async() => 1", options: ["never"], parserOptions: {ecmaVersion: 8} },
+        { code: "async () => 1", options: [{asyncArrow: "always"}], parserOptions: {ecmaVersion: 8} },
+        { code: "async() => 1", options: [{asyncArrow: "never"}], parserOptions: {ecmaVersion: 8} },
+        { code: "async () => 1", options: [{asyncArrow: "ignore"}], parserOptions: {ecmaVersion: 8} },
+        { code: "async() => 1", options: [{asyncArrow: "ignore"}], parserOptions: {ecmaVersion: 8} },
     ],
 
     invalid: [
@@ -406,6 +417,7 @@ ruleTester.run("space-before-function-paren", rule, {
         },
         {
             code: "var foo = function() {}",
+            output: "var foo = function () {}",
             options: [ { named: "ignore", anonymous: "always" } ],
             errors: [
                 {
@@ -418,6 +430,7 @@ ruleTester.run("space-before-function-paren", rule, {
         },
         {
             code: "var foo = function () {}",
+            output: "var foo = function() {}",
             options: [ { named: "ignore", anonymous: "never" } ],
             errors: [
                 {
@@ -430,6 +443,7 @@ ruleTester.run("space-before-function-paren", rule, {
         },
         {
             code: "var bar = function foo() {}",
+            output: "var bar = function foo () {}",
             options: [ { named: "always", anonymous: "ignore" } ],
             errors: [
                 {
@@ -442,6 +456,7 @@ ruleTester.run("space-before-function-paren", rule, {
         },
         {
             code: "var bar = function foo () {}",
+            output: "var bar = function foo() {}",
             options: [ { named: "never", anonymous: "ignore" } ],
             errors: [
                 {
@@ -451,6 +466,42 @@ ruleTester.run("space-before-function-paren", rule, {
                     column: 23
                 }
             ]
-        }
+        },
+
+        // Async arrow functions
+        {
+            code: "async() => 1",
+            output: "async () => 1",
+            parserOptions: {ecmaVersion: 8},
+            errors: ["Missing space before function parentheses."]
+        },
+        {
+            code: "async() => 1",
+            output: "async () => 1",
+            options: ["always"],
+            parserOptions: {ecmaVersion: 8},
+            errors: ["Missing space before function parentheses."]
+        },
+        {
+            code: "async () => 1",
+            output: "async() => 1",
+            options: ["never"],
+            parserOptions: {ecmaVersion: 8},
+            errors: ["Unexpected space before function parentheses."]
+        },
+        {
+            code: "async() => 1",
+            output: "async () => 1",
+            options: [{asyncArrow: "always"}],
+            parserOptions: {ecmaVersion: 8},
+            errors: ["Missing space before function parentheses."]
+        },
+        {
+            code: "async () => 1",
+            output: "async() => 1",
+            options: [{asyncArrow: "never"}],
+            parserOptions: {ecmaVersion: 8},
+            errors: ["Unexpected space before function parentheses."]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

- [space-before-function-paren](http://eslint.org/docs/rules/space-before-function-paren)

**Does this change cause the rule to produce more or fewer warnings?**

- In espree, this does not change errors. 
- This may increase errors if someone is using async arrow functions.

**How will the change be implemented? (New option, new default behavior, etc.)?**

- This checks spacing between `async` keyword and `(` of arrow functions by default.
- Also, `asyncArrow` option allows configuring the behavior.

**Please provide some example code that this change will affect:**

```js
/*eslint space-before-function-paren: error*/

// ✔ GOOD
async () => {}
async a => a

// ✘ BAD
async() => {}  // this is a new error.
```

```js
/*eslint space-before-function-paren: [error, never]*/

// ✔ GOOD
async() => {}
async a => a

// ✘ BAD
async () => {}  // this is a new error.
```

```js
/*eslint space-before-function-paren: [error, {asyncArrow: ignore}]*/

// ✔ GOOD
async () => {}
async() => {}
async a => a
```

**What does the rule currently do for this code?**

- Do nothing.

**What will the rule do after it's changed?**

- Check the space for async arrow functions.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This PR modifies `space-before-function-paren` to handle async arrow functions.
This PR adds `asyncArrow` option to configure the behavior for async arrow functions.

- `{"asyncArrow": "always"}` (default) it requires a space before `(` of async arrow functions.
- `{"asyncArrow": "never"}` it disallows a space before `(` of async arrow functions.
- `{"asyncArrow": "ignore"}` do nothing for async arrow functions.

**Is there anything you'd like reviewers to focus on?**

There is the discussion about which rule should handle the space of between `async` and function-paren: https://github.com/eslint/eslint/issues/7101#issuecomment-246084656

Also, does this change need a major bump?