### PR TITLE
Update: `comma-dangle` supports trailing function commas (refs #7101)

### DIFF
--- a/docs/rules/comma-dangle.md
+++ b/docs/rules/comma-dangle.md
@@ -39,12 +39,39 @@ This rule enforces consistent use of trailing commas in object and array literal
 
 ## Options
 
-This rule has a string option:
+This rule has a string option or an object option:
+
+```json
+{
+    "comma-dangle": ["error", "never"],
+    // or
+    "comma-dangle": ["error", {
+        "arrays": "never",
+        "objects": "never",
+        "imports": "never",
+        "exports": "never",
+        "functions": "ignore",
+    }]
+}
+```
 
 * `"never"` (default) disallows trailing commas
 * `"always"` requires trailing commas
 * `"always-multiline"` requires trailing commas when the last element or property is in a *different* line than the closing `]` or `}` and disallows trailing commas when the last element or property is on the *same* line as the closing `]` or `}`
 * `"only-multiline"` allows (but does not require) trailing commas when the last element or property is in a *different* line than the closing `]` or `}` and disallows trailing commas when the last element or property is on the *same* line as the closing `]` or `}`
+
+Trailing commas in function declarations and function calls are valid syntax since ECMAScript 2017; however, the string option does not check these situations for backwards compatibility.
+
+You can also use an object option to configure this rule for each type of syntax.
+Each of the following options can be set to `"never"`, `"always"`, `"always-multiline"`, `"only-multiline"`, or `"ignore"`.
+The default for each option is `"never"` unless otherwise specified.
+
+* `arrays` is for array literals and array patterns of destructuring. (e.g. `let [a,] = [1,];`)
+* `objects` is for object literals and object patterns of destructuring. (e.g. `let {a,} = {a: 1};`)
+* `imports` is for import declarations of ES Modules. (e.g. `import {a,} from "foo";`)
+* `exports` is for export declarations of ES Modules. (e.g. `export {a,};`)
+* `functions` is for function declarations and function calls. (e.g. `(function(a,){ })(b,);`)<br>
+  `functions` is set to `"ignore"` by default for consistency with the string option.
 
 ### never
 
@@ -235,6 +262,56 @@ foo({
   bar: "baz",
   qux: "quux"
 });
+```
+
+### functions
+
+Examples of **incorrect** code for this rule with the `{"functions": "never"}` option:
+
+```js
+/*eslint comma-dangle: ["error", {"functions": "never"}]*/
+
+function foo(a, b,) {
+}
+
+foo(a, b,);
+new foo(a, b,);
+```
+
+Examples of **correct** code for this rule with the `{"functions": "never"}` option:
+
+```js
+/*eslint comma-dangle: ["error", {"functions": "never"}]*/
+
+function foo(a, b) {
+}
+
+foo(a, b);
+new foo(a, b);
+```
+
+Examples of **incorrect** code for this rule with the `{"functions": "always"}` option:
+
+```js
+/*eslint comma-dangle: ["error", {"functions": "always"}]*/
+
+function foo(a, b) {
+}
+
+foo(a, b);
+new foo(a, b);
+```
+
+Examples of **correct** code for this rule with the `{"functions": "always"}` option:
+
+```js
+/*eslint comma-dangle: ["error", {"functions": "always"}]*/
+
+function foo(a, b,) {
+}
+
+foo(a, b,);
+new foo(a, b,);
 ```
 
 ## When Not To Use It

--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -11,19 +11,62 @@
 
 const lodash = require("lodash");
 
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+const DEFAULT_OPTIONS = Object.freeze({
+    arrays: "never",
+    objects: "never",
+    imports: "never",
+    exports: "never",
+    functions: "ignore",
+});
+
 /**
  * Checks whether or not a trailing comma is allowed in a given node.
- * `ArrayPattern` which has `RestElement` or `ObjectPattern` which has `RestProperty` disallows it.
+ * If the `lastItem` is `RestElement` or `RestProperty`, it disallows trailing commas.
  *
- * @param {ASTNode} node - A node to check.
  * @param {ASTNode} lastItem - The node of the last element in the given node.
  * @returns {boolean} `true` if a trailing comma is allowed.
  */
-function isTrailingCommaAllowed(node, lastItem) {
+function isTrailingCommaAllowed(lastItem) {
     return !(
-        (node.type === "ArrayPattern" && lastItem.type === "RestElement") ||
-        (node.type === "ObjectPattern" && (lastItem.type === "RestProperty" || lastItem.type === "ExperimentalRestProperty"))
+        lastItem.type === "RestElement" ||
+        lastItem.type === "RestProperty" ||
+        lastItem.type === "ExperimentalRestProperty"
     );
+}
+
+/**
+ * Normalize option value.
+ *
+ * @param {string|Object|undefined} optionValue - The 1st option value to normalize.
+ * @returns {Object} The normalized option value.
+ */
+function normalizeOptions(optionValue) {
+    if (typeof optionValue === "string") {
+        return {
+            arrays: optionValue,
+            objects: optionValue,
+            imports: optionValue,
+            exports: optionValue,
+
+            // For backward compatibility, always ignore functions.
+            functions: "ignore",
+        };
+    }
+    if (typeof optionValue === "object" && optionValue !== null) {
+        return {
+            arrays: optionValue.arrays || DEFAULT_OPTIONS.arrays,
+            objects: optionValue.objects || DEFAULT_OPTIONS.objects,
+            imports: optionValue.imports || DEFAULT_OPTIONS.imports,
+            exports: optionValue.exports || DEFAULT_OPTIONS.exports,
+            functions: optionValue.functions || DEFAULT_OPTIONS.functions,
+        };
+    }
+
+    return DEFAULT_OPTIONS;
 }
 
 //------------------------------------------------------------------------------
@@ -42,15 +85,111 @@ module.exports = {
 
         schema: [
             {
-                enum: ["always", "always-multiline", "only-multiline", "never"]
-            }
+                defs: {
+                    value: {
+                        enum: [
+                            "always",
+                            "always-multiline",
+                            "only-multiline",
+                            "never"
+                        ]
+                    },
+                    valueWithIgnore: {
+                        anyOf: [
+                            {
+                                $ref: "#/defs/value"
+                            },
+                            {
+                                enum: ["ignore"]
+                            }
+                        ]
+                    }
+                },
+                anyOf: [
+                    {
+                        $ref: "#/defs/value"
+                    },
+                    {
+                        type: "object",
+                        properties: {
+                            arrays: {$refs: "#/defs/valueWithIgnore"},
+                            objects: {$refs: "#/defs/valueWithIgnore"},
+                            imports: {$refs: "#/defs/valueWithIgnore"},
+                            exports: {$refs: "#/defs/valueWithIgnore"},
+                            functions: {$refs: "#/defs/valueWithIgnore"}
+                        },
+                        additionalProperties: false
+                    }
+                ]
+            },
         ]
     },
 
     create(context) {
-        const mode = context.options[0];
+        const options = normalizeOptions(context.options[0]);
+        const sourceCode = context.getSourceCode();
         const UNEXPECTED_MESSAGE = "Unexpected trailing comma.";
         const MISSING_MESSAGE = "Missing trailing comma.";
+
+        /**
+         * Gets the last item of the given node.
+         * @param {ASTNode} node - The node to get.
+         * @returns {ASTNode|null} The last node or null.
+         */
+        function getLastItem(node) {
+            switch (node.type) {
+                case "ObjectExpression":
+                case "ObjectPattern":
+                    return lodash.last(node.properties);
+                case "ArrayExpression":
+                case "ArrayPattern":
+                    return lodash.last(node.elements);
+                case "ImportDeclaration":
+                case "ExportNamedDeclaration":
+                    return lodash.last(node.specifiers);
+                case "FunctionDeclaration":
+                case "FunctionExpression":
+                case "ArrowFunctionExpression":
+                    return lodash.last(node.params);
+                case "CallExpression":
+                case "NewExpression":
+                    return lodash.last(node.arguments);
+                default:
+                    return null;
+            }
+        }
+
+        /**
+         * Gets the trailing comma token of the given node.
+         * If the trailing comma does not exist, this returns the token which is
+         * the insertion point of the trailing comma token.
+         *
+         * @param {ASTNode} node - The node to get.
+         * @param {ASTNode} lastItem - The last item of the node.
+         * @returns {Token} The trailing comma token or the insertion point.
+         */
+        function getTrailingToken(node, lastItem) {
+            switch (node.type) {
+                case "ObjectExpression":
+                case "ObjectPattern":
+                case "ArrayExpression":
+                case "ArrayPattern":
+                case "CallExpression":
+                case "NewExpression":
+                    return sourceCode.getLastToken(node, 1);
+                case "FunctionDeclaration":
+                case "FunctionExpression":
+                    return sourceCode.getTokenBefore(node.body, 1);
+                default: {
+                    const nextToken = sourceCode.getTokenAfter(lastItem);
+
+                    if (nextToken.value === ",") {
+                        return nextToken;
+                    }
+                    return sourceCode.getLastToken(lastItem);
+                }
+            }
+        }
 
         /**
          * Checks whether or not a given node is multiline.
@@ -61,26 +200,14 @@ module.exports = {
          * @returns {boolean} `true` if the node is multiline.
          */
         function isMultiline(node) {
-            const lastItem = lodash.last(node.properties || node.elements || node.specifiers);
+            const lastItem = getLastItem(node);
 
             if (!lastItem) {
                 return false;
             }
 
-            const sourceCode = context.getSourceCode();
-            let penultimateToken = sourceCode.getLastToken(lastItem),
-                lastToken = sourceCode.getTokenAfter(penultimateToken);
-
-            // parentheses are a pain
-            while (lastToken.value === ")") {
-                penultimateToken = lastToken;
-                lastToken = sourceCode.getTokenAfter(lastToken);
-            }
-
-            if (lastToken.value === ",") {
-                penultimateToken = lastToken;
-                lastToken = sourceCode.getTokenAfter(lastToken);
-            }
+            const penultimateToken = getTrailingToken(node, lastItem);
+            const lastToken = sourceCode.getTokenAfter(penultimateToken);
 
             return lastToken.loc.end.line !== penultimateToken.loc.end.line;
         }
@@ -94,21 +221,13 @@ module.exports = {
          * @returns {void}
          */
         function forbidTrailingComma(node) {
-            const lastItem = lodash.last(node.properties || node.elements || node.specifiers);
+            const lastItem = getLastItem(node);
 
             if (!lastItem || (node.type === "ImportDeclaration" && lastItem.type !== "ImportSpecifier")) {
                 return;
             }
 
-            const sourceCode = context.getSourceCode();
-            let trailingToken;
-
-            // last item can be surrounded by parentheses for object and array literals
-            if (node.type === "ObjectExpression" || node.type === "ArrayExpression") {
-                trailingToken = sourceCode.getTokenBefore(sourceCode.getLastToken(node));
-            } else {
-                trailingToken = sourceCode.getTokenAfter(lastItem);
-            }
+            const trailingToken = getTrailingToken(node, lastItem);
 
             if (trailingToken.value === ",") {
                 context.report({
@@ -135,33 +254,25 @@ module.exports = {
          * @returns {void}
          */
         function forceTrailingComma(node) {
-            const lastItem = lodash.last(node.properties || node.elements || node.specifiers);
+            const lastItem = getLastItem(node);
 
             if (!lastItem || (node.type === "ImportDeclaration" && lastItem.type !== "ImportSpecifier")) {
                 return;
             }
-            if (!isTrailingCommaAllowed(node, lastItem)) {
+            if (!isTrailingCommaAllowed(lastItem)) {
                 forbidTrailingComma(node);
                 return;
             }
 
-            const sourceCode = context.getSourceCode();
-            let penultimateToken = lastItem,
-                trailingToken = sourceCode.getTokenAfter(lastItem);
-
-            // Skip close parentheses.
-            while (trailingToken.value === ")") {
-                penultimateToken = trailingToken;
-                trailingToken = sourceCode.getTokenAfter(trailingToken);
-            }
+            const trailingToken = getTrailingToken(node, lastItem);
 
             if (trailingToken.value !== ",") {
                 context.report({
                     node: lastItem,
-                    loc: penultimateToken.loc.end,
+                    loc: trailingToken.loc.end,
                     message: MISSING_MESSAGE,
                     fix(fixer) {
-                        return fixer.insertTextAfter(penultimateToken, ",");
+                        return fixer.insertTextAfter(trailingToken, ",");
                     }
                 });
             }
@@ -201,26 +312,30 @@ module.exports = {
             }
         }
 
-        // Chooses a checking function.
-        let checkForTrailingComma;
-
-        if (mode === "always") {
-            checkForTrailingComma = forceTrailingComma;
-        } else if (mode === "always-multiline") {
-            checkForTrailingComma = forceTrailingCommaIfMultiline;
-        } else if (mode === "only-multiline") {
-            checkForTrailingComma = allowTrailingCommaIfMultiline;
-        } else {
-            checkForTrailingComma = forbidTrailingComma;
-        }
+        const predicate = {
+            always: forceTrailingComma,
+            "always-multiline": forceTrailingCommaIfMultiline,
+            "only-multiline": allowTrailingCommaIfMultiline,
+            never: forbidTrailingComma,
+            ignore: lodash.noop,
+        };
 
         return {
-            ObjectExpression: checkForTrailingComma,
-            ObjectPattern: checkForTrailingComma,
-            ArrayExpression: checkForTrailingComma,
-            ArrayPattern: checkForTrailingComma,
-            ImportDeclaration: checkForTrailingComma,
-            ExportNamedDeclaration: checkForTrailingComma
+            ObjectExpression: predicate[options.objects],
+            ObjectPattern: predicate[options.objects],
+
+            ArrayExpression: predicate[options.arrays],
+            ArrayPattern: predicate[options.arrays],
+
+            ImportDeclaration: predicate[options.imports],
+
+            ExportNamedDeclaration: predicate[options.exports],
+
+            FunctionDeclaration: predicate[options.functions],
+            FunctionExpression: predicate[options.functions],
+            ArrowFunctionExpression: predicate[options.functions],
+            CallExpression: predicate[options.functions],
+            NewExpression: predicate[options.functions],
         };
     }
 };

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -223,7 +223,152 @@ ruleTester.run("comma-dangle", rule, {
             code: "import {foo} from \n'foo';",
             parserOptions: { sourceType: "module" },
             options: ["only-multiline"]
-        }
+        },
+
+
+        // trailing comma in functions -- ignore by default
+        {
+            code: "function foo(a,) {}",
+            parserOptions: {ecmaVersion: 8},
+            options: ["never"],
+        },
+        {
+            code: "foo(a,)",
+            parserOptions: {ecmaVersion: 8},
+            options: ["never"],
+        },
+        {
+            code: "function foo(a) {}",
+            parserOptions: {ecmaVersion: 8},
+            options: ["always"],
+        },
+        {
+            code: "foo(a)",
+            parserOptions: {ecmaVersion: 8},
+            options: ["always"],
+        },
+        {
+            code: "function foo(\na,\nb\n) {}",
+            parserOptions: {ecmaVersion: 8},
+            options: ["always-multiline"],
+        },
+        {
+            code: "foo(\na,\mb\m)",
+            parserOptions: {ecmaVersion: 8},
+            options: ["always-multiline"],
+        },
+        {
+            code: "function foo(a,b,) {}",
+            parserOptions: {ecmaVersion: 8},
+            options: ["always-multiline"],
+        },
+        {
+            code: "foo(a,b,)",
+            parserOptions: {ecmaVersion: 8},
+            options: ["always-multiline"],
+        },
+        {
+            code: "function foo(a,b,) {}",
+            parserOptions: {ecmaVersion: 8},
+            options: ["only-multiline"],
+        },
+        {
+            code: "foo(a,b,)",
+            parserOptions: {ecmaVersion: 8},
+            options: ["only-multiline"],
+        },
+
+        // trailing comma in functions
+        {
+            code: "function foo(a) {} ",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "never"}],
+        },
+        {
+            code: "foo(a)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "never"}],
+        },
+        {
+            code: "function foo(a,) {}",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always"}],
+        },
+        {
+            code: "function bar(a, ...b) {}",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always"}],
+        },
+        {
+            code: "foo(a,)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always"}],
+        },
+        {
+            code: "bar(...a,)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always"}],
+        },
+        {
+            code: "function foo(a) {} ",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always-multiline"}],
+        },
+        {
+            code: "foo(a)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always-multiline"}],
+        },
+        {
+            code: "function foo(\na,\nb,\n) {} ",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always-multiline"}],
+        },
+        {
+            code: "function foo(\na,\n...b\n) {} ",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always-multiline"}],
+        },
+        {
+            code: "foo(\na,\nb,\n)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always-multiline"}],
+        },
+        {
+            code: "foo(\na,\n...b,\n)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "always-multiline"}],
+        },
+        {
+            code: "function foo(a) {} ",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "only-multiline"}],
+        },
+        {
+            code: "foo(a)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "only-multiline"}],
+        },
+        {
+            code: "function foo(\na,\nb,\n) {} ",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "only-multiline"}],
+        },
+        {
+            code: "foo(\na,\nb,\n)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "only-multiline"}],
+        },
+        {
+            code: "function foo(\na,\nb\n) {} ",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "only-multiline"}],
+        },
+        {
+            code: "foo(\na,\nb\n)",
+            parserOptions: {ecmaVersion: 8},
+            options: [{functions: "only-multiline"}],
+        },
     ],
     invalid: [
         {
@@ -950,6 +1095,320 @@ ruleTester.run("comma-dangle", rule, {
             output: "var foo = [\n1,\n(2),\n]",
             options: ["always-multiline"],
             errors: [{message: "Missing trailing comma.", type: "Literal"}]
-        }
+        },
+
+        // trailing commas in functions
+        {
+            code: "function foo(a,) {}",
+            output: "function foo(a) {}",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(function foo(a,) {})",
+            output: "(function foo(a) {})",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(a,) => a",
+            output: "(a) => a",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(a,) => (a)",
+            output: "(a) => (a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "({foo(a,) {}})",
+            output: "({foo(a) {}})",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "class A {foo(a,) {}}",
+            output: "class A {foo(a) {}}",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(a,)",
+            output: "foo(a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(...a,)",
+            output: "foo(...a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma.", type: "SpreadElement"}]
+        },
+
+        {
+            code: "function foo(a) {}",
+            output: "function foo(a,) {}",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(function foo(a) {})",
+            output: "(function foo(a,) {})",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(a) => a",
+            output: "(a,) => a",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(a) => (a)",
+            output: "(a,) => (a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "({foo(a) {}})",
+            output: "({foo(a,) {}})",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "class A {foo(a) {}}",
+            output: "class A {foo(a,) {}}",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(a)",
+            output: "foo(a,)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(...a)",
+            output: "foo(...a,)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma.", type: "SpreadElement"}]
+        },
+
+        {
+            code: "function foo(a,) {}",
+            output: "function foo(a) {}",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(function foo(a,) {})",
+            output: "(function foo(a) {})",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(a,)",
+            output: "foo(a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(...a,)",
+            output: "foo(...a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "SpreadElement"}]
+        },
+        {
+            code: "function foo(\na,\nb\n) {}",
+            output: "function foo(\na,\nb,\n) {}",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always-multiline"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(\na,\nb\n)",
+            output: "foo(\na,\nb,\n)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always-multiline"}],
+            errors: [{message: "Missing trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(\n...a,\n...b\n)",
+            output: "foo(\n...a,\n...b,\n)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "always-multiline"}],
+            errors: [{message: "Missing trailing comma.", type: "SpreadElement"}]
+        },
+
+        {
+            code: "function foo(a,) {}",
+            output: "function foo(a) {}",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "only-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "(function foo(a,) {})",
+            output: "(function foo(a) {})",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "only-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(a,)",
+            output: "foo(a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "only-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "Identifier"}]
+        },
+        {
+            code: "foo(...a,)",
+            output: "foo(...a)",
+            parserOptions: { ecmaVersion: 8 },
+            options: [{functions: "only-multiline"}],
+            errors: [{message: "Unexpected trailing comma.", type: "SpreadElement"}]
+        },
+
+        // separated options
+        {
+            code: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            output: `let {a} = {a: 1};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            parserOptions: { ecmaVersion: 8, sourceType: "module" },
+            options: [{
+                objects: "never",
+                arrays: "ignore",
+                imports: "ignore",
+                exports: "ignore",
+                functions: "ignore"
+            }],
+            errors: [
+                {message: "Unexpected trailing comma.", line: 1},
+                {message: "Unexpected trailing comma.", line: 1}
+            ]
+        },
+        {
+            code: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            output: `let {a,} = {a: 1,};
+let [b] = [1];
+import {c,} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            parserOptions: { ecmaVersion: 8, sourceType: "module" },
+            options: [{
+                objects: "ignore",
+                arrays: "never",
+                imports: "ignore",
+                exports: "ignore",
+                functions: "ignore"
+            }],
+            errors: [
+                {message: "Unexpected trailing comma.", line: 2},
+                {message: "Unexpected trailing comma.", line: 2}
+            ]
+        },
+        {
+            code: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            output: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            parserOptions: { ecmaVersion: 8, sourceType: "module" },
+            options: [{
+                objects: "ignore",
+                arrays: "ignore",
+                imports: "never",
+                exports: "ignore",
+                functions: "ignore"
+            }],
+            errors: [
+                {message: "Unexpected trailing comma.", line: 3}
+            ]
+        },
+        {
+            code: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            output: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d};
+(function foo(e,) {})(f,);`,
+            parserOptions: { ecmaVersion: 8, sourceType: "module" },
+            options: [{
+                objects: "ignore",
+                arrays: "ignore",
+                imports: "ignore",
+                exports: "never",
+                functions: "ignore"
+            }],
+            errors: [
+                {message: "Unexpected trailing comma.", line: 4}
+            ]
+        },
+        {
+            code: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d,};
+(function foo(e,) {})(f,);`,
+            output: `let {a,} = {a: 1,};
+let [b,] = [1,];
+import {c,} from "foo";
+export {d,};
+(function foo(e) {})(f);`,
+            parserOptions: { ecmaVersion: 8, sourceType: "module" },
+            options: [{
+                objects: "ignore",
+                arrays: "ignore",
+                imports: "ignore",
+                exports: "ignore",
+                functions: "never"
+            }],
+            errors: [
+                {message: "Unexpected trailing comma.", line: 5},
+                {message: "Unexpected trailing comma.", line: 5}
+            ]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

- [comma-dangle](http://eslint.org/docs/rules/comma-dangle)

**Does this change cause the rule to produce more or fewer warnings?**

- This increases warnings by opt-in.

**How will the change be implemented? (New option, new default behavior, etc.)?**

- This adds `{"function": true}` option to check trailing comma in functions.

**Please provide some example code that this change will affect:**

```js
/*eslint comma-dangle: [error, never]*/

// ✔ GOOD
function foo(a, b) { }
foo(a, b);
function foo(a, b,) { }
foo(a, b,);
```

```js
/*eslint comma-dangle: [error, never, {function: true}]*/

// ✔ GOOD
function foo(a, b) { }
foo(a, b);

// ✘ BAD
function foo(a, b,) { }
foo(a, b,);
```

**What does the rule currently do for this code?**

- Nothing.

**What will the rule do after it's changed?**

- It checks trailing commas in functions and notifies proper warnings.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This PR adds `{"function": true}` option to check trailing comma in functions to `comma-dangle` rule.
People will enable the option if they will use ES2017.

`Semver-minor`: this is a new option to an existing rule that does not result in ESLint reporting more errors by default.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

Refs #7101.

----

I'm a champion.