### PR TITLE
Fix: Handle number literals correctly in `no-whitespace-before-property`

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -715,5 +715,27 @@ module.exports = {
         }
 
         return directives;
+    },
+
+
+    /**
+     * Determines whether this node is a decimal integer literal. If a node is a decimal integer literal, a dot added
+     after the node will be parsed as a decimal point, rather than a property-access dot.
+     * @param {ASTNode} node - The node to check.
+     * @returns {boolean} `true` if this node is a decimal integer.
+     * @example
+     *
+     * 5       // true
+     * 5.      // false
+     * 5.0     // false
+     * 05      // false
+     * 0x5     // false
+     * 0b101   // false
+     * 0o5     // false
+     * 5e0     // false
+     * '5'     // false
+     */
+    isDecimalInteger(node) {
+        return node.type === "Literal" && typeof node.value === "number" && /^(0|[1-9]\d*)$/.test(node.raw);
     }
 };

--- a/lib/rules/no-whitespace-before-property.js
+++ b/lib/rules/no-whitespace-before-property.js
@@ -62,6 +62,12 @@ module.exports = {
                     propName: sourceCode.getText(node.property)
                 },
                 fix(fixer) {
+                    if (!node.computed && astUtils.isDecimalInteger(node.object)) {
+
+                        // If the object is a number literal, fixing it to something like 5.toString() would cause a SyntaxError.
+                        // Don't fix this case.
+                        return null;
+                    }
                     return fixer.replaceTextRange([leftToken.range[1], rightToken.range[0]], replacementText);
                 }
             });

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -646,4 +646,24 @@ describe("ast-utils", function() {
             assert.equal(result[1].expression.value, "use asm");
         });
     });
+
+    describe("isDecimalInteger", function() {
+        const expectedResults = {
+            5: true,
+            0: true,
+            "5.": false,
+            "5.0": false,
+            "05": false,
+            "0x5": false,
+            "5e0": false,
+            "5e-0": false,
+            "'5'": false
+        };
+
+        Object.keys(expectedResults).forEach(key => {
+            it(`should return ${expectedResults[key]} for ${key}`, function() {
+                assert.strictEqual(astUtils.isDecimalInteger(espree.parse(key).body[0].expression), expectedResults[key]);
+            });
+        });
+    });
 });

--- a/tests/lib/rules/no-whitespace-before-property.js
+++ b/tests/lib/rules/no-whitespace-before-property.js
@@ -98,7 +98,8 @@ ruleTester.run("no-whitespace-before-property", rule, {
         "foo[0][[('baz')]]",
         "foo[bar.baz('qux')]",
         "foo[(bar.baz() + 0) + qux]",
-        "foo['bar ' + 1 + ' baz']"
+        "foo['bar ' + 1 + ' baz']",
+        "5['toExponential']()"
     ],
 
     invalid: [
@@ -507,6 +508,51 @@ ruleTester.run("no-whitespace-before-property", rule, {
             code: "foo ['bar ' + 1 + ' baz']",
             output: "foo['bar ' + 1 + ' baz']",
             errors: ["Unexpected whitespace before property 'bar ' + 1 + ' baz'."]
+        },
+        {
+            code: "5 .toExponential()",
+            output: "5 .toExponential()", // This case is not fixed; can't be sure whether 5..toExponential or (5).toExponential is preferred
+            errors: ["Unexpected whitespace before property toExponential."]
+        },
+        {
+            code: "5       .toExponential()",
+            output: "5       .toExponential()", // Not fixed
+            errors: ["Unexpected whitespace before property toExponential."]
+        },
+        {
+            code: "5. .toExponential()",
+            output: "5..toExponential()",
+            errors: ["Unexpected whitespace before property toExponential."]
+        },
+        {
+            code: "5.0 .toExponential()",
+            output: "5.0.toExponential()",
+            errors: ["Unexpected whitespace before property toExponential."]
+        },
+        {
+            code: "0x5 .toExponential()",
+            output: "0x5.toExponential()",
+            errors: ["Unexpected whitespace before property toExponential."]
+        },
+        {
+            code: "5e0 .toExponential()",
+            output: "5e0.toExponential()",
+            errors: ["Unexpected whitespace before property toExponential."]
+        },
+        {
+            code: "5e-0 .toExponential()",
+            output: "5e-0.toExponential()",
+            errors: ["Unexpected whitespace before property toExponential."]
+        },
+        {
+            code: "5 ['toExponential']()",
+            output: "5['toExponential']()",
+            errors: ["Unexpected whitespace before property 'toExponential'."]
+        },
+        {
+            code: "05 .toExponential()",
+            output: "05.toExponential()",
+            errors: ["Unexpected whitespace before property toExponential."]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 6.6.0
* **npm Version:** 3.10.3

**What parser (default, Babel-ESLint, etc.) are you using?**

default

**Please show your full configuration:**

none

**What did you do? Please include the actual source code causing the issue.**

```js
/* eslint no-whitespace-before-property: 2 */

5      .toExponential();
5 .toExponential();
```

**What did you expect to happen?**

I expected an error to be reported on the first line, since there is extraneous whitespace before the property. I expected an error to *not* be reported on the second line, since that whitespace is necessary and causes a SyntaxError if removed.

**What actually happened? Please include the actual, raw output from ESLint.**

ESLint reported an error on both lines:

```
  3:1  error  Unexpected whitespace before property toExponential  no-whitespace-before-property
  4:1  error  Unexpected whitespace before property toExponential  no-whitespace-before-property
```

In addition, when I ran `eslint --fix` on the file, ESLint removed spaces from both lines and caused a SyntaxError. The resulting file looked like this:

```js
/* eslint no-whitespace-before-property: 2 */

5.toExponential();
5.toExponential();
```

This is a SyntaxError because the `.` after the 5 is parsed as a decimal point rather than a property accessor.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This fixes the `no-whitespace-before-property` rule's behavior with number literals:

* ~~The rule no longer warns `5 .toExponential()` (a single space after a number literal)~~
* ~~The autofixer now inserts a space after number literals to avoid causing SyntaxErrors.~~

**edit**: The behavior of this PR changed a bit; now `no-whitespace-before-property` still reports number literals, but the fixer doesn't fix anything in those cases.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

