### PR TITLE
Update: Add a fixer for `dot-location`

### DIFF
--- a/docs/rules/dot-location.md
+++ b/docs/rules/dot-location.md
@@ -1,5 +1,7 @@
 # Enforce newline before and after dot (dot-location)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 JavaScript allows you to place newlines before or after a dot in a member expression.
 
 Consistency in placing a newline before or after the dot can greatly increase readability.

--- a/tests/lib/rules/dot-location.js
+++ b/tests/lib/rules/dot-location.js
@@ -42,18 +42,45 @@ ruleTester.run("dot-location", rule, {
     invalid: [
         {
             code: "obj\n.property",
+            output: "obj.\nproperty",
             options: [ "object" ],
             errors: [ { message: "Expected dot to be on same line as object.", type: "MemberExpression", line: 2, column: 1 } ]
         },
         {
             code: "obj.\nproperty",
+            output: "obj\n.property",
             options: [ "property" ],
             errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 4 } ]
         },
         {
             code: "(obj).\nproperty",
+            output: "(obj)\n.property",
             options: [ "property" ],
             errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 6 } ]
+        },
+        {
+            code: "5\n.toExponential()",
+            output: "5 .\ntoExponential()",
+            options: [ "object" ],
+            errors: [ { message: "Expected dot to be on same line as object.", type: "MemberExpression", line: 2, column: 1 } ]
+        },
+        {
+            code: "-5\n.toExponential()",
+            output: "-5 .\ntoExponential()",
+            options: [ "object" ],
+            errors: [ { message: "Expected dot to be on same line as object.", type: "MemberExpression", line: 2, column: 1 } ]
+        },
+        {
+            code: "foo /* a */ . /* b */ \n /* c */ bar",
+            output: "foo /* a */  /* b */ \n /* c */ .bar",
+            options: [ "property" ],
+            errors: [ { message: "Expected dot to be on same line as property.", type: "MemberExpression", line: 1, column: 13 } ]
+        },
+        {
+            code: "foo /* a */ \n /* b */ . /* c */ bar",
+            output: "foo. /* a */ \n /* b */  /* c */ bar",
+            options: [ "object" ],
+            errors: [ { message: "Expected dot to be on same line as object.", type: "MemberExpression", line: 2, column: 10 } ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds an autofixer for [`dot-location`](http://eslint.org/docs/rules/dot-location).

Given a `MemberExpression` where the dot is in the wrong location, the fixer will move the dot to the correct location. All comments between the object and the property are preserved.

```js
/* eslint dot-location: [2, "property"] */

foo.
  bar;

baz. /* comment */
  qux;

// gets fixed to:

foo
  .bar;

baz /* comment */
  .qux;
```

```js
/* eslint dot-location: [2, "object"] */

foo
  .bar;

5
  .toExponential();

// gets fixed to:

foo.
  bar;

5 .
  toExponential();

// (A space is added after `5` to ensure that the dot isn't parsed as a decimal point)
```

**Is there anything you'd like reviewers to focus on?**

I marked this as `fixable: "code"`, but should it be `fixable: "whitespace"` instead since it doesn't change the AST?