### PR TITLE
Fix: valid-jsdoc does not throw on FieldType without value (fixes #7184)

### DIFF
--- a/lib/rules/valid-jsdoc.js
+++ b/lib/rules/valid-jsdoc.js
@@ -165,7 +165,7 @@ module.exports = {
         }
 
         /**
-         * Check if return tag type is void or undefined
+         * Validate type for a given JSDoc node
          * @param {Object} jsdocNode JSDoc node
          * @param {Object} type JSDoc tag
          * @returns {void}
@@ -192,7 +192,9 @@ module.exports = {
                     elements = type.elements;
                     break;
                 case "FieldType":  // Array.<{count: number, votes: number}>
-                    typesToCheck.push(getCurrentExpectedTypes(type.value));
+                    if (type.value) {
+                        typesToCheck.push(getCurrentExpectedTypes(type.value));
+                    }
                     break;
                 default:
                     typesToCheck.push(getCurrentExpectedTypes(type));

--- a/tests/lib/rules/valid-jsdoc.js
+++ b/tests/lib/rules/valid-jsdoc.js
@@ -317,6 +317,21 @@ ruleTester.run("valid-jsdoc", rule, {
             code:
             "/**\n" +
             "* Foo\n" +
+            "* @param {{String:foo}} hi - desc\n" +
+            "* @returns {ASTNode} returns a node\n" +
+            "*/\n" +
+            "function foo(hi){}",
+            options: [{
+                preferType: {
+                    String: "string",
+                    astnode: "ASTNode"
+                }
+            }]
+        },
+        {
+            code:
+            "/**\n" +
+            "* Foo\n" +
             "* @param {String|number|Test} hi - desc\n" +
             "* @returns {Astnode} returns a node\n" +
             "*/\n" +
@@ -541,6 +556,56 @@ ruleTester.run("valid-jsdoc", rule, {
                 "}"
             ].join("\n"),
             parserOptions: {ecmaVersion: 6}
+        },
+
+        // https://github.com/eslint/eslint/issues/7184
+        {
+            code:
+            "/**\n" +
+            "* Foo\n" +
+            "* @param {{foo}} hi - desc\n" +
+            "* @returns {ASTNode} returns a node\n" +
+            "*/\n" +
+            "function foo(hi){}"
+        },
+        {
+            code:
+            "/**\n" +
+            "* Foo\n" +
+            "* @param {{foo:String, bar, baz:Array}} hi - desc\n" +
+            "* @returns {ASTNode} returns a node\n" +
+            "*/\n" +
+            "function foo(hi){}"
+        },
+        {
+            code:
+            "/**\n" +
+            "* Foo\n" +
+            "* @param {{String}} hi - desc\n" +
+            "* @returns {ASTNode} returns a node\n" +
+            "*/\n" +
+            "function foo(hi){}",
+            options: [{
+                preferType: {
+                    String: "string",
+                    astnode: "ASTNode"
+                }
+            }]
+        },
+        {
+            code:
+            "/**\n" +
+            "* Foo\n" +
+            "* @param {{foo:string, astnode:Object, bar}} hi - desc\n" +
+            "* @returns {ASTNode} returns a node\n" +
+            "*/\n" +
+            "function foo(hi){}",
+            options: [{
+                preferType: {
+                    String: "string",
+                    astnode: "ASTNode"
+                }
+            }]
         }
     ],
 
@@ -1226,6 +1291,29 @@ ruleTester.run("valid-jsdoc", rule, {
                 },
                 {
                     message: "Use 'Object' instead of 'object'.",
+                    type: "Block"
+                }
+            ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7184
+        {
+            code:
+            "/**\n" +
+            "* Foo\n" +
+            "* @param {{foo:String, astnode:Object, bar}} hi - desc\n" +
+            "* @returns {ASTnode} returns a node\n" +
+            "*/\n" +
+            "function foo(hi){}",
+            options: [{
+                preferType: {
+                    String: "string",
+                    astnode: "ASTNode"
+                }
+            }],
+            errors: [
+                {
+                    message: "Use 'string' instead of 'String'.",
                     type: "Block"
                 }
             ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
`valid-jsdoc` currently throws a `TypeError` when it encounters a `FieldType` that contains a key with a missing value. This is because `type.value` is actually `null` for `FieldType`s that have a key but no value (here's the [relevant code from Doctrine](https://github.com/eslint/doctrine/blob/12c7ad9d610a7f185bdbce7f6acf4b6c9a5c768b/lib/typed.js#L598-L601)).

Both [Doctrine](https://github.com/eslint/doctrine/blob/12c7ad9d610a7f185bdbce7f6acf4b6c9a5c768b/lib/typed.js#L577-L579) and the [JSDoc documentation](http://usejsdoc.org/tags-type.html) seem to indicate that this is valid.

From the JSDoc documentation:
>An object called 'myObj' with properties 'a' (a number), 'b' (a string) and 'c' (any type).
`{{a: number, b: string, c}} myObj`.

This change makes it so that the rule only validates the values of `FieldType`s with values (it should never check the key, as those are the property names, not types).

**Is there anything you'd like reviewers to focus on?**
Want to make sure my interpretation of the JSDoc documentation is correct :)


