### PR TITLE
Update: add fixer for `no-useless-escape`

### DIFF
--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -1,5 +1,7 @@
 # Disallow unnecessary escape usage (no-useless-escape)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Escaping non-special characters in strings and regular expressions doesn't have any effects on results, as in the following example:
 
 ```js

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -65,7 +65,9 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -93,7 +95,8 @@ module.exports = {
                     message: "Unnecessary escape character: {{character}}.",
                     data: {
                         character: elm[0]
-                    }
+                    },
+                    fix: fixer => fixer.replaceTextRange([node.range[0] + elm.index, node.range[0] + elm.index + 2], elm[0].slice(1))
                 });
             }
         }

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -51,20 +51,69 @@ ruleTester.run("no-useless-escape", rule, {
     ],
 
     invalid: [
-        { code: "var foo = /\\#/;", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "Literal"}] },
-        { code: "var foo = /\\;/;", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\;.", type: "Literal"}] },
-        { code: "var foo = \"\\'\";", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\'.", type: "Literal"}] },
-        { code: "var foo = \"\\#/\";", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "Literal"}] },
-        { code: "var foo = \"\\a\"", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\a.", type: "Literal"}] },
-        { code: "var foo = \"\\B\";", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\B.", type: "Literal"}] },
-        { code: "var foo = \"\\@\";", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\@.", type: "Literal"}] },
-        { code: "var foo = \"foo \\a bar\";", errors: [{ line: 1, column: 16, message: "Unnecessary escape character: \\a.", type: "Literal"}] },
-        { code: "var foo = '\\\"';", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\\".", type: "Literal"}] },
-        { code: "var foo = '\\#';", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "Literal"}] },
-        { code: "var foo = '\\$';", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "Literal"}] },
-        { code: "var foo = '\\p';", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\p.", type: "Literal"}] },
+        {
+            code: "var foo = /\\#/;",
+            output: "var foo = /#/;",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "Literal" }]
+        },
+        {
+            code: "var foo = /\\;/;",
+            output: "var foo = /;/;",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\;.", type: "Literal"}]
+        },
+        {
+            code: "var foo = \"\\'\";",
+            output: "var foo = \"'\";",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\'.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"\\#/\";",
+            output: "var foo = \"#/\";",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"\\a\"",
+            output: "var foo = \"a\"",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\a.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"\\B\";",
+            output: "var foo = \"B\";",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\B.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"\\@\";",
+            output: "var foo = \"@\";",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\@.", type: "Literal" }]
+        },
+        {
+            code: "var foo = \"foo \\a bar\";",
+            output: "var foo = \"foo a bar\";",
+            errors: [{ line: 1, column: 16, message: "Unnecessary escape character: \\a.", type: "Literal" }]
+        },
+        {
+            code: "var foo = '\\\"';",
+            output: "var foo = '\"';",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\\".", type: "Literal" }]
+        },
+        {
+            code: "var foo = '\\#';",
+            output: "var foo = '#';",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\#.", type: "Literal" }]
+        },
+        {
+            code: "var foo = '\\$';",
+            output: "var foo = '$';",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\$.", type: "Literal" }]
+        },
+        {
+            code: "var foo = '\\p';",
+            output: "var foo = 'p';",
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\p.", type: "Literal" }]
+        },
         {
             code: "var foo = '\\p\\a\\@';",
+            output: "var foo = 'p\\a@';", // The a is fixed on the next pass due to fix conflicts
             errors: [
                 {line: 1, column: 12, message: "Unnecessary escape character: \\p.", type: "Literal"},
                 {line: 1, column: 14, message: "Unnecessary escape character: \\a.", type: "Literal"},
@@ -73,6 +122,7 @@ ruleTester.run("no-useless-escape", rule, {
         },
         {
             code: "<foo attr={\"\\d\"}/>",
+            output: "<foo attr={\"d\"}/>",
             parserOptions: {ecmaFeatures: {jsx: true}},
             errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\d.", type: "Literal"}]
         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds an autofixer for [`no-useless-escape`](http://eslint.org/docs/rules/no-useless-escape). When a character is being uselessly escaped (e.g. `"\z"`), the fixer removes the backslash (`"z"`).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

