### PR TITLE
Update: Add `CallExpression` option for `indent` (fixes #5946)

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -80,6 +80,8 @@ This rule has an object option:
 * `"FunctionExpression"` takes an object to define rules for function expressions.
     * `parameters` (off by default) enforces indentation level for parameters in a function expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all parameters of the expression must be aligned with the first parameter.
     * `body` (default: 1) enforces indentation level for the body of a function expression.
+* `"CallExpression"` takes an object to define rules for function call expressions.
+    * `arguments` (off by default) enforces indentation level for arguments in a call expression. This can either be a number indicating indentation level, or the string `"first"` indicating that all arguments of the expression must be aligned with the first argument.
 
 Level of indentation denotes the multiple of the indent specified. Example:
 
@@ -384,6 +386,48 @@ var foo = function(bar, baz,
                    qux, boop) {
   qux();
 }
+```
+
+### CallExpression
+
+Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
+
+foo(bar,
+    baz,
+      qux
+);
+```
+
+Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:
+
+```js
+/*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/
+
+foo(bar,
+  baz,
+  qux
+);
+```
+
+Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
+
+foo(bar, baz,
+  baz, boop, beep);
+```
+
+Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:
+
+```js
+/*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/
+
+foo(bar, baz,
+    baz, boop, beep);
 ```
 
 ## Compatibility

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -113,6 +113,22 @@ module.exports = {
                                 minimum: 0
                             }
                         }
+                    },
+                    CallExpression: {
+                        type: "object",
+                        properties: {
+                            parameters: {
+                                oneOf: [
+                                    {
+                                        type: "integer",
+                                        minimum: 0
+                                    },
+                                    {
+                                        enum: ["first"]
+                                    }
+                                ]
+                            }
+                        }
                     }
                 },
                 additionalProperties: false
@@ -142,6 +158,9 @@ module.exports = {
             FunctionExpression: {
                 parameters: DEFAULT_PARAMETER_INDENT,
                 body: DEFAULT_FUNCTION_BODY_INDENT
+            },
+            CallExpression: {
+                arguments: DEFAULT_PARAMETER_INDENT
             }
         };
 
@@ -186,6 +205,10 @@ module.exports = {
 
                 if (typeof opts.FunctionExpression === "object") {
                     Object.assign(options.FunctionExpression, opts.FunctionExpression);
+                }
+
+                if (typeof opts.CallExpression === "object") {
+                    Object.assign(options.CallExpression, opts.CallExpression);
                 }
             }
         }
@@ -1044,6 +1067,17 @@ module.exports = {
                     checkLastReturnStatementLineIndent(node, firstLineIndent);
                 } else {
                     checkNodeIndent(node, firstLineIndent);
+                }
+            },
+
+            CallExpression(node) {
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+                if (options.CallExpression.arguments === "first" && node.arguments.length) {
+                    checkNodesIndent(node.arguments.slice(1), node.arguments[0].loc.start.column);
+                } else if (options.CallExpression.arguments !== null) {
+                    checkNodesIndent(node.arguments, getNodeIndent(node).goodChar + indentSize * options.CallExpression.arguments);
                 }
             }
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1515,7 +1515,7 @@ ruleTester.run("indent", rule, {
             "{\n" +
             "      bar();\n" +
             "}",
-            options: [2, {FunctionDeclaration: {body: 3}}] // FIXME: what is the default for `parameters`?
+            options: [2, {FunctionDeclaration: {body: 3}}]
         },
         {
             code:
@@ -1524,7 +1524,7 @@ ruleTester.run("indent", rule, {
             "  bbb) {\n" +
             "    bar();\n" +
             "}",
-            options: [2, {FunctionDeclaration: {parameters: "first", body: 2}}] // FIXME: make sure this is correct
+            options: [2, {FunctionDeclaration: {parameters: "first", body: 2}}]
         },
         {
             code:
@@ -1561,7 +1561,7 @@ ruleTester.run("indent", rule, {
             "  ddd, eee) {\n" +
             "      bar();\n" +
             "}",
-            options: [2, {FunctionExpression: {parameters: "first", body: 3}}] // FIXME: make sure this is correct
+            options: [2, {FunctionExpression: {parameters: "first", body: 3}}]
         },
         {
             code:
@@ -1641,6 +1641,63 @@ ruleTester.run("indent", rule, {
             "    (z === 3 || z === 4));\n" +
             "}",
             options: [2]
+        }, {
+            code:
+            "foo(\n" +
+            "  bar,\n" +
+            "  baz,\n" +
+            "  qux\n" +
+            ");",
+            options: [2, {CallExpression: {arguments: 1}}]
+        }, {
+            code:
+            "foo(\n" +
+            "\tbar,\n" +
+            "\tbaz,\n" +
+            "\tqux\n" +
+            ");",
+            options: ["tab", {CallExpression: {arguments: 1}}]
+        }, {
+            code:
+            "foo(bar,\n" +
+            "        baz,\n" +
+            "        qux);",
+            options: [4, {CallExpression: {arguments: 2}}]
+        }, {
+            code:
+            "foo(\n" +
+            "bar,\n" +
+            "baz,\n" +
+            "qux\n" +
+            ");",
+            options: [2, {CallExpression: {arguments: 0}}]
+        }, {
+            code:
+            "foo(bar,\n" +
+            "    baz,\n" +
+            "    qux\n" +
+            ");",
+            options: [2, {CallExpression: {arguments: "first"}}]
+        }, {
+            code:
+            "foo(bar, baz,\n" +
+            "    qux, barbaz,\n" +
+            "    barqux, bazqux);",
+            options: [2, {CallExpression: {arguments: "first"}}]
+        }, {
+            code:
+            "foo(\n" +
+            "                        bar, baz,\n" +
+            "                        qux);",
+            options: [2, {CallExpression: {arguments: "first"}}]
+        }, {
+            code:
+            "foo(bar,\n" +
+            "        1 + 2,\n" +
+            "        !baz,\n" +
+            "        new Car('!')\n" +
+            ");",
+            options: [2, {CallExpression: {arguments: 4}}]
         }
     ],
     invalid: [
@@ -3335,5 +3392,81 @@ ruleTester.run("indent", rule, {
             options: [2],
             errors: expectedErrors([[2, "2 spaces", "3", "ReturnStatement"]])
         },
+        {
+            code:
+            "foo(\n" +
+            "bar,\n" +
+            "  baz,\n" +
+            "    qux);",
+            output:
+            "foo(\n" +
+            "  bar,\n" +
+            "  baz,\n" +
+            "  qux);",
+            options: [2, {CallExpression: {arguments: 1}}],
+            errors: expectedErrors([[2, 2, 0, "Identifier"], [4, 2, 4, "Identifier"]])
+        },
+        {
+            code:
+            "foo(\n" +
+            "\tbar,\n" +
+            "\tbaz);",
+            output:
+            "foo(\n" +
+            "    bar,\n" +
+            "    baz);",
+            options: [2, {CallExpression: {arguments: 2}}],
+            errors: expectedErrors([[2, "4 spaces", "1 tab", "Identifier"], [3, "4 spaces", "1 tab", "Identifier"]])
+        },
+        {
+            code:
+            "foo(bar,\n" +
+            "\t\tbaz,\n" +
+            "\t\tqux);",
+            output:
+            "foo(bar,\n" +
+            "\tbaz,\n" +
+            "\tqux);",
+            options: ["tab", {CallExpression: {arguments: 1}}],
+            errors: expectedErrors("tab", [[2, 1, 2, "Identifier"], [3, 1, 2, "Identifier"]])
+        },
+        {
+            code:
+            "foo(bar, baz,\n" +
+            "         qux);",
+            output:
+            "foo(bar, baz,\n" +
+            "    qux);",
+            options: [2, {CallExpression: {arguments: "first"}}],
+            errors: expectedErrors([2, 4, 9, "Identifier"])
+        },
+        {
+            code:
+            "foo(\n" +
+            "          bar,\n" +
+            "    baz);",
+            output:
+            "foo(\n" +
+            "          bar,\n" +
+            "          baz);",
+            options: [2, {CallExpression: {arguments: "first"}}],
+            errors: expectedErrors([3, 10, 4, "Identifier"])
+        },
+        {
+            code:
+            "foo(bar,\n" +
+            "  1 + 2,\n" +
+            "              !baz,\n" +
+            "        new Car('!')\n" +
+            ");",
+            output:
+            "foo(bar,\n" +
+            "      1 + 2,\n" +
+            "      !baz,\n" +
+            "      new Car('!')\n" +
+            ");",
+            options: [2, {CallExpression: {arguments: 3}}],
+            errors: expectedErrors([[2, 6, 2, "BinaryExpression"], [3, 6, 14, "UnaryExpression"], [4, 6, 8, "NewExpression"]])
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

[`indent`](http://eslint.org/docs/rules/indent)

**Does this change cause the rule to produce more or fewer warnings?**

The rule produces more warnings by opt-in.

**How will the change be implemented? (New option, new default behavior, etc.)?**

A new `CallExpression` option is added to the `indent` rule, to specify indentation for the arguments of `CallExpression` nodes. (Also see: #5946)

**Please provide some example code that this change will affect:**

Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:

```js
/*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/

foo(bar,
    baz,
      qux
);
```

Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": 1} }` option:

```js
/*eslint indent: ["error", 2, { "CallExpression": {"arguments": 1} }]*/

foo(bar,
  baz,
  qux
);
```

Examples of **incorrect** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:

```js
/*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/

foo(bar, baz,
  baz, boop, beep);
```

Examples of **correct** code for this rule with the `2, { "CallExpression": {"arguments": "first"} }` option:

```js
/*eslint indent: ["error", 2, {"CallExpression": {"arguments": "first"}}]*/

foo(bar, baz,
    baz, boop, beep);
```

**What does the rule currently do for this code?**

It raises an error because the schema is invalid. Without the `CallExpression` option, the indentation of CallExpression arguments is currently not linted at all.

**What will the rule do after it's changed?**

It will check the indentation of `CallExpression` arguments (see above).

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a `CallExpression` option to the `indent` rule. The option is an object with one key: `arguments`.

If the value of `arguments` is a number, the rule enforces that indentation level for `CallExpression` arguments (similar to all the other `indent` options).

If the value of `arguments` is the string `"first"`, all arguments in the CallExpression must be aligned with the first argument of the expression (similar to `{FunctionDeclaration: {parameters: "first"}}` and `{FunctionExpression: {parameters: "first"}}`).

**Is there anything you'd like reviewers to focus on?**

I wasn't sure about how to design the schema; at the moment it's `{CallExpression: {arguments: 1}}`, but it could also just be `{CallExpression: 1}` since `arguments` is the only key of that object. I went with this schema because it makes it clearer that the option deals with the *arguments* of the CallExpression, rather than the expression itself.