### PR TITLE
Update: add fixer for `wrap-iife`

### DIFF
--- a/docs/rules/wrap-iife.md
+++ b/docs/rules/wrap-iife.md
@@ -1,5 +1,7 @@
 # Require IIFEs to be Wrapped (wrap-iife)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 You can immediately invoke function expressions, but not function declarations. A common technique to create an immediately-invoked function expression (IIFE) is to wrap a function declaration in parentheses. The opening parentheses causes the contained function to be parsed as an expression, rather than a declaration.
 
 ```js

--- a/lib/rules/wrap-iife.js
+++ b/lib/rules/wrap-iife.js
@@ -69,10 +69,12 @@ module.exports = {
                             message: "Wrap only the function expression in parens.",
                             fix(fixer) {
 
-                                // The outer call expression will always be wrapped at this point.
-                                // Replace the range between the end of the function expression and the end of the call expression.
-                                // for example, in `(function(foo) {}(bar))`, the range `(bar))` should get replaced with `)(bar)`.
-                                // Replace the parens from the outer expression, and parenthesize the function expression.
+                                /*
+                                 * The outer call expression will always be wrapped at this point.
+                                 * Replace the range between the end of the function expression and the end of the call expression.
+                                 * for example, in `(function(foo) {}(bar))`, the range `(bar))` should get replaced with `)(bar)`.
+                                 * Replace the parens from the outer expression, and parenthesize the function expression.
+                                 */
                                 const parenAfter = sourceCode.getTokenAfter(node);
 
                                 return fixer.replaceTextRange(
@@ -87,10 +89,12 @@ module.exports = {
                             message: "Move the invocation into the parens that contain the function.",
                             fix(fixer) {
 
-                                // The inner function expression will always be wrapped at this point.
-                                // It's only necessary to replace the range between the end of the function expression
-                                // and the call expression. For example, in `(function(foo) {})(bar)`, the range `)(bar)`
-                                // should get replaced with `(bar))`.
+                                /*
+                                 * The inner function expression will always be wrapped at this point.
+                                 * It's only necessary to replace the range between the end of the function expression
+                                 * and the call expression. For example, in `(function(foo) {})(bar)`, the range `)(bar)`
+                                 * should get replaced with `(bar))`.
+                                 */
                                 const parenAfter = sourceCode.getTokenAfter(node.callee);
 
                                 return fixer.replaceTextRange(

--- a/lib/rules/wrap-iife.js
+++ b/lib/rules/wrap-iife.js
@@ -21,7 +21,9 @@ module.exports = {
             {
                 enum: ["outside", "inside", "any"]
             }
-        ]
+        ],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -52,11 +54,51 @@ module.exports = {
                         functionExpressionWrapped = wrapped(node.callee);
 
                     if (!callExpressionWrapped && !functionExpressionWrapped) {
-                        context.report(node, "Wrap an immediate function invocation in parentheses.");
+                        context.report({
+                            node,
+                            message: "Wrap an immediate function invocation in parentheses.",
+                            fix(fixer) {
+                                const nodeToSurround = style === "inside" ? node.callee : node;
+
+                                return fixer.replaceText(nodeToSurround, `(${sourceCode.getText(nodeToSurround)})`);
+                            }
+                        });
                     } else if (style === "inside" && !functionExpressionWrapped) {
-                        context.report(node, "Wrap only the function expression in parens.");
+                        context.report({
+                            node,
+                            message: "Wrap only the function expression in parens.",
+                            fix(fixer) {
+
+                                // The outer call expression will always be wrapped at this point.
+                                // Replace the range between the end of the function expression and the end of the call expression.
+                                // for example, in `(function(foo) {}(bar))`, the range `(bar))` should get replaced with `)(bar)`.
+                                // Replace the parens from the outer expression, and parenthesize the function expression.
+                                const parenAfter = sourceCode.getTokenAfter(node);
+
+                                return fixer.replaceTextRange(
+                                    [node.callee.range[1], parenAfter.range[1]],
+                                    `)${sourceCode.getText().slice(node.callee.range[1], parenAfter.range[0])}`
+                                );
+                            }
+                        });
                     } else if (style === "outside" && !callExpressionWrapped) {
-                        context.report(node, "Move the invocation into the parens that contain the function.");
+                        context.report({
+                            node,
+                            message: "Move the invocation into the parens that contain the function.",
+                            fix(fixer) {
+
+                                // The inner function expression will always be wrapped at this point.
+                                // It's only necessary to replace the range between the end of the function expression
+                                // and the call expression. For example, in `(function(foo) {})(bar)`, the range `)(bar)`
+                                // should get replaced with `(bar))`.
+                                const parenAfter = sourceCode.getTokenAfter(node.callee);
+
+                                return fixer.replaceTextRange(
+                                    [parenAfter.range[0], node.range[1]],
+                                    `${sourceCode.getText().slice(parenAfter.range[1], node.range[1])})`
+                                );
+                            }
+                        });
                     }
                 }
             }

--- a/tests/lib/rules/wrap-iife.js
+++ b/tests/lib/rules/wrap-iife.js
@@ -49,29 +49,49 @@ ruleTester.run("wrap-iife", rule, {
     invalid: [
         {
             code: "0, function(){ }();",
+            output: "0, (function(){ }());",
             errors: [{ message: "Wrap an immediate function invocation in parentheses.", type: "CallExpression"}]
         },
         {
             code: "[function(){ }()];",
+            output: "[(function(){ }())];",
             errors: [{ message: "Wrap an immediate function invocation in parentheses.", type: "CallExpression"}]
         },
         {
             code: "var a = function(){ }();",
+            output: "var a = (function(){ }());",
             errors: [{ message: "Wrap an immediate function invocation in parentheses.", type: "CallExpression"}]
         },
         {
             code: "(function(){ }(), 0);",
+            output: "((function(){ }()), 0);",
             errors: [{ message: "Wrap an immediate function invocation in parentheses.", type: "CallExpression"}]
         },
         {
             code: "(function a(){ })();",
+            output: "(function a(){ }());",
             options: ["outside"],
             errors: [{ message: "Move the invocation into the parens that contain the function.", type: "CallExpression" }]
         },
         {
             code: "(function a(){ }());",
+            output: "(function a(){ })();",
             options: ["inside"],
             errors: [{ message: "Wrap only the function expression in parens.", type: "CallExpression" }]
+        },
+        {
+
+            // Ensure all comments get preserved when autofixing.
+            code: "( /* a */ function /* b */ foo /* c */ ( /* d */ bar /* e */ ) /* f */ { /* g */ return; /* h */ } /* i */ ( /* j */ baz /* k */) /* l */ ) /* m */ ;",
+            output: "( /* a */ function /* b */ foo /* c */ ( /* d */ bar /* e */ ) /* f */ { /* g */ return; /* h */ }) /* i */ ( /* j */ baz /* k */) /* l */  /* m */ ;",
+            options: ["inside"],
+            errors: [{ message: "Wrap only the function expression in parens.", type: "CallExpression" }]
+        },
+        {
+            code: "( /* a */ function /* b */ foo /* c */ ( /* d */ bar /* e */ ) /* f */ { /* g */ return; /* h */ } /* i */ ) /* j */ ( /* k */ baz /* l */) /* m */ ;",
+            output: "( /* a */ function /* b */ foo /* c */ ( /* d */ bar /* e */ ) /* f */ { /* g */ return; /* h */ } /* i */  /* j */ ( /* k */ baz /* l */)) /* m */ ;",
+            options: ["outside"],
+            errors: [{ message: "Move the invocation into the parens that contain the function.", type: "CallExpression" }]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`wrap-iife`](http://eslint.org/docs/rules/wrap-iife).

If the IIFE has no surrounding parentheses, the fixer surrounds it with parentheses. The fixer also removes parentheses that are in the wrong place according to the rule option:

```js
/* eslint wrap-iife: [2, "outside"] */

var foo = function() {}();
(function() {})();

// gets fixed to:

var foo = (function() {}());
(function() {}());
```

```js
/* eslint wrap-iife: [2, "inside"] */

var foo = function() {}();
(function() {}());

// gets fixed to:

var foo = (function() {})();
(function() {})();
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
