### PR TITLE
Fix: Return statement spacing. Fix for indent rule. (fixes #7164)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -229,20 +229,22 @@ module.exports = {
          * @param {int} gottenTabs Indentation tab count in the actual node/code
          * @param {Object=} loc Error line and column location
          * @param {boolean} isLastNodeCheck Is the error for last node check
+         * @param {int} lastNodeCheckEndOffset Number of charecters to skip from the end
          * @returns {void}
          */
-        function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck) {
-
+        function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck, lastNodeCheckEndOffset) {
             if (gottenSpaces && gottenTabs) {
 
                 // To avoid conflicts with `no-mixed-spaces-and-tabs`, don't report lines that have both spaces and tabs.
                 return;
             }
 
-            const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed);
+            lastNodeCheckEndOffset = lastNodeCheckEndOffset || 0;
+
+            const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed - lastNodeCheckEndOffset);
 
             const textRange = isLastNodeCheck
-                ? [node.range[1] - gottenSpaces - gottenTabs - 1, node.range[1] - 1]
+                ? [node.range[1] - gottenSpaces - gottenTabs - 1, node.range[1] - 1 - lastNodeCheckEndOffset]
                 : [node.range[0] - gottenSpaces - gottenTabs, node.range[0]];
 
             context.report({
@@ -350,6 +352,40 @@ module.exports = {
                     endIndent.tab,
                     { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
                     true
+                );
+            }
+        }
+
+        /**
+         * Check last node line indent this detects, that block closed correctly
+         * This function for more complicated return statement case, where closing parenthesis may be followed by ';'
+         * @param {ASTNode} node Node to examine
+         * @param {int} lastLineIndent needed indent
+         * @returns {void}
+         */
+        function checkLastReturnStatementLineIndent(node, lastLineIndent) {
+            const nodeLastToken = sourceCode.getLastToken(node);
+            let lastNodeCheckEndOffset = 0;
+            let lastToken = nodeLastToken;
+
+            // in case if return statement ends with ');' we have traverse back to ')'
+            // otherwise we'll measure indent for ';' and replace ')'
+            while (lastToken.value !== ")") {
+                lastNodeCheckEndOffset++;
+                lastToken = sourceCode.getTokenBefore(lastToken);
+            }
+
+            const endIndent = getNodeIndent(lastToken, true);
+
+            if ((endIndent.goodChar !== lastLineIndent || endIndent.badChar !== 0) && isNodeFirstInLine(node)) {
+                report(
+                    node,
+                    lastLineIndent,
+                    endIndent.space,
+                    endIndent.tab,
+                    { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
+                    true,
+                    lastNodeCheckEndOffset
                 );
             }
         }
@@ -832,6 +868,20 @@ module.exports = {
             }
         }
 
+        /**
+         * Checks wether a return statement is wrapped in ()
+         * @param {ASTNode} node node to examine
+         * @returns {boolean} the result
+         */
+        function isWrappedInParenthesis(node) {
+            const regex = /^return\s*?\(\s*?\);*?/;
+
+            const statementWithoutArgument = sourceCode.getText(node).replace(
+                sourceCode.getText(node.argument), "");
+
+            return regex.test(statementWithoutArgument);
+        }
+
         return {
             Program(node) {
                 if (node.body.length > 0) {
@@ -952,7 +1002,23 @@ module.exports = {
                 } else if (options.FunctionExpression.parameters !== null) {
                     checkNodesIndent(node.params, getNodeIndent(node).goodChar + indentSize * options.FunctionExpression.parameters);
                 }
+            },
+
+            ReturnStatement(node) {
+                if (isSingleLineNode(node)) {
+                    return;
+                }
+
+                const returnIndent = getNodeIndent(node).goodChar;
+
+                // in case if return statement is wrapped in parenthesis
+                if (isWrappedInParenthesis(node)) {
+                    checkLastReturnStatementLineIndent(node, returnIndent);
+                } else {
+                    checkNodeIndent(node, returnIndent);
+                }
             }
+
         };
 
     }

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -360,10 +360,11 @@ module.exports = {
          * Check last node line indent this detects, that block closed correctly
          * This function for more complicated return statement case, where closing parenthesis may be followed by ';'
          * @param {ASTNode} node Node to examine
-         * @param {int} lastLineIndent needed indent
+         * @param {int} firstLineIndent first line needed indent
+         * @param {int} lastLineIndent last line needed indent
          * @returns {void}
          */
-        function checkLastReturnStatementLineIndent(node, lastLineIndent) {
+        function checkLastReturnStatementLineIndent(node, firstLineIndent, lastLineIndent) {
             const nodeLastToken = sourceCode.getLastToken(node);
             let lastNodeCheckEndOffset = 0;
             let lastToken = nodeLastToken;
@@ -375,12 +376,25 @@ module.exports = {
                 lastToken = sourceCode.getTokenBefore(lastToken);
             }
 
+            const textBeforeClosingParenthesis = sourceCode.getText(lastToken, lastToken.loc.start.column).slice(0, -1);
+            const indentChar = indentType === "space" ? " " : "\t";
+            const replaceRegExp = new RegExp(indentChar, "g");
+            const textLenWithoutIndentation = textBeforeClosingParenthesis.replace(replaceRegExp, "").length;
             const endIndent = getNodeIndent(lastToken, true);
 
-            if ((endIndent.goodChar !== lastLineIndent || endIndent.badChar !== 0) && isNodeFirstInLine(node)) {
+            /* we consider both of these cases legit:
+                return ((bar === 1 || bar === 2) &&
+                  (z === 3 || z === 4)
+                );
+                return ((bar === 1 || bar === 2) &&
+                  (z === 3 || z === 4));
+              */
+            if ((((endIndent.goodChar !== firstLineIndent && !textLenWithoutIndentation)
+                    || (textLenWithoutIndentation && endIndent.goodChar !== lastLineIndent))
+                || endIndent.badChar !== 0) && isNodeFirstInLine(node)) {
                 report(
                     node,
-                    lastLineIndent,
+                    textBeforeClosingParenthesis ? firstLineIndent : lastLineIndent,
                     endIndent.space,
                     endIndent.tab,
                     { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
@@ -1009,13 +1023,15 @@ module.exports = {
                     return;
                 }
 
-                const returnIndent = getNodeIndent(node).goodChar;
+                const firstLineIndent = getNodeIndent(node).goodChar;
 
                 // in case if return statement is wrapped in parenthesis
                 if (isWrappedInParenthesis(node)) {
-                    checkLastReturnStatementLineIndent(node, returnIndent);
+                    const lastLineIndent = getNodeIndent(node, true).goodChar;
+
+                    checkLastReturnStatementLineIndent(node, firstLineIndent, lastLineIndent);
                 } else {
-                    checkNodeIndent(node, returnIndent);
+                    checkNodeIndent(node, firstLineIndent);
                 }
             }
 

--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -361,10 +361,9 @@ module.exports = {
          * This function for more complicated return statement case, where closing parenthesis may be followed by ';'
          * @param {ASTNode} node Node to examine
          * @param {int} firstLineIndent first line needed indent
-         * @param {int} lastLineIndent last line needed indent
          * @returns {void}
          */
-        function checkLastReturnStatementLineIndent(node, firstLineIndent, lastLineIndent) {
+        function checkLastReturnStatementLineIndent(node, firstLineIndent) {
             const nodeLastToken = sourceCode.getLastToken(node);
             let lastNodeCheckEndOffset = 0;
             let lastToken = nodeLastToken;
@@ -377,24 +376,19 @@ module.exports = {
             }
 
             const textBeforeClosingParenthesis = sourceCode.getText(lastToken, lastToken.loc.start.column).slice(0, -1);
-            const indentChar = indentType === "space" ? " " : "\t";
-            const replaceRegExp = new RegExp(indentChar, "g");
-            const textLenWithoutIndentation = textBeforeClosingParenthesis.replace(replaceRegExp, "").length;
+
+            if (textBeforeClosingParenthesis.trim()) {
+
+                // There are tokens before the closing paren, don't report this case
+                return;
+            }
+
             const endIndent = getNodeIndent(lastToken, true);
 
-            /* we consider both of these cases legit:
-                return ((bar === 1 || bar === 2) &&
-                  (z === 3 || z === 4)
-                );
-                return ((bar === 1 || bar === 2) &&
-                  (z === 3 || z === 4));
-              */
-            if ((((endIndent.goodChar !== firstLineIndent && !textLenWithoutIndentation)
-                    || (textLenWithoutIndentation && endIndent.goodChar !== lastLineIndent))
-                || endIndent.badChar !== 0) && isNodeFirstInLine(node)) {
+            if (endIndent.goodChar !== firstLineIndent) {
                 report(
                     node,
-                    textBeforeClosingParenthesis ? firstLineIndent : lastLineIndent,
+                    firstLineIndent,
                     endIndent.space,
                     endIndent.tab,
                     { line: lastToken.loc.start.line, column: lastToken.loc.start.column },
@@ -1027,9 +1021,7 @@ module.exports = {
 
                 // in case if return statement is wrapped in parenthesis
                 if (isWrappedInParenthesis(node)) {
-                    const lastLineIndent = getNodeIndent(node, true).goodChar;
-
-                    checkLastReturnStatementLineIndent(node, firstLineIndent, lastLineIndent);
+                    checkLastReturnStatementLineIndent(node, firstLineIndent);
                 } else {
                     checkNodeIndent(node, firstLineIndent);
                 }

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -48,8 +48,7 @@ function looksLikeLiteral(node) {
         node.operator === "-" &&
         node.prefix &&
         node.argument.type === "Literal" &&
-        typeof node.argument.value === "number"
-    );
+        typeof node.argument.value === "number");
 }
 
 /**
@@ -181,8 +180,7 @@ module.exports = {
                     (leftLiteral = getNormalizedLiteral(left.left)) &&
                     (rightLiteral = getNormalizedLiteral(right.right)) &&
                     leftLiteral.value <= rightLiteral.value &&
-                    same(left.right, right.left)
-                );
+                    same(left.right, right.left));
             }
 
             /**
@@ -196,8 +194,7 @@ module.exports = {
                     (leftLiteral = getNormalizedLiteral(left.right)) &&
                     (rightLiteral = getNormalizedLiteral(right.left)) &&
                     leftLiteral.value <= rightLiteral.value &&
-                    same(left.left, right.right)
-                );
+                    same(left.left, right.right));
             }
 
             /**
@@ -212,8 +209,7 @@ module.exports = {
                 return ((tokenBefore = sourceCode.getTokenBefore(node)) &&
                     tokenBefore.value === "(" &&
                     (tokenAfter = sourceCode.getTokenAfter(node)) &&
-                    tokenAfter.value === ")"
-                );
+                    tokenAfter.value === ")");
             }
 
             return (node.type === "LogicalExpression" &&
@@ -222,8 +218,7 @@ module.exports = {
                 isRangeTestOperator(left.operator) &&
                 isRangeTestOperator(right.operator) &&
                 (isBetweenTest() || isOutsideTest()) &&
-                isParenWrapped()
-            );
+                isParenWrapped());
         }
 
         const OPERATOR_FLIP_MAP = {

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -48,7 +48,8 @@ function looksLikeLiteral(node) {
         node.operator === "-" &&
         node.prefix &&
         node.argument.type === "Literal" &&
-        typeof node.argument.value === "number");
+        typeof node.argument.value === "number"
+    );
 }
 
 /**
@@ -180,7 +181,8 @@ module.exports = {
                     (leftLiteral = getNormalizedLiteral(left.left)) &&
                     (rightLiteral = getNormalizedLiteral(right.right)) &&
                     leftLiteral.value <= rightLiteral.value &&
-                    same(left.right, right.left));
+                    same(left.right, right.left)
+                );
             }
 
             /**
@@ -194,7 +196,8 @@ module.exports = {
                     (leftLiteral = getNormalizedLiteral(left.right)) &&
                     (rightLiteral = getNormalizedLiteral(right.left)) &&
                     leftLiteral.value <= rightLiteral.value &&
-                    same(left.left, right.right));
+                    same(left.left, right.right)
+                );
             }
 
             /**
@@ -209,7 +212,8 @@ module.exports = {
                 return ((tokenBefore = sourceCode.getTokenBefore(node)) &&
                     tokenBefore.value === "(" &&
                     (tokenAfter = sourceCode.getTokenAfter(node)) &&
-                    tokenAfter.value === ")");
+                    tokenAfter.value === ")"
+                );
             }
 
             return (node.type === "LogicalExpression" &&
@@ -218,7 +222,8 @@ module.exports = {
                 isRangeTestOperator(left.operator) &&
                 isRangeTestOperator(right.operator) &&
                 (isBetweenTest() || isOutsideTest()) &&
-                isParenWrapped());
+                isParenWrapped()
+            );
         }
 
         const OPERATOR_FLIP_MAP = {

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1622,6 +1622,14 @@ ruleTester.run("indent", rule, {
             "  );\n" +
             "}",
             options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return ((bar === 1 || bar === 2) &&\n" +
+            "    (z === 3 || z === 4));\n" +
+            "}",
+            options: [2]
         }
     ],
     invalid: [

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1596,6 +1596,32 @@ ruleTester.run("indent", rule, {
             "  };\n" +
             "}",
             options: [2, {FunctionExpression: {parameters: 3}}]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (bar === 1 || bar === 2 &&\n" +
+            "    (/Function/.test(grandparent.type))) &&\n" +
+            "    directives(parent).indexOf(node) >= 0;\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (bar === 1 || bar === 2) &&\n" +
+            "    (z === 3 || z === 4);\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return ((bar === 1 || bar === 2) &&\n" +
+            "    (z === 3 || z === 4)\n" +
+            "  );\n" +
+            "}",
+            options: [2]
         }
     ],
     invalid: [
@@ -2971,6 +2997,106 @@ ruleTester.run("indent", rule, {
             "}",
             options: [2, {FunctionExpression: {parameters: 3}}],
             errors: expectedErrors([3, 8, 10, "Identifier"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "\t\t}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "    )\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "  )\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[4, "2 spaces", "4", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "    );\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return (\n" +
+            "    1\n" +
+            "  );\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[4, "2 spaces", "4", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "\t\t}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+        },
+        {
+            code:
+            "function test(){\n" +
+            "  switch(length){\n" +
+            "    case 1: return function(a){\n" +
+            "    return fn.call(that, a);\n" +
+            "    };\n" +
+            "  }\n" +
+            "}",
+            output:
+            "function test(){\n" +
+            "  switch(length){\n" +
+            "    case 1: return function(a){\n" +
+            "      return fn.call(that, a);\n" +
+            "    };\n" +
+            "  }\n" +
+            "}",
+            options: [2, {VariableDeclarator: 2, SwitchCase: 1}],
+            errors: expectedErrors([[4, "6 spaces", "4", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "   return 1\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return 1\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[2, "2 spaces", "3", "ReturnStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "   return 1;\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  return 1;\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[2, "2 spaces", "3", "ReturnStatement"]])
         }
     ]
 });


### PR DESCRIPTION
Fix: Return statement spacing. Fix for indent rule. (fixes: #7164)

**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [X] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [X] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
indent rule won't check return statement spacing. Here is failing example:
```
function() {
  return (
     1
    );
}
```
More details in the issue #7164
**Is there anything you'd like reviewers to focus on?**
It's little bit tricky to check whether a statement ends with ')' or ');'. I had to create a new function named checkLastReturnStatementLineIndent in order to traverse back to the very first token. Also, I had to add a parameter in report function. lastNodeCheckEndOffset is an offset in case if a statement end with ');'. Please let me know if you have better ideas how to do this.


