### PR TITLE
Update: add fixer for `strict` (fixes #6668)

### DIFF
--- a/docs/rules/strict.md
+++ b/docs/rules/strict.md
@@ -1,5 +1,7 @@
 # require or disallow strict mode directives (strict)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 A strict mode directive is a `"use strict"` literal at the beginning of a script or function body. It enables strict mode semantics.
 
 When a directive occurs in global scope, strict mode applies to the entire script:

--- a/tests/lib/rules/strict.js
+++ b/tests/lib/rules/strict.js
@@ -123,6 +123,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "\"use strict\"; foo();",
+            output: " foo();",
             options: ["never"],
             parserOptions: { sourceType: "module" },
             errors: [
@@ -130,6 +131,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["never"],
             parserOptions: { ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -138,6 +140,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["never"],
             parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -189,12 +192,14 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; 'use strict'; foo();",
+            output: "'use strict';  foo();",
             options: ["global"],
             errors: [
                 { message: "Multiple 'use strict' directives.", type: "ExpressionStatement" }
             ]
         }, {
             code: "'use strict'; foo();",
+            output: " foo();",
             options: ["global"],
             parserOptions: { sourceType: "module" },
             errors: [
@@ -202,6 +207,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["global"],
             parserOptions: { ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -210,6 +216,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["global"],
             parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -233,6 +240,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "(function() { 'use strict'; function f() { 'use strict'; return } return true; }());",
+            output: "(function() { 'use strict'; function f() {  return } return true; }());",
             options: ["function"],
             errors: [
                 { message: "Unnecessary 'use strict' directive.", type: "ExpressionStatement" }
@@ -266,18 +274,21 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "function foo() { 'use strict'; 'use strict'; return; }",
+            output: "function foo() { 'use strict';  return; }",
             options: ["function"],
             errors: [
                 { message: "Multiple 'use strict' directives.", type: "ExpressionStatement" }
             ]
         }, {
             code: "var foo = function() { 'use strict'; 'use strict'; return; }",
+            output: "var foo = function() { 'use strict';  return; }",
             options: ["function"],
             errors: [
                 { message: "Multiple 'use strict' directives.", type: "ExpressionStatement" }
             ]
         }, {
             code: "var foo = function() {  'use strict'; return; }",
+            output: "var foo = function() {   return; }",
             options: ["function"],
             parserOptions: { sourceType: "module" },
             errors: [
@@ -285,6 +296,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["function"],
             parserOptions: { ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -293,6 +305,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["function"],
             parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -325,6 +338,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "function foo() { 'use strict'; return function() { 'use strict'; 'use strict'; return; }; }",
+            output: "function foo() { 'use strict'; return function() {   return; }; }",
             options: ["function"],
             errors: [
                 { message: "Unnecessary 'use strict' directive.", type: "ExpressionStatement" },
@@ -332,6 +346,7 @@ ruleTester.run("strict", rule, {
             ]
         }, {
             code: "var foo = function() { 'use strict'; function bar() { 'use strict'; 'use strict'; return; } }",
+            output: "var foo = function() { 'use strict'; function bar() {   return; } }",
             options: ["function"],
             errors: [
                 { message: "Unnecessary 'use strict' directive.", type: "ExpressionStatement" },
@@ -348,18 +363,21 @@ ruleTester.run("strict", rule, {
         // Classes
         {
             code: "class A { constructor() { \"use strict\"; } }",
+            output: "class A { constructor() {  } }",
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: [{ message: "'use strict' is unnecessary inside of classes.", type: "ExpressionStatement"}]
         },
         {
             code: "class A { foo() { \"use strict\"; } }",
+            output: "class A { foo() {  } }",
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: [{ message: "'use strict' is unnecessary inside of classes.", type: "ExpressionStatement"}]
         },
         {
             code: "class A { foo() { function bar() { \"use strict\"; } } }",
+            output: "class A { foo() { function bar() {  } } }",
             parserOptions: { ecmaVersion: 6 },
             options: ["function"],
             errors: [{ message: "'use strict' is unnecessary inside of classes.", type: "ExpressionStatement"}]
@@ -386,6 +404,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["safe"],
             parserOptions: { ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -395,6 +414,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             options: ["safe"],
             parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
             errors: [
@@ -425,6 +445,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             parserOptions: { ecmaFeatures: { impliedStrict: true } },
             errors: [
                 { message: "'use strict' is unnecessary when implied strict mode is enabled.", type: "ExpressionStatement" },
@@ -433,6 +454,7 @@ ruleTester.run("strict", rule, {
         },
         {
             code: "'use strict'; function foo() { 'use strict'; return; }",
+            output: " function foo() {  return; }",
             parserOptions: { sourceType: "module", ecmaFeatures: { impliedStrict: true } },
             errors: [
                 { message: "'use strict' is unnecessary inside of modules.", type: "ExpressionStatement" },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for `strict`. The fixer removes unnecessary `'use strict';` directives. Other errors reported by the `strict` rule are not fixed, to avoid breaking any working code.

See also: #6668, #6856

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
