### PR TITLE
Update: for `yoda`, add a fixer

### DIFF
--- a/docs/rules/yoda.md
+++ b/docs/rules/yoda.md
@@ -1,5 +1,7 @@
 # Require or disallow Yoda Conditions (yoda)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Yoda conditions are so named because the literal value of the condition comes first while the variable comes second. For example, the following is a Yoda condition:
 
 ```js

--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -141,7 +141,9 @@ module.exports = {
                 },
                 additionalProperties: false
             }
-        ]
+        ],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -219,46 +221,57 @@ module.exports = {
                 isParenWrapped());
         }
 
+        const OPERATOR_FLIP_MAP = {
+            "===": "===",
+            "!==": "!==",
+            "==": "==",
+            "!=": "!=",
+            "<": ">",
+            ">": "<",
+            "<=": ">=",
+            ">=": "<="
+        };
+
+        /**
+        * Returns a string representation of a BinaryExpression node with its sides/operator flipped around.
+        * @param {ASTNode} node The BinaryExpression node
+        * @returns {string} A string representation of the node with the sides and operator flipped
+        */
+        function getFlippedString(node) {
+            const operatorToken = sourceCode.getTokensBetween(node.left, node.right).find(token => token.value === node.operator);
+            const textBeforeOperator = sourceCode.getText().slice(node.left.range[1], operatorToken.range[0]);
+            const textAfterOperator = sourceCode.getText().slice(operatorToken.range[1], node.right.range[0]);
+            const leftText = sourceCode.getText(node.left);
+            const rightText = sourceCode.getText(node.right);
+
+            return rightText + textBeforeOperator + OPERATOR_FLIP_MAP[operatorToken.value] + textAfterOperator + leftText;
+        }
+
         //--------------------------------------------------------------------------
         // Public
         //--------------------------------------------------------------------------
 
         return {
-            BinaryExpression: always ? function(node) {
+            BinaryExpression(node) {
+                const expectedLiteral = always ? node.left : node.right;
+                const expectedNonLiteral = always ? node.right : node.left;
 
-                // Comparisons must always be yoda-style: if ("blue" === color)
+                // If `expectedLiteral` is not a literal, and `expectedNonLiteral` is a literal, raise an error.
                 if (
-                    (node.right.type === "Literal" || looksLikeLiteral(node.right)) &&
-                    !(node.left.type === "Literal" || looksLikeLiteral(node.left)) &&
+                    (expectedNonLiteral.type === "Literal" || looksLikeLiteral(expectedNonLiteral)) &&
+                    !(expectedLiteral.type === "Literal" || looksLikeLiteral(expectedLiteral)) &&
                     !(!isEqualityOperator(node.operator) && onlyEquality) &&
                     isComparisonOperator(node.operator) &&
                     !(exceptRange && isRangeTest(context.getAncestors().pop()))
                 ) {
                     context.report({
                         node,
-                        message: "Expected literal to be on the left side of {{operator}}.",
+                        message: "Expected literal to be on the {{expectedSide}} side of {{operator}}.",
                         data: {
-                            operator: node.operator
-                        }
-                    });
-                }
-
-            } : function(node) {
-
-                // Comparisons must never be yoda-style (default)
-                if (
-                    (node.left.type === "Literal" || looksLikeLiteral(node.left)) &&
-                    !(node.right.type === "Literal" || looksLikeLiteral(node.right)) &&
-                    !(!isEqualityOperator(node.operator) && onlyEquality) &&
-                    isComparisonOperator(node.operator) &&
-                    !(exceptRange && isRangeTest(context.getAncestors().pop()))
-                ) {
-                    context.report({
-                        node,
-                        message: "Expected literal to be on the right side of {{operator}}.",
-                        data: {
-                            operator: node.operator
-                        }
+                            operator: node.operator,
+                            expectedSide: always ? "left" : "right"
+                        },
+                        fix: fixer => fixer.replaceText(node, getFlippedString(node))
                     });
                 }
 

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -79,6 +79,7 @@ ruleTester.run("yoda", rule, {
 
         {
             code: "if (\"red\" == value) {}",
+            output: "if (value == \"red\") {}",
             options: ["never"],
             errors: [
                 {
@@ -89,6 +90,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (true === value) {}",
+            output: "if (value === true) {}",
             options: ["never"],
             errors: [
                 {
@@ -99,6 +101,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (5 != value) {}",
+            output: "if (value != 5) {}",
             options: ["never"],
             errors: [
                 {
@@ -109,6 +112,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (null !== value) {}",
+            output: "if (value !== null) {}",
             options: ["never"],
             errors: [
                 {
@@ -119,6 +123,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (\"red\" <= value) {}",
+            output: "if (value >= \"red\") {}",
             options: ["never"],
             errors: [
                 {
@@ -129,6 +134,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (true >= value) {}",
+            output: "if (value <= true) {}",
             options: ["never"],
             errors: [
                 {
@@ -139,6 +145,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "var foo = (5 < value) ? true : false",
+            output: "var foo = (value > 5) ? true : false",
             options: ["never"],
             errors: [
                 {
@@ -149,6 +156,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "function foo() { return (null > value); }",
+            output: "function foo() { return (value < null); }",
             options: ["never"],
             errors: [
                 {
@@ -159,6 +167,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (-1 < str.indexOf(substr)) {}",
+            output: "if (str.indexOf(substr) > -1) {}",
             options: ["never"],
             errors: [
                 {
@@ -169,6 +178,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (value == \"red\") {}",
+            output: "if (\"red\" == value) {}",
             options: ["always"],
             errors: [
                 {
@@ -179,6 +189,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (value === true) {}",
+            output: "if (true === value) {}",
             options: ["always"],
             errors: [
                 {
@@ -189,6 +200,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (a < 0 && 0 <= b && b < 1) {}",
+            output: "if (a < 0 && b >= 0 && b < 1) {}",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -199,6 +211,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (0 <= a && a < 1 && b < 1) {}",
+            output: "if (a >= 0 && a < 1 && b < 1) {}",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -209,6 +222,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (1 < a && a < 0) {}",
+            output: "if (a > 1 && a < 0) {}",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -219,6 +233,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "0 < a && a < 1",
+            output: "a > 0 && a < 1",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -229,6 +244,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "var a = b < 0 || 1 <= b;",
+            output: "var a = b < 0 || b >= 1;",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -239,6 +255,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (0 <= x && x < -1) {}",
+            output: "if (x >= 0 && x < -1) {}",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -249,6 +266,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "var a = (b < 0 && 0 <= b);",
+            output: "var a = (0 > b && 0 <= b);",
             options: ["always", { exceptRange: true }],
             errors: [
                 {
@@ -259,6 +277,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (0 <= a[b] && a['b'] < 1) {}",
+            output: "if (a[b] >= 0 && a['b'] < 1) {}",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -269,6 +288,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (0 <= a[b()] && a[b()] < 1) {}",
+            output: "if (a[b()] >= 0 && a[b()] < 1) {}",
             options: ["never", { exceptRange: true }],
             errors: [
                 {
@@ -279,6 +299,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (3 == a) {}",
+            output: "if (a == 3) {}",
             options: ["never", { onlyEquality: true }],
             errors: [
                 {
@@ -289,6 +310,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "foo(3 === a);",
+            output: "foo(a === 3);",
             options: ["never", { onlyEquality: true }],
             errors: [
                 {
@@ -299,6 +321,7 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "foo(a === 3);",
+            output: "foo(3 === a);",
             options: ["always", { onlyEquality: true }],
             errors: [
                 {
@@ -309,13 +332,57 @@ ruleTester.run("yoda", rule, {
         },
         {
             code: "if (0 <= x && x < 1) {}",
+            output: "if (x >= 0 && x < 1) {}",
             errors: [
                 {
                     message: "Expected literal to be on the right side of <=.",
                     type: "BinaryExpression"
                 }
             ]
+        },
+        {
+            code: "if ( /* a */ 0 /* b */ < /* c */ foo /* d */ ) {}",
+            output: "if ( /* a */ foo /* b */ > /* c */ 0 /* d */ ) {}",
+            options: ["never"],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of <.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if ( /* a */ foo /* b */ > /* c */ 0 /* d */ ) {}",
+            output: "if ( /* a */ 0 /* b */ < /* c */ foo /* d */ ) {}",
+            options: ["always"],
+            errors: [
+                {
+                    message: "Expected literal to be on the left side of >.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (foo()===1) {}",
+            output: "if (1===foo()) {}",
+            options: ["always"],
+            errors: [
+                {
+                    message: "Expected literal to be on the left side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (foo()     === 1) {}",
+            output: "if (1     === foo()) {}",
+            options: ["always"],
+            errors: [
+                {
+                    message: "Expected literal to be on the left side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
         }
-
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`yoda`](http://eslint.org/docs/rules/yoda). When `yoda` reports that a binary expression should be flipped, the fixer can flip the sides of the expression, along with the operator, to fix the issue.

**Is there anything you'd like reviewers to focus on?**

In general, flipping around the order of a comparison is unsafe, because it changes execution order (e.g. in `if (foo() === bar())`, `foo()` gets called before `bar()`). However, I don't think this is a problem for `yoda` because one side of the expression is always a literal, so it won't have side-effects.