### PR TITLE
Update: add fixer for `no-lonely-if`

### DIFF
--- a/docs/rules/no-lonely-if.md
+++ b/docs/rules/no-lonely-if.md
@@ -1,5 +1,7 @@
 # disallow `if` statements as the only statement in `else` blocks (no-lonely-if)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 If an `if` statement is the only statement in the `else` block, it is often clearer to use an `else if` form.
 
 ```js

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -41,9 +41,8 @@ module.exports = {
                             const openingElseCurly = sourceCode.getFirstToken(parent);
                             const closingElseCurly = sourceCode.getLastToken(parent);
                             const elseKeyword = sourceCode.getTokenBefore(openingElseCurly);
-                            const closingIfParen = sourceCode.getTokenAfter(node.test);
-                            const ifKeyword = sourceCode.getTokenBefore(node.test, 1);
-                            const ifConsequentText = node.consequent.type === "BlockStatement" ? sourceCode.getText(node.consequent).slice(1, -1) : sourceCode.getText(node.consequent);
+                            const tokenAfterElseBlock = sourceCode.getTokenAfter(closingElseCurly);
+                            const lastIfToken = sourceCode.getLastToken(node.consequent);
                             const sourceText = sourceCode.getText();
 
                             if (sourceText.slice(openingElseCurly.range[1], node.range[0]).trim() || sourceText.slice(node.range[1], closingElseCurly.range[0]).trim()) {
@@ -52,9 +51,26 @@ module.exports = {
                                 return null;
                             }
 
+                            if (
+                                node.consequent.type !== "BlockStatement" && lastIfToken.value !== ";" && tokenAfterElseBlock &&
+                                (
+                                    node.consequent.loc.end.line === tokenAfterElseBlock.loc.start.line ||
+                                    /^[(\[\/+`-]/.test(tokenAfterElseBlock.value) ||
+                                    lastIfToken.value === "++" ||
+                                    lastIfToken.value === "--"
+                                )
+                            ) {
+
+                                /*
+                                 * If the `if` statement has no block, and is not followed by a semicolon, make sure that fixing
+                                 * the issue would not change semantics due to ASI. If this would happen, don't do a fix.
+                                 */
+                                return null;
+                            }
+
                             return fixer.replaceTextRange(
-                                [elseKeyword.range[1], closingElseCurly.range[0]],
-                                " " + sourceText.slice(ifKeyword.range[0], closingIfParen.range[1]) + sourceText.slice(elseKeyword.range[1], openingElseCurly.range[1]) + ifConsequentText
+                                [openingElseCurly.range[0], closingElseCurly.range[1]],
+                                (elseKeyword.range[1] === openingElseCurly.range[0] ? " " : "") + sourceCode.getText(node)
                             );
                         }
                     });

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -16,10 +16,13 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
 
         return {
             IfStatement(node) {
@@ -31,7 +34,30 @@ module.exports = {
                         parent.body.length === 1 && grandparent &&
                         grandparent.type === "IfStatement" &&
                         parent === grandparent.alternate) {
-                    context.report(node, "Unexpected if as the only statement in an else block.");
+                    context.report({
+                        node,
+                        message: "Unexpected if as the only statement in an else block.",
+                        fix(fixer) {
+                            const openingElseCurly = sourceCode.getFirstToken(parent);
+                            const closingElseCurly = sourceCode.getLastToken(parent);
+                            const elseKeyword = sourceCode.getTokenBefore(openingElseCurly);
+                            const closingIfParen = sourceCode.getTokenAfter(node.test);
+                            const ifKeyword = sourceCode.getTokenBefore(node.test, 1);
+                            const ifConsequentText = node.consequent.type === "BlockStatement" ? sourceCode.getText(node.consequent).slice(1, -1) : sourceCode.getText(node.consequent);
+                            const sourceText = sourceCode.getText();
+
+                            if (sourceText.slice(openingElseCurly.range[1], node.range[0]).trim() || sourceText.slice(node.range[1], closingElseCurly.range[0]).trim()) {
+
+                                // Don't fix if there are any non-whitespace characters interfering (e.g. comments)
+                                return null;
+                            }
+
+                            return fixer.replaceTextRange(
+                                [elseKeyword.range[1], closingElseCurly.range[0]],
+                                " " + sourceText.slice(ifKeyword.range[0], closingIfParen.range[1]) + sourceText.slice(elseKeyword.range[1], openingElseCurly.range[1]) + ifConsequentText
+                            );
+                        }
+                    });
                 }
             }
         };

--- a/tests/lib/rules/no-lonely-if.js
+++ b/tests/lib/rules/no-lonely-if.js
@@ -16,6 +16,7 @@ const rule = require("../../../lib/rules/no-lonely-if"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
+const errors = [{ message: "Unexpected if as the only statement in an else block.", type: "IfStatement" }];
 
 ruleTester.run("no-lonely-if", rule, {
 
@@ -26,11 +27,105 @@ ruleTester.run("no-lonely-if", rule, {
     ],
 
     // Examples of code that should trigger the rule
-    invalid: [{
-        code: "if (a) {;} else { if (b) {;} }",
-        errors: [{
-            message: "Unexpected if as the only statement in an else block.",
-            type: "IfStatement"
-        }]
-    }]
+    invalid: [
+        {
+            code: "if (a) {;} else { if (b) {;} }",
+            output: "if (a) {;} else if (b) {;}",
+            errors
+        },
+        {
+            code:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  if (b) {\n" +
+            "    bar();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else if (b) {\n" +
+            "    bar();\n" +
+            "  }",
+            errors
+        },
+        {
+            code:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else /* comment */ {\n" +
+            "  if (b) {\n" +
+            "    bar();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else if (b) /* comment */ {\n" +
+            "    bar();\n" +
+            "  }",
+            errors
+        },
+        {
+            code:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  /* otherwise, do the other thing */ if (b) {\n" +
+            "    bar();\n" +
+            "  }\n" +
+            "}",
+            output: // Not fixed, comment interferes
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  /* otherwise, do the other thing */ if (b) {\n" +
+            "    bar();\n" +
+            "  }\n" +
+            "}",
+            errors
+        },
+        {
+            code:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  if /* this comment is ok */ (b) {\n" +
+            "    bar();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else if /* this comment is ok */ (b) {\n" +
+            "    bar();\n" +
+            "  }",
+            errors
+        },
+        {
+            code:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  if (b) {\n" +
+            "    bar();\n" +
+            "  } /* this comment will prevent this test case from being autofixed. */\n" +
+            "}",
+            output:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  if (b) {\n" +
+            "    bar();\n" +
+            "  } /* this comment will prevent this test case from being autofixed. */\n" +
+            "}",
+            errors
+        },
+        {
+            code: "if (foo) {} else { if (bar) baz(); }",
+            output: "if (foo) {} else if (bar) {baz();}",
+            errors
+        }
+    ]
 });

--- a/tests/lib/rules/no-lonely-if.js
+++ b/tests/lib/rules/no-lonely-if.js
@@ -62,7 +62,7 @@ ruleTester.run("no-lonely-if", rule, {
             output:
             "if (a) {\n" +
             "  foo();\n" +
-            "} else if (b) /* comment */ {\n" +
+            "} else /* comment */ if (b) {\n" +
             "    bar();\n" +
             "  }",
             errors
@@ -124,7 +124,115 @@ ruleTester.run("no-lonely-if", rule, {
         },
         {
             code: "if (foo) {} else { if (bar) baz(); }",
-            output: "if (foo) {} else if (bar) {baz();}",
+            output: "if (foo) {} else if (bar) baz();",
+            errors
+        },
+        {
+
+            // Not fixed; removing the braces would cause a SyntaxError.
+            code: "if (foo) {} else { if (bar) baz() } qux();",
+            output: "if (foo) {} else { if (bar) baz() } qux();",
+            errors
+        },
+        {
+
+            // This is fixed because there is a semicolon after baz().
+            code: "if (foo) {} else { if (bar) baz(); } qux();",
+            output: "if (foo) {} else if (bar) baz(); qux();",
+            errors
+        },
+        {
+
+            // Not fixed; removing the braces would change the semantics due to ASI.
+            code:
+            "if (foo) {\n" +
+            "} else {\n" +
+            "  if (bar) baz()\n" +
+            "}\n" +
+            "[1, 2, 3].forEach(foo);",
+            output:
+            "if (foo) {\n" +
+            "} else {\n" +
+            "  if (bar) baz()\n" +
+            "}\n" +
+            "[1, 2, 3].forEach(foo);",
+            errors
+        },
+        {
+
+            // Not fixed; removing the braces would change the semantics due to ASI.
+            code:
+            "if (foo) {\n" +
+            "} else {\n" +
+            "  if (bar) baz++\n" +
+            "}\n" +
+            "foo;",
+            output:
+            "if (foo) {\n" +
+            "} else {\n" +
+            "  if (bar) baz++\n" +
+            "}\n" +
+            "foo;",
+            errors
+        },
+        {
+
+            // This is fixed because there is a semicolon after baz++
+            code:
+            "if (foo) {\n" +
+            "} else {\n" +
+            "  if (bar) baz++;\n" +
+            "}\n" +
+            "foo;",
+            output:
+            "if (foo) {\n" +
+            "} else if (bar) baz++;\n" +
+            "foo;",
+            errors
+        },
+        {
+
+            // Not fixed; bar() would be interpreted as a template literal tag
+            code:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  if (b) bar()\n" +
+            "}\n" +
+            "`template literal`;",
+            output:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  if (b) bar()\n" +
+            "}\n" +
+            "`template literal`;",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else {\n" +
+            "  if (b) {\n" +
+            "    bar();\n" +
+            "  } else if (c) {\n" +
+            "    baz();\n" +
+            "  } else {\n" +
+            "    qux();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "if (a) {\n" +
+            "  foo();\n" +
+            "} else if (b) {\n" +
+            "    bar();\n" +
+            "  } else if (c) {\n" +
+            "    baz();\n" +
+            "  } else {\n" +
+            "    qux();\n" +
+            "  }",
             errors
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-lonely-if`](http://eslint.org/docs/rules/no-lonely-if). When it encounters an `if` statement as the only statement in an `else` block, the fixer replaces it with an `else if` block.

```js
if (foo) {
} else {
  if (bar) {
    baz();
  }
}

// gets fixed to:

if (foo) {
} else if (bar) {
    baz();
  }
```

If there are any non-whitespace characters such as comments between `else {` and `if`, no fix is performed.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.