### PR TITLE
Add `skipCommentMatch` (see note)

### DIFF
--- a/lib/rules/no-trailing-spaces.js
+++ b/lib/rules/no-trailing-spaces.js
@@ -24,6 +24,9 @@ module.exports = {
                 properties: {
                     skipBlankLines: {
                         type: "boolean"
+                    },
+                    skipCommentedLines: {
+                        type: "boolean"
                     }
                 },
                 additionalProperties: false
@@ -36,10 +39,17 @@ module.exports = {
 
         const BLANK_CLASS = "[ \t\u00a0\u2000-\u200b\u2028\u2029\u3000]",
             SKIP_BLANK = `^${BLANK_CLASS}*$`,
-            NONBLANK = `${BLANK_CLASS}+$`;
+            NONBLANK = `${BLANK_CLASS}+$`,
+            /*
+             * Big caveat on this regular expression; it only checks single lines
+             * and it will IGNORE comments at the end (or in the middle) of lines
+             * ...in other words, a regular expression is not a parser...
+             */
+            SKIP_COMMENT = "^\W*?(//|/\*)";
 
         const options = context.options[0] || {},
-            skipBlankLines = options.skipBlankLines || false;
+            skipBlankLines = options.skipBlankLines || false,
+            skipCommentedLines = options.skipCommentedLines || false;
 
         /**
          * Report the error message
@@ -79,9 +89,11 @@ module.exports = {
                 // fetch the source code and do matching via regexps.
 
                 const re = new RegExp(NONBLANK),
-                    skipMatch = new RegExp(SKIP_BLANK),
+                    skipBlankMatch = new RegExp(SKIP_BLANK),
+                    skipCommentMatch = new RegExp(SKIP_COMMENT),
                     lines = sourceCode.lines,
                     linebreaks = sourceCode.getText().match(/\r\n|\r|\n|\u2028|\u2029/g);
+
                 let totalLength = 0,
                     fixRange = [];
 
@@ -112,8 +124,12 @@ module.exports = {
                         }
 
                         // If the line has only whitespace, and skipBlankLines
+                        // Or, if the line has comments and skipCommentedLines
                         // is true, don't report it
-                        if (skipBlankLines && skipMatch.test(lines[i])) {
+                        if (
+                            (skipBlankLines && skipBlankMatch.test(lines[i]) ||
+                            (skipCommentedLines && skipCommentMatch.test(lines[i])))
+                        ) {
                             totalLength += lineLength;
                             continue;
                         }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[x] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests) **but I took the easy route...maybe when I have more time, I'll do an actual PR**
- [ ] I've included tests for my change
- [ ] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
For the rule `no-trailing-spaces` add option `skipCommentedLines` to ignore lines that start with comments. The big caveat being it only checks single lines; it will IGNORE comments at the end (or in the middle) of lines. In other words, a regular expression is not a parser!

**Is there anything you'd like reviewers to focus on?**
This pull request is not complete—it doesn't have tests or documentation updates. Therefore, I welcome continued contribution. I just wanted to get the ball rolling.