### PR TITLE
Update: add fixer for `prefer-numeric-literals`

### DIFF
--- a/docs/rules/prefer-numeric-literals.md
+++ b/docs/rules/prefer-numeric-literals.md
@@ -1,5 +1,7 @@
 # disallow `parseInt()` in favor of binary, octal, and hexadecimal literals (prefer-numeric-literals)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 The `parseInt()` function can be used to turn binary, octal, and hexadecimal strings into integers. As binary, octal, and hexadecimal literals are supported in ES6, this rule encourages use of those numeric literals instead of `parseInt()`.
 
 ```js

--- a/lib/rules/prefer-numeric-literals.js
+++ b/lib/rules/prefer-numeric-literals.js
@@ -17,7 +17,9 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -25,6 +27,12 @@ module.exports = {
             2: "binary",
             8: "octal",
             16: "hexadecimal"
+        };
+
+        const prefixMap = {
+            2: "0b",
+            8: "0o",
+            16: "0x"
         };
 
         //--------------------------------------------------------------------------
@@ -53,6 +61,17 @@ module.exports = {
                         message: "Use {{radixName}} literals instead of parseInt().",
                         data: {
                             radixName
+                        },
+                        fix(fixer) {
+                            const newPrefix = prefixMap[node.arguments[1].value];
+
+                            if (+(newPrefix + node.arguments[0].value) !== parseInt(node.arguments[0].value, node.arguments[1].value)) {
+
+                                // If the newly-produced literal would be invalid, (e.g. 0b1234),
+                                // or it would yield an incorrect parseInt result for some other reason, don't make a fix.
+                                return null;
+                            }
+                            return fixer.replaceText(node, prefixMap[node.arguments[1].value] + node.arguments[0].value);
                         }
                     });
                 }

--- a/tests/lib/rules/prefer-numeric-literals.js
+++ b/tests/lib/rules/prefer-numeric-literals.js
@@ -32,16 +32,39 @@ ruleTester.run("prefer-numeric-literals", rule, {
     invalid: [
         {
             code: "parseInt(\"111110111\", 2) === 503;",
+            output: "0b111110111 === 503;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use binary literals instead of parseInt()." }]
         }, {
             code: "parseInt(\"767\", 8) === 503;",
+            output: "0o767 === 503;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use octal literals instead of parseInt()." }]
         }, {
             code: "parseInt(\"1F7\", 16) === 255;",
+            output: "0x1F7 === 255;",
             parserOptions: { ecmaVersion: 6 },
             errors: [{ message: "Use hexadecimal literals instead of parseInt()." }]
+        }, {
+            code: "parseInt('7999', 8);",
+            output: "parseInt('7999', 8);", // not fixed, unexpected 9 in parseInt string
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Use octal literals instead of parseInt()." }]
+        }, {
+            code: "parseInt('1234', 2);",
+            output: "parseInt('1234', 2);", // not fixed, invalid binary string
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Use binary literals instead of parseInt()." }]
+        }, {
+            code: "parseInt('1234.5', 8);",
+            output: "parseInt('1234.5', 8);", // not fixed, this isn't an integer
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Use octal literals instead of parseInt()." }]
+        }, {
+            code: "parseInt('1️⃣3️⃣3️⃣7️⃣', 16);",
+            output: "parseInt('1️⃣3️⃣3️⃣7️⃣', 16);", // not fixed, javascript doesn't support emoji literals
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Use hexadecimal literals instead of parseInt()."}]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`prefer-numeric-literals`](http://eslint.org/docs/rules/prefer-numeric-literals).

When given a function call such as `parseInt('123', 16)`, the fixer replaces it with `0x123`.

`parseInt` has some weird behavior; it accepts strings that look invalid. For example, `parseInt('1 foo bar baz', 16)` returns `1`. The fixer only performs a fix if the literal in `parseInt()` would also be parseable as a regular number literal.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.