### PR TITLE
Fix: Reworking/improving optionator configuration for --print-config

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -137,6 +137,21 @@ const cli = {
 
             log.info("v" + require("../package.json").version);
 
+        } else if (currentOptions.printConfig) {
+            if (files.length) {
+                log.error("The --print-config option must be used with exactly one file name.");
+                return 1;
+            } else if (text) {
+                log.error("The --print-config option is not available for piped-in code.");
+                return 1;
+            }
+
+            const engine = new CLIEngine(translateOptions(currentOptions));
+
+            const fileConfig = engine.getConfigForFile(currentOptions.printConfig);
+
+            log.info(JSON.stringify(fileConfig, null, "  "));
+            return 0;
         } else if (currentOptions.help || (!files.length && !text)) {
 
             log.info(options.generateHelp());
@@ -152,24 +167,6 @@ const cli = {
             }
 
             const engine = new CLIEngine(translateOptions(currentOptions));
-
-            if (currentOptions.printConfig) {
-                if (files.length !== 1) {
-                    log.error("The --print-config option requires a " +
-                        "single file as positional argument.");
-                    return 1;
-                }
-
-                if (text) {
-                    log.error("The --print-config option is not available for piped-in code.");
-                    return 1;
-                }
-
-                const fileConfig = engine.getConfigForFile(files[0]);
-
-                log.info(JSON.stringify(fileConfig, null, "  "));
-                return 0;
-            }
 
             const report = text ? engine.executeOnText(text, currentOptions.stdinFilename, true) : engine.executeOnFiles(files);
 

--- a/lib/options.js
+++ b/lib/options.js
@@ -216,8 +216,8 @@ module.exports = optionator({
         },
         {
             option: "print-config",
-            type: "Boolean",
-            description: "Print the configuration to be used"
+            type: "path::String",
+            description: "Print the configuration for the given file"
         }
     ]
 });

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "lodash": "^4.0.0",
     "mkdirp": "^0.5.0",
     "natural-compare": "^1.4.0",
-    "optionator": "^0.8.1",
+    "optionator": "^0.8.2",
     "path-is-inside": "^1.0.1",
     "pluralize": "^1.2.1",
     "progress": "^1.1.8",

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -880,7 +880,7 @@ describe("cli", function() {
             assert.equal(exitCode, 0);
         });
 
-        it("should require a single positional file argument", function() {
+        it("should error if any positional file arguments are passed", function() {
             const filePath1 = getFixturePath("files", "bar.js");
             const filePath2 = getFixturePath("files", "foo.js");
 

--- a/tests/lib/options.js
+++ b/tests/lib/options.js
@@ -359,10 +359,10 @@ describe("options", function() {
     });
 
     describe("--print-config", function() {
-        it("should return true when passed --print-config", function() {
-            const currentOptions = options.parse("--print-config");
+        it("should return file path when passed --print-config", function() {
+            const currentOptions = options.parse("--print-config file.js");
 
-            assert.isTrue(currentOptions.printConfig);
+            assert.strictEqual(currentOptions.printConfig, "file.js");
         });
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

Changing behavior of a CLI option (--print-config).

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Since --print-config operates on one file, I've changed the option from being boolean-valued to being string-valued (in other words, the file for which user wants to print a config becomes an argument to the option itself).

~~This is technically a breaking change because this use is now broken: `eslint --print-config --other-options-here fileName.js`. In addition, it will no longer flag if too many files are passed in. However, the advantage of this is the optionator output for this option is improved and we get validation for free.~~ Consensus seems to be that this is not a breaking change, because `--print-config --some-option fileName.js` was never really intended to work, it just happened to because of the implementation.

Needed to update optionator to pick up a bugfix (otherwise, non-boolean options at the end of a command line were not validated properly).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.