### PR TITLE
Update: add fixer for `no-useless-computed-key`

### DIFF
--- a/docs/rules/no-useless-computed-key.md
+++ b/docs/rules/no-useless-computed-key.md
@@ -1,5 +1,7 @@
 # Disallow unnecessary computed property keys on objects (no-useless-computed-key)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 It's unnecessary to use computed properties with literals such as:
 
 ```js

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -18,7 +18,9 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
     create(context) {
         const sourceCode = context.getSourceCode();
@@ -33,7 +35,24 @@ module.exports = {
                     nodeType = typeof key.value;
 
                 if (key.type === "Literal" && (nodeType === "string" || nodeType === "number")) {
-                    context.report(node, MESSAGE_UNNECESSARY_COMPUTED, { property: sourceCode.getText(key) });
+                    context.report({
+                        node,
+                        message: MESSAGE_UNNECESSARY_COMPUTED,
+                        data: { property: sourceCode.getText(key) },
+                        fix(fixer) {
+                            const leftSquareBracket = sourceCode.getFirstToken(node);
+                            const rightSquareBracket = sourceCode.getTokensBetween(node.key, node.value).find(token => token.value === "]");
+
+                            const tokensBetween = sourceCode.getTokensBetween(leftSquareBracket, rightSquareBracket, 1);
+
+                            if (tokensBetween.slice(0, -1).some((token, index) => sourceCode.getText().slice(token.range[1], tokensBetween[index + 1].range[0]).trim())) {
+
+                                // If there are comments between the brackets and the property name, don't do a fix.
+                                return null;
+                            }
+                            return fixer.replaceTextRange([leftSquareBracket.range[0], rightSquareBracket.range[1]], key.raw);
+                        }
+                    });
                 }
             }
         };

--- a/lib/rules/no-useless-computed-key.js
+++ b/lib/rules/no-useless-computed-key.js
@@ -40,7 +40,7 @@ module.exports = {
                         message: MESSAGE_UNNECESSARY_COMPUTED,
                         data: { property: sourceCode.getText(key) },
                         fix(fixer) {
-                            const leftSquareBracket = sourceCode.getFirstToken(node);
+                            const leftSquareBracket = sourceCode.getFirstToken(node, node.value.generator || node.value.async ? 1 : 0);
                             const rightSquareBracket = sourceCode.getTokensBetween(node.key, node.value).find(token => token.value === "]");
 
                             const tokensBetween = sourceCode.getTokensBetween(leftSquareBracket, rightSquareBracket, 1);

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -81,6 +81,20 @@ ruleTester.run("no-useless-computed-key", rule, {
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
+        }, {
+            code: "({ *['x']() {} })",
+            output: "({ *'x'() {} })",
+            env: {es6: true},
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "Property"
+            }]
+        }, {
+            code: "({ async ['x']() {} })",
+            output: "({ async 'x'() {} })",
+            parserOptions: { ecmaVersion: 8 },
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "Property"
+            }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-computed-key.js
+++ b/tests/lib/rules/no-useless-computed-key.js
@@ -27,30 +27,56 @@ ruleTester.run("no-useless-computed-key", rule, {
     invalid: [
         {
             code: "({ ['0']: 0 })",
+            output: "({ '0': 0 })",
             env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['0'] found.", type: "Property"
             }]
         }, {
             code: "({ ['0+1,234']: 0 })",
+            output: "({ '0+1,234': 0 })",
             env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['0+1,234'] found.", type: "Property"
             }]
         }, {
             code: "({ [0]: 0 })",
+            output: "({ 0: 0 })",
             env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property [0] found.", type: "Property"
             }]
         }, {
             code: "({ ['x']: 0 })",
+            output: "({ 'x': 0 })",
             env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"
             }]
         }, {
             code: "({ ['x']() {} })",
+            output: "({ 'x'() {} })",
+            env: {es6: true},
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "Property"
+            }]
+        }, {
+            code: "({ [/* this comment prevents a fix */ 'x']: 0 })",
+            output: "({ [/* this comment prevents a fix */ 'x']: 0 })",
+            env: {es6: true},
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "Property"
+            }]
+        }, {
+            code: "({ ['x' /* this comment also prevents a fix */]: 0 })",
+            output: "({ ['x' /* this comment also prevents a fix */]: 0 })",
+            env: {es6: true},
+            errors: [{
+                message: "Unnecessarily computed property ['x'] found.", type: "Property"
+            }]
+        }, {
+            code: "({ [('x')]: 0 })",
+            output: "({ 'x': 0 })",
             env: {es6: true},
             errors: [{
                 message: "Unnecessarily computed property ['x'] found.", type: "Property"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-useless-computed-key`](http://eslint.org/docs/rules/no-useless-computed-key).

The fixer removes the square brackets around unnecessary computed keys. For example, `({ ['x']: 0 })` is fixed to `({ 'x': 0 })`.

If there are comments between the square brackets and the key, no fix is performed.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.