### PR TITLE
Update: add fixer for `no-undef-init`

### DIFF
--- a/docs/rules/no-undef-init.md
+++ b/docs/rules/no-undef-init.md
@@ -1,5 +1,7 @@
 # Disallow Initializing to undefined (no-undef-init)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 In JavaScript, a variable that is declared and not initialized to any value automatically gets the value of `undefined`. For example:
 
 ```js

--- a/lib/rules/no-undef-init.js
+++ b/lib/rules/no-undef-init.js
@@ -5,6 +5,8 @@
 
 "use strict";
 
+const astUtils = require("../ast-utils");
+
 //------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
@@ -17,19 +19,38 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
 
+        const sourceCode = context.getSourceCode();
+
         return {
 
             VariableDeclarator(node) {
-                const name = node.id.name,
-                    init = node.init && node.init.name;
+                const name = sourceCode.getText(node.id),
+                    init = node.init && node.init.name,
+                    scope = context.getScope(),
+                    undefinedVar = astUtils.getVariableByName(scope, "undefined"),
+                    shadowed = undefinedVar && undefinedVar.defs.length > 0;
 
-                if (init === "undefined" && node.parent.kind !== "const") {
-                    context.report(node, "It's not necessary to initialize '{{name}}' to undefined.", { name });
+                if (init === "undefined" && node.parent.kind !== "const" && !shadowed) {
+                    context.report({
+                        node,
+                        message: "It's not necessary to initialize '{{name}}' to undefined.",
+                        data: {name},
+                        fix(fixer) {
+                            if (node.id.type === "ArrayPattern" || node.id.type === "ObjectPattern") {
+
+                                // Don't fix destructuring assignment to `undefined`.
+                                return null;
+                            }
+                            return fixer.removeRange([node.id.range[1], node.range[1]]);
+                        }
+                    });
                 }
             }
         };

--- a/tests/lib/rules/no-undef-init.js
+++ b/tests/lib/rules/no-undef-init.js
@@ -21,9 +21,36 @@ const ruleTester = new RuleTester();
 ruleTester.run("no-undef-init", rule, {
     valid: [
         "var a;",
-        { code: "const foo = undefined", parserOptions: { ecmaVersion: 6 } }
+        { code: "const foo = undefined", parserOptions: { ecmaVersion: 6 } },
+        "var undefined = 5; var foo = undefined;"
     ],
     invalid: [
-        { code: "var a = undefined;", errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator"}] }
+        {
+            code: "var a = undefined;",
+            output: "var a;",
+            errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator"}]
+        },
+        {
+            code: "var a = undefined, b = 1;",
+            output: "var a, b = 1;",
+            errors: [{ message: "It's not necessary to initialize 'a' to undefined.", type: "VariableDeclarator"}]
+        },
+        {
+            code: "var a = 1, b = undefined, c = 5;",
+            output: "var a = 1, b, c = 5;",
+            errors: [{ message: "It's not necessary to initialize 'b' to undefined.", type: "VariableDeclarator"}]
+        },
+        {
+            code: "var [a] = undefined;",
+            output: "var [a] = undefined;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize '[a]' to undefined.", type: "VariableDeclarator"}]
+        },
+        {
+            code: "var {a} = undefined;",
+            output: "var {a} = undefined;",
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "It's not necessary to initialize '{a}' to undefined.", type: "VariableDeclarator"}]
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-undef-init`](http://eslint.org/docs/rules/no-undef-init).

The fixer replaces `var x = undefined;` with `var x;`. It does not apply a fix if destructuring is used, e.g. `var [x] = undefined;`

This PR also prevents `no-undef-init` from reporting errors if an `undefined` variable is declared in local scope, similar to `no-console`, `no-alert`, and `no-regex-spaces`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
