### PR TITLE
Fix: object-shorthand's consistent-as-needed option (issue #7214)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -156,7 +156,7 @@ module.exports = {
                 property.value && property.value.id && property.value.id.name === property.key.name ||
 
                 // A property
-                property.value && property.value.name === property.key.name
+                property.value && (property.value.name || property.value.value) === (property.key.name || property.key.value)
             ));
         }
 

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -15,6 +15,11 @@ const OPTIONS = {
 };
 
 //------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
 // Rule Definition
 //------------------------------------------------------------------------------
 module.exports = {
@@ -150,14 +155,16 @@ module.exports = {
          * @private
          **/
         function isRedudant(property) {
-            return (property.key && (
+            const value = property.value;
 
-                // A function expression
-                property.value && property.value.id && property.value.id.name === property.key.name ||
+            if (value.type === "FunctionExpression") {
+                return !value.id; // Only anonymous should be shorthand method.
+            }
+            if (value.type === "Identifier") {
+                return astUtils.getStaticPropertyName(property) === value.name;
+            }
 
-                // A property
-                property.value && (property.value.name || property.value.value) === (property.key.name || property.key.value)
-            ));
+            return false;
         }
 
         /**

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -154,7 +154,7 @@ module.exports = {
          * @returns {boolean} True if the key and value are named equally, false if not.
          * @private
          **/
-        function isRedudant(property) {
+        function isRedundant(property) {
             const value = property.value;
 
             if (value.type === "FunctionExpression") {
@@ -192,8 +192,8 @@ module.exports = {
                     } else if (checkRedundancy) {
 
                         // If all properties of the object contain a method or value with a name matching it's key,
-                        // all the keys are redudant.
-                        const canAlwaysUseShorthand = properties.every(isRedudant);
+                        // all the keys are redundant.
+                        const canAlwaysUseShorthand = properties.every(isRedundant);
 
                         if (canAlwaysUseShorthand) {
                             context.report(node, "Expected shorthand for all properties.");

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -104,8 +104,12 @@ ruleTester.run("object-shorthand", rule, {
         // consistent-as-needed
         { code: "var x = {a, b}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
         { code: "var x = {a, b, get test(){return 1;}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {0: 'foo'}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
-        { code: "var x = {'key': 'baz'}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] }
+        { code: "var x = {0: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
+        { code: "var x = {'key': 'baz'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
+        { code: "var x = {foo: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
+        { code: "var x = {[foo]: foo}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
+        { code: "var x = {foo: function foo() {}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
+        { code: "var x = {[foo]: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] }
     ],
     invalid: [
         { code: "var x = {x: x}", output: "var x = {x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
@@ -160,6 +164,7 @@ ruleTester.run("object-shorthand", rule, {
 
         // consistent-as-needed
         { code: "var x = {a: a, b: b}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
-        { code: "var x = {a, z: function z(){}}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent-as-needed"] }
+        { code: "var x = {a, z: function z(){}}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent-as-needed"] },
+        { code: "var x = {foo: function() {}}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
     ]
 });

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -103,7 +103,9 @@ ruleTester.run("object-shorthand", rule, {
 
         // consistent-as-needed
         { code: "var x = {a, b}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {a, b, get test(){return 1;}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] }
+        { code: "var x = {a, b, get test(){return 1;}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
+        { code: "var x = {0: 'foo'}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
+        { code: "var x = {'key': 'baz'}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] }
     ],
     invalid: [
         { code: "var x = {x: x}", output: "var x = {x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
This PR fixes issue #7214.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

`object-shorthand`'s `consistent-as-needed` rule was failing when keys were either numbers or quoted strings. We (@ahuth and I) fixed this by changing the conditions under which an object is determined to have redundant properties.

**Is there anything you'd like reviewers to focus on?**



