### PR TITLE
Build: Do not strip .md extension from absolute URLs

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -658,8 +658,8 @@ target.gensite = function(prereleaseVersion) {
                 text = "---\ntitle: " + title + "\nlayout: doc\n---\n<!-- Note: No pull requests accepted for this file. See README.md in the root directory for details. -->\n\n" + text;
             }
 
-            // 6. Remove .md extension for links and change README to empty string
-            text = text.replace(/\.md(.*?\))/g, ")").replace("README.html", "");
+            // 6. Remove .md extension for relative links and change README to empty string
+            text = text.replace(/\((?!https?:\/\/)(.*?)\.md.*?\)/g, "($1)").replace("README.html", "");
 
             // 7. Check if there's a trailing white line at the end of the file, if there isn't one, add it
             if (!/\n$/.test(text)) {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:

Fixes https://github.com/eslint/eslint.github.io/issues/288.

We currently strip the .md extension from all URLs, but we actually do want to send users to the template .md files on GitHub in this case.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [ ] I've included tests for my change
- [ ] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
Updated the site generator to not strip `.md` from links that start with `http` and `https`.

**Is there anything you'd like reviewers to focus on?**
Nope!

