### PR TITLE
Fix: Use error templates even when reading from stdin (fixes #7213)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -87,7 +87,8 @@ const NODE = "node ", // intentional extra space
  */
 function getTestFilePatterns() {
     const testLibPath = "tests/lib/",
-        testTemplatesPath = "tests/templates/";
+        testTemplatesPath = "tests/templates/",
+        testBinPath = "tests/bin/";
 
     return ls(testLibPath).filter(function(pathToCheck) {
         return test("-d", testLibPath + pathToCheck);
@@ -96,7 +97,7 @@ function getTestFilePatterns() {
             initialValue.push(testLibPath + currentValues + "/**/*.js");
         }
         return initialValue;
-    }, [testLibPath + "rules/**/*.js", testLibPath + "*.js", testTemplatesPath + "*.js"]).join(" ");
+    }, [testLibPath + "rules/**/*.js", testLibPath + "*.js", testTemplatesPath + "*.js", testBinPath + "**/*.js"]).join(" ");
 }
 
 /**

--- a/bin/eslint.js
+++ b/bin/eslint.js
@@ -53,13 +53,7 @@ process.on("uncaughtException", function(err){
 
 if (useStdIn) {
     process.stdin.pipe(concat({ encoding: "string" }, function(text) {
-        try {
-            process.exitCode = cli.execute(process.argv, text);
-        } catch (ex) {
-            console.error(ex.message);
-            console.error(ex.stack);
-            process.exitCode = 1;
-        }
+        process.exitCode = cli.execute(process.argv, text);
     }));
 } else if (init) {
     var configInit = require("../lib/config/config-initializer");

--- a/tests/bin/.eslintrc.yml
+++ b/tests/bin/.eslintrc.yml
@@ -1,0 +1,2 @@
+env:
+    mocha: true

--- a/tests/bin/eslint.js
+++ b/tests/bin/eslint.js
@@ -1,0 +1,112 @@
+/**
+ * @fileoverview Tests for the eslint.js executable.
+ * @author Teddy Katz
+ */
+
+"use strict";
+
+const childProcess = require("child_process");
+const assert = require("chai").assert;
+const EXECUTABLE_PATH = require("path").resolve(`${__dirname}/../../bin/eslint.js`);
+
+/**
+* Asserts that the exit code of a given child process will equal the given value.
+* @param {ChildProcess} exitingProcess The child process
+* @param {number} expectedExitCode The expected exit code of the child process
+* @returns {Promise} A Promise that fufills if the exit code ends up matching, and rejects otherwise.
+*/
+function assertExitCode(exitingProcess, expectedExitCode) {
+    return new Promise((resolve, reject) => {
+        exitingProcess.once("exit", exitCode => {
+            if (exitCode === expectedExitCode) {
+                resolve();
+            } else {
+                reject(new Error(`Expected an exit code of ${expectedExitCode} but got ${exitCode}.`));
+            }
+        });
+    });
+}
+
+/**
+* Returns a Promise for the stdout of a process.
+* @param {ChildProcess} runningProcess The child process
+* @returns {Promise<string>} A Promise that fulfills with all of the stdout output produced by the process when it exits.
+*/
+function getStdout(runningProcess) {
+    let stdout = "";
+
+    runningProcess.stdout.on("data", data => {
+        stdout += data;
+    });
+
+    return new Promise(resolve => {
+        runningProcess.once("exit", () => resolve(stdout));
+    });
+}
+
+describe("bin/eslint.js", () => {
+    const forkedProcesses = new Set();
+
+    /**
+    * Forks the process to run an instance of ESLint.
+    * @param {string[]} [args] An array of arguments
+    * @param {Object} [options] An object containing options for the resulting child process
+    * @returns {ChildProcess} The resulting child process
+    */
+    function runESLint(args, options) {
+        const newProcess = childProcess.fork(EXECUTABLE_PATH, args, Object.assign({silent: true}, options));
+
+        forkedProcesses.add(newProcess);
+        return newProcess;
+    }
+
+    describe("reading from stdin", () => {
+        it("has exit code 0 if no linting errors are reported", () => {
+            const child = runESLint(["--stdin", "--no-eslintrc"]);
+
+            child.stdin.write("var foo = bar;\n");
+            child.stdin.end();
+            return assertExitCode(child, 0);
+        });
+
+        it("has exit code 1 if a syntax error is thrown", () => {
+            const child = runESLint(["--stdin", "--no-eslintrc"]);
+
+            child.stdin.write("This is not valid JS syntax.\n");
+            child.stdin.end();
+            return assertExitCode(child, 1);
+        });
+
+        it("has exit code 1 if a linting error occurs", () => {
+            const child = runESLint(["--stdin", "--no-eslintrc", "--rule", "semi:2"]);
+
+            child.stdin.write("var foo = bar // <-- no semicolon\n");
+            child.stdin.end();
+            return assertExitCode(child, 1);
+        });
+
+        it("gives a detailed error message if no config file is found", () => {
+            const child = runESLint(["--stdin"], {cwd: "/"}); // Assumes the root directory has no .eslintrc file
+
+            const exitCodePromise = assertExitCode(child, 1);
+            const stdoutPromise = getStdout(child).then(stdout => {
+                assert.match(stdout, /ESLint couldn't find a configuration file/);
+            });
+
+            child.stdin.write("var foo = bar\n");
+            child.stdin.end();
+
+            return Promise.all([exitCodePromise, stdoutPromise]);
+        });
+
+    });
+
+    afterEach(() => {
+
+        // Clean up all the processes after every test.
+        forkedProcesses.forEach(child => child.kill());
+        forkedProcesses.clear();
+    });
+
+    // TODO (not-an-aardvark): Add tests for non-stdin functionality
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #7213 for template answers.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This updates `bin/eslint.js` to treat stdin errors like all other errors. ESLint has a generic `process.on('uncaughtException')` handler that handles error templates, but previously the code for the stdin flag had its own error handling logic. This PR removes the error handling logic from `stdin`, which allows stdin errors to cascade to the `uncaughtException` handler.

**Is there anything you'd like reviewers to focus on?**

~~This PR should not be merged yet, as it still needs tests. However, I didn't notice any existing tests for `bin/eslint.js`. Is there a file with tests that I missed, or should I create a new one?~~

edit: The PR now has tests.