### PR TITLE
Docs: `class-methods-use-this`: fix option name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@ v3.6.0 - September 23, 2016
 * a876673 Update: no-implicit-coercion checks TemplateLiterals (fixes #7062) (#7121) (Kai Cataldo)
 * 8db4f0c Chore: Enable `typeof` check for `no-undef` rule in eslint-config-eslint (#7103) (Teddy Katz)
 * 7e8316f Docs: Update release process (#7127) (Nicholas C. Zakas)
-* 22edd8a Update: `class-methods-use-this`: `exceptions` option (fixes #7085) (#7120) (Jordan Harband)
+* 22edd8a Update: `class-methods-use-this`: `exceptMethods` option (fixes #7085) (#7120) (Jordan Harband)
 * afd132a Fix: line-comment-position "above" string option now works (fixes #7100) (#7102) (Kevin Partington)
 * 1738b2e Chore: fix name of internal-no-invalid-meta test file (#7142) (Vitor Balocco)
 * ac0bb62 Docs: Fixes examples for allowTemplateLiterals (fixes #7115) (#7135) (Zoe Ingram)

--- a/docs/rules/class-methods-use-this.md
+++ b/docs/rules/class-methods-use-this.md
@@ -89,12 +89,12 @@ class A {
 ### Exceptions
 
 ```
-"class-methods-use-this": [<enabled>, { "exceptions": [<...exceptions>] }]
+"class-methods-use-this": [<enabled>, { "exceptMethods": [<...exceptions>] }]
 ```
 
-The `exceptions` option allows you to pass an array of method names for which you would like to ignore warnings.
+The `exceptMethods` option allows you to pass an array of method names for which you would like to ignore warnings.
 
-Examples of **incorrect** code for this rule when used without exceptions:
+Examples of **incorrect** code for this rule when used without exceptMethods:
 
 ```js
 /*eslint class-methods-use-this: "error"*/
@@ -105,10 +105,10 @@ class A {
 }
 ```
 
-Examples of **correct** code for this rule when used with exceptions:
+Examples of **correct** code for this rule when used with exceptMethods:
 
 ```js
-/*eslint class-methods-use-this: ["error", { "exceptions": ["foo"] }] */
+/*eslint class-methods-use-this: ["error", { "exceptMethods": ["foo"] }] */
 
 class A {
     foo() {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**
The option is named "exceptMethods", not "exceptions"

**Is there anything you'd like reviewers to focus on?**
¯\\\_(ツ)\_/¯ 