### PR TITLE
Docs: Default option from `operator-linebreak` is `after`and not always

### DIFF
--- a/docs/rules/operator-linebreak.md
+++ b/docs/rules/operator-linebreak.md
@@ -36,7 +36,7 @@ Object option:
 
 ### after
 
-Examples of **incorrect** code for this rule with the default `"always"` option:
+Examples of **incorrect** code for this rule with the default `"after"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/
@@ -60,7 +60,7 @@ answer = everything
   : foo;
 ```
 
-Examples of **correct** code for this rule with the default `"always"` option:
+Examples of **correct** code for this rule with the default `"after"` option:
 
 ```js
 /*eslint operator-linebreak: ["error", "after"]*/


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

- [X] Documentation update
- [ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
- [ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
- [ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [X] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [X] I've included tests for my change
- [X] I've updated documentation for my change (if appropriate)





