### PR TITLE
Update: Fix `no-extra-parens` false negative (fixes #7229)

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -367,15 +367,15 @@ module.exports = {
          * @private
          */
         function dryBinaryLogical(node) {
-            if (!NESTED_BINARY) {
-                const prec = precedence(node);
+            const prec = precedence(node);
+            const shouldSkipLeft = NESTED_BINARY && (node.left.type === "BinaryExpression" || node.left.type === "LogicalExpression");
+            const shouldSkipRight = NESTED_BINARY && (node.right.type === "BinaryExpression" || node.right.type === "LogicalExpression");
 
-                if (hasExcessParens(node.left) && precedence(node.left) >= prec) {
-                    report(node.left);
-                }
-                if (hasExcessParens(node.right) && precedence(node.right) > prec) {
-                    report(node.right);
-                }
+            if (!shouldSkipLeft && hasExcessParens(node.left) && precedence(node.left) >= prec) {
+                report(node.left);
+            }
+            if (!shouldSkipRight && hasExcessParens(node.right) && precedence(node.right) > prec) {
+                report(node.right);
             }
         }
 

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -284,6 +284,14 @@ ruleTester.run("no-extra-parens", rule, {
         { code: "async function a() { await (a + await b) }", parserOptions: { ecmaVersion: 8 } },
         { code: "async function a() { (await a)() }", parserOptions: { ecmaVersion: 8 } },
         { code: "async function a() { new (await a) }", parserOptions: { ecmaVersion: 8 } },
+        { code: "(foo instanceof bar) instanceof baz", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "(foo in bar) in baz", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "(foo + bar) + baz", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "(foo && bar) && baz", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "foo instanceof (bar instanceof baz)", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "foo in (bar in baz)", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "foo + (bar + baz)", options: ["all", { nestedBinaryExpressions: false }] },
+        { code: "foo && (bar && baz)", options: ["all", { nestedBinaryExpressions: false }] },
     ],
 
     invalid: [
@@ -690,5 +698,13 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("async function a() { await (a()); }", "async function a() { await a(); }", "CallExpression", null, {parserOptions: { ecmaVersion: 8 }}),
         invalid("async function a() { await (+a); }", "async function a() { await +a; }", "UnaryExpression", null, {parserOptions: { ecmaVersion: 8 }}),
         invalid("async function a() { +(await a); }", "async function a() { +await a; }", "AwaitExpression", null, {parserOptions: { ecmaVersion: 8 }}),
+        invalid("(foo) instanceof bar", "foo instanceof bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("(foo) in bar", "foo in bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("(foo) + bar", "foo + bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("(foo) && bar", "foo && bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("foo instanceof (bar)", "foo instanceof bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("foo in (bar)", "foo in bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("foo + (bar)", "foo + bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]}),
+        invalid("foo && (bar)", "foo && bar", "Identifier", 1, {options: ["all", {nestedBinaryExpressions: false}]})
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7229 for more info on the bug.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Previously, the `nestedBinaryExpressions: false` option would cause `no-extra-parens` to ignore *all* binary expressions, even non-nested ones.

```js
/* eslint no-extra-parens: [2, "all", {"nestedBinaryExpressions": false}]*/

(foo) + baz // foo is not nested, so this should be reported
(foo * bar) + baz // (foo * bar) is itself a binary expression, so this should not be reported.
```

**Is there anything you'd like reviewers to focus on?**



