### PR TITLE
Update: add enforceInMethodNames option to no-underscore-dangle (fixes #7065)

### DIFF
--- a/docs/rules/no-underscore-dangle.md
+++ b/docs/rules/no-underscore-dangle.md
@@ -42,6 +42,7 @@ This rule has an object option:
 * `"allow"` allows specified identifiers to have dangling underscores
 * `"allowAfterThis": false` (default) disallows dangling underscores in members of the `this` object
 * `"allowAfterSuper": false` (default) disallows dangling underscores in members of the `super` object
+* `"enforceInMethodNames": false (default) allows dangling underscores in method names`
 
 ### allow
 
@@ -74,6 +75,30 @@ Examples of **correct** code for this rule with the `{ "allowAfterSuper": true }
 
 var a = super.foo_;
 super._bar();
+```
+
+### enforceInMethodNames
+
+Examples of incorrect code for this rule with the `{ "enforceInMethodNames": true }` option:
+
+```js
+/*eslint no-underscore-dangle: ["error", { "enforceInMethodNames": true }]*/
+
+class Foo {
+  _bar() {}
+}
+
+class Foo {
+  bar_() {}
+}
+
+const o = {
+  _bar() {}
+};
+
+const o = {
+  bar_() = {}
+};
 ```
 
 ## When Not To Use It

--- a/tests/lib/rules/no-underscore-dangle.js
+++ b/tests/lib/rules/no-underscore-dangle.js
@@ -32,7 +32,13 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "foo._bar;", options: [{ allow: ["_bar"] }] },
         { code: "function _foo() {}", options: [{ allow: ["_foo"] }] },
         { code: "this._bar;", options: [{ allowAfterThis: true }] },
-        { code: "class foo { constructor() { super._bar; } }", parserOptions: { ecmaVersion: 6 }, options: [{ allowAfterSuper: true }] }
+        { code: "class foo { constructor() { super._bar; } }", parserOptions: { ecmaVersion: 6 }, options: [{ allowAfterSuper: true }] },
+        { code: "class foo { _onClick() { } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "class foo { onClick_() { } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "const o = { _onClick() { } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "const o = { onClick_() { } }", parserOptions: { ecmaVersion: 6 } },
+        { code: "const o = { _foo: 'bar' }", parserOptions: { ecmaVersion: 6 } },
+        { code: "const o = { foo_: 'bar' }", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
         { code: "var _foo = 1", errors: [{ message: "Unexpected dangling '_' in '_foo'.", type: "VariableDeclarator" }] },
@@ -43,6 +49,10 @@ ruleTester.run("no-underscore-dangle", rule, {
         { code: "foo._bar;", errors: [{ message: "Unexpected dangling '_' in '_bar'.", type: "MemberExpression" }] },
         { code: "this._prop;", errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression" }] },
         { code: "class foo { constructor() { super._prop; } }", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression" }] },
-        { code: "class foo { constructor() { this._prop; } }", options: [{ allowAfterSuper: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression" }] }
+        { code: "class foo { constructor() { this._prop; } }", options: [{ allowAfterSuper: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_prop'.", type: "MemberExpression" }] },
+        { code: "class foo { _onClick() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_onClick'.", type: "MethodDefinition" }] },
+        { code: "class foo { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in 'onClick_'.", type: "MethodDefinition" }] },
+        { code: "const o = { _onClick() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in '_onClick'.", type: "Property" }] },
+        { code: "const o = { onClick_() { } }", options: [{ enforceInMethodNames: true }], parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Unexpected dangling '_' in 'onClick_'.", type: "Property" }] }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:
#7065

**Please check each item to ensure your pull request is ready:**
- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
When `enforceInMethodNames` is `true`, the rule checks for dangling
underscores in method names too. This includes methods of classes
and method properties of objects.

The rule is `false` by default, in order to preserve backward compatibility.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular.
