### PR TITLE
Update: add fixer for `no-extra-bind`

### DIFF
--- a/docs/rules/no-extra-bind.md
+++ b/docs/rules/no-extra-bind.md
@@ -1,5 +1,7 @@
 # Disallow unnecessary function binding (no-extra-bind)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 The `bind()` method is used to create functions with specific `this` values and, optionally, binds arguments to specific values. When used to specify the value of `this`, it's important that the function actually use `this` in its function body. For example:
 
 ```js

--- a/lib/rules/no-extra-bind.js
+++ b/lib/rules/no-extra-bind.js
@@ -22,7 +22,9 @@ module.exports = {
             recommended: false
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
@@ -39,7 +41,14 @@ module.exports = {
             context.report({
                 node: node.parent.parent,
                 message: "The function binding is unnecessary.",
-                loc: node.parent.property.loc.start
+                loc: node.parent.property.loc.start,
+                fix(fixer) {
+                    const firstTokenToRemove = context.getSourceCode()
+                        .getTokensBetween(node.parent.object, node.parent.property)
+                        .find(token => token.value !== ")");
+
+                    return fixer.removeRange([firstTokenToRemove.range[0], node.parent.parent.range[1]]);
+                }
             });
         }
 

--- a/tests/lib/rules/no-extra-bind.js
+++ b/tests/lib/rules/no-extra-bind.js
@@ -16,6 +16,7 @@ const rule = require("../../../lib/rules/no-extra-bind"),
 //------------------------------------------------------------------------------
 
 const ruleTester = new RuleTester();
+const errors = [{ message: "The function binding is unnecessary.", type: "CallExpression"}];
 
 ruleTester.run("no-extra-bind", rule, {
     valid: [
@@ -31,13 +32,47 @@ ruleTester.run("no-extra-bind", rule, {
         { code: "var a = function() { return () => this; }.bind(b)", parserOptions: { ecmaVersion: 6 } }
     ],
     invalid: [
-        { code: "var a = function() { return 1; }.bind(b)", errors: [{ message: "The function binding is unnecessary.", type: "CallExpression"}] },
-        { code: "var a = function() { return 1; }['bind'](b)", errors: [{ message: "The function binding is unnecessary.", type: "CallExpression"}] },
-        { code: "var a = function() { return 1; }[`bind`](b)", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "The function binding is unnecessary.", type: "CallExpression"}] },
-        { code: "var a = (() => { return 1; }).bind(b)", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "The function binding is unnecessary.", type: "CallExpression"}] },
-        { code: "var a = (() => { return this; }).bind(b)", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "The function binding is unnecessary.", type: "CallExpression"}] },
-        { code: "var a = function() { (function(){ this.c }) }.bind(b)", errors: [{ message: "The function binding is unnecessary.", type: "CallExpression"}] },
-        { code: "var a = function() { function c(){ this.d } }.bind(b)", errors: [{ message: "The function binding is unnecessary.", type: "CallExpression"}] },
-        { code: "var a = function() { (function(){ (function(){ this.d }.bind(c)) }) }.bind(b)", errors: [{ message: "The function binding is unnecessary.", type: "CallExpression", column: 71}] }
+        {
+            code: "var a = function() { return 1; }.bind(b)",
+            output: "var a = function() { return 1; }",
+            errors
+        },
+        {
+            code: "var a = function() { return 1; }['bind'](b)",
+            output: "var a = function() { return 1; }",
+            errors
+        },
+        {
+            code: "var a = function() { return 1; }[`bind`](b)",
+            output: "var a = function() { return 1; }",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code: "var a = (() => { return 1; }).bind(b)",
+            output: "var a = (() => { return 1; })",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code: "var a = (() => { return this; }).bind(b)",
+            output: "var a = (() => { return this; })",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code: "var a = function() { (function(){ this.c }) }.bind(b)",
+            output: "var a = function() { (function(){ this.c }) }",
+            errors
+        },
+        {
+            code: "var a = function() { function c(){ this.d } }.bind(b)",
+            output: "var a = function() { function c(){ this.d } }",
+            errors
+        },
+        {
+            code: "var a = function() { (function(){ (function(){ this.d }.bind(c)) }) }.bind(b)",
+            output: "var a = function() { (function(){ (function(){ this.d }.bind(c)) }) }",
+            errors: [{ message: "The function binding is unnecessary.", type: "CallExpression", column: 71}] }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-extra-bind`](http://eslint.org/docs/rules/no-extra-bind). The fixer removes the unnecessary calls to `.bind` that the rule reports.

**Is there anything you'd like reviewers to focus on?**

We should make sure that [this logic](https://github.com/not-an-aardvark/eslint/blob/9462c6dca60185d7ff30f12ba0ab91ff3e7c2156/lib/rules/no-extra-bind.js#L46-L48) is valid and doesn't cause any tokens to be removed incorrectly.