### PR TITLE
Update: add fixer for `arrow-body-style`

### DIFF
--- a/docs/rules/arrow-body-style.md
+++ b/docs/rules/arrow-body-style.md
@@ -1,5 +1,7 @@
 # Require braces in arrow function body (arrow-body-style)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Arrow functions have two syntactic forms for their function bodies.  They may be defined with a *block* body (denoted by curly braces) `() => { ... }` or with a single expression `() => ...`, whose value is implicitly returned.
 
 ## Rule Details

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -46,7 +46,9 @@ module.exports = {
                     maxItems: 2
                 }
             ]
-        }
+        },
+
+        fixable: "code"
     },
 
     create(context) {
@@ -55,6 +57,7 @@ module.exports = {
         const asNeeded = !options[0] || options[0] === "as-needed";
         const never = options[0] === "never";
         const requireReturnForObjectLiteral = options[1] && options[1].requireReturnForObjectLiteral;
+        const sourceCode = context.getSourceCode();
 
         /**
          * Determines whether a arrow function body needs braces
@@ -65,38 +68,57 @@ module.exports = {
             const arrowBody = node.body;
 
             if (arrowBody.type === "BlockStatement") {
-                if (never) {
+                const blockBody = arrowBody.body;
+
+                if (blockBody.length !== 1 && !never) {
+                    return;
+                }
+
+                if (asNeeded && requireReturnForObjectLiteral && blockBody[0].type === "ReturnStatement" &&
+                    blockBody[0].argument.type === "ObjectExpression") {
+                    return;
+                }
+
+                if (never || asNeeded && blockBody[0].type === "ReturnStatement") {
                     context.report({
                         node,
                         loc: arrowBody.loc.start,
-                        message: "Unexpected block statement surrounding arrow body."
+                        message: "Unexpected block statement surrounding arrow body.",
+                        fix(fixer) {
+                            if (blockBody.length !== 1 || blockBody[0].type !== "ReturnStatement") {
+                                return null;
+                            }
+
+                            const returnValue = blockBody[0].argument;
+                            const sourceText = sourceCode.getText();
+                            const textBeforeReturn = sourceText.slice(arrowBody.range[0] + 1, blockBody[0].range[0]);
+                            const textBetweenReturnAndValue = sourceText.slice(sourceCode.getFirstToken(blockBody[0]).range[1], returnValue.range[0]);
+                            const returnValueText = returnValue.type === "ObjectExpression" ? `(${sourceCode.getText(returnValue)})` : sourceCode.getText(returnValue);
+                            const textAfterValue = sourceText.slice(returnValue.range[1], blockBody[0].range[1] - 1);
+                            const textAfterReturnStatement = sourceText.slice(blockBody[0].range[1], arrowBody.range[1] - 1);
+
+                            return fixer.replaceText(arrowBody, textBeforeReturn + textBetweenReturnAndValue + returnValueText + textAfterValue + textAfterReturnStatement);
+                        }
                     });
-                } else {
-                    const blockBody = arrowBody.body;
-
-                    if (blockBody.length !== 1) {
-                        return;
-                    }
-
-                    if (asNeeded && requireReturnForObjectLiteral && blockBody[0].type === "ReturnStatement" &&
-                        blockBody[0].argument.type === "ObjectExpression") {
-                        return;
-                    }
-
-                    if (asNeeded && blockBody[0].type === "ReturnStatement") {
-                        context.report({
-                            node,
-                            loc: arrowBody.loc.start,
-                            message: "Unexpected block statement surrounding arrow body."
-                        });
-                    }
                 }
             } else {
                 if (always || (asNeeded && requireReturnForObjectLiteral && arrowBody.type === "ObjectExpression")) {
                     context.report({
                         node,
                         loc: arrowBody.loc.start,
-                        message: "Expected block statement surrounding arrow body."
+                        message: "Expected block statement surrounding arrow body.",
+                        fix(fixer) {
+                            const lastTokenBeforeBody = sourceCode.getTokensBetween(sourceCode.getFirstToken(node), arrowBody)
+                                .reverse()
+                                .find(token => token.value !== "(");
+
+                            const firstBodyToken = sourceCode.getTokenAfter(lastTokenBeforeBody);
+
+                            return fixer.replaceTextRange(
+                                [firstBodyToken.range[0], node.range[1]],
+                                `{return ${sourceCode.getText().slice(firstBodyToken.range[0], node.range[1])}}`
+                            );
+                        }
                     });
                 }
             }

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -118,7 +118,14 @@ module.exports = {
                             const textAfterValue = sourceText.slice(lastValueToken.range[1], blockBody[0].range[1] - 1);
                             const textAfterReturnStatement = sourceText.slice(blockBody[0].range[1], arrowBody.range[1] - 1);
 
-                            return fixer.replaceText(arrowBody, textBeforeReturn + textBetweenReturnAndValue + returnValueText + textAfterValue + textAfterReturnStatement);
+                            /*
+                             * For fixes that only contain spaces around the return value, remove the extra spaces.
+                             * This avoids ugly fixes that end up with extra spaces after the arrow, e.g. `() =>   0 ;`
+                             */
+                            return fixer.replaceText(
+                                arrowBody,
+                                (textBeforeReturn + textBetweenReturnAndValue).replace(/^ *$/, "") + returnValueText + (textAfterValue + textAfterReturnStatement).replace(/^ *$/, "")
+                            );
                         }
                     });
                 }

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -103,6 +103,14 @@ module.exports = {
                                 lastValueToken = sourceCode.getTokenBefore(lastValueToken);
                             }
 
+                            const tokenAfterArrowBody = sourceCode.getTokenAfter(arrowBody);
+
+                            if (tokenAfterArrowBody && tokenAfterArrowBody.type === "Punctuator" && /^[(\[\/`+-]/.test(tokenAfterArrowBody.value)) {
+
+                                // Don't do a fix if the next token would cause ASI issues when preceded by the returned value.
+                                return null;
+                            }
+
                             const textBeforeReturn = sourceText.slice(arrowBody.range[0] + 1, returnKeyword.range[0]);
                             const textBetweenReturnAndValue = sourceText.slice(returnKeyword.range[1], firstValueToken.range[0]);
                             const rawReturnValueText = sourceText.slice(firstValueToken.range[0], lastValueToken.range[1]);

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -75,7 +75,7 @@ module.exports = {
                 }
 
                 if (asNeeded && requireReturnForObjectLiteral && blockBody[0].type === "ReturnStatement" &&
-                    blockBody[0].argument.type === "ObjectExpression") {
+                    blockBody[0].argument && blockBody[0].argument.type === "ObjectExpression") {
                     return;
                 }
 
@@ -85,16 +85,29 @@ module.exports = {
                         loc: arrowBody.loc.start,
                         message: "Unexpected block statement surrounding arrow body.",
                         fix(fixer) {
-                            if (blockBody.length !== 1 || blockBody[0].type !== "ReturnStatement") {
+                            if (blockBody.length !== 1 || blockBody[0].type !== "ReturnStatement" || !blockBody[0].argument) {
                                 return null;
                             }
 
-                            const returnValue = blockBody[0].argument;
                             const sourceText = sourceCode.getText();
-                            const textBeforeReturn = sourceText.slice(arrowBody.range[0] + 1, blockBody[0].range[0]);
-                            const textBetweenReturnAndValue = sourceText.slice(sourceCode.getFirstToken(blockBody[0]).range[1], returnValue.range[0]);
-                            const returnValueText = returnValue.type === "ObjectExpression" ? `(${sourceCode.getText(returnValue)})` : sourceCode.getText(returnValue);
-                            const textAfterValue = sourceText.slice(returnValue.range[1], blockBody[0].range[1] - 1);
+                            const returnKeyword = sourceCode.getFirstToken(blockBody[0]);
+                            const firstValueToken = sourceCode.getTokenAfter(returnKeyword);
+                            let lastValueToken = sourceCode.getLastToken(blockBody[0]);
+
+                            if (lastValueToken.type === "Punctuator" && lastValueToken.value === ";") {
+
+                                /* The last token of the returned value is the last token of the ReturnExpression (if
+                                 * the ReturnExpression has no semicolon), or the second-to-last token (if the ReturnExpression
+                                 * has a semicolon).
+                                 */
+                                lastValueToken = sourceCode.getTokenBefore(lastValueToken);
+                            }
+
+                            const textBeforeReturn = sourceText.slice(arrowBody.range[0] + 1, returnKeyword.range[0]);
+                            const textBetweenReturnAndValue = sourceText.slice(returnKeyword.range[1], firstValueToken.range[0]);
+                            const rawReturnValueText = sourceText.slice(firstValueToken.range[0], lastValueToken.range[1]);
+                            const returnValueText = firstValueToken.value === "{" ? `(${rawReturnValueText})` : rawReturnValueText;
+                            const textAfterValue = sourceText.slice(lastValueToken.range[1], blockBody[0].range[1] - 1);
                             const textAfterReturnStatement = sourceText.slice(blockBody[0].range[1], arrowBody.range[1] - 1);
 
                             return fixer.replaceText(arrowBody, textBeforeReturn + textBetweenReturnAndValue + returnValueText + textAfterValue + textAfterReturnStatement);

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -200,6 +200,51 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+
+            // Not fixed; fixing would cause ASI issues.
+            code:
+            "var foo = () => { return bar }\n" +
+            "[1, 2, 3].map(foo)",
+            output:
+            "var foo = () => { return bar }\n" +
+            "[1, 2, 3].map(foo)",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["never"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+
+            // Not fixed; fixing would cause ASI issues.
+            code:
+            "var foo = () => { return bar }\n" +
+            "(1).toString();",
+            output:
+            "var foo = () => { return bar }\n" +
+            "(1).toString();",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["never"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+
+            // Fixing here is ok because the arrow function has a semicolon afterwards.
+            code:
+            "var foo = () => { return bar };\n" +
+            "[1, 2, 3].map(foo)",
+            output:
+            "var foo = () =>   bar ;\n" +
+            "[1, 2, 3].map(foo)",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["never"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
             code: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ { /* e */ return /* f */ 5 /* g */ ; /* h */ } /* i */ ;",
             output: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */  /* e */  /* f */ 5 /* g */  /* h */  /* i */ ;",
             parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -66,7 +66,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return 0; };",
-            output: "var foo = () =>   0 ;",
+            output: "var foo = () => 0;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -75,7 +75,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return 0 };",
-            output: "var foo = () =>   0 ;",
+            output: "var foo = () => 0;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -84,7 +84,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return bar(); };",
-            output: "var foo = () =>   bar() ;",
+            output: "var foo = () => bar();",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -102,7 +102,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return { bar: 0 }; };",
-            output: "var foo = () =>   ({ bar: 0 }) ;",
+            output: "var foo = () => ({ bar: 0 });",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -120,7 +120,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return ( /* a */ {ok: true} /* b */ ) };",
-            output: "var foo = () =>   ( /* a */ {ok: true} /* b */ ) ;",
+            output: "var foo = () => ( /* a */ {ok: true} /* b */ );",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -129,7 +129,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return '{' };",
-            output: "var foo = () =>   '{' ;",
+            output: "var foo = () => '{';",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -138,7 +138,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return { bar: 0 }.bar; };",
-            output: "var foo = () =>   ({ bar: 0 }.bar) ;",
+            output: "var foo = () => ({ bar: 0 }.bar);",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -156,7 +156,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return 0; };",
-            output: "var foo = () =>   0 ;",
+            output: "var foo = () => 0;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
@@ -165,7 +165,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return bar(); };",
-            output: "var foo = () =>   bar() ;",
+            output: "var foo = () => bar();",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
@@ -236,7 +236,7 @@ ruleTester.run("arrow-body-style", rule, {
             "var foo = () => { return bar };\n" +
             "[1, 2, 3].map(foo)",
             output:
-            "var foo = () =>   bar ;\n" +
+            "var foo = () => bar;\n" +
             "[1, 2, 3].map(foo)",
             parserOptions: { ecmaVersion: 6 },
             options: ["never"],

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -110,6 +110,42 @@ ruleTester.run("arrow-body-style", rule, {
             ]
         },
         {
+            code: "var foo = () => { return; };",
+            output: "var foo = () => { return; };", // not fixed
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed", {requireReturnForObjectLiteral: true}],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => { return ( /* a */ {ok: true} /* b */ ) };",
+            output: "var foo = () =>   ( /* a */ {ok: true} /* b */ ) ;",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => { return '{' };",
+            output: "var foo = () =>   '{' ;",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => { return { bar: 0 }.bar; };",
+            output: "var foo = () =>   ({ bar: 0 }.bar) ;",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
             code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};",
             output: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};", // not fixed
             parserOptions: { ecmaVersion: 6 },

--- a/tests/lib/rules/arrow-body-style.js
+++ b/tests/lib/rules/arrow-body-style.js
@@ -48,6 +48,7 @@ ruleTester.run("arrow-body-style", rule, {
     invalid: [
         {
             code: "var foo = () => 0;",
+            output: "var foo = () => {return 0};",
             parserOptions: { ecmaVersion: 6 },
             options: ["always"],
             errors: [
@@ -56,6 +57,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => ({});",
+            output: "var foo = () => {return ({})};",
             parserOptions: { ecmaVersion: 6 },
             options: ["always"],
             errors: [
@@ -64,6 +66,16 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return 0; };",
+            output: "var foo = () =>   0 ;",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed"],
+            errors: [
+                { line: 1, column: 17, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => { return 0 };",
+            output: "var foo = () =>   0 ;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -72,6 +84,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return bar(); };",
+            output: "var foo = () =>   bar() ;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -80,6 +93,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => {\nreturn 0;\n};",
+            output: "var foo = () => \n 0\n;",
             parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
@@ -88,6 +102,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return { bar: 0 }; };",
+            output: "var foo = () =>   ({ bar: 0 }) ;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed"],
             errors: [
@@ -96,6 +111,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};",
+            output: "var foo = (retv, name) => {\nretv[name] = true;\nreturn retv;\n};", // not fixed
             parserOptions: { ecmaVersion: 6 },
             options: ["never"],
             errors: [
@@ -104,6 +120,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return 0; };",
+            output: "var foo = () =>   0 ;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
@@ -112,6 +129,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => { return bar(); };",
+            output: "var foo = () =>   bar() ;",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
@@ -120,6 +138,7 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => ({});",
+            output: "var foo = () => {return ({})};",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
@@ -128,10 +147,38 @@ ruleTester.run("arrow-body-style", rule, {
         },
         {
             code: "var foo = () => ({ bar: 0 });",
+            output: "var foo = () => {return ({ bar: 0 })};",
             parserOptions: { ecmaVersion: 6 },
             options: ["as-needed", {requireReturnForObjectLiteral: true }],
             errors: [
                 { line: 1, column: 18, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = () => (((((((5)))))));",
+            output: "var foo = () => {return (((((((5)))))))};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["always"],
+            errors: [
+                { line: 1, column: 24, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ { /* e */ return /* f */ 5 /* g */ ; /* h */ } /* i */ ;",
+            output: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */  /* e */  /* f */ 5 /* g */  /* h */  /* i */ ;",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["as-needed"],
+            errors: [
+                { line: 1, column: 50, type: "ArrowFunctionExpression", message: "Unexpected block statement surrounding arrow body." }
+            ]
+        },
+        {
+            code: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ ( /* e */ 5 /* f */ ) /* g */ ;",
+            output: "var foo = /* a */ ( /* b */ ) /* c */ => /* d */ {return ( /* e */ 5 /* f */ )} /* g */ ;",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["always"],
+            errors: [
+                { line: 1, column: 60, type: "ArrowFunctionExpression", message: "Expected block statement surrounding arrow body." }
             ]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`arrow-body-style`](http://eslint.org/docs/rules/arrow-body-style).

```js
/* eslint arrow-body-style: [2, "as-needed"] */

var foo = () => { return 5; };
var bar = () => { return {ok: true}; };

// gets fixed to:

var foo = () =>   5 ;
var bar = () =>   ({ok: true}) ;
```

```js
/* eslint arrow-body-style: [2, "always"] */

var foo = () => 5;
var bar = () => ({ok: true});

// gets fixed to:

var foo = () => {return 5};
var bar = () => {return ({ok: true})};
```

```js
/* eslint arrow-body-style: [2, "never"] */

var foo = () => { bar(); return baz(); }; // not fixed
```

The fixer preserves all comments and whitespace. On the next pass, the fixers for `brace-style`, `indent`, `no-multi-spaces`, `no-extra-parens`, `semi`, and `keyword-spacing` will be able to clean up stylistic issues from the outputted code.

**Is there anything you'd like reviewers to focus on?**

We should make sure there are no cases where replacing a block body with a literal (or vice versa) causes a SyntaxError.

~~The build will fail at the moment due to https://github.com/eslint/eslint/issues/7239. I'll rebase onto master after that's fixed.~~
