### PR TITLE
Update: Allow `func-names` to recognize inferred ES6 names (fixes #7235)

### DIFF
--- a/docs/rules/func-names.md
+++ b/docs/rules/func-names.md
@@ -17,6 +17,7 @@ This rule can enforce or disallow the use of named function expressions.
 This rule has a string option:
 
 * `"always"` (default) requires function expressions to have a name
+* `"as-needed"` requires function expressions to have a name, if the name cannot be assigned automatically in an ES6 environment
 * `"never"` disallows named function expressions, except in recursive functions, where a name is needed
 
 ### always
@@ -39,6 +40,34 @@ Examples of **correct** code for this rule with the default `"always"` option:
 /*eslint func-names: ["error", "always"]*/
 
 Foo.prototype.bar = function bar() {};
+
+(function bar() {
+    // ...
+}())
+```
+
+### as-needed
+
+ECMAScript 6 introduced a `name` property on all functions. The value of `name` is determined by evaluating the code around the function to see if a name can be inferred. For example, a function assigned to a variable will automatically have a `name` property equal to the name of the variable. The value of `name` is then used in stack traces for easier debugging.
+
+Examples of **incorrect** code for this rule with the default `"as-needed"` option:
+
+```js
+/*eslint func-names: ["error", "as-needed"]*/
+
+Foo.prototype.bar = function() {};
+
+(function() {
+    // ...
+}())
+```
+
+Examples of **correct** code for this rule with the default `"as-needed"` option:
+
+```js
+/*eslint func-names: ["error", "as-needed"]*/
+
+var bar = function() {};
 
 (function bar() {
     // ...
@@ -74,6 +103,7 @@ Foo.prototype.bar = function() {};
 ## Further Reading
 
 * [Functions Explained](http://markdaggett.com/blog/2013/02/15/functions-explained/)
+* [Function Names in ES6](http://www.2ality.com/2015/09/function-names-es6.html)
 
 ## Compatibility
 

--- a/lib/rules/func-names.js
+++ b/lib/rules/func-names.js
@@ -28,21 +28,23 @@ module.exports = {
 
         schema: [
             {
-                enum: ["always", "never"]
+                enum: ["always", "as-needed", "never"]
             }
         ]
     },
 
     create(context) {
         const never = context.options[0] === "never";
+        const asNeeded = context.options[0] === "as-needed";
 
         /**
          * Determines whether the current FunctionExpression node is a get, set, or
          * shorthand method in an object literal or a class.
+         * @param {ASTNode} node - A node to check.
          * @returns {boolean} True if the node is a get, set, or shorthand method.
          */
-        function isObjectOrClassMethod() {
-            const parent = context.getAncestors().pop();
+        function isObjectOrClassMethod(node) {
+            const parent = node.parent;
 
             return (parent.type === "MethodDefinition" || (
                 parent.type === "Property" && (
@@ -51,6 +53,23 @@ module.exports = {
                     parent.kind === "set"
                 )
             ));
+        }
+
+        /**
+         * Determines whether the current FunctionExpression node has a name that would be
+         * inferred from context in a conforming ES6 environment.
+         * @param {ASTNode} node - A node to check.
+         * @returns {boolean} True if the node would have a name assigned automatically.
+         */
+        function hasInferredName(node) {
+            const parent = node.parent;
+
+            return isObjectOrClassMethod(node) ||
+                (parent.type === "VariableDeclarator" && parent.id.type === "Identifier" && parent.init === node) ||
+                (parent.type === "Property" && parent.value === node) ||
+                (parent.type === "AssignmentExpression" && parent.left.type === "Identifier" && parent.right === node) ||
+                (parent.type === "ExportDefaultDeclaration" && parent.declaration === node) ||
+                (parent.type === "AssignmentPattern" && parent.right === node);
         }
 
         return {
@@ -70,7 +89,7 @@ module.exports = {
                         context.report(node, "Unexpected function expression name.");
                     }
                 } else {
-                    if (!name && !isObjectOrClassMethod()) {
+                    if (!name && (asNeeded ? !hasInferredName(node) : !isObjectOrClassMethod(node))) {
                         context.report(node, "Missing function expression name.");
                     }
                 }

--- a/tests/lib/rules/func-names.js
+++ b/tests/lib/rules/func-names.js
@@ -43,6 +43,56 @@ ruleTester.run("func-names", rule, {
             options: ["always"]
         },
         {
+            code: "class A { constructor(){} foo(){} get bar(){} set baz(value){} static qux(){}}",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "({ foo() {} });",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "var foo = function(){};",
+            options: ["as-needed"]
+        },
+        {
+            code: "({foo: function(){}});",
+            options: ["as-needed"]
+        },
+        {
+            code: "(foo = function(){});",
+            options: ["as-needed"]
+        },
+        {
+            code: "export default (function(){});",
+            options: ["as-needed"],
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            }
+        },
+        {
+            code: "({foo = function(){}} = {});",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "({key: foo = function(){}} = {});",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "[foo = function(){}] = [];",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "function fn(foo = function(){}) {}",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "function foo() {}",
             options: ["never"]
         },
@@ -84,6 +134,37 @@ ruleTester.run("func-names", rule, {
         { code: "var a = new Date(function() {});", errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}] },
         { code: "var test = function(d, e, f) {};", errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}] },
         { code: "new function() {}", errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}] },
+        {
+            code: "Foo.prototype.bar = function() {};",
+            options: ["as-needed"],
+            errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}]
+        },
+        {
+            code: "(function(){}())",
+            options: ["as-needed"],
+            errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}]
+        },
+        {
+            code: "f(function(){})",
+            options: ["as-needed"],
+            errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}]
+        },
+        {
+            code: "var a = new Date(function() {});",
+            options: ["as-needed"],
+            errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}]
+        },
+        {
+            code: "new function() {}",
+            options: ["as-needed"],
+            errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}]
+        },
+        {
+            code: "var {foo} = function(){};",
+            options: ["as-needed"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [{ message: "Missing function expression name.", type: "FunctionExpression"}]
+        },
         {
             code: "var x = function named() {};",
             options: ["never"],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
- [ ] Documentation update
- [ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
- [ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
- [x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
- [ ] Add autofixing to a rule
- [ ] Add a CLI option
- [ ] Add something to the core
- [ ] Other, please explain:

**What rule do you want to change?**

`func-names`

**Does this change cause the rule to produce more or fewer warnings?**

Fewer, when `uninferred` is in use rather than `always`.

**How will the change be implemented? (New option, new default behavior, etc.)?**

New option

**Please provide some example code that this change will affect:**

``` js
var foo = function(){};
```

**What does the rule currently do for this code?**

It will error because the function has no name. While true for ES5, in ES6 the function will be given a name based on the variable it is assigned to.

**What will the rule do after it's changed?**

If `uninferred` is used instead, it will not recognize this as an error.

**Please check each item to ensure your pull request is ready:**
- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

I added new logic that will check the parent nodes to detect more cases where the function name is not strictly needed.

**Is there anything you'd like reviewers to focus on?**

Not specifically, should be relatively straightforward.
