### PR TITLE
Don't require semicolons before unary operators

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -53,7 +53,7 @@ module.exports = {
 
     create(context) {
 
-        const OPT_OUT_PATTERN = /[\[\(\/\+\-]/; // One of [(/+-
+        const OPT_OUT_PATTERN = /^[-[(\/+]$/; // One of [(/+-, but not ++ or --
         const options = context.options[1];
         const never = context.options[0] === "never",
             exceptOneLine = options && options.omitLastInOneLineBlock === true,

--- a/tests/lib/rules/semi.js
+++ b/tests/lib/rules/semi.js
@@ -90,7 +90,9 @@ ruleTester.run("semi", rule, {
         { code: "export default foo || bar", options: ["never"], parserOptions: { sourceType: "module" } },
         { code: "export default (foo) => foo.bar()", options: ["never"], parserOptions: { sourceType: "module" } },
         { code: "export default foo = 42", options: ["never"], parserOptions: { sourceType: "module" } },
-        { code: "export default foo += 42", options: ["never"], parserOptions: { sourceType: "module" } }
+        { code: "export default foo += 42", options: ["never"], parserOptions: { sourceType: "module" } },
+        { code: "++\nfoo;", options: ["always"] },
+        { code: "var a = b;\n+ c", options: ["never"] }
 
     ],
     invalid: [
@@ -163,6 +165,7 @@ ruleTester.run("semi", rule, {
         { code: "export default foo || bar;", output: "export default foo || bar", options: ["never"], parserOptions: { sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
         { code: "export default (foo) => foo.bar();", output: "export default (foo) => foo.bar()", options: ["never"], parserOptions: { sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
         { code: "export default foo = 42;", output: "export default foo = 42", options: ["never"], parserOptions: { sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
-        { code: "export default foo += 42;", output: "export default foo += 42", options: ["never"], parserOptions: { sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] }
+        { code: "export default foo += 42;", output: "export default foo += 42", options: ["never"], parserOptions: { sourceType: "module" }, errors: [{ message: "Extra semicolon.", type: "ExportDefaultDeclaration" }] },
+        { code: "a;\n++b", output: "a\n++b", options: ["never"], errors: [{ message: "Extra semicolon." }] }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

**What rule do you want to change?**

semi

**Does this change cause the rule to produce more or fewer warnings?**

more (with `"never"`)

**How will the change be implemented? (New option, new default behavior, etc.)?**

Change to behavior of `"never"` option

**Please provide some example code that this change will affect:**

```js
a;
++b;
```

**What does the rule currently do for this code?**

Give only one error.

**What will the rule do after it's changed?**

Give two errors.


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [ ] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [X] I've included tests for my change
- [ ] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**


**Is there anything you'd like reviewers to focus on?**