### PR TITLE
Fix: `no-unused-vars` false positive (fixes #7250)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -428,12 +428,12 @@ module.exports = {
                 return true;
             }
 
-            // if all parameters preceded by this variable are ignored, this is the last.
+            // if all parameters preceded by this variable are ignored and unused, this is the last.
             if (config.argsIgnorePattern) {
                 const params = context.getDeclaredVariables(def.node);
                 const posteriorParams = params.slice(params.indexOf(variable) + 1);
 
-                if (posteriorParams.every(v => config.argsIgnorePattern.test(v.name))) {
+                if (posteriorParams.every(v => v.references.length === 0 && config.argsIgnorePattern.test(v.name))) {
                     return true;
                 }
             }

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -225,6 +225,17 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{argsIgnorePattern: "d"}],
             parserOptions: {ecmaVersion: 6}
         },
+
+        // https://github.com/eslint/eslint/issues/7250
+        {
+            code: "(function(a, b, c) { c })",
+            options: [{argsIgnorePattern: "c"}],
+        },
+        {
+            code: "(function(a, b, {c, d}) { c })",
+            options: [{argsIgnorePattern: "[cd]"}],
+            parserOptions: {ecmaVersion: 6},
+        },
     ],
     invalid: [
         { code: "function foox() { return foox(); }", errors: [{ message: "'foox' is defined but never used.", type: "Identifier"}] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #7250 for template.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- ~~I've updated documentation for my change (if appropriate)~~

**What changes did you make? (Give an overview)**

I had changed the `after-used` option's behavior in #7143 in order to fix the false negative that the rule overlooks unused variables if the last parameter is ignored by `argsIgnorePattern`.

Now, the rule has false positive that it warns the last non-ignored parameter even if the last (ignored) parameter is used.
This PR fixes the false positive.

`semver-patch`: A bug fix in a rule that results in ESLint reporting fewer errors.

**Is there anything you'd like reviewers to focus on?**

- Is this fix needed?
