### PR TITLE
Update: Ensure `indent` handles nested functions correctly (fixes #7249)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -939,7 +939,7 @@ module.exports = {
                 if (options.FunctionDeclaration.parameters === "first" && node.params.length) {
                     checkNodesIndent(node.params.slice(1), node.params[0].loc.start.column);
                 } else if (options.FunctionDeclaration.parameters !== null) {
-                    checkNodesIndent(node.params, indentSize * options.FunctionDeclaration.parameters);
+                    checkNodesIndent(node.params, getNodeIndent(node).goodChar + indentSize * options.FunctionDeclaration.parameters);
                 }
             },
 
@@ -950,7 +950,7 @@ module.exports = {
                 if (options.FunctionExpression.parameters === "first" && node.params.length) {
                     checkNodesIndent(node.params.slice(1), node.params[0].loc.start.column);
                 } else if (options.FunctionExpression.parameters !== null) {
-                    checkNodesIndent(node.params, indentSize * options.FunctionExpression.parameters);
+                    checkNodesIndent(node.params, getNodeIndent(node).goodChar + indentSize * options.FunctionExpression.parameters);
                 }
             }
         };

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1564,10 +1564,39 @@ ruleTester.run("indent", rule, {
         {
             code:
             "function foo() {\n" +
+            "  function bar() {\n" +
+            "    baz();\n" +
+            "  }\n" +
+            "}",
+            options: [2, {FunctionDeclaration: {body: 1}}]
+        },
+        {
+            code:
+            "function foo() {\n" +
             "  bar();\n" +
             "   \t\t}",
             options: [2]
         },
+        {
+            code:
+            "function foo() {\n" +
+            "  function bar(baz,\n" +
+            "      qux) {\n" +
+            "    foobar();\n" +
+            "  }\n" +
+            "}",
+            options: [2, {FunctionDeclaration: {body: 1, parameters: 2}}]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  var bar = function(baz,\n" +
+            "        qux) {\n" +
+            "    foobar();\n" +
+            "  };\n" +
+            "}",
+            options: [2, {FunctionExpression: {parameters: 3}}]
+        }
     ],
     invalid: [
         {
@@ -2878,6 +2907,70 @@ ruleTester.run("indent", rule, {
             "}",
             options: ["tab"],
             errors: expectedErrors("tab", [[3, "1 tab", "2 spaces", "ExpressionStatement"], [4, "1 tab", "14 spaces", "ExpressionStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "\t\t}",
+            output:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "}",
+            options: [2],
+            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  function bar() {\n" +
+            "        baz();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  function bar() {\n" +
+            "    baz();\n" +
+            "  }\n" +
+            "}",
+            options: [2, {FunctionDeclaration: {body: 1}}],
+            errors: expectedErrors([3, 4, 8, "ExpressionStatement"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  function bar(baz,\n" +
+            "    qux) {\n" +
+            "    foobar();\n" +
+            "  }\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  function bar(baz,\n" +
+            "      qux) {\n" +
+            "    foobar();\n" +
+            "  }\n" +
+            "}",
+            options: [2, {FunctionDeclaration: {body: 1, parameters: 2}}],
+            errors: expectedErrors([3, 6, 4, "Identifier"])
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  var bar = function(baz,\n" +
+            "          qux) {\n" +
+            "    foobar();\n" +
+            "  };\n" +
+            "}",
+            output:
+            "function foo() {\n" +
+            "  var bar = function(baz,\n" +
+            "        qux) {\n" +
+            "    foobar();\n" +
+            "  };\n" +
+            "}",
+            options: [2, {FunctionExpression: {parameters: 3}}],
+            errors: expectedErrors([3, 8, 10, "Identifier"])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #7249


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This ensures that `indent` handles the parameters of nested function declarations and function expressions correctly. Previously, it was not accounting for the initial offset of a function, so it would always require the same parameter indent regardless of whether the function itself was indented.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
