### PR TITLE
Fix: avoid indent and no-mixed-spaces-and-tabs conflicts (fixes #7248)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -233,6 +233,12 @@ module.exports = {
          */
         function report(node, needed, gottenSpaces, gottenTabs, loc, isLastNodeCheck) {
 
+            if (gottenSpaces && gottenTabs) {
+
+                // To avoid conflicts with `no-mixed-spaces-and-tabs`, don't report lines that have both spaces and tabs.
+                return;
+            }
+
             const desiredIndent = (indentType === "space" ? " " : "\t").repeat(needed);
 
             const textRange = isLastNodeCheck

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1551,7 +1551,23 @@ ruleTester.run("indent", rule, {
             "      bar();\n" +
             "}",
             options: [2, {FunctionExpression: {parameters: "first", body: 3}}] // FIXME: make sure this is correct
-        }
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "  \tbaz();\n" +
+            "\t   \t\t\t  \t\t\t  \t   \tqux();\n" +
+            "}",
+            options: [2]
+        },
+        {
+            code:
+            "function foo() {\n" +
+            "  bar();\n" +
+            "   \t\t}",
+            options: [2]
+        },
     ],
     invalid: [
         {
@@ -2840,35 +2856,19 @@ ruleTester.run("indent", rule, {
         {
             code:
             "var foo = bar;\n" +
-            "  \t  \t  \t  var baz = qux;",
+            "\t\t\tvar baz = qux;",
             output:
             "var foo = bar;\n" +
             "var baz = qux;",
             options: [2],
-            errors: expectedErrors([2, "0 spaces", "8 spaces and 3 tabs", "VariableDeclaration"])
-        },
-        {
-            code:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "  \tbaz();\n" +
-            "\t   \t\t\t  \t\t\t  \t   \tqux();\n" +
-            "}",
-            output:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "  baz();\n" +
-            "  qux();\n" +
-            "}",
-            options: [2],
-            errors: expectedErrors([[3, "2 spaces", "2 spaces and 1 tab", "ExpressionStatement"], [4, "2 spaces", "10 spaces and 9 tabs", "ExpressionStatement"]])
+            errors: expectedErrors([2, "0 spaces", "3 tabs", "VariableDeclaration"])
         },
         {
             code:
             "function foo() {\n" +
             "\tbar();\n" +
-            "\t  baz();\n" +
-            "  \t\t \t     \t   \t  \t\t\t qux();\n" +
+            "  baz();\n" +
+            "              qux();\n" +
             "}",
             output:
             "function foo() {\n" +
@@ -2877,19 +2877,7 @@ ruleTester.run("indent", rule, {
             "\tqux();\n" +
             "}",
             options: ["tab"],
-            errors: expectedErrors("tab", [[3, "1 tab", "2 spaces and 1 tab", "ExpressionStatement"], [4, "1 tab", "14 spaces and 8 tabs", "ExpressionStatement"]])
-        },
-        {
-            code:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "\t\t}",
-            output:
-            "function foo() {\n" +
-            "  bar();\n" +
-            "}",
-            options: [2],
-            errors: expectedErrors([[3, "0 spaces", "2 tabs", "BlockStatement"]])
+            errors: expectedErrors("tab", [[3, "1 tab", "2 spaces", "ExpressionStatement"], [4, "1 tab", "14 spaces", "ExpressionStatement"]])
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7248

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This updates `indent` to not report lines that have mixed spaces and tabs, to avoid conflicts with the `no-mixed-spaces-and-tabs` rule.

I think this is better than reverting https://github.com/eslint/eslint/commit/8b3fc321535b6e4103b9dbf66109af1cc9d3104d, because if that commit is reverted, then `indent`'s autofix will be broken again on lines containing mixed spaces and tabs (see https://github.com/eslint/eslint/issues/4274).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
