### PR TITLE
Update: add fixer for `prefer-spread`

### DIFF
--- a/docs/rules/prefer-spread.md
+++ b/docs/rules/prefer-spread.md
@@ -1,5 +1,7 @@
 # Suggest using the spread operator instead of `.apply()`. (prefer-spread)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Before ES2015, one must use `Function.prototype.apply()` to call variadic functions.
 
 ```js

--- a/tests/lib/rules/prefer-spread.js
+++ b/tests/lib/rules/prefer-spread.js
@@ -16,7 +16,7 @@ const RuleTester = require("../../../lib/testers/rule-tester");
 // Tests
 //------------------------------------------------------------------------------
 
-const errors = [{message: "use the spread operator instead of the '.apply()'.", type: "CallExpression"}];
+const errors = [{message: "Use the spread operator instead of '.apply()'.", type: "CallExpression"}];
 
 const ruleTester = new RuleTester();
 
@@ -38,16 +38,60 @@ ruleTester.run("prefer-spread", rule, {
 
         // ignores incomplete things.
         {code: "foo.apply();"},
-        {code: "obj.foo.apply();"}
+        {code: "obj.foo.apply();"},
+        {
+            code: "obj.foo.apply(obj, ...args)",
+            parserOptions: {ecmaVersion: 6}
+        }
     ],
     invalid: [
-        {code: "foo.apply(undefined, args);", errors},
-        {code: "foo.apply(void 0, args);", errors},
-        {code: "foo.apply(null, args);", errors},
-        {code: "obj.foo.apply(obj, args);", errors},
-        {code: "a.b.c.foo.apply(a.b.c, args);", errors},
-        {code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);", errors},
-        {code: "[].concat.apply([ ], args);", errors},
-        {code: "[].concat.apply([\n/*empty*/\n], args);", errors}
+        {
+            code: "foo.apply(undefined, args);",
+            output: "foo(...args);",
+            errors
+        },
+        {
+            code: "foo.apply(void 0, args);",
+            output: "foo(...args);",
+            errors
+        },
+        {
+            code: "foo.apply(null, args);",
+            output: "foo(...args);",
+            errors
+        },
+        {
+            code: "obj.foo.apply(obj, args);",
+            output: "obj.foo(...args);",
+            errors
+        },
+        {
+
+            // Not fixed: a.b.c might activate getters
+            code: "a.b.c.foo.apply(a.b.c, args);",
+            output: "a.b.c.foo.apply(a.b.c, args);",
+            errors
+        },
+        {
+
+            // Not fixed: a.b(x, y).c might activate getters
+            code: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);",
+            output: "a.b(x, y).c.foo.apply(a.b(x, y).c, args);",
+            errors
+        },
+        {
+
+            // Not fixed (not an identifier)
+            code: "[].concat.apply([ ], args);",
+            output: "[].concat.apply([ ], args);",
+            errors
+        },
+        {
+
+            // Not fixed (not an identifier)
+            code: "[].concat.apply([\n/*empty*/\n], args);",
+            output: "[].concat.apply([\n/*empty*/\n], args);",
+            errors
+        }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`prefer-spread`](http://eslint.org/docs/rules/prefer-spread).

```js
foo.apply(null, bar);
foo.bar.apply(foo, qux);

// gets fixed to:

foo(...bar);
foo.bar(...qux);
```

To avoid breaking code if getters are used, the following is not fixed:

```js
// not fixed; the fix might cause an error if `foo.bar` activates a getter.
foo.bar.baz.apply(foo.bar, qux);
```

**Is there anything you'd like reviewers to focus on?**

There are a few contrived scenarios where this fix will change the behavior of code. Specifically, the spread operator works on any object with `Symbol.iterator`, but `Function.prototype.apply` only works with array-like objects.

```js
function foo() {
  console.log(arguments[0]);
}

foo.apply(null, new Set([5])); // => undefined
foo(...new Set([5])); // => 5
```

As far as I'm aware, there is no reason that someone would be using `Function.prototype.apply` on a non-array-like iterable, but this is worth considering regardless.