### PR TITLE
Fix: `RuleTester` didn't support `mocha --watch`

### DIFF
--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -182,13 +182,53 @@ RuleTester.resetDefaultConfig = function() {
 };
 
 // default separators for testing
-RuleTester.describe = (typeof describe === "function") ? describe : /* istanbul ignore next */ function(text, method) {
-    return method.apply(this);
-};
+const DESCRIBE = Symbol("describe");
+const IT = Symbol("it");
 
-RuleTester.it = (typeof it === "function") ? it : /* istanbul ignore next */ function(text, method) {
+RuleTester[DESCRIBE] = RuleTester[IT] = null;
+
+/**
+ * This is `it` or `describe` if those don't exist.
+ * @this {Mocha}
+ * @param {string} text - The description of the test case.
+ * @param {Function} method - The logic of the test case.
+ * @returns {any} Returned value of `method`.
+ */
+function defaultHandler(text, method) {
     return method.apply(this);
-};
+}
+
+// If people use `mocha test.js --watch` command, `describe` and `it` function
+// instances are different for each execution. So this should get fresh instance
+// always.
+Object.defineProperties(RuleTester, {
+    describe: {
+        get() {
+            return (
+                RuleTester[DESCRIBE] ||
+                (typeof describe === "function" ? describe : defaultHandler)
+            );
+        },
+        set(value) {
+            RuleTester[DESCRIBE] = value;
+        },
+        configurable: true,
+        enumerable: true,
+    },
+    it: {
+        get() {
+            return (
+                RuleTester[IT] ||
+                (typeof it === "function" ? it : defaultHandler)
+            );
+        },
+        set(value) {
+            RuleTester[IT] = value;
+        },
+        configurable: true,
+        enumerable: true,
+    },
+});
 
 RuleTester.prototype = {
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))

**Tell us about your environment**

* **ESLint Version:** master
* **Node Version:** 6.3.0
* **npm Version:** 3.8.9

**What parser (default, Babel-ESLint, etc.) are you using?**

- default

**Please show your full configuration:**

- https://www.npmjs.com/package/eslint-config-mysticatea

**What did you do? Please include the actual source code causing the issue.**

1. Clone https://github.com/mysticatea/eslint-plugin-node
2. `npm install`
3. `mocha tests/lib/rules/*.js --watch --reporter progress`
4. Edit a `.js` file in the repo.

**What did you expect to happen?**

Mocha re-runs all tests.

```
$ mocha tests/lib/rules/*.js --reporter progress --watch


  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  1348 passing (3s)


  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  1348 passing (3s)
```

**What actually happened? Please include the actual, raw output from ESLint.**

Mocha did not re-run all tests of `eslint.RuleTester`, did re-run other tests.

```
$ mocha tests/lib/rules/*.js --watch --reporter progress


  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  1348 passing (3s)


  [▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬▬]

  3 passing (6ms)
```

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [ ] I've included tests for my change; It's hard to test the behavior of mocha in mocha.
- ~~I've updated documentation for my change (if appropriate)~~

**What changes did you make? (Give an overview)**

There is the cause in `RuleTester`.

`RuleTester` stores `it` and `describe` into the static properties of itself when initialized.
However, when it re-runs tests for a file change, mocha re-defines `it` and `describe`, then mocha re-load js files except inside of node_modules. Then, old `it` and `describe` functions (`RuleTester.it` and `RuleTester.describe` are old!) don't work.

So `RuleTester.it` and `RuleTester.describe` should be fresh instances always.

This PR changes `RuleTester.it` and `RuleTester.describe` to getter/setter pairs.
Those are fresh `it` and `describe` by default.

**Is there anything you'd like reviewers to focus on?**

To write tests about this issue is very hard since we are using mocha itself to run tests.
I confirmed that this PR resolves this issue as doing the repro steps in my local machine.
