### PR TITLE
Fix: no-implicit-coercion should not fix ~. Fixes #7272

### DIFF
--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -224,7 +224,13 @@ module.exports = {
                 if (!operatorAllowed && options.boolean && isBinaryNegatingOfIndexOf(node)) {
                     const recommendation = `${sourceCode.getText(node.argument)} !== -1`;
 
-                    report(node, recommendation);
+                    context.report({
+                        node,
+                        message: "use `{{recommendation}}` instead.",
+                        data: {
+                            recommendation
+                        }
+                    });
                 }
 
                 // +foo

--- a/lib/rules/no-implicit-coercion.js
+++ b/lib/rules/no-implicit-coercion.js
@@ -192,19 +192,24 @@ module.exports = {
         * Reports an error and autofixes the node
         * @param {ASTNode} node - An ast node to report the error on.
         * @param {string} recommendation - The recommended code for the issue
+        * @param {bool} shouldFix - Whether this report should fix the node
         * @returns {void}
         */
-        function report(node, recommendation) {
-            context.report({
+        function report(node, recommendation, shouldFix) {
+            shouldFix = typeof shouldFix === "undefined" ? true : shouldFix;
+            const reportObj = {
                 node,
                 message: "use `{{recommendation}}` instead.",
                 data: {
                     recommendation
-                },
-                fix(fixer) {
-                    return fixer.replaceText(node, recommendation);
                 }
-            });
+            };
+
+            if (shouldFix) {
+                reportObj.fix = fixer => fixer.replaceText(node, recommendation);
+            }
+
+            context.report(reportObj);
         }
 
         return {
@@ -224,13 +229,7 @@ module.exports = {
                 if (!operatorAllowed && options.boolean && isBinaryNegatingOfIndexOf(node)) {
                     const recommendation = `${sourceCode.getText(node.argument)} !== -1`;
 
-                    context.report({
-                        node,
-                        message: "use `{{recommendation}}` instead.",
-                        data: {
-                            recommendation
-                        }
-                    });
+                    report(node, recommendation, false);
                 }
 
                 // +foo

--- a/tests/lib/rules/no-implicit-coercion.js
+++ b/tests/lib/rules/no-implicit-coercion.js
@@ -104,12 +104,12 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "~foo.indexOf(1)",
             errors: [{message: "use `foo.indexOf(1) !== -1` instead.", type: "UnaryExpression"}],
-            output: "foo.indexOf(1) !== -1"
+            output: "~foo.indexOf(1)"
         },
         {
             code: "~foo.bar.indexOf(2)",
             errors: [{message: "use `foo.bar.indexOf(2) !== -1` instead.", type: "UnaryExpression"}],
-            output: "foo.bar.indexOf(2) !== -1"
+            output: "~foo.bar.indexOf(2)"
         },
         {
             code: "+foo",
@@ -199,7 +199,7 @@ ruleTester.run("no-implicit-coercion", rule, {
         {
             code: "var a = ~foo.indexOf(1)", options: [{boolean: true, allow: ["!!"]}],
             errors: [{message: "use `foo.indexOf(1) !== -1` instead.", type: "UnaryExpression"}],
-            output: "var a = foo.indexOf(1) !== -1"
+            output: "var a = ~foo.indexOf(1)"
         },
         {
             code: "var a = 1 * foo", options: [{boolean: true, allow: ["+"]}],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://github.com/eslint/eslint/blob/master/templates/bug-report.md))
[ ] New rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://github.com/eslint/eslint/blob/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->
https://github.com/eslint/eslint/issues/7272


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
no-implic-coercion now only makes recommendations and will not attempt to fix anything using the `~` operator.

**Is there anything you'd like reviewers to focus on?**
Nope


