### PR TITLE
Fix: Use the correct location for `comma-dangle` errors (fixes #7291)

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -155,7 +155,7 @@ module.exports = {
             if (trailingToken.value !== ",") {
                 context.report({
                     node: lastItem,
-                    loc: lastItem.loc.end,
+                    loc: penultimateToken.loc.end,
                     message: MISSING_MESSAGE,
                     fix(fixer) {
                         return fixer.insertTextAfter(penultimateToken, ",");

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -527,6 +527,33 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+
+            // https://github.com/eslint/eslint/issues/7291
+            code:
+            "var foo = [\n" +
+            "  (bar\n" +
+            "    ? baz\n" +
+            "    : qux\n" +
+            "  )\n" +
+            "];",
+            output:
+            "var foo = [\n" +
+            "  (bar\n" +
+            "    ? baz\n" +
+            "    : qux\n" +
+            "  ),\n" +
+            "];",
+            options: [ "always" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "ConditionalExpression",
+                    line: 5,
+                    column: 4
+                }
+            ]
+        },
+        {
             code: "var foo = { bar: 'baz', }",
             output: "var foo = { bar: 'baz' }",
             options: [ "always-multiline" ],

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -477,6 +477,56 @@ ruleTester.run("comma-dangle", rule, {
             ]
         },
         {
+            code:
+            "var foo = [\n" +
+            "  bar,\n" +
+            "  (\n" +
+            "    baz\n" +
+            "  )\n" +
+            "];",
+            output:
+            "var foo = [\n" +
+            "  bar,\n" +
+            "  (\n" +
+            "    baz\n" +
+            "  ),\n" +
+            "];",
+            options: [ "always" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Identifier",
+                    line: 5,
+                    column: 4
+                }
+            ]
+        },
+        {
+            code:
+            "var foo = {\n" +
+            "  foo: 'bar',\n" +
+            "  baz: (\n" +
+            "    qux\n" +
+            "  )\n" +
+            "};",
+            output:
+            "var foo = {\n" +
+            "  foo: 'bar',\n" +
+            "  baz: (\n" +
+            "    qux\n" +
+            "  ),\n" +
+            "};",
+            options: [ "always" ],
+            errors: [
+                {
+                    message: "Missing trailing comma.",
+                    type: "Property",
+                    line: 5,
+                    column: 4
+                }
+            ]
+        },
+        {
             code: "var foo = { bar: 'baz', }",
             output: "var foo = { bar: 'baz' }",
             options: [ "always-multiline" ],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See #7291

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Previously, `comma-dangle` would report the location of the last node in an array/object if a trailing comma was missing. As a result, the error would sometimes be reported on the wrong line if the node was parenthesized.

This PR fixes the error location; now it always reports the location of the token before the closing `]` or `}`.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

