### PR TITLE
Update: add fixer for `one-var-declaration-per-line`

### DIFF
--- a/docs/rules/one-var-declaration-per-line.md
+++ b/docs/rules/one-var-declaration-per-line.md
@@ -1,5 +1,7 @@
 # require or disallow newlines around variable declarations (one-var-declaration-per-line)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 Some developers declare multiple var statements on the same line:
 
 ```js

--- a/lib/rules/one-var-declaration-per-line.js
+++ b/lib/rules/one-var-declaration-per-line.js
@@ -20,7 +20,9 @@ module.exports = {
             {
                 enum: ["always", "initializations"]
             }
-        ]
+        ],
+
+        fixable: "whitespace"
     },
 
     create(context) {
@@ -63,7 +65,8 @@ module.exports = {
                         context.report({
                             node,
                             message: ERROR_MESSAGE,
-                            loc: current.loc.start
+                            loc: current.loc.start,
+                            fix: fixer => fixer.insertTextBefore(current, "\n")
                         });
                     }
                 }

--- a/tests/lib/rules/one-var-declaration-per-line.js
+++ b/tests/lib/rules/one-var-declaration-per-line.js
@@ -68,22 +68,22 @@ ruleTester.run("one-var-declaration-per-line", rule, {
     ],
 
     invalid: [
-        {code: "var a, b;", options: ["always"], errors: [errorAt(1, 8)]},
-        {code: "let a, b;", options: ["always"], errors: [errorAt(1, 8)], parserOptions: { ecmaVersion: 6 } },
-        {code: "var a, b = 0;", options: ["always"], errors: [errorAt(1, 8)]},
-        {code: "var a = {\n foo: bar\n}, b;", options: ["always"], errors: [errorAt(3, 4)]},
-        {code: "var a\n=0, b;", options: ["always"], errors: [errorAt(2, 5)]},
-        {code: "let a, b = 0;", options: ["always"], errors: [errorAt(1, 8)], parserOptions: { ecmaVersion: 6 } },
-        {code: "const a = 0, b = 0;", options: ["always"], errors: [errorAt(1, 14)], parserOptions: { ecmaVersion: 6 } },
+        {code: "var a, b;", output: "var a, \nb;", options: ["always"], errors: [errorAt(1, 8)]},
+        {code: "let a, b;", output: "let a, \nb;", options: ["always"], errors: [errorAt(1, 8)], parserOptions: { ecmaVersion: 6 } },
+        {code: "var a, b = 0;", output: "var a, \nb = 0;", options: ["always"], errors: [errorAt(1, 8)]},
+        {code: "var a = {\n foo: bar\n}, b;", output: "var a = {\n foo: bar\n}, \nb;", options: ["always"], errors: [errorAt(3, 4)]},
+        {code: "var a\n=0, b;", output: "var a\n=0, \nb;", options: ["always"], errors: [errorAt(2, 5)]},
+        {code: "let a, b = 0;", output: "let a, \nb = 0;", options: ["always"], errors: [errorAt(1, 8)], parserOptions: { ecmaVersion: 6 } },
+        {code: "const a = 0, b = 0;", output: "const a = 0, \nb = 0;", options: ["always"], errors: [errorAt(1, 14)], parserOptions: { ecmaVersion: 6 } },
 
-        {code: "var a, b, c = 0;", options: ["initializations"], errors: [errorAt(1, 11)] },
-        {code: "var a, b,\nc = 0, d;", options: ["initializations"], errors: [errorAt(2, 8)] },
-        {code: "var a, b,\nc = 0, d = 0;", options: ["initializations"], errors: [errorAt(2, 8)] },
-        {code: "var a\n=0, b = 0;", options: ["initializations"], errors: [errorAt(2, 5)] },
-        {code: "var a = {\n foo: bar\n}, b;", options: ["initializations"], errors: [errorAt(3, 4)] },
+        {code: "var a, b, c = 0;", output: "var a, b, \nc = 0;", options: ["initializations"], errors: [errorAt(1, 11)] },
+        {code: "var a, b,\nc = 0, d;", output: "var a, b,\nc = 0, \nd;", options: ["initializations"], errors: [errorAt(2, 8)] },
+        {code: "var a, b,\nc = 0, d = 0;", output: "var a, b,\nc = 0, \nd = 0;", options: ["initializations"], errors: [errorAt(2, 8)] },
+        {code: "var a\n=0, b = 0;", output: "var a\n=0, \nb = 0;", options: ["initializations"], errors: [errorAt(2, 5)] },
+        {code: "var a = {\n foo: bar\n}, b;", output: "var a = {\n foo: bar\n}, \nb;", options: ["initializations"], errors: [errorAt(3, 4)] },
 
-        {code: "for(var a = 0, b = 0;;){\nvar c,d;}", options: ["always"], errors: [errorAt(2, 7)] },
-        {code: "export let a, b;", options: ["always"], errors: [errorAt(1, 15)], parserOptions: { sourceType: "module" } },
-        {code: "export let a, b = 0;", options: ["initializations"], errors: [errorAt(1, 15)], parserOptions: { sourceType: "module" } }
+        {code: "for(var a = 0, b = 0;;){\nvar c,d;}", output: "for(var a = 0, b = 0;;){\nvar c,\nd;}", options: ["always"], errors: [errorAt(2, 7)] },
+        {code: "export let a, b;", output: "export let a, \nb;", options: ["always"], errors: [errorAt(1, 15)], parserOptions: { sourceType: "module" } },
+        {code: "export let a, b = 0;", output: "export let a, \nb = 0;", options: ["initializations"], errors: [errorAt(1, 15)], parserOptions: { sourceType: "module" } }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This adds a fixer for [`one-var-declaration-per-line`](http://eslint.org/docs/rules/one-var-declaration-per-line). It inserts a newline before variable declarators where the rule reports an error.

```js
/* eslint one-var-declaration-per-line: 2 */

var a = 1, b = 2;

// gets fixed to:

var a = 1, 
b = 2;
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
