### PR TITLE
Fix: Don't require commas after rest properties (fixes #7297)

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -13,14 +13,17 @@ const lodash = require("lodash");
 
 /**
  * Checks whether or not a trailing comma is allowed in a given node.
- * `ArrayPattern` which has `RestElement` disallows it.
+ * `ArrayPattern` which has `RestElement` or `ObjectPattern` which has `RestProperty` disallows it.
  *
  * @param {ASTNode} node - A node to check.
  * @param {ASTNode} lastItem - The node of the last element in the given node.
  * @returns {boolean} `true` if a trailing comma is allowed.
  */
 function isTrailingCommaAllowed(node, lastItem) {
-    return node.type !== "ArrayPattern" || lastItem.type !== "RestElement";
+    return !(
+        (node.type === "ArrayPattern" && lastItem.type === "RestElement") ||
+        (node.type === "ObjectPattern" && (lastItem.type === "RestProperty" || lastItem.type === "ExperimentalRestProperty"))
+    );
 }
 
 //------------------------------------------------------------------------------

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -116,6 +116,13 @@ ruleTester.run("comma-dangle", rule, {
             options: ["always"]
         },
 
+        // https://github.com/eslint/eslint/issues/7297
+        {
+            code: "var {foo, ...bar} = baz",
+            parserOptions: { ecmaVersion: 8, ecmaFeatures: { experimentalObjectRestSpread: true } },
+            options: ["always"]
+        },
+
         // https://github.com/eslint/eslint/issues/3794
         {
             code: "import {foo,} from 'foo';",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7297

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This fixes `comma-dangle` to not require trailing commas after rest properties with `experimentalObjectRestSpread` enabled, since this is a SyntaxError according to the [spec](https://sebmarkbage.github.io/ecmascript-rest-spread/).

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

