### PR TITLE
Update: Use characters instead of code units for `max-len`

### DIFF
--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -10,8 +10,6 @@ var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficu
 
 This rule enforces a maximum line length to increase code readability and maintainability.
 
-**Note:** This rule calculates the length of a line via code units, not characters. That means if you use a double-byte character in your code, it will count as 2 code units instead of 1, and 2 will be used to calculate line length. This is a technical limitation of JavaScript that is made easier with ES2015, and we will look to update this when ES2015 is available in Node.js.
-
 ## Options
 
 This rule has a number or object option:

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -8,7 +8,7 @@ var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficu
 
 ## Rule Details
 
-This rule enforces a maximum line length to increase code readability and maintainability. The length of a line is defined as the number of unicode characters in the line. (Some unicode characters are composed of more than one code unit.)
+This rule enforces a maximum line length to increase code readability and maintainability. The length of a line is defined as the number of unicode characters in the line.
 
 ## Options
 

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -8,7 +8,7 @@ var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficu
 
 ## Rule Details
 
-This rule enforces a maximum line length to increase code readability and maintainability. The length of a line is defined as the number of unicode characters in the line.
+This rule enforces a maximum line length to increase code readability and maintainability. The length of a line is defined as the number of Unicode characters in the line.
 
 ## Options
 

--- a/docs/rules/max-len.md
+++ b/docs/rules/max-len.md
@@ -8,7 +8,7 @@ var foo = { "bar": "This is a bar.", "baz": { "qux": "This is a qux" }, "difficu
 
 ## Rule Details
 
-This rule enforces a maximum line length to increase code readability and maintainability.
+This rule enforces a maximum line length to increase code readability and maintainability. The length of a line is defined as the number of unicode characters in the line. (Some unicode characters are composed of more than one code unit.)
 
 ## Options
 

--- a/lib/rules/max-len.js
+++ b/lib/rules/max-len.js
@@ -107,7 +107,7 @@ module.exports = {
 
                 extraCharacterCount += spaceCount - 1;  // -1 for the replaced tab
             });
-            return line.length + extraCharacterCount;
+            return Array.from(line).length + extraCharacterCount;
         }
 
         // The options object must be the last option specified…

--- a/tests/lib/rules/max-len.js
+++ b/tests/lib/rules/max-len.js
@@ -158,7 +158,13 @@ ruleTester.run("max-len", rule, {
         },
 
         // blank line
-        ""
+        "",
+
+        // Multi-code-point unicode glyphs
+        {
+            code: "'🙂😀😆😎😊😜😉👍'",
+            options: [10]
+        }
     ],
 
     invalid: [
@@ -499,6 +505,20 @@ ruleTester.run("max-len", rule, {
                     message: "Line 3 exceeds the maximum line length of 29.",
                     type: "Program",
                     line: 3,
+                    column: 1
+                }
+            ]
+        },
+
+        // Multi-code-point unicode glyphs
+        {
+            code: "'🙁😁😟☹️😣😖😩😱👎'",
+            options: [10],
+            errors: [
+                {
+                    message: "Line 1 exceeds the maximum line length of 10.",
+                    type: "Program",
+                    line: 1,
                     column: 1
                 }
             ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

Also see: https://github.com/eslint/eslint/issues/2370

**What rule do you want to change?**

[`max-len`](http://eslint.org/docs/rules/max-len)

**Does this change cause the rule to produce more or fewer warnings?**

Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**

This will change the default behavior.

**Please provide some example code that this change will affect:**

```js
/* eslint max-len: [2, 6] */

'😀🙂😛'
```

**What does the rule currently do for this code?**

It reports an error, because multi-code-unit characters have a `length` of more than 1.

**What will the rule do after it's changed?**

It will not report an error, because the rule will count characters instead of code units.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This updates `max-len` to count the number of characters in a line, rather than the number of code units. Since every character has at least one code unit, the length of a line by this new measurement will never be more than the length by the old measurement, so this will not cause any more errors to be reported.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
