### PR TITLE
Update: Run appveyor tests against travis node versions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,6 +7,8 @@ version: "{build}"
 # What combinations to test
 environment:
   matrix:
+    - nodejs_version: 6
+    - nodejs_version: 5
     - nodejs_version: 4
 
 install:


### PR DESCRIPTION
This updates the appveyor tests to run tests against the same versions that travis runs on.