### PR TITLE
Update: add source property to LintResult object (fixes #7098)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -240,7 +240,15 @@ The return value is an object containing the results of the linting operation. H
 }
 ```
 
-The top-level report object has a `results` array containing all linting results for files that had warnings or errors (any files that did not produce a warning or error are omitted). Each file result includes the `filePath`, a `messages` array, `errorCount`, `warningCount`, and optionally `output`. The `messages` array contains the result of calling `linter.verify()` on the given file. The `errorCount` and `warningCount` give the exact number of errors and warnings respectively on the given file. The `output` property gives the source code for the file with as many fixes applied as possible, so you can use that to rewrite the files if necessary. The top-level report object also has `errorCount` and `warningCount` which give the exact number of errors and warnings respectively on all the files.
+The top-level report object has a `results` array containing all linting results for files that had warnings or errors (any files that did not produce a warning or error are omitted). Each file result includes:
+
+* `filePath` - Path to the given file.
+* `messages` - Array containing the result of calling `linter.verify()` on the given file.
+* `errorCount` and `warningCount` - The exact number of errors and warnings respectively on the given file.
+* `source` - The source code for the given file. This property is omitted if this file has no errors/warnings or if the `output` property is present.
+* `output` - The source code for the given file with as many fixes applied as possible, so you can use that to rewrite the files if necessary. This property is omitted if no fix is available.
+
+The top-level report object also has `errorCount` and `warningCount` which give the exact number of errors and warnings respectively on all the files.
 
 Once you get a report object, it's up to you to determine how to output the results. Fixes will not be automatically applied to the files, even if you set `fix: true` when constructing the `CLIEngine` instance. To apply fixes to the files, call [`outputFixes`](#outputfixes).
 

--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -124,6 +124,8 @@ The information available for each linting message is:
 * `endLine` - the end line of the range on which the error occurred (this property is omitted if it's not range).
 * `fix` - an object describing the fix for the problem (this property is omitted if no fix is available).
 
+**Please note**: the `source` property will be removed from the linting messages in an upcoming breaking release. If you depend on this property, you can still use the `getSourceCode` method described below to get the line of code for each message.
+
 You can also get an instance of the `SourceCode` object used inside of `linter` by using the `getSourceCode()` method:
 
 ```js
@@ -249,6 +251,8 @@ The top-level report object has a `results` array containing all linting results
 * `output` - The source code for the given file with as many fixes applied as possible, so you can use that to rewrite the files if necessary. This property is omitted if no fix is available.
 
 The top-level report object also has `errorCount` and `warningCount` which give the exact number of errors and warnings respectively on all the files.
+
+**Please note**: the `source` property will be removed from the linting messages returned in `messages` in an upcoming breaking release. If you depend on this property, you should now use the top-level `source` or `output` properties instead.
 
 Once you get a report object, it's up to you to determine how to output the results. Fixes will not be automatically applied to the files, even if you set `fix: true` when constructing the `CLIEngine` instance. To apply fixes to the files, call [`outputFixes`](#outputfixes).
 

--- a/docs/developer-guide/working-with-custom-formatters.md
+++ b/docs/developer-guide/working-with-custom-formatters.md
@@ -84,6 +84,8 @@ The following are the fields of the result object:
 - **nodeType**: the type of the node in the [AST](https://github.com/estree/estree/blob/master/spec.md#node-objects)
 - **source**: a extract of the code the line where the failure happened.
 
+**Please note**: the `source` property will be removed from the message object in an upcoming breaking release. If you depend on this property, you should now use the `source` or `output` properties from [the result object](#the-result-object) instead.
+
 ## Examples
 
 ### Summary formatter

--- a/docs/developer-guide/working-with-custom-formatters.md
+++ b/docs/developer-guide/working-with-custom-formatters.md
@@ -28,23 +28,24 @@ The output of the previous command will be something like this
                 "ruleId": "curly",
                 "severity": 2,
                 "message": "Expected { after 'if' condition.",
-                "line": 41,
-                "column": 2,
+                "line": 2,
+                "column": 1,
                 "nodeType": "IfStatement",
-                "source": "  if ( err ) console.log( 'failed tests: ' + err );"
+                "source": "if (err) console.log('failed tests: ' + err);"
             },
             {
                 "ruleId": "no-process-exit",
                 "severity": 2,
                 "message": "Don't use process.exit(); throw an error instead.",
-                "line": 42,
-                "column": 2,
+                "line": 3,
+                "column": 1,
                 "nodeType": "CallExpression",
-                "source": "  process.exit( exitCode );"
+                "source": "process.exit(1);"
             }
         ],
         "errorCount": 2,
-        "warningCount": 0
+        "warningCount": 0,
+        "source": "var err = doStuff();\nif (err) console.log('failed tests: ' + err);\nprocess.exit(1);\n"
     },
     {
         "filePath": "Gruntfile.js",
@@ -67,9 +68,11 @@ the list of messages for `errors` and/or `warnings`.
 The following are the fields of the result object:
 
 - **filePath**: The path to the file relative to the current working directory (the path from which eslint was executed).
-- **messages**: An array of message objects. See below for more info about messages
-- **errorCount**: The number of errors for the given file
-- **warningCount**: the number of warnings for the give file
+- **messages**: An array of message objects. See below for more info about messages.
+- **errorCount**: The number of errors for the given file.
+- **warningCount**: The number of warnings for the given file.
+- **source**: The source code for the given file. This property is omitted if this file has no errors/warnings or if the `output` property is present.
+- **output**: The source code for the given file with as many fixes applied as possible. This property is omitted if no fix is available.
 
 ### The message object
 

--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -75,6 +75,8 @@ const debug = require("debug")("eslint:cli-engine");
  * @property {LintMessage[]} messages All of the messages for the result.
  * @property {number} errorCount Number or errors for the result.
  * @property {number} warningCount Number or warnings for the result.
+ * @property {string=} [source] The source code of the file that was linted.
+ * @property {string=} [output] The source code of the file that was linted, with as many fixes applied as possible.
  */
 
 //------------------------------------------------------------------------------
@@ -175,7 +177,7 @@ function multipassFix(text, config, options) {
 
 
     /*
-     * If the last result had fixes, we need to lint again to me sure we have
+     * If the last result had fixes, we need to lint again to be sure we have
      * the most up-to-date information.
      */
     if (fixedResult.fixed) {
@@ -198,7 +200,7 @@ function multipassFix(text, config, options) {
  * @param {string} filename An optional string representing the texts filename.
  * @param {boolean} fix Indicates if fixes should be processed.
  * @param {boolean} allowInlineConfig Allow/ignore comments that change config.
- * @returns {Result} The results for linting on this text.
+ * @returns {LintResult} The results for linting on this text.
  * @private
  */
 function processText(text, configHelper, filename, fix, allowInlineConfig) {
@@ -279,6 +281,10 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
         result.output = fixedResult.output;
     }
 
+    if (result.errorCount + result.warningCount > 0 && typeof result.output === "undefined") {
+        result.source = text;
+    }
+
     return result;
 }
 
@@ -288,7 +294,7 @@ function processText(text, configHelper, filename, fix, allowInlineConfig) {
  * @param {string} filename The filename of the file being checked.
  * @param {Object} configHelper The configuration options for ESLint.
  * @param {Object} options The CLIEngine options object.
- * @returns {Result} The results for linting on this file.
+ * @returns {LintResult} The results for linting on this file.
  * @private
  */
 function processFile(filename, configHelper, options) {
@@ -304,7 +310,7 @@ function processFile(filename, configHelper, options) {
  * Returns result with warning by ignore settings
  * @param {string} filePath - File path of checked code
  * @param {string} baseDir  - Absolute path of base directory
- * @returns {Result}           Result with single warning
+ * @returns {LintResult} Result with single warning
  * @private
  */
 function createIgnoreResult(filePath, baseDir) {
@@ -524,12 +530,13 @@ CLIEngine.getErrorResults = function(results) {
         const filteredMessages = result.messages.filter(isErrorMessage);
 
         if (filteredMessages.length > 0) {
-            filtered.push({
-                filePath: result.filePath,
-                messages: filteredMessages,
-                errorCount: filteredMessages.length,
-                warningCount: 0
-            });
+            filtered.push(
+                Object.assign(result, {
+                    messages: filteredMessages,
+                    errorCount: filteredMessages.length,
+                    warningCount: 0
+                })
+            );
         }
     });
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

This PR refers to #7098.

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
Add a source property containing the entire file contents as a string into the linting results for each file that has linting errors. This can be used by formatters to output source code along with lint messages. This is a non-breaking change.

**Is there anything you'd like reviewers to focus on?**
A couple of important API decisions were done during the development of this PR in an effort to minimize redundancy and memory usage, and I would like to know if the rest of the team agrees with them:

- The `source` property is omitted if no errors or warnings are present. As there is nothing to report, there is no need for the source code to be present.
- The `source` property is also omitted if there were fixes and a `output` property is present. In this case, the `source` property would be redundant as the `output` property already contains the source code (also, the messages' `column` and `line` properties are updated to correspond to the location on the source code after the fixes)



