### PR TITLE
Fix: avoid `object-shorthand` crash with spread properties (fixes #7305)

### DIFF
--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -175,7 +175,7 @@ module.exports = {
          **/
         function checkConsistency(node, checkRedundancy) {
 
-            // We are excluding getters and setters as they are considered neither longform nor shorthand.
+            // We are excluding getters/setters and spread properties as they are considered neither longform nor shorthand.
             const properties = node.properties.filter(canHaveShorthand);
 
             // Do we still have properties left after filtering the getters and setters?

--- a/lib/rules/object-shorthand.js
+++ b/lib/rules/object-shorthand.js
@@ -118,13 +118,13 @@ module.exports = {
         }
 
         /**
-         * Determines if the property is not a getter and a setter.
+         * Determines if the property can have a shorthand form.
          * @param {ASTNode} property Property AST node
-         * @returns {boolean} True if the property is not a getter and a setter, false if it is.
+         * @returns {boolean} True if the property can have a shorthand form
          * @private
          **/
-        function isNotGetterOrSetter(property) {
-            return (property.kind !== "set" && property.kind !== "get");
+        function canHaveShorthand(property) {
+            return (property.kind !== "set" && property.kind !== "get" && property.type !== "SpreadProperty" && property.type !== "ExperimentalSpreadProperty");
         }
 
         /**
@@ -176,7 +176,7 @@ module.exports = {
         function checkConsistency(node, checkRedundancy) {
 
             // We are excluding getters and setters as they are considered neither longform nor shorthand.
-            const properties = node.properties.filter(isNotGetterOrSetter);
+            const properties = node.properties.filter(canHaveShorthand);
 
             // Do we still have properties left after filtering the getters and setters?
             if (properties.length > 0) {

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -109,7 +109,8 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {foo: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
         { code: "var x = {[foo]: foo}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
         { code: "var x = {foo: function foo() {}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var x = {[foo]: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] }
+        { code: "var x = {[foo]: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
+        { code: "var foo = {...bar}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] }
     ],
     invalid: [
         { code: "var x = {x: x}", output: "var x = {x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },

--- a/tests/lib/rules/object-shorthand.js
+++ b/tests/lib/rules/object-shorthand.js
@@ -94,12 +94,17 @@ ruleTester.run("object-shorthand", rule, {
 
         // ignore object shorthand
         { code: "let {a, b} = o;", parserOptions: { ecmaVersion: 6 }, options: ["never"] },
+        { code: "var x = {foo: foo, bar: bar, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["never"] },
 
         // consistent
         { code: "var x = {a: a, b: b}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
         { code: "var x = {a: b, c: d, f: g}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
         { code: "var x = {a, b}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
         { code: "var x = {a, b, get test() { return 1; }}", parserOptions: { ecmaVersion: 6}, options: ["consistent"] },
+        { code: "var x = {...bar}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
+        { code: "var x = {foo, bar, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent"] },
+        { code: "var x = {bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent"] },
+        { code: "var x = {...foo, bar: bar, baz: baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent"] },
 
         // consistent-as-needed
         { code: "var x = {a, b}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
@@ -110,7 +115,10 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {[foo]: foo}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
         { code: "var x = {foo: function foo() {}}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
         { code: "var x = {[foo]: 'foo'}", parserOptions: { ecmaVersion: 6}, options: ["consistent-as-needed"] },
-        { code: "var foo = {...bar}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] }
+        { code: "var x = {...bar}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
+        { code: "var x = {bar, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
+        { code: "var x = {bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
+        { code: "var x = {...foo, bar, baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, options: ["consistent-as-needed"] },
     ],
     invalid: [
         { code: "var x = {x: x}", output: "var x = {x}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }] },
@@ -151,6 +159,8 @@ ruleTester.run("object-shorthand", rule, {
         { code: "var x = {y: {x}}", output: "var x = {y: {x: x}}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform property syntax.", type: "Property" }], options: ["never"]},
         { code: "var x = {ConstructorFunction(){}, a: b}", output: "var x = {ConstructorFunction: function(){}, a: b}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
         { code: "var x = {notConstructorFunction(){}, b: c}", output: "var x = {notConstructorFunction: function(){}, b: c}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected longform method syntax.", type: "Property" }], options: ["never"] },
+        { code: "var x = {foo: foo, bar: baz, ...qux}", output: "var x = {foo, bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Expected property shorthand.", type: "" }], options: ["always"] },
+        { code: "var x = {foo, bar: baz, ...qux}", output: "var x = {foo: foo, bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Expected longform property syntax.", type: "" }], options: ["never"] },
 
         // avoidQuotes
         { code: "var x = {a: a}", output: "var x = {a}", parserOptions: { ecmaVersion: 6 }, errors: [{ message: "Expected property shorthand.", type: "Property" }], options: ["always", {avoidQuotes: true}] },
@@ -162,10 +172,13 @@ ruleTester.run("object-shorthand", rule, {
         // consistent
         { code: "var x = {a: a, b}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent"] },
         { code: "var x = {b, c: d, f: g}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent"] },
+        { code: "var x = {foo, bar: baz, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent"] },
 
         // consistent-as-needed
         { code: "var x = {a: a, b: b}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
         { code: "var x = {a, z: function z(){}}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent-as-needed"] },
         { code: "var x = {foo: function() {}}", parserOptions: { ecmaVersion: 6}, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
+        { code: "var x = {a: a, b: b, ...baz}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Expected shorthand for all properties.", type: "" }], options: ["consistent-as-needed"] },
+        { code: "var x = {foo, bar: bar, ...qux}", parserOptions: { ecmaVersion: 6, ecmaFeatures: { experimentalObjectRestSpread: true } }, errors: [{ message: "Unexpected mix of shorthand and non-shorthand properties.", type: "" }], options: ["consistent-as-needed"] }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7305

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This updates `object-shorthand` to work correctly with spread properties. Previously, it would crash when it encountered them with the `consistent-as-needed` option; now it categorizes them with getters and setters as properties that do not have a shorthand form.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

