### PR TITLE
Update: Fix false negative of `no-multiple-empty-lines` (fixes #7312)

### DIFF
--- a/lib/rules/no-multiple-empty-lines.js
+++ b/lib/rules/no-multiple-empty-lines.js
@@ -113,8 +113,10 @@ module.exports = {
                 });
 
                 // add the notEmpty lines in there with a placeholder
-                notEmpty.forEach(function(x, i) {
-                    trimmedLines[i] = x;
+                notEmpty.forEach(function(nonEmptyLineNumber) {
+
+                    // FIXME: (not-an-aardvark) Use a better strategy after refactoring this rule
+                    trimmedLines[nonEmptyLineNumber] = "non-empty placeholder string";
                 });
 
                 if (typeof maxEOF === "undefined") {

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -286,6 +286,22 @@ ruleTester.run("no-multiple-empty-lines", rule, {
             output: "// invalid 21\n// unix line endings\nvar a = 5;\nvar b = 3;\n\n",
             errors: [ getExpectedErrorEOF(1) ],
             options: [ { max: 1 } ]
+        },
+        {
+            code:
+            "'foo';\n" +
+            "\n" +
+            "\n" +
+            "`bar`;\n" +
+            "`baz`;",
+            output:
+            "'foo';\n" +
+            "\n" +
+            "`bar`;\n" +
+            "`baz`;",
+            errors: [ getExpectedError(1) ],
+            options: [ { max: 1 } ],
+            parserOptions: { ecmaVersion: 6 }
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7312

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This commit is intended to change as little of the rule's logic as possible in order to fix the issue. I think this rule could use refactoring, which I plan to do afterwards (edit: see https://github.com/eslint/eslint/pull/7314). I made this commit based on the old logic to allow for an easier revert if the refactoring goes wrong somehow.

Bug explanation: The rule stores a list of strings containing the lines of a file, with whitespace trimmed from the start and end of each line. It detects an empty line by checking whether the trimmed line in its list is an empty string.

The rule also has to account for empty lines in template literals (see https://github.com/eslint/eslint/issues/2605). In order to do this, for each line in the file that overlaps a template literal, the rule tries to overwrite the corresponding value in its list of lines with something other than an empty string, to prevent it from detected as an empty line.

Due to a logical error, the rule was overwriting the strings at the *beginning* of its list of lines, rather than the lines that actually contained template literals.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.