### PR TITLE
Update: Improve the error messages for `no-unused-vars` (fixes #7282)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -60,7 +60,8 @@ module.exports = {
 
     create(context) {
 
-        const MESSAGE = "'{{name}}' is defined but never used.";
+        const DEFINED_MESSAGE = "'{{name}}' is defined but never used.";
+        const ASSIGNED_MESSAGE = "'{{name}}' is assigned a value but never used.";
 
         const config = {
             vars: "all",
@@ -596,13 +597,13 @@ module.exports = {
                         context.report({
                             node: programNode,
                             loc: getLocation(unusedVar),
-                            message: MESSAGE,
+                            message: DEFINED_MESSAGE,
                             data: unusedVar
                         });
                     } else if (unusedVar.defs.length > 0) {
                         context.report({
                             node: unusedVar.identifiers[0],
-                            message: MESSAGE,
+                            message: unusedVar.references.some(ref => ref.isWrite()) ? ASSIGNED_MESSAGE : DEFINED_MESSAGE,
                             data: unusedVar
                         });
                     }

--- a/tests/lib/util/source-code.js
+++ b/tests/lib/util/source-code.js
@@ -1199,7 +1199,7 @@ describe("SourceCode", function() {
                 });
 
             assert.equal(messages.length, 1);
-            assert.equal(messages[0].message, "'foo' is defined but never used.");
+            assert.equal(messages[0].message, "'foo' is assigned a value but never used.");
         });
     });
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**


**Does this change cause the rule to produce more or fewer warnings?**

The same amount

**How will the change be implemented? (New option, new default behavior, etc.)?**

The error message will change for the current behavior.

**Please provide some example code that this change will affect:**

```js
var foo;

foo = 1;
```

**What does the rule currently do for this code?**

```
1:5  error  'foo' is defined but never used  no-unused-vars
```

**What will the rule do after it's changed?**

```
1:5  error  'foo' is assigned a value but never used  no-unused-vars
```

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

Also see: https://github.com/eslint/eslint/issues/7282#issuecomment-250937430

This updates the error message for `no-unused-vars`. The new error message is used whenever a variable is assigned at least once (e.g. `var foo = 5;`, `var foo; foo = 5;`). The old error message is used if the variable is never assigned (`var foo;`).

The current behavior has led to a lot of confusion for users (see the linked comment for some examples), so I think this would be a beneficial change.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

