### PR TITLE
Fix: Handle parentheses correctly in `yoda` fixer (fixes #7326)

### DIFF
--- a/lib/rules/yoda.js
+++ b/lib/rules/yoda.js
@@ -239,10 +239,10 @@ module.exports = {
         */
         function getFlippedString(node) {
             const operatorToken = sourceCode.getTokensBetween(node.left, node.right).find(token => token.value === node.operator);
-            const textBeforeOperator = sourceCode.getText().slice(node.left.range[1], operatorToken.range[0]);
-            const textAfterOperator = sourceCode.getText().slice(operatorToken.range[1], node.right.range[0]);
-            const leftText = sourceCode.getText(node.left);
-            const rightText = sourceCode.getText(node.right);
+            const textBeforeOperator = sourceCode.getText().slice(sourceCode.getTokenBefore(operatorToken).range[1], operatorToken.range[0]);
+            const textAfterOperator = sourceCode.getText().slice(operatorToken.range[1], sourceCode.getTokenAfter(operatorToken).range[0]);
+            const leftText = sourceCode.getText().slice(sourceCode.getFirstToken(node).range[0], sourceCode.getTokenBefore(operatorToken).range[1]);
+            const rightText = sourceCode.getText().slice(sourceCode.getTokenAfter(operatorToken).range[0], sourceCode.getLastToken(node).range[1]);
 
             return rightText + textBeforeOperator + OPERATOR_FLIP_MAP[operatorToken.value] + textAfterOperator + leftText;
         }

--- a/tests/lib/rules/yoda.js
+++ b/tests/lib/rules/yoda.js
@@ -383,6 +383,63 @@ ruleTester.run("yoda", rule, {
                     type: "BinaryExpression"
                 }
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7326
+        {
+            code: "while (0 === (a));",
+            output: "while ((a) === 0);",
+            options: ["never"],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "while (0 === (a = b));",
+            output: "while ((a = b) === 0);",
+            options: ["never"],
+            errors: [
+                {
+                    message: "Expected literal to be on the right side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "while ((a) === 0);",
+            output: "while (0 === (a));",
+            options: ["always"],
+            errors: [
+                {
+                    message: "Expected literal to be on the left side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "while ((a = b) === 0);",
+            output: "while (0 === (a = b));",
+            options: ["always"],
+            errors: [
+                {
+                    message: "Expected literal to be on the left side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
+        },
+        {
+            code: "if (((((((((((foo)))))))))) === ((((((5)))))));",
+            output: "if (((((((5)))))) === ((((((((((foo)))))))))));",
+            options: ["always"],
+            errors: [
+                {
+                    message: "Expected literal to be on the left side of ===.",
+                    type: "BinaryExpression"
+                }
+            ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7326

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This updates the fixer for `yoda` to correctly handle expressions where the operands are parenthesized. Previously, the location of parentheses was not swapped when the fixer swapped the order of operands.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
