### PR TITLE
Update: no-useless-escape checks template literals (fixes #7331)

### DIFF
--- a/docs/rules/no-useless-escape.md
+++ b/docs/rules/no-useless-escape.md
@@ -1,10 +1,11 @@
 # Disallow unnecessary escape usage (no-useless-escape)
 
-Escaping non-special characters in strings and regular expressions doesn't have any effects on results, as in the following example:
+Escaping non-special characters in strings, template literals, and regular expressions doesn't have any effect, as demonstrated in the following example:
 
 ```js
 let foo = "hol\a"; // > foo = "hola"
-let bar = /\:/ // same functionality with /:/
+let bar = `${foo}\!`; // > bar = "hola!"
+let baz = /\:/ // same functionality with /:/
 ```
 
 ## Rule Details
@@ -20,6 +21,9 @@ The following patterns are considered problems:
 '\"';
 "\#";
 "\e";
+`\"`;
+`\"${foo}\"`;
+`\#{foo}`;
 /\!/;
 /\@/;
 
@@ -36,6 +40,9 @@ The following patterns are not considered problems:
 "\u00a9";
 "\371";
 "xs\u2111";
+`\``;
+`\${${foo}\}`;
+`$\{${foo}\}`;
 /\\/g;
 /\t/g;
 /\\w\\$\\*\\^\\./;

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -47,7 +47,35 @@ ruleTester.run("no-useless-escape", rule, {
         "var foo = '\\\n';",
         "var foo = '\\\r\n';",
         {code: "<foo attr=\"\\d\"/>", parserOptions: {ecmaFeatures: {jsx: true}}},
-        {code: "<foo attr='\\d'></foo>", parserOptions: {ecmaFeatures: {jsx: true}}}
+        {code: "<foo attr='\\d'></foo>", parserOptions: {ecmaFeatures: {jsx: true}}},
+        {code: "var foo = `\\x123`", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\u00a9`", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `xs\\u2111`", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `foo \\\\ bar`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\t`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `foo \\b bar`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\n`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `foo \\r bar`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\v`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\f`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\\n`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\\r\n`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo} \\x123`", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo} \\u00a9`", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo} xs\\u2111`", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo} \\\\ ${bar}`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo} \\b ${bar}`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo}\\t`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo}\\n`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo}\\r`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo}\\v`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo}\\f`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo}\\\n`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `${foo}\\\r\n`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\\``", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\\`${foo}\\\``", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `\\${{${foo}`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = `$\\{{${foo}`;", parserOptions: {ecmaVersion: 6}}
     ],
 
     invalid: [
@@ -75,6 +103,59 @@ ruleTester.run("no-useless-escape", rule, {
             code: "<foo attr={\"\\d\"}/>",
             parserOptions: {ecmaFeatures: {jsx: true}},
             errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\d.", type: "Literal"}]
+        },
+        { code: "var foo = '\\`';", errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\`.", type: "Literal"}] },
+        { code: "var foo = `\\\"`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\\".", type: "TemplateElement"}] },
+        { code: "var foo = `\\'`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\'.", type: "TemplateElement"}] },
+        { code: "var foo = `\\#`;", parserOptions: {ecmaVersion: 6}, errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\#.", type: "TemplateElement"}] },
+        {
+            code: "var foo = '\\\`foo\\\`';",
+            errors: [
+                { line: 1, column: 12, message: "Unnecessary escape character: \\`.", type: "Literal"},
+                { line: 1, column: 17, message: "Unnecessary escape character: \\`.", type: "Literal"},
+            ]
+        },
+        {
+            code: "var foo = `\\\"${foo}\\\"`;",
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { line: 1, column: 11, message: "Unnecessary escape character: \\\".", type: "TemplateElement"},
+                { line: 1, column: 19, message: "Unnecessary escape character: \\\".", type: "TemplateElement"},
+            ]
+        },
+        {
+            code: "var foo = `\\\'${foo}\\\'`;",
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { line: 1, column: 11, message: "Unnecessary escape character: \\'.", type: "TemplateElement"},
+                { line: 1, column: 19, message: "Unnecessary escape character: \\'.", type: "TemplateElement"}
+            ]
+        },
+        {
+            code: "var foo = `\\#${foo}`;",
+            parserOptions: {ecmaVersion: 6},
+            errors: [{ line: 1, column: 11, message: "Unnecessary escape character: \\#.", type: "TemplateElement"}]
+        },
+        {
+            code: "var foo = `\\$\\{{${foo}`;",
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { line: 1, column: 11, message: "Unnecessary escape character: \\$.", type: "TemplateElement"},
+            ]
+        },
+        {
+            code: "var foo = `\\$a${foo}`;",
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { line: 1, column: 11, message: "Unnecessary escape character: \\$.", type: "TemplateElement"},
+            ]
+        },
+        {
+            code: "var foo = `a\\{{${foo}`;",
+            parserOptions: {ecmaVersion: 6},
+            errors: [
+                { line: 1, column: 12, message: "Unnecessary escape character: \\{.", type: "TemplateElement"},
+            ]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- [x] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
`no-useless-escape` is currently missing support for checking template literals (most likely because the rule was created before ESLint supported ES6).

**Is there anything you'd like reviewers to focus on?**
Nothing in particular