### PR TITLE
Update: Make the `prefer-template` fixer unescape quotes (fixes #7330)

### DIFF
--- a/lib/rules/prefer-template.js
+++ b/lib/rules/prefer-template.js
@@ -147,7 +147,9 @@ module.exports = {
                         return `\\${matched}`;
                     }
                     return matched;
-                })}\``;
+
+                // Unescape any quotes that appear in the original Literal that no longer need to be escaped.
+                }).replace(new RegExp(`\\\\${currentNode.raw[0]}`, "g"), currentNode.raw[0])}\``;
             }
 
             if (currentNode.type === "TemplateLiteral") {

--- a/tests/lib/rules/prefer-template.js
+++ b/tests/lib/rules/prefer-template.js
@@ -184,6 +184,36 @@ ruleTester.run("prefer-template", rule, {
             output: "var foo = `${bar  }baz` + `qux${  boop}`;",
             parserOptions: { ecmaVersion: 6 },
             errors
+        },
+        {
+            code: "foo + 'unescapes an escaped single quote in a single-quoted string: \\''",
+            output: "`${foo  }unescapes an escaped single quote in a single-quoted string: '`",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code: "foo + \"unescapes an escaped double quote in a double-quoted string: \\\"\"",
+            output: "`${foo  }unescapes an escaped double quote in a double-quoted string: \"`",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code: "foo + 'does not unescape an escaped double quote in a single-quoted string: \\\"'",
+            output: "`${foo  }does not unescape an escaped double quote in a single-quoted string: \\\"`",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code: "foo + \"does not unescape an escaped single quote in a double-quoted string: \\'\"",
+            output: "`${foo  }does not unescape an escaped single quote in a double-quoted string: \\'`",
+            parserOptions: { ecmaVersion: 6 },
+            errors
+        },
+        {
+            code: "foo + 'handles unicode escapes correctly: \\x27'", // "\x27" === "'"
+            output: "`${foo  }handles unicode escapes correctly: \\x27`",
+            parserOptions: { ecmaVersion: 6 },
+            errors
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7330

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This updates the `prefer-template` fixer to unescape quotes when replacing strings with template literals, as described in https://github.com/eslint/eslint/issues/7330.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

