### PR TITLE
Fix: Don't report setter params in class bodies as unused (fixes #7351)

### DIFF
--- a/lib/rules/no-unused-vars.js
+++ b/lib/rules/no-unused-vars.js
@@ -494,7 +494,7 @@ module.exports = {
                         if (type === "Parameter") {
 
                             // skip any setter argument
-                            if (def.node.parent.type === "Property" && def.node.parent.kind === "set") {
+                            if ((def.node.parent.type === "Property" || def.node.parent.type === "MethodDefinition") && def.node.parent.kind === "set") {
                                 continue;
                             }
 

--- a/tests/lib/rules/no-unused-vars.js
+++ b/tests/lib/rules/no-unused-vars.js
@@ -256,6 +256,16 @@ ruleTester.run("no-unused-vars", rule, {
             options: [{argsIgnorePattern: "[cd]"}],
             parserOptions: {ecmaVersion: 6},
         },
+
+        // https://github.com/eslint/eslint/issues/7351
+        {
+            code: "(class { set foo(UNUSED) {} })",
+            parserOptions: {ecmaVersion: 6}
+        },
+        {
+            code: "class Foo { set bar(UNUSED) {} } console.log(Foo)",
+            parserOptions: {ecmaVersion: 6}
+        }
     ],
     invalid: [
         { code: "function foox() { return foox(); }", errors: [definedError("foox")] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7351

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [x] I've included tests for my change
- (n/a) I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**

This updates `no-unused-vars` to avoid reporting setter parameters in class bodies as unused.

```js
(class {
  set foo(param) { // <-- don't report `param`
  }
})
```

Setter functions must always have exactly one parameter, so the parameter cannot be omitted if it's unused. The rule already has an exception for setters in object literals, but it didn't have one for setters in class bodies.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

