### PR TITLE
Chore: run prefer-template autofixer on test files

### DIFF
--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -1120,7 +1120,7 @@ describe("CLIEngine", function() {
                     }
                 });
 
-                const report = engine.executeOnFiles([path.resolve(fixtureDir, fixtureDir + "/fixmode")]);
+                const report = engine.executeOnFiles([path.resolve(fixtureDir, `${fixtureDir}/fixmode`)]);
 
                 report.results.forEach(convertCRLF);
                 assert.deepEqual(report, {
@@ -1192,7 +1192,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
@@ -1207,7 +1207,7 @@ describe("CLIEngine", function() {
                     useEslintrc: false
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes-node.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes-node.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
@@ -1220,7 +1220,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/process-exit.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
@@ -1233,7 +1233,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/process-exit.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/process-exit.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
@@ -1246,7 +1246,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1261,7 +1261,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1276,7 +1276,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/subsubbroken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1291,7 +1291,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/subdir/wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1306,7 +1306,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
@@ -1319,7 +1319,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/subdir/subsubdir/subsubsubdir/wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1334,7 +1334,7 @@ describe("CLIEngine", function() {
                     cwd: path.join(fixtureDir, "..")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/packagejson/wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/packagejson/wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1347,10 +1347,10 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
-                    configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
+                    configFile: `${fixtureDir}/config-hierarchy/broken/add-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -1365,10 +1365,10 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
-                    configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
+                    configFile: `${fixtureDir}/config-hierarchy/broken/override-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
@@ -1379,10 +1379,10 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
-                    configFile: fixtureDir + "/config-hierarchy/broken/add-conf.yaml"
+                    configFile: `${fixtureDir}/config-hierarchy/broken/add-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 2);
@@ -1400,7 +1400,7 @@ describe("CLIEngine", function() {
                     configFile: getFixturePath("config-hierarchy/broken/override-conf.yaml")
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/subbroken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/subbroken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1413,10 +1413,10 @@ describe("CLIEngine", function() {
 
                 engine = new CLIEngine({
                     cwd: path.join(fixtureDir, ".."),
-                    configFile: fixtureDir + "/config-hierarchy/broken/override-conf.yaml"
+                    configFile: `${fixtureDir}/config-hierarchy/broken/override-conf.yaml`
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 0);
@@ -1433,7 +1433,7 @@ describe("CLIEngine", function() {
                     }
                 });
 
-                const report = engine.executeOnFiles([fs.realpathSync(fixtureDir + "/config-hierarchy/broken/console-wrong-quotes.js")]);
+                const report = engine.executeOnFiles([fs.realpathSync(`${fixtureDir}/config-hierarchy/broken/console-wrong-quotes.js`)]);
 
                 assert.equal(report.results.length, 1);
                 assert.equal(report.results[0].messages.length, 1);
@@ -1638,7 +1638,7 @@ describe("CLIEngine", function() {
 
                     engine.executeOnFiles([file]);
 
-                    assert.isTrue(shell.test("-f", path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
+                    assert.isTrue(shell.test("-f", path.resolve(`./tmp/.cacheFileDir/.cache_${hash(process.cwd())}`)), "the cache for eslint was created");
 
                     sandbox.restore();
                 });
@@ -1665,7 +1665,7 @@ describe("CLIEngine", function() {
 
                 engine.executeOnFiles([file]);
 
-                assert.isTrue(shell.test("-f", path.resolve("./tmp/.cacheFileDir/.cache_" + hash(process.cwd()))), "the cache for eslint was created");
+                assert.isTrue(shell.test("-f", path.resolve(`./tmp/.cacheFileDir/.cache_${hash(process.cwd())}`)), "the cache for eslint was created");
 
                 sandbox.restore();
             });
@@ -2345,7 +2345,7 @@ describe("CLIEngine", function() {
 
             assert.throws(function() {
                 engine.getFormatter(formatterPath);
-            }, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module '" + formatterPath + "'");
+            }, `There was a problem loading formatter: ${formatterPath}\nError: Cannot find module '${formatterPath}'`);
         });
 
         it("should return null when a built-in formatter doesn't exist", function() {
@@ -2362,7 +2362,7 @@ describe("CLIEngine", function() {
 
             assert.throws(function() {
                 engine.getFormatter(formatterPath);
-            }, "There was a problem loading formatter: " + formatterPath + "\nError: Cannot find module 'this-module-does-not-exist'");
+            }, `There was a problem loading formatter: ${formatterPath}\nError: Cannot find module 'this-module-does-not-exist'`);
         });
 
         it("should return null when a non-string formatter name is passed", function() {
@@ -2517,7 +2517,7 @@ describe("CLIEngine", function() {
             ["../", "../**/*.js"]
         ], function(input, expected) {
 
-            it("should correctly resolve " + input + " to " + expected, function() {
+            it(`should correctly resolve ${input} to ${expected}`, function() {
                 const engine = new CLIEngine();
 
                 const result = engine.resolveFileGlobPatterns([input]);

--- a/tests/lib/cli.js
+++ b/tests/lib/cli.js
@@ -79,7 +79,7 @@ describe("cli", function() {
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
     before(function() {
-        fixtureDir = os.tmpdir() + "/eslint/fixtures";
+        fixtureDir = `${os.tmpdir()}/eslint/fixtures`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/.", fixtureDir);
     });
@@ -96,21 +96,21 @@ describe("cli", function() {
     describe("execute()", function() {
         it("should return error when text with incorrect quotes is passed as argument", function() {
             const configFile = getFixturePath("configurations", "quotes-error.json");
-            const result = cli.execute("-c " + configFile, "var foo = 'bar';");
+            const result = cli.execute(`-c ${configFile}`, "var foo = 'bar';");
 
             assert.equal(result, 1);
         });
 
         it("should return no error when --ext .js2 is specified", function() {
             const filePath = getFixturePath("files");
-            const result = cli.execute("--ext .js2 " + filePath);
+            const result = cli.execute(`--ext .js2 ${filePath}`);
 
             assert.equal(result, 0);
         });
 
         it("should exit with console error when passed unsupported arguments", function() {
             const filePath = getFixturePath("files");
-            const result = cli.execute("--blah --another " + filePath);
+            const result = cli.execute(`--blah --another ${filePath}`);
 
             assert.equal(result, 1);
         });
@@ -123,7 +123,7 @@ describe("cli", function() {
             const filePath = getFixturePath("passing.js");
 
             assert.doesNotThrow(function() {
-                cli.execute("--config " + configPath + " " + filePath);
+                cli.execute(`--config ${configPath} ${filePath}`);
             });
         });
     });
@@ -150,7 +150,7 @@ describe("cli", function() {
         it("should exit with an error status (1)", function() {
             const configPath = getFixturePath("configurations", "quotes-error.json");
             const filePath = getFixturePath("single-quoted.js");
-            const code = "--no-ignore --config " + configPath + " " + filePath;
+            const code = `--no-ignore --config ${configPath} ${filePath}`;
 
             const exitStatus = cli.execute(code);
 
@@ -162,7 +162,7 @@ describe("cli", function() {
         it("should load and execute without error", function() {
             const configPath = getFixturePath("configurations", "semi-error.json");
             const filePath = getFixturePath("formatters");
-            const code = "--config " + configPath + " " + filePath;
+            const code = `--config ${configPath} ${filePath}`;
 
             let exitStatus;
 
@@ -178,7 +178,7 @@ describe("cli", function() {
         it("should execute without any errors", function() {
             const configPath = getFixturePath("configurations", "env-browser.json");
             const filePath = getFixturePath("globals-browser.js");
-            const code = "--config " + configPath + " " + filePath;
+            const code = `--config ${configPath} ${filePath}`;
 
             const exit = cli.execute(code);
 
@@ -190,7 +190,7 @@ describe("cli", function() {
         it("should execute without any errors", function() {
             const configPath = getFixturePath("configurations", "env-node.json");
             const filePath = getFixturePath("globals-node.js");
-            const code = "--config " + configPath + " " + filePath;
+            const code = `--config ${configPath} ${filePath}`;
 
             const exit = cli.execute(code);
 
@@ -202,7 +202,7 @@ describe("cli", function() {
         it("should execute without any errors", function() {
             const configPath = getFixturePath("configurations", "env-nashorn.json");
             const filePath = getFixturePath("globals-nashorn.js");
-            const code = "--config " + configPath + " " + filePath;
+            const code = `--config ${configPath} ${filePath}`;
 
             const exit = cli.execute(code);
 
@@ -214,7 +214,7 @@ describe("cli", function() {
         it("should execute without any errors", function() {
             const configPath = getFixturePath("configurations", "env-webextensions.json");
             const filePath = getFixturePath("globals-webextensions.js");
-            const code = "--config " + configPath + " " + filePath;
+            const code = `--config ${configPath} ${filePath}`;
 
             const exit = cli.execute(code);
 
@@ -225,7 +225,7 @@ describe("cli", function() {
     describe("when given a valid built-in formatter name", function() {
         it("should execute without any errors", function() {
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("-f checkstyle " + filePath);
+            const exit = cli.execute(`-f checkstyle ${filePath}`);
 
             assert.equal(exit, 0);
         });
@@ -234,7 +234,7 @@ describe("cli", function() {
     describe("when given an invalid built-in formatter name", function() {
         it("should execute with error", function() {
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("-f fakeformatter " + filePath);
+            const exit = cli.execute(`-f fakeformatter ${filePath}`);
 
             assert.equal(exit, 1);
         });
@@ -244,7 +244,7 @@ describe("cli", function() {
         it("should execute without any errors", function() {
             const formatterPath = getFixturePath("formatters", "simple.js");
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("-f " + formatterPath + " " + filePath);
+            const exit = cli.execute(`-f ${formatterPath} ${filePath}`);
 
             assert.equal(exit, 0);
         });
@@ -254,7 +254,7 @@ describe("cli", function() {
         it("should execute with error", function() {
             const formatterPath = getFixturePath("formatters", "file-does-not-exist.js");
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("-f " + formatterPath + " " + filePath);
+            const exit = cli.execute(`-f ${formatterPath} ${filePath}`);
 
             assert.equal(exit, 1);
         });
@@ -263,7 +263,7 @@ describe("cli", function() {
     describe("when executing a file with a lint error", function() {
         it("should exit with error", function() {
             const filePath = getFixturePath("undef.js");
-            const code = "--no-ignore --config --rule no-undef:2 " + filePath;
+            const code = `--no-ignore --config --rule no-undef:2 ${filePath}`;
 
             const exit = cli.execute(code);
 
@@ -274,7 +274,7 @@ describe("cli", function() {
     describe("when executing a file with a syntax error", function() {
         it("should exit with error", function() {
             const filePath = getFixturePath("syntax-error.js");
-            const exit = cli.execute("--no-ignore " + filePath);
+            const exit = cli.execute(`--no-ignore ${filePath}`);
 
             assert.equal(exit, 1);
         });
@@ -285,13 +285,13 @@ describe("cli", function() {
             const filePath = getFixturePath("missing-semicolon.js");
             const passingPath = getFixturePath("passing.js");
 
-            cli.execute("--no-ignore --rule semi:2 " + filePath);
+            cli.execute(`--no-ignore --rule semi:2 ${filePath}`);
 
             assert.isTrue(log.info.called, "Log should have been called.");
 
             log.info.reset();
 
-            cli.execute("--no-ignore --rule semi:2 " + passingPath);
+            cli.execute(`--no-ignore --rule semi:2 ${passingPath}`);
             assert.isTrue(log.info.notCalled);
 
         });
@@ -317,7 +317,7 @@ describe("cli", function() {
         it("should not process any files", function() {
             const ignorePath = getFixturePath(".eslintignore");
             const filePath = getFixturePath(".");
-            const exit = cli.execute("--ignore-path " + ignorePath + " " + filePath);
+            const exit = cli.execute(`--ignore-path ${ignorePath} ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
             assert.equal(exit, 0);
@@ -329,7 +329,7 @@ describe("cli", function() {
         it("should not process the file", function() {
             const ignorePath = getFixturePath(".eslintignore");
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("--ignore-path " + ignorePath + " " + filePath);
+            const exit = cli.execute(`--ignore-path ${ignorePath} ${filePath}`);
 
             // a warning about the ignored file
             assert.isTrue(log.info.called);
@@ -339,7 +339,7 @@ describe("cli", function() {
         it("should process the file when forced", function() {
             const ignorePath = getFixturePath(".eslintignore");
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("--ignore-path " + ignorePath + " --no-ignore " + filePath);
+            const exit = cli.execute(`--ignore-path ${ignorePath} --no-ignore ${filePath}`);
 
             // no warnings
             assert.isFalse(log.info.called);
@@ -351,7 +351,7 @@ describe("cli", function() {
         it("should not process any files", function() {
             const ignoredFile = getFixturePath("cli/syntax-error.js");
             const filePath = getFixturePath("cli/passing.js");
-            const exit = cli.execute("--ignore-pattern cli/ " + ignoredFile + " " + filePath);
+            const exit = cli.execute(`--ignore-pattern cli/ ${ignoredFile} ${filePath}`);
 
             // warnings about the ignored files
             assert.isTrue(log.info.called);
@@ -364,7 +364,7 @@ describe("cli", function() {
             const ignorePaths = ["a", "b"];
 
             const cmd = ignorePaths.map(function(ignorePath) {
-                return "--ignore-pattern " + ignorePath;
+                return `--ignore-pattern ${ignorePath}`;
             }).concat(".").join(" ");
 
             const opts = {
@@ -379,7 +379,7 @@ describe("cli", function() {
 
         it("should execute without error", function() {
             const filePath = getFixturePath("shebang.js");
-            const exit = cli.execute("--no-ignore " + filePath);
+            const exit = cli.execute(`--no-ignore ${filePath}`);
 
             assert.equal(exit, 0);
         });
@@ -391,7 +391,7 @@ describe("cli", function() {
             const rulesPath = getFixturePath("rules", "wrong");
             const configPath = getFixturePath("rules", "eslint.json");
             const filePath = getFixturePath("rules", "test", "test-custom-rule.js");
-            const code = "--rulesdir " + rulesPath + " --config " + configPath + " --no-ignore " + filePath;
+            const code = `--rulesdir ${rulesPath} --config ${configPath} --no-ignore ${filePath}`;
 
             assert.throws(function() {
                 const exit = cli.execute(code);
@@ -404,7 +404,7 @@ describe("cli", function() {
             const rulesPath = getFixturePath("rules");
             const configPath = getFixturePath("rules", "eslint.json");
             const filePath = getFixturePath("rules", "test", "test-custom-rule.js");
-            const code = "--rulesdir " + rulesPath + " --config " + configPath + " --no-ignore " + filePath;
+            const code = `--rulesdir ${rulesPath} --config ${configPath} --no-ignore ${filePath}`;
 
             cli.execute(code);
 
@@ -417,7 +417,7 @@ describe("cli", function() {
             const rulesPath2 = getFixturePath("rules", "dir2");
             const configPath = getFixturePath("rules", "multi-rulesdirs.json");
             const filePath = getFixturePath("rules", "test-multi-rulesdirs.js");
-            const code = "--rulesdir " + rulesPath + " --rulesdir " + rulesPath2 + " --config " + configPath + " --no-ignore " + filePath;
+            const code = `--rulesdir ${rulesPath} --rulesdir ${rulesPath2} --config ${configPath} --no-ignore ${filePath}`;
             const exit = cli.execute(code);
 
             const call = log.info.getCall(0);
@@ -436,7 +436,7 @@ describe("cli", function() {
     describe("when executing with no-eslintrc flag", function() {
         it("should ignore a local config file", function() {
             const filePath = getFixturePath("eslintrc", "quotes.js");
-            const exit = cli.execute("--no-eslintrc --no-ignore " + filePath);
+            const exit = cli.execute(`--no-eslintrc --no-ignore ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
             assert.equal(exit, 0);
@@ -446,7 +446,7 @@ describe("cli", function() {
     describe("when executing without no-eslintrc flag", function() {
         it("should load a local config file", function() {
             const filePath = getFixturePath("eslintrc", "quotes.js");
-            const exit = cli.execute("--no-ignore " + filePath);
+            const exit = cli.execute(`--no-ignore ${filePath}`);
 
             assert.isTrue(log.info.calledOnce);
             assert.equal(exit, 1);
@@ -460,7 +460,7 @@ describe("cli", function() {
                 getFixturePath("globals-node.js")
             ];
 
-            cli.execute("--no-eslintrc --config ./conf/eslint.json --no-ignore " + files.join(" "));
+            cli.execute(`--no-eslintrc --config ./conf/eslint.json --no-ignore ${files.join(" ")}`);
 
             assert.equal(log.info.args[0][0].split("\n").length, 11);
         });
@@ -469,7 +469,7 @@ describe("cli", function() {
     describe("when executing with global flag", function() {
         it("should default defined variables to read-only", function() {
             const filePath = getFixturePath("undef.js");
-            const exit = cli.execute("--global baz,bat --no-ignore --rule no-global-assign:2 " + filePath);
+            const exit = cli.execute(`--global baz,bat --no-ignore --rule no-global-assign:2 ${filePath}`);
 
             assert.isTrue(log.info.calledOnce);
             assert.equal(exit, 1);
@@ -477,7 +477,7 @@ describe("cli", function() {
 
         it("should allow defining writable global variables", function() {
             const filePath = getFixturePath("undef.js");
-            const exit = cli.execute("--global baz:false,bat:true --no-ignore " + filePath);
+            const exit = cli.execute(`--global baz:false,bat:true --no-ignore ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
             assert.equal(exit, 0);
@@ -485,7 +485,7 @@ describe("cli", function() {
 
         it("should allow defining variables with multiple flags", function() {
             const filePath = getFixturePath("undef.js");
-            const exit = cli.execute("--global baz --global bat:true --no-ignore " + filePath);
+            const exit = cli.execute(`--global baz --global bat:true --no-ignore ${filePath}`);
 
             assert.isTrue(log.info.notCalled);
             assert.equal(exit, 0);
@@ -495,7 +495,7 @@ describe("cli", function() {
     describe("when supplied with rule flag and severity level set to error", function() {
         it("should exit with an error status (2)", function() {
             const filePath = getFixturePath("single-quoted.js");
-            const code = "--no-ignore --rule 'quotes: [2, double]' " + filePath;
+            const code = `--no-ignore --rule 'quotes: [2, double]' ${filePath}`;
             const exitStatus = cli.execute(code);
 
             assert.equal(exitStatus, 1);
@@ -506,7 +506,7 @@ describe("cli", function() {
 
         it("should only print error", function() {
             const filePath = getFixturePath("single-quoted.js");
-            const cliArgs = "--no-ignore --quiet  -f compact --rule 'quotes: [2, double]' --rule 'no-unused-vars: 1' " + filePath;
+            const cliArgs = `--no-ignore --quiet  -f compact --rule 'quotes: [2, double]' --rule 'no-unused-vars: 1' ${filePath}`;
 
             cli.execute(cliArgs);
 
@@ -520,7 +520,7 @@ describe("cli", function() {
 
         it("should print nothing if there are no errors", function() {
             const filePath = getFixturePath("single-quoted.js");
-            const cliArgs = "--quiet  -f compact --rule 'quotes: [1, double]' --rule 'no-unused-vars: 1' " + filePath;
+            const cliArgs = `--quiet  -f compact --rule 'quotes: [1, double]' --rule 'no-unused-vars: 1' ${filePath}`;
 
             cli.execute(cliArgs);
 
@@ -536,7 +536,7 @@ describe("cli", function() {
 
         it("should write the file and create dirs if they don't exist", function() {
             const filePath = getFixturePath("single-quoted.js");
-            const code = "--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt " + filePath;
+            const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
 
             cli.execute(code);
 
@@ -546,7 +546,7 @@ describe("cli", function() {
 
         it("should return an error if the path is a directory", function() {
             const filePath = getFixturePath("single-quoted.js");
-            const code = "--no-ignore --rule 'quotes: [1, double]' --o tests/output " + filePath;
+            const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output ${filePath}`;
 
             fs.mkdirSync("tests/output");
 
@@ -559,7 +559,7 @@ describe("cli", function() {
 
         it("should return an error if the path could not be written to", function() {
             const filePath = getFixturePath("single-quoted.js");
-            const code = "--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt " + filePath;
+            const code = `--no-ignore --rule 'quotes: [1, double]' --o tests/output/eslint-output.txt ${filePath}`;
 
             fs.writeFileSync("tests/output", "foo");
 
@@ -576,7 +576,7 @@ describe("cli", function() {
         it("should pass plugins to CLIEngine", function() {
             const examplePluginName = "eslint-plugin-example";
 
-            verifyCLIEngineOpts("--no-ignore --plugin " + examplePluginName + " foo.js", {
+            verifyCLIEngineOpts(`--no-ignore --plugin ${examplePluginName} foo.js`, {
                 plugins: [examplePluginName]
             });
         });
@@ -586,14 +586,14 @@ describe("cli", function() {
     describe("when given an parser name", function() {
         it("should exit with error if parser is invalid", function() {
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("--no-ignore --parser test111 " + filePath);
+            const exit = cli.execute(`--no-ignore --parser test111 ${filePath}`);
 
             assert.equal(exit, 1);
         });
 
         it("should exit with no error if parser is valid", function() {
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("--no-ignore --parser espree " + filePath);
+            const exit = cli.execute(`--no-ignore --parser espree ${filePath}`);
 
             assert.equal(exit, 0);
         });
@@ -602,28 +602,28 @@ describe("cli", function() {
     describe("when given parser options", function() {
         it("should exit with error if parser options are invalid", function() {
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("--no-ignore --parser-options test111 " + filePath);
+            const exit = cli.execute(`--no-ignore --parser-options test111 ${filePath}`);
 
             assert.equal(exit, 1);
         });
 
         it("should exit with no error if parser is valid", function() {
             const filePath = getFixturePath("passing.js");
-            const exit = cli.execute("--no-ignore --parser-options=ecmaVersion:6 " + filePath);
+            const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`);
 
             assert.equal(exit, 0);
         });
 
         it("should exit with an error on ecmaVersion 7 feature in ecmaVersion 6", function() {
             const filePath = getFixturePath("passing-es7.js");
-            const exit = cli.execute("--no-ignore --parser-options=ecmaVersion:6 " + filePath);
+            const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:6 ${filePath}`);
 
             assert.equal(exit, 1);
         });
 
         it("should exit with no error on ecmaVersion 7 feature in ecmaVersion 7", function() {
             const filePath = getFixturePath("passing-es7.js");
-            const exit = cli.execute("--no-ignore --parser-options=ecmaVersion:7 " + filePath);
+            const exit = cli.execute(`--no-ignore --parser-options=ecmaVersion:7 ${filePath}`);
 
             assert.equal(exit, 0);
         });
@@ -631,7 +631,7 @@ describe("cli", function() {
         it("should exit with no error on ecmaVersion 7 feature with config ecmaVersion 6 and command line ecmaVersion 7", function() {
             const configPath = getFixturePath("configurations", "es6.json");
             const filePath = getFixturePath("passing-es7.js");
-            const exit = cli.execute("--no-ignore --config " + configPath + " --parser-options=ecmaVersion:7 " + filePath);
+            const exit = cli.execute(`--no-ignore --config ${configPath} --parser-options=ecmaVersion:7 ${filePath}`);
 
             assert.equal(exit, 0);
         });
@@ -640,14 +640,14 @@ describe("cli", function() {
     describe("when given the max-warnings flag", function() {
         it("should not change exit code if warning count under threshold", function() {
             const filePath = getFixturePath("max-warnings");
-            const exitCode = cli.execute("--no-ignore --max-warnings 10 " + filePath);
+            const exitCode = cli.execute(`--no-ignore --max-warnings 10 ${filePath}`);
 
             assert.equal(exitCode, 0);
         });
 
         it("should exit with exit code 1 if warning count exceeds threshold", function() {
             const filePath = getFixturePath("max-warnings");
-            const exitCode = cli.execute("--no-ignore --max-warnings 5 " + filePath);
+            const exitCode = cli.execute(`--no-ignore --max-warnings 5 ${filePath}`);
 
             assert.equal(exitCode, 1);
             assert.ok(log.error.calledOnce);
@@ -656,7 +656,7 @@ describe("cli", function() {
 
         it("should not change exit code if warning count equals threshold", function() {
             const filePath = getFixturePath("max-warnings");
-            const exitCode = cli.execute("--no-ignore --max-warnings 6 " + filePath);
+            const exitCode = cli.execute(`--no-ignore --max-warnings 6 ${filePath}`);
 
             assert.equal(exitCode, 0);
         });
@@ -874,7 +874,7 @@ describe("cli", function() {
         it("should print out the configuration", function() {
             const filePath = getFixturePath("files");
 
-            const exitCode = cli.execute("--print-config " + filePath);
+            const exitCode = cli.execute(`--print-config ${filePath}`);
 
             assert.isTrue(log.info.calledOnce);
             assert.equal(exitCode, 0);
@@ -884,7 +884,7 @@ describe("cli", function() {
             const filePath1 = getFixturePath("files", "bar.js");
             const filePath2 = getFixturePath("files", "foo.js");
 
-            const exitCode = cli.execute("--print-config " + filePath1 + " " + filePath2);
+            const exitCode = cli.execute(`--print-config ${filePath1} ${filePath2}`);
 
             assert.isTrue(log.info.notCalled);
             assert.isTrue(log.error.calledOnce);

--- a/tests/lib/config.js
+++ b/tests/lib/config.js
@@ -116,7 +116,7 @@ describe("Config", function() {
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
     before(function() {
-        fixtureDir = os.tmpdir() + "/eslint/fixtures";
+        fixtureDir = `${os.tmpdir()}/eslint/fixtures`;
         mkdir("-p", fixtureDir);
         cp("-r", "./tests/fixtures/config-hierarchy", fixtureDir);
     });

--- a/tests/lib/config/config-file.js
+++ b/tests/lib/config/config-file.js
@@ -53,7 +53,7 @@ function getFixturePath(filepath) {
  * @private
  */
 function readJSModule(code) {
-    return eval("var module = {};\n" + code);  // eslint-disable-line no-eval
+    return eval(`var module = {};\n${code}`);  // eslint-disable-line no-eval
 }
 
 /**
@@ -84,7 +84,7 @@ function writeTempConfigFile(config, filename, existingTmpDir) {
 function writeTempJsConfigFile(config, filename, existingTmpDir) {
     const tmpFileDir = existingTmpDir || temp.mkdirSync("eslint-tests-"),
         tmpFilePath = path.join(tmpFileDir, filename),
-        tmpFileContents = "module.exports = " + JSON.stringify(config);
+        tmpFileContents = `module.exports = ${JSON.stringify(config)}`;
 
     fs.writeFileSync(tmpFilePath, tmpFileContents);
     return tmpFilePath;
@@ -130,7 +130,7 @@ function createStubModuleResolver(mapping) {
             return mapping[name];
         }
 
-        throw new Error("Cannot find module '" + name + "'");
+        throw new Error(`Cannot find module '${name}'`);
     };
 
     return StubModuleResolver;
@@ -812,7 +812,7 @@ describe("ConfigFile", function() {
                 [ "@foo/bar", getProjectModulePath("@foo/eslint-config-bar") ],
                 [ "plugin:foo/bar", getProjectModulePath("eslint-plugin-foo") ]
             ], function(input, expected) {
-                it("should return " + expected + " when passed " + input, function() {
+                it(`should return ${expected} when passed ${input}`, function() {
 
                     const configDeps = {
                         "eslint-config-foo": getProjectModulePath("eslint-config-foo"),
@@ -846,7 +846,7 @@ describe("ConfigFile", function() {
                 [ "@foo/bar", getRelativeModulePath("@foo/eslint-config-bar", relativePath), relativePath],
                 [ "plugin:@foo/bar/baz", getRelativeModulePath("@foo/eslint-plugin-bar", relativePath), relativePath]
             ], function(input, expected, relativeTo) {
-                it("should return " + expected + " when passed " + input, function() {
+                it(`should return ${expected} when passed ${input}`, function() {
 
                     const configDeps = {
                         "eslint-config-foo": getRelativeModulePath("eslint-config-foo", relativePath),
@@ -873,7 +873,7 @@ describe("ConfigFile", function() {
                 [ "eslint-config-foo/bar", path.resolve("./node_modules", "eslint-config-foo/bar", "index.js"), relativePath],
                 [ "eslint-config-foo/bar", path.resolve("./node_modules", "eslint-config-foo", "bar.js"), relativePath]
             ], function(input, expected, relativeTo) {
-                it("should return " + expected + " when passed " + input, function() {
+                it(`should return ${expected} when passed ${input}`, function() {
 
                     const configDeps = {
                         "eslint-config-foo/bar": expected
@@ -968,7 +968,7 @@ describe("ConfigFile", function() {
             [ getFixturePath("json"), ".eslintrc.json" ],
             [ getFixturePath("js"), ".eslintrc.js" ]
         ], function(input, expected) {
-            it("should return " + expected + " when passed " + input, function() {
+            it(`should return ${expected} when passed ${input}`, function() {
                 const result = ConfigFile.getFilenameForDirectory(input);
 
                 assert.equal(result, path.resolve(input, expected));
@@ -988,7 +988,7 @@ describe("ConfigFile", function() {
             [ "@z/eslint-config", "@z/eslint-config" ],
             [ "@z/eslint-config-foo", "@z/eslint-config-foo" ]
         ], function(input, expected) {
-            it("should return " + expected + " when passed " + input, function() {
+            it(`should return ${expected} when passed ${input}`, function() {
                 const result = ConfigFile.normalizePackageName(input, "eslint-config");
 
                 assert.equal(result, expected);
@@ -1027,7 +1027,7 @@ describe("ConfigFile", function() {
             ["YML", "foo.yml", yaml.safeLoad]
         ], function(fileType, filename, validate) {
 
-            it("should write a file through fs when a " + fileType + " path is passed", function() {
+            it(`should write a file through fs when a ${fileType} path is passed`, function() {
                 const fakeFS = leche.fake(fs);
 
                 sandbox.mock(fakeFS).expects("writeFileSync").withExactArgs(

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -63,7 +63,7 @@ describe("configInitializer", function() {
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
     before(function() {
-        fixtureDir = os.tmpdir() + "/eslint/fixtures/config-initializer";
+        fixtureDir = `${os.tmpdir()}/eslint/fixtures/config-initializer`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/config-initializer/.", fixtureDir);
         fixtureDir = fs.realpathSync(fixtureDir);

--- a/tests/lib/config/config-ops.js
+++ b/tests/lib/config/config-ops.js
@@ -785,7 +785,7 @@ describe("ConfigOps", function() {
             [[2, "baz"], true]
         ], function(input, expected) {
 
-            it("should return " + expected + "when passed " + input, function() {
+            it(`should return ${expected}when passed ${input}`, function() {
                 const result = ConfigOps.isErrorSeverity(input);
 
                 assert.equal(result, expected);

--- a/tests/lib/eslint.js
+++ b/tests/lib/eslint.js
@@ -23,7 +23,7 @@ function compatRequire(name, windowName) {
     } else if (typeof require === "function") {
         return require(name);
     } else {
-        throw new Error("Cannot find object '" + name + "'.");
+        throw new Error(`Cannot find object '${name}'.`);
     }
 }
 

--- a/tests/lib/ignored-paths.js
+++ b/tests/lib/ignored-paths.js
@@ -465,7 +465,7 @@ describe("IgnoredPaths", function() {
         it("should not ignore absolute paths containing '..'", function() {
             const ignoredPaths = new IgnoredPaths({ ignore: true, cwd: getFixturePath() });
 
-            assert.isFalse(ignoredPaths.contains(getFixturePath("foo") + "/../unignored.js"));
+            assert.isFalse(ignoredPaths.contains(`${getFixturePath("foo")}/../unignored.js`));
         });
 
         it("should ignore /node_modules/ at top level relative to .eslintignore when loaded", function() {

--- a/tests/lib/rules/complexity.js
+++ b/tests/lib/rules/complexity.js
@@ -26,7 +26,7 @@ function createComplexity(complexity) {
     let funcString = "function test (a) { if (a === 1) {";
 
     for (let i = 2; i < complexity; i++) {
-        funcString += "} else if (a === " + i + ") {";
+        funcString += `} else if (a === ${i}) {`;
     }
 
     funcString += "} };";

--- a/tests/lib/rules/keyword-spacing.js
+++ b/tests/lib/rules/keyword-spacing.js
@@ -57,7 +57,7 @@ function override(keyword, value) {
  * @returns {string[]} An error message.
  */
 function expectedBefore(keyword) {
-    return ["Expected space(s) before \"" + keyword + "\"."];
+    return [`Expected space(s) before "${keyword}".`];
 }
 
 /**
@@ -67,7 +67,7 @@ function expectedBefore(keyword) {
  * @returns {string[]} An error message.
  */
 function expectedAfter(keyword) {
-    return ["Expected space(s) after \"" + keyword + "\"."];
+    return [`Expected space(s) after "${keyword}".`];
 }
 
 /**
@@ -79,8 +79,8 @@ function expectedAfter(keyword) {
  */
 function expectedBeforeAndAfter(keyword) {
     return [
-        "Expected space(s) before \"" + keyword + "\".",
-        "Expected space(s) after \"" + keyword + "\"."
+        `Expected space(s) before "${keyword}".`,
+        `Expected space(s) after "${keyword}".`
     ];
 }
 
@@ -91,7 +91,7 @@ function expectedBeforeAndAfter(keyword) {
  * @returns {string[]} An error message.
  */
 function unexpectedBefore(keyword) {
-    return ["Unexpected space(s) before \"" + keyword + "\"."];
+    return [`Unexpected space(s) before "${keyword}".`];
 }
 
 /**
@@ -101,7 +101,7 @@ function unexpectedBefore(keyword) {
  * @returns {string[]} An error message.
  */
 function unexpectedAfter(keyword) {
-    return ["Unexpected space(s) after \"" + keyword + "\"."];
+    return [`Unexpected space(s) after "${keyword}".`];
 }
 
 /**
@@ -113,8 +113,8 @@ function unexpectedAfter(keyword) {
  */
 function unexpectedBeforeAndAfter(keyword) {
     return [
-        "Unexpected space(s) before \"" + keyword + "\".",
-        "Unexpected space(s) after \"" + keyword + "\"."
+        `Unexpected space(s) before "${keyword}".`,
+        `Unexpected space(s) after "${keyword}".`
     ];
 }
 

--- a/tests/lib/rules/max-lines.js
+++ b/tests/lib/rules/max-lines.js
@@ -26,8 +26,7 @@ const ruleTester = new RuleTester();
  * @returns {string} error message
  */
 function errorMessage(limitLines, actualLines) {
-    return "File must be at most " + limitLines + " lines long. It's "
-        + actualLines + " lines long.";
+    return `File must be at most ${limitLines} lines long. It's ${actualLines} lines long.`;
 }
 
 ruleTester.run("max-lines", rule, {

--- a/tests/lib/rules/no-control-regex.js
+++ b/tests/lib/rules/no-control-regex.js
@@ -21,7 +21,7 @@ const ruleTester = new RuleTester();
 ruleTester.run("no-control-regex", rule, {
     valid: [
         "var regex = /x1f/",
-        "var regex =" + /\\x1f/,
+        `var regex =${/\\x1f/}`,
         "var regex = new RegExp('x1f')",
         "var regex = RegExp('x1f')",
         "new RegExp('[')",
@@ -29,10 +29,10 @@ ruleTester.run("no-control-regex", rule, {
         "new (function foo(){})('\\x1f')"
     ],
     invalid: [
-        { code: "var regex = " + /\x1f/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f.", type: "Literal"}] }, // eslint-disable-line no-control-regex
-        { code: "var regex = " + /\\\x1f\\x1e/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1e.", type: "Literal"}] }, // eslint-disable-line no-control-regex
-        { code: "var regex = " + /\\\x1fFOO\\x00/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x00.", type: "Literal"}] }, // eslint-disable-line no-control-regex
-        { code: "var regex = " + /FOO\\\x1fFOO\\x1f/, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1f.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: `var regex = ${/\x1f/}`, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: `var regex = ${/\\\x1f\\x1e/}`, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1e.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: `var regex = ${/\\\x1fFOO\\x00/}`, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x00.", type: "Literal"}] }, // eslint-disable-line no-control-regex
+        { code: `var regex = ${/FOO\\\x1fFOO\\x1f/}`, errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1f.", type: "Literal"}] }, // eslint-disable-line no-control-regex
         { code: "var regex = new RegExp('\\x1f\\x1e')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1e.", type: "Literal"}] },
         { code: "var regex = new RegExp('\\x1fFOO\\x00')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x00.", type: "Literal"}] },
         { code: "var regex = new RegExp('FOO\\x1fFOO\\x1f')", errors: [{ message: "Unexpected control character(s) in regular expression: \\x1f, \\x1f.", type: "Literal"}] },

--- a/tests/lib/rules/no-empty-function.js
+++ b/tests/lib/rules/no-empty-function.js
@@ -52,7 +52,7 @@ function toValidInvalid(patterns, item) {
             parserOptions: {ecmaVersion: 6}
         },
         {
-            code: item.code + " // allow: " + item.allow,
+            code: `${item.code} // allow: ${item.allow}`,
             options: [{allow: [item.allow]}],
             parserOptions: {ecmaVersion: 6}
         }
@@ -72,7 +72,7 @@ function toValidInvalid(patterns, item) {
 
             // non related "allow" option has no effect.
             patterns.invalid.push({
-                code: item.code + " // allow: " + allow,
+                code: `${item.code} // allow: ${allow}`,
                 errors: [item.message],
                 options: [{allow: [allow]}],
                 parserOptions: {ecmaVersion: 6}

--- a/tests/lib/rules/no-invalid-this.js
+++ b/tests/lib/rules/no-invalid-this.js
@@ -33,7 +33,7 @@ function NORMAL() {
  * @returns {void}
  */
 function USE_STRICT(pattern) {
-    pattern.code = "\"use strict\"; " + pattern.code;
+    pattern.code = `"use strict"; ${pattern.code}`;
 }
 
 /**
@@ -43,7 +43,7 @@ function USE_STRICT(pattern) {
  * @returns {void}
  */
 function IMPLIED_STRICT(pattern) {
-    pattern.code = "/* implied strict mode */ " + pattern.code;
+    pattern.code = `/* implied strict mode */ ${pattern.code}`;
     pattern.parserOptions.ecmaFeatures = pattern.parserOptions.ecmaFeatures || {};
     pattern.parserOptions.ecmaFeatures.impliedStrict = true;
 }
@@ -55,7 +55,7 @@ function IMPLIED_STRICT(pattern) {
  * @returns {void}
  */
 function MODULES(pattern) {
-    pattern.code = "/* modules */ " + pattern.code;
+    pattern.code = `/* modules */ ${pattern.code}`;
     pattern.parserOptions.sourceType = "module";
 }
 

--- a/tests/lib/rules/no-multiple-empty-lines.js
+++ b/tests/lib/rules/no-multiple-empty-lines.js
@@ -26,7 +26,7 @@ const ruleTester = new RuleTester();
 function getExpectedError(lines) {
     const message = lines === 1
         ? "More than 1 blank line not allowed."
-        : "More than " + lines + " blank lines not allowed.";
+        : `More than ${lines} blank lines not allowed.`;
 
     return {
         message,
@@ -47,7 +47,7 @@ function getExpectedErrorEOF(lines) {
     }
 
     return {
-        message: "Too many blank lines at the end of file. Max of " + lines + " allowed.",
+        message: `Too many blank lines at the end of file. Max of ${lines} allowed.`,
         type: "Program",
         column: 1
     };
@@ -65,7 +65,7 @@ function getExpectedErrorBOF(lines) {
     }
 
     return {
-        message: "Too many blank lines at the beginning of file. Max of " + lines + " allowed.",
+        message: `Too many blank lines at the beginning of file. Max of ${lines} allowed.`,
         type: "Program",
         column: 1
     };

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -40,7 +40,7 @@ function getFixturePath() {
 describe("globUtil", function() {
 
     before(function() {
-        fixtureDir = os.tmpdir() + "/eslint/tests/fixtures/";
+        fixtureDir = `${os.tmpdir()}/eslint/tests/fixtures/`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/", fixtureDir);
     });
@@ -67,7 +67,7 @@ describe("globUtil", function() {
                 cwd: getFixturePath("glob-util")
             };
             const result = globUtil.resolveFileGlobPatterns(patterns, opts);
-            const expected = [getFixturePath("glob-util", "one-js-file").replace(/\\/g, "/") + "/**/*.js"];
+            const expected = [`${getFixturePath("glob-util", "one-js-file").replace(/\\/g, "/")}/**/*.js`];
 
             assert.deepEqual(result, expected);
         });

--- a/tests/lib/util/source-code-fixer.js
+++ b/tests/lib/util/source-code-fixer.js
@@ -174,14 +174,14 @@ describe("SourceCodeFixer", function() {
             it("should insert text in the middle of the code", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE ]);
 
-                assert.equal(result.output, TEST_CODE.replace("6 *", INSERT_IN_MIDDLE.fix.text + "6 *"));
+                assert.equal(result.output, TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`));
                 assert.equal(result.messages.length, 0);
             });
 
             it("should insert text at the beginning, middle, and end of the code", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END ]);
 
-                assert.equal(result.output, INSERT_AT_START.fix.text + TEST_CODE.replace("6 *", INSERT_IN_MIDDLE.fix.text + "6 *") + INSERT_AT_END.fix.text);
+                assert.equal(result.output, INSERT_AT_START.fix.text + TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`) + INSERT_AT_END.fix.text);
                 assert.equal(result.messages.length, 0);
             });
 
@@ -333,7 +333,7 @@ describe("SourceCodeFixer", function() {
             it("should insert BOM with an insertion of '\uFEFF' at 0", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE);
+                assert.equal(result.output, `\uFEFF${TEST_CODE}`);
                 assert.isTrue(result.fixed);
                 assert.equal(result.messages.length, 0);
             });
@@ -341,7 +341,7 @@ describe("SourceCodeFixer", function() {
             it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM_WITH_TEXT ]);
 
-                assert.equal(result.output, "\uFEFF// start\n" + TEST_CODE);
+                assert.equal(result.output, `\uFEFF// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
                 assert.equal(result.messages.length, 0);
             });
@@ -357,7 +357,7 @@ describe("SourceCodeFixer", function() {
             it("should replace BOM with a negative range and 'foobar'", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_BOM_WITH_TEXT ]);
 
-                assert.equal(result.output, "// start\n" + TEST_CODE);
+                assert.equal(result.output, `// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
                 assert.equal(result.messages.length, 0);
             });
@@ -373,7 +373,7 @@ describe("SourceCodeFixer", function() {
         let sourceCode;
 
         beforeEach(function() {
-            sourceCode = new SourceCode("\uFEFF" + TEST_CODE, TEST_AST);
+            sourceCode = new SourceCode(`\uFEFF${TEST_CODE}`, TEST_AST);
         });
 
         describe("Text Insertion", function() {
@@ -381,28 +381,29 @@ describe("SourceCodeFixer", function() {
             it("should insert text at the end of the code", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_END ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE + INSERT_AT_END.fix.text);
+                assert.equal(result.output, `\uFEFF${TEST_CODE}${INSERT_AT_END.fix.text}`);
                 assert.equal(result.messages.length, 0);
             });
 
             it("should insert text at the beginning of the code", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_AT_START ]);
 
-                assert.equal(result.output, "\uFEFF" + INSERT_AT_START.fix.text + TEST_CODE);
+                assert.equal(result.output, `\uFEFF${INSERT_AT_START.fix.text}${TEST_CODE}`);
                 assert.equal(result.messages.length, 0);
             });
 
             it("should insert text in the middle of the code", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("6 *", INSERT_IN_MIDDLE.fix.text + "6 *"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`)}`);
                 assert.equal(result.messages.length, 0);
             });
 
             it("should insert text at the beginning, middle, and end of the code", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_IN_MIDDLE, INSERT_AT_START, INSERT_AT_END ]);
+                const insertInMiddle = TEST_CODE.replace("6 *", `${INSERT_IN_MIDDLE.fix.text}6 *`);
 
-                assert.equal(result.output, "\uFEFF" + INSERT_AT_START.fix.text + TEST_CODE.replace("6 *", INSERT_IN_MIDDLE.fix.text + "6 *") + INSERT_AT_END.fix.text);
+                assert.equal(result.output, `\uFEFF${INSERT_AT_START.fix.text}${insertInMiddle}${INSERT_AT_END.fix.text}`);
                 assert.equal(result.messages.length, 0);
             });
 
@@ -414,7 +415,7 @@ describe("SourceCodeFixer", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_VAR ]);
 
                 assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("var", "let"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("var", "let")}`);
                 assert.isTrue(result.fixed);
             });
 
@@ -422,7 +423,7 @@ describe("SourceCodeFixer", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_ID ]);
 
                 assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "foo"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
                 assert.isTrue(result.fixed);
             });
 
@@ -430,7 +431,7 @@ describe("SourceCodeFixer", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_NUM ]);
 
                 assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("6", "5"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("6", "5")}`);
                 assert.isTrue(result.fixed);
             });
 
@@ -450,7 +451,7 @@ describe("SourceCodeFixer", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START ]);
 
                 assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("var ", ""));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("var ", "")}`);
                 assert.isTrue(result.fixed);
             });
 
@@ -458,7 +459,7 @@ describe("SourceCodeFixer", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE ]);
 
                 assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "a"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
                 assert.isTrue(result.fixed);
             });
 
@@ -466,7 +467,7 @@ describe("SourceCodeFixer", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_END ]);
 
                 assert.equal(result.messages.length, 0);
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace(" * 7", ""));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace(" * 7", "")}`);
                 assert.isTrue(result.fixed);
             });
 
@@ -492,7 +493,7 @@ describe("SourceCodeFixer", function() {
             it("should only apply one fix when ranges overlap", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "a"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
                 assert.equal(result.messages.length, 1);
                 assert.equal(result.messages[0].message, "foo");
                 assert.isTrue(result.fixed);
@@ -501,7 +502,7 @@ describe("SourceCodeFixer", function() {
             it("should apply one fix when the end of one range is the same as the start of a previous range overlap", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_START, REPLACE_ID ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "foo"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "foo")}`);
                 assert.equal(result.messages.length, 1);
                 assert.equal(result.messages[0].message, "removestart");
                 assert.isTrue(result.fixed);
@@ -510,7 +511,7 @@ describe("SourceCodeFixer", function() {
             it("should only apply one fix when ranges overlap and one message has no fix", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REMOVE_MIDDLE, REPLACE_ID, NO_FIX ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE.replace("answer", "a"));
+                assert.equal(result.output, `\uFEFF${TEST_CODE.replace("answer", "a")}`);
                 assert.equal(result.messages.length, 2);
                 assert.equal(result.messages[0].message, "nofix");
                 assert.equal(result.messages[1].message, "foo");
@@ -531,7 +532,7 @@ describe("SourceCodeFixer", function() {
             it("should only apply one fix when ranges overlap and one message has no fix", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ NO_FIX ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE);
+                assert.equal(result.output, `\uFEFF${TEST_CODE}`);
                 assert.equal(result.messages.length, 1);
                 assert.equal(result.messages[0].message, "nofix");
                 assert.isFalse(result.fixed);
@@ -544,7 +545,7 @@ describe("SourceCodeFixer", function() {
             it("should insert BOM with an insertion of '\uFEFF' at 0", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM ]);
 
-                assert.equal(result.output, "\uFEFF" + TEST_CODE);
+                assert.equal(result.output, `\uFEFF${TEST_CODE}`);
                 assert.isTrue(result.fixed);
                 assert.equal(result.messages.length, 0);
             });
@@ -552,7 +553,7 @@ describe("SourceCodeFixer", function() {
             it("should insert BOM with an insertion of '\uFEFFfoobar' at 0", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ INSERT_BOM_WITH_TEXT ]);
 
-                assert.equal(result.output, "\uFEFF// start\n" + TEST_CODE);
+                assert.equal(result.output, `\uFEFF// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
                 assert.equal(result.messages.length, 0);
             });
@@ -568,7 +569,7 @@ describe("SourceCodeFixer", function() {
             it("should replace BOM with a negative range and 'foobar'", function() {
                 const result = SourceCodeFixer.applyFixes(sourceCode, [ REPLACE_BOM_WITH_TEXT ]);
 
-                assert.equal(result.output, "// start\n" + TEST_CODE);
+                assert.equal(result.output, `// start\n${TEST_CODE}`);
                 assert.isTrue(result.fixed);
                 assert.equal(result.messages.length, 0);
             });

--- a/tests/lib/util/source-code-util.js
+++ b/tests/lib/util/source-code-util.js
@@ -59,7 +59,7 @@ describe("SourceCodeUtil", function() {
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
     before(function() {
-        fixtureDir = os.tmpdir() + "/eslint/fixtures/source-code-util";
+        fixtureDir = `${os.tmpdir()}/eslint/fixtures/source-code-util`;
         sh.mkdir("-p", fixtureDir);
         sh.cp("-r", "./tests/fixtures/source-code-util/.", fixtureDir);
         fixtureDir = fs.realpathSync(fixtureDir);

--- a/tests/templates/pr-create.md.ejs.js
+++ b/tests/templates/pr-create.md.ejs.js
@@ -133,7 +133,7 @@ describe("pr-create.md.ejs", function() {
     });
 
     ["Breaking", "Build", "Chore", "Docs", "Fix", "New", "Update", "Upgrade"].forEach(function(type) {
-        it("should not mention missing issue or length check when there's one " + type + " commit", function() {
+        it(`should not mention missing issue or length check when there's one ${type} commit`, function() {
             const result = ejs.render(TEMPLATE_TEXT, {
                 payload: {
                     sender: {
@@ -146,7 +146,7 @@ describe("pr-create.md.ejs", function() {
                     commits: [
                         {
                             commit: {
-                                message: type + ": Foo bar (fixes #1234)\nSome really long string. abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz"
+                                message: `${type}: Foo bar (fixes #1234)\nSome really long string. abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz abcdefghijklmnopqrstuvwxyz`
                             }
                         }
                     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[X] Other, please explain:
Chore: using the new prefer-template autofix to start converting files so we can enable prefer-template in the ESLint repo. Originally discussed here.

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**

- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [ ] I've included tests for my change
- [ ] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
Used the new prefer-template autofix (followed up by the template-curly-spacing, which is already enabled in the ESLint repo) on JS files in tests/.

**Is there anything you'd like reviewers to focus on?**
I changed two things manually for ease of reading. Will comment on them directly.

