### PR TITLE
Docs: Update example of results returned from `executeOnFiles`

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -220,20 +220,75 @@ The return value is an object containing the results of the linting operation. H
 {
     results: [
         {
-            filePath: "./myfile.js",
-            output: "foo;",
+            filePath: "/Users/eslint/project/myfile.js",
+            messages: [{
+                ruleId: "semi",
+                severity: 2,
+                message: "Missing semicolon.",
+                line: 1,
+                column: 13,
+                nodeType: "ExpressionStatement",
+                source: "\"use strict\"", // Deprecated: see "please note" paragraph below.
+                fix: { range: [12, 12], text: ";" }
+            }],
+            errorCount: 1,
+            warningCount: 0,
+            source: "\"use strict\"\n"
+        }
+    ],
+    errorCount: 1,
+    warningCount: 0
+}
+```
+
+You can also pass `fix: true` when instantiating the `CLIEngine` in order to have it figure out what fixes can be applied.
+
+```js
+var CLIEngine = require("eslint").CLIEngine;
+
+var cli = new CLIEngine({
+    envs: ["browser", "mocha"],
+    fix: true, // difference from last example
+    useEslintrc: false,
+    rules: {
+        semi: 2,
+        quotes: [2, "double"]
+    }
+});
+
+// lint myfile.js and all files in lib/
+var report = cli.executeOnFiles(["myfile.js", "lib/"]);
+```
+
+```js
+{
+    results: [
+        {
+            filePath: "/Users/eslint/project/myfile.js",
             messages: [
                 {
-                    severity: 2,
                     ruleId: "semi",
                     severity: 2,
+                    message: "Missing semicolon.",
                     line: 1,
-                    column: 23,
-                    message: "Expected a semicolon."
+                    column: 13,
+                    nodeType: "ExpressionStatement",
+                    source: "\"use strict\"", // Deprecated: see "please note" paragraph below.
+                    fix: { range: [12, 12], text: ";" }
+                },
+                {
+                    ruleId: "func-name-matching",
+                    severity: 2,
+                    message: "Function name `bar` should match variable name `foo`",
+                    line: 2,
+                    column: 5,
+                    nodeType: "VariableDeclarator",
+                    source: "var foo = function bar() {};"
                 }
             ],
             errorCount: 1,
-            warningCount: 0
+            warningCount: 0,
+            output: "\"use strict\";\nvar foo = function bar() {};\nfoo();\n"
         }
     ],
     errorCount: 1,
@@ -482,6 +537,7 @@ var CLIEngine = require("eslint").CLIEngine;
 
 var cli = new CLIEngine({
     envs: ["browser", "mocha"],
+    fix: true,
     useEslintrc: false,
     rules: {
         semi: 2


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

I just noticed `severity` being there twice. Then I though to double check what the output actually is, and it's quite different, so I changed the whole thing.

<!--
    The following is required for all pull requests:
-->

**Please check each item to ensure your pull request is ready:**
- [x] I've read the [pull request guide](http://eslint.org/docs/developer-guide/contributing/pull-requests)
- [ ] I've included tests for my change
- [ ] I've updated documentation for my change (if appropriate)

**What changes did you make? (Give an overview)**
Replace example of returned object from `executeOnFiles`.

**Is there anything you'd like reviewers to focus on?**
- Should other examples be updated as well?
- `fatal: false` is missing, should it? I suppose formatters just do `if (false)` or something like that, so if it's `undefined` or `false` doesn't really matter
