### PR TITLE
Fix: id-length rule incorrectly firing on member access (fixes #6475)

### DIFF
--- a/lib/rules/id-length.js
+++ b/lib/rules/id-length.js
@@ -61,7 +61,9 @@ module.exports = {
                 return !parent.computed && (
 
                     // regular property assignment
-                    (parent.parent.left === parent || // or the last identifier in an ObjectPattern destructuring
+                    (parent.parent.left === parent && parent.parent.type === "AssignmentExpression" ||
+
+                    // or the last identifier in an ObjectPattern destructuring
                     parent.parent.type === "Property" && parent.parent.value === parent &&
                     parent.parent.parent.type === "ObjectPattern" && parent.parent.parent.parent.left === parent.parent.parent)
                 );

--- a/tests/lib/rules/id-length.js
+++ b/tests/lib/rules/id-length.js
@@ -35,6 +35,8 @@ ruleTester.run("id-length", rule, {
         "var xyz = new ΣΣ();",
         "unrelatedExpressionThatNeedsToBeIgnored();",
         "var obj = { 'a': 1, bc: 2 }; obj.tk = obj.a;",
+        "var query = location.query.q || '';",
+        "var query = location.query.q ? location.query.q : ''",
         { code: "var x = Foo(42)", options: [{ min: 1 }] },
         { code: "var x = Foo(42)", options: [{ min: 0 }] },
         { code: "foo.$x = Foo(42)", options: [{ min: 1 }] },
@@ -64,6 +66,7 @@ ruleTester.run("id-length", rule, {
     invalid: [
         { code: "var x = 1;", errors: [{ message: "Identifier name 'x' is too short (< 2).", type: "Identifier" }] },
         { code: "var x;", errors: [{ message: "Identifier name 'x' is too short (< 2).", type: "Identifier" }] },
+        { code: "obj.e = document.body;", errors: [{ message: "Identifier name 'e' is too short (< 2).", type: "Identifier" }] },
         { code: "function x() {};", errors: [{ message: "Identifier name 'x' is too short (< 2).", type: "Identifier" }] },
         { code: "function xyz(a) {};", errors: [{ message: "Identifier name 'a' is too short (< 2).", type: "Identifier" }] },
         { code: "var obj = { a: 1, bc: 2 };", errors: [{ message: "Identifier name 'a' is too short (< 2).", type: "Identifier" }] },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What changes did you make? (Give an overview)**

Corrected the `MemberExpression` check on the parent node when determining assignment to an object property.

**Is there anything you'd like reviewers to focus on?**

Nope.

