### PR TITLE
Docs: Document the deprecated meta property

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -61,6 +61,8 @@ The source file for a rule exports an object with the following properties.
 
 * `schema` (array) specifies the [options](#options-schemas) so ESLint can prevent invalid [rule configurations](../user-guide/configuring#configuring-rules)
 
+* `deprecated` (boolean) indicates whether the rule has been deprecated.  You may omit the `deprecated` property if the rule has not been deprecated.
+
 `create` (function) returns an object with methods that ESLint calls to "visit" nodes while traversing the abstract syntax tree (AST as defined by [ESTree](https://github.com/estree/estree)) of JavaScript code:
 
 * if a key is a node type, ESLint calls that **visitor** function while going **down** the tree


### PR DESCRIPTION
Over on [eslint-find-rules](https://github.com/sarbbottam/eslint-find-rules), there has been some discussion about being able to detect deprecated rules in order to [not report them as unused](https://github.com/sarbbottam/eslint-find-rules/issues/172) and to [report when they are still being used](https://github.com/sarbbottam/eslint-find-rules/issues/188).

In order to implement those features, there needs to be a way to detect that a rule has been deprecated.  Core ESLint rules that are deprecated are marked as such in their metadata, but this property is not currently documented.

This PR adds documentation about the meta property so that plugin authors can see that it is something they can use on their rules.
