### PR TITLE
Fix: `comma-dangle` was confused by type annotations (fixes #7370)

### DIFF
--- a/lib/rules/comma-dangle.js
+++ b/lib/rules/comma-dangle.js
@@ -171,15 +171,10 @@ module.exports = {
         function getTrailingToken(node, lastItem) {
             switch (node.type) {
                 case "ObjectExpression":
-                case "ObjectPattern":
                 case "ArrayExpression":
-                case "ArrayPattern":
                 case "CallExpression":
                 case "NewExpression":
                     return sourceCode.getLastToken(node, 1);
-                case "FunctionDeclaration":
-                case "FunctionExpression":
-                    return sourceCode.getTokenBefore(node.body, 1);
                 default: {
                     const nextToken = sourceCode.getTokenAfter(lastItem);
 

--- a/tests/fixtures/parsers/comma-dangle/object-pattern-1.js
+++ b/tests/fixtures/parsers/comma-dangle/object-pattern-1.js
@@ -1,0 +1,1148 @@
+"use strict";
+
+// The AST of the following code:
+//
+//     function foo({a}: {a: string,}) {}
+//
+
+module.exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 34,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 1,
+            column: 34
+        }
+    },
+    sourceType: "module",
+    body: [
+        {
+            type: "FunctionDeclaration",
+            start: 0,
+            end: 34,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 34
+                }
+            },
+            id: {
+                type: "Identifier",
+                start: 9,
+                end: 12,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 9
+                    },
+                    end: {
+                        line: 1,
+                        column: 12
+                    }
+                },
+                name: "foo",
+                range: [
+                    9,
+                    12
+                ],
+                _babelType: "Identifier"
+            },
+            generator: false,
+            expression: false,
+            async: false,
+            params: [
+                {
+                    type: "ObjectPattern",
+                    start: 13,
+                    end: 30,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 13
+                        },
+                        end: {
+                            line: 1,
+                            column: 30
+                        }
+                    },
+                    properties: [
+                        {
+                            type: "Property",
+                            start: 14,
+                            end: 15,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 14
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 15
+                                }
+                            },
+                            method: false,
+                            shorthand: true,
+                            computed: false,
+                            key: {
+                                type: "Identifier",
+                                start: 14,
+                                end: 15,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 14
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 15
+                                    }
+                                },
+                                name: "a",
+                                range: [
+                                    14,
+                                    15
+                                ],
+                                _babelType: "Identifier"
+                            },
+                            kind: "init",
+                            value: {
+                                type: "Identifier",
+                                start: 14,
+                                end: 15,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 14
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 15
+                                    }
+                                },
+                                name: "a",
+                                range: [
+                                    14,
+                                    15
+                                ],
+                                _babelType: "Identifier"
+                            },
+                            range: [
+                                14,
+                                15
+                            ],
+                            _babelType: "Property"
+                        }
+                    ],
+                    typeAnnotation: {
+                        type: "TypeAnnotation",
+                        start: 16,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 16
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        typeAnnotation: {
+                            type: "ObjectTypeAnnotation",
+                            start: 18,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 18
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            callProperties: [],
+                            properties: [
+                                {
+                                    type: "ObjectTypeProperty",
+                                    start: 19,
+                                    end: 29,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 19
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 29
+                                        }
+                                    },
+                                    value: {
+                                        type: "StringTypeAnnotation",
+                                        start: 22,
+                                        end: 28,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 22
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 28
+                                            }
+                                        },
+                                        range: [
+                                            22,
+                                            28
+                                        ],
+                                        _babelType: "StringTypeAnnotation"
+                                    },
+                                    optional: false,
+                                    range: [
+                                        19,
+                                        29
+                                    ],
+                                    _babelType: "ObjectTypeProperty"
+                                }
+                            ],
+                            indexers: [],
+                            range: [
+                                18,
+                                30
+                            ],
+                            _babelType: "ObjectTypeAnnotation"
+                        },
+                        range: [
+                            16,
+                            30
+                        ],
+                        _babelType: "TypeAnnotation"
+                    },
+                    range: [
+                        13,
+                        30
+                    ],
+                    _babelType: "ObjectPattern"
+                }
+            ],
+            body: {
+                type: "BlockStatement",
+                start: 32,
+                end: 34,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 32
+                    },
+                    end: {
+                        line: 1,
+                        column: 34
+                    }
+                },
+                body: [],
+                range: [
+                    32,
+                    34
+                ],
+                _babelType: "BlockStatement"
+            },
+            range: [
+                0,
+                34
+            ],
+            _babelType: "FunctionDeclaration"
+        }
+    ],
+    tokens: [
+        {
+            type: "Keyword",
+            value: "function",
+            start: 0,
+            end: 8,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 8
+                }
+            },
+            range: [
+                0,
+                8
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "foo",
+            start: 9,
+            end: 12,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 9
+                },
+                end: {
+                    line: 1,
+                    column: 12
+                }
+            },
+            range: [
+                9,
+                12
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 12,
+            end: 13,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 12
+                },
+                end: {
+                    line: 1,
+                    column: 13
+                }
+            },
+            range: [
+                12,
+                13
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 13,
+            end: 14,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 13
+                },
+                end: {
+                    line: 1,
+                    column: 14
+                }
+            },
+            range: [
+                13,
+                14
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 14,
+            end: 15,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 14
+                },
+                end: {
+                    line: 1,
+                    column: 15
+                }
+            },
+            range: [
+                14,
+                15
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 15,
+            end: 16,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 15
+                },
+                end: {
+                    line: 1,
+                    column: 16
+                }
+            },
+            range: [
+                15,
+                16
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 16,
+            end: 17,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 16
+                },
+                end: {
+                    line: 1,
+                    column: 17
+                }
+            },
+            range: [
+                16,
+                17
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 18,
+            end: 19,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 18
+                },
+                end: {
+                    line: 1,
+                    column: 19
+                }
+            },
+            range: [
+                18,
+                19
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 19,
+            end: 20,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 19
+                },
+                end: {
+                    line: 1,
+                    column: 20
+                }
+            },
+            range: [
+                19,
+                20
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 20,
+            end: 21,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 20
+                },
+                end: {
+                    line: 1,
+                    column: 21
+                }
+            },
+            range: [
+                20,
+                21
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "string",
+            start: 22,
+            end: 28,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 22
+                },
+                end: {
+                    line: 1,
+                    column: 28
+                }
+            },
+            range: [
+                22,
+                28
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ",",
+            start: 28,
+            end: 29,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 28
+                },
+                end: {
+                    line: 1,
+                    column: 29
+                }
+            },
+            range: [
+                28,
+                29
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 29,
+            end: 30,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 29
+                },
+                end: {
+                    line: 1,
+                    column: 30
+                }
+            },
+            range: [
+                29,
+                30
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 30,
+            end: 31,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 30
+                },
+                end: {
+                    line: 1,
+                    column: 31
+                }
+            },
+            range: [
+                30,
+                31
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 32,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 32
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            range: [
+                32,
+                33
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 33,
+            end: 34,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 33
+                },
+                end: {
+                    line: 1,
+                    column: 34
+                }
+            },
+            range: [
+                33,
+                34
+            ]
+        },
+        {
+            type: {
+                label: "eof",
+                beforeExpr: false,
+                startsExpr: false,
+                rightAssociative: false,
+                isLoop: false,
+                isAssign: false,
+                prefix: false,
+                postfix: false,
+                binop: null,
+                updateContext: null
+            },
+            start: 34,
+            end: 34,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 34
+                },
+                end: {
+                    line: 1,
+                    column: 34
+                }
+            },
+            range: [
+                34,
+                34
+            ]
+        }
+    ],
+    comments: [],
+    range: [
+        0,
+        34
+    ],
+    _paths: [
+        {
+            contexts: [],
+            parent: "[Circular ~]",
+            data: {},
+            shouldSkip: false,
+            shouldStop: false,
+            removed: false,
+            opts: {
+                noScope: true,
+                enter: [
+                    null
+                ],
+                exit: [
+                    null
+                ],
+                _exploded: true,
+                _verified: true
+            },
+            skipKeys: {},
+            parentPath: null,
+            context: {
+                queue: null,
+                opts: {
+                    noScope: true,
+                    enter: [
+                        null
+                    ],
+                    exit: [
+                        null
+                    ],
+                    _exploded: true,
+                    _verified: true
+                }
+            },
+            container: [
+                {
+                    type: "FunctionDeclaration",
+                    start: 0,
+                    end: 34,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 0
+                        },
+                        end: {
+                            line: 1,
+                            column: 34
+                        }
+                    },
+                    id: {
+                        type: "Identifier",
+                        start: 9,
+                        end: 12,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 9
+                            },
+                            end: {
+                                line: 1,
+                                column: 12
+                            }
+                        },
+                        name: "foo",
+                        range: [
+                            9,
+                            12
+                        ],
+                        _babelType: "Identifier"
+                    },
+                    generator: false,
+                    expression: false,
+                    async: false,
+                    params: [
+                        {
+                            type: "ObjectPattern",
+                            start: 13,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 13
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            properties: [
+                                {
+                                    type: "Property",
+                                    start: 14,
+                                    end: 15,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 14
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 15
+                                        }
+                                    },
+                                    method: false,
+                                    shorthand: true,
+                                    computed: false,
+                                    key: {
+                                        type: "Identifier",
+                                        start: 14,
+                                        end: 15,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 14
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 15
+                                            }
+                                        },
+                                        name: "a",
+                                        range: [
+                                            14,
+                                            15
+                                        ],
+                                        _babelType: "Identifier"
+                                    },
+                                    kind: "init",
+                                    value: {
+                                        type: "Identifier",
+                                        start: 14,
+                                        end: 15,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 14
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 15
+                                            }
+                                        },
+                                        name: "a",
+                                        range: [
+                                            14,
+                                            15
+                                        ],
+                                        _babelType: "Identifier"
+                                    },
+                                    range: [
+                                        14,
+                                        15
+                                    ],
+                                    _babelType: "Property"
+                                }
+                            ],
+                            typeAnnotation: {
+                                type: "TypeAnnotation",
+                                start: 16,
+                                end: 30,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 16
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 30
+                                    }
+                                },
+                                typeAnnotation: {
+                                    type: "ObjectTypeAnnotation",
+                                    start: 18,
+                                    end: 30,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 18
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 30
+                                        }
+                                    },
+                                    callProperties: [],
+                                    properties: [
+                                        {
+                                            type: "ObjectTypeProperty",
+                                            start: 19,
+                                            end: 29,
+                                            loc: {
+                                                start: {
+                                                    line: 1,
+                                                    column: 19
+                                                },
+                                                end: {
+                                                    line: 1,
+                                                    column: 29
+                                                }
+                                            },
+                                            value: {
+                                                type: "StringTypeAnnotation",
+                                                start: 22,
+                                                end: 28,
+                                                loc: {
+                                                    start: {
+                                                        line: 1,
+                                                        column: 22
+                                                    },
+                                                    end: {
+                                                        line: 1,
+                                                        column: 28
+                                                    }
+                                                },
+                                                range: [
+                                                    22,
+                                                    28
+                                                ],
+                                                _babelType: "StringTypeAnnotation"
+                                            },
+                                            optional: false,
+                                            range: [
+                                                19,
+                                                29
+                                            ],
+                                            _babelType: "ObjectTypeProperty"
+                                        }
+                                    ],
+                                    indexers: [],
+                                    range: [
+                                        18,
+                                        30
+                                    ],
+                                    _babelType: "ObjectTypeAnnotation"
+                                },
+                                range: [
+                                    16,
+                                    30
+                                ],
+                                _babelType: "TypeAnnotation"
+                            },
+                            range: [
+                                13,
+                                30
+                            ],
+                            _babelType: "ObjectPattern"
+                        }
+                    ],
+                    body: {
+                        type: "BlockStatement",
+                        start: 32,
+                        end: 34,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 32
+                            },
+                            end: {
+                                line: 1,
+                                column: 34
+                            }
+                        },
+                        body: [],
+                        range: [
+                            32,
+                            34
+                        ],
+                        _babelType: "BlockStatement"
+                    },
+                    range: [
+                        0,
+                        34
+                    ],
+                    _babelType: "FunctionDeclaration"
+                }
+            ],
+            listKey: "body",
+            inList: true,
+            parentKey: "body",
+            key: 0,
+            node: {
+                type: "FunctionDeclaration",
+                start: 0,
+                end: 34,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 1,
+                        column: 34
+                    }
+                },
+                id: {
+                    type: "Identifier",
+                    start: 9,
+                    end: 12,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 9
+                        },
+                        end: {
+                            line: 1,
+                            column: 12
+                        }
+                    },
+                    name: "foo",
+                    range: [
+                        9,
+                        12
+                    ],
+                    _babelType: "Identifier"
+                },
+                generator: false,
+                expression: false,
+                async: false,
+                params: [
+                    {
+                        type: "ObjectPattern",
+                        start: 13,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 13
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        properties: [
+                            {
+                                type: "Property",
+                                start: 14,
+                                end: 15,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 14
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 15
+                                    }
+                                },
+                                method: false,
+                                shorthand: true,
+                                computed: false,
+                                key: {
+                                    type: "Identifier",
+                                    start: 14,
+                                    end: 15,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 14
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 15
+                                        }
+                                    },
+                                    name: "a",
+                                    range: [
+                                        14,
+                                        15
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                kind: "init",
+                                value: {
+                                    type: "Identifier",
+                                    start: 14,
+                                    end: 15,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 14
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 15
+                                        }
+                                    },
+                                    name: "a",
+                                    range: [
+                                        14,
+                                        15
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                range: [
+                                    14,
+                                    15
+                                ],
+                                _babelType: "Property"
+                            }
+                        ],
+                        typeAnnotation: {
+                            type: "TypeAnnotation",
+                            start: 16,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 16
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            typeAnnotation: {
+                                type: "ObjectTypeAnnotation",
+                                start: 18,
+                                end: 30,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 18
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 30
+                                    }
+                                },
+                                callProperties: [],
+                                properties: [
+                                    {
+                                        type: "ObjectTypeProperty",
+                                        start: 19,
+                                        end: 29,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 19
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 29
+                                            }
+                                        },
+                                        value: {
+                                            type: "StringTypeAnnotation",
+                                            start: 22,
+                                            end: 28,
+                                            loc: {
+                                                start: {
+                                                    line: 1,
+                                                    column: 22
+                                                },
+                                                end: {
+                                                    line: 1,
+                                                    column: 28
+                                                }
+                                            },
+                                            range: [
+                                                22,
+                                                28
+                                            ],
+                                            _babelType: "StringTypeAnnotation"
+                                        },
+                                        optional: false,
+                                        range: [
+                                            19,
+                                            29
+                                        ],
+                                        _babelType: "ObjectTypeProperty"
+                                    }
+                                ],
+                                indexers: [],
+                                range: [
+                                    18,
+                                    30
+                                ],
+                                _babelType: "ObjectTypeAnnotation"
+                            },
+                            range: [
+                                16,
+                                30
+                            ],
+                            _babelType: "TypeAnnotation"
+                        },
+                        range: [
+                            13,
+                            30
+                        ],
+                        _babelType: "ObjectPattern"
+                    }
+                ],
+                body: {
+                    type: "BlockStatement",
+                    start: 32,
+                    end: 34,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 32
+                        },
+                        end: {
+                            line: 1,
+                            column: 34
+                        }
+                    },
+                    body: [],
+                    range: [
+                        32,
+                        34
+                    ],
+                    _babelType: "BlockStatement"
+                },
+                range: [
+                    0,
+                    34
+                ],
+                _babelType: "FunctionDeclaration"
+            },
+            scope: null,
+            type: "FunctionDeclaration",
+            typeAnnotation: null
+        }
+    ]
+});

--- a/tests/fixtures/parsers/comma-dangle/object-pattern-2.js
+++ b/tests/fixtures/parsers/comma-dangle/object-pattern-2.js
@@ -1,0 +1,1148 @@
+"use strict";
+
+// The AST of the following code:
+//
+//     function foo({a,}: {a: string}) {}
+//
+
+module.exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 34,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 1,
+            column: 34
+        }
+    },
+    sourceType: "module",
+    body: [
+        {
+            type: "FunctionDeclaration",
+            start: 0,
+            end: 34,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 34
+                }
+            },
+            id: {
+                type: "Identifier",
+                start: 9,
+                end: 12,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 9
+                    },
+                    end: {
+                        line: 1,
+                        column: 12
+                    }
+                },
+                name: "foo",
+                range: [
+                    9,
+                    12
+                ],
+                _babelType: "Identifier"
+            },
+            generator: false,
+            expression: false,
+            async: false,
+            params: [
+                {
+                    type: "ObjectPattern",
+                    start: 13,
+                    end: 30,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 13
+                        },
+                        end: {
+                            line: 1,
+                            column: 30
+                        }
+                    },
+                    properties: [
+                        {
+                            type: "Property",
+                            start: 14,
+                            end: 15,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 14
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 15
+                                }
+                            },
+                            method: false,
+                            shorthand: true,
+                            computed: false,
+                            key: {
+                                type: "Identifier",
+                                start: 14,
+                                end: 15,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 14
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 15
+                                    }
+                                },
+                                name: "a",
+                                range: [
+                                    14,
+                                    15
+                                ],
+                                _babelType: "Identifier"
+                            },
+                            kind: "init",
+                            value: {
+                                type: "Identifier",
+                                start: 14,
+                                end: 15,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 14
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 15
+                                    }
+                                },
+                                name: "a",
+                                range: [
+                                    14,
+                                    15
+                                ],
+                                _babelType: "Identifier"
+                            },
+                            range: [
+                                14,
+                                15
+                            ],
+                            _babelType: "Property"
+                        }
+                    ],
+                    typeAnnotation: {
+                        type: "TypeAnnotation",
+                        start: 17,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 17
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        typeAnnotation: {
+                            type: "ObjectTypeAnnotation",
+                            start: 19,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 19
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            callProperties: [],
+                            properties: [
+                                {
+                                    type: "ObjectTypeProperty",
+                                    start: 20,
+                                    end: 29,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 20
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 29
+                                        }
+                                    },
+                                    value: {
+                                        type: "StringTypeAnnotation",
+                                        start: 23,
+                                        end: 29,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 23
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 29
+                                            }
+                                        },
+                                        range: [
+                                            23,
+                                            29
+                                        ],
+                                        _babelType: "StringTypeAnnotation"
+                                    },
+                                    optional: false,
+                                    range: [
+                                        20,
+                                        29
+                                    ],
+                                    _babelType: "ObjectTypeProperty"
+                                }
+                            ],
+                            indexers: [],
+                            range: [
+                                19,
+                                30
+                            ],
+                            _babelType: "ObjectTypeAnnotation"
+                        },
+                        range: [
+                            17,
+                            30
+                        ],
+                        _babelType: "TypeAnnotation"
+                    },
+                    range: [
+                        13,
+                        30
+                    ],
+                    _babelType: "ObjectPattern"
+                }
+            ],
+            body: {
+                type: "BlockStatement",
+                start: 32,
+                end: 34,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 32
+                    },
+                    end: {
+                        line: 1,
+                        column: 34
+                    }
+                },
+                body: [],
+                range: [
+                    32,
+                    34
+                ],
+                _babelType: "BlockStatement"
+            },
+            range: [
+                0,
+                34
+            ],
+            _babelType: "FunctionDeclaration"
+        }
+    ],
+    tokens: [
+        {
+            type: "Keyword",
+            value: "function",
+            start: 0,
+            end: 8,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 8
+                }
+            },
+            range: [
+                0,
+                8
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "foo",
+            start: 9,
+            end: 12,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 9
+                },
+                end: {
+                    line: 1,
+                    column: 12
+                }
+            },
+            range: [
+                9,
+                12
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 12,
+            end: 13,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 12
+                },
+                end: {
+                    line: 1,
+                    column: 13
+                }
+            },
+            range: [
+                12,
+                13
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 13,
+            end: 14,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 13
+                },
+                end: {
+                    line: 1,
+                    column: 14
+                }
+            },
+            range: [
+                13,
+                14
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 14,
+            end: 15,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 14
+                },
+                end: {
+                    line: 1,
+                    column: 15
+                }
+            },
+            range: [
+                14,
+                15
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ",",
+            start: 15,
+            end: 16,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 15
+                },
+                end: {
+                    line: 1,
+                    column: 16
+                }
+            },
+            range: [
+                15,
+                16
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 16,
+            end: 17,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 16
+                },
+                end: {
+                    line: 1,
+                    column: 17
+                }
+            },
+            range: [
+                16,
+                17
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 17,
+            end: 18,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 17
+                },
+                end: {
+                    line: 1,
+                    column: 18
+                }
+            },
+            range: [
+                17,
+                18
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 19,
+            end: 20,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 19
+                },
+                end: {
+                    line: 1,
+                    column: 20
+                }
+            },
+            range: [
+                19,
+                20
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 20,
+            end: 21,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 20
+                },
+                end: {
+                    line: 1,
+                    column: 21
+                }
+            },
+            range: [
+                20,
+                21
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 21,
+            end: 22,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 21
+                },
+                end: {
+                    line: 1,
+                    column: 22
+                }
+            },
+            range: [
+                21,
+                22
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "string",
+            start: 23,
+            end: 29,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 23
+                },
+                end: {
+                    line: 1,
+                    column: 29
+                }
+            },
+            range: [
+                23,
+                29
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 29,
+            end: 30,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 29
+                },
+                end: {
+                    line: 1,
+                    column: 30
+                }
+            },
+            range: [
+                29,
+                30
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 30,
+            end: 31,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 30
+                },
+                end: {
+                    line: 1,
+                    column: 31
+                }
+            },
+            range: [
+                30,
+                31
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 32,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 32
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            range: [
+                32,
+                33
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 33,
+            end: 34,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 33
+                },
+                end: {
+                    line: 1,
+                    column: 34
+                }
+            },
+            range: [
+                33,
+                34
+            ]
+        },
+        {
+            type: {
+                label: "eof",
+                beforeExpr: false,
+                startsExpr: false,
+                rightAssociative: false,
+                isLoop: false,
+                isAssign: false,
+                prefix: false,
+                postfix: false,
+                binop: null,
+                updateContext: null
+            },
+            start: 34,
+            end: 34,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 34
+                },
+                end: {
+                    line: 1,
+                    column: 34
+                }
+            },
+            range: [
+                34,
+                34
+            ]
+        }
+    ],
+    comments: [],
+    range: [
+        0,
+        34
+    ],
+    _paths: [
+        {
+            contexts: [],
+            parent: "[Circular ~]",
+            data: {},
+            shouldSkip: false,
+            shouldStop: false,
+            removed: false,
+            opts: {
+                noScope: true,
+                enter: [
+                    null
+                ],
+                exit: [
+                    null
+                ],
+                _exploded: true,
+                _verified: true
+            },
+            skipKeys: {},
+            parentPath: null,
+            context: {
+                queue: null,
+                opts: {
+                    noScope: true,
+                    enter: [
+                        null
+                    ],
+                    exit: [
+                        null
+                    ],
+                    _exploded: true,
+                    _verified: true
+                }
+            },
+            container: [
+                {
+                    type: "FunctionDeclaration",
+                    start: 0,
+                    end: 34,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 0
+                        },
+                        end: {
+                            line: 1,
+                            column: 34
+                        }
+                    },
+                    id: {
+                        type: "Identifier",
+                        start: 9,
+                        end: 12,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 9
+                            },
+                            end: {
+                                line: 1,
+                                column: 12
+                            }
+                        },
+                        name: "foo",
+                        range: [
+                            9,
+                            12
+                        ],
+                        _babelType: "Identifier"
+                    },
+                    generator: false,
+                    expression: false,
+                    async: false,
+                    params: [
+                        {
+                            type: "ObjectPattern",
+                            start: 13,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 13
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            properties: [
+                                {
+                                    type: "Property",
+                                    start: 14,
+                                    end: 15,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 14
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 15
+                                        }
+                                    },
+                                    method: false,
+                                    shorthand: true,
+                                    computed: false,
+                                    key: {
+                                        type: "Identifier",
+                                        start: 14,
+                                        end: 15,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 14
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 15
+                                            }
+                                        },
+                                        name: "a",
+                                        range: [
+                                            14,
+                                            15
+                                        ],
+                                        _babelType: "Identifier"
+                                    },
+                                    kind: "init",
+                                    value: {
+                                        type: "Identifier",
+                                        start: 14,
+                                        end: 15,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 14
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 15
+                                            }
+                                        },
+                                        name: "a",
+                                        range: [
+                                            14,
+                                            15
+                                        ],
+                                        _babelType: "Identifier"
+                                    },
+                                    range: [
+                                        14,
+                                        15
+                                    ],
+                                    _babelType: "Property"
+                                }
+                            ],
+                            typeAnnotation: {
+                                type: "TypeAnnotation",
+                                start: 17,
+                                end: 30,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 17
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 30
+                                    }
+                                },
+                                typeAnnotation: {
+                                    type: "ObjectTypeAnnotation",
+                                    start: 19,
+                                    end: 30,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 19
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 30
+                                        }
+                                    },
+                                    callProperties: [],
+                                    properties: [
+                                        {
+                                            type: "ObjectTypeProperty",
+                                            start: 20,
+                                            end: 29,
+                                            loc: {
+                                                start: {
+                                                    line: 1,
+                                                    column: 20
+                                                },
+                                                end: {
+                                                    line: 1,
+                                                    column: 29
+                                                }
+                                            },
+                                            value: {
+                                                type: "StringTypeAnnotation",
+                                                start: 23,
+                                                end: 29,
+                                                loc: {
+                                                    start: {
+                                                        line: 1,
+                                                        column: 23
+                                                    },
+                                                    end: {
+                                                        line: 1,
+                                                        column: 29
+                                                    }
+                                                },
+                                                range: [
+                                                    23,
+                                                    29
+                                                ],
+                                                _babelType: "StringTypeAnnotation"
+                                            },
+                                            optional: false,
+                                            range: [
+                                                20,
+                                                29
+                                            ],
+                                            _babelType: "ObjectTypeProperty"
+                                        }
+                                    ],
+                                    indexers: [],
+                                    range: [
+                                        19,
+                                        30
+                                    ],
+                                    _babelType: "ObjectTypeAnnotation"
+                                },
+                                range: [
+                                    17,
+                                    30
+                                ],
+                                _babelType: "TypeAnnotation"
+                            },
+                            range: [
+                                13,
+                                30
+                            ],
+                            _babelType: "ObjectPattern"
+                        }
+                    ],
+                    body: {
+                        type: "BlockStatement",
+                        start: 32,
+                        end: 34,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 32
+                            },
+                            end: {
+                                line: 1,
+                                column: 34
+                            }
+                        },
+                        body: [],
+                        range: [
+                            32,
+                            34
+                        ],
+                        _babelType: "BlockStatement"
+                    },
+                    range: [
+                        0,
+                        34
+                    ],
+                    _babelType: "FunctionDeclaration"
+                }
+            ],
+            listKey: "body",
+            inList: true,
+            parentKey: "body",
+            key: 0,
+            node: {
+                type: "FunctionDeclaration",
+                start: 0,
+                end: 34,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 1,
+                        column: 34
+                    }
+                },
+                id: {
+                    type: "Identifier",
+                    start: 9,
+                    end: 12,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 9
+                        },
+                        end: {
+                            line: 1,
+                            column: 12
+                        }
+                    },
+                    name: "foo",
+                    range: [
+                        9,
+                        12
+                    ],
+                    _babelType: "Identifier"
+                },
+                generator: false,
+                expression: false,
+                async: false,
+                params: [
+                    {
+                        type: "ObjectPattern",
+                        start: 13,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 13
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        properties: [
+                            {
+                                type: "Property",
+                                start: 14,
+                                end: 15,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 14
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 15
+                                    }
+                                },
+                                method: false,
+                                shorthand: true,
+                                computed: false,
+                                key: {
+                                    type: "Identifier",
+                                    start: 14,
+                                    end: 15,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 14
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 15
+                                        }
+                                    },
+                                    name: "a",
+                                    range: [
+                                        14,
+                                        15
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                kind: "init",
+                                value: {
+                                    type: "Identifier",
+                                    start: 14,
+                                    end: 15,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 14
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 15
+                                        }
+                                    },
+                                    name: "a",
+                                    range: [
+                                        14,
+                                        15
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                range: [
+                                    14,
+                                    15
+                                ],
+                                _babelType: "Property"
+                            }
+                        ],
+                        typeAnnotation: {
+                            type: "TypeAnnotation",
+                            start: 17,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 17
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            typeAnnotation: {
+                                type: "ObjectTypeAnnotation",
+                                start: 19,
+                                end: 30,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 19
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 30
+                                    }
+                                },
+                                callProperties: [],
+                                properties: [
+                                    {
+                                        type: "ObjectTypeProperty",
+                                        start: 20,
+                                        end: 29,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 20
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 29
+                                            }
+                                        },
+                                        value: {
+                                            type: "StringTypeAnnotation",
+                                            start: 23,
+                                            end: 29,
+                                            loc: {
+                                                start: {
+                                                    line: 1,
+                                                    column: 23
+                                                },
+                                                end: {
+                                                    line: 1,
+                                                    column: 29
+                                                }
+                                            },
+                                            range: [
+                                                23,
+                                                29
+                                            ],
+                                            _babelType: "StringTypeAnnotation"
+                                        },
+                                        optional: false,
+                                        range: [
+                                            20,
+                                            29
+                                        ],
+                                        _babelType: "ObjectTypeProperty"
+                                    }
+                                ],
+                                indexers: [],
+                                range: [
+                                    19,
+                                    30
+                                ],
+                                _babelType: "ObjectTypeAnnotation"
+                            },
+                            range: [
+                                17,
+                                30
+                            ],
+                            _babelType: "TypeAnnotation"
+                        },
+                        range: [
+                            13,
+                            30
+                        ],
+                        _babelType: "ObjectPattern"
+                    }
+                ],
+                body: {
+                    type: "BlockStatement",
+                    start: 32,
+                    end: 34,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 32
+                        },
+                        end: {
+                            line: 1,
+                            column: 34
+                        }
+                    },
+                    body: [],
+                    range: [
+                        32,
+                        34
+                    ],
+                    _babelType: "BlockStatement"
+                },
+                range: [
+                    0,
+                    34
+                ],
+                _babelType: "FunctionDeclaration"
+            },
+            scope: null,
+            type: "FunctionDeclaration",
+            typeAnnotation: null
+        }
+    ]
+});

--- a/tests/fixtures/parsers/comma-dangle/return-type-1.js
+++ b/tests/fixtures/parsers/comma-dangle/return-type-1.js
@@ -1,0 +1,907 @@
+"use strict";
+
+// The AST of the following code:
+//
+//     function foo(a): {b: boolean,} {}
+//
+
+module.exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 33,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 1,
+            column: 33
+        }
+    },
+    sourceType: "module",
+    body: [
+        {
+            type: "FunctionDeclaration",
+            start: 0,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            id: {
+                type: "Identifier",
+                start: 9,
+                end: 12,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 9
+                    },
+                    end: {
+                        line: 1,
+                        column: 12
+                    }
+                },
+                name: "foo",
+                range: [
+                    9,
+                    12
+                ],
+                _babelType: "Identifier"
+            },
+            generator: false,
+            expression: false,
+            async: false,
+            params: [
+                {
+                    type: "Identifier",
+                    start: 13,
+                    end: 14,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 13
+                        },
+                        end: {
+                            line: 1,
+                            column: 14
+                        }
+                    },
+                    name: "a",
+                    range: [
+                        13,
+                        14
+                    ],
+                    _babelType: "Identifier"
+                }
+            ],
+            returnType: {
+                type: "TypeAnnotation",
+                start: 15,
+                end: 30,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 15
+                    },
+                    end: {
+                        line: 1,
+                        column: 30
+                    }
+                },
+                typeAnnotation: {
+                    type: "ObjectTypeAnnotation",
+                    start: 17,
+                    end: 30,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 17
+                        },
+                        end: {
+                            line: 1,
+                            column: 30
+                        }
+                    },
+                    callProperties: [],
+                    properties: [
+                        {
+                            type: "ObjectTypeProperty",
+                            start: 18,
+                            end: 29,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 18
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 29
+                                }
+                            },
+                            value: {
+                                type: "BooleanTypeAnnotation",
+                                start: 21,
+                                end: 28,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 21
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 28
+                                    }
+                                },
+                                range: [
+                                    21,
+                                    28
+                                ],
+                                _babelType: "BooleanTypeAnnotation"
+                            },
+                            optional: false,
+                            range: [
+                                18,
+                                29
+                            ],
+                            _babelType: "ObjectTypeProperty"
+                        }
+                    ],
+                    indexers: [],
+                    range: [
+                        17,
+                        30
+                    ],
+                    _babelType: "ObjectTypeAnnotation"
+                },
+                range: [
+                    15,
+                    30
+                ],
+                _babelType: "TypeAnnotation"
+            },
+            body: {
+                type: "BlockStatement",
+                start: 31,
+                end: 33,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 31
+                    },
+                    end: {
+                        line: 1,
+                        column: 33
+                    }
+                },
+                body: [],
+                range: [
+                    31,
+                    33
+                ],
+                _babelType: "BlockStatement"
+            },
+            range: [
+                0,
+                33
+            ],
+            _babelType: "FunctionDeclaration"
+        }
+    ],
+    tokens: [
+        {
+            type: "Keyword",
+            value: "function",
+            start: 0,
+            end: 8,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 8
+                }
+            },
+            range: [
+                0,
+                8
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "foo",
+            start: 9,
+            end: 12,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 9
+                },
+                end: {
+                    line: 1,
+                    column: 12
+                }
+            },
+            range: [
+                9,
+                12
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 12,
+            end: 13,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 12
+                },
+                end: {
+                    line: 1,
+                    column: 13
+                }
+            },
+            range: [
+                12,
+                13
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 13,
+            end: 14,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 13
+                },
+                end: {
+                    line: 1,
+                    column: 14
+                }
+            },
+            range: [
+                13,
+                14
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 14,
+            end: 15,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 14
+                },
+                end: {
+                    line: 1,
+                    column: 15
+                }
+            },
+            range: [
+                14,
+                15
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 15,
+            end: 16,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 15
+                },
+                end: {
+                    line: 1,
+                    column: 16
+                }
+            },
+            range: [
+                15,
+                16
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 17,
+            end: 18,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 17
+                },
+                end: {
+                    line: 1,
+                    column: 18
+                }
+            },
+            range: [
+                17,
+                18
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "b",
+            start: 18,
+            end: 19,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 18
+                },
+                end: {
+                    line: 1,
+                    column: 19
+                }
+            },
+            range: [
+                18,
+                19
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 19,
+            end: 20,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 19
+                },
+                end: {
+                    line: 1,
+                    column: 20
+                }
+            },
+            range: [
+                19,
+                20
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "boolean",
+            start: 21,
+            end: 28,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 21
+                },
+                end: {
+                    line: 1,
+                    column: 28
+                }
+            },
+            range: [
+                21,
+                28
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ",",
+            start: 28,
+            end: 29,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 28
+                },
+                end: {
+                    line: 1,
+                    column: 29
+                }
+            },
+            range: [
+                28,
+                29
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 29,
+            end: 30,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 29
+                },
+                end: {
+                    line: 1,
+                    column: 30
+                }
+            },
+            range: [
+                29,
+                30
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 31,
+            end: 32,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 31
+                },
+                end: {
+                    line: 1,
+                    column: 32
+                }
+            },
+            range: [
+                31,
+                32
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 32,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 32
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            range: [
+                32,
+                33
+            ]
+        },
+        {
+            type: {
+                label: "eof",
+                beforeExpr: false,
+                startsExpr: false,
+                rightAssociative: false,
+                isLoop: false,
+                isAssign: false,
+                prefix: false,
+                postfix: false,
+                binop: null,
+                updateContext: null
+            },
+            start: 33,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 33
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            range: [
+                33,
+                33
+            ]
+        }
+    ],
+    comments: [],
+    range: [
+        0,
+        33
+    ],
+    _paths: [
+        {
+            contexts: [],
+            parent: "[Circular ~]",
+            data: {},
+            shouldSkip: false,
+            shouldStop: false,
+            removed: false,
+            opts: {
+                noScope: true,
+                enter: [
+                    null
+                ],
+                exit: [
+                    null
+                ],
+                _exploded: true,
+                _verified: true
+            },
+            skipKeys: {},
+            parentPath: null,
+            context: {
+                queue: null,
+                opts: {
+                    noScope: true,
+                    enter: [
+                        null
+                    ],
+                    exit: [
+                        null
+                    ],
+                    _exploded: true,
+                    _verified: true
+                }
+            },
+            container: [
+                {
+                    type: "FunctionDeclaration",
+                    start: 0,
+                    end: 33,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 0
+                        },
+                        end: {
+                            line: 1,
+                            column: 33
+                        }
+                    },
+                    id: {
+                        type: "Identifier",
+                        start: 9,
+                        end: 12,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 9
+                            },
+                            end: {
+                                line: 1,
+                                column: 12
+                            }
+                        },
+                        name: "foo",
+                        range: [
+                            9,
+                            12
+                        ],
+                        _babelType: "Identifier"
+                    },
+                    generator: false,
+                    expression: false,
+                    async: false,
+                    params: [
+                        {
+                            type: "Identifier",
+                            start: 13,
+                            end: 14,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 13
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 14
+                                }
+                            },
+                            name: "a",
+                            range: [
+                                13,
+                                14
+                            ],
+                            _babelType: "Identifier"
+                        }
+                    ],
+                    returnType: {
+                        type: "TypeAnnotation",
+                        start: 15,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 15
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        typeAnnotation: {
+                            type: "ObjectTypeAnnotation",
+                            start: 17,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 17
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            callProperties: [],
+                            properties: [
+                                {
+                                    type: "ObjectTypeProperty",
+                                    start: 18,
+                                    end: 29,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 18
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 29
+                                        }
+                                    },
+                                    value: {
+                                        type: "BooleanTypeAnnotation",
+                                        start: 21,
+                                        end: 28,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 21
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 28
+                                            }
+                                        },
+                                        range: [
+                                            21,
+                                            28
+                                        ],
+                                        _babelType: "BooleanTypeAnnotation"
+                                    },
+                                    optional: false,
+                                    range: [
+                                        18,
+                                        29
+                                    ],
+                                    _babelType: "ObjectTypeProperty"
+                                }
+                            ],
+                            indexers: [],
+                            range: [
+                                17,
+                                30
+                            ],
+                            _babelType: "ObjectTypeAnnotation"
+                        },
+                        range: [
+                            15,
+                            30
+                        ],
+                        _babelType: "TypeAnnotation"
+                    },
+                    body: {
+                        type: "BlockStatement",
+                        start: 31,
+                        end: 33,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 31
+                            },
+                            end: {
+                                line: 1,
+                                column: 33
+                            }
+                        },
+                        body: [],
+                        range: [
+                            31,
+                            33
+                        ],
+                        _babelType: "BlockStatement"
+                    },
+                    range: [
+                        0,
+                        33
+                    ],
+                    _babelType: "FunctionDeclaration"
+                }
+            ],
+            listKey: "body",
+            inList: true,
+            parentKey: "body",
+            key: 0,
+            node: {
+                type: "FunctionDeclaration",
+                start: 0,
+                end: 33,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 1,
+                        column: 33
+                    }
+                },
+                id: {
+                    type: "Identifier",
+                    start: 9,
+                    end: 12,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 9
+                        },
+                        end: {
+                            line: 1,
+                            column: 12
+                        }
+                    },
+                    name: "foo",
+                    range: [
+                        9,
+                        12
+                    ],
+                    _babelType: "Identifier"
+                },
+                generator: false,
+                expression: false,
+                async: false,
+                params: [
+                    {
+                        type: "Identifier",
+                        start: 13,
+                        end: 14,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 13
+                            },
+                            end: {
+                                line: 1,
+                                column: 14
+                            }
+                        },
+                        name: "a",
+                        range: [
+                            13,
+                            14
+                        ],
+                        _babelType: "Identifier"
+                    }
+                ],
+                returnType: {
+                    type: "TypeAnnotation",
+                    start: 15,
+                    end: 30,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 15
+                        },
+                        end: {
+                            line: 1,
+                            column: 30
+                        }
+                    },
+                    typeAnnotation: {
+                        type: "ObjectTypeAnnotation",
+                        start: 17,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 17
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        callProperties: [],
+                        properties: [
+                            {
+                                type: "ObjectTypeProperty",
+                                start: 18,
+                                end: 29,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 18
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 29
+                                    }
+                                },
+                                value: {
+                                    type: "BooleanTypeAnnotation",
+                                    start: 21,
+                                    end: 28,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 21
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 28
+                                        }
+                                    },
+                                    range: [
+                                        21,
+                                        28
+                                    ],
+                                    _babelType: "BooleanTypeAnnotation"
+                                },
+                                optional: false,
+                                range: [
+                                    18,
+                                    29
+                                ],
+                                _babelType: "ObjectTypeProperty"
+                            }
+                        ],
+                        indexers: [],
+                        range: [
+                            17,
+                            30
+                        ],
+                        _babelType: "ObjectTypeAnnotation"
+                    },
+                    range: [
+                        15,
+                        30
+                    ],
+                    _babelType: "TypeAnnotation"
+                },
+                body: {
+                    type: "BlockStatement",
+                    start: 31,
+                    end: 33,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 31
+                        },
+                        end: {
+                            line: 1,
+                            column: 33
+                        }
+                    },
+                    body: [],
+                    range: [
+                        31,
+                        33
+                    ],
+                    _babelType: "BlockStatement"
+                },
+                range: [
+                    0,
+                    33
+                ],
+                _babelType: "FunctionDeclaration"
+            },
+            scope: null,
+            type: "FunctionDeclaration",
+            typeAnnotation: null
+        }
+    ]
+});

--- a/tests/fixtures/parsers/comma-dangle/return-type-2.js
+++ b/tests/fixtures/parsers/comma-dangle/return-type-2.js
@@ -1,0 +1,907 @@
+"use strict";
+
+// The AST of the following code:
+//
+//     function foo(a,): {b: boolean} {}
+//
+
+module.exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 33,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 1,
+            column: 33
+        }
+    },
+    sourceType: "module",
+    body: [
+        {
+            type: "FunctionDeclaration",
+            start: 0,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            id: {
+                type: "Identifier",
+                start: 9,
+                end: 12,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 9
+                    },
+                    end: {
+                        line: 1,
+                        column: 12
+                    }
+                },
+                name: "foo",
+                range: [
+                    9,
+                    12
+                ],
+                _babelType: "Identifier"
+            },
+            generator: false,
+            expression: false,
+            async: false,
+            params: [
+                {
+                    type: "Identifier",
+                    start: 13,
+                    end: 14,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 13
+                        },
+                        end: {
+                            line: 1,
+                            column: 14
+                        }
+                    },
+                    name: "a",
+                    range: [
+                        13,
+                        14
+                    ],
+                    _babelType: "Identifier"
+                }
+            ],
+            returnType: {
+                type: "TypeAnnotation",
+                start: 16,
+                end: 30,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 16
+                    },
+                    end: {
+                        line: 1,
+                        column: 30
+                    }
+                },
+                typeAnnotation: {
+                    type: "ObjectTypeAnnotation",
+                    start: 18,
+                    end: 30,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 18
+                        },
+                        end: {
+                            line: 1,
+                            column: 30
+                        }
+                    },
+                    callProperties: [],
+                    properties: [
+                        {
+                            type: "ObjectTypeProperty",
+                            start: 19,
+                            end: 29,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 19
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 29
+                                }
+                            },
+                            value: {
+                                type: "BooleanTypeAnnotation",
+                                start: 22,
+                                end: 29,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 22
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 29
+                                    }
+                                },
+                                range: [
+                                    22,
+                                    29
+                                ],
+                                _babelType: "BooleanTypeAnnotation"
+                            },
+                            optional: false,
+                            range: [
+                                19,
+                                29
+                            ],
+                            _babelType: "ObjectTypeProperty"
+                        }
+                    ],
+                    indexers: [],
+                    range: [
+                        18,
+                        30
+                    ],
+                    _babelType: "ObjectTypeAnnotation"
+                },
+                range: [
+                    16,
+                    30
+                ],
+                _babelType: "TypeAnnotation"
+            },
+            body: {
+                type: "BlockStatement",
+                start: 31,
+                end: 33,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 31
+                    },
+                    end: {
+                        line: 1,
+                        column: 33
+                    }
+                },
+                body: [],
+                range: [
+                    31,
+                    33
+                ],
+                _babelType: "BlockStatement"
+            },
+            range: [
+                0,
+                33
+            ],
+            _babelType: "FunctionDeclaration"
+        }
+    ],
+    tokens: [
+        {
+            type: "Keyword",
+            value: "function",
+            start: 0,
+            end: 8,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 8
+                }
+            },
+            range: [
+                0,
+                8
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "foo",
+            start: 9,
+            end: 12,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 9
+                },
+                end: {
+                    line: 1,
+                    column: 12
+                }
+            },
+            range: [
+                9,
+                12
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 12,
+            end: 13,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 12
+                },
+                end: {
+                    line: 1,
+                    column: 13
+                }
+            },
+            range: [
+                12,
+                13
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 13,
+            end: 14,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 13
+                },
+                end: {
+                    line: 1,
+                    column: 14
+                }
+            },
+            range: [
+                13,
+                14
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ",",
+            start: 14,
+            end: 15,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 14
+                },
+                end: {
+                    line: 1,
+                    column: 15
+                }
+            },
+            range: [
+                14,
+                15
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 15,
+            end: 16,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 15
+                },
+                end: {
+                    line: 1,
+                    column: 16
+                }
+            },
+            range: [
+                15,
+                16
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 16,
+            end: 17,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 16
+                },
+                end: {
+                    line: 1,
+                    column: 17
+                }
+            },
+            range: [
+                16,
+                17
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 18,
+            end: 19,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 18
+                },
+                end: {
+                    line: 1,
+                    column: 19
+                }
+            },
+            range: [
+                18,
+                19
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "b",
+            start: 19,
+            end: 20,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 19
+                },
+                end: {
+                    line: 1,
+                    column: 20
+                }
+            },
+            range: [
+                19,
+                20
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 20,
+            end: 21,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 20
+                },
+                end: {
+                    line: 1,
+                    column: 21
+                }
+            },
+            range: [
+                20,
+                21
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "boolean",
+            start: 22,
+            end: 29,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 22
+                },
+                end: {
+                    line: 1,
+                    column: 29
+                }
+            },
+            range: [
+                22,
+                29
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 29,
+            end: 30,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 29
+                },
+                end: {
+                    line: 1,
+                    column: 30
+                }
+            },
+            range: [
+                29,
+                30
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "{",
+            start: 31,
+            end: 32,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 31
+                },
+                end: {
+                    line: 1,
+                    column: 32
+                }
+            },
+            range: [
+                31,
+                32
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "}",
+            start: 32,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 32
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            range: [
+                32,
+                33
+            ]
+        },
+        {
+            type: {
+                label: "eof",
+                beforeExpr: false,
+                startsExpr: false,
+                rightAssociative: false,
+                isLoop: false,
+                isAssign: false,
+                prefix: false,
+                postfix: false,
+                binop: null,
+                updateContext: null
+            },
+            start: 33,
+            end: 33,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 33
+                },
+                end: {
+                    line: 1,
+                    column: 33
+                }
+            },
+            range: [
+                33,
+                33
+            ]
+        }
+    ],
+    comments: [],
+    range: [
+        0,
+        33
+    ],
+    _paths: [
+        {
+            contexts: [],
+            parent: "[Circular ~]",
+            data: {},
+            shouldSkip: false,
+            shouldStop: false,
+            removed: false,
+            opts: {
+                noScope: true,
+                enter: [
+                    null
+                ],
+                exit: [
+                    null
+                ],
+                _exploded: true,
+                _verified: true
+            },
+            skipKeys: {},
+            parentPath: null,
+            context: {
+                queue: null,
+                opts: {
+                    noScope: true,
+                    enter: [
+                        null
+                    ],
+                    exit: [
+                        null
+                    ],
+                    _exploded: true,
+                    _verified: true
+                }
+            },
+            container: [
+                {
+                    type: "FunctionDeclaration",
+                    start: 0,
+                    end: 33,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 0
+                        },
+                        end: {
+                            line: 1,
+                            column: 33
+                        }
+                    },
+                    id: {
+                        type: "Identifier",
+                        start: 9,
+                        end: 12,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 9
+                            },
+                            end: {
+                                line: 1,
+                                column: 12
+                            }
+                        },
+                        name: "foo",
+                        range: [
+                            9,
+                            12
+                        ],
+                        _babelType: "Identifier"
+                    },
+                    generator: false,
+                    expression: false,
+                    async: false,
+                    params: [
+                        {
+                            type: "Identifier",
+                            start: 13,
+                            end: 14,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 13
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 14
+                                }
+                            },
+                            name: "a",
+                            range: [
+                                13,
+                                14
+                            ],
+                            _babelType: "Identifier"
+                        }
+                    ],
+                    returnType: {
+                        type: "TypeAnnotation",
+                        start: 16,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 16
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        typeAnnotation: {
+                            type: "ObjectTypeAnnotation",
+                            start: 18,
+                            end: 30,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 18
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 30
+                                }
+                            },
+                            callProperties: [],
+                            properties: [
+                                {
+                                    type: "ObjectTypeProperty",
+                                    start: 19,
+                                    end: 29,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 19
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 29
+                                        }
+                                    },
+                                    value: {
+                                        type: "BooleanTypeAnnotation",
+                                        start: 22,
+                                        end: 29,
+                                        loc: {
+                                            start: {
+                                                line: 1,
+                                                column: 22
+                                            },
+                                            end: {
+                                                line: 1,
+                                                column: 29
+                                            }
+                                        },
+                                        range: [
+                                            22,
+                                            29
+                                        ],
+                                        _babelType: "BooleanTypeAnnotation"
+                                    },
+                                    optional: false,
+                                    range: [
+                                        19,
+                                        29
+                                    ],
+                                    _babelType: "ObjectTypeProperty"
+                                }
+                            ],
+                            indexers: [],
+                            range: [
+                                18,
+                                30
+                            ],
+                            _babelType: "ObjectTypeAnnotation"
+                        },
+                        range: [
+                            16,
+                            30
+                        ],
+                        _babelType: "TypeAnnotation"
+                    },
+                    body: {
+                        type: "BlockStatement",
+                        start: 31,
+                        end: 33,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 31
+                            },
+                            end: {
+                                line: 1,
+                                column: 33
+                            }
+                        },
+                        body: [],
+                        range: [
+                            31,
+                            33
+                        ],
+                        _babelType: "BlockStatement"
+                    },
+                    range: [
+                        0,
+                        33
+                    ],
+                    _babelType: "FunctionDeclaration"
+                }
+            ],
+            listKey: "body",
+            inList: true,
+            parentKey: "body",
+            key: 0,
+            node: {
+                type: "FunctionDeclaration",
+                start: 0,
+                end: 33,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 1,
+                        column: 33
+                    }
+                },
+                id: {
+                    type: "Identifier",
+                    start: 9,
+                    end: 12,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 9
+                        },
+                        end: {
+                            line: 1,
+                            column: 12
+                        }
+                    },
+                    name: "foo",
+                    range: [
+                        9,
+                        12
+                    ],
+                    _babelType: "Identifier"
+                },
+                generator: false,
+                expression: false,
+                async: false,
+                params: [
+                    {
+                        type: "Identifier",
+                        start: 13,
+                        end: 14,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 13
+                            },
+                            end: {
+                                line: 1,
+                                column: 14
+                            }
+                        },
+                        name: "a",
+                        range: [
+                            13,
+                            14
+                        ],
+                        _babelType: "Identifier"
+                    }
+                ],
+                returnType: {
+                    type: "TypeAnnotation",
+                    start: 16,
+                    end: 30,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 16
+                        },
+                        end: {
+                            line: 1,
+                            column: 30
+                        }
+                    },
+                    typeAnnotation: {
+                        type: "ObjectTypeAnnotation",
+                        start: 18,
+                        end: 30,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 18
+                            },
+                            end: {
+                                line: 1,
+                                column: 30
+                            }
+                        },
+                        callProperties: [],
+                        properties: [
+                            {
+                                type: "ObjectTypeProperty",
+                                start: 19,
+                                end: 29,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 19
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 29
+                                    }
+                                },
+                                value: {
+                                    type: "BooleanTypeAnnotation",
+                                    start: 22,
+                                    end: 29,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 22
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 29
+                                        }
+                                    },
+                                    range: [
+                                        22,
+                                        29
+                                    ],
+                                    _babelType: "BooleanTypeAnnotation"
+                                },
+                                optional: false,
+                                range: [
+                                    19,
+                                    29
+                                ],
+                                _babelType: "ObjectTypeProperty"
+                            }
+                        ],
+                        indexers: [],
+                        range: [
+                            18,
+                            30
+                        ],
+                        _babelType: "ObjectTypeAnnotation"
+                    },
+                    range: [
+                        16,
+                        30
+                    ],
+                    _babelType: "TypeAnnotation"
+                },
+                body: {
+                    type: "BlockStatement",
+                    start: 31,
+                    end: 33,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 31
+                        },
+                        end: {
+                            line: 1,
+                            column: 33
+                        }
+                    },
+                    body: [],
+                    range: [
+                        31,
+                        33
+                    ],
+                    _babelType: "BlockStatement"
+                },
+                range: [
+                    0,
+                    33
+                ],
+                _babelType: "FunctionDeclaration"
+            },
+            scope: null,
+            type: "FunctionDeclaration",
+            typeAnnotation: null
+        }
+    ]
+});

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -9,8 +9,26 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/comma-dangle"),
+const path = require("path"),
+    rule = require("../../../lib/rules/comma-dangle"),
     RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the path to the parser of the given name.
+ *
+ * @param {string} name - The name of a parser to get.
+ * @returns {string} The path to the specified parser.
+ */
+function parser(name) {
+    return path.resolve(
+        __dirname,
+        `../../fixtures/parsers/comma-dangle/${name}.js`
+    );
+}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -368,6 +386,28 @@ ruleTester.run("comma-dangle", rule, {
             code: "foo(\na,\nb\n)",
             parserOptions: {ecmaVersion: 8},
             options: [{functions: "only-multiline"}],
+        },
+
+        // https://github.com/eslint/eslint/issues/7370
+        {
+            code: "function foo({a}: {a: string,}) {}",
+            parser: parser("object-pattern-1"),
+            options: ["never"],
+        },
+        {
+            code: "function foo({a,}: {a: string}) {}",
+            parser: parser("object-pattern-2"),
+            options: ["always"],
+        },
+        {
+            code: "function foo(a): {b: boolean,} {}",
+            parser: parser("return-type-1"),
+            options: [{functions: "never"}],
+        },
+        {
+            code: "function foo(a,): {b: boolean} {}",
+            parser: parser("return-type-2"),
+            options: [{functions: "always"}],
         },
     ],
     invalid: [
@@ -1409,6 +1449,32 @@ export {d,};
                 {message: "Unexpected trailing comma.", line: 5},
                 {message: "Unexpected trailing comma.", line: 5}
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7370
+        {
+            code: "function foo({a}: {a: string,}) {}",
+            parser: parser("object-pattern-1"),
+            options: ["always"],
+            errors: [{message: "Missing trailing comma."}],
+        },
+        {
+            code: "function foo({a,}: {a: string}) {}",
+            parser: parser("object-pattern-2"),
+            options: ["never"],
+            errors: [{message: "Unexpected trailing comma."}],
+        },
+        {
+            code: "function foo(a): {b: boolean,} {}",
+            parser: parser("return-type-1"),
+            options: [{functions: "always"}],
+            errors: [{message: "Missing trailing comma."}],
+        },
+        {
+            code: "function foo(a,): {b: boolean} {}",
+            parser: parser("return-type-2"),
+            options: [{functions: "never"}],
+            errors: [{message: "Unexpected trailing comma."}],
         },
     ]
 });

--- a/tests/lib/rules/comma-dangle.js
+++ b/tests/lib/rules/comma-dangle.js
@@ -1454,24 +1454,28 @@ export {d,};
         // https://github.com/eslint/eslint/issues/7370
         {
             code: "function foo({a}: {a: string,}) {}",
+            output: "function foo({a,}: {a: string,}) {}",
             parser: parser("object-pattern-1"),
             options: ["always"],
             errors: [{message: "Missing trailing comma."}],
         },
         {
             code: "function foo({a,}: {a: string}) {}",
+            output: "function foo({a}: {a: string}) {}",
             parser: parser("object-pattern-2"),
             options: ["never"],
             errors: [{message: "Unexpected trailing comma."}],
         },
         {
             code: "function foo(a): {b: boolean,} {}",
+            output: "function foo(a,): {b: boolean,} {}",
             parser: parser("return-type-1"),
             options: [{functions: "always"}],
             errors: [{message: "Missing trailing comma."}],
         },
         {
             code: "function foo(a,): {b: boolean} {}",
+            output: "function foo(a): {b: boolean} {}",
             parser: parser("return-type-2"),
             options: [{functions: "never"}],
             errors: [{message: "Unexpected trailing comma."}],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See #7370 for the template.

**What changes did you make? (Give an overview)**

Since c8796e98af6804cccc947ab3e3b06d884a8d035f, `comma-dangle` rule have been confused by type annotations.
This PR modifies the rule as supporting type annotations correctly. (it just removes optimization code.)

This follows #6723 about the way to test type annotations.
The AST was created by `babel-eslint` of http://astexplorer.net/ .

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.


