### PR TITLE
Add information about `fatal` property to lint message documentation

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -224,7 +224,6 @@ The return value is an object containing the results of the linting operation. H
             output: "foo;",
             messages: [
                 {
-                    fatal: false,
                     severity: 2,
                     ruleId: "semi",
                     severity: 2,
@@ -235,6 +234,34 @@ The return value is an object containing the results of the linting operation. H
             ],
             errorCount: 1,
             warningCount: 0
+        }
+    ],
+    errorCount: 1,
+    warningCount: 0
+}
+```
+
+If the operation ends with a parsing error, you will get a single message for this file, with `fatal: true` added as an extra property.
+
+```js
+{
+    results: [
+        {
+            filePath: "./myfile.js",
+            messages: [
+                {
+                    ruleId: null,
+                    fatal: true,
+                    severity: 2,
+                    source: "fucntion foo() {}",
+                    message: "Parsing error: Unexpected token foo",
+                    line: 1,
+                    column: 10
+                }
+            ],
+            errorCount: 1,
+            warningCount: 0,
+            source: "fucntion foo() {}"
         }
     ],
     errorCount: 1,


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
Made sure that a `fatal` property is always present on every `message`.

It came up while looking at the docs for programmatic usage (#7362), which erroneously included `fatal: false`. While `if (message.fatal)` would produce the same result, having it in the docs is useful for people writing custom formatters. But having it there when it's actually not present seems weird.
And it's trivial to add it in 😄 


**Is there anything you'd like reviewers to focus on?**
n/a