### PR TITLE
Update: recommend no-process-exit rule per Node.js

### DIFF
--- a/lib/rules/no-process-exit.js
+++ b/lib/rules/no-process-exit.js
@@ -13,7 +13,7 @@ module.exports = {
         docs: {
             description: "disallow the use of `process.exit()`",
             category: "Node.js and CommonJS",
-            recommended: false
+            recommended: true
         },
 
         schema: []


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**

- [no-process-exit](http://eslint.org/docs/rules/no-process-exit)

**Does this change cause the rule to produce more or fewer warnings?**

- more warnings, but the logic in the rule itself is not changed

- ESLint users extending the "eslint:recommended" rules will possibly encounter new warnings against existing projects

**How will the change be implemented? (New option, new default behavior, etc.)?**

- this PR includes the no-process-exit rule in the "eslint:recommended" rule set

**Please provide some example code that this change will affect:**

.eslintrc.json:

```json
{ "extends": [ "eslint:recommended" ] }
```

**What does the rule currently do for this code?**

- nothing, the rule is currently not in the "eslint:recommended" set

**What will the rule do after it's changed?**

- after this PR, projects that use "eslint:recommended" will receive ESLint warnings about uses of `process.exit()`

**What changes did you make? (Give an overview)**

- toggled the "recommended" boolean flag in the metadata accompanying the no-process-exit rule

**Is there anything you'd like reviewers to focus on?**

It's worth re-reading the upstream recommendations in the Node.js documentation, as they highlight the problems with using `process.exit()`:

- https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_process_exit_code

> The reason this is problematic is because writes to process.stdout in Node.js are sometimes _non-blocking_ and may occur over multiple ticks of the Node.js event loop. Calling `process.exit()`, however, forces the process to exit before those additional writes to stdout can be performed.

> Rather than calling `process.exit()` directly, the code should set the process.exitCode and allow the process to exit naturally by avoiding scheduling any additional work for the event loop

- https://nodejs.org/dist/latest-v6.x/docs/api/process.html#process_process_exitcode

It seems that the upstream Node.js team recommends against using this API, so it follows that ESLint should also recommend against its use.