### PR TITLE
Fix: Allow useless escapes in tagged template literals (fixes #7383)

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -132,6 +132,12 @@ module.exports = {
             let nodeEscapes,
                 match;
 
+            if (isTemplateElement && node.parent && node.parent.parent && node.parent.parent.type === "TaggedTemplateExpression") {
+
+                // Don't report tagged template literals, because the backslash character is accessible to the tag function.
+                return;
+            }
+
             if (typeof node.value === "string" || isTemplateElement) {
 
                 /*

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -75,7 +75,9 @@ ruleTester.run("no-useless-escape", rule, {
         {code: "var foo = `\\\``", parserOptions: {ecmaVersion: 6}},
         {code: "var foo = `\\\`${foo}\\\``", parserOptions: {ecmaVersion: 6}},
         {code: "var foo = `\\${{${foo}`;", parserOptions: {ecmaVersion: 6}},
-        {code: "var foo = `$\\{{${foo}`;", parserOptions: {ecmaVersion: 6}}
+        {code: "var foo = `$\\{{${foo}`;", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = String.raw`\\.`", parserOptions: {ecmaVersion: 6}},
+        {code: "var foo = myFunc`\\.`", parserOptions: {ecmaVersion: 6}}
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7383

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `no-useless-escape` to not report escaped characters in tagged template literals, because the backslash is visible to the tag function.

Useless escapes in non-tagged template literals are still reported as errors.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
