### PR TITLE
Update: add fixer for `no-extra-boolean-cast`

### DIFF
--- a/docs/rules/no-extra-boolean-cast.md
+++ b/docs/rules/no-extra-boolean-cast.md
@@ -1,5 +1,7 @@
 # disallow unnecessary boolean casts (no-extra-boolean-cast)
 
+(fixable) The `--fix` option on the [command line](../user-guide/command-line-interface#fix) automatically fixes problems reported by this rule.
+
 In contexts such as an `if` statement's test where the result of the expression will already be coerced to a Boolean, casting to a Boolean via double negation (`!!`) or a `Boolean` call is unnecessary. For example, these `if` statements are equivalent:
 
 ```js

--- a/lib/rules/no-extra-boolean-cast.js
+++ b/lib/rules/no-extra-boolean-cast.js
@@ -17,10 +17,13 @@ module.exports = {
             recommended: true
         },
 
-        schema: []
+        schema: [],
+
+        fixable: "code"
     },
 
     create(context) {
+        const sourceCode = context.getSourceCode();
 
         // Node types which have a test which will coerce values to booleans.
         const BOOLEAN_NODE_TYPES = [
@@ -70,7 +73,11 @@ module.exports = {
                         grandparent.callee.type === "Identifier" &&
                         grandparent.callee.name === "Boolean")
                 ) {
-                    context.report(node, "Redundant double negation.");
+                    context.report({
+                        node,
+                        message: "Redundant double negation.",
+                        fix: fixer => fixer.replaceText(parent, sourceCode.getText(node.argument))
+                    });
                 }
             },
             CallExpression(node) {
@@ -81,7 +88,11 @@ module.exports = {
                 }
 
                 if (isInBooleanContext(node, parent)) {
-                    context.report(node, "Redundant Boolean call.");
+                    context.report({
+                        node,
+                        message: "Redundant Boolean call.",
+                        fix: fixer => fixer.replaceText(node, sourceCode.getText(node.arguments[0]))
+                    });
                 }
             }
         };

--- a/tests/lib/rules/no-extra-boolean-cast.js
+++ b/tests/lib/rules/no-extra-boolean-cast.js
@@ -37,6 +37,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
     invalid: [
         {
             code: "if (!!foo) {}",
+            output: "if (foo) {}",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -44,6 +45,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "do {} while (!!foo)",
+            output: "do {} while (foo)",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -51,6 +53,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "while (!!foo) {}",
+            output: "while (foo) {}",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -58,6 +61,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "!!foo ? bar : baz",
+            output: "foo ? bar : baz",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -65,6 +69,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "for (; !!foo;) {}",
+            output: "for (; foo;) {}",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -72,6 +77,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "!!!foo",
+            output: "!foo",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -79,6 +85,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "Boolean(!!foo)",
+            output: "Boolean(foo)",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -86,6 +93,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "new Boolean(!!foo)",
+            output: "new Boolean(foo)",
             errors: [{
                 message: "Redundant double negation.",
                 type: "UnaryExpression"
@@ -93,6 +101,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "if (Boolean(foo)) {}",
+            output: "if (foo) {}",
             errors: [{
                 message: "Redundant Boolean call.",
                 type: "CallExpression"
@@ -100,6 +109,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "do {} while (Boolean(foo))",
+            output: "do {} while (foo)",
             errors: [{
                 message: "Redundant Boolean call.",
                 type: "CallExpression"
@@ -107,6 +117,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "while (Boolean(foo)) {}",
+            output: "while (foo) {}",
             errors: [{
                 message: "Redundant Boolean call.",
                 type: "CallExpression"
@@ -114,6 +125,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "Boolean(foo) ? bar : baz",
+            output: "foo ? bar : baz",
             errors: [{
                 message: "Redundant Boolean call.",
                 type: "CallExpression"
@@ -121,6 +133,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "for (; Boolean(foo);) {}",
+            output: "for (; foo;) {}",
             errors: [{
                 message: "Redundant Boolean call.",
                 type: "CallExpression"
@@ -128,6 +141,7 @@ ruleTester.run("no-extra-boolean-cast", rule, {
         },
         {
             code: "!Boolean(foo)",
+            output: "!foo",
             errors: [{
                 message: "Redundant Boolean call.",
                 type: "CallExpression"


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[x] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This adds a fixer for [`no-extra-boolean-cast`](http://eslint.org/docs/rules/no-extra-boolean-cast).

``` js
if (!!foo);
if (Boolean(bar));
Boolean(!!baz);

// gets fixed to:

if (foo);
if (bar);
Boolean(baz);
```

**Is there anything you'd like reviewers to focus on?**

We should double-check that removing parens (e.g. `Boolean(bar)` --> `bar`) cannot cause a syntax error.
