### PR TITLE
Breaking: report file not found errors (fixes #7390)

### DIFF
--- a/lib/cli-engine.js
+++ b/lib/cli-engine.js
@@ -705,7 +705,6 @@ CLIEngine.prototype = {
 
 
 
-        patterns = this.resolveFileGlobPatterns(patterns);
         const fileList = globUtil.listFilesToProcess(patterns, options);
 
         fileList.forEach(function(fileInfo) {

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -74,6 +74,22 @@ function processPath(options) {
     };
 }
 
+/**
+ * The error type for file not found.
+ */
+class NotFoundError extends Error {
+
+    /**
+     * @param {string} pattern - The glob pattern which was not found.
+     */
+    constructor(pattern) {
+        super(`'${pattern}' was not found.`);
+
+        this.messageTemplate = "file-not-found";
+        this.messageData = {pattern};
+    }
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -109,6 +125,10 @@ function listFilesToProcess(globPatterns, options) {
         added = {};
 
     const cwd = (options && options.cwd) || process.cwd();
+
+    // The test "should use default options if none are provided" (source-code-util.js) checks that 'module.exports.resolveFileGlobPatterns' was called.
+    // So it cannot use the local function "resolveFileGlobPatterns".
+    const resolvedGlobPatterns = module.exports.resolveFileGlobPatterns(globPatterns, options);
 
     /**
      * Executes the linter on a file defined by the `filename`. Skips
@@ -150,13 +170,15 @@ function listFilesToProcess(globPatterns, options) {
     }
 
     debug("Creating list of files to process.");
-    globPatterns.forEach(function(pattern) {
+    resolvedGlobPatterns.forEach(function(pattern, index) {
         const file = path.resolve(cwd, pattern);
+        const originalPattern = globPatterns[index];
+        const originalFile = path.resolve(cwd, originalPattern);
 
         if (shell.test("-f", file)) {
             const ignoredPaths = new IgnoredPaths(options);
 
-            addFile(fs.realpathSync(file), !shell.test("-d", file), ignoredPaths);
+            addFile(fs.realpathSync(file), true, ignoredPaths);
         } else {
 
             // regex to find .hidden or /.hidden patterns, but not ./relative or ../relative
@@ -169,8 +191,12 @@ function listFilesToProcess(globPatterns, options) {
                 dot: true,
                 cwd,
             };
+            const found = new GlobSync(pattern, globOptions, shouldIgnore).found;
 
-            new GlobSync(pattern, globOptions, shouldIgnore).found.forEach(function(globMatch) {
+            if (found.length === 0 && !ignoredPaths.contains(originalFile) && !shell.test("-d", originalFile)) {
+                throw new NotFoundError(originalPattern);
+            }
+            found.forEach(function(globMatch) {
                 addFile(path.resolve(cwd, globMatch), false, ignoredPaths);
             });
         }

--- a/lib/util/source-code-util.js
+++ b/lib/util/source-code-util.js
@@ -82,7 +82,6 @@ function getSourceCodeOfFiles(patterns, options, cb) {
         opts = Object.assign({}, defaultOptions, options);
     }
     debug("constructed options:", opts);
-    patterns = globUtil.resolveFileGlobPatterns(patterns, opts);
 
     const filenames = globUtil.listFilesToProcess(patterns, opts).reduce(function(files, fileInfo) {
         return !fileInfo.ignored ? files.concat(fileInfo.filename) : files;

--- a/messages/file-not-found.txt
+++ b/messages/file-not-found.txt
@@ -1,0 +1,2 @@
+The given pattern "<%= pattern %>" was not found.
+Please check for typing mistakes in the pattern.

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -2307,6 +2307,43 @@ describe("CLIEngine", function() {
                 assert.equal(report.results[0].messages[0].ruleId, "post-processed");
             });
         });
+
+        describe("Patterns which match no file should throw errors.", () => {
+            beforeEach(() => {
+                engine = new CLIEngine({
+                    cwd: getFixturePath("cli-engine"),
+                    useEslintrc: false,
+                });
+            });
+
+            it("one file", function() {
+                assert.throws(() => {
+                    engine.executeOnFiles(["non-exist.js"]);
+                }, "'non-exist.js' was not found.");
+            });
+
+            it("should not throw if the directory exists", function() {
+                engine.executeOnFiles(["empty"]);
+            });
+
+            it("one glob pattern", function() {
+                assert.throws(() => {
+                    engine.executeOnFiles(["non-exist/**/*.js"]);
+                }, "'non-exist/**/*.js' was not found.");
+            });
+
+            it("two files", function() {
+                assert.throws(() => {
+                    engine.executeOnFiles(["aaa.js", "bbb.js"]);
+                }, "'aaa.js' was not found.");
+            });
+
+            it("a mix of an exist file and a non-exist file", function() {
+                assert.throws(() => {
+                    engine.executeOnFiles(["console.js", "non-exist.js"]);
+                }, "'non-exist.js' was not found.");
+            });
+        });
     });
 
     describe("getConfigForFile", function() {

--- a/tests/lib/config/config-initializer.js
+++ b/tests/lib/config/config-initializer.js
@@ -289,7 +289,7 @@ describe("configInitializer", function() {
                 process.chdir(fixtureDir);
                 assert.throws(function() {
                     config = init.processAnswers(answers);
-                }, "Automatic Configuration failed.  No files were able to be parsed.");
+                }, "'not-a-real-filename' was not found.");
                 process.chdir(originalDir);
                 autoconfig.extendFromRecommended.restore();
             });

--- a/tests/lib/util/glob-util.js
+++ b/tests/lib/util/glob-util.js
@@ -265,10 +265,14 @@ describe("globUtil", function() {
         });
 
         it("should not return a file which does not exist", function() {
-            const patterns = ["tests/fixtures/glob-util/hidden/bar.js"];
-            const result = globUtil.listFilesToProcess(patterns);
+            const filename = getFixturePath("glob-util", "hidden", "bar.js");
+            const patterns = [filename];
 
-            assert.equal(result.length, 0);
+            assert.throws(() => {
+                globUtil.listFilesToProcess(patterns, {
+                    cwd: getFixturePath()
+                });
+            }, `'${filename}' was not found.`);
         });
 
         it("should not return an ignored file", function() {

--- a/tests/lib/util/source-code-util.js
+++ b/tests/lib/util/source-code-util.js
@@ -160,9 +160,10 @@ describe("SourceCodeUtil", function() {
 
         it("should should not include non-existent filesnames in results", function() {
             const filename = getFixturePath("missing.js");
-            const sourceCode = getSourceCodeOfFiles(filename, {cwd: fixtureDir});
 
-            assert.notProperty(sourceCode, filename);
+            assert.throws(() => {
+                getSourceCodeOfFiles(filename, {cwd: fixtureDir});
+            }, `'${filename}' was not found.`);
         });
 
         it("should throw for files with parsing errors", function() {
@@ -251,9 +252,8 @@ describe("SourceCodeUtil", function() {
             const firstFn = getFixturePath("foo.js");
             const secondFn = getFixturePath("bar.js");
             const thirdFn = getFixturePath("nested/foo.js");
-            const missingFn = getFixturePath("missing.js");
 
-            getSourceCodeOfFiles([firstFn, secondFn, thirdFn, missingFn], {cwd: fixtureDir}, callback);
+            getSourceCodeOfFiles([firstFn, secondFn, thirdFn], {cwd: fixtureDir}, callback);
             assert(callback.calledWith(3));
         });
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See #7390 for the template.

**What changes did you make? (Give an overview)**

Since #1296 and #1831, ESLint should throw errors if the given file did not be found. But ESLint does nothing (then exits with zero) since v1.4.0 due to the glob pattern support. I think this is unintentional because we seemed to do no discussion about the behavior that patterns matches no file.

ESLint shows nothing if target files have no problem, too. So the users cannot distinguish between no problem and typo from the result. I think it's not good.

This PR changes the behavior about patterns which match no file.
~~It judges for each pattern, then it generates an error message "File Not Found" for the file if the pattern matches no file.~~ If there are one or more patterns which match no file, ESLint will throw a fatal error.

<details><summary>

~~**For Examples:**~~</summary>



Those are old.

```
$ eslint non-exist.js

non-exist.js
  1:1  error  File Not Found

✖ 1 problem (1 error, 0 warnings)
```

```
$ eslint non-exist/**/*.js

non-exist/**/*.js
  1:1  error  File Not Found

✖ 1 problem (1 error, 0 warnings)
```

```
$ eslint non-exist/**/*.js test.js

C:\Users\t-nagashima.AD\Documents\GitHub\eslint\test.js
  0:0  warning  File ignored because of a matching ignore pattern. Use "--no-ignore" to override

non-exist/**/*.js
  1:1  error  File Not Found

✖ 2 problems (1 error, 1 warning)
```

```
$ eslint test.js non-exist/**/*.js --no-ignore

C:\Users\t-nagashima.AD\Documents\GitHub\eslint\test.js
  2:1  error  Use the global form of 'use strict'  strict
  2:1  error  Unexpected console statement         no-console

non-exist/**/*.js
  1:1  error  File Not Found

✖ 3 problems (3 errors, 0 warnings)
```

</details>

<details><summary>

**For Examples:**</summary>



```
$ eslint non-exist.js

Oops! Something went wrong! :(

The given pattern "non-exist.js" was not found.
Please check for typing mistakes in the pattern.
```

```
$ eslint non-exist/**/*.js

Oops! Something went wrong! :(

The given pattern "non-exist/**/*.js" was not found.
Please check for typing mistakes in the pattern.
```

```
$ eslint test.js non-exist/**/*.js

Oops! Something went wrong! :(

The given pattern "non-exist/**/*.js" was not found.
Please check for typing mistakes in the pattern.
```

```
$ eslint test.js non-exist/**/*.js --no-ignore

Oops! Something went wrong! :(

The given pattern "test.js" was not found.
Please check for typing mistakes in the pattern.
```

</details>

**Is there anything you'd like reviewers to focus on?**
- Is the direction of this PR good?
- We have a long time since v1.4.0. Though this PR is a bug fix which increases errors, maybe we should mark this PR as breaking.
