### PR TITLE
Docs: add additional examples/explanation for MemberExpressions indent

### DIFF
--- a/docs/rules/indent.md
+++ b/docs/rules/indent.md
@@ -94,6 +94,9 @@ Level of indentation denotes the multiple of the indent specified. Example:
 * Indent of 2 spaces with `MemberExpression` set to `0` will indent the multi-line property chains with 0 spaces.
 * Indent of 2 spaces with `MemberExpression` set to `1` will indent the multi-line property chains with 2 spaces.
 * Indent of 2 spaces with `MemberExpression` set to `2` will indent the multi-line property chains with 4 spaces.
+* Indent of 4 spaces with `MemberExpression` set to `0` will indent the multi-line property chains with 0 spaces.
+* Indent of 4 spaces with `MemberExpression` set to `1` will indent the multi-line property chains with 4 spaces.
+* Indent of 4 spaces with `MemberExpression` set to `2` will indent the multi-line property chains with 8 spaces.
 
 ### tab
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:


**What changes did you make? (Give an overview)**
Added additional explanation for the `MemberExpression` option in the Indent rule to make it more clear that there are many options for setting indent to something other than `2` when using `MemberExpressions`. This gives the user more information to understand how the rule will be evaluated when using a common indent count such as `4` spaces.
