### PR TITLE
Fix: avoid `camelcase` false positive with NewExpressions (fixes #7363)

### DIFF
--- a/docs/rules/camelcase.md
+++ b/docs/rules/camelcase.md
@@ -52,6 +52,8 @@ var foo = bar.baz_boom;
 var foo = { qux: bar.baz_boom };
 
 obj.do_something();
+do_something();
+new do_something();
 
 var { category_id: category } = query;
 ```

--- a/lib/rules/camelcase.js
+++ b/lib/rules/camelcase.js
@@ -38,6 +38,7 @@ module.exports = {
 
         // contains reported nodes to avoid reporting twice on destructuring with shorthand notation
         const reported = [];
+        const ALLOWED_PARENT_TYPES = new Set(["CallExpression", "NewExpression"]);
 
         /**
          * Checks if a string contains an underscore and isn't all upper-case
@@ -118,7 +119,7 @@ module.exports = {
                         return;
                     }
 
-                    if (isUnderscored(name) && effectiveParent.type !== "CallExpression") {
+                    if (isUnderscored(name) && !ALLOWED_PARENT_TYPES.has(effectiveParent.type)) {
                         report(node);
                     }
 
@@ -131,7 +132,7 @@ module.exports = {
                     }
 
                 // Report anything that is underscored that isn't a CallExpression
-                } else if (isUnderscored(name) && effectiveParent.type !== "CallExpression") {
+                } else if (isUnderscored(name) && !ALLOWED_PARENT_TYPES.has(effectiveParent.type)) {
                     report(node);
                 }
             }

--- a/tests/lib/rules/camelcase.js
+++ b/tests/lib/rules/camelcase.js
@@ -26,6 +26,8 @@ ruleTester.run("camelcase", rule, {
         "myPrivateVariable_ = \"Patrick\"",
         "function doSomething(){}",
         "do_something()",
+        "new do_something",
+        "new do_something()",
         "foo.do_something()",
         "var foo = bar.baz_boom;",
         "var foo = bar.baz_boom.something;",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7363

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `camelcase` to allow `NewExpression`s with non-camelcase identifiers. Previously, `CallExpression`s were allowed but `NewExpression`s were not.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
