### PR TITLE
Update: Handle ForAwaitStatement in semi

### DIFF
--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -187,7 +187,9 @@ module.exports = {
                 parent = ancestors[parentIndex];
 
             if ((parent.type !== "ForStatement" || parent.init !== node) &&
-                (!/^For(?:In|Of)Statement/.test(parent.type) || parent.left !== node)
+                (!/^For(?:In|Of|Await)Statement/.test(parent.type) ||
+                    parent.left !== node
+                )
             ) {
                 checkForSemicolon(node);
             }


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[X] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**
I updated `semi` to handle `ForAwaitStatement` like `ForOfStatement`.

**Is there anything you'd like reviewers to focus on?**
No.

**What rule do you want to change?**
`semi`

**Does this change cause the rule to produce more or fewer warnings?**
Fewer

**How will the change be implemented? (New option, new default behavior, etc.)?**
Change to unconfigurable behavior

**Please provide some example code that this change will affect:**

```js
for await (const item of asyncIterable) {
  // ...
}
```

**What does the rule currently do for this code?**
Warn on a purportedly missing semicolon after `item`.

**What will the rule do after it's changed?**
Nothing.