### PR TITLE
Docs: Fix typo and explain static func calls for class-methods-use-this

### DIFF
--- a/docs/rules/class-methods-use-this.md
+++ b/docs/rules/class-methods-use-this.md
@@ -19,7 +19,7 @@ class A {
     }
 }
 
-let aObj = new A();
+let a = new A();
 a.sayHi(); // => "hi"
 ```
 
@@ -42,6 +42,8 @@ class A {
 
 A.sayHi(); // => "hi"
 ```
+
+Also note in the above examples that the code calling the function on an *instance* of the class (`let a = new A(); a.sayHi();`) changes to calling it on the *class* itself (`A.sayHi();`).
 
 ## Rule Details
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Documentation update

**What changes did you make? (Give an overview)**

The documentation for `class-methods-use-this` starts with the following statement:

> If a class method does not use this, it can *safely* be made a static function.

The inclusion of the word "safely" here may give some developers the impression that they can simply add the `static` keyword to any functions reported as errors by this rule.

As we know though, making a function static means that the function can no longer be called on an *instance* of the class, and must be called on the *class* itself.

Though the existing code examples **do** show this, I felt that it wasn't immediately clear to the reader that making an existing function static would also require changing **all** code that *calls* that function.

So I added a note below the example code, to hopefully reinforce this:

> Also note in the above examples that the code calling the function on an *instance* of the class (`let a = new A(); a.sayHi();`) changes to calling it on the *class* itself (`A.sayHi();`).

Also fixed a typo in the first example (`let aObj = new A()` changed to `let a = new A()`)

**Is there anything you'd like reviewers to focus on?**



