### PR TITLE
Update: Fix `no-useless-escape` false negative in regexes (fixes #7424)

### DIFF
--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -21,7 +21,7 @@ const arrayOrTypedArrayPattern = /Array$/;
 const arrayMethodPattern = /^(?:every|filter|find|findIndex|forEach|map|some)$/;
 const bindOrCallOrApplyPattern = /^(?:bind|call|apply)$/;
 const breakableTypePattern = /^(?:(?:Do)?While|For(?:In|Of)?|Switch)Statement$/;
-const thisTagPattern = /^[\s\*]*@this/m;
+const thisTagPattern = /^[\s*]*@this/m;
 
 /**
  * Checks reference if is non initializer and writable.

--- a/lib/config/config-file.js
+++ b/lib/config/config-file.js
@@ -441,7 +441,7 @@ function normalizePackageName(name, prefix) {
              * for scoped packages, insert the eslint-config after the first / unless
              * the path is already @scope/eslint or @scope/eslint-config-xxx
              */
-            name = name.replace(/^@([^\/]+)\/(.*)$/, `@$1/${prefix}-$2`);
+            name = name.replace(/^@([^/]+)\/(.*)$/, `@$1/${prefix}-$2`);
         }
     } else if (name.indexOf(`${prefix}-`) !== 0) {
         name = `${prefix}-${name}`;

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -107,7 +107,7 @@ function parseJsonConfig(string, location, messages) {
     // Optionator cannot parse commaless notations.
     // But we are supporting that. So this is a fallback for that.
     items = {};
-    string = string.replace(/([a-zA-Z0-9\-\/]+):/g, "\"$1\":").replace(/(]|[0-9])\s+(?=")/, "$1,");
+    string = string.replace(/([a-zA-Z0-9\-/]+):/g, "\"$1\":").replace(/(]|[0-9])\s+(?=")/, "$1,");
     try {
         items = JSON.parse(`{${string}}`);
     } catch (ex) {

--- a/lib/eslint.js
+++ b/lib/eslint.js
@@ -107,7 +107,7 @@ function parseJsonConfig(string, location, messages) {
     // Optionator cannot parse commaless notations.
     // But we are supporting that. So this is a fallback for that.
     items = {};
-    string = string.replace(/([a-zA-Z0-9\-\/]+):/g, "\"$1\":").replace(/(\]|[0-9])\s+(?=")/, "$1,");
+    string = string.replace(/([a-zA-Z0-9\-\/]+):/g, "\"$1\":").replace(/(]|[0-9])\s+(?=")/, "$1,");
     try {
         items = JSON.parse(`{${string}}`);
     } catch (ex) {

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -105,7 +105,7 @@ module.exports = {
 
                             const tokenAfterArrowBody = sourceCode.getTokenAfter(arrowBody);
 
-                            if (tokenAfterArrowBody && tokenAfterArrowBody.type === "Punctuator" && /^[([\/`+-]/.test(tokenAfterArrowBody.value)) {
+                            if (tokenAfterArrowBody && tokenAfterArrowBody.type === "Punctuator" && /^[([/`+-]/.test(tokenAfterArrowBody.value)) {
 
                                 // Don't do a fix if the next token would cause ASI issues when preceded by the returned value.
                                 return null;

--- a/lib/rules/arrow-body-style.js
+++ b/lib/rules/arrow-body-style.js
@@ -105,7 +105,7 @@ module.exports = {
 
                             const tokenAfterArrowBody = sourceCode.getTokenAfter(arrowBody);
 
-                            if (tokenAfterArrowBody && tokenAfterArrowBody.type === "Punctuator" && /^[(\[\/`+-]/.test(tokenAfterArrowBody.value)) {
+                            if (tokenAfterArrowBody && tokenAfterArrowBody.type === "Punctuator" && /^[([\/`+-]/.test(tokenAfterArrowBody.value)) {
 
                                 // Don't do a fix if the next token would cause ASI issues when preceded by the returned value.
                                 return null;

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -195,7 +195,7 @@ module.exports = {
                 return true;
             }
 
-            if (/^[([\/`+-]/.test(tokenAfter.value)) {
+            if (/^[([/`+-]/.test(tokenAfter.value)) {
 
                 // If the next token starts with a character that would disrupt ASI, insert a semicolon.
                 return true;

--- a/lib/rules/curly.js
+++ b/lib/rules/curly.js
@@ -195,7 +195,7 @@ module.exports = {
                 return true;
             }
 
-            if (/^[(\[\/`+-]/.test(tokenAfter.value)) {
+            if (/^[([\/`+-]/.test(tokenAfter.value)) {
 
                 // If the next token starts with a character that would disrupt ASI, insert a semicolon.
                 return true;

--- a/lib/rules/keyword-spacing.js
+++ b/lib/rules/keyword-spacing.js
@@ -16,10 +16,10 @@ const astUtils = require("../ast-utils"),
 // Constants
 //------------------------------------------------------------------------------
 
-const PREV_TOKEN = /^[\)\]\}>]$/;
-const NEXT_TOKEN = /^(?:[\(\[\{<~!]|\+\+?|--?)$/;
-const PREV_TOKEN_M = /^[\)\]\}>*]$/;
-const NEXT_TOKEN_M = /^[\{*]$/;
+const PREV_TOKEN = /^[)\]}>]$/;
+const NEXT_TOKEN = /^(?:[([{<~!]|\+\+?|--?)$/;
+const PREV_TOKEN_M = /^[)\]}>*]$/;
+const NEXT_TOKEN_M = /^[{*]$/;
 const TEMPLATE_OPEN_PAREN = /\$\{$/;
 const TEMPLATE_CLOSE_PAREN = /^\}/;
 const CHECK_TYPE = /^(?:JSXElement|RegularExpression|String|Template)$/;

--- a/lib/rules/no-empty-character-class.js
+++ b/lib/rules/no-empty-character-class.js
@@ -21,7 +21,7 @@ plain-English description of the following regexp:
 4. `[gimuy]*`: optional regexp flags
 5. `$`: fix the match at the end of the string
 */
-const regex = /^\/([^\\[]|\\.|\[([^\\\]]|\\.)+\])*\/[gimuy]*$/;
+const regex = /^\/([^\\[]|\\.|\[([^\\\]]|\\.)+])*\/[gimuy]*$/;
 
 //------------------------------------------------------------------------------
 // Rule Definition

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -55,7 +55,7 @@ module.exports = {
                                 node.consequent.type !== "BlockStatement" && lastIfToken.value !== ";" && tokenAfterElseBlock &&
                                 (
                                     node.consequent.loc.end.line === tokenAfterElseBlock.loc.start.line ||
-                                    /^[([\/+`-]/.test(tokenAfterElseBlock.value) ||
+                                    /^[([/+`-]/.test(tokenAfterElseBlock.value) ||
                                     lastIfToken.value === "++" ||
                                     lastIfToken.value === "--"
                                 )

--- a/lib/rules/no-lonely-if.js
+++ b/lib/rules/no-lonely-if.js
@@ -55,7 +55,7 @@ module.exports = {
                                 node.consequent.type !== "BlockStatement" && lastIfToken.value !== ";" && tokenAfterElseBlock &&
                                 (
                                     node.consequent.loc.end.line === tokenAfterElseBlock.loc.start.line ||
-                                    /^[(\[\/+`-]/.test(tokenAfterElseBlock.value) ||
+                                    /^[([\/+`-]/.test(tokenAfterElseBlock.value) ||
                                     lastIfToken.value === "++" ||
                                     lastIfToken.value === "--"
                                 )

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -38,7 +38,6 @@ const VALID_STRING_ESCAPES = [
 
 const REGEX_GENERAL_ESCAPES = new Set([
     "\\",
-    "^",
     "b",
     "c",
     "d",
@@ -57,6 +56,7 @@ const REGEX_GENERAL_ESCAPES = new Set([
 ]);
 const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set(["]"]));
 const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
+    "^",
     "/",
     ".",
     "$",
@@ -82,11 +82,11 @@ const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
 *
 * returns:
 * [
-*   {text: 'a', index: 0, escaped: false, inCharClass: false},
-*   {text: 'b', index: 2, escaped: true, inCharClass: false},
-*   {text: 'c', index: 4, escaped: false, inCharClass: true},
-*   {text: 'd', index: 5, escaped: false, inCharClass: true},
-*   {text: '-', index: 6, escaped: false, inCharClass: true}
+*   {text: 'a', index: 0, escaped: false, inCharClass: false, startsCharClass: false, endsCharClass: false},
+*   {text: 'b', index: 2, escaped: true, inCharClass: false, startsCharClass: false, endsCharClass: false},
+*   {text: 'c', index: 4, escaped: false, inCharClass: true, startsCharClass: true, endsCharClass: false},
+*   {text: 'd', index: 5, escaped: false, inCharClass: true, startsCharClass: false, endsCharClass: false},
+*   {text: '-', index: 6, escaped: false, inCharClass: true, startsCharClass: false, endsCharClass: false}
 * ]
 */
 function parseRegExp(regExpText) {
@@ -98,28 +98,20 @@ function parseRegExp(regExpText) {
                 return Object.assign(state, {escapeNextChar: true});
             }
             if (char === "[" && !state.inCharClass) {
-                return Object.assign(state, {inCharClass: true});
+                return Object.assign(state, {inCharClass: true, startingCharClass: true});
             }
             if (char === "]" && state.inCharClass) {
-                return Object.assign(state, {inCharClass: false});
+                if (charList.length && charList[charList.length - 1].inCharClass) {
+                    charList[charList.length - 1].endsCharClass = true;
+                }
+                return Object.assign(state, {inCharClass: false, startingCharClass: false});
             }
         }
-        charList.push({text: char, index, escaped: state.escapeNextChar, inCharClass: state.inCharClass});
-        return Object.assign(state, {escapeNextChar: false});
-    }, {escapeNextChar: false, inCharClass: false});
+        charList.push({text: char, index, escaped: state.escapeNextChar, inCharClass: state.inCharClass, startsCharClass: state.startingCharClass, endsCharClass: false});
+        return Object.assign(state, {escapeNextChar: false, startingCharClass: false});
+    }, {escapeNextChar: false, inCharClass: false, startingCharClass: false});
 
     return charList;
-}
-
-/**
-* Determines whether a given character is a regex range indicator('-') in a character class.
-* @param {Object} charInfo Information about the character's position in the regex (see parseRegExp)
-* @param {number} index The index of this character in the list of characters returned from parseRegExp
-* @param {Object[]} charList The entire parsed list of characters for this regex (returned from parseRegExp)
-* @returns {boolean} false if this character is a range indicator, true if it is not
-*/
-function isNotRangeDash(charInfo, index, charList) {
-    return charInfo.text !== "-" || !charInfo.inCharClass || index === 0 || index === charList.length - 1 || !charList[index - 1].inCharClass || !charList[index + 1].inCharClass;
 }
 
 module.exports = {
@@ -234,7 +226,15 @@ module.exports = {
                      * characters to be valid in general, and filter out '-' characters that appear in the middle of a
                      * character class.
                      */
-                    .filter(isNotRangeDash)
+                    .filter(charInfo => !(charInfo.text === "-" && charInfo.inCharClass && !charInfo.startsCharClass && !charInfo.endsCharClass))
+
+                    /*
+                     * The '^' character is also a special case; it must always be escaped outside of character classes, but
+                     * it only needs to be escaped in character classes if it's at the beginning of the character class. To
+                     * account for this, consider it to be a valid escape character outside of character classes, and filter
+                     * out '^' characters that appear at the start of a character class.
+                     */
+                    .filter(charInfo => !(charInfo.text === "^" && charInfo.startsCharClass))
 
                     // Filter out characters that aren't escaped.
                     .filter(charInfo => charInfo.escaped)

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -214,7 +214,7 @@ module.exports = {
                     validateString(VALID_STRING_ESCAPES, node, match);
                 }
             } else if (node.regex) {
-                parseRegExp(node.raw.slice(1, -1))
+                parseRegExp(node.regex.pattern)
 
                     /*
                      * The '-' character is a special case, because it's only valid to escape it if it's in a character

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -9,6 +9,19 @@
 // Rule Definition
 //------------------------------------------------------------------------------
 
+/**
+* Returns the union of two sets.
+* @param {Set} setA The first set
+* @param {Set} setB The second set
+* @returns {Set} The union of the two sets
+*/
+function union(setA, setB) {
+    return new Set(function *() {
+        yield* setA;
+        yield* setB;
+    }());
+}
+
 const VALID_STRING_ESCAPES = [
     "\\",
     "n",
@@ -23,22 +36,10 @@ const VALID_STRING_ESCAPES = [
     "\r"
 ];
 
-const VALID_REGEX_ESCAPES = [
+const REGEX_GENERAL_ESCAPES = new Set([
     "\\",
-    ".",
-    "-",
+    "/",
     "^",
-    "$",
-    "*",
-    "+",
-    "?",
-    "{",
-    "}",
-    "[",
-    "]",
-    "|",
-    "(",
-    ")",
     "b",
     "B",
     "c",
@@ -55,7 +56,59 @@ const VALID_REGEX_ESCAPES = [
     "W",
     "x",
     "u"
-];
+]);
+const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set(["]"]));
+const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
+    ".",
+    "$",
+    "*",
+    "+",
+    "?",
+    "[",
+    "{",
+    "}",
+    "|",
+    "(",
+    ")",
+]));
+
+/**
+* Parses a regular expression into a list of characters with character class info.
+* @param {string} regExpText The raw text used to create the regular expression
+* @returns {Object[]} A list of characters, each with info on escaping and whether they're in a character class.
+* @example
+*
+* parseRegExp('a\\b[cd-]')
+*
+* returns:
+* [
+*   {text: 'a', index: 0, escaped: false, charClass: false},
+*   {text: 'b', index: 2, escaped: true, charClass: false},
+*   {text: 'c', index: 4, escaped: false, charClass: true},
+*   {text: 'd', index: 5, escaped: false, charClass: true},
+*   {text: '-', index: 6, escaped: false, charClass: true}
+* ]
+*/
+function parseRegExp(regExpText) {
+    return regExpText.split("").reduce((state, char, index) => {
+        if (!state.escapeNextChar) {
+            if (char === "\\") {
+                return Object.assign({}, state, {escapeNextChar: true, index});
+            }
+            if (char === "[" && !state.inCharClass) {
+                return Object.assign({}, state, {inCharClass: true, index});
+            }
+            if (char === "]" && state.inCharClass) {
+                return Object.assign({}, state, {inCharClass: false, index});
+            }
+        }
+        return {
+            charList: state.charList.concat({text: char, escaped: state.escapeNextChar, inCharClass: state.inCharClass, index}),
+            escapeNextChar: false,
+            inCharClass: state.inCharClass
+        };
+    }, {charList: [], escapeNextChar: false, inCharClass: false}).charList;
+}
 
 module.exports = {
     meta: {
@@ -71,7 +124,26 @@ module.exports = {
     create(context) {
 
         /**
-         * Checks if the escape character in given slice is unnecessary.
+         * Reports a node
+         * @param {ASTNode} node The node to report
+         * @param {number} startOffset The backslash's offset from the start of the node
+         * @param {string} character The uselessly escaped character (not including the backslash)
+         * @returns {void}
+         */
+        function report(node, startOffset, character) {
+            context.report({
+                node,
+                loc: {
+                    line: node.loc.start.line,
+                    column: node.loc.start.column + startOffset
+                },
+                message: "Unnecessary escape character: \\{{character}}.",
+                data: {character}
+            });
+        }
+
+        /**
+         * Checks if the escape character in given string slice is unnecessary.
          *
          * @private
          * @param {string[]} escapes - list of valid escapes
@@ -79,7 +151,7 @@ module.exports = {
          * @param {string} match - string slice to validate.
          * @returns {void}
          */
-        function validate(escapes, node, match) {
+        function validateString(escapes, node, match) {
             const isTemplateElement = node.type === "TemplateElement";
             const escapedChar = match[0][1];
             let isUnnecessaryEscape = escapes.indexOf(escapedChar) === -1;
@@ -105,17 +177,7 @@ module.exports = {
             }
 
             if (isUnnecessaryEscape && !isQuoteEscape) {
-                context.report({
-                    node,
-                    loc: {
-                        line: node.loc.start.line,
-                        column: node.loc.start.column + match.index
-                    },
-                    message: "Unnecessary escape character: {{character}}.",
-                    data: {
-                        character: match[0]
-                    }
-                });
+                report(node, match.index, match[0].slice(1));
             }
         }
 
@@ -129,8 +191,6 @@ module.exports = {
             const isTemplateElement = node.type === "TemplateElement";
             const value = isTemplateElement ? node.value.raw : node.raw;
             const pattern = /\\[^\d]/g;
-            let nodeEscapes,
-                match;
 
             if (isTemplateElement && node.parent && node.parent.parent && node.parent.parent.type === "TaggedTemplateExpression") {
 
@@ -148,16 +208,32 @@ module.exports = {
                     return;
                 }
 
-                nodeEscapes = VALID_STRING_ESCAPES;
+                let match;
+
+                while ((match = pattern.exec(value))) {
+                    validateString(VALID_STRING_ESCAPES, node, match);
+                }
             } else if (node.regex) {
-                nodeEscapes = VALID_REGEX_ESCAPES;
-            } else {
-                return;
+                parseRegExp(node.raw.slice(1, -1))
+
+                    /*
+                     * The '-' character is a special case, because it's only valid to escape it if it's in a character
+                     * class, and is not at either edge of the character class. To account for this, don't consider '-'
+                     * characters to be valid in general, and filter out '-' characters that appear in the middle of a
+                     * character class.
+                     */
+                    .filter((charInfo, index, array) => charInfo.text !== "-" || !charInfo.inCharClass || index === 0 || index === array.length - 1 || !array[index - 1].inCharClass || !array[index + 1].inCharClass)
+
+                    // Filter out characters that aren't escaped.
+                    .filter(charInfo => charInfo.escaped)
+
+                    // Filter out characters that are valid to escape, based on their position in the regular expression.
+                    .filter(charInfo => !(charInfo.inCharClass ? REGEX_CHARCLASS_ESCAPES : REGEX_NON_CHARCLASS_ESCAPES).has(charInfo.text))
+
+                    // Report all the remaining characters.
+                    .forEach(charInfo => report(node, charInfo.index, charInfo.text));
             }
 
-            while ((match = pattern.exec(value))) {
-                validate(nodeEscapes, node, match);
-            }
         }
 
         return {

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -40,7 +40,6 @@ const REGEX_GENERAL_ESCAPES = new Set([
     "\\",
     "^",
     "b",
-    "B",
     "c",
     "d",
     "D",
@@ -70,6 +69,7 @@ const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
     "|",
     "(",
     ")",
+    "B"
 ]));
 
 /**

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -38,7 +38,6 @@ const VALID_STRING_ESCAPES = [
 
 const REGEX_GENERAL_ESCAPES = new Set([
     "\\",
-    "/",
     "^",
     "b",
     "B",
@@ -59,6 +58,7 @@ const REGEX_GENERAL_ESCAPES = new Set([
 ]);
 const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set(["]"]));
 const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
+    "/",
     ".",
     "$",
     "*",

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -82,32 +82,33 @@ const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
 *
 * returns:
 * [
-*   {text: 'a', index: 0, escaped: false, charClass: false},
-*   {text: 'b', index: 2, escaped: true, charClass: false},
-*   {text: 'c', index: 4, escaped: false, charClass: true},
-*   {text: 'd', index: 5, escaped: false, charClass: true},
-*   {text: '-', index: 6, escaped: false, charClass: true}
+*   {text: 'a', index: 0, escaped: false, inCharClass: false},
+*   {text: 'b', index: 2, escaped: true, inCharClass: false},
+*   {text: 'c', index: 4, escaped: false, inCharClass: true},
+*   {text: 'd', index: 5, escaped: false, inCharClass: true},
+*   {text: '-', index: 6, escaped: false, inCharClass: true}
 * ]
 */
 function parseRegExp(regExpText) {
-    return regExpText.split("").reduce((state, char, index) => {
+    const charList = [];
+
+    regExpText.split("").reduce((state, char, index) => {
         if (!state.escapeNextChar) {
             if (char === "\\") {
-                return Object.assign({}, state, {escapeNextChar: true, index});
+                return Object.assign(state, {escapeNextChar: true});
             }
             if (char === "[" && !state.inCharClass) {
-                return Object.assign({}, state, {inCharClass: true, index});
+                return Object.assign(state, {inCharClass: true});
             }
             if (char === "]" && state.inCharClass) {
-                return Object.assign({}, state, {inCharClass: false, index});
+                return Object.assign(state, {inCharClass: false});
             }
         }
-        return {
-            charList: state.charList.concat({text: char, escaped: state.escapeNextChar, inCharClass: state.inCharClass, index}),
-            escapeNextChar: false,
-            inCharClass: state.inCharClass
-        };
-    }, {charList: [], escapeNextChar: false, inCharClass: false}).charList;
+        charList.push({text: char, index, escaped: state.escapeNextChar, inCharClass: state.inCharClass});
+        return Object.assign(state, {escapeNextChar: false});
+    }, {escapeNextChar: false, inCharClass: false});
+
+    return charList;
 }
 
 /**

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -110,6 +110,17 @@ function parseRegExp(regExpText) {
     }, {charList: [], escapeNextChar: false, inCharClass: false}).charList;
 }
 
+/**
+* Determines whether a given character is a regex range indicator('-') in a character class.
+* @param {Object} charInfo Information about the character's position in the regex (see parseRegExp)
+* @param {number} index The index of this character in the list of characters returned from parseRegExp
+* @param {Object[]} charList The entire parsed list of characters for this regex (returned from parseRegExp)
+* @returns {boolean} false if this character is a range indicator, true if it is not
+*/
+function isNotRangeDash(charInfo, index, charList) {
+    return charInfo.text !== "-" || !charInfo.inCharClass || index === 0 || index === charList.length - 1 || !charList[index - 1].inCharClass || !charList[index + 1].inCharClass;
+}
+
 module.exports = {
     meta: {
         docs: {
@@ -222,7 +233,7 @@ module.exports = {
                      * characters to be valid in general, and filter out '-' characters that appear in the middle of a
                      * character class.
                      */
-                    .filter((charInfo, index, array) => charInfo.text !== "-" || !charInfo.inCharClass || index === 0 || index === array.length - 1 || !array[index - 1].inCharClass || !array[index + 1].inCharClass)
+                    .filter(isNotRangeDash)
 
                     // Filter out characters that aren't escaped.
                     .filter(charInfo => charInfo.escaped)

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -54,7 +54,7 @@ module.exports = {
          * @returns {RegExp} The term converted to a RegExp
          */
         function convertToRegExp(term) {
-            const escaped = term.replace(/[-/\\$\^*+?.()|[\]{}]/g, "\\$&");
+            const escaped = term.replace(/[-/\\$^*+?.()|[\]{}]/g, "\\$&");
             let prefix;
 
             /*

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -54,7 +54,7 @@ module.exports = {
          * @returns {RegExp} The term converted to a RegExp
          */
         function convertToRegExp(term) {
-            const escaped = term.replace(/[-\/\\$\^*+?.()|[\]{}]/g, "\\$&");
+            const escaped = term.replace(/[-/\\$\^*+?.()|[\]{}]/g, "\\$&");
             let prefix;
 
             /*

--- a/lib/rules/no-warning-comments.js
+++ b/lib/rules/no-warning-comments.js
@@ -54,7 +54,7 @@ module.exports = {
          * @returns {RegExp} The term converted to a RegExp
          */
         function convertToRegExp(term) {
-            const escaped = term.replace(/[-\/\\$\^*+?.()|\[\]{}]/g, "\\$&");
+            const escaped = term.replace(/[-\/\\$\^*+?.()|[\]{}]/g, "\\$&");
             let prefix;
 
             /*

--- a/lib/rules/semi.js
+++ b/lib/rules/semi.js
@@ -53,7 +53,7 @@ module.exports = {
 
     create(context) {
 
-        const OPT_OUT_PATTERN = /^[-[(\/+]$/; // One of [(/+-, but not ++ or --
+        const OPT_OUT_PATTERN = /^[-[(/+]$/; // One of [(/+-, but not ++ or --
         const options = context.options[1];
         const never = context.options[0] === "never",
             exceptOneLine = options && options.omitLastInOneLineBlock === true,

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -160,7 +160,7 @@ function listFilesToProcess(globPatterns, options) {
         } else {
 
             // regex to find .hidden or /.hidden patterns, but not ./relative or ../relative
-            const globIncludesDotfiles = /(?:(?:^\.)|(?:[\/\\]\.))[^\/\\\.].*/.test(pattern);
+            const globIncludesDotfiles = /(?:(?:^\.)|(?:[\/\\]\.))[^\/\\.].*/.test(pattern);
 
             const ignoredPaths = new IgnoredPaths(Object.assign({}, options, {dotfiles: options.dotfiles || globIncludesDotfiles}));
             const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();

--- a/lib/util/glob-util.js
+++ b/lib/util/glob-util.js
@@ -67,7 +67,7 @@ function processPath(options) {
         const resolvedPath = path.resolve(cwd, pathname);
 
         if (shell.test("-d", resolvedPath)) {
-            newPath = pathname.replace(/[\/\\]$/, "") + suffix;
+            newPath = pathname.replace(/[/\\]$/, "") + suffix;
         }
 
         return pathUtil.convertPathToPosix(newPath);
@@ -160,7 +160,7 @@ function listFilesToProcess(globPatterns, options) {
         } else {
 
             // regex to find .hidden or /.hidden patterns, but not ./relative or ../relative
-            const globIncludesDotfiles = /(?:(?:^\.)|(?:[\/\\]\.))[^\/\\.].*/.test(pattern);
+            const globIncludesDotfiles = /(?:(?:^\.)|(?:[/\\]\.))[^/\\.].*/.test(pattern);
 
             const ignoredPaths = new IgnoredPaths(Object.assign({}, options, {dotfiles: options.dotfiles || globIncludesDotfiles}));
             const shouldIgnore = ignoredPaths.getIgnoredFoldersGlobChecker();

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -31,7 +31,7 @@ ruleTester.run("no-useless-escape", rule, {
         "var foo = /\\w\\$\\*\\./",
         "var foo = /\\^\\+\\./",
         "var foo = /\\|\\}\\{\\./",
-        "var foo = /\\]\\[\\(\\)\\//",
+        "var foo = /]\\[\\(\\)\\//",
         "var foo = \"\\x123\"",
         "var foo = \"\\u00a9\"",
         "var foo = \"\\377\"",
@@ -77,7 +77,21 @@ ruleTester.run("no-useless-escape", rule, {
         {code: "var foo = `\\${{${foo}`;", parserOptions: {ecmaVersion: 6}},
         {code: "var foo = `$\\{{${foo}`;", parserOptions: {ecmaVersion: 6}},
         {code: "var foo = String.raw`\\.`", parserOptions: {ecmaVersion: 6}},
-        {code: "var foo = myFunc`\\.`", parserOptions: {ecmaVersion: 6}}
+        {code: "var foo = myFunc`\\.`", parserOptions: {ecmaVersion: 6}},
+
+        String.raw`var foo = /[\d]/`,
+        String.raw`var foo = /[a\-b]/`,
+        String.raw`var foo = /foo\?/`,
+        String.raw`var foo = /example\.com/`,
+        String.raw`var foo = /foo\|bar/`,
+        String.raw`var foo = /\^bar/`,
+        String.raw`var foo = /[\^bar]/`,
+        String.raw`var foo = /\(bar\)/`,
+        String.raw`var foo = /[[\]]/`, // A character class containing '[' and ']'
+        String.raw`var foo = /[[]\./`, // A character class containing '[', followed by a '.' character
+        String.raw`var foo = /[\]\]]/`, // A (redundant) character class containing ']'
+        String.raw`var foo = /\[abc]/`, // Matches the literal string '[abc]'
+        String.raw`var foo = /\[foo\.bar]/` // Matches the literal string '[foo.bar]'
     ],
 
     invalid: [
@@ -158,6 +172,58 @@ ruleTester.run("no-useless-escape", rule, {
             errors: [
                 { line: 1, column: 12, message: "Unnecessary escape character: \\{.", type: "TemplateElement"},
             ]
+        },
+        {
+            code: String.raw`var foo = /[ab\-]/`,
+            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\-.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[\-ab]/`,
+            errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\-.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[ab\?]/`,
+            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\?.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[ab\.]/`,
+            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\..", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[a\|b]/`,
+            errors: [{ line: 1, column: 14, message: "Unnecessary escape character: \\|.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /\-/`,
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\-.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[\-]/`,
+            errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\-.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[ab\$]/`,
+            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\$.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[\(paren]/`,
+            errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\(.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[\[]/`,
+            errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\[.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /foo\]/`,
+            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\].", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[[]\]/`, // A character class containing '[', followed by a ']' character
+            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\]." }]
+        },
+        {
+            code: String.raw`var foo = /\[foo\.bar\]/`, // Matches the literal string '[foo.bar]'
+            errors: [{ line: 1, column: 22, message: "Unnecessary escape character: \\]." }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -234,6 +234,18 @@ ruleTester.run("no-useless-escape", rule, {
         {
             code: String.raw`var foo = /[\B]/`,
             errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\B.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[a][\-b]/`,
+            errors: [{ line: 1, column: 16, message: "Unnecessary escape character: \\-.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /\-[]/`,
+            errors: [{ line: 1, column: 12, message: "Unnecessary escape character: \\-.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[a\^]/`,
+            errors: [{ line: 1, column: 14, message: "Unnecessary escape character: \\^.", type: "Literal" }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -220,11 +220,15 @@ ruleTester.run("no-useless-escape", rule, {
         },
         {
             code: String.raw`var foo = /[[]\]/`, // A character class containing '[', followed by a ']' character
-            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\]." }]
+            errors: [{ line: 1, column: 15, message: "Unnecessary escape character: \\].", type: "Literal" }]
         },
         {
             code: String.raw`var foo = /\[foo\.bar\]/`, // Matches the literal string '[foo.bar]'
-            errors: [{ line: 1, column: 22, message: "Unnecessary escape character: \\]." }]
+            errors: [{ line: 1, column: 22, message: "Unnecessary escape character: \\].", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[\/]/`, // A character class containing '/'
+            errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\/.", type: "Literal" }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -92,7 +92,8 @@ ruleTester.run("no-useless-escape", rule, {
         String.raw`var foo = /[\]\]]/`, // A (redundant) character class containing ']'
         String.raw`var foo = /\[abc]/`, // Matches the literal string '[abc]'
         String.raw`var foo = /\[foo\.bar]/`, // Matches the literal string '[foo.bar]'
-        String.raw`var foo = /vi/m`
+        String.raw`var foo = /vi/m`,
+        String.raw`var foo = /\B/`
     ],
 
     invalid: [
@@ -229,6 +230,10 @@ ruleTester.run("no-useless-escape", rule, {
         {
             code: String.raw`var foo = /[\/]/`, // A character class containing '/'
             errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\/.", type: "Literal" }]
+        },
+        {
+            code: String.raw`var foo = /[\B]/`,
+            errors: [{ line: 1, column: 13, message: "Unnecessary escape character: \\B.", type: "Literal" }]
         }
     ]
 });

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -91,7 +91,8 @@ ruleTester.run("no-useless-escape", rule, {
         String.raw`var foo = /[[]\./`, // A character class containing '[', followed by a '.' character
         String.raw`var foo = /[\]\]]/`, // A (redundant) character class containing ']'
         String.raw`var foo = /\[abc]/`, // Matches the literal string '[abc]'
-        String.raw`var foo = /\[foo\.bar]/` // Matches the literal string '[foo.bar]'
+        String.raw`var foo = /\[foo\.bar]/`, // Matches the literal string '[foo.bar]'
+        String.raw`var foo = /vi/m`
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7424

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `no-useless-escape` to verify whether a character needs to be escaped based on its position in a regular expression. Previously, `no-useless-escape` had a list of escapable characters for regexes, and it would never report cases where any of them were escaped. However, some characters only need to be escaped if they appear in a character class, and other characters only need to be escaped if they appear outside of a character class. This PR updates the rule to parse the regular expression to determine which characters are in character classes, and report the characters if they are escaped inside a character class and only need to be escaped outside a class (or vice versa).

**Is there anything you'd like reviewers to focus on?**

We should make sure that the `REGEX_GENERAL_ESCAPES`, `REGEX_CHARCLASS_ESCAPES`, and `REGEX_NON_CHARCLASS_ESCAPES` lists are correct.
