### PR TITLE
Build: ensure that all files are linted on bash (fixes #7426)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -62,13 +62,13 @@ const NODE = "node ", // intentional extra space
 
     // Files
     MAKEFILE = "./Makefile.js",
-    JS_FILES = "lib/**/*.js conf/**/*.js bin/**/*.js",
+    JS_FILES = "\"lib/**/*.js\" \"conf/**/*.js\" \"bin/**/*.js\"",
     JSON_FILES = find("conf/").filter(fileType("json")),
     MARKDOWN_FILES_ARRAY = find("docs/").concat(ls(".")).filter(fileType("md")),
     TEST_FILES = getTestFilePatterns(),
     PERF_ESLINTRC = path.join(PERF_TMP_DIR, "eslintrc.yml"),
     PERF_MULTIFILES_TARGET_DIR = path.join(PERF_TMP_DIR, "eslint"),
-    PERF_MULTIFILES_TARGETS = `${PERF_MULTIFILES_TARGET_DIR + path.sep}{lib,tests${path.sep}lib}${path.sep}**${path.sep}*.js`,
+    PERF_MULTIFILES_TARGETS = `"${PERF_MULTIFILES_TARGET_DIR + path.sep}{lib,tests${path.sep}lib}${path.sep}**${path.sep}*.js"`,
 
     // Regex
     TAG_REGEX = /^(?:Breaking|Build|Chore|Docs|Fix|New|Update|Upgrade):/,
@@ -94,10 +94,10 @@ function getTestFilePatterns() {
         return test("-d", testLibPath + pathToCheck);
     }).reduce(function(initialValue, currentValues) {
         if (currentValues !== "rules") {
-            initialValue.push(`${testLibPath + currentValues}/**/*.js`);
+            initialValue.push(`"${testLibPath + currentValues}/**/*.js"`);
         }
         return initialValue;
-    }, [`${testLibPath}rules/**/*.js`, `${testLibPath}*.js`, `${testTemplatesPath}*.js`, `${testBinPath}**/*.js`]).join(" ");
+    }, [`"${testLibPath}rules/**/*.js"`, `"${testLibPath}*.js"`, `"${testTemplatesPath}*.js"`, `"${testBinPath}**/*.js"`]).join(" ");
 }
 
 /**


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7426

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `Makefile.js` to add quotes around the linting glob patterns. This ensures that the globs get handled by ESLint's glob parser, rather than getting handled by bash before getting passed to ESLint.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.

