### PR TITLE
Update: `func-name-matching`: add “always/never” string (fixes #7391)

### DIFF
--- a/lib/rules/func-name-matching.js
+++ b/lib/rules/func-name-matching.js
@@ -54,6 +54,17 @@ function isIdentifier(name, ecmaVersion) {
 // Rule Definition
 //------------------------------------------------------------------------------
 
+const alwaysOrNever = { enum: ["always", "never"] };
+const optionsObject = {
+    type: "object",
+    properties: {
+        includeCommonJSModuleExports: {
+            type: "boolean"
+        }
+    },
+    additionalProperties: false
+};
+
 module.exports = {
     meta: {
         docs: {
@@ -62,23 +73,34 @@ module.exports = {
             recommended: false
         },
 
-        schema: [
-            {
-                type: "object",
-                properties: {
-                    includeCommonJSModuleExports: {
-                        type: "boolean"
-                    }
-                },
-                additionalProperties: false
-            }
-        ]
+        schema: {
+            anyOf: [{
+                type: "array",
+                additionalItems: false,
+                items: [alwaysOrNever, optionsObject]
+            }, {
+                type: "array",
+                additionalItems: false,
+                items: [optionsObject]
+            }]
+        }
     },
 
     create(context) {
-
-        const includeModuleExports = context.options[0] && context.options[0].includeCommonJSModuleExports;
+        const options = (typeof context.options[0] === "object" ? context.options[0] : context.options[1]) || {};
+        const nameMatches = typeof context.options[0] === "string" ? context.options[0] : "always";
+        const includeModuleExports = options.includeCommonJSModuleExports;
         const ecmaVersion = context.parserOptions && context.parserOptions.ecmaVersion ? context.parserOptions.ecmaVersion : 5;
+
+        /**
+         * Compares identifiers based on the nameMatches option
+         * @param {string} x the first identifier
+         * @param {string} y the second identifier
+         * @returns {boolean} whether the two identifiers should warn.
+         */
+        function shouldWarn(x, y) {
+            return (nameMatches === "always" && x !== y) || (nameMatches === "never" && x === y);
+        }
 
         /**
          * Reports
@@ -89,10 +111,20 @@ module.exports = {
          * @returns {void}
          */
         function report(node, name, funcName, isProp) {
+            let message;
+
+            if (nameMatches === "always" && isProp) {
+                message = "Function name `{{funcName}}` should match property name `{{name}}`";
+            } else if (nameMatches === "always") {
+                message = "Function name `{{funcName}}` should match variable name `{{name}}`";
+            } else if (isProp) {
+                message = "Function name `{{funcName}}` should not match property name `{{name}}`";
+            } else {
+                message = "Function name `{{funcName}}` should not match variable name `{{name}}`";
+            }
             context.report({
                 node,
-                message: isProp ? "Function name `{{funcName}}` should match property name `{{name}}`"
-                                : "Function name `{{funcName}}` should match variable name `{{name}}`",
+                message,
                 data: {
                     name,
                     funcName
@@ -110,7 +142,7 @@ module.exports = {
                 if (!node.init || node.init.type !== "FunctionExpression") {
                     return;
                 }
-                if (node.init.id && node.id.name !== node.init.id.name) {
+                if (node.init.id && shouldWarn(node.id.name, node.init.id.name)) {
                     report(node, node.id.name, node.init.id.name, false);
                 }
             },
@@ -126,7 +158,7 @@ module.exports = {
                 const isProp = node.left.type === "MemberExpression" ? true : false;
                 const name = isProp ? astUtils.getStaticPropertyName(node.left) : node.left.name;
 
-                if (node.right.id && isIdentifier(name) && name !== node.right.id.name) {
+                if (node.right.id && isIdentifier(name) && shouldWarn(name, node.right.id.name)) {
                     report(node, name, node.right.id.name, isProp);
                 }
             },
@@ -135,12 +167,13 @@ module.exports = {
                 if (node.value.type !== "FunctionExpression" || !node.value.id || node.computed && node.key.type !== "Literal") {
                     return;
                 }
-                if (node.key.type === "Identifier" && node.key.name !== node.value.id.name) {
+                if (node.key.type === "Identifier" && shouldWarn(node.key.name, node.value.id.name)) {
                     report(node, node.key.name, node.value.id.name, true);
-                } else if (node.key.type === "Literal" &&
-                           isIdentifier(node.key.value, ecmaVersion) &&
-                           node.key.value !== node.value.id.name
-                          ) {
+                } else if (
+                    node.key.type === "Literal" &&
+                    isIdentifier(node.key.value, ecmaVersion) &&
+                    shouldWarn(node.key.value, node.value.id.name)
+                ) {
                     report(node, node.key.value, node.value.id.name, true);
                 }
             }

--- a/tests/lib/rules/func-name-matching.js
+++ b/tests/lib/rules/func-name-matching.js
@@ -22,19 +22,43 @@ ruleTester.run("func-name-matching", rule, {
     valid: [
         { code: "var foo;" },
         { code: "var foo = function foo() {};" },
+        { code: "var foo = function foo() {};", options: ["always"] },
+        { code: "var foo = function bar() {};", options: ["never"] },
         { code: "var foo = function() {}"},
         { code: "var foo = () => {}", parserOptions: { ecmaVersion: 6} },
         { code: "foo = function foo() {};" },
+        { code: "foo = function foo() {};", options: ["always"] },
+        { code: "foo = function bar() {};", options: ["never"] },
         { code: "obj.foo = function foo() {};" },
+        { code: "obj.foo = function foo() {};", options: ["always"] },
+        { code: "obj.foo = function bar() {};", options: ["never"] },
         { code: "obj.foo = function() {};" },
+        { code: "obj.foo = function() {};", options: ["always"] },
+        { code: "obj.foo = function() {};", options: ["never"] },
         { code: "obj.bar.foo = function foo() {};" },
+        { code: "obj.bar.foo = function foo() {};", options: ["always"] },
+        { code: "obj.bar.foo = function baz() {};", options: ["never"] },
         { code: "obj['foo'] = function foo() {};" },
-        { code: "obj['foo//bar'] = function foo() {};"},
+        { code: "obj['foo'] = function foo() {};", options: ["always"] },
+        { code: "obj['foo'] = function bar() {};", options: ["never"] },
+        { code: "obj['foo//bar'] = function foo() {};" },
+        { code: "obj['foo//bar'] = function foo() {};", options: ["always"] },
+        { code: "obj['foo//bar'] = function foo() {};", options: ["never"] },
         { code: "obj[foo] = function bar() {};" },
+        { code: "obj[foo] = function bar() {};", options: ["always"] },
+        { code: "obj[foo] = function bar() {};", options: ["never"] },
         { code: "var obj = {foo: function foo() {}};" },
+        { code: "var obj = {foo: function foo() {}};", options: ["always"] },
+        { code: "var obj = {foo: function bar() {}};", options: ["never"] },
         { code: "var obj = {'foo': function foo() {}};" },
+        { code: "var obj = {'foo': function foo() {}};", options: ["always"] },
+        { code: "var obj = {'foo': function bar() {}};", options: ["never"] },
         { code: "var obj = {'foo//bar': function foo() {}};" },
+        { code: "var obj = {'foo//bar': function foo() {}};", options: ["always"] },
+        { code: "var obj = {'foo//bar': function foo() {}};", options: ["never"] },
         { code: "var obj = {foo: function() {}};" },
+        { code: "var obj = {foo: function() {}};", options: ["always"] },
+        { code: "var obj = {foo: function() {}};", options: ["never"] },
         { code: "var obj = {[foo]: function bar() {}} ", parserOptions: { ecmaVersion: 6} },
         { code: "var obj = {['x' + 2]: function bar(){}};", parserOptions: { ecmaVersion: 6} },
         { code: "obj['x' + 2] = function bar(){};" },
@@ -48,12 +72,42 @@ ruleTester.run("func-name-matching", rule, {
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "module.exports = function foo(name) {};",
+            options: ["always", { includeCommonJSModuleExports: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "module.exports = function foo(name) {};",
+            options: ["never", { includeCommonJSModuleExports: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "module['exports'] = function foo(name) {};",
             options: [{ includeCommonJSModuleExports: false }],
             parserOptions: { ecmaVersion: 6 }
         },
         {
+            code: "module['exports'] = function foo(name) {};",
+            options: ["always", { includeCommonJSModuleExports: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "module['exports'] = function foo(name) {};",
+            options: ["never", { includeCommonJSModuleExports: false }],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
             code: "({['foo']: function foo() {}})",
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "({['foo']: function foo() {}})",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 }
+        },
+        {
+            code: "({['foo']: function bar() {}})",
+            options: ["never"],
             parserOptions: { ecmaVersion: 6 }
         },
         {
@@ -66,6 +120,14 @@ ruleTester.run("func-name-matching", rule, {
         }
     ],
     invalid: [
+        {
+            code: "let foo = function bar() {};",
+            options: ["always"],
+            parserOptions: { ecmaVersion: 6 },
+            errors: [
+                { message: "Function name `bar` should match variable name `foo`" }
+            ]
+        },
         {
             code: "let foo = function bar() {};",
             parserOptions: { ecmaVersion: 6 },
@@ -131,11 +193,57 @@ ruleTester.run("func-name-matching", rule, {
             ]
         },
         {
+            code: "module.exports = function foo(name) {};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["always", { includeCommonJSModuleExports: true }],
+            errors: [
+                { message: "Function name `foo` should match property name `exports`" }
+            ]
+        },
+        {
+            code: "module.exports = function exports(name) {};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["never", { includeCommonJSModuleExports: true }],
+            errors: [
+                { message: "Function name `exports` should not match property name `exports`" }
+            ]
+        },
+        {
             code: "module['exports'] = function foo(name) {};",
             parserOptions: { ecmaVersion: 6 },
             options: [{ includeCommonJSModuleExports: true }],
             errors: [
                 { message: "Function name `foo` should match property name `exports`" }
+            ]
+        },
+        {
+            code: "module['exports'] = function foo(name) {};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["always", { includeCommonJSModuleExports: true }],
+            errors: [
+                { message: "Function name `foo` should match property name `exports`" }
+            ]
+        },
+        {
+            code: "module['exports'] = function exports(name) {};",
+            parserOptions: { ecmaVersion: 6 },
+            options: ["never", { includeCommonJSModuleExports: true }],
+            errors: [
+                { message: "Function name `exports` should not match property name `exports`" }
+            ]
+        },
+        {
+            code: "var foo = function foo(name) {};",
+            options: ["never"],
+            errors: [
+                { message: "Function name `foo` should not match variable name `foo`" }
+            ]
+        },
+        {
+            code: "obj.foo = function foo(name) {};",
+            options: ["never"],
+            errors: [
+                { message: "Function name `foo` should not match property name `foo`" }
             ]
         }
     ]


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
[`func-name-matching`](https://github.com/eslint/eslint/issues/7391)

**Does this change cause the rule to produce more or fewer warnings?**
It adds an "always"/"never" string option so that the things it currently warns for can be inverted.

**How will the change be implemented? (New option, new default behavior, etc.)?**
New string option, optionally passed before the options object. When omitted, defaults to "always" which is the current behavior.

**Please provide some example code that this change will affect:**
**What does the rule currently do for this code?**
```js
const foo = function foo() {}; // warns with "never", not with "always"
const foo = function bar() {}; // warns with "always", not with "never"
```

**What will the rule do after it's changed?**
When the option is set, warn when function names match, instead of when they do not match.