### PR TITLE
New: RuleTester supports grouping tests into scenarios

### DIFF
--- a/docs/developer-guide/working-with-rules.md
+++ b/docs/developer-guide/working-with-rules.md
@@ -482,6 +482,56 @@ invalid: [
 ]
 ```
 
+### Grouping Test Cases
+
+You can group both valid and invalid test cases by supplying an object instead of an array of test cases. When you decide to use an object instead of an array, the keys of the object represent scenario names or descriptions and will show up in the test output. The values of a scenario object must be either an array of test cases or another scenario object. You can nest scenario objects indefinitely.
+
+Here is an example:
+
+```js
+ruleTester.run("my-rule", rule, {
+    valid: {
+        "No options": [
+            "someCode();"
+        ],
+
+        "With option foo:bar": {
+            "And no other options": [
+                { code: "someMoreCode();", options: [{ foo: "bar" }] }
+            ],
+
+            "Combined with baz:quux": [
+                { code: "yetMoreCode();", options: [{ foo: "bar", baz: "quux" }] }
+            ]
+        }
+    },
+
+    invalid: {
+        "No options": [
+            { code: "someCode();", errors: ["Some error message"] }
+        ],
+
+        "With option foo:bar": {
+            "And no other options": [
+                {
+                    code: "someMoreCode();",
+                    options: [{ foo: "bar" }],
+                    errors: ["Some error message"]
+                }
+            ],
+
+            "Combined with baz:quux": [
+                {
+                    code: "yetMoreCode();",
+                    options: [{ foo: "bar", baz: "quux" }],
+                    errors: ["Some error message", "And another one"]
+                }
+            ]
+        }
+    }
+});
+```
+
 ### Specifying Globals
 
 If your rule relies on globals to be specified, you can provide global variable declarations by using the `globals` property. For example:

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -21,6 +21,26 @@
  *      ]
  *  });
  *
+ * Also supported: Use an object to represent different scenarios.
+ * Format:
+ * RuleTester.run("{ruleName}", rule, {
+ *     valid: {
+ *         "No options": [
+ *             "{code}"
+ *         ],
+ *
+ *         "With option foo:bar": [
+ *             { code: "{code}", options: {options} }
+ *         ]
+ *     },
+ *
+ *     invalid: {
+ *         "No options": [
+ *             { code: "{code}", errors: [{ message: "{errorMessage}", type: "{errorNodeType}", line: 1, column: 1 }] }
+ *         ]
+ *     }
+ * });
+ *
  * Variables:
  * {code} - String that represents the code to be tested
  * {options} - Arguments that are passed to the configurable rules.
@@ -482,25 +502,70 @@ RuleTester.prototype = {
             assertASTDidntChange(result.beforeAST, result.afterAST);
         }
 
+        /**
+         * Process a single valid test case.
+         *
+         * @param {Object|string} testCase The test case to be run.
+         * @returns {void}
+         */
+        function processValidTestCase(testCase) {
+            RuleTester.it(testCase.code || testCase, () => {
+                testValidTemplate(ruleName, testCase);
+            });
+        }
+
+        /**
+         * Process a single invalid test case.
+         *
+         * @param {Object|string} testCase The test case to be run.
+         * @returns {void}
+         */
+        function processInvalidTestCase(testCase) {
+            RuleTester.it(testCase.code, () => {
+                testInvalidTemplate(ruleName, testCase);
+            });
+        }
+
+        /**
+         * Processes an array or group of tests, calling the supplied callback
+         * on every individual test case.
+         *
+         * The tests may be represented as an array of tests or a scenario
+         * object. A scenario object has keys representing scenario descriptions
+         * and values which are (again) an array of tests or a scenario object.
+         * Scenario objects can be nested indefinitely.
+         *
+         * @param {Object|Array} testArrayOrGroup The test cases to be processed.
+         * @param {Function} executeTestFn The test execution callback.
+         * @returns {void}
+         */
+        function processTests(testArrayOrGroup, executeTestFn) {
+            if (Array.isArray(testArrayOrGroup)) {
+                testArrayOrGroup.forEach(executeTestFn);
+            } else if (typeof testArrayOrGroup === "object") {
+                Object.keys(testArrayOrGroup).forEach(scenario => {
+                    const scenarioTests = testArrayOrGroup[scenario];
+
+                    RuleTester.describe(scenario, () => {
+                        processTests(scenarioTests, executeTestFn);
+                    });
+                });
+            } else {
+                throw new TypeError("Must supply an array of tests or a scenario object");
+            }
+        }
+
         /*
          * This creates a mocha test suite and pipes all supplied info through
          * one of the templates above.
          */
         RuleTester.describe(ruleName, () => {
             RuleTester.describe("valid", () => {
-                test.valid.forEach(valid => {
-                    RuleTester.it(valid.code || valid, () => {
-                        testValidTemplate(ruleName, valid);
-                    });
-                });
+                processTests(test.valid, processValidTestCase);
             });
 
             RuleTester.describe("invalid", () => {
-                test.invalid.forEach(invalid => {
-                    RuleTester.it(invalid.code, () => {
-                        testInvalidTemplate(ruleName, invalid);
-                    });
-                });
+                processTests(test.invalid, processInvalidTestCase);
             });
         });
 

--- a/tests/lib/testers/rule-tester.js
+++ b/tests/lib/testers/rule-tester.js
@@ -657,14 +657,14 @@ describe("RuleTester", () => {
                     valid: "not an array or object",
                     invalid: []
                 });
-            });
+            }, /^Must supply an array of tests or a scenario object$/);
 
             assert.throws(() => {
                 ruleTester.run("foo", emptyRule, {
                     valid() {},
                     invalid: []
                 });
-            });
+            }, /^Must supply an array of tests or a scenario object$/);
         });
 
         it("should throw if 'invalid' value is not an array or object", () => {
@@ -673,14 +673,14 @@ describe("RuleTester", () => {
                     valid: [],
                     invalid: "not an array or object"
                 });
-            });
+            }, /^Must supply an array of tests or a scenario object$/);
 
             assert.throws(() => {
                 ruleTester.run("foo", emptyRule, {
                     valid: [],
                     invalid() {}
                 });
-            });
+            }, /^Must supply an array of tests or a scenario object$/);
         });
     });
 


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[x] Add something to the core
[ ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Changed `lib/testers/rule-tester.js` so that valid and invalid tests can now be grouped into "scenarios". Basically, instead of passing an array of tests, you can pass an object. The keys of that object are scenario descriptions, and the values are either an array of tests or another object with sub-scenarios.

**Is there anything you'd like reviewers to focus on?**

RuleTester error handling/coverage is pretty light in general. Please let me know if I should try to cover more error cases.

Goal is for this to be fully backwards-compatible. Pretty sure I've achieved that or else tests would be failing throughout, but still.
