### PR TITLE
Update: fix false negative of `no-extra-parens` (fixes #7122)

### DIFF
--- a/lib/rules/no-extra-parens.js
+++ b/lib/rules/no-extra-parens.js
@@ -509,7 +509,7 @@ module.exports = {
                         !(
                             (node.object.type === "Literal" &&
                             typeof node.object.value === "number" &&
-                            /^[0-9]+$/.test(sourceCode.getFirstToken(node.object).value))
+                            astUtils.isDecimalInteger(node.object))
                             ||
 
                             // RegExp literal is allowed to have parens (#1589)

--- a/tests/lib/rules/no-extra-parens.js
+++ b/tests/lib/rules/no-extra-parens.js
@@ -358,6 +358,7 @@ ruleTester.run("no-extra-parens", rule, {
         invalid("(0.0).a", "0.0.a", "Literal"),
         invalid("(0xBEEF).a", "0xBEEF.a", "Literal"),
         invalid("(1e6).a", "1e6.a", "Literal"),
+        invalid("(0123).a", "0123.a", "Literal"),
         invalid("a[(function() {})]", "a[function() {}]", "FunctionExpression"),
         invalid("new (function(){})", "new function(){}", "FunctionExpression"),
         invalid("new (\nfunction(){}\n)", "new \nfunction(){}\n", "FunctionExpression", 1),


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See #7122 for the template.

**What changes did you make? (Give an overview)**

This PR changes `no-extra-parens` as reporting parentheses around octal integer literals.

```js
(0123).a    // Gratuitous parentheses around expression.
```

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
