### PR TITLE
Update: `no-restricted-{imports,modules}`: add “patterns” (fixes #6963)

### DIFF
--- a/docs/rules/no-restricted-imports.md
+++ b/docs/rules/no-restricted-imports.md
@@ -14,10 +14,25 @@ This rule allows you to specify imports that you don't want to use in your appli
 
 ## Options
 
-The syntax to specify restricted modules looks like this:
+The syntax to specify restricted imports looks like this:
 
 ```json
 "no-restricted-imports": ["error", "import1", "import2"]
+```
+
+or like this:
+
+```json
+"no-restricted-imports": ["error", { "paths": ["import1", "import2"] }]
+```
+
+When using the object form, you can also specify an array of gitignore-style patterns:
+
+```json
+"no-restricted-imports": ["error", {
+    "paths": ["import1", "import2"],
+    "patterns": ["import1/private/*", "import2/*", "!import2/good"]
+}]
 ```
 
 To restrict the use of all Node.js core imports (via https://github.com/nodejs/node/tree/master/lib):
@@ -39,9 +54,15 @@ import fs from 'fs';
 ```
 
 ```js
-/*eslint no-restricted-imports: ["error", "cluster"]*/
+/*eslint no-restricted-imports: ["error", { "paths": ["cluster"] }]*/
 
-import cluster from ' cluster ';
+import cluster from 'cluster';
+```
+
+```js
+/*eslint no-restricted-imports: ["error", { "patterns": ["lodash/*"] }]*/
+
+import pick from 'lodash/pick';
 ```
 
 Examples of **correct** code for this rule:
@@ -50,6 +71,13 @@ Examples of **correct** code for this rule:
 /*eslint no-restricted-imports: ["error", "fs"]*/
 
 import crypto from 'crypto';
+```
+
+```js
+/*eslint no-restricted-imports: ["error", { "paths": ["fs"], "patterns": ["eslint/*"] }]*/
+
+import crypto from 'crypto';
+import eslint from 'eslint';
 ```
 
 ## When Not To Use It

--- a/docs/rules/no-restricted-modules.md
+++ b/docs/rules/no-restricted-modules.md
@@ -14,6 +14,8 @@ This rule allows you to specify modules that you don't want to use in your appli
 
 The rule takes one or more strings as options: the names of restricted modules.
 
+It can also take an object with lists of "paths" and gitignore-style "patterns" strings.
+
 For example, to restrict the use of all Node.js core modules (via https://github.com/nodejs/node/tree/master/lib):
 
 ```json
@@ -30,7 +32,19 @@ Examples of **incorrect** code for this rule with sample `"fs", "cluster"` restr
 /*eslint no-restricted-modules: ["error", "fs", "cluster"]*/
 
 var fs = require('fs');
-var cluster = require(' cluster ');
+var cluster = require('cluster');
+```
+
+```js
+/*eslint no-restricted-modules: ["error", { "paths": ["cluster"] }]*/
+
+var cluster = require('cluster');
+```
+
+```js
+/*eslint no-restricted-modules: ["error", { "patterns": ["lodash/*"] }]*/
+
+var cluster = require('lodash/pick');
 ```
 
 Examples of **correct** code for this rule with sample `"fs", "cluster"` restricted modules:
@@ -39,4 +53,14 @@ Examples of **correct** code for this rule with sample `"fs", "cluster"` restric
 /*eslint no-restricted-modules: ["error", "fs", "cluster"]*/
 
 var crypto = require('crypto');
+```
+
+```js
+/*eslint no-restricted-modules: ["error", {
+    "paths": ["fs", "cluster"],
+    "patterns": ["lodash/*", "!lodash/pick"]
+}]*/
+
+var crypto = require('crypto');
+var eslint = require('lodash/pick');
 ```

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "file-entry-cache": "^2.0.0",
     "glob": "^7.0.3",
     "globals": "^9.2.0",
-    "ignore": "^3.1.5",
+    "ignore": "^3.2.0",
     "imurmurhash": "^0.1.4",
     "inquirer": "^0.12.0",
     "is-my-json-valid": "^2.10.0",

--- a/tests/lib/rules/no-restricted-imports.js
+++ b/tests/lib/rules/no-restricted-imports.js
@@ -24,13 +24,48 @@ ruleTester.run("no-restricted-imports", rule, {
         { code: "import fs from \"fs\";", options: ["crypto"], parserOptions: { sourceType: "module" } },
         { code: "import path from \"path\";", options: ["crypto", "stream", "os"], parserOptions: { sourceType: "module" } },
         { code: "import async from \"async\";", parserOptions: { sourceType: "module" } },
-        { code: "import \"foo\"", options: ["crypto"], parserOptions: { sourceType: "module" } }
+        { code: "import \"foo\"", options: ["crypto"], parserOptions: { sourceType: "module" } },
+        { code: "import \"foo/bar\";", options: ["foo"], parserOptions: { sourceType: "module" } },
+        { code: "import withPaths from \"foo/bar\";", options: [{ paths: ["foo", "bar"] }], parserOptions: { sourceType: "module" } },
+        { code: "import withPatterns from \"foo/bar\";", options: [{ patterns: ["foo/c*"] }], parserOptions: { sourceType: "module" } },
+        {
+            code: "import withPatternsAndPaths from \"foo/bar\";",
+            options: [{ paths: ["foo"], patterns: ["foo/c*"] }],
+            parserOptions: { sourceType: "module" }
+        },
+        {
+            code: "import withGitignores from \"foo/bar\";",
+            options: [{ patterns: ["foo/*", "!foo/bar"] }],
+            parserOptions: { sourceType: "module" }
+        }
     ],
     invalid: [{
         code: "import \"fs\"", options: ["fs"], parserOptions: { sourceType: "module" },
         errors: [{ message: "'fs' import is restricted from being used.", type: "ImportDeclaration"}]
     }, {
-        code: "import os from \"os \";", options: ["fs", "crypto ", "stream", "os"], parserOptions: { sourceType: "module" },
+        code: "import os from \"os \";",
+        options: ["fs", "crypto ", "stream", "os"],
+        parserOptions: { sourceType: "module" },
         errors: [{ message: "'os' import is restricted from being used.", type: "ImportDeclaration"}]
+    }, {
+        code: "import \"foo/bar\";",
+        options: ["foo/bar"],
+        parserOptions: { sourceType: "module" },
+        errors: [{ message: "'foo/bar' import is restricted from being used.", type: "ImportDeclaration"}]
+    }, {
+        code: "import withPaths from \"foo/bar\";",
+        options: [{ paths: ["foo/bar"] }],
+        parserOptions: { sourceType: "module" },
+        errors: [{ message: "'foo/bar' import is restricted from being used.", type: "ImportDeclaration"}]
+    }, {
+        code: "import withPatterns from \"foo/bar\";",
+        options: [{ patterns: ["foo/*"] }],
+        parserOptions: { sourceType: "module" },
+        errors: [{ message: "'foo/bar' import is restricted from being used by a pattern.", type: "ImportDeclaration"}]
+    }, {
+        code: "import withGitignores from \"foo/bar\";",
+        options: [{ patterns: ["foo/*", "!foo/baz"] }],
+        parserOptions: { sourceType: "module" },
+        errors: [{ message: "'foo/bar' import is restricted from being used by a pattern.", type: "ImportDeclaration"}]
     }]
 });

--- a/tests/lib/rules/no-restricted-modules.js
+++ b/tests/lib/rules/no-restricted-modules.js
@@ -25,13 +25,40 @@ ruleTester.run("no-restricted-modules", rule, {
         { code: "require(\"fs \")", args: 0 },
         { code: "require(2)", options: ["crypto"]},
         { code: "require(foo)", options: ["crypto"]},
-        { code: "var foo = bar('crypto');", options: ["crypto"]}
+        { code: "var foo = bar('crypto');", options: ["crypto"]},
+        { code: "require(\"foo/bar\");", option: ["foo"]},
+        { code: "var withPaths = require(\"foo/bar\");", option: [{ paths: ["foo", "bar"] }]},
+        { code: "var withPatterns = require(\"foo/bar\");", option: [{ patterns: ["foo/c*"] }]},
+        { code: "var withPatternsAndPaths = require(\"foo/bar\");", option: [{ paths: ["foo"], patterns: ["foo/c*"] }]},
+        { code: "var withGitignores = require(\"foo/bar\");", option: [{ paths: ["foo"], patterns: ["foo/*", "!foo/bar"] }]}
     ],
     invalid: [{
-        code: "require(\"fs\")", options: ["fs"],
+        code: "require(\"fs\")",
+        options: ["fs"],
         errors: [{ message: "'fs' module is restricted from being used.", type: "CallExpression"}]
     }, {
-        code: "require(\"os \")", options: ["fs", "crypto ", "stream", "os"],
+        code: "require(\"os \")",
+        options: ["fs", "crypto ", "stream", "os"],
         errors: [{ message: "'os' module is restricted from being used.", type: "CallExpression"}]
+    }, {
+        code: "require(\"foo/bar\");",
+        options: ["foo/bar"],
+        errors: [{ message: "'foo/bar' module is restricted from being used.", type: "CallExpression"}]
+    }, {
+        code: "var withPaths = require(\"foo/bar\");",
+        options: [{ paths: ["foo/bar"] }],
+        errors: [{ message: "'foo/bar' module is restricted from being used.", type: "CallExpression"}]
+    }, {
+        code: "var withPatterns = require(\"foo/bar\");",
+        options: [{ patterns: ["foo/*"] }],
+        errors: [{ message: "'foo/bar' module is restricted from being used by a pattern.", type: "CallExpression"}]
+    }, {
+        code: "var withPatternsAndPaths = require(\"foo/bar\");",
+        options: [{ patterns: ["foo/*"], paths: ["foo"] }],
+        errors: [{ message: "'foo/bar' module is restricted from being used by a pattern.", type: "CallExpression"}]
+    }, {
+        code: "var withGitignores = require(\"foo/bar\");",
+        options: [{ patterns: ["foo/*", "!foo/baz"], paths: ["foo"] }],
+        errors: [{ message: "'foo/bar' module is restricted from being used by a pattern.", type: "CallExpression"}]
     }]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[x] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

**What rule do you want to change?**
`no-restricted-imports` and `no-restricted-modules`

**Does this change cause the rule to produce more or fewer warnings?**
More, only when the "patterns" option is set.

**How will the change be implemented? (New option, new default behavior, etc.)?**
New schema - the existing schema of an array of strings will continue to work; an alternative object schema with "paths" will also be accepted. A "patterns" property can be added to this object to opt in to the new behavior.

**Please provide some example code that this change will affect:**

``` js
import pick from 'lodash/pick';
/* or */
var pick = require('lodash/pick');
```

**What does the rule currently do for this code?**
Does not warn unless the exact full path is provided.

**What will the rule do after it's changed?**
Allow a pattern to be provided such that a partial path may be provided.

Fixes #6963.
