### PR TITLE
New: `require-await` rule (fixes #6820)

### DIFF
--- a/conf/eslint.json
+++ b/conf/eslint.json
@@ -208,6 +208,7 @@
         "quote-props": "off",
         "quotes": "off",
         "radix": "off",
+        "require-await": "off",
         "require-jsdoc": "off",
         "require-yield": "error",
         "rest-spread-spacing": "off",

--- a/docs/rules/require-await.md
+++ b/docs/rules/require-await.md
@@ -1,0 +1,54 @@
+# Disallow async functions which have no `await` expression (require-await)
+
+Async functions which have no `await` expression may be the unintentional result of refactoring.
+
+## Rule Details
+
+This rule warns async functions which have no `await` expression.
+
+Examples of **incorrect** code for this rule:
+
+```js
+/*eslint require-await: "error"*/
+
+async function foo() {
+    doSomething();
+}
+
+bar(async () => {
+    doSomething();
+});
+```
+
+Examples of **correct** code for this rule:
+
+```js
+/*eslint require-await: "error"*/
+
+async function foo() {
+    await doSomething();
+}
+
+bar(async () => {
+    await doSomething();
+});
+
+function foo() {
+    doSomething();
+}
+
+bar(() => {
+    doSomething();
+});
+
+// Allow empty functions.
+async function noop() {}
+```
+
+## When Not To Use It
+
+If you don't want to notify async functions which have no `await` expression, then it's safe to disable this rule.
+
+## Related Rules
+
+* [require-yield](require-yield.md)

--- a/docs/rules/require-yield.md
+++ b/docs/rules/require-yield.md
@@ -35,3 +35,11 @@ function foo() {
 // This rule does not warn on empty generator functions.
 function* foo() { }
 ```
+
+## When Not To Use It
+
+If you don't want to notify generator functions that have `yield` expression, then it's safe to disable this rule.
+
+## Related Rules
+
+* [require-await](require-await.md)

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -197,6 +197,40 @@ function isParenthesised(sourceCode, node) {
         nextToken.value === ")" && nextToken.range[0] >= node.range[1];
 }
 
+/**
+ * Gets the `=>` token of the given arrow function node.
+ *
+ * @param {ASTNode} node - The arrow function node to get.
+ * @param {SourceCode} sourceCode - The source code object to get tokens.
+ * @returns {Token} `=>` token.
+ */
+function getArrowToken(node, sourceCode) {
+    let token = sourceCode.getTokenBefore(node.body);
+
+    while (token.value !== "=>") {
+        token = sourceCode.getTokenBefore(token);
+    }
+
+    return token;
+}
+
+/**
+ * Gets the `(` token of the given function node.
+ *
+ * @param {ASTNode} node - The function node to get.
+ * @param {SourceCode} sourceCode - The source code object to get tokens.
+ * @returns {Token} `(` token.
+ */
+function getOpeningParenOfParams(node, sourceCode) {
+    let token = node.id ? sourceCode.getTokenAfter(node.id) : sourceCode.getFirstToken(node);
+
+    while (token.value !== "(") {
+        token = sourceCode.getTokenAfter(token);
+    }
+
+    return token;
+}
+
 //------------------------------------------------------------------------------
 // Public Interface
 //------------------------------------------------------------------------------
@@ -738,5 +772,213 @@ module.exports = {
      */
     isDecimalInteger(node) {
         return node.type === "Literal" && typeof node.value === "number" && /^(0|[1-9]\d*)$/.test(node.raw);
+    },
+
+    /**
+     * Gets the name and kind of the given function node.
+     *
+     * - `function foo() {}`  .................... `function 'foo'`
+     * - `(function foo() {})`  .................. `function 'foo'`
+     * - `(function() {})`  ...................... `function`
+     * - `function* foo() {}`  ................... `generator function 'foo'`
+     * - `(function* foo() {})`  ................. `generator function 'foo'`
+     * - `(function*() {})`  ..................... `generator function`
+     * - `() => {}`  ............................. `arrow function`
+     * - `async () => {}`  ....................... `async arrow function`
+     * - `({ foo: function foo() {} })`  ......... `method 'foo'`
+     * - `({ foo: function() {} })`  ............. `method 'foo'`
+     * - `({ ['foo']: function() {} })`  ......... `method 'foo'`
+     * - `({ [foo]: function() {} })`  ........... `method`
+     * - `({ foo() {} })`  ....................... `method 'foo'`
+     * - `({ foo: function* foo() {} })`  ........ `generator method 'foo'`
+     * - `({ foo: function*() {} })`  ............ `generator method 'foo'`
+     * - `({ ['foo']: function*() {} })`  ........ `generator method 'foo'`
+     * - `({ [foo]: function*() {} })`  .......... `generator method`
+     * - `({ *foo() {} })`  ...................... `generator method 'foo'`
+     * - `({ foo: async function foo() {} })`  ... `async method 'foo'`
+     * - `({ foo: async function() {} })`  ....... `async method 'foo'`
+     * - `({ ['foo']: async function() {} })`  ... `async method 'foo'`
+     * - `({ [foo]: async function() {} })`  ..... `async method`
+     * - `({ async foo() {} })`  ................. `async method 'foo'`
+     * - `({ get foo() {} })`  ................... `getter 'foo'`
+     * - `({ set foo(a) {} })`  .................. `setter 'foo'`
+     * - `class A { constructor() {} }`  ......... `constructor`
+     * - `class A { foo() {} }`  ................. `method 'foo'`
+     * - `class A { *foo() {} }`  ................ `generator method 'foo'`
+     * - `class A { async foo() {} }`  ........... `async method 'foo'`
+     * - `class A { ['foo']() {} }`  ............. `method 'foo'`
+     * - `class A { *['foo']() {} }`  ............ `generator method 'foo'`
+     * - `class A { async ['foo']() {} }`  ....... `async method 'foo'`
+     * - `class A { [foo]() {} }`  ............... `method`
+     * - `class A { *[foo]() {} }`  .............. `generator method`
+     * - `class A { async [foo]() {} }`  ......... `async method`
+     * - `class A { get foo() {} }`  ............. `getter 'foo'`
+     * - `class A { set foo(a) {} }`  ............ `setter 'foo'`
+     * - `class A { static foo() {} }`  .......... `static method 'foo'`
+     * - `class A { static *foo() {} }`  ......... `static generator method 'foo'`
+     * - `class A { static async foo() {} }`  .... `static async method 'foo'`
+     * - `class A { static get foo() {} }`  ...... `static getter 'foo'`
+     * - `class A { static set foo(a) {} }`  ..... `static setter 'foo'`
+     *
+     * @param {ASTNode} node - The function node to get.
+     * @returns {string} The name and kind of the function node.
+     */
+    getFunctionNameWithKind(node) {
+        const parent = node.parent;
+        const tokens = [];
+
+        if (parent.type === "MethodDefinition" && parent.static) {
+            tokens.push("static");
+        }
+        if (node.async) {
+            tokens.push("async");
+        }
+        if (node.generator) {
+            tokens.push("generator");
+        }
+
+        if (node.type === "ArrowFunctionExpression") {
+            tokens.push("arrow", "function");
+        } else if (parent.type === "Property" || parent.type === "MethodDefinition") {
+            if (parent.kind === "constructor") {
+                return "constructor";
+            } else if (parent.kind === "get") {
+                tokens.push("getter");
+            } else if (parent.kind === "set") {
+                tokens.push("setter");
+            } else {
+                tokens.push("method");
+            }
+        } else {
+            tokens.push("function");
+        }
+
+        if (node.id) {
+            tokens.push(`'${node.id.name}'`);
+        } else {
+            const name = module.exports.getStaticPropertyName(parent);
+
+            if (name) {
+                tokens.push(`'${name}'`);
+            }
+        }
+
+        return tokens.join(" ");
+    },
+
+    /**
+     * Gets the location of the given function node for reporting.
+     *
+     * - `function foo() {}`
+     *    ^^^^^^^^^^^^
+     * - `(function foo() {})`
+     *     ^^^^^^^^^^^^
+     * - `(function() {})`
+     *     ^^^^^^^^
+     * - `function* foo() {}`
+     *    ^^^^^^^^^^^^^
+     * - `(function* foo() {})`
+     *     ^^^^^^^^^^^^^
+     * - `(function*() {})`
+     *     ^^^^^^^^^
+     * - `() => {}`
+     *       ^^
+     * - `async () => {}`
+     *             ^^
+     * - `({ foo: function foo() {} })`
+     *       ^^^^^^^^^^^^^^^^^
+     * - `({ foo: function() {} })`
+     *       ^^^^^^^^^^^^^
+     * - `({ ['foo']: function() {} })`
+     *       ^^^^^^^^^^^^^^^^^
+     * - `({ [foo]: function() {} })`
+     *       ^^^^^^^^^^^^^^^
+     * - `({ foo() {} })`
+     *       ^^^
+     * - `({ foo: function* foo() {} })`
+     *       ^^^^^^^^^^^^^^^^^^
+     * - `({ foo: function*() {} })`
+     *       ^^^^^^^^^^^^^^
+     * - `({ ['foo']: function*() {} })`
+     *       ^^^^^^^^^^^^^^^^^^
+     * - `({ [foo]: function*() {} })`
+     *       ^^^^^^^^^^^^^^^^
+     * - `({ *foo() {} })`
+     *       ^^^^
+     * - `({ foo: async function foo() {} })`
+     *       ^^^^^^^^^^^^^^^^^^^^^^^
+     * - `({ foo: async function() {} })`
+     *       ^^^^^^^^^^^^^^^^^^^
+     * - `({ ['foo']: async function() {} })`
+     *       ^^^^^^^^^^^^^^^^^^^^^^^
+     * - `({ [foo]: async function() {} })`
+     *       ^^^^^^^^^^^^^^^^^^^^^
+     * - `({ async foo() {} })`
+     *       ^^^^^^^^^
+     * - `({ get foo() {} })`
+     *       ^^^^^^^
+     * - `({ set foo(a) {} })`
+     *       ^^^^^^^
+     * - `class A { constructor() {} }`
+     *              ^^^^^^^^^^^
+     * - `class A { foo() {} }`
+     *              ^^^
+     * - `class A { *foo() {} }`
+     *              ^^^^
+     * - `class A { async foo() {} }`
+     *              ^^^^^^^^^
+     * - `class A { ['foo']() {} }`
+     *              ^^^^^^^
+     * - `class A { *['foo']() {} }`
+     *              ^^^^^^^^
+     * - `class A { async ['foo']() {} }`
+     *              ^^^^^^^^^^^^^
+     * - `class A { [foo]() {} }`
+     *              ^^^^^
+     * - `class A { *[foo]() {} }`
+     *              ^^^^^^
+     * - `class A { async [foo]() {} }`
+     *              ^^^^^^^^^^^
+     * - `class A { get foo() {} }`
+     *              ^^^^^^^
+     * - `class A { set foo(a) {} }`
+     *              ^^^^^^^
+     * - `class A { static foo() {} }`
+     *              ^^^^^^^^^^
+     * - `class A { static *foo() {} }`
+     *              ^^^^^^^^^^^
+     * - `class A { static async foo() {} }`
+     *              ^^^^^^^^^^^^^^^^
+     * - `class A { static get foo() {} }`
+     *              ^^^^^^^^^^^^^^
+     * - `class A { static set foo(a) {} }`
+     *              ^^^^^^^^^^^^^^
+     *
+     * @param {ASTNode} node - The function node to get.
+     * @param {SourceCode} sourceCode - The source code object to get tokens.
+     * @returns {string} The location of the function node for reporting.
+     */
+    getFunctionHeadLoc(node, sourceCode) {
+        const parent = node.parent;
+        let start = null;
+        let end = null;
+
+        if (node.type === "ArrowFunctionExpression") {
+            const arrowToken = getArrowToken(node, sourceCode);
+
+            start = arrowToken.loc.start;
+            end = arrowToken.loc.end;
+        } else if (parent.type === "Property" || parent.type === "MethodDefinition") {
+            start = parent.loc.start;
+            end = getOpeningParenOfParams(node, sourceCode).loc.start;
+        } else {
+            start = node.loc.start;
+            end = getOpeningParenOfParams(node, sourceCode).loc.start;
+        }
+
+        return {
+            start: Object.assign({}, start),
+            end: Object.assign({}, end),
+        };
     }
 };

--- a/lib/ast-utils.js
+++ b/lib/ast-utils.js
@@ -649,6 +649,26 @@ module.exports = {
     },
 
     /**
+     * Checks whether the given node is an empty block node or not.
+     *
+     * @param {ASTNode|null} node - The node to check.
+     * @returns {boolean} `true` if the node is an empty block.
+     */
+    isEmptyBlock(node) {
+        return Boolean(node && node.type === "BlockStatement" && node.body.length === 0);
+    },
+
+    /**
+     * Checks whether the given node is an empty function node or not.
+     *
+     * @param {ASTNode|null} node - The node to check.
+     * @returns {boolean} `true` if the node is an empty function.
+     */
+    isEmptyFunction(node) {
+        return module.exports.isFunction(node) && module.exports.isEmptyBlock(node.body);
+    },
+
+    /**
      * Gets the property name of a given node.
      * The node can be a MemberExpression, a Property, or a MethodDefinition.
      *

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -1,5 +1,5 @@
 /**
- * @fileoverview Rule to
+ * @fileoverview Rule to disallow async functions which have no `await` expression.
  * @author Toru Nagashima
  */
 

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -1,0 +1,105 @@
+/**
+ * @fileoverview Rule to
+ * @author Toru Nagashima
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const astUtils = require("../ast-utils");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Checks whether the given function node is an empty function or not.
+ *
+ * @param {ASTNode} node - The function node to check.
+ * @returns {boolean} `true` if the function node is an empty function.
+ */
+function isEmpty(node) {
+    return node.body.type === "BlockStatement" && node.body.body.length === 0;
+}
+
+/**
+ * Capitalize the 1st letter of the given text.
+ *
+ * @param {string} text - The text to capitalize.
+ * @returns {string} The text that the 1st letter was capitalized.
+ */
+function capitalizeFirstLetter(text) {
+    return text[0].toUpperCase() + text.slice(1);
+}
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+    meta: {
+        docs: {
+            description: "disallow async functions which have no `await` expression",
+            category: "Best Practices",
+            recommended: false
+        },
+        schema: []
+    },
+
+    create(context) {
+        const sourceCode = context.getSourceCode();
+        let scopeInfo = null;
+
+        /**
+         * Push the scope info object to the stack.
+         *
+         * @returns {void}
+         */
+        function enterFunction() {
+            scopeInfo = {
+                upper: scopeInfo,
+                hasAwait: false,
+            };
+        }
+
+        /**
+         * Pop the top scope info object from the stack.
+         * Also, it reports the function if needed.
+         *
+         * @param {ASTNode} node - The node to report.
+         * @returns {void}
+         */
+        function exitFunction(node) {
+            if (node.async && !scopeInfo.hasAwait && !isEmpty(node)) {
+                context.report({
+                    node,
+                    loc: astUtils.getFunctionHeadLoc(node, sourceCode),
+                    message: "{{name}} has no 'await' expression.",
+                    data: {
+                        name: capitalizeFirstLetter(
+                            astUtils.getFunctionNameWithKind(node)
+                        )
+                    }
+                });
+            }
+
+            scopeInfo = scopeInfo.upper;
+        }
+
+        return {
+            FunctionDeclaration: enterFunction,
+            FunctionExpression: enterFunction,
+            ArrowFunctionExpression: enterFunction,
+            "FunctionDeclaration:exit": exitFunction,
+            "FunctionExpression:exit": exitFunction,
+            "ArrowFunctionExpression:exit": exitFunction,
+
+            AwaitExpression() {
+                scopeInfo.hasAwait = true;
+            }
+        };
+    }
+};

--- a/lib/rules/require-await.js
+++ b/lib/rules/require-await.js
@@ -16,16 +16,6 @@ const astUtils = require("../ast-utils");
 //------------------------------------------------------------------------------
 
 /**
- * Checks whether the given function node is an empty function or not.
- *
- * @param {ASTNode} node - The function node to check.
- * @returns {boolean} `true` if the function node is an empty function.
- */
-function isEmpty(node) {
-    return node.body.type === "BlockStatement" && node.body.body.length === 0;
-}
-
-/**
  * Capitalize the 1st letter of the given text.
  *
  * @param {string} text - The text to capitalize.
@@ -73,7 +63,7 @@ module.exports = {
          * @returns {void}
          */
         function exitFunction(node) {
-            if (node.async && !scopeInfo.hasAwait && !isEmpty(node)) {
+            if (node.async && !scopeInfo.hasAwait && !astUtils.isEmptyFunction(node)) {
                 context.report({
                     node,
                     loc: astUtils.getFunctionHeadLoc(node, sourceCode),

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -666,4 +666,161 @@ describe("ast-utils", function() {
             });
         });
     });
+
+    describe("getFunctionNameWithKind", function() {
+        const expectedResults = {
+            "function foo() {}": "function 'foo'",
+            "(function foo() {})": "function 'foo'",
+            "(function() {})": "function",
+            "function* foo() {}": "generator function 'foo'",
+            "(function* foo() {})": "generator function 'foo'",
+            "(function*() {})": "generator function",
+            "() => {}": "arrow function",
+            "async () => {}": "async arrow function",
+            "({ foo: function foo() {} })": "method 'foo'",
+            "({ foo: function() {} })": "method 'foo'",
+            "({ ['foo']: function() {} })": "method 'foo'",
+            "({ [foo]: function() {} })": "method",
+            "({ foo() {} })": "method 'foo'",
+            "({ foo: function* foo() {} })": "generator method 'foo'",
+            "({ foo: function*() {} })": "generator method 'foo'",
+            "({ ['foo']: function*() {} })": "generator method 'foo'",
+            "({ [foo]: function*() {} })": "generator method",
+            "({ *foo() {} })": "generator method 'foo'",
+            "({ foo: async function foo() {} })": "async method 'foo'",
+            "({ foo: async function() {} })": "async method 'foo'",
+            "({ ['foo']: async function() {} })": "async method 'foo'",
+            "({ [foo]: async function() {} })": "async method",
+            "({ async foo() {} })": "async method 'foo'",
+            "({ get foo() {} })": "getter 'foo'",
+            "({ set foo(a) {} })": "setter 'foo'",
+            "class A { constructor() {} }": "constructor",
+            "class A { foo() {} }": "method 'foo'",
+            "class A { *foo() {} }": "generator method 'foo'",
+            "class A { async foo() {} }": "async method 'foo'",
+            "class A { ['foo']() {} }": "method 'foo'",
+            "class A { *['foo']() {} }": "generator method 'foo'",
+            "class A { async ['foo']() {} }": "async method 'foo'",
+            "class A { [foo]() {} }": "method",
+            "class A { *[foo]() {} }": "generator method",
+            "class A { async [foo]() {} }": "async method",
+            "class A { get foo() {} }": "getter 'foo'",
+            "class A { set foo(a) {} }": "setter 'foo'",
+            "class A { static foo() {} }": "static method 'foo'",
+            "class A { static *foo() {} }": "static generator method 'foo'",
+            "class A { static async foo() {} }": "static async method 'foo'",
+            "class A { static get foo() {} }": "static getter 'foo'",
+            "class A { static set foo(a) {} }": "static setter 'foo'",
+        };
+
+        Object.keys(expectedResults).forEach(key => {
+            it(`should return "${expectedResults[key]}" for "${key}".`, function() {
+                let called = false;
+
+                /**
+                 * Verify.
+                 * @param {ASTNode} node - The function node to verify.
+                 * @returns {void}
+                 */
+                function verify(node) {
+                    assert.strictEqual(
+                        astUtils.getFunctionNameWithKind(node),
+                        expectedResults[key]
+                    );
+                    called = true;
+                }
+
+                eslint.on("FunctionDeclaration", verify);
+                eslint.on("FunctionExpression", verify);
+                eslint.on("ArrowFunctionExpression", verify);
+                eslint.verify(key, {parserOptions: {ecmaVersion: 8}}, "test.js", true);
+
+                assert(called);
+            });
+        });
+    });
+
+    describe("getFunctionHeadLoc", function() {
+        const expectedResults = {
+            "function foo() {}": [0, 12],
+            "(function foo() {})": [1, 13],
+            "(function() {})": [1, 9],
+            "function* foo() {}": [0, 13],
+            "(function* foo() {})": [1, 14],
+            "(function*() {})": [1, 10],
+            "() => {}": [3, 5],
+            "async () => {}": [9, 11],
+            "({ foo: function foo() {} })": [3, 20],
+            "({ foo: function() {} })": [3, 16],
+            "({ ['foo']: function() {} })": [3, 20],
+            "({ [foo]: function() {} })": [3, 18],
+            "({ foo() {} })": [3, 6],
+            "({ foo: function* foo() {} })": [3, 21],
+            "({ foo: function*() {} })": [3, 17],
+            "({ ['foo']: function*() {} })": [3, 21],
+            "({ [foo]: function*() {} })": [3, 19],
+            "({ *foo() {} })": [3, 7],
+            "({ foo: async function foo() {} })": [3, 26],
+            "({ foo: async function() {} })": [3, 22],
+            "({ ['foo']: async function() {} })": [3, 26],
+            "({ [foo]: async function() {} })": [3, 24],
+            "({ async foo() {} })": [3, 12],
+            "({ get foo() {} })": [3, 10],
+            "({ set foo(a) {} })": [3, 10],
+            "class A { constructor() {} }": [10, 21],
+            "class A { foo() {} }": [10, 13],
+            "class A { *foo() {} }": [10, 14],
+            "class A { async foo() {} }": [10, 19],
+            "class A { ['foo']() {} }": [10, 17],
+            "class A { *['foo']() {} }": [10, 18],
+            "class A { async ['foo']() {} }": [10, 23],
+            "class A { [foo]() {} }": [10, 15],
+            "class A { *[foo]() {} }": [10, 16],
+            "class A { async [foo]() {} }": [10, 21],
+            "class A { get foo() {} }": [10, 17],
+            "class A { set foo(a) {} }": [10, 17],
+            "class A { static foo() {} }": [10, 20],
+            "class A { static *foo() {} }": [10, 21],
+            "class A { static async foo() {} }": [10, 26],
+            "class A { static get foo() {} }": [10, 24],
+            "class A { static set foo(a) {} }": [10, 24],
+        };
+
+        Object.keys(expectedResults).forEach(key => {
+            const expectedLoc = {
+                start: {
+                    line: 1,
+                    column: expectedResults[key][0]
+                },
+                end: {
+                    line: 1,
+                    column: expectedResults[key][1]
+                }
+            };
+
+            it(`should return "${JSON.stringify(expectedLoc)}" for "${key}".`, function() {
+                let called = false;
+
+                /**
+                 * Verify.
+                 * @param {ASTNode} node - The function node to verify.
+                 * @returns {void}
+                 */
+                function verify(node) {
+                    assert.deepEqual(
+                        astUtils.getFunctionHeadLoc(node, eslint.getSourceCode()),
+                        expectedLoc
+                    );
+                    called = true;
+                }
+
+                eslint.on("FunctionDeclaration", verify);
+                eslint.on("FunctionExpression", verify);
+                eslint.on("ArrowFunctionExpression", verify);
+                eslint.verify(key, {parserOptions: {ecmaVersion: 8}}, "test.js", true);
+
+                assert(called);
+            });
+        });
+    });
 });

--- a/tests/lib/ast-utils.js
+++ b/tests/lib/ast-utils.js
@@ -823,4 +823,38 @@ describe("ast-utils", function() {
             });
         });
     });
+
+    describe("isEmptyBlock", function() {
+        const expectedResults = {
+            "{}": true,
+            "{ a }": false,
+            a: false,
+        };
+
+        Object.keys(expectedResults).forEach(key => {
+            it(`should return ${expectedResults[key]} for ${key}`, function() {
+                const ast = espree.parse(key);
+
+                assert.strictEqual(astUtils.isEmptyBlock(ast.body[0]), expectedResults[key]);
+            });
+        });
+    });
+
+    describe("isEmptyFunction", function() {
+        const expectedResults = {
+            "(function foo() {})": true,
+            "(function foo() { a })": false,
+            "(a) => {}": true,
+            "(a) => { a }": false,
+            "(a) => a": false,
+        };
+
+        Object.keys(expectedResults).forEach(key => {
+            it(`should return ${expectedResults[key]} for ${key}`, function() {
+                const ast = espree.parse(key, {ecmaVersion: 6});
+
+                assert.strictEqual(astUtils.isEmptyFunction(ast.body[0].expression), expectedResults[key]);
+            });
+        });
+    });
 });

--- a/tests/lib/rules/require-await.js
+++ b/tests/lib/rules/require-await.js
@@ -1,0 +1,81 @@
+/**
+ * @fileoverview Tests for require-await rule.
+ * @author Toru Nagashima
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require("../../../lib/rules/require-await"),
+    RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+const ruleTester = new RuleTester({
+    parserOptions: {
+        ecmaVersion: 2017
+    }
+});
+
+ruleTester.run("require-await", rule, {
+    valid: [
+        "async function foo() { await doSomething() }",
+        "(async function() { await doSomething() })",
+        "async () => { await doSomething() }",
+        "async () => await doSomething()",
+        "({ async foo() { await doSomething() } })",
+        "class A { async foo() { await doSomething() } }",
+        "(class { async foo() { await doSomething() } })",
+        "async function foo() { await async () => { await doSomething() } }",
+
+        // empty functions are ok.
+        "async function foo() {}",
+        "async () => {}",
+
+        // normal functions are ok.
+        "function foo() { doSomething() }",
+    ],
+    invalid: [
+        {
+            code: "async function foo() { doSomething() }",
+            errors: ["Async function 'foo' has no 'await' expression."],
+        },
+        {
+            code: "(async function() { doSomething() })",
+            errors: ["Async function has no 'await' expression."],
+        },
+        {
+            code: "async () => { doSomething() }",
+            errors: ["Async arrow function has no 'await' expression."],
+        },
+        {
+            code: "async () => doSomething()",
+            errors: ["Async arrow function has no 'await' expression."],
+        },
+        {
+            code: "({ async foo() { doSomething() } })",
+            errors: ["Async method 'foo' has no 'await' expression."],
+        },
+        {
+            code: "class A { async foo() { doSomething() } }",
+            errors: ["Async method 'foo' has no 'await' expression."],
+        },
+        {
+            code: "(class { async foo() { doSomething() } })",
+            errors: ["Async method 'foo' has no 'await' expression."],
+        },
+        {
+            code: "async function foo() { async () => { await doSomething() } }",
+            errors: ["Async function 'foo' has no 'await' expression."],
+        },
+        {
+            code: "async function foo() { await async () => { doSomething() } }",
+            errors: ["Async arrow function has no 'await' expression."],
+        },
+    ]
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))

**Please describe what the rule should do:**

This rule disallows `async` functions which have no `await` expression.
Async functions which have no `await` expression may be the unintentional result of refactoring.

See #6820 also.

**What category of rule is this? (place an "X" next to just one item)**

[X] Enforces code style
[ ] Warns about a potential error
[ ] Suggests an alternate way of doing something
[ ] Other (please specify:)

**Provide 2-3 code examples that this rule will warn about:**

``` js
/*eslint require-await: error*/

//------------------------------------------------------------------------------
// ✔ GOOD
async function foo() {
    await doSomething()
}

// This rule ignores empty functions as same as `require-yield` rule.
async function noop() {
    // do nothing.
}

function foo() {
    doSomething()
}

//------------------------------------------------------------------------------
// ✘ BAD
async function foo() {
    doSomething()
}
```

**Why should this rule be included in ESLint (instead of a plugin)?**
- This is a general matter for JavaScript language.
- ESLint has `require-yield` rule which does the same check for generator functions.

**What changes did you make? (Give an overview)**

This PR adds the `require-await` rule into core.

In addition, this PR adds 2 functions to `ast-utils`.
- `getFunctionNameWithKind(node)` gets the name and kind of the given function. I intended that this is an utility to use for #7260. Please see JSDoc comment for details.
- `getFunctionHeadLoc(node, sourceCode)` gets the location of the function head. I intended that this is an utility to use for #3307. Please see JSDoc comment for details.

**Is there anything you'd like reviewers to focus on?**
- Messages and documents.
- Added 2 utilities.
