### PR TITLE
Fix: `arrow-parens` supports type annotations (fixes #7406)

### DIFF
--- a/lib/rules/arrow-parens.js
+++ b/lib/rules/arrow-parens.js
@@ -58,7 +58,9 @@ module.exports = {
                 requireForBlockBody &&
                 node.params.length === 1 &&
                 node.params[0].type === "Identifier" &&
-                node.body.type !== "BlockStatement"
+                !node.params[0].typeAnnotation &&
+                node.body.type !== "BlockStatement" &&
+                !node.returnType
             ) {
                 if (token.type === "Punctuator" && token.value === "(") {
                     context.report({
@@ -95,7 +97,12 @@ module.exports = {
             }
 
             // "as-needed": x => x
-            if (asNeeded && node.params.length === 1 && node.params[0].type === "Identifier") {
+            if (asNeeded &&
+                node.params.length === 1 &&
+                node.params[0].type === "Identifier" &&
+                !node.params[0].typeAnnotation &&
+                !node.returnType
+            ) {
                 if (token.type === "Punctuator" && token.value === "(") {
                     context.report({
                         node,

--- a/tests/fixtures/parsers/arrow-parens/identifer-type.js
+++ b/tests/fixtures/parsers/arrow-parens/identifer-type.js
@@ -1,0 +1,349 @@
+"use strict";
+
+// (a: T) => a
+
+exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 11,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 1,
+            column: 11
+        }
+    },
+    sourceType: "module",
+    body: [
+        {
+            type: "ExpressionStatement",
+            start: 0,
+            end: 11,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 11
+                }
+            },
+            expression: {
+                type: "ArrowFunctionExpression",
+                start: 0,
+                end: 11,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 1,
+                        column: 11
+                    }
+                },
+                id: null,
+                generator: false,
+                expression: true,
+                async: false,
+                params: [
+                    {
+                        type: "Identifier",
+                        start: 1,
+                        end: 2,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 1
+                            },
+                            end: {
+                                line: 1,
+                                column: 2
+                            }
+                        },
+                        name: "a",
+                        typeAnnotation: {
+                            type: "TypeAnnotation",
+                            start: 2,
+                            end: 5,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 2
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 5
+                                }
+                            },
+                            typeAnnotation: {
+                                type: "GenericTypeAnnotation",
+                                start: 4,
+                                end: 5,
+                                loc: {
+                                    start: {
+                                        line: 1,
+                                        column: 4
+                                    },
+                                    end: {
+                                        line: 1,
+                                        column: 5
+                                    }
+                                },
+                                typeParameters: null,
+                                id: {
+                                    type: "Identifier",
+                                    start: 4,
+                                    end: 5,
+                                    loc: {
+                                        start: {
+                                            line: 1,
+                                            column: 4
+                                        },
+                                        end: {
+                                            line: 1,
+                                            column: 5
+                                        }
+                                    },
+                                    name: "T",
+                                    range: [
+                                        4,
+                                        5
+                                    ],
+                                    _babelType: "Identifier"
+                                },
+                                range: [
+                                    4,
+                                    5
+                                ],
+                                _babelType: "GenericTypeAnnotation"
+                            },
+                            range: [
+                                2,
+                                5
+                            ],
+                            _babelType: "TypeAnnotation"
+                        },
+                        range: [
+                            1,
+                            2
+                        ],
+                        _babelType: "Identifier"
+                    }
+                ],
+                body: {
+                    type: "Identifier",
+                    start: 10,
+                    end: 11,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 10
+                        },
+                        end: {
+                            line: 1,
+                            column: 11
+                        }
+                    },
+                    name: "a",
+                    range: [
+                        10,
+                        11
+                    ],
+                    _babelType: "Identifier"
+                },
+                range: [
+                    0,
+                    11
+                ],
+                _babelType: "ArrowFunctionExpression"
+            },
+            range: [
+                0,
+                11
+            ],
+            _babelType: "ExpressionStatement"
+        }
+    ],
+    tokens: [
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 0,
+            end: 1,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 1
+                }
+            },
+            range: [
+                0,
+                1
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 1,
+            end: 2,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 1
+                },
+                end: {
+                    line: 1,
+                    column: 2
+                }
+            },
+            range: [
+                1,
+                2
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 2,
+            end: 3,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 2
+                },
+                end: {
+                    line: 1,
+                    column: 3
+                }
+            },
+            range: [
+                2,
+                3
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            start: 4,
+            end: 5,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 4
+                },
+                end: {
+                    line: 1,
+                    column: 5
+                }
+            },
+            range: [
+                4,
+                5
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 5,
+            end: 6,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 5
+                },
+                end: {
+                    line: 1,
+                    column: 6
+                }
+            },
+            range: [
+                5,
+                6
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "=>",
+            start: 7,
+            end: 9,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 7
+                },
+                end: {
+                    line: 1,
+                    column: 9
+                }
+            },
+            range: [
+                7,
+                9
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 10,
+            end: 11,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 10
+                },
+                end: {
+                    line: 1,
+                    column: 11
+                }
+            },
+            range: [
+                10,
+                11
+            ]
+        },
+        {
+            type: {
+                label: "eof",
+                beforeExpr: false,
+                startsExpr: false,
+                rightAssociative: false,
+                isLoop: false,
+                isAssign: false,
+                prefix: false,
+                postfix: false,
+                binop: null,
+                updateContext: null
+            },
+            start: 11,
+            end: 11,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 11
+                },
+                end: {
+                    line: 1,
+                    column: 11
+                }
+            },
+            range: [
+                11,
+                11
+            ]
+        }
+    ],
+    comments: [],
+    range: [
+        0,
+        11
+    ]
+});

--- a/tests/fixtures/parsers/arrow-parens/return-type.js
+++ b/tests/fixtures/parsers/arrow-parens/return-type.js
@@ -1,0 +1,350 @@
+"use strict";
+
+// (a): T => a
+
+exports.parse = () => ({
+    type: "Program",
+    start: 0,
+    end: 11,
+    loc: {
+        start: {
+            line: 1,
+            column: 0
+        },
+        end: {
+            line: 1,
+            column: 11
+        }
+    },
+    sourceType: "module",
+    body: [
+        {
+            type: "ExpressionStatement",
+            start: 0,
+            end: 11,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 11
+                }
+            },
+            expression: {
+                type: "ArrowFunctionExpression",
+                start: 0,
+                end: 11,
+                loc: {
+                    start: {
+                        line: 1,
+                        column: 0
+                    },
+                    end: {
+                        line: 1,
+                        column: 11
+                    }
+                },
+                id: null,
+                generator: false,
+                expression: true,
+                async: false,
+                params: [
+                    {
+                        type: "Identifier",
+                        start: 1,
+                        end: 2,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 1
+                            },
+                            end: {
+                                line: 1,
+                                column: 2
+                            }
+                        },
+                        name: "a",
+                        parenthesizedExpression: true,
+                        range: [
+                            1,
+                            2
+                        ],
+                        _babelType: "Identifier"
+                    }
+                ],
+                body: {
+                    type: "Identifier",
+                    start: 10,
+                    end: 11,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 10
+                        },
+                        end: {
+                            line: 1,
+                            column: 11
+                        }
+                    },
+                    name: "a",
+                    range: [
+                        10,
+                        11
+                    ],
+                    _babelType: "Identifier"
+                },
+                returnType: {
+                    type: "TypeAnnotation",
+                    start: 3,
+                    end: 6,
+                    loc: {
+                        start: {
+                            line: 1,
+                            column: 3
+                        },
+                        end: {
+                            line: 1,
+                            column: 6
+                        }
+                    },
+                    typeAnnotation: {
+                        type: "GenericTypeAnnotation",
+                        start: 5,
+                        end: 6,
+                        loc: {
+                            start: {
+                                line: 1,
+                                column: 5
+                            },
+                            end: {
+                                line: 1,
+                                column: 6
+                            }
+                        },
+                        typeParameters: null,
+                        id: {
+                            type: "Identifier",
+                            start: 5,
+                            end: 6,
+                            loc: {
+                                start: {
+                                    line: 1,
+                                    column: 5
+                                },
+                                end: {
+                                    line: 1,
+                                    column: 6
+                                }
+                            },
+                            name: "T",
+                            range: [
+                                5,
+                                6
+                            ],
+                            _babelType: "Identifier"
+                        },
+                        range: [
+                            5,
+                            6
+                        ],
+                        _babelType: "GenericTypeAnnotation"
+                    },
+                    range: [
+                        3,
+                        6
+                    ],
+                    _babelType: "TypeAnnotation"
+                },
+                range: [
+                    0,
+                    11
+                ],
+                _babelType: "ArrowFunctionExpression"
+            },
+            range: [
+                0,
+                11
+            ],
+            _babelType: "ExpressionStatement"
+        }
+    ],
+    tokens: [
+        {
+            type: "Punctuator",
+            value: "(",
+            start: 0,
+            end: 1,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 0
+                },
+                end: {
+                    line: 1,
+                    column: 1
+                }
+            },
+            range: [
+                0,
+                1
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 1,
+            end: 2,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 1
+                },
+                end: {
+                    line: 1,
+                    column: 2
+                }
+            },
+            range: [
+                1,
+                2
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ")",
+            start: 2,
+            end: 3,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 2
+                },
+                end: {
+                    line: 1,
+                    column: 3
+                }
+            },
+            range: [
+                2,
+                3
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: ":",
+            start: 3,
+            end: 4,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 3
+                },
+                end: {
+                    line: 1,
+                    column: 4
+                }
+            },
+            range: [
+                3,
+                4
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "T",
+            start: 5,
+            end: 6,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 5
+                },
+                end: {
+                    line: 1,
+                    column: 6
+                }
+            },
+            range: [
+                5,
+                6
+            ]
+        },
+        {
+            type: "Punctuator",
+            value: "=>",
+            start: 7,
+            end: 9,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 7
+                },
+                end: {
+                    line: 1,
+                    column: 9
+                }
+            },
+            range: [
+                7,
+                9
+            ]
+        },
+        {
+            type: "Identifier",
+            value: "a",
+            start: 10,
+            end: 11,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 10
+                },
+                end: {
+                    line: 1,
+                    column: 11
+                }
+            },
+            range: [
+                10,
+                11
+            ]
+        },
+        {
+            type: {
+                label: "eof",
+                beforeExpr: false,
+                startsExpr: false,
+                rightAssociative: false,
+                isLoop: false,
+                isAssign: false,
+                prefix: false,
+                postfix: false,
+                binop: null,
+                updateContext: null
+            },
+            start: 11,
+            end: 11,
+            loc: {
+                start: {
+                    line: 1,
+                    column: 11
+                },
+                end: {
+                    line: 1,
+                    column: 11
+                }
+            },
+            range: [
+                11,
+                11
+            ]
+        }
+    ],
+    comments: [],
+    range: [
+        0,
+        11
+    ]
+});

--- a/tests/lib/rules/arrow-parens.js
+++ b/tests/lib/rules/arrow-parens.js
@@ -9,8 +9,23 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/arrow-parens"),
+const path = require("path"),
+    rule = require("../../../lib/rules/arrow-parens"),
     RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the path to the specified parser.
+ *
+ * @param {string} name - The parser name to get.
+ * @returns {string} The path to the specified parser.
+ */
+function parser(name) {
+    return path.resolve(__dirname, `../../fixtures/parsers/arrow-parens/${name}.js`);
+}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -48,6 +63,8 @@ const valid = [
     { code: "(a, b) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 6 } },
     { code: "async ([a, b]) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 8 } },
     { code: "async (a, b) => {}", options: ["as-needed"], parserOptions: { ecmaVersion: 8 } },
+    { code: "(a: T) => a", options: ["as-needed"], parserOptions: { ecmaVersion: 6 }, parser: parser("identifer-type") },
+    { code: "(a): T => a", options: ["as-needed"], parserOptions: { ecmaVersion: 6 }, parser: parser("return-type") },
 
     // "as-needed", { "requireForBlockBody": true }
     { code: "() => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
@@ -61,7 +78,9 @@ const valid = [
     { code: "(a, b) => {}", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
     { code: "a => ({})", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 } },
     { code: "async a => ({})", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 8 } },
-    { code: "async a => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 8 } }
+    { code: "async a => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 8 } },
+    { code: "(a: T) => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 }, parser: parser("identifer-type") },
+    { code: "(a): T => a", options: ["as-needed", {requireForBlockBody: true}], parserOptions: { ecmaVersion: 6 }, parser: parser("return-type") },
 ];
 
 const message = "Expected parentheses around arrow function argument.";


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See #7406 for the template.

**What changes did you make? (Give an overview)**

If there is a type annotation, we cannot remove parentheses around parameters of arrow functions. But `arrow-parens` has warned those.

``` js
(a: T) => a;
(a): T => a;
```

This PR fixes the bug.
I generated the ASTs with type annotations by http://astexplorer.net/

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
