### PR TITLE
New: Codeframe (JSCS) formatter (fixes #5860)

### DIFF
--- a/docs/developer-guide/nodejs-api.md
+++ b/docs/developer-guide/nodejs-api.md
@@ -402,6 +402,7 @@ var isIgnored = cli.isPathIgnored("foo/bar.js");
 Retrieves a formatter, which you can then use to format a report object. The argument is either the name of a built-in formatter:
 
 * "[checkstyle](../user-guide/formatters#checkstyle)"
+* "[codeframe](../user-guide/formatters#codeframe)"
 * "[compact](../user-guide/formatters#compact)"
 * "[html](../user-guide/formatters#html)"
 * "[jslint-xml](../user-guide/formatters#jslint-xml)"

--- a/docs/user-guide/command-line-interface.md
+++ b/docs/user-guide/command-line-interface.md
@@ -308,6 +308,7 @@ When specified, the given format is output into the provided file name.
 This option specifies the output format for the console. Possible formats are:
 
 * [checkstyle](formatters/#checkstyle)
+* [codeframe](formatters/#codeframe)
 * [compact](formatters/#compact)
 * [html](formatters/#html)
 * [jslint-xml](formatters/#jslint-xml)

--- a/lib/formatters/codeframe.js
+++ b/lib/formatters/codeframe.js
@@ -1,0 +1,121 @@
+/**
+ * @fileoverview Codeframe reporter
+ * @author Vitor Balocco
+ */
+"use strict";
+
+const chalk = require("chalk");
+const codeFrame = require("babel-code-frame");
+const path = require("path");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Given a word and a count, append an s if count is not one.
+ * @param   {string} word  A word in its singular form.
+ * @param   {number} count A number controlling whether word should be pluralized.
+ * @returns {string}       The original word with an s on the end if count is not one.
+ */
+function pluralize(word, count) {
+    return (count === 1 ? word : `${word}s`);
+}
+
+/**
+ * Gets a formatted relative file path from an absolute path and a line/column in the file.
+ * @param   {string} filePath The absolute file path to format.
+ * @param   {number} line     The line from the file to use for formatting.
+ * @param   {number} column   The column from the file to use for formatting.
+ * @returns {string}          The formatted file path.
+ */
+function formatFilePath(filePath, line, column) {
+    let relPath = path.relative(process.cwd(), filePath);
+
+    if (line && column) {
+        relPath += `:${line}:${column}`;
+    }
+
+    return chalk.green(relPath);
+}
+
+/**
+ * Gets the formatted output for a given message.
+ * @param   {Object} message      The object that represents this message.
+ * @param   {Object} parentResult The result object that this message belongs to.
+ * @returns {string}              The formatted output.
+ */
+function formatMessage(message, parentResult) {
+    const type = (message.fatal || message.severity === 2) ? chalk.red("error") : chalk.yellow("warning");
+    const msg = `${chalk.bold(message.message.replace(/\.$/, ""))}`;
+    const ruleId = message.fatal ? "" : chalk.dim(`(${message.ruleId})`);
+    const filePath = formatFilePath(parentResult.filePath, message.line, message.column);
+    const sourceCode = parentResult.output ? parentResult.output : parentResult.source;
+
+    const firstLine = [
+        `${type}:`,
+        `${msg}`,
+        ruleId ? `${ruleId}` : "",
+        sourceCode ? `at ${filePath}:` : `at ${filePath}`,
+    ].filter(String).join(" ");
+
+    const result = [ firstLine ];
+
+    if (sourceCode) {
+        result.push(
+            codeFrame(sourceCode, message.line, message.column, { highlightCode: false })
+        );
+    }
+
+    return result.join("\n");
+}
+
+/**
+ * Gets the formatted output summary for a given number of errors and warnings.
+ * @param   {number} errors   The number of errors.
+ * @param   {number} warnings The number of warnings.
+ * @returns {string}          The formatted output summary.
+ */
+function formatSummary(errors, warnings) {
+    const summaryColor = errors > 0 ? "red" : "yellow";
+    const summary = [];
+
+    if (errors > 0) {
+        summary.push(`${errors} ${pluralize("error", errors)}`);
+    }
+
+    if (warnings > 0) {
+        summary.push(`${warnings} ${pluralize("warning", warnings)}`);
+    }
+
+    return chalk[summaryColor].bold(`${summary.join(" and ")} found.`);
+}
+
+//------------------------------------------------------------------------------
+// Public Interface
+//------------------------------------------------------------------------------
+
+module.exports = function(results) {
+    let errors = 0;
+    let warnings = 0;
+    const resultsWithMessages = results.filter(result => result.messages.length > 0);
+
+    let output = resultsWithMessages.reduce((resultsOutput, result) => {
+        const messages = result.messages.map(message => {
+            if (message.fatal || message.severity === 2) {
+                errors++;
+            } else {
+                warnings++;
+            }
+
+            return `${formatMessage(message, result)}\n\n`;
+        });
+
+        return resultsOutput.concat(messages);
+    }, []).join("\n");
+
+    output += "\n";
+    output += formatSummary(errors, warnings);
+
+    return (errors + warnings) > 0 ? output : "";
+};

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "homepage": "http://eslint.org",
   "bugs": "https://github.com/eslint/eslint/issues/",
   "dependencies": {
+    "babel-code-frame": "^6.16.0",
     "chalk": "^1.1.3",
     "concat-stream": "^1.4.6",
     "debug": "^2.1.1",

--- a/tests/lib/formatters/codeframe.js
+++ b/tests/lib/formatters/codeframe.js
@@ -1,0 +1,324 @@
+/**
+ * @fileoverview Tests for codeframe reporter.
+ * @author Vitor Balocco
+ */
+
+"use strict";
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const assert = require("chai").assert;
+const sinon = require("sinon");
+const proxyquire = require("proxyquire");
+const chalk = require("chalk");
+const path = require("path");
+
+// Chalk protects its methods so we need to inherit from it for Sinon to work.
+const chalkStub = Object.create(chalk, {
+    yellow: {
+        value(str) {
+            return chalk.yellow(str);
+        },
+        writable: true
+    },
+    red: {
+        value(str) {
+            return chalk.red(str);
+        },
+        writable: true
+    }
+});
+
+chalkStub.yellow.bold = chalk.yellow.bold;
+chalkStub.red.bold = chalk.red.bold;
+
+const formatter = proxyquire("../../../lib/formatters/codeframe", { chalk: chalkStub });
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+describe("formatter:codeframe", function() {
+    let sandbox;
+
+    beforeEach(function() {
+        sandbox = sinon.sandbox.create();
+    });
+
+    afterEach(function() {
+        sandbox.verifyAndRestore();
+    });
+
+    describe("when passed no messages", function() {
+        const code = [{
+            filePath: "foo.js",
+            messages: []
+        }];
+
+        it("should return nothing", function() {
+            const result = formatter(code);
+
+            assert.equal(result, "");
+        });
+    });
+
+    describe("when passed a single message", function() {
+        const code = [{
+            filePath: path.join(process.cwd(), "lib", "foo.js"),
+            source: "var foo = 1;\n var bar = 2;\n",
+            messages: [{
+                message: "Unexpected foo.",
+                severity: 2,
+                line: 1,
+                column: 5,
+                ruleId: "foo"
+            }]
+        }];
+
+        it("should return a string in the correct format for errors", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), [
+                `error: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
+                "> 1 | var foo = 1;",
+                "    |     ^",
+                "  2 |  var bar = 2;",
+                "  3 | ",
+                "\n",
+                "1 error found."
+            ].join("\n"));
+        });
+
+        it("should return a string in the correct format for warnings", function() {
+            code[0].messages[0].severity = 1;
+
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), [
+                `warning: Unexpected foo (foo) at ${path.join("lib", "foo.js")}:1:5:`,
+                "> 1 | var foo = 1;",
+                "    |     ^",
+                "  2 |  var bar = 2;",
+                "  3 | ",
+                "\n",
+                "1 warning found."
+            ].join("\n"));
+        });
+
+        it("should return bold red summary when there are errors", function() {
+            sandbox.spy(chalkStub.yellow, "bold");
+            sandbox.spy(chalkStub.red, "bold");
+            code[0].messages[0].severity = 2;
+
+            formatter(code);
+
+            assert.equal(chalkStub.yellow.bold.callCount, 0);
+            assert.equal(chalkStub.red.bold.callCount, 1);
+        });
+
+        it("should return bold yellow summary when there are only warnings", function() {
+            sandbox.spy(chalkStub.yellow, "bold");
+            sandbox.spy(chalkStub.red, "bold");
+            code[0].messages[0].severity = 1;
+
+            formatter(code);
+
+            assert.equal(chalkStub.yellow.bold.callCount, 1);
+            assert.equal(chalkStub.red.bold.callCount, 0);
+        });
+    });
+
+    describe("when passed multiple messages", function() {
+        const code = [{
+            filePath: "foo.js",
+            source: "const foo = 1\n",
+            messages: [{
+                message: "Missing semicolon.",
+                severity: 2,
+                line: 1,
+                column: 14,
+                ruleId: "semi"
+            }, {
+                message: "'foo' is assigned a value but never used.",
+                severity: 2,
+                line: 1,
+                column: 7,
+                ruleId: "no-unused-vars"
+            }],
+        }];
+
+        it("should return a string with multiple entries", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), [
+                "error: Missing semicolon (semi) at foo.js:1:14:",
+                "> 1 | const foo = 1",
+                "    |              ^",
+                "  2 | ",
+                "\n",
+                "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:1:7:",
+                "> 1 | const foo = 1",
+                "    |       ^",
+                "  2 | ",
+                "\n",
+                "2 errors found."
+            ].join("\n"));
+        });
+
+        it("should return bold red summary when at least 1 of the messages is an error", function() {
+            sandbox.spy(chalkStub.yellow, "bold");
+            sandbox.spy(chalkStub.red, "bold");
+            code[0].messages[0].severity = 1;
+
+            formatter(code);
+
+            assert.equal(chalkStub.yellow.bold.callCount, 0);
+            assert.equal(chalkStub.red.bold.callCount, 1);
+        });
+    });
+
+    describe("when passed one file with 1 message and fixes applied", function() {
+        const code = [{
+            filePath: "foo.js",
+            messages: [{
+                ruleId: "no-unused-vars",
+                severity: 2,
+                message: "'foo' is assigned a value but never used.",
+                line: 4,
+                column: 11,
+                source: "    const foo = 1;"
+            }],
+            output: "function foo() {\n\n    // a comment\n    const foo = 1;\n}\n\n"
+        }];
+
+        it("should return a string with code preview pointing to the correct location after fixes", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), [
+                "error: 'foo' is assigned a value but never used (no-unused-vars) at foo.js:4:11:",
+                "  2 | ",
+                "  3 |     // a comment",
+                "> 4 |     const foo = 1;",
+                "    |           ^",
+                "  5 | }",
+                "  6 | ",
+                "  7 | ",
+                "\n",
+                "1 error found."
+            ].join("\n"));
+        });
+    });
+
+    describe("when passed multiple files with 1 message each", function() {
+        const code = [{
+            filePath: "foo.js",
+            source: "const foo = 1\n",
+            messages: [{
+                message: "Missing semicolon.",
+                severity: 2,
+                line: 1,
+                column: 14,
+                ruleId: "semi"
+            }]
+        }, {
+            filePath: "bar.js",
+            source: "const bar = 2\n",
+            messages: [{
+                message: "Missing semicolon.",
+                severity: 2,
+                line: 1,
+                column: 14,
+                ruleId: "semi"
+            }]
+        }];
+
+        it("should return a string with multiple entries", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), [
+                "error: Missing semicolon (semi) at foo.js:1:14:",
+                "> 1 | const foo = 1",
+                "    |              ^",
+                "  2 | ",
+                "\n",
+                "error: Missing semicolon (semi) at bar.js:1:14:",
+                "> 1 | const bar = 2",
+                "    |              ^",
+                "  2 | ",
+                "\n",
+                "2 errors found."
+            ].join("\n"));
+        });
+    });
+
+    describe("when passed a fatal error message", function() {
+        const code = [{
+            filePath: "foo.js",
+            source: "e{}\n",
+            messages: [{
+                ruleId: null,
+                fatal: true,
+                severity: 2,
+                source: "e{}",
+                message: "Parsing error: Unexpected token {",
+                line: 1,
+                column: 2
+            }]
+        }];
+
+        it("should return a string in the correct format", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), [
+                "error: Parsing error: Unexpected token { at foo.js:1:2:",
+                "> 1 | e{}",
+                "    |  ^",
+                "  2 | ",
+                "\n",
+                "1 error found."
+            ].join("\n"));
+        });
+    });
+
+    describe("when passed one file not found message", function() {
+        const code = [{
+            filePath: "foo.js",
+            messages: [{
+                fatal: true,
+                message: "Couldn't find foo.js."
+            }]
+        }];
+
+        it("should return a string without code preview (codeframe)", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), "error: Couldn't find foo.js at foo.js\n\n\n1 error found.");
+        });
+    });
+
+    describe("when passed a single message with no line or column", function() {
+        const code = [{
+            filePath: "foo.js",
+            messages: [{
+                ruleId: "foo",
+                message: "Unexpected foo.",
+                severity: 2,
+                source: "foo"
+            }]
+        }];
+
+        it("should return a string without code preview (codeframe)", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
+        });
+
+        it("should output filepath but without 'line:column' appended", function() {
+            const result = formatter(code);
+
+            assert.equal(chalk.stripColor(result), "error: Unexpected foo (foo) at foo.js\n\n\n1 error found.");
+        });
+    });
+});


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Add something to the core

**What changes did you make? (Give an overview)**
Implements the `codeframe` formatter, which closely resembles the default JSCS formatter. Here are some screenshots of how it looks like under different circumstances:

When only errors are reported:
<img width="658" alt="screenshot 2016-10-21 23 15 31" src="https://cloud.githubusercontent.com/assets/626038/19613492/323d3b74-97ed-11e6-9fb9-bfe49541fafa.png">

When errors and warnings are reported:
<img width="663" alt="screenshot 2016-10-21 23 15 54" src="https://cloud.githubusercontent.com/assets/626038/19613495/34dc8e20-97ed-11e6-8783-c54584a7d1d3.png">

When only warnings are reported:
<img width="668" alt="screenshot 2016-10-21 23 16 51" src="https://cloud.githubusercontent.com/assets/626038/19613499/3869521c-97ed-11e6-8f51-4ba560a1d84f.png">

When a parsing error is reported:
<img width="487" alt="screenshot 2016-10-21 23 18 39" src="https://cloud.githubusercontent.com/assets/626038/19613505/3bee0b08-97ed-11e6-8ce9-b9e87175c452.png">

When an error that has no line/column is reported:
<img width="327" alt="screenshot 2016-10-21 23 20 01" src="https://cloud.githubusercontent.com/assets/626038/19613506/3fbb8cd8-97ed-11e6-8033-5c833337be97.png">


**Is there anything you'd like reviewers to focus on?**
- Is this a "`Core`" or a "`New`" change? I was not sure :(
- I took the liberty of suggesting a name for the formatter that is not "JSCS", as I believe it would be a confusing name after a year or two from now. More than happy to rename to something different or keep "JSCS", if we prefer!
- I tried to format the filepath in a way that it shows more than just the filename (for more context), but relative to the current working directory (to avoid super long paths).
- I also added the `line:column` format to the end of the filepath so editors can open the file directly on the line/column of the error.