### PR TITLE
Fix: Support type annotations in array-bracket-spacing

### DIFF
--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -180,7 +180,7 @@ module.exports = {
             const first = sourceCode.getFirstToken(node),
                 second = sourceCode.getFirstToken(node, 1),
                 last = node.typeAnnotation
-                    ? sourceCode.getFirstElement(node.typeAnnotation, -1)
+                    ? sourceCode.getFirstToken(node.typeAnnotation, -1)
                     : sourceCode.getLastToken(node),
                 penultimate = sourceCode.getTokenBefore(last),
                 firstElement = node.elements[0],

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -179,8 +179,10 @@ module.exports = {
 
             const first = sourceCode.getFirstToken(node),
                 second = sourceCode.getFirstToken(node, 1),
-                penultimate = sourceCode.getLastToken(node, 1),
-                last = sourceCode.getLastToken(node),
+                last = node.typeAnnotation
+                    ? sourceCode.getFirstElement(node.typeAnnotation, -1)
+                    : sourceCode.getLastToken(node),
+                penultimate = sourceCode.getTokenBefore(last),
                 firstElement = node.elements[0],
                 lastElement = node.elements[node.elements.length - 1];
 

--- a/lib/rules/array-bracket-spacing.js
+++ b/lib/rules/array-bracket-spacing.js
@@ -180,7 +180,7 @@ module.exports = {
             const first = sourceCode.getFirstToken(node),
                 second = sourceCode.getFirstToken(node, 1),
                 last = node.typeAnnotation
-                    ? sourceCode.getFirstToken(node.typeAnnotation, -1)
+                    ? sourceCode.getTokenBefore(node.typeAnnotation)
                     : sourceCode.getLastToken(node),
                 penultimate = sourceCode.getTokenBefore(last),
                 firstElement = node.elements[0],

--- a/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-1.js
+++ b/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-1.js
@@ -1,0 +1,491 @@
+"use strict";
+
+// ([ 1, 1 ]: Array<any>)
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 22,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 22
+        }
+    },
+    "comments": [],
+    "tokens": [
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 0,
+            "end": 1,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 1
+                }
+            },
+            "range": [
+                0,
+                1
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "start": 1,
+            "end": 2,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 1
+                },
+                "end": {
+                    "line": 1,
+                    "column": 2
+                }
+            },
+            "range": [
+                1,
+                2
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "1",
+            "start": 3,
+            "end": 4,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 3
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            },
+            "range": [
+                3,
+                4
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 4,
+            "end": 5,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 4
+                },
+                "end": {
+                    "line": 1,
+                    "column": 5
+                }
+            },
+            "range": [
+                4,
+                5
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "1",
+            "start": 6,
+            "end": 7,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "range": [
+                6,
+                7
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "start": 8,
+            "end": 9,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 8
+                },
+                "end": {
+                    "line": 1,
+                    "column": 9
+                }
+            },
+            "range": [
+                8,
+                9
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 9,
+            "end": 10,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 10
+                }
+            },
+            "range": [
+                9,
+                10
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "Array",
+            "start": 11,
+            "end": 16,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 11
+                },
+                "end": {
+                    "line": 1,
+                    "column": 16
+                }
+            },
+            "range": [
+                11,
+                16
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "start": 16,
+            "end": 17,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 17
+                }
+            },
+            "range": [
+                16,
+                17
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "any",
+            "start": 17,
+            "end": 20,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 17
+                },
+                "end": {
+                    "line": 1,
+                    "column": 20
+                }
+            },
+            "range": [
+                17,
+                20
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 21,
+            "end": 22,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "range": [
+                21,
+                22
+            ]
+        }
+    ],
+    "range": [
+        0,
+        22
+    ],
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "start": 0,
+            "end": 22,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "expression": {
+                "type": "TypeCastExpression",
+                "start": 1,
+                "end": 21,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 1
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 21
+                    }
+                },
+                "expression": {
+                    "type": "ArrayExpression",
+                    "start": 1,
+                    "end": 9,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 9
+                        }
+                    },
+                    "elements": [
+                        {
+                            "type": "Literal",
+                            "start": 3,
+                            "end": 4,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 3
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 4
+                                }
+                            },
+                            "extra": {
+                                "rawValue": 1,
+                                "raw": "1"
+                            },
+                            "value": 1,
+                            "range": [
+                                3,
+                                4
+                            ],
+                            "_babelType": "NumericLiteral",
+                            "raw": "1"
+                        },
+                        {
+                            "type": "Literal",
+                            "start": 6,
+                            "end": 7,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 6
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 7
+                                }
+                            },
+                            "extra": {
+                                "rawValue": 1,
+                                "raw": "1"
+                            },
+                            "value": 1,
+                            "range": [
+                                6,
+                                7
+                            ],
+                            "_babelType": "NumericLiteral",
+                            "raw": "1"
+                        }
+                    ],
+                    "range": [
+                        1,
+                        9
+                    ],
+                    "_babelType": "ArrayExpression"
+                },
+                "typeAnnotation": {
+                    "type": "TypeAnnotation",
+                    "start": 9,
+                    "end": 21,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 9
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 21
+                        }
+                    },
+                    "typeAnnotation": {
+                        "type": "GenericTypeAnnotation",
+                        "start": 11,
+                        "end": 21,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 11
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 21
+                            }
+                        },
+                        "typeParameters": {
+                            "type": "TypeParameterInstantiation",
+                            "start": 16,
+                            "end": 21,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 16
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 21
+                                }
+                            },
+                            "params": [
+                                {
+                                    "type": "AnyTypeAnnotation",
+                                    "start": 17,
+                                    "end": 20,
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 17
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 20
+                                        }
+                                    },
+                                    "range": [
+                                        17,
+                                        20
+                                    ],
+                                    "_babelType": "AnyTypeAnnotation"
+                                }
+                            ],
+                            "range": [
+                                16,
+                                21
+                            ],
+                            "_babelType": "TypeParameterInstantiation"
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "start": 11,
+                            "end": 16,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 11
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 16
+                                },
+                                "identifierName": "Array"
+                            },
+                            "name": "Array",
+                            "range": [
+                                11,
+                                16
+                            ],
+                            "_babelType": "Identifier"
+                        },
+                        "range": [
+                            11,
+                            21
+                        ],
+                        "_babelType": "GenericTypeAnnotation"
+                    },
+                    "range": [
+                        9,
+                        21
+                    ],
+                    "_babelType": "TypeAnnotation"
+                },
+                "extra": {
+                    "parenthesized": true,
+                    "parenStart": 0
+                },
+                "range": [
+                    1,
+                    21
+                ],
+                "_babelType": "TypeCastExpression"
+            },
+            "range": [
+                0,
+                22
+            ],
+            "_babelType": "ExpressionStatement"
+        }
+    ]
+});

--- a/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-1.js
+++ b/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-1.js
@@ -1,11 +1,11 @@
 "use strict";
 
-// ([ 1, 1 ]: Array<any>)
+// ([ a, b ]: Array<any>) => {}
 
 exports.parse = () => ({
     "type": "Program",
     "start": 0,
-    "end": 22,
+    "end": 28,
     "loc": {
         "start": {
             "line": 1,
@@ -13,7 +13,7 @@ exports.parse = () => ({
         },
         "end": {
             "line": 1,
-            "column": 22
+            "column": 28
         }
     },
     "comments": [],
@@ -59,8 +59,8 @@ exports.parse = () => ({
             ]
         },
         {
-            "type": "Numeric",
-            "value": "1",
+            "type": "Identifier",
+            "value": "a",
             "start": 3,
             "end": 4,
             "loc": {
@@ -99,8 +99,8 @@ exports.parse = () => ({
             ]
         },
         {
-            "type": "Numeric",
-            "value": "1",
+            "type": "Identifier",
+            "value": "b",
             "start": 6,
             "end": 7,
             "loc": {
@@ -257,18 +257,78 @@ exports.parse = () => ({
                 21,
                 22
             ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=>",
+            "start": 23,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "range": [
+                23,
+                25
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 26,
+            "end": 27,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "range": [
+                26,
+                27
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 27,
+            "end": 28,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "range": [
+                27,
+                28
+            ]
         }
     ],
     "range": [
         0,
-        22
+        28
     ],
     "sourceType": "module",
     "body": [
         {
             "type": "ExpressionStatement",
             "start": 0,
-            "end": 22,
+            "end": 28,
             "loc": {
                 "start": {
                     "line": 1,
@@ -276,214 +336,230 @@ exports.parse = () => ({
                 },
                 "end": {
                     "line": 1,
-                    "column": 22
+                    "column": 28
                 }
             },
             "expression": {
-                "type": "TypeCastExpression",
-                "start": 1,
-                "end": 21,
+                "type": "ArrowFunctionExpression",
+                "start": 0,
+                "end": 28,
                 "loc": {
                     "start": {
                         "line": 1,
-                        "column": 1
+                        "column": 0
                     },
                     "end": {
                         "line": 1,
-                        "column": 21
+                        "column": 28
                     }
                 },
-                "expression": {
-                    "type": "ArrayExpression",
-                    "start": 1,
-                    "end": 9,
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 1
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 9
-                        }
-                    },
-                    "elements": [
-                        {
-                            "type": "Literal",
-                            "start": 3,
-                            "end": 4,
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 3
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 4
-                                }
-                            },
-                            "extra": {
-                                "rawValue": 1,
-                                "raw": "1"
-                            },
-                            "value": 1,
-                            "range": [
-                                3,
-                                4
-                            ],
-                            "_babelType": "NumericLiteral",
-                            "raw": "1"
-                        },
-                        {
-                            "type": "Literal",
-                            "start": 6,
-                            "end": 7,
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 6
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 7
-                                }
-                            },
-                            "extra": {
-                                "rawValue": 1,
-                                "raw": "1"
-                            },
-                            "value": 1,
-                            "range": [
-                                6,
-                                7
-                            ],
-                            "_babelType": "NumericLiteral",
-                            "raw": "1"
-                        }
-                    ],
-                    "range": [
-                        1,
-                        9
-                    ],
-                    "_babelType": "ArrayExpression"
-                },
-                "typeAnnotation": {
-                    "type": "TypeAnnotation",
-                    "start": 9,
-                    "end": 21,
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 9
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 21
-                        }
-                    },
-                    "typeAnnotation": {
-                        "type": "GenericTypeAnnotation",
-                        "start": 11,
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": false,
+                "params": [
+                    {
+                        "type": "ArrayPattern",
+                        "start": 1,
                         "end": 21,
                         "loc": {
                             "start": {
                                 "line": 1,
-                                "column": 11
+                                "column": 1
                             },
                             "end": {
                                 "line": 1,
                                 "column": 21
                             }
                         },
-                        "typeParameters": {
-                            "type": "TypeParameterInstantiation",
-                            "start": 16,
+                        "elements": [
+                            {
+                                "type": "Identifier",
+                                "start": 3,
+                                "end": 4,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 3
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 4
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "name": "a",
+                                "range": [
+                                    3,
+                                    4
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            {
+                                "type": "Identifier",
+                                "start": 6,
+                                "end": 7,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 6
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 7
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "name": "b",
+                                "range": [
+                                    6,
+                                    7
+                                ],
+                                "_babelType": "Identifier"
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "start": 9,
                             "end": 21,
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 16
+                                    "column": 9
                                 },
                                 "end": {
                                     "line": 1,
                                     "column": 21
                                 }
                             },
-                            "params": [
-                                {
-                                    "type": "AnyTypeAnnotation",
-                                    "start": 17,
-                                    "end": 20,
+                            "typeAnnotation": {
+                                "type": "GenericTypeAnnotation",
+                                "start": 11,
+                                "end": 21,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 11
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 21
+                                    }
+                                },
+                                "typeParameters": {
+                                    "type": "TypeParameterInstantiation",
+                                    "start": 16,
+                                    "end": 21,
                                     "loc": {
                                         "start": {
                                             "line": 1,
-                                            "column": 17
+                                            "column": 16
                                         },
                                         "end": {
                                             "line": 1,
-                                            "column": 20
+                                            "column": 21
                                         }
                                     },
-                                    "range": [
-                                        17,
-                                        20
+                                    "params": [
+                                        {
+                                            "type": "AnyTypeAnnotation",
+                                            "start": 17,
+                                            "end": 20,
+                                            "loc": {
+                                                "start": {
+                                                    "line": 1,
+                                                    "column": 17
+                                                },
+                                                "end": {
+                                                    "line": 1,
+                                                    "column": 20
+                                                }
+                                            },
+                                            "range": [
+                                                17,
+                                                20
+                                            ],
+                                            "_babelType": "AnyTypeAnnotation"
+                                        }
                                     ],
-                                    "_babelType": "AnyTypeAnnotation"
-                                }
-                            ],
+                                    "range": [
+                                        16,
+                                        21
+                                    ],
+                                    "_babelType": "TypeParameterInstantiation"
+                                },
+                                "id": {
+                                    "type": "Identifier",
+                                    "start": 11,
+                                    "end": 16,
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 11
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 16
+                                        },
+                                        "identifierName": "Array"
+                                    },
+                                    "name": "Array",
+                                    "range": [
+                                        11,
+                                        16
+                                    ],
+                                    "_babelType": "Identifier"
+                                },
+                                "range": [
+                                    11,
+                                    21
+                                ],
+                                "_babelType": "GenericTypeAnnotation"
+                            },
                             "range": [
-                                16,
+                                9,
                                 21
                             ],
-                            "_babelType": "TypeParameterInstantiation"
-                        },
-                        "id": {
-                            "type": "Identifier",
-                            "start": 11,
-                            "end": 16,
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 11
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 16
-                                },
-                                "identifierName": "Array"
-                            },
-                            "name": "Array",
-                            "range": [
-                                11,
-                                16
-                            ],
-                            "_babelType": "Identifier"
+                            "_babelType": "TypeAnnotation"
                         },
                         "range": [
-                            11,
+                            1,
                             21
                         ],
-                        "_babelType": "GenericTypeAnnotation"
+                        "_babelType": "ArrayPattern"
+                    }
+                ],
+                "body": {
+                    "type": "BlockStatement",
+                    "start": 26,
+                    "end": 28,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 28
+                        }
                     },
+                    "body": [],
                     "range": [
-                        9,
-                        21
+                        26,
+                        28
                     ],
-                    "_babelType": "TypeAnnotation"
-                },
-                "extra": {
-                    "parenthesized": true,
-                    "parenStart": 0
+                    "_babelType": "BlockStatement"
                 },
                 "range": [
-                    1,
-                    21
+                    0,
+                    28
                 ],
-                "_babelType": "TypeCastExpression"
+                "_babelType": "ArrowFunctionExpression",
+                "defaults": []
             },
             "range": [
                 0,
-                22
+                28
             ],
             "_babelType": "ExpressionStatement"
         }

--- a/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-2.js
+++ b/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-2.js
@@ -1,0 +1,491 @@
+"use strict";
+
+// ([1, 1]: Array< any >)
+
+exports.parse = () => ({
+    "type": "Program",
+    "start": 0,
+    "end": 22,
+    "loc": {
+        "start": {
+            "line": 1,
+            "column": 0
+        },
+        "end": {
+            "line": 1,
+            "column": 22
+        }
+    },
+    "comments": [],
+    "tokens": [
+        {
+            "type": "Punctuator",
+            "value": "(",
+            "start": 0,
+            "end": 1,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 1
+                }
+            },
+            "range": [
+                0,
+                1
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "[",
+            "start": 1,
+            "end": 2,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 1
+                },
+                "end": {
+                    "line": 1,
+                    "column": 2
+                }
+            },
+            "range": [
+                1,
+                2
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "1",
+            "start": 2,
+            "end": 3,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 2
+                },
+                "end": {
+                    "line": 1,
+                    "column": 3
+                }
+            },
+            "range": [
+                2,
+                3
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ",",
+            "start": 3,
+            "end": 4,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 3
+                },
+                "end": {
+                    "line": 1,
+                    "column": 4
+                }
+            },
+            "range": [
+                3,
+                4
+            ]
+        },
+        {
+            "type": "Numeric",
+            "value": "1",
+            "start": 5,
+            "end": 6,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 5
+                },
+                "end": {
+                    "line": 1,
+                    "column": 6
+                }
+            },
+            "range": [
+                5,
+                6
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "]",
+            "start": 6,
+            "end": 7,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 6
+                },
+                "end": {
+                    "line": 1,
+                    "column": 7
+                }
+            },
+            "range": [
+                6,
+                7
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ":",
+            "start": 7,
+            "end": 8,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 7
+                },
+                "end": {
+                    "line": 1,
+                    "column": 8
+                }
+            },
+            "range": [
+                7,
+                8
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "Array",
+            "start": 9,
+            "end": 14,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 9
+                },
+                "end": {
+                    "line": 1,
+                    "column": 14
+                }
+            },
+            "range": [
+                9,
+                14
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "<",
+            "start": 14,
+            "end": 15,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 14
+                },
+                "end": {
+                    "line": 1,
+                    "column": 15
+                }
+            },
+            "range": [
+                14,
+                15
+            ]
+        },
+        {
+            "type": "Identifier",
+            "value": "any",
+            "start": 16,
+            "end": 19,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 16
+                },
+                "end": {
+                    "line": 1,
+                    "column": 19
+                }
+            },
+            "range": [
+                16,
+                19
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ">",
+            "start": 20,
+            "end": 21,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 20
+                },
+                "end": {
+                    "line": 1,
+                    "column": 21
+                }
+            },
+            "range": [
+                20,
+                21
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": ")",
+            "start": 21,
+            "end": 22,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 21
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "range": [
+                21,
+                22
+            ]
+        }
+    ],
+    "range": [
+        0,
+        22
+    ],
+    "sourceType": "module",
+    "body": [
+        {
+            "type": "ExpressionStatement",
+            "start": 0,
+            "end": 22,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 0
+                },
+                "end": {
+                    "line": 1,
+                    "column": 22
+                }
+            },
+            "expression": {
+                "type": "TypeCastExpression",
+                "start": 1,
+                "end": 21,
+                "loc": {
+                    "start": {
+                        "line": 1,
+                        "column": 1
+                    },
+                    "end": {
+                        "line": 1,
+                        "column": 21
+                    }
+                },
+                "expression": {
+                    "type": "ArrayExpression",
+                    "start": 1,
+                    "end": 7,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 1
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 7
+                        }
+                    },
+                    "elements": [
+                        {
+                            "type": "Literal",
+                            "start": 2,
+                            "end": 3,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 2
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 3
+                                }
+                            },
+                            "extra": {
+                                "rawValue": 1,
+                                "raw": "1"
+                            },
+                            "value": 1,
+                            "range": [
+                                2,
+                                3
+                            ],
+                            "_babelType": "NumericLiteral",
+                            "raw": "1"
+                        },
+                        {
+                            "type": "Literal",
+                            "start": 5,
+                            "end": 6,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 5
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 6
+                                }
+                            },
+                            "extra": {
+                                "rawValue": 1,
+                                "raw": "1"
+                            },
+                            "value": 1,
+                            "range": [
+                                5,
+                                6
+                            ],
+                            "_babelType": "NumericLiteral",
+                            "raw": "1"
+                        }
+                    ],
+                    "range": [
+                        1,
+                        7
+                    ],
+                    "_babelType": "ArrayExpression"
+                },
+                "typeAnnotation": {
+                    "type": "TypeAnnotation",
+                    "start": 7,
+                    "end": 21,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 7
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 21
+                        }
+                    },
+                    "typeAnnotation": {
+                        "type": "GenericTypeAnnotation",
+                        "start": 9,
+                        "end": 21,
+                        "loc": {
+                            "start": {
+                                "line": 1,
+                                "column": 9
+                            },
+                            "end": {
+                                "line": 1,
+                                "column": 21
+                            }
+                        },
+                        "typeParameters": {
+                            "type": "TypeParameterInstantiation",
+                            "start": 14,
+                            "end": 21,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 14
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 21
+                                }
+                            },
+                            "params": [
+                                {
+                                    "type": "AnyTypeAnnotation",
+                                    "start": 16,
+                                    "end": 19,
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 16
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 19
+                                        }
+                                    },
+                                    "range": [
+                                        16,
+                                        19
+                                    ],
+                                    "_babelType": "AnyTypeAnnotation"
+                                }
+                            ],
+                            "range": [
+                                14,
+                                21
+                            ],
+                            "_babelType": "TypeParameterInstantiation"
+                        },
+                        "id": {
+                            "type": "Identifier",
+                            "start": 9,
+                            "end": 14,
+                            "loc": {
+                                "start": {
+                                    "line": 1,
+                                    "column": 9
+                                },
+                                "end": {
+                                    "line": 1,
+                                    "column": 14
+                                },
+                                "identifierName": "Array"
+                            },
+                            "name": "Array",
+                            "range": [
+                                9,
+                                14
+                            ],
+                            "_babelType": "Identifier"
+                        },
+                        "range": [
+                            9,
+                            21
+                        ],
+                        "_babelType": "GenericTypeAnnotation"
+                    },
+                    "range": [
+                        7,
+                        21
+                    ],
+                    "_babelType": "TypeAnnotation"
+                },
+                "extra": {
+                    "parenthesized": true,
+                    "parenStart": 0
+                },
+                "range": [
+                    1,
+                    21
+                ],
+                "_babelType": "TypeCastExpression"
+            },
+            "range": [
+                0,
+                22
+            ],
+            "_babelType": "ExpressionStatement"
+        }
+    ]
+});

--- a/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-2.js
+++ b/tests/fixtures/parsers/array-bracket-spacing/flow-destructuring-2.js
@@ -1,11 +1,11 @@
 "use strict";
 
-// ([1, 1]: Array< any >)
+// ([a, b]: Array< any >) => {}
 
 exports.parse = () => ({
     "type": "Program",
     "start": 0,
-    "end": 22,
+    "end": 28,
     "loc": {
         "start": {
             "line": 1,
@@ -13,7 +13,7 @@ exports.parse = () => ({
         },
         "end": {
             "line": 1,
-            "column": 22
+            "column": 28
         }
     },
     "comments": [],
@@ -59,8 +59,8 @@ exports.parse = () => ({
             ]
         },
         {
-            "type": "Numeric",
-            "value": "1",
+            "type": "Identifier",
+            "value": "a",
             "start": 2,
             "end": 3,
             "loc": {
@@ -99,8 +99,8 @@ exports.parse = () => ({
             ]
         },
         {
-            "type": "Numeric",
-            "value": "1",
+            "type": "Identifier",
+            "value": "b",
             "start": 5,
             "end": 6,
             "loc": {
@@ -257,18 +257,78 @@ exports.parse = () => ({
                 21,
                 22
             ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "=>",
+            "start": 23,
+            "end": 25,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 23
+                },
+                "end": {
+                    "line": 1,
+                    "column": 25
+                }
+            },
+            "range": [
+                23,
+                25
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "{",
+            "start": 26,
+            "end": 27,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 26
+                },
+                "end": {
+                    "line": 1,
+                    "column": 27
+                }
+            },
+            "range": [
+                26,
+                27
+            ]
+        },
+        {
+            "type": "Punctuator",
+            "value": "}",
+            "start": 27,
+            "end": 28,
+            "loc": {
+                "start": {
+                    "line": 1,
+                    "column": 27
+                },
+                "end": {
+                    "line": 1,
+                    "column": 28
+                }
+            },
+            "range": [
+                27,
+                28
+            ]
         }
     ],
     "range": [
         0,
-        22
+        28
     ],
     "sourceType": "module",
     "body": [
         {
             "type": "ExpressionStatement",
             "start": 0,
-            "end": 22,
+            "end": 28,
             "loc": {
                 "start": {
                     "line": 1,
@@ -276,214 +336,230 @@ exports.parse = () => ({
                 },
                 "end": {
                     "line": 1,
-                    "column": 22
+                    "column": 28
                 }
             },
             "expression": {
-                "type": "TypeCastExpression",
-                "start": 1,
-                "end": 21,
+                "type": "ArrowFunctionExpression",
+                "start": 0,
+                "end": 28,
                 "loc": {
                     "start": {
                         "line": 1,
-                        "column": 1
+                        "column": 0
                     },
                     "end": {
                         "line": 1,
-                        "column": 21
+                        "column": 28
                     }
                 },
-                "expression": {
-                    "type": "ArrayExpression",
-                    "start": 1,
-                    "end": 7,
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 1
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 7
-                        }
-                    },
-                    "elements": [
-                        {
-                            "type": "Literal",
-                            "start": 2,
-                            "end": 3,
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 2
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 3
-                                }
-                            },
-                            "extra": {
-                                "rawValue": 1,
-                                "raw": "1"
-                            },
-                            "value": 1,
-                            "range": [
-                                2,
-                                3
-                            ],
-                            "_babelType": "NumericLiteral",
-                            "raw": "1"
-                        },
-                        {
-                            "type": "Literal",
-                            "start": 5,
-                            "end": 6,
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 5
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 6
-                                }
-                            },
-                            "extra": {
-                                "rawValue": 1,
-                                "raw": "1"
-                            },
-                            "value": 1,
-                            "range": [
-                                5,
-                                6
-                            ],
-                            "_babelType": "NumericLiteral",
-                            "raw": "1"
-                        }
-                    ],
-                    "range": [
-                        1,
-                        7
-                    ],
-                    "_babelType": "ArrayExpression"
-                },
-                "typeAnnotation": {
-                    "type": "TypeAnnotation",
-                    "start": 7,
-                    "end": 21,
-                    "loc": {
-                        "start": {
-                            "line": 1,
-                            "column": 7
-                        },
-                        "end": {
-                            "line": 1,
-                            "column": 21
-                        }
-                    },
-                    "typeAnnotation": {
-                        "type": "GenericTypeAnnotation",
-                        "start": 9,
+                "id": null,
+                "generator": false,
+                "expression": false,
+                "async": false,
+                "params": [
+                    {
+                        "type": "ArrayPattern",
+                        "start": 1,
                         "end": 21,
                         "loc": {
                             "start": {
                                 "line": 1,
-                                "column": 9
+                                "column": 1
                             },
                             "end": {
                                 "line": 1,
                                 "column": 21
                             }
                         },
-                        "typeParameters": {
-                            "type": "TypeParameterInstantiation",
-                            "start": 14,
+                        "elements": [
+                            {
+                                "type": "Identifier",
+                                "start": 2,
+                                "end": 3,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 2
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 3
+                                    },
+                                    "identifierName": "a"
+                                },
+                                "name": "a",
+                                "range": [
+                                    2,
+                                    3
+                                ],
+                                "_babelType": "Identifier"
+                            },
+                            {
+                                "type": "Identifier",
+                                "start": 5,
+                                "end": 6,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 5
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 6
+                                    },
+                                    "identifierName": "b"
+                                },
+                                "name": "b",
+                                "range": [
+                                    5,
+                                    6
+                                ],
+                                "_babelType": "Identifier"
+                            }
+                        ],
+                        "typeAnnotation": {
+                            "type": "TypeAnnotation",
+                            "start": 7,
                             "end": 21,
                             "loc": {
                                 "start": {
                                     "line": 1,
-                                    "column": 14
+                                    "column": 7
                                 },
                                 "end": {
                                     "line": 1,
                                     "column": 21
                                 }
                             },
-                            "params": [
-                                {
-                                    "type": "AnyTypeAnnotation",
-                                    "start": 16,
-                                    "end": 19,
+                            "typeAnnotation": {
+                                "type": "GenericTypeAnnotation",
+                                "start": 9,
+                                "end": 21,
+                                "loc": {
+                                    "start": {
+                                        "line": 1,
+                                        "column": 9
+                                    },
+                                    "end": {
+                                        "line": 1,
+                                        "column": 21
+                                    }
+                                },
+                                "typeParameters": {
+                                    "type": "TypeParameterInstantiation",
+                                    "start": 14,
+                                    "end": 21,
                                     "loc": {
                                         "start": {
                                             "line": 1,
-                                            "column": 16
+                                            "column": 14
                                         },
                                         "end": {
                                             "line": 1,
-                                            "column": 19
+                                            "column": 21
                                         }
                                     },
-                                    "range": [
-                                        16,
-                                        19
+                                    "params": [
+                                        {
+                                            "type": "AnyTypeAnnotation",
+                                            "start": 16,
+                                            "end": 19,
+                                            "loc": {
+                                                "start": {
+                                                    "line": 1,
+                                                    "column": 16
+                                                },
+                                                "end": {
+                                                    "line": 1,
+                                                    "column": 19
+                                                }
+                                            },
+                                            "range": [
+                                                16,
+                                                19
+                                            ],
+                                            "_babelType": "AnyTypeAnnotation"
+                                        }
                                     ],
-                                    "_babelType": "AnyTypeAnnotation"
-                                }
-                            ],
+                                    "range": [
+                                        14,
+                                        21
+                                    ],
+                                    "_babelType": "TypeParameterInstantiation"
+                                },
+                                "id": {
+                                    "type": "Identifier",
+                                    "start": 9,
+                                    "end": 14,
+                                    "loc": {
+                                        "start": {
+                                            "line": 1,
+                                            "column": 9
+                                        },
+                                        "end": {
+                                            "line": 1,
+                                            "column": 14
+                                        },
+                                        "identifierName": "Array"
+                                    },
+                                    "name": "Array",
+                                    "range": [
+                                        9,
+                                        14
+                                    ],
+                                    "_babelType": "Identifier"
+                                },
+                                "range": [
+                                    9,
+                                    21
+                                ],
+                                "_babelType": "GenericTypeAnnotation"
+                            },
                             "range": [
-                                14,
+                                7,
                                 21
                             ],
-                            "_babelType": "TypeParameterInstantiation"
-                        },
-                        "id": {
-                            "type": "Identifier",
-                            "start": 9,
-                            "end": 14,
-                            "loc": {
-                                "start": {
-                                    "line": 1,
-                                    "column": 9
-                                },
-                                "end": {
-                                    "line": 1,
-                                    "column": 14
-                                },
-                                "identifierName": "Array"
-                            },
-                            "name": "Array",
-                            "range": [
-                                9,
-                                14
-                            ],
-                            "_babelType": "Identifier"
+                            "_babelType": "TypeAnnotation"
                         },
                         "range": [
-                            9,
+                            1,
                             21
                         ],
-                        "_babelType": "GenericTypeAnnotation"
+                        "_babelType": "ArrayPattern"
+                    }
+                ],
+                "body": {
+                    "type": "BlockStatement",
+                    "start": 26,
+                    "end": 28,
+                    "loc": {
+                        "start": {
+                            "line": 1,
+                            "column": 26
+                        },
+                        "end": {
+                            "line": 1,
+                            "column": 28
+                        }
                     },
+                    "body": [],
                     "range": [
-                        7,
-                        21
+                        26,
+                        28
                     ],
-                    "_babelType": "TypeAnnotation"
-                },
-                "extra": {
-                    "parenthesized": true,
-                    "parenStart": 0
+                    "_babelType": "BlockStatement"
                 },
                 "range": [
-                    1,
-                    21
+                    0,
+                    28
                 ],
-                "_babelType": "TypeCastExpression"
+                "_babelType": "ArrowFunctionExpression",
+                "defaults": []
             },
             "range": [
                 0,
-                22
+                28
             ],
             "_babelType": "ExpressionStatement"
         }

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -8,8 +8,23 @@
 // Requirements
 //------------------------------------------------------------------------------
 
-const rule = require("../../../lib/rules/array-bracket-spacing"),
+const path = require("path"),
+    rule = require("../../../lib/rules/array-bracket-spacing"),
     RuleTester = require("../../../lib/testers/rule-tester");
+
+//------------------------------------------------------------------------------
+// Helpers
+//------------------------------------------------------------------------------
+
+/**
+ * Gets the path to the specified parser.
+ *
+ * @param {string} name - The parser name to get.
+ * @returns {string} The path to the specified parser.
+ */
+function parser(name) {
+    return path.resolve(__dirname, `../../fixtures/parsers/array-bracket-spacing/${name}.js`);
+}
 
 //------------------------------------------------------------------------------
 // Tests
@@ -159,8 +174,11 @@ ruleTester.run("array-bracket-spacing", rule, {
         { code: "var foo = [1, {'bar': 'baz'}, 5];", options: ["never"] },
         { code: "var foo = [{'bar': 'baz'}, 1,  5];", options: ["never"] },
         { code: "var foo = [1, 5, {'bar': 'baz'}];", options: ["never"] },
-        { code: "var obj = {'foo': [1, 2]}", options: ["never"] }
+        { code: "var obj = {'foo': [1, 2]}", options: ["never"] },
 
+        // destructuring with type annotation
+        { code: "([ 1, 1 ]: Array<any>)", options: ["always"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-1") },
+        { code: "([1, 1]: Array< any >)", options: ["never"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-2") },
     ],
 
     invalid: [
@@ -670,6 +688,54 @@ ruleTester.run("array-bracket-spacing", rule, {
                     column: 26
                 }
             ]
-        }
-    ]
+        },
+
+        // destructuring with type annotation
+        {
+            code: "([ 1, 1 ]: Array<any>)",
+            output: "([1, 1]: Array<any>)",
+            options: ["never"],
+            ecmaFeatures: {
+                ecmaVersion: 6,
+            },
+            errors: [
+                {
+                    message: "There should be no space after '['.",
+                    type: "ArrayExpression",
+                    line: 1,
+                    column: 2,
+                },
+                {
+                    message: "There should be no space before ']'.",
+                    type: "ArrayExpression",
+                    line: 1,
+                    column: 9
+                },
+            ],
+            parser: parser("flow-destructuring-1"),
+        },
+        {
+            code: "([1, 1]: Array< any >)",
+            output: "([ 1, 1 ]: Array< any >)",
+            options: ["always"],
+            ecmaFeatures: {
+                ecmaVersion: 6,
+            },
+            errors: [
+                {
+                    message: "A space is required after '['.",
+                    type: "ArrayExpression",
+                    line: 1,
+                    column: 2,
+                },
+                {
+                    message: "A space is required before ']'.",
+                    type: "ArrayExpression",
+                    line: 1,
+                    column: 7,
+                },
+            ],
+            parser: parser("flow-destructuring-2"),
+        },
+    ],
 });

--- a/tests/lib/rules/array-bracket-spacing.js
+++ b/tests/lib/rules/array-bracket-spacing.js
@@ -177,8 +177,8 @@ ruleTester.run("array-bracket-spacing", rule, {
         { code: "var obj = {'foo': [1, 2]}", options: ["never"] },
 
         // destructuring with type annotation
-        { code: "([ 1, 1 ]: Array<any>)", options: ["always"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-1") },
-        { code: "([1, 1]: Array< any >)", options: ["never"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-2") },
+        { code: "([ a, b ]: Array<any>) => {}", options: ["always"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-1") },
+        { code: "([a, b]: Array< any >) => {}", options: ["never"], parserOptions: { ecmaVersion: 6 }, parser: parser("flow-destructuring-2") },
     ],
 
     invalid: [
@@ -692,8 +692,8 @@ ruleTester.run("array-bracket-spacing", rule, {
 
         // destructuring with type annotation
         {
-            code: "([ 1, 1 ]: Array<any>)",
-            output: "([1, 1]: Array<any>)",
+            code: "([ a, b ]: Array<any>) => {}",
+            output: "([a, b]: Array<any>) => {}",
             options: ["never"],
             ecmaFeatures: {
                 ecmaVersion: 6,
@@ -701,13 +701,13 @@ ruleTester.run("array-bracket-spacing", rule, {
             errors: [
                 {
                     message: "There should be no space after '['.",
-                    type: "ArrayExpression",
+                    type: "ArrayPattern",
                     line: 1,
                     column: 2,
                 },
                 {
                     message: "There should be no space before ']'.",
-                    type: "ArrayExpression",
+                    type: "ArrayPattern",
                     line: 1,
                     column: 9
                 },
@@ -715,8 +715,8 @@ ruleTester.run("array-bracket-spacing", rule, {
             parser: parser("flow-destructuring-1"),
         },
         {
-            code: "([1, 1]: Array< any >)",
-            output: "([ 1, 1 ]: Array< any >)",
+            code: "([a, b]: Array< any >) => {}",
+            output: "([ a, b ]: Array< any >) => {}",
             options: ["always"],
             ecmaFeatures: {
                 ecmaVersion: 6,
@@ -724,13 +724,13 @@ ruleTester.run("array-bracket-spacing", rule, {
             errors: [
                 {
                     message: "A space is required after '['.",
-                    type: "ArrayExpression",
+                    type: "ArrayPattern",
                     line: 1,
                     column: 2,
                 },
                 {
                     message: "A space is required before ']'.",
-                    type: "ArrayExpression",
+                    type: "ArrayPattern",
                     line: 1,
                     column: 7,
                 },


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[X] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

Original issue: #4753

Per `comma-dangle`, `object-curly-spacing`, and #7436, it appears that these updates can belong in ESLint now.

**What changes did you make? (Give an overview)**
In `array-bracket-spacing`, if a type annotation is present, take the last token and the penultimate token before the type annotation.

**Is there anything you'd like reviewers to focus on?**
This code is slightly different from the code in `eslint-plugin-babel`. The code there just steps backward until it finds a `]`. Here I instead look at the token immediately before the beginning of the type annotation. This avoids issues when the type annotation is of the form `Type[]`.

cc @zaygraveyard