### PR TITLE
Chore: Pin mock-fs dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -97,7 +97,7 @@
     "load-perf": "^0.2.0",
     "markdownlint": "^0.2.0",
     "mocha": "^2.4.5",
-    "mock-fs": "^3.10.0",
+    "mock-fs": "3.11.0",
     "npm-license": "^0.3.2",
     "phantomjs-prebuilt": "^2.1.7",
     "proxyquire": "^1.7.10",


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[ ] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[x ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

`mock-fs` release 3.12.0 broke master. Everything is fine for 3.11.0
Issue created because of this change: https://github.com/tschaub/mock-fs/pull/141

**Is there anything you'd like reviewers to focus on?**



