### PR TITLE
Fix: allow escaped backreferences in `no-useless-escape` (fixes #7472)

### DIFF
--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -36,6 +36,8 @@ const VALID_STRING_ESCAPES = [
     "\r"
 ];
 
+const DIGITS = "0123456789".split("");
+
 const REGEX_GENERAL_ESCAPES = new Set([
     "\\",
     "b",
@@ -53,7 +55,8 @@ const REGEX_GENERAL_ESCAPES = new Set([
     "W",
     "x",
     "u"
-]);
+].concat(DIGITS));
+
 const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set(["]"]));
 const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
     "^",

--- a/lib/rules/no-useless-escape.js
+++ b/lib/rules/no-useless-escape.js
@@ -22,58 +22,10 @@ function union(setA, setB) {
     }());
 }
 
-const VALID_STRING_ESCAPES = [
-    "\\",
-    "n",
-    "r",
-    "v",
-    "t",
-    "b",
-    "f",
-    "u",
-    "x",
-    "\n",
-    "\r"
-];
-
-const DIGITS = "0123456789".split("");
-
-const REGEX_GENERAL_ESCAPES = new Set([
-    "\\",
-    "b",
-    "c",
-    "d",
-    "D",
-    "f",
-    "n",
-    "r",
-    "s",
-    "S",
-    "t",
-    "v",
-    "w",
-    "W",
-    "x",
-    "u"
-].concat(DIGITS));
-
-const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set(["]"]));
-const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set([
-    "^",
-    "/",
-    ".",
-    "$",
-    "*",
-    "+",
-    "?",
-    "[",
-    "{",
-    "}",
-    "|",
-    "(",
-    ")",
-    "B"
-]));
+const VALID_STRING_ESCAPES = new Set("\\nrvtbfux\n\r");
+const REGEX_GENERAL_ESCAPES = new Set("\\bcdDfnrsStvwWxu0123456789");
+const REGEX_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("]"));
+const REGEX_NON_CHARCLASS_ESCAPES = union(REGEX_GENERAL_ESCAPES, new Set("^/.$*+?[{}|()B"));
 
 /**
 * Parses a regular expression into a list of characters with character class info.
@@ -153,15 +105,14 @@ module.exports = {
          * Checks if the escape character in given string slice is unnecessary.
          *
          * @private
-         * @param {string[]} escapes - list of valid escapes
          * @param {ASTNode} node - node to validate.
          * @param {string} match - string slice to validate.
          * @returns {void}
          */
-        function validateString(escapes, node, match) {
+        function validateString(node, match) {
             const isTemplateElement = node.type === "TemplateElement";
             const escapedChar = match[0][1];
-            let isUnnecessaryEscape = escapes.indexOf(escapedChar) === -1;
+            let isUnnecessaryEscape = !VALID_STRING_ESCAPES.has(escapedChar);
             let isQuoteEscape;
 
             if (isTemplateElement) {
@@ -218,7 +169,7 @@ module.exports = {
                 let match;
 
                 while ((match = pattern.exec(value))) {
-                    validateString(VALID_STRING_ESCAPES, node, match);
+                    validateString(node, match);
                 }
             } else if (node.regex) {
                 parseRegExp(node.regex.pattern)

--- a/tests/lib/rules/no-useless-escape.js
+++ b/tests/lib/rules/no-useless-escape.js
@@ -93,7 +93,14 @@ ruleTester.run("no-useless-escape", rule, {
         String.raw`var foo = /\[abc]/`, // Matches the literal string '[abc]'
         String.raw`var foo = /\[foo\.bar]/`, // Matches the literal string '[foo.bar]'
         String.raw`var foo = /vi/m`,
-        String.raw`var foo = /\B/`
+        String.raw`var foo = /\B/`,
+
+        // https://github.com/eslint/eslint/issues/7472
+        String.raw`var foo = /\0/`, // null character
+        "var foo = /\\1/", // \x01 character (octal literal)
+        "var foo = /(a)\\1/", // backreference
+        "var foo = /(a)\\12/", // backreference
+        "var foo = /[\\0]/" // null character in character class
     ],
 
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7472

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This updates `no-useless-escape` to allow digit characters to be escaped in regular expressions. Escaped digits can either be backreferences or octal literals, so the rule should not warn when it encounters them.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
