### PR TITLE
Gh 7470 comma style for functions calls and imports

### DIFF
--- a/docs/rules/comma-style.md
+++ b/docs/rules/comma-style.md
@@ -30,7 +30,14 @@ This rule also accepts an additional `exceptions` object:
 * `"exceptions"` has properties whose names correspond to node types in the abstract syntax tree (AST) of JavaScript code:
 
     * `"ArrayExpression": true` ignores comma style in array literals
+    * `"ArrayPattern": true` ignores comma style in array patterns of destructuring
+    * `"ArrowFunctionExpression": true` ignores comma style in the parameters of arrow function expressions
+    * `"CallExpression": true` ignores comma style in the arguments of function calls
+    * `"FunctionDeclaration": true` ignores comma style in the parameters of function declarations
+    * `"FunctionExpression": true` ignores comma style in the parameters of function expressions
+    * `"ImportDeclaration": true` ignores comma style in the specifiers of import declarations
     * `"ObjectExpression": true` ignores comma style in object literals
+    * `"ObjectPattern": true` ignores comma style in object patterns of destructuring
     * `"VariableDeclaration": true` ignores comma style in variable declarations
 
 A way to determine the node types as defined by [ESTree](https://github.com/estree/estree) is to use the [online demo](http://eslint.org/parser).

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -166,7 +166,7 @@ module.exports = {
          */
         function validateComma(node, property) {
             const items = node[property],
-                arrayLiteral = (node.type === "ArrayExpression");
+                arrayLiteral = (node.type === "ArrayExpression" || node.type === "ArrayPattern");
 
             if (items.length > 1 || arrayLiteral) {
 
@@ -245,10 +245,45 @@ module.exports = {
                 validateComma(node, "properties");
             };
         }
+        if (!exceptions.ObjectPattern) {
+            nodes.ObjectPattern = function(node) {
+                validateComma(node, "properties");
+            };
+        }
         if (!exceptions.ArrayExpression) {
             nodes.ArrayExpression = function(node) {
                 validateComma(node, "elements");
             };
+        }
+        if (!exceptions.ArrayPattern) {
+            nodes.ArrayPattern = function(node) {
+                validateComma(node, "elements");
+            };
+        }
+        if (!exceptions.FunctionDeclaration) {
+            nodes.FunctionDeclaration = function(node) {
+                validateComma(node, "params");
+            }
+        }
+        if (!exceptions.FunctionExpression) {
+            nodes.FunctionExpression = function(node) {
+                validateComma(node, "params");
+            }
+        }
+        if (!exceptions.ArrowFunctionExpression) {
+            nodes.ArrowFunctionExpression = function(node) {
+                validateComma(node, "params");
+            }
+        }
+        if (!exceptions.CallExpression) {
+            nodes.CallExpression = function(node) {
+                validateComma(node, "arguments");
+            }
+        }
+        if (!exceptions.ImportDeclaration) {
+            nodes.ImportDeclaration = function(node) {
+                validateComma(node, "specifiers");
+            }
         }
 
         return nodes;

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -263,27 +263,27 @@ module.exports = {
         if (!exceptions.FunctionDeclaration) {
             nodes.FunctionDeclaration = function(node) {
                 validateComma(node, "params");
-            }
+            };
         }
         if (!exceptions.FunctionExpression) {
             nodes.FunctionExpression = function(node) {
                 validateComma(node, "params");
-            }
+            };
         }
         if (!exceptions.ArrowFunctionExpression) {
             nodes.ArrowFunctionExpression = function(node) {
                 validateComma(node, "params");
-            }
+            };
         }
         if (!exceptions.CallExpression) {
             nodes.CallExpression = function(node) {
                 validateComma(node, "arguments");
-            }
+            };
         }
         if (!exceptions.ImportDeclaration) {
             nodes.ImportDeclaration = function(node) {
                 validateComma(node, "specifiers");
-            }
+            };
         }
 
         return nodes;

--- a/lib/rules/comma-style.js
+++ b/lib/rules/comma-style.js
@@ -41,10 +41,22 @@ module.exports = {
     create(context) {
         const style = context.options[0] || "last",
             sourceCode = context.getSourceCode();
-        let exceptions = {};
+        const exceptions = {
+            ArrayPattern: true,
+            ArrowFunctionExpression: true,
+            CallExpression: true,
+            FunctionDeclaration: true,
+            FunctionExpression: true,
+            ImportDeclaration: true,
+            ObjectPattern: true,
+        };
 
         if (context.options.length === 2 && context.options[1].hasOwnProperty("exceptions")) {
-            exceptions = context.options[1].exceptions;
+            const keys = Object.keys(context.options[1].exceptions);
+
+            for (let i = 0; i < keys.length; i++) {
+                exceptions[keys[i]] = context.options[1].exceptions[keys[i]];
+            }
         }
 
         //--------------------------------------------------------------------------

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -448,7 +448,7 @@ RuleTester.prototype = {
                         }
 
                         if (item.errors[i].type) {
-                            assert.equal(messages[i].nodeType, item.errors[i].type, `Error type should be ${item.errors[i].type} but is ${messages[i].nodeType}`);
+                            assert.equal(messages[i].nodeType, item.errors[i].type, `Error type should be ${item.errors[i].type}`);
                         }
 
                         if (item.errors[i].hasOwnProperty("line")) {
@@ -476,7 +476,7 @@ RuleTester.prototype = {
                 if (item.hasOwnProperty("output")) {
                     const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
 
-                    assert.equal(fixResult.output, item.output, `Output is incorrect. ${fixResult.output} != ${item.output}`);
+                    assert.equal(fixResult.output, item.output, "Output is incorrect.");
                 }
 
             }

--- a/lib/testers/rule-tester.js
+++ b/lib/testers/rule-tester.js
@@ -448,7 +448,7 @@ RuleTester.prototype = {
                         }
 
                         if (item.errors[i].type) {
-                            assert.equal(messages[i].nodeType, item.errors[i].type, `Error type should be ${item.errors[i].type}`);
+                            assert.equal(messages[i].nodeType, item.errors[i].type, `Error type should be ${item.errors[i].type} but is ${messages[i].nodeType}`);
                         }
 
                         if (item.errors[i].hasOwnProperty("line")) {
@@ -476,7 +476,7 @@ RuleTester.prototype = {
                 if (item.hasOwnProperty("output")) {
                     const fixResult = SourceCodeFixer.applyFixes(eslint.getSourceCode(), messages);
 
-                    assert.equal(fixResult.output, item.output, "Output is incorrect.");
+                    assert.equal(fixResult.output, item.output, `Output is incorrect. ${fixResult.output} != ${item.output}`);
                 }
 
             }

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -49,6 +49,8 @@ ruleTester.run("comma-style", rule, {
         {code: "var foo = [1 \n ,2 \n, 3];", options: ["first"]},
         {code: "function foo(){return {'a': 1\n,'b': 2}}", options: ["first"]},
         {code: "function foo(){var a=[1\n, 2]}", options: ["first"]},
+        {code: "f(1\n, 2);"},
+        {code: "function foo(a\n, b) { return a + b; }"},
         {
             code: "var a = 'a',\no = 'o';",
             options: ["first", {exceptions: {VariableDeclaration: true}}]
@@ -82,6 +84,143 @@ ruleTester.run("comma-style", rule, {
                     VariableDeclaration: true
                 }
             }]
+        },
+        {
+            code: "const foo = (a\n, b) => { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "function foo([a\n, b]) { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const foo = ([a\n, b]) => { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "import { a\n, b } from './source';",
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            }
+        },
+        {
+            code: "const foo = function (a\n, b) { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+            options: ["first", {
+                exceptions: {
+                    ObjectPattern: true
+                }
+            }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "f(1\n, 2);",
+            options: ["last", {
+                exceptions: {
+                    CallExpression: true
+                }
+            }]
+        },
+        {
+            code: "function foo(a\n, b) { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    FunctionDeclaration: true
+                }
+            }]
+        },
+        {
+            code: "const foo = function (a\n, b) { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    FunctionExpression: true
+                }
+            }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "function foo([a\n, b]) { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: true
+                }
+            }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const foo = (a\n, b) => { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    ArrowFunctionExpression: true
+                },
+            }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "const foo = ([a\n, b]) => { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: true
+                }
+            }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
+        },
+        {
+            code: "import { a\n, b } from './source';",
+            options: ["last", {
+                exceptions: {
+                    ImportDeclaration: true
+                }
+            }],
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            }
+        },
+        {
+            code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+            options: ["last", {
+                exceptions: {
+                    ObjectPattern: true
+                }
+            }],
+            parserOptions: {
+                ecmaVersion: 6
+            }
         }
     ],
 
@@ -168,6 +307,11 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var [foo\n, bar] = ['apples', 'oranges'];",
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
+                }
+            }],
             output: "var [foo,\n bar] = ['apples', 'oranges'];",
             parserOptions: {
                 ecmaVersion: 6
@@ -179,6 +323,11 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "f(1\n, 2);",
+            options: ["last", {
+                exceptions: {
+                    CallExpression: false
+                }
+            }],
             output: "f(1,\n 2);",
             errors: [{
                 message: LAST_MSG,
@@ -187,6 +336,11 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "function foo(a\n, b) { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    FunctionDeclaration: false
+                }
+            }],
             output: "function foo(a,\n b) { return a + b; }",
             errors: [{
                 message: LAST_MSG,
@@ -194,7 +348,29 @@ ruleTester.run("comma-style", rule, {
             }]
         },
         {
+            code: "const foo = function (a\n, b) { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    FunctionExpression: false
+                }
+            }],
+            output: "const foo = function (a,\n b) { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            },
+            errors: [{
+                message: LAST_MSG,
+                type: "Identifier"
+            }]
+        },
+        {
             code: "function foo([a\n, b]) { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
+                }
+            }],
             output: "function foo([a,\n b]) { return a + b; }",
             parserOptions: {
                 ecmaVersion: 6
@@ -206,6 +382,11 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "const foo = (a\n, b) => { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    ArrowFunctionExpression: false
+                },
+            }],
             output: "const foo = (a,\n b) => { return a + b; }",
             parserOptions: {
                 ecmaVersion: 6
@@ -217,6 +398,11 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "const foo = ([a\n, b]) => { return a + b; }",
+            options: ["last", {
+                exceptions: {
+                    ArrayPattern: false
+                }
+            }],
             output: "const foo = ([a,\n b]) => { return a + b; }",
             parserOptions: {
                 ecmaVersion: 6
@@ -228,6 +414,11 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "import { a\n, b } from './source';",
+            options: ["last", {
+                exceptions: {
+                    ImportDeclaration: false
+                }
+            }],
             output: "import { a,\n b } from './source';",
             parserOptions: {
                 ecmaVersion: 6,
@@ -240,6 +431,11 @@ ruleTester.run("comma-style", rule, {
         },
         {
             code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+            options: ["last", {
+                exceptions: {
+                    ObjectPattern: false
+                }
+            }],
             output: "var {foo,\n bar} = {foo:'apples', bar:'oranges'};",
             parserOptions: {
                 ecmaVersion: 6

--- a/tests/lib/rules/comma-style.js
+++ b/tests/lib/rules/comma-style.js
@@ -167,6 +167,89 @@ ruleTester.run("comma-style", rule, {
             }]
         },
         {
+            code: "var [foo\n, bar] = ['apples', 'oranges'];",
+            output: "var [foo,\n bar] = ['apples', 'oranges'];",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                message: LAST_MSG,
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "f(1\n, 2);",
+            output: "f(1,\n 2);",
+            errors: [{
+                message: LAST_MSG,
+                type: "Literal"
+            }]
+        },
+        {
+            code: "function foo(a\n, b) { return a + b; }",
+            output: "function foo(a,\n b) { return a + b; }",
+            errors: [{
+                message: LAST_MSG,
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "function foo([a\n, b]) { return a + b; }",
+            output: "function foo([a,\n b]) { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                message: LAST_MSG,
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "const foo = (a\n, b) => { return a + b; }",
+            output: "const foo = (a,\n b) => { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                message: LAST_MSG,
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "const foo = ([a\n, b]) => { return a + b; }",
+            output: "const foo = ([a,\n b]) => { return a + b; }",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                message: LAST_MSG,
+                type: "Identifier"
+            }]
+        },
+        {
+            code: "import { a\n, b } from './source';",
+            output: "import { a,\n b } from './source';",
+            parserOptions: {
+                ecmaVersion: 6,
+                sourceType: "module"
+            },
+            errors: [{
+                message: LAST_MSG,
+                type: "ImportSpecifier"
+            }]
+        },
+        {
+            code: "var {foo\n, bar} = {foo:'apples', bar:'oranges'};",
+            output: "var {foo,\n bar} = {foo:'apples', bar:'oranges'};",
+            parserOptions: {
+                ecmaVersion: 6
+            },
+            errors: [{
+                message: LAST_MSG,
+                type: "Property"
+            }]
+        },
+        {
             code: "var foo = 1,\nbar = 2;",
             output: "var foo = 1\n,bar = 2;",
             options: ["first"],


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**
- [x] Changes an existing rule
- [x] Documentation update

**What rule do you want to change?**

comma-style

**Does this change cause the rule to produce more or fewer warnings?**

More.

**How will the change be implemented? (New option, new default behavior, etc.)?**

This change adds new default behavior to `comma-style`, and includes new options to disable the default behavior. I'm happy to reverse the defaults (so that the new behavior is opt-in), but started with opt-out for consistency with the existing code.

**Please provide some example code that this change will affect:**

``` js
import {
    A
  , B
} from 'source';

const [
    quux
  , baz
] = "a b".split(" ");

const {
    push
  , pop
} = Array.prototype;

const foo = ([
    a
  , b
]) => {
    return a * b;
}

function bip(a
    , b) { return a - b }

const bar = ({
    a
  , b
}) => {
    return `${a} then ${b}`;
}

foo(1
  , 2);
```

**What does the rule currently do for this code?**

Currently, the `comma-style` rule treats the code above as compatible with the `last` mode of `comma-style` rule.

**What will the rule do after it's changed?**

The submitted code changes will cause the `comma-style` rule to report placement errors for each of the commas appearing in the code above. While the example code given here is oriented to the `last` mode, errors will also be reported for equivalent comma (mis)placements that violate the `first` mode.

**What changes did you make? (Give an overview)**

I updated the `comma-style` rule to report errors for more node types, added tests and updated documentation to reflect the changes.

**Is there anything you'd like reviewers to focus on?**
