### PR TITLE
Fix: `no-useless-return` false positive on conditionals (fixes #7477)

### DIFF
--- a/lib/rules/no-useless-return.js
+++ b/lib/rules/no-useless-return.js
@@ -254,6 +254,9 @@ module.exports = {
 
             // Adds ReturnStatement node to check whether it's useless or not.
             ReturnStatement(node) {
+                if (node.argument) {
+                    markReturnStatementsOnCurrentSegmentsAsUsed();
+                }
                 if (node.argument || isInLoop(node) || isInFinally(node)) {
                     return;
                 }

--- a/tests/lib/rules/no-useless-return.js
+++ b/tests/lib/rules/no-useless-return.js
@@ -125,7 +125,30 @@ ruleTester.run("no-useless-return", rule, {
         {
             code: "if (foo) { return; } doSomething();",
             parserOptions: {ecmaFeatures: {globalReturn: true}}
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/7477
+        `
+          function foo() {
+            if (bar) return;
+            return baz;
+          }
+        `,
+        `
+          function foo() {
+            if (bar) {
+              return;
+            }
+            return baz;
+          }
+        `,
+        `
+          function foo() {
+            if (bar) baz();
+            else return;
+            return 5;
+          }
+        `
     ],
 
     invalid: [
@@ -154,6 +177,28 @@ ruleTester.run("no-useless-return", rule, {
             code: "if (foo) { bar(); return; } else { baz(); }",
             output: "if (foo) { bar();  } else { baz(); }",
             parserOptions: {ecmaFeatures: {globalReturn: true}}
+        },
+        {
+            code: `
+              function foo() {
+                if (foo) {
+                  return;
+                }
+                return;
+              }
+            `,
+            output: `
+              function foo() {
+                if (foo) {
+                  
+                }
+                
+              }
+            `,
+            errors: [
+                {message: "Unnecessary return statement.", type: "ReturnStatement"},
+                {message: "Unnecessary return statement.", type: "ReturnStatement"},
+            ]
         },
         {
             code: `
@@ -305,28 +350,10 @@ ruleTester.run("no-useless-return", rule, {
               }
             `
         },
-        {
-            code: `
-              function foo() {
-                try {
-                  foo();
-                  return;
-                } catch (err) {
-                  return 5;
-                }
-              }
-            `,
-            output: `
-              function foo() {
-                try {
-                  foo();
-                  
-                } catch (err) {
-                  return 5;
-                }
-              }
-            `
-        },
+
+        // FIXME: Re-add this case (removed due to https://github.com/eslint/eslint/issues/7481):
+        // https://github.com/eslint/eslint/blob/261d7287820253408ec87c344beccdba2fe829a4/tests/lib/rules/no-useless-return.js#L308-L329
+
         {
             code: `
               function foo() {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See https://github.com/eslint/eslint/issues/7477

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This ensures that if a `return` statement has an argument, and it's on the same code path as another return statement, the first return statement is not considered to be a useless return.

**Is there anything you'd like reviewers to focus on?**

Nothing in particular.
