### PR TITLE
Update: Fix `lines-around-directive` semicolon handling (fixes #7450)

### DIFF
--- a/tests/lib/rules/lines-around-directive.js
+++ b/tests/lib/rules/lines-around-directive.js
@@ -655,6 +655,16 @@ ruleTester.run("lines-around-directive", rule, {
             parserOptions: { ecmaVersion: 6 },
             options: [{ before: "always", after: "never" }]
         },
+
+        // https://github.com/eslint/eslint/issues/7450
+        {
+            code: "'use strict'\n\n;foo();",
+            options: [{ before: "never", after: "always" }]
+        },
+        {
+            code: "'use strict'\n;foo();",
+            options: [{ before: "never", after: "never" }]
+        }
     ],
 
     invalid: [
@@ -1598,6 +1608,27 @@ ruleTester.run("lines-around-directive", rule, {
                 "Expected newline before \"use strict\" directive.",
                 "Unexpected newline after \"use asm\" directive."
             ]
+        },
+
+        // https://github.com/eslint/eslint/issues/7450
+        {
+
+            code: "'use strict'\n\n;foo();",
+            output: "'use strict'\n;foo();",
+            options: [{ before: "never", after: "never" }],
+            errors: ["Unexpected newline after \"use strict\" directive."]
+        },
+        {
+            code: "'use strict'\n;foo();",
+            output: "'use strict'\n\n;foo();",
+            options: [{ before: "never", after: "always" }],
+            errors: ["Expected newline after \"use strict\" directive."]
+        },
+        {
+            code: "'use strict'\n;\nfoo();",
+            output: "'use strict'\n\n;\nfoo();",
+            options: [{ before: "never", after: "always" }],
+            errors: ["Expected newline after \"use strict\" directive."]
         }
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See https://github.com/eslint/eslint/issues/7450

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This allows `lines-around-directive` to correctly handle directives that have a trailing semicolon on a different line.

``` js
'use strict'

; [1, 2, 3].map(foo)
```

**Is there anything you'd like reviewers to focus on?**

This is _semver-minor_ with our semver policy, because it can cause more warnings to be reported in cases like this:
