### PR TITLE
Fix: incorrect `indent` check for array property access (fixes #7484)

### DIFF
--- a/lib/rules/indent.js
+++ b/lib/rules/indent.js
@@ -695,19 +695,11 @@ module.exports = {
             // TODO - come up with a better strategy in future
             if (isNodeFirstInLine(node)) {
                 const parent = node.parent;
-                let effectiveParent = parent;
 
-                if (parent.type === "MemberExpression") {
-                    if (isNodeFirstInLine(parent)) {
-                        effectiveParent = parent.parent.parent;
-                    } else {
-                        effectiveParent = parent.parent;
-                    }
-                }
-                nodeIndent = getNodeIndent(effectiveParent).goodChar;
+                nodeIndent = getNodeIndent(parent).goodChar;
                 if (parentVarNode && parentVarNode.loc.start.line !== node.loc.start.line) {
                     if (parent.type !== "VariableDeclarator" || parentVarNode === parentVarNode.parent.declarations[0]) {
-                        if (parent.type === "VariableDeclarator" && parentVarNode.loc.start.line === effectiveParent.loc.start.line) {
+                        if (parent.type === "VariableDeclarator" && parentVarNode.loc.start.line === parent.loc.start.line) {
                             nodeIndent = nodeIndent + (indentSize * options.VariableDeclarator[parentVarNode.parent.kind]);
                         } else if (
                             parent.type === "ObjectExpression" ||
@@ -720,7 +712,7 @@ module.exports = {
                             nodeIndent = nodeIndent + indentSize;
                         }
                     }
-                } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && effectiveParent.type !== "MemberExpression" && effectiveParent.type !== "ExpressionStatement" && effectiveParent.type !== "AssignmentExpression" && effectiveParent.type !== "Property") {
+                } else if (!parentVarNode && !isFirstArrayElementOnSameLine(parent) && parent.type !== "MemberExpression" && parent.type !== "ExpressionStatement" && parent.type !== "AssignmentExpression" && parent.type !== "Property") {
                     nodeIndent = nodeIndent + indentSize;
                 }
 

--- a/tests/lib/rules/indent.js
+++ b/tests/lib/rules/indent.js
@@ -1698,6 +1698,18 @@ ruleTester.run("indent", rule, {
             "        new Car('!')\n" +
             ");",
             options: [2, {CallExpression: {arguments: 4}}]
+        },
+
+        // https://github.com/eslint/eslint/issues/7484
+        {
+            code:
+            "var foo = function() {\n" +
+            "  return bar(\n" +
+            "    [{\n" +
+            "    }].concat(baz)\n" +
+            "  );\n" +
+            "};",
+            options: [2]
         }
     ],
     invalid: [


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[ ] Documentation update
[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))
[ ] New rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-proposal.md))
[ ] Changes an existing rule ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/rule-change-proposal.md))
[ ] Add autofixing to a rule
[ ] Add a CLI option
[ ] Add something to the core
[ ] Other, please explain:

See https://github.com/eslint/eslint/issues/7484

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

This fixes an issue where array indentation was calculated incorrectly for MemberExpression nodes.

It does this by removing some outdated logic from the `checkIndentInArrayOrObjectBlock` function. As far as I can tell, this logic is no longer necessary because `indent` no longer has a special case for nested arrays.

**Is there anything you'd like reviewers to focus on?**

We should verify that this removed logic wasn't doing something else that I'm unaware of. It passes all the tests and doesn't appear to be necessary anymore, but it would be good to have confirmation of its original purpose. (It looks like it was introduced in https://github.com/eslint/eslint/commit/b11c3c491ae54858e67b23c2129caacae73f8527) /cc @gyandeeps @BYK 
