### PR TITLE
Upgrade: mock-fs to ^3.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "load-perf": "^0.2.0",
     "markdownlint": "^0.2.0",
     "mocha": "^2.4.5",
-    "mock-fs": "3.11.0",
+    "mock-fs": "^3.12.0",
     "npm-license": "^0.3.2",
     "phantomjs-prebuilt": "^2.1.7",
     "proxyquire": "^1.7.10",

--- a/tests/lib/cli-engine.js
+++ b/tests/lib/cli-engine.js
@@ -15,7 +15,6 @@ const assert = require("chai").assert,
     leche = require("leche"),
     shell = require("shelljs"),
     Config = require("../../lib/config"),
-    Plugins = require("../../lib/config/plugins"),
     fs = require("fs"),
     os = require("os"),
     hash = require("../../lib/util/hash");
@@ -42,6 +41,7 @@ describe("CLIEngine", function() {
         examplePreprocessorName = "eslint-plugin-processor",
         originalDir = process.cwd();
     let CLIEngine,
+        Plugins,
         fixtureDir;
 
     /**
@@ -65,6 +65,8 @@ describe("CLIEngine", function() {
 
     // copy into clean area so as not to get "infected" by this project's .eslintrc files
     before(function() {
+        Plugins = require("../../lib/config/plugins");
+
         fixtureDir = path.join(os.tmpdir(), "/eslint/fixtures");
         mkdir("-p", fixtureDir);
         cp("-r", "./tests/fixtures/.", fixtureDir);


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

Due to a change in mock-fs 3.12.0, the `require` cache is cleared as soon as the mock-fs library is loaded (see https://github.com/tschaub/mock-fs/pull/141). Our `lib/cli-engine.js` test uses `const Plugins = require('../../lib/plugins.js')` at the top level, and then some of the later tests use `require('mock-fs')` at the top level. Some of the `lib/cli-engine.js` tests have a requirement that `Plugins === require('../../lib/plugins.js')`, so using `require('mock-fs')` was causing the `require('../../lib/plugins.js')` value to change, which caused the tests to fail.

This commit fixes the issue by moving the `const Plugins = require('../../lib/plugins.js')` into a `before` hook, so that it gets run _after_ `mock-fs` is loaded.

**Is there anything you'd like reviewers to focus on?**

Once this is merged, we can start testing Node 7 on travis :tada:
