### PR TITLE
Build: handle deprecated rules with no 'replacedBy' (refs #7471)

### DIFF
--- a/Makefile.js
+++ b/Makefile.js
@@ -211,7 +211,7 @@ function generateRuleIndexPage(basedir) {
         if (rule.meta.deprecated) {
             categoriesData.deprecated.rules.push({
                 name: basename,
-                replacedBy: rule.meta.docs.replacedBy
+                replacedBy: rule.meta.docs.replacedBy || []
             });
         } else {
             const output = {


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Other, please explain:

Make sure deprecated rules that have no `meta.docs.replacedBy` property don't break the build. This PR is also related to https://github.com/eslint/eslint.github.io/pull/308.

**What changes did you make? (Give an overview)**
I've made it so the `generateRuleIndexPage()` function uses an empty array as a default when it finds a deprecated rule that has no `meta.docs.replacedBy` property.

**Is there anything you'd like reviewers to focus on?**
Nothing in particular, I think.


