### PR TITLE
Update: fix `brace-style` false negative on multiline node (fixes #7493)

### DIFF
--- a/lib/rules/brace-style.js
+++ b/lib/rules/brace-style.js
@@ -143,7 +143,7 @@ module.exports = {
                         });
                     }
 
-                    if (curlyTokenEnd.loc.start.line === block.body[block.body.length - 1].loc.start.line) {
+                    if (curlyTokenEnd.loc.start.line === block.body[block.body.length - 1].loc.end.line) {
                         context.report({
                             node: block.body[block.body.length - 1],
                             message: CLOSE_MESSAGE_SINGLE,

--- a/tests/lib/rules/brace-style.js
+++ b/tests/lib/rules/brace-style.js
@@ -458,6 +458,35 @@ ruleTester.run("brace-style", rule, {
             code: "if (foo) // comment \n{\nbar();\n}",
             output: "if (foo) // comment \n{\nbar();\n}",
             errors: [{ message: OPEN_MESSAGE, type: "IfStatement" }]
-        }
+        },
+
+        // https://github.com/eslint/eslint/issues/7493
+        {
+            code: "if (foo) {\n bar\n.baz }",
+            output: "if (foo) {\n bar\n.baz \n}",
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+        },
+        {
+            code: "if (foo)\n{\n bar\n.baz }",
+            output: "if (foo)\n{\n bar\n.baz \n}",
+            options: ["allman"],
+            errors: [{ message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+        },
+        {
+            code: "if (foo) { bar\n.baz }",
+            output: "if (foo) {\n bar\n.baz \n}",
+            options: ["1tbs", { allowSingleLine: true }],
+            errors: [{ message: BODY_MESSAGE, type: "ExpressionStatement" }, { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }]
+        },
+        {
+            code: "if (foo) { bar\n.baz }",
+            output: "if (foo) \n{\n bar\n.baz \n}",
+            options: ["allman", { allowSingleLine: true }],
+            errors: [
+                { message: OPEN_MESSAGE_ALLMAN, type: "IfStatement" },
+                { message: BODY_MESSAGE, type: "ExpressionStatement" },
+                { message: CLOSE_MESSAGE_SINGLE, type: "ExpressionStatement" }
+            ]
+        },
     ]
 });


### PR DESCRIPTION
**What is the purpose of this pull request? (put an "X" next to item)**

[x] Bug fix ([template](https://raw.githubusercontent.com/eslint/eslint/master/templates/bug-report.md))

See https://github.com/eslint/eslint/issues/7493

<!--
    Please ensure your pull request is ready:

    - Read the pull request guide (http://eslint.org/docs/developer-guide/contributing/pull-requests)
    - Include tests for this change
    - Update documentation for this change (if appropriate)
-->

<!--
    The following is required for all pull requests:
-->

**What changes did you make? (Give an overview)**

[`brace-style`](http://eslint.org/docs/rules/brace-style) currently checks whether the closing `}` in a BlockStatement is on the same line as the rest of the block. However, it was checking the position of the `}` against the *start* position of the last statement in the block, which caused false negatives like https://github.com/eslint/eslint/issues/7493. It should check against the *end* position of the last statement of the block instead.

**Is there anything you'd like reviewers to focus on?**

This is a semver-minor change according to our semver policy, because it fixes a false negative.

